### PR TITLE
Implement Perl debugger output parsing and control

### DIFF
--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -33,6 +33,7 @@ url = "2.5"
 rustc-hash = "2.1.0"
 md5 = "0.7"
 phf = { version = "0.11", features = ["macros"] }
+nix = { version = "0.28", default-features = false, features = ["signal"] }
 
 # Core dependencies for position mapping
 ropey = { version = "1.6.1" }

--- a/crates/perl-parser/tests/debug_adapter_integration.rs
+++ b/crates/perl-parser/tests/debug_adapter_integration.rs
@@ -1,0 +1,33 @@
+use perl_parser::debug_adapter::{DapMessage, DebugAdapter};
+use serde_json::json;
+use std::io::Write;
+
+
+#[test]
+fn launch_and_disconnect() {
+    let mut script = tempfile::NamedTempFile::new().unwrap();
+    writeln!(script, "print \"hi\\n\";").unwrap();
+    let path = script.path().to_str().unwrap().to_string();
+
+    let mut adapter = DebugAdapter::new();
+
+    // initialize
+    let resp = adapter.handle_request(1, "initialize", None);
+    matches!(resp, DapMessage::Response { success: true, .. });
+
+    // launch debugger
+    let launch_args = json!({"program": path, "stopOnEntry": true});
+    let resp = adapter.handle_request(2, "launch", Some(launch_args));
+    match resp {
+        DapMessage::Response { success, .. } => assert!(success),
+        _ => panic!("expected response"),
+    }
+
+    // disconnect
+    let resp = adapter.handle_request(3, "disconnect", None);
+    match resp {
+        DapMessage::Response { success, .. } => assert!(success),
+        _ => panic!("expected response"),
+    }
+}
+


### PR DESCRIPTION
## Summary
- parse Perl debugger stdout/stderr and emit DAP events
- send real debugger commands for configuration, stepping and interrupts
- add basic integration test launching debugger

## Testing
- `cargo test -p perl-parser test_debug_adapter_creation -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68adee63314c833383e88cb93d341f9b