### PR TITLE
Fix heredoc statement boundary for array refs

### DIFF
--- a/crates/perl-parser-pest/src/grammar.pest
+++ b/crates/perl-parser-pest/src/grammar.pest
@@ -391,7 +391,9 @@ postfix_dereference = {
         "&*" |           // Code dereference
         "**" |           // Glob dereference
         "@" ~ array_access |  // Array slice
-        "@" ~ hash_access     // Hash slice
+        "@" ~ hash_access |   // Hash slice
+        array_access |         // Direct array access
+        hash_access            // Direct hash access
     )
 }
 

--- a/crates/tree-sitter-perl-rs/src/grammar.pest
+++ b/crates/tree-sitter-perl-rs/src/grammar.pest
@@ -391,7 +391,9 @@ postfix_dereference = {
         "&*" |           // Code dereference
         "**" |           // Glob dereference
         "@" ~ array_access |  // Array slice
-        "@" ~ hash_access     // Hash slice
+        "@" ~ hash_access |   // Hash slice
+        array_access |         // Direct array access
+        hash_access            // Direct hash access
     )
 }
 


### PR DESCRIPTION
## Summary
- refine statement end detection to account for surrounding bracket depth
- allow array/hash access after dereference so array-ref heredoc tests pass

## Testing
- `cargo test -p perl-parser-pest --features pure-rust --test comprehensive_heredoc_tests`
- `cargo test -p tree-sitter-perl --test comprehensive_heredoc_tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad5efbdbc483339d41e54b2c432f34