### PR TITLE
Advertise and handle new LSP execute commands

### DIFF
--- a/crates/perl-parser/src/capabilities.rs
+++ b/crates/perl-parser/src/capabilities.rs
@@ -346,13 +346,16 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
     }
 
     if build.execute_command {
+        let mut commands = vec![
+            "perl.tidy".to_string(),
+            "perl.critic".to_string(),
+            "perl.extractVariable".to_string(),
+            "perl.extractSubroutine".to_string(),
+        ];
+        // Advertise executeCommandProvider commands from the execute_command module
+        commands.extend(crate::execute_command::get_supported_commands());
         caps.execute_command_provider = Some(ExecuteCommandOptions {
-            commands: vec![
-                "perl.tidy".to_string(),
-                "perl.critic".to_string(),
-                "perl.extractVariable".to_string(),
-                "perl.extractSubroutine".to_string(),
-            ],
+            commands,
             work_done_progress_options: WorkDoneProgressOptions::default(),
         });
     }

--- a/crates/perl-parser/src/lsp_server.rs
+++ b/crates/perl-parser/src/lsp_server.rs
@@ -6585,7 +6585,7 @@ impl LspServer {
                     }
                 }
                 // New commands handled by ExecuteCommandProvider
-                "perl.runTests" | "perl.runFile" | "perl.runTestSub" => {
+                "perl.runTests" | "perl.runFile" | "perl.runTestSub" | "perl.debugTests" => {
                     match provider.execute_command(command, arguments) {
                         Ok(result) => return Ok(Some(result)),
                         Err(e) => {
@@ -6594,7 +6594,7 @@ impl LspServer {
                     }
                 }
                 // Debug commands (stub implementation for now)
-                "perl.debugFile" | "perl.debugTests" => {
+                "perl.debugFile" => {
                     eprintln!("Debug command requested: {}", command);
                     // Return a success status - actual DAP integration can be added later
                     return Ok(Some(


### PR DESCRIPTION
## Summary
- expose new `perl.runTests`, `perl.runFile`, `perl.runTestSub`, and `perl.debugTests` LSP commands in server capabilities
- route `perl.debugTests` through the execute command provider

## Testing
- `cargo test -p perl-lsp --test lsp_execute_command_tests -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68ba3f52113083338b9d0166d851a0e7