### PR TITLE
Use rope for document content

### DIFF
--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -31,6 +31,7 @@ encoding_rs = "0.8.35"
 serde_json = "1.0.142"
 once_cell = "1.21.3"
 lazy_static = "1.5.0"
+ropey = { version = "1.6.1" }
 
 [dev-dependencies]
 criterion = "0.7.0"


### PR DESCRIPTION
## Summary
- switch DocumentState content from String to Rope
- update incremental edits to apply directly on rope
- convert parser utilities to work with rope
- format imports

## Testing
- ✅ `cargo fmt --manifest-path crates/tree-sitter-perl-rs/Cargo.toml`
- ⚠️ `cargo test -p tree-sitter-perl` *(hung after build; manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c95dc5988333b8b6478c47d9afca