### PR TITLE
feat: add workspace refactor tools and tests

### DIFF
--- a/crates/perl-parser/src/import_optimizer.rs
+++ b/crates/perl-parser/src/import_optimizer.rs
@@ -1,9 +1,14 @@
-//! Import optimization for Perl modules (stub implementation)
+//! Import optimization for Perl modules
 //!
-//! This module analyzes import statements and usage to optimize imports.
-//! Currently a stub implementation to demonstrate the architecture.
+//! The previous version of this module only contained empty stubs.  The
+//! implementation below performs a very small amount of static analysis on a
+//! source file: duplicate and unused imports are detected, missing imports are
+//! suggested and a basic suggestion for reorganisation is produced.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::Path;
 
 /// Result of import analysis
@@ -59,21 +64,138 @@ impl ImportOptimizer {
         Self
     }
 
-    /// Analyze imports in a file (stub implementation)
-    pub fn analyze_file(&self, _file_path: &Path) -> Result<ImportAnalysis, String> {
-        // Stub implementation
+    /// Analyze imports in a file.
+    pub fn analyze_file(&self, file_path: &Path) -> Result<ImportAnalysis, String> {
+        let content = fs::read_to_string(file_path)
+            .map_err(|e| format!("Failed to read {}: {}", file_path.display(), e))?;
+
+        let lines: Vec<&str> = content.lines().collect();
+        let use_re = Regex::new(r"^\s*use\s+([A-Za-z0-9_:]+)(?:\s+qw\(([^)]*)\))?")
+            .map_err(|e| e.to_string())?;
+
+        let mut module_lines: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut module_symbols: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (i, line) in lines.iter().enumerate() {
+            if let Some(caps) = use_re.captures(line) {
+                let module = caps.get(1).unwrap().as_str().to_string();
+                let symbols = caps
+                    .get(2)
+                    .map(|m| {
+                        m.as_str().split_whitespace().map(|s| s.to_string()).collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                module_lines.entry(module.clone()).or_default().push(i + 1);
+                if !symbols.is_empty() {
+                    module_symbols.insert(module.clone(), symbols);
+                }
+            }
+        }
+
+        // Detect duplicate imports
+        let mut duplicate_imports = Vec::new();
+        for (module, lines) in &module_lines {
+            if lines.len() > 1 {
+                duplicate_imports.push(DuplicateImport {
+                    module: module.clone(),
+                    lines: lines.clone(),
+                    can_merge: true,
+                });
+            }
+        }
+
+        // Detect unused imports by searching for module or imported symbols
+        let mut unused_imports = Vec::new();
+        for (module, lines_vec) in &module_lines {
+            let mut used = false;
+            let module_re = Regex::new(&format!(r"\b{}::", regex::escape(module))).unwrap();
+            if module_re.is_match(&content) {
+                for m in module_re.find_iter(&content) {
+                    // Ignore the import lines themselves
+                    let line = content[..m.start()].lines().count() + 1;
+                    if !lines_vec.contains(&line) {
+                        used = true;
+                        break;
+                    }
+                }
+            }
+
+            if !used {
+                if let Some(symbols) = module_symbols.get(module) {
+                    let symbol_used = symbols.iter().any(|s| {
+                        Regex::new(&format!(r"\\b{}\\b", regex::escape(s)))
+                            .unwrap()
+                            .is_match(&content)
+                    });
+                    used = symbol_used;
+                }
+            }
+
+            if !used {
+                unused_imports.push(UnusedImport {
+                    module: module.clone(),
+                    symbols: module_symbols.get(module).cloned().unwrap_or_default(),
+                    line: lines_vec[0],
+                    reason: "Import not used".into(),
+                });
+            }
+        }
+
+        // Detect missing imports by scanning for module paths followed by `::symbol`
+        let usage_re = Regex::new(r"([A-Za-z0-9_]+(?:::[A-Za-z0-9_]+)*)::[A-Za-z0-9_]+").unwrap();
+        let mut imported: HashSet<String> = module_lines.keys().cloned().collect();
+        let mut missing_imports = Vec::new();
+        for cap in usage_re.captures_iter(&content) {
+            let module = cap[1].to_string();
+            if !imported.contains(&module) {
+                imported.insert(module.clone());
+                missing_imports.push(MissingImport {
+                    module,
+                    symbols: vec![],
+                    suggested_location: 1,
+                    confidence: 0.5,
+                });
+            }
+        }
+
+        let organization_suggestions = if !duplicate_imports.is_empty()
+            || !unused_imports.is_empty()
+            || !missing_imports.is_empty()
+        {
+            vec![OrganizationSuggestion {
+                description: "Sort and deduplicate imports".into(),
+                priority: SuggestionPriority::Medium,
+            }]
+        } else {
+            Vec::new()
+        };
+
         Ok(ImportAnalysis {
-            unused_imports: vec![],
-            missing_imports: vec![],
-            duplicate_imports: vec![],
-            organization_suggestions: vec![],
+            unused_imports,
+            missing_imports,
+            duplicate_imports,
+            organization_suggestions,
         })
     }
 
-    /// Generate optimized import statements (stub implementation)
-    pub fn generate_optimized_imports(&self, _analysis: &ImportAnalysis) -> String {
-        // Stub implementation
-        String::new()
+    /// Generate optimized import statements based on analysis.
+    ///
+    /// The returned string contains one `use` line per module, sorted
+    /// alphabetically. Unused imports are omitted and missing imports are
+    /// included.
+    pub fn generate_optimized_imports(&self, analysis: &ImportAnalysis) -> String {
+        let mut modules: HashSet<String> =
+            analysis.duplicate_imports.iter().map(|d| d.module.clone()).collect();
+
+        for miss in &analysis.missing_imports {
+            modules.insert(miss.module.clone());
+        }
+
+        // Unused imports are intentionally not added back
+        let mut modules: Vec<String> = modules.into_iter().collect();
+        modules.sort();
+        modules.into_iter().map(|m| format!("use {}\n", m)).collect()
     }
 }
 

--- a/crates/perl-parser/src/workspace_refactor.rs
+++ b/crates/perl-parser/src/workspace_refactor.rs
@@ -1,10 +1,15 @@
-//! Workspace-wide refactoring operations (stub implementation)
+//! Workspace-wide refactoring operations
 //!
-//! This module provides refactoring capabilities that span multiple files.
-//! Currently a stub implementation to demonstrate the architecture.
+//! This module implements a few high level refactoring operations that can be
+//! executed across multiple files.  The original version of this module only
+//! contained empty stubs – the real behaviour has now been implemented using
+//! the [`WorkspaceIndex`]'s document store.
 
-use crate::workspace_index::WorkspaceIndex;
+use crate::import_optimizer::ImportOptimizer;
+use crate::workspace_index::{uri_to_fs_path, WorkspaceIndex};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// A file edit as part of a refactoring operation
@@ -32,15 +37,20 @@ pub struct RefactorResult {
 
 /// Workspace-wide refactoring provider
 pub struct WorkspaceRefactor {
-    _index: WorkspaceIndex,
+    /// Index containing all documents in the workspace
+    index: WorkspaceIndex,
 }
 
 impl WorkspaceRefactor {
     pub fn new(index: WorkspaceIndex) -> Self {
-        Self { _index: index }
+        Self { index }
     }
 
-    /// Rename a symbol across all files (stub implementation)
+    /// Rename a symbol across all files.
+    ///
+    /// The implementation is intentionally simple – it performs a textual
+    /// search across every open document and returns the edits required to
+    /// rename all occurrences of `old_name` to `new_name`.
     pub fn rename_symbol(
         &self,
         old_name: &str,
@@ -48,15 +58,36 @@ impl WorkspaceRefactor {
         _file_path: &Path,
         _position: (usize, usize),
     ) -> Result<RefactorResult, String> {
-        // Stub implementation
+        let mut file_edits = Vec::new();
+        let re =
+            Regex::new(&format!(r"\b{}\b", regex::escape(old_name))).map_err(|e| e.to_string())?;
+
+        for doc in self.index.document_store().all_documents() {
+            let mut edits = Vec::new();
+            for m in re.find_iter(&doc.text) {
+                edits.push(TextEdit {
+                    start: m.start(),
+                    end: m.end(),
+                    new_text: new_name.to_string(),
+                });
+            }
+            if !edits.is_empty() {
+                if let Some(path) = uri_to_fs_path(&doc.uri) {
+                    file_edits.push(FileEdit { file_path: path, edits });
+                }
+            }
+        }
+
         Ok(RefactorResult {
-            file_edits: vec![],
+            file_edits,
             description: format!("Rename '{}' to '{}'", old_name, new_name),
             warnings: vec![],
         })
     }
 
-    /// Extract selected code into a new module (stub implementation)
+    /// Extract selected code into a new module.
+    ///
+    /// `start_line` and `end_line` are 1-based inclusive line numbers.
     pub fn extract_module(
         &self,
         file_path: &Path,
@@ -64,9 +95,44 @@ impl WorkspaceRefactor {
         end_line: usize,
         module_name: &str,
     ) -> Result<RefactorResult, String> {
-        // Stub implementation
+        let content = fs::read_to_string(file_path)
+            .map_err(|e| format!("Failed to read {}: {}", file_path.display(), e))?;
+
+        let lines: Vec<&str> = content.lines().collect();
+        if start_line == 0 || end_line < start_line || end_line > lines.len() {
+            return Err("Invalid line range for extraction".to_string());
+        }
+
+        // Determine byte offsets for the range we want to remove
+        let mut line_offsets = Vec::with_capacity(lines.len() + 1);
+        let mut offset = 0;
+        for line in &lines {
+            line_offsets.push(offset);
+            offset += line.len() + 1; // include newline
+        }
+        line_offsets.push(offset);
+
+        let start_offset = line_offsets[start_line - 1];
+        let end_offset = line_offsets[end_line];
+        let extracted: Vec<&str> = lines[start_line - 1..end_line].to_vec();
+
+        // Build edits: remove from original file and create new module file
+        let mut file_edits = Vec::new();
+        file_edits.push(FileEdit {
+            file_path: file_path.to_path_buf(),
+            edits: vec![TextEdit { start: start_offset, end: end_offset, new_text: String::new() }],
+        });
+
+        let new_module_path = file_path.with_file_name(format!("{}.pm", module_name));
+        let mut module_content = extracted.join("\n");
+        module_content.push('\n');
+        file_edits.push(FileEdit {
+            file_path: new_module_path,
+            edits: vec![TextEdit { start: 0, end: 0, new_text: module_content }],
+        });
+
         Ok(RefactorResult {
-            file_edits: vec![],
+            file_edits,
             description: format!(
                 "Extract {} lines from {} into module '{}'",
                 end_line - start_line + 1,
@@ -77,11 +143,80 @@ impl WorkspaceRefactor {
         })
     }
 
-    /// Optimize imports across the workspace (stub implementation)
+    /// Optimize imports across the workspace.
+    ///
+    /// The optimizer removes duplicate and unused imports and adds any missing
+    /// imports that were detected.  The resulting import block is sorted
+    /// alphabetically.
     pub fn optimize_imports(&self) -> Result<RefactorResult, String> {
-        // Stub implementation
+        let mut file_edits = Vec::new();
+        let optimizer = ImportOptimizer::new();
+
+        for doc in self.index.document_store().all_documents() {
+            let Some(path) = uri_to_fs_path(&doc.uri) else { continue };
+            let analysis = optimizer.analyze_file(&path)?;
+            if analysis.unused_imports.is_empty()
+                && analysis.duplicate_imports.is_empty()
+                && analysis.missing_imports.is_empty()
+            {
+                continue;
+            }
+
+            // Find import lines in the document
+            let mut import_lines = Vec::new();
+            for (i, line) in doc.text.lines().enumerate() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("use ") || trimmed.starts_with("require ") {
+                    import_lines.push(i);
+                }
+            }
+            if import_lines.is_empty() {
+                continue;
+            }
+
+            // Compute byte offsets
+            let mut line_offsets = Vec::with_capacity(doc.text.lines().count() + 1);
+            let mut off = 0;
+            for line in doc.text.lines() {
+                line_offsets.push(off);
+                off += line.len() + 1;
+            }
+            line_offsets.push(off);
+            let start_offset = line_offsets[import_lines[0]];
+            let end_offset = line_offsets[import_lines.last().unwrap() + 1];
+
+            // Gather existing modules in import block
+            let mut modules: Vec<String> = import_lines
+                .iter()
+                .filter_map(|i| doc.text.lines().nth(*i))
+                .filter_map(|line| line.split_whitespace().nth(1))
+                .map(|m| m.trim_end_matches(';').to_string())
+                .collect();
+
+            // Remove duplicates and unused modules
+            let unused: std::collections::HashSet<_> =
+                analysis.unused_imports.iter().map(|u| u.module.as_str()).collect();
+            modules.retain(|m| !unused.contains(m.as_str()));
+            modules.sort();
+            modules.dedup();
+            // Add missing imports
+            for miss in &analysis.missing_imports {
+                if !modules.contains(&miss.module) {
+                    modules.push(miss.module.clone());
+                }
+            }
+            modules.sort();
+
+            let new_block: String = modules.into_iter().map(|m| format!("use {}\n", m)).collect();
+
+            file_edits.push(FileEdit {
+                file_path: path,
+                edits: vec![TextEdit { start: start_offset, end: end_offset, new_text: new_block }],
+            });
+        }
+
         Ok(RefactorResult {
-            file_edits: vec![],
+            file_edits,
             description: "Optimize imports across workspace".to_string(),
             warnings: vec![],
         })

--- a/crates/perl-parser/tests/workspace_tools_tests.rs
+++ b/crates/perl-parser/tests/workspace_tools_tests.rs
@@ -1,0 +1,71 @@
+use perl_parser::{
+    dead_code_detector::DeadCodeDetector,
+    import_optimizer::ImportOptimizer,
+    workspace_index::WorkspaceIndex,
+    workspace_refactor::{TextEdit, WorkspaceRefactor},
+};
+use std::io::Write;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+fn apply_edits(text: String, edits: &[TextEdit]) -> String {
+    // apply from end to start so offsets remain valid
+    let mut result = text;
+    for edit in edits.iter().rev() {
+        result.replace_range(edit.start..edit.end, &edit.new_text);
+    }
+    result
+}
+
+#[test]
+fn test_workspace_rename() {
+    let index = WorkspaceIndex::new();
+    let file1_uri = "file:///workspace/lib/Foo.pm";
+    let file1_content = "package Foo;\nsub foo { 1 }\n1;";
+    index.index_file(url::Url::parse(file1_uri).unwrap(), file1_content.to_string()).unwrap();
+    let file2_uri = "file:///workspace/main.pl";
+    let file2_content = "use Foo;\nFoo::foo();";
+    index.index_file(url::Url::parse(file2_uri).unwrap(), file2_content.to_string()).unwrap();
+
+    let refactor = WorkspaceRefactor::new(index);
+    let result = refactor.rename_symbol("foo", "bar", Path::new("dummy"), (0, 0)).unwrap();
+    assert_eq!(result.file_edits.len(), 2);
+    for edit in &result.file_edits {
+        let orig = if edit.file_path.to_string_lossy().ends_with("Foo.pm") {
+            file1_content
+        } else {
+            file2_content
+        };
+        let new_text = apply_edits(orig.to_string(), &edit.edits);
+        assert!(!new_text.contains("foo"));
+        assert!(new_text.contains("bar"));
+    }
+}
+
+#[test]
+fn test_import_optimizer_analysis() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "use Foo;").unwrap();
+    writeln!(file, "use Foo;").unwrap();
+    writeln!(file, "use Bar;").unwrap();
+    writeln!(file, "my $x = Foo::baz();").unwrap();
+    writeln!(file, "Baz::qux();").unwrap();
+    let path = file.into_temp_path();
+
+    let optimizer = ImportOptimizer::new();
+    let analysis = optimizer.analyze_file(path.as_ref()).unwrap();
+    assert_eq!(analysis.duplicate_imports.len(), 1);
+    assert_eq!(analysis.unused_imports.len(), 1);
+    assert_eq!(analysis.missing_imports.len(), 1);
+}
+
+#[test]
+fn test_dead_code_detection() {
+    let index = WorkspaceIndex::new();
+    let file_uri = "file:///workspace/lib/Test.pm";
+    let content = "sub used { 1 }\nsub unused { 2 }\nused();\n1;";
+    index.index_file(url::Url::parse(file_uri).unwrap(), content.to_string()).unwrap();
+    let detector = DeadCodeDetector::new(index);
+    let analysis = detector.analyze_workspace();
+    assert!(analysis.dead_code.iter().any(|d| d.name.as_deref() == Some("unused")));
+}


### PR DESCRIPTION
## Summary
- implement workspace-wide rename, module extraction and import optimization
- add basic import and dead code analyzers
- cover new functionality with regression tests

## Testing
- `cargo test -p perl-parser --test workspace_tools_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f0b6a74833392d8cc71fc643043