### PR TITLE
fix: improve comment doc extraction and wire source

### DIFF
--- a/crates/perl-parser/src/completion.rs
+++ b/crates/perl-parser/src/completion.rs
@@ -117,7 +117,16 @@ const TEST_MORE_EXPORTS: &[(&str, &str, &str)] = &[
 impl CompletionProvider {
     /// Create a new completion provider from parsed AST
     pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        let symbol_table = SymbolExtractor::new().extract(ast);
+        Self::new_with_index_and_source(ast, "", workspace_index)
+    }
+
+    /// Create a new completion provider from parsed AST and source
+    pub fn new_with_index_and_source(
+        ast: &Node,
+        source: &str,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+    ) -> Self {
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
 
         let keywords = [
             "my",

--- a/crates/perl-parser/src/diagnostics.rs
+++ b/crates/perl-parser/src/diagnostics.rs
@@ -54,7 +54,7 @@ pub struct DiagnosticsProvider {
 impl DiagnosticsProvider {
     /// Create a new diagnostics provider
     pub fn new(ast: &Node, source: String) -> Self {
-        let extractor = SymbolExtractor::new();
+        let extractor = SymbolExtractor::new_with_source(&source);
         let symbol_table = extractor.extract(ast);
         let scope_analyzer = ScopeAnalyzer::new();
         let error_classifier = ErrorClassifier::new();

--- a/crates/perl-parser/src/lsp_server.rs
+++ b/crates/perl-parser/src/lsp_server.rs
@@ -1442,8 +1442,11 @@ impl LspServer {
                 #[cfg_attr(not(feature = "workspace"), allow(unused_mut))]
                 let mut completions = if let Some(ast) = &doc.ast {
                     // Get completions from the local completion provider
-                    let provider =
-                        CompletionProvider::new_with_index(ast, self.workspace_index.clone());
+                    let provider = CompletionProvider::new_with_index_and_source(
+                        ast,
+                        &doc.content,
+                        self.workspace_index.clone(),
+                    );
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.content, offset, Some(uri));
@@ -3974,7 +3977,7 @@ impl LspServer {
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     // Extract symbols from AST
-                    let extractor = crate::symbol::SymbolExtractor::new();
+                    let extractor = crate::symbol::SymbolExtractor::new_with_source(&doc.content);
                     let symbol_table = extractor.extract(ast);
 
                     // Convert to DocumentSymbol format
@@ -7593,7 +7596,7 @@ impl LspServer {
             if let Some(doc) = doc_opt {
                 if let Some(ast) = &doc.ast {
                     // Find the symbol in the AST to get more accurate information
-                    let extractor = crate::symbol::SymbolExtractor::new();
+                    let extractor = crate::symbol::SymbolExtractor::new_with_source(&doc.content);
                     let symbol_table = extractor.extract(ast);
 
                     // Find matching symbol

--- a/crates/perl-parser/src/rename.rs
+++ b/crates/perl-parser/src/rename.rs
@@ -57,7 +57,7 @@ pub struct RenameProvider {
 impl RenameProvider {
     /// Create a new rename provider
     pub fn new(ast: &Node, source: String) -> Self {
-        let symbol_table = SymbolExtractor::new().extract(ast);
+        let symbol_table = SymbolExtractor::new_with_source(&source).extract(ast);
 
         RenameProvider { symbol_table, source }
     }

--- a/crates/perl-parser/src/semantic.rs
+++ b/crates/perl-parser/src/semantic.rs
@@ -101,7 +101,7 @@ impl SemanticAnalyzer {
 
     /// Create a new semantic analyzer from an AST and source text
     pub fn analyze_with_source(ast: &Node, source: &str) -> Self {
-        let symbol_table = SymbolExtractor::new().extract(ast);
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
 
         let mut analyzer = SemanticAnalyzer {
             symbol_table,

--- a/crates/perl-parser/src/signature_help.rs
+++ b/crates/perl-parser/src/signature_help.rs
@@ -52,7 +52,12 @@ pub struct SignatureHelpProvider {
 impl SignatureHelpProvider {
     /// Create a new signature help provider
     pub fn new(ast: &Node) -> Self {
-        let symbol_table = SymbolExtractor::new().extract(ast);
+        Self::new_with_source(ast, "")
+    }
+
+    /// Create a new signature help provider with source
+    pub fn new_with_source(ast: &Node, source: &str) -> Self {
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let builtin_signatures = create_builtin_signatures();
 
         SignatureHelpProvider { symbol_table, builtin_signatures }

--- a/crates/perl-parser/src/symbol.rs
+++ b/crates/perl-parser/src/symbol.rs
@@ -674,7 +674,8 @@ impl SymbolExtractor {
         }
         let mut end = start.min(self.source.len());
         let bytes = self.source.as_bytes();
-        while end > 0 && (bytes[end - 1] == b' ' || bytes[end - 1] == b'\t') {
+        // Trim all preceding whitespace, including newlines, to find the real end of comments.
+        while end > 0 && bytes[end - 1].is_ascii_whitespace() {
             end -= 1;
         }
         let prefix = &self.source[..end];
@@ -684,9 +685,8 @@ impl SymbolExtractor {
             let trimmed = line.trim_start();
             if trimmed.starts_with('#') {
                 docs.push(trimmed.trim_start_matches('#').trim_start().to_string());
-            } else if trimmed.is_empty() {
-                break;
             } else {
+                // Stop at any non-comment line (including empty lines).
                 break;
             }
         }
@@ -804,7 +804,7 @@ sub bar {
         let mut parser = Parser::new(code);
         let ast = parser.parse().unwrap();
 
-        let extractor = SymbolExtractor::new();
+        let extractor = SymbolExtractor::new_with_source(code);
         let table = extractor.extract(&ast);
 
         // Check package symbol

--- a/crates/perl-parser/src/symbol.rs
+++ b/crates/perl-parser/src/symbol.rs
@@ -4,8 +4,8 @@
 //! that tracks definitions, references, and scopes for IDE features like
 //! go-to-definition, find-all-references, and semantic highlighting.
 
-use crate::ast::{Node, NodeKind};
 use crate::SourceLocation;
+use crate::ast::{Node, NodeKind};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 

--- a/crates/perl-parser/src/workspace_symbols.rs
+++ b/crates/perl-parser/src/workspace_symbols.rs
@@ -76,8 +76,8 @@ impl WorkspaceSymbolsProvider {
     }
 
     /// Index a document's symbols
-    pub fn index_document(&mut self, uri: &str, ast: &Node, _source: &str) {
-        let extractor = SymbolExtractor::new();
+    pub fn index_document(&mut self, uri: &str, ast: &Node, source: &str) {
+        let extractor = SymbolExtractor::new_with_source(source);
         let table = extractor.extract(ast);
 
         let mut symbols = Vec::new();

--- a/crates/perl-parser/tests/symbol_documentation_tests.rs
+++ b/crates/perl-parser/tests/symbol_documentation_tests.rs
@@ -21,3 +21,36 @@ fn variable_comment_is_captured() {
     let symbols = table.symbols.get("x").expect("symbol x");
     assert_eq!(symbols[0].documentation.as_deref(), Some("var docs"));
 }
+
+#[test]
+fn comment_separated_by_blank_line_is_not_captured() {
+    let src = "# this is not for foo\n\n# foo docs\nsub foo {}\n";
+    let mut parser = Parser::new(src);
+    let ast = parser.parse().expect("parse");
+    let extractor = SymbolExtractor::new_with_source(src);
+    let table = extractor.extract(&ast);
+    let symbols = table.symbols.get("foo").expect("symbol foo");
+    assert_eq!(symbols[0].documentation.as_deref(), Some("foo docs"));
+}
+
+#[test]
+fn symbol_with_no_comment() {
+    let src = "\n\nsub foo {}\n";
+    let mut parser = Parser::new(src);
+    let ast = parser.parse().expect("parse");
+    let extractor = SymbolExtractor::new_with_source(src);
+    let table = extractor.extract(&ast);
+    let symbols = table.symbols.get("foo").expect("symbol foo");
+    assert_eq!(symbols[0].documentation, None);
+}
+
+#[test]
+fn comment_with_extra_hashes_and_spaces() {
+    let src = "  ###   var docs\n  my $x = 1;\n";
+    let mut parser = Parser::new(src);
+    let ast = parser.parse().expect("parse");
+    let extractor = SymbolExtractor::new_with_source(src);
+    let table = extractor.extract(&ast);
+    let symbols = table.symbols.get("x").expect("symbol x");
+    assert_eq!(symbols[0].documentation.as_deref(), Some("var docs"));
+}


### PR DESCRIPTION
## Summary
- handle leading comment extraction across blank lines and whitespace
- thread file source into symbol analysis and LSP features
- add tests covering comment edge cases

## Testing
- `cargo test -p perl-parser --test symbol_documentation_tests --target-dir /tmp/target`


------
https://chatgpt.com/codex/tasks/task_e_68b57286d19c83338cca7443079052bc