### PR TITLE
Add bindgen generation task

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -21,3 +21,4 @@ perl-parser = { workspace = true }
 tree-sitter = { workspace = true }
 regex = "1.11.1"
 serde_yaml = "0.9"
+bindgen = "0.72.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -183,8 +183,12 @@ enum Commands {
 
     /// Generate bindings
     Bindings {
-        /// Output directory for bindings
-        #[arg(long, default_value = "crates/tree-sitter-perl/src/bindings")]
+        /// Header file to generate bindings from
+        #[arg(long, default_value = "crates/tree-sitter-perl-rs/src/tree_sitter/parser.h")]
+        header: PathBuf,
+
+        /// Output file for bindings
+        #[arg(long, default_value = "crates/tree-sitter-perl-rs/src/bindings.rs")]
         output: PathBuf,
     },
 
@@ -368,7 +372,7 @@ fn main() -> Result<()> {
         }
         Commands::Highlight { path, scanner } => highlight::run(path, scanner),
         Commands::Clean { all } => clean::run(all),
-        Commands::Bindings { output } => bindings::run(output),
+        Commands::Bindings { header, output } => bindings::run(header, output),
         Commands::Dev { watch, port } => dev::run(watch, port),
         Commands::ParseRust { source, sexp, ast, bench } => {
             parse_rust::run(source, sexp, ast, bench)

--- a/xtask/src/tasks/bindings.rs
+++ b/xtask/src/tasks/bindings.rs
@@ -1,10 +1,15 @@
 //! Bindings generation task implementation
 
-use color_eyre::eyre::Result;
-use indicatif::{ProgressBar, ProgressStyle};
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-pub fn run(_output: PathBuf) -> Result<()> {
+use bindgen::Builder;
+use color_eyre::eyre::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// Generate Rust bindings from C headers using bindgen.
+pub fn run(header: PathBuf, output: PathBuf) -> Result<()> {
     let spinner = ProgressBar::new_spinner();
     spinner.set_style(
         ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}").unwrap(),
@@ -12,12 +17,29 @@ pub fn run(_output: PathBuf) -> Result<()> {
 
     spinner.set_message("Generating bindings");
 
-    // TODO: Implement bindings generation
-    // This would typically involve:
-    // 1. Running bindgen on C headers
-    // 2. Processing the generated Rust code
-    // 3. Writing to the output directory
+    // Ensure output directory exists
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).context("failed to create output directory")?;
+    }
 
-    spinner.finish_with_message("✅ Bindings generated (placeholder)");
+    let header_dir = header.parent().map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from("."));
+
+    // Run bindgen on the provided header
+    let bindings = Builder::default()
+        .header(header.to_string_lossy())
+        .clang_arg(format!("-I{}", header_dir.display()))
+        .allowlist_function("tree_sitter_perl.*")
+        .allowlist_type("TS.*")
+        .allowlist_var("TREE_SITTER_LANGUAGE_VERSION")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .context("unable to generate bindings")?;
+
+    bindings.write_to_file(&output).context("failed to write bindings")?;
+
+    // Format the generated bindings if rustfmt is available
+    let _ = Command::new("rustfmt").arg(&output).status();
+
+    spinner.finish_with_message("✅ Bindings generated");
     Ok(())
 }

--- a/xtask/src/tasks/features.rs
+++ b/xtask/src/tasks/features.rs
@@ -13,7 +13,7 @@ struct FeaturesCatalog {
 struct Meta {
     version: String,
     lsp_version: String,
-    compliance_percent: Option<u32>,
+    _compliance_percent: Option<u32>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -72,7 +72,7 @@ fn sync_docs_impl() -> Result<()> {
 }
 
 fn update_roadmap(
-    catalog: &FeaturesCatalog,
+    _catalog: &FeaturesCatalog,
     area_stats: &HashMap<String, (usize, usize)>,
 ) -> Result<()> {
     let roadmap_path = Path::new("ROADMAP.md");
@@ -311,7 +311,6 @@ fn verify_features() -> Result<()> {
     }
 
     // Verify compliance percentage matches what's documented
-    let total_features = catalog.feature.len();
     let non_planned = catalog.feature.iter().filter(|f| f.maturity != "planned").count();
     let advertised_ga_prod = catalog
         .feature


### PR DESCRIPTION
## Summary
- invoke bindgen over a header path and write formatted bindings
- expose header and output path options for `xtask bindings`
- tidy up warnings in `features` task for clean build output

## Testing
- `cargo check -p xtask`
- `cargo test -p xtask`


------
https://chatgpt.com/codex/tasks/task_e_68adc4dcca3c8333bc5bb1a7e29def30