### PR TITLE
Re-enable variable supertype and add variable regression test

### DIFF
--- a/tree-sitter-perl/grammar.js
+++ b/tree-sitter-perl/grammar.js
@@ -88,7 +88,7 @@ module.exports = grammar({
   name: 'perl',
   supertypes: $ => [
     $.primitive,
-    // $.variables, // TODO - i don't know why, but these just went crazy
+    $.variables,
     $.postfix_deref,
     $.subscripted,
     $.slices,
@@ -168,7 +168,7 @@ module.exports = grammar({
     [$.return_expression],
     [$.function, $.bareword],
     [$.function, $.function_call_expression],
-    [$._variables, $.indirect_object],
+    [$.variables, $.indirect_object],
     [$.expression_statement, $._tricky_indirob_hashref],
     [$.autoquoted_bareword],
     // nameless params need extra lookahead
@@ -503,7 +503,7 @@ module.exports = grammar({
       $.command_heredoc_token,
       $.stub_expression,
       // all the variable handlings
-      $._variables,
+      $.variables,
       $.subscripted,
       $.slices,
       $.postfix_deref,
@@ -820,7 +820,7 @@ module.exports = grammar({
     )),
     method: $ => choice($._bareword, $.scalar),
 
-    _variables: $ => choice(
+    variables: $ => choice(
       $.scalar,
       $.array,
       $.hash,

--- a/tree-sitter-perl/test/corpus/variables
+++ b/tree-sitter-perl/test/corpus/variables
@@ -409,3 +409,19 @@ glob access
       (glob_deref_expression
         (scalar
           (varname))))))
+
+================================================================================
+variable as indirect object
+================================================================================
+print $fh 'hi';
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (ambiguous_function_call_expression
+      (function)
+      (indirect_object
+        (scalar
+          (varname)))
+      (string_literal
+        (string_content)))))


### PR DESCRIPTION
## Summary
- restore `variables` supertype and associated rule
- use new `variables` node in conflicts and term handling
- add regression test covering variables as indirect object

## Testing
- `npx tree-sitter test -i 'variable as indirect object'`
- `cargo test` *(fails: test_cross_file_definition has been running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68ba65b052dc833390b060b1d96287bc