### PR TITLE
feat: extract docs from comments for symbols

### DIFF
--- a/crates/perl-parser/src/symbol.rs
+++ b/crates/perl-parser/src/symbol.rs
@@ -4,8 +4,8 @@
 //! that tracks definitions, references, and scopes for IDE features like
 //! go-to-definition, find-all-references, and semantic highlighting.
 
-use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
+use crate::SourceLocation;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
@@ -243,6 +243,8 @@ impl SymbolTable {
 /// Extract symbols from an AST
 pub struct SymbolExtractor {
     table: SymbolTable,
+    /// Source code for comment extraction
+    source: String,
 }
 
 impl Default for SymbolExtractor {
@@ -252,9 +254,14 @@ impl Default for SymbolExtractor {
 }
 
 impl SymbolExtractor {
-    /// Create a new symbol extractor
+    /// Create a new symbol extractor without source (no documentation extraction)
     pub fn new() -> Self {
-        SymbolExtractor { table: SymbolTable::new() }
+        SymbolExtractor { table: SymbolTable::new(), source: String::new() }
+    }
+
+    /// Create a symbol extractor with source text for documentation extraction
+    pub fn new_with_source(source: &str) -> Self {
+        SymbolExtractor { table: SymbolTable::new(), source: source.to_string() }
     }
 
     /// Extract symbols from an AST node
@@ -273,11 +280,13 @@ impl SymbolExtractor {
             }
 
             NodeKind::VariableDeclaration { declarator, variable, attributes, initializer } => {
+                let doc = self.extract_leading_comment(node.location.start);
                 self.handle_variable_declaration(
                     declarator,
                     variable,
                     attributes,
                     variable.location,
+                    doc,
                 );
                 if let Some(init) = initializer {
                     self.visit_node(init);
@@ -290,8 +299,15 @@ impl SymbolExtractor {
                 attributes,
                 initializer,
             } => {
+                let doc = self.extract_leading_comment(node.location.start);
                 for var in variables {
-                    self.handle_variable_declaration(declarator, var, attributes, var.location);
+                    self.handle_variable_declaration(
+                        declarator,
+                        var,
+                        attributes,
+                        var.location,
+                        doc.clone(),
+                    );
                 }
                 if let Some(init) = initializer {
                     self.visit_node(init);
@@ -322,6 +338,7 @@ impl SymbolExtractor {
                     name.as_ref().map(|n| n.to_string()).unwrap_or_else(|| "<anon>".to_string());
 
                 if name.is_some() {
+                    let documentation = self.extract_leading_comment(node.location.start);
                     let symbol = Symbol {
                         name: sub_name.clone(),
                         qualified_name: format!("{}::{}", self.table.current_package, sub_name),
@@ -329,7 +346,7 @@ impl SymbolExtractor {
                         location: node.location,
                         scope_id: self.table.current_scope(),
                         declaration: None,
-                        documentation: None, // TODO: Extract from preceding comments
+                        documentation,
                         attributes: attributes.clone(),
                     };
 
@@ -425,7 +442,7 @@ impl SymbolExtractor {
                 self.table.push_scope(ScopeKind::Block, node.location);
 
                 // The loop variable is implicitly declared
-                self.handle_variable_declaration("my", variable, &[], variable.location);
+                self.handle_variable_declaration("my", variable, &[], variable.location, None);
                 self.visit_node(list);
                 self.visit_node(body);
 
@@ -578,6 +595,7 @@ impl SymbolExtractor {
             }
 
             NodeKind::Method { name, params: _, body } => {
+                let documentation = self.extract_leading_comment(node.location.start);
                 let symbol = Symbol {
                     name: name.clone(),
                     qualified_name: format!("{}::{}", self.table.current_package, name),
@@ -585,7 +603,7 @@ impl SymbolExtractor {
                     location: node.location,
                     scope_id: self.table.current_scope(),
                     declaration: None,
-                    documentation: None,
+                    documentation,
                     attributes: vec!["method".to_string()],
                 };
                 self.table.add_symbol(symbol);
@@ -649,6 +667,37 @@ impl SymbolExtractor {
         }
     }
 
+    /// Extract a block of line comments immediately preceding a declaration
+    fn extract_leading_comment(&self, start: usize) -> Option<String> {
+        if self.source.is_empty() || start == 0 {
+            return None;
+        }
+        let mut end = start.min(self.source.len());
+        let bytes = self.source.as_bytes();
+        while end > 0 && (bytes[end - 1] == b' ' || bytes[end - 1] == b'\t') {
+            end -= 1;
+        }
+        let prefix = &self.source[..end];
+        let mut lines = prefix.lines().rev();
+        let mut docs = Vec::new();
+        for line in &mut lines {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('#') {
+                docs.push(trimmed.trim_start_matches('#').trim_start().to_string());
+            } else if trimmed.is_empty() {
+                break;
+            } else {
+                break;
+            }
+        }
+        if docs.is_empty() {
+            None
+        } else {
+            docs.reverse();
+            Some(docs.join("\n"))
+        }
+    }
+
     /// Handle variable declaration
     fn handle_variable_declaration(
         &mut self,
@@ -656,6 +705,7 @@ impl SymbolExtractor {
         variable: &Node,
         attributes: &[String],
         location: SourceLocation,
+        documentation: Option<String>,
     ) {
         if let NodeKind::Variable { sigil, name } = &variable.kind {
             let kind = match sigil.as_str() {
@@ -676,7 +726,7 @@ impl SymbolExtractor {
                 location,
                 scope_id: self.table.current_scope(),
                 declaration: Some(declarator.to_string()),
-                documentation: None, // TODO: Extract from preceding comments
+                documentation,
                 attributes: attributes.to_vec(),
             };
 

--- a/crates/perl-parser/tests/symbol_documentation_tests.rs
+++ b/crates/perl-parser/tests/symbol_documentation_tests.rs
@@ -1,0 +1,23 @@
+use perl_parser::{Parser, SymbolExtractor};
+
+#[test]
+fn sub_comment_is_captured() {
+    let src = "# sub docs\n# line two\nsub foo {}\n";
+    let mut parser = Parser::new(src);
+    let ast = parser.parse().expect("parse");
+    let extractor = SymbolExtractor::new_with_source(src);
+    let table = extractor.extract(&ast);
+    let symbols = table.symbols.get("foo").expect("symbol foo");
+    assert_eq!(symbols[0].documentation.as_deref(), Some("sub docs\nline two"));
+}
+
+#[test]
+fn variable_comment_is_captured() {
+    let src = "# var docs\nmy $x = 1;\n$x;\n";
+    let mut parser = Parser::new(src);
+    let ast = parser.parse().expect("parse");
+    let extractor = SymbolExtractor::new_with_source(src);
+    let table = extractor.extract(&ast);
+    let symbols = table.symbols.get("x").expect("symbol x");
+    assert_eq!(symbols[0].documentation.as_deref(), Some("var docs"));
+}


### PR DESCRIPTION
## Summary
- collect preceding `#` comments when extracting symbols
- store comment text in the `documentation` field
- add tests ensuring subs and variables pick up docs

## Testing
- `cargo test -p perl-parser --test symbol_documentation_tests --target-dir /tmp/target`


------
https://chatgpt.com/codex/tasks/task_e_68b212c570f08333a83210da0aa9117f