### PR TITLE
Implement highlight scope tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ members = [
     "crates/perl-parser",
     "crates/perl-corpus",
     "crates/perl-lsp",
+    "crates/tree-sitter-perl-rs",
+    "xtask",
 ]
 exclude = [
     "tree-sitter-perl",
     "tree-sitter-perl-c",  # Excluded: requires libclang-dev system package for bindgen (legacy C parser)
     "crates/perl-parser-pest",  # Excluded: legacy Pest parser with bindgen dependency
-    "crates/tree-sitter-perl-rs",  # Excluded: internal testing crate with bindgen dependency
     "crates/parser-benchmarks",  # Excluded: benchmarking crate with potential dependencies
     "crates/parser-tests",  # Excluded: test harness with potential dependencies
-    "xtask",  # Excluded: depends on excluded tree-sitter-perl crate
 ]
 
 [workspace.dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = "1.0.98"
 indicatif = "0.18.0"
 console = "0.16.0"
 chrono = { version = "0.4.41", features = ["serde"] }
-perl-parser = { workspace = true }
-tree-sitter = { workspace = true }
+perl-parser = { path = "../crates/perl-parser" }
+tree-sitter = "0.25.8"
 tree-sitter-perl = { path = "../crates/tree-sitter-perl-rs" }
 regex = "1.11.1"
 serde_yaml = "0.9"

--- a/xtask/src/tasks/highlight.rs
+++ b/xtask/src/tasks/highlight.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use walkdir::WalkDir;
-use tree_sitter::{Query, QueryCursor};
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
 
 /// Highlight expectation from test file comments
 #[derive(Clone, Debug)]
@@ -173,10 +173,11 @@ fn run_highlight_test_case(
 
     let mut cursor = QueryCursor::new();
     let mut actual_scopes = HashSet::new();
-    for m in cursor.matches(&query, tree.root_node(), test_case.source.as_bytes()) {
+    let mut matches = cursor.matches(&query, tree.root_node(), test_case.source.as_bytes());
+    while let Some(m) = matches.next() {
         for c in m.captures {
-            let name = &query.capture_names()[c.index as usize];
-            actual_scopes.insert(name.clone());
+            let name = query.capture_names()[c.index as usize].to_string();
+            actual_scopes.insert(name);
         }
     }
 


### PR DESCRIPTION
## Summary
- use tree-sitter-perl to parse highlight test sources
- apply `queries/highlights.scm` and compare against expected scopes
- wire in tree-sitter-perl dependency for xtask

## Testing
- `cargo test` *(fails: failed to parse manifest at `/workspace/tree-sitter-perl-rs/xtask/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_68badb8f1b9c8333bbb6beb013069fb4