### PR TITLE
Reject numeric identifiers after my

### DIFF
--- a/crates/tree-sitter-perl-rs/src/grammar.js
+++ b/crates/tree-sitter-perl-rs/src/grammar.js
@@ -670,20 +670,43 @@ module.exports = grammar({
       alias($._declare_array, $.array),
       alias($._declare_hash, $.hash),
     ),
+    _my_declared_vars: $ => choice(
+      alias($._lexical_scalar, $.scalar),
+      alias($._lexical_array, $.array),
+      alias($._lexical_hash, $.hash),
+    ),
 
     variable_declaration: $ => prec.left(TERMPREC.QUESTION_MARK + 1,
-      seq(
-        choice('my', 'state', 'our', 'field'),
-        choice(
-          field('variable', $._declared_vars),
-          field('variables', $._decl_variable_list)),
-        optseq(':', optional(field('attributes', $.attrlist))))
+      choice(
+        seq(
+          'my',
+          choice(
+            field('variable', $._my_declared_vars),
+            field('variables', $._my_decl_variable_list)
+          ),
+          optseq(':', optional(field('attributes', $.attrlist)))
+        ),
+        seq(
+          choice('state', 'our', 'field'),
+          choice(
+            field('variable', $._declared_vars),
+            field('variables', $._decl_variable_list)
+          ),
+          optseq(':', optional(field('attributes', $.attrlist)))
+        )
+      )
     ),
 
     _decl_variable_list: $ => paren_list_of(
       choice(
         $.undef_expression,
         $._declared_vars
+      )
+    ),
+    _my_decl_variable_list: $ => paren_list_of(
+      choice(
+        $.undef_expression,
+        $._my_declared_vars
       )
     ),
 
@@ -824,9 +847,11 @@ module.exports = grammar({
     scalar: $ => seq('$', $._var_indirob),
     _declare_scalar: $ => seq('$', $.varname),
     _signature_scalar: $ => seq('$', $._signature_varname),
+    _lexical_scalar: $ => seq('$', $._signature_varname),
     array: $ => seq('@', $._var_indirob),
     _declare_array: $ => seq('@', $.varname),
     _signature_array: $ => seq('@', $._signature_varname),
+    _lexical_array: $ => seq('@', $._signature_varname),
     // these need to have higher prec than the equivalent operator symbols
     _HASH_PERCENT: $ => alias(token(prec(2, '%')), '%'), // self-aliasing b/c token
     _SUB_AMPER: $ => alias(token(prec(2, '&')), '&'), // self-aliasing b/c token
@@ -835,6 +860,7 @@ module.exports = grammar({
     hash: $ => seq($._HASH_PERCENT, $._var_indirob),
     _declare_hash: $ => seq($._HASH_PERCENT, $.varname),
     _signature_hash: $ => seq($._HASH_PERCENT, $._signature_varname),
+    _lexical_hash: $ => seq($._HASH_PERCENT, $._signature_varname),
 
     arraylen: $ => seq('$#', $._var_indirob),
     glob: $ => seq($._GLOB_STAR, $._var_indirob),
@@ -853,7 +879,7 @@ module.exports = grammar({
     ),
     varname: $ => choice(
       $._identifier,
-      $._ident_special // TODO - not sure if we wanna make `my $1` error out
+      $._ident_special
     ),
     // not all indirobs are alike; for variables, they have autoquoting behavior
     _var_indirob_autoquote: $ => seq(

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -653,3 +653,18 @@ class Example :isa(BaseClass) {
         (block
           (expression_statement
             (number)))))))
+
+================================================================================
+numeric identifier after my
+================================================================================
+my $foo;
+my $1;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (variable_declaration
+      variable: (scalar
+        (varname))))
+  (expression_statement
+    (ERROR)))

--- a/tree-sitter-perl/grammar.js
+++ b/tree-sitter-perl/grammar.js
@@ -677,20 +677,43 @@ module.exports = grammar({
       alias($._declare_array, $.array),
       alias($._declare_hash, $.hash),
     ),
+    _my_declared_vars: $ => choice(
+      alias($._lexical_scalar, $.scalar),
+      alias($._lexical_array, $.array),
+      alias($._lexical_hash, $.hash),
+    ),
 
     variable_declaration: $ => prec.left(TERMPREC.QUESTION_MARK + 1,
-      seq(
-        choice('my', 'state', 'our', 'field'),
-        choice(
-          field('variable', $._declared_vars),
-          field('variables', $._decl_variable_list)),
-        optseq(':', optional(field('attributes', $.attrlist))))
+      choice(
+        seq(
+          'my',
+          choice(
+            field('variable', $._my_declared_vars),
+            field('variables', $._my_decl_variable_list)
+          ),
+          optseq(':', optional(field('attributes', $.attrlist)))
+        ),
+        seq(
+          choice('state', 'our', 'field'),
+          choice(
+            field('variable', $._declared_vars),
+            field('variables', $._decl_variable_list)
+          ),
+          optseq(':', optional(field('attributes', $.attrlist)))
+        )
+      )
     ),
 
     _decl_variable_list: $ => paren_list_of(
       choice(
         $.undef_expression,
         $._declared_vars
+      )
+    ),
+    _my_decl_variable_list: $ => paren_list_of(
+      choice(
+        $.undef_expression,
+        $._my_declared_vars
       )
     ),
 
@@ -831,9 +854,11 @@ module.exports = grammar({
     scalar: $ => seq('$', $._var_indirob),
     _declare_scalar: $ => seq('$', $.varname),
     _signature_scalar: $ => seq('$', $._signature_varname),
+    _lexical_scalar: $ => seq('$', $._signature_varname),
     array: $ => seq('@', $._var_indirob),
     _declare_array: $ => seq('@', $.varname),
     _signature_array: $ => seq('@', $._signature_varname),
+    _lexical_array: $ => seq('@', $._signature_varname),
     // these need to have higher prec than the equivalent operator symbols
     _HASH_PERCENT: $ => alias(token(prec(2, '%')), '%'), // self-aliasing b/c token
     _SUB_AMPER: $ => alias(token(prec(2, '&')), '&'), // self-aliasing b/c token
@@ -842,6 +867,7 @@ module.exports = grammar({
     hash: $ => seq($._HASH_PERCENT, $._var_indirob),
     _declare_hash: $ => seq($._HASH_PERCENT, $.varname),
     _signature_hash: $ => seq($._HASH_PERCENT, $._signature_varname),
+    _lexical_hash: $ => seq($._HASH_PERCENT, $._signature_varname),
 
     arraylen: $ => seq('$#', $._var_indirob),
     glob: $ => seq($._GLOB_STAR, $._var_indirob),
@@ -860,7 +886,7 @@ module.exports = grammar({
     ),
     varname: $ => choice(
       $._identifier,
-      $._ident_special // TODO - not sure if we wanna make `my $1` error out
+      $._ident_special
     ),
     // not all indirobs are alike; for variables, they have autoquoting behavior
     _var_indirob_autoquote: $ => seq(

--- a/tree-sitter-perl/test/corpus/statements
+++ b/tree-sitter-perl/test/corpus/statements
@@ -653,3 +653,18 @@ class Example :isa(BaseClass) {
         (block
           (expression_statement
             (number)))))))
+
+================================================================================
+numeric identifier after my
+================================================================================
+my $foo;
+my $1;
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (variable_declaration
+      variable: (scalar
+        (varname))))
+  (expression_statement
+    (ERROR)))


### PR DESCRIPTION
## Summary
- disallow numeric identifiers in `my` declarations
- test numeric identifiers after `my`

## Testing
- Unable to run tests: tree-sitter CLI and Node not installed

------
https://chatgpt.com/codex/tasks/task_e_68ba65ba7bf883338701ba36c2c4ab33