### PR TITLE
Refactor module resolution into reusable resolver

### DIFF
--- a/crates/perl-parser/src/completion.rs
+++ b/crates/perl-parser/src/completion.rs
@@ -224,6 +224,7 @@ pub struct CompletionProvider {
     keywords: HashSet<&'static str>,
     builtins: HashSet<&'static str>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
+    module_resolver: Option<Arc<dyn Fn(&str) -> Option<String>>>,
 }
 
 // Test::More function completions
@@ -259,8 +260,12 @@ const TEST_MORE_EXPORTS: &[(&str, &str, &str)] = &[
 
 impl CompletionProvider {
     /// Create a new completion provider from parsed AST
-    pub fn new_with_index(ast: &Node, workspace_index: Option<Arc<WorkspaceIndex>>) -> Self {
-        Self::new_with_index_and_source(ast, "", workspace_index)
+    pub fn new_with_index(
+        ast: &Node,
+        workspace_index: Option<Arc<WorkspaceIndex>>,
+        module_resolver: Option<Arc<dyn Fn(&str) -> Option<String>>>,
+    ) -> Self {
+        Self::new_with_index_and_source(ast, "", workspace_index, module_resolver)
     }
 
     /// Create a new completion provider from parsed AST and source
@@ -268,6 +273,7 @@ impl CompletionProvider {
         ast: &Node,
         source: &str,
         workspace_index: Option<Arc<WorkspaceIndex>>,
+        module_resolver: Option<Arc<dyn Fn(&str) -> Option<String>>>,
     ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
 
@@ -458,12 +464,12 @@ impl CompletionProvider {
         .into_iter()
         .collect();
 
-        CompletionProvider { symbol_table, keywords, builtins, workspace_index }
+        CompletionProvider { symbol_table, keywords, builtins, workspace_index, module_resolver }
     }
 
     /// Create a new completion provider from parsed AST without workspace context
     pub fn new(ast: &Node) -> Self {
-        Self::new_with_index(ast, None)
+        Self::new_with_index(ast, None, None)
     }
 
     /// Get completions at a given position (with optional filepath for test detection)
@@ -540,6 +546,25 @@ impl CompletionProvider {
         } else if context.trigger_character == Some('>') && context.prefix.ends_with("->") {
             // Method completion
             self.add_method_completions(&mut completions, &context, source);
+        } else if context.prefix.starts_with("use ") {
+            if let Some(resolver) = &self.module_resolver {
+                let module_name = context.prefix[4..].trim();
+                if !module_name.is_empty() {
+                    if let Some(path) = resolver(module_name) {
+                        completions.push(CompletionItem {
+                            label: module_name.to_string(),
+                            kind: CompletionItemKind::Module,
+                            detail: Some(path),
+                            documentation: None,
+                            insert_text: Some(module_name.to_string()),
+                            sort_text: Some(format!("0_{}", module_name)),
+                            filter_text: Some(module_name.to_string()),
+                            additional_edits: vec![],
+                            text_edit_range: Some((context.prefix_start + 4, context.position)),
+                        });
+                    }
+                }
+            }
         } else if context.in_string {
             // String interpolation or file path
             let line_prefix = &source[..context.position];
@@ -968,6 +993,11 @@ impl CompletionProvider {
         }
         let member_prefix = parts.pop().unwrap_or("");
         let package_name = parts.join("::");
+        if let Some(resolver) = &self.module_resolver {
+            if resolver(&package_name).is_none() {
+                return;
+            }
+        }
 
         // Query workspace index for members of the package
         let members = index.get_package_members(&package_name);
@@ -1711,7 +1741,7 @@ sub internal_sub { }
         let mut parser = Parser::new(code);
         let ast = parser.parse().unwrap();
 
-        let provider = CompletionProvider::new_with_index(&ast, Some(index));
+        let provider = CompletionProvider::new_with_index(&ast, Some(index), None);
         let completions = provider.get_completions(code, code.len());
 
         assert!(

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -152,6 +152,7 @@ pub mod lsp_on_type_formatting;
 pub mod lsp_selection_range;
 pub mod lsp_server;
 pub mod lsp_utils;
+pub mod module_resolver;
 pub mod on_type_formatting;
 pub mod parser;
 pub mod parser_context;

--- a/crates/perl-parser/src/module_resolver.rs
+++ b/crates/perl-parser/src/module_resolver.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Resolve a module name to a file path URI.
+///
+/// The generic `D` allows this resolver to work with any document state
+/// representation, as only the document keys (URIs) are inspected.
+pub fn resolve_module_to_path<D>(
+    documents: &Arc<Mutex<HashMap<String, D>>>,
+    workspace_folders: &Arc<Mutex<Vec<String>>>,
+    module_name: &str,
+) -> Option<String> {
+    // Convert Module::Name to Module/Name.pm
+    let relative_path = format!("{}.pm", module_name.replace("::", "/"));
+
+    // Fast path: check already-open documents
+    let documents = documents.lock().unwrap();
+    for (uri, _doc) in documents.iter() {
+        if uri.ends_with(&relative_path) {
+            return Some(uri.clone());
+        }
+    }
+    drop(documents);
+
+    // Time-limited filesystem search
+    let start_time = Instant::now();
+    let timeout = Duration::from_millis(50);
+
+    let workspace_folders = workspace_folders.lock().unwrap().clone();
+    let search_dirs = ["lib", ".", "local/lib/perl5"];
+
+    for workspace_folder in workspace_folders.iter() {
+        if start_time.elapsed() > timeout {
+            return None;
+        }
+
+        let workspace_path = if workspace_folder.starts_with("file://") {
+            workspace_folder.strip_prefix("file://").unwrap_or(workspace_folder)
+        } else {
+            workspace_folder
+        };
+
+        for dir in &search_dirs {
+            let full_path = if *dir == "." {
+                format!("{}/{}", workspace_path, relative_path)
+            } else {
+                format!("{}/{}/{}", workspace_path, dir, relative_path)
+            };
+
+            if start_time.elapsed() > timeout {
+                return None;
+            }
+
+            if let Ok(meta) = std::fs::metadata(&full_path) {
+                if meta.is_file() {
+                    return Some(format!("file://{}", full_path));
+                }
+            }
+
+            if start_time.elapsed() > timeout {
+                return None;
+            }
+        }
+    }
+
+    // Don't search system paths to avoid blocking on network filesystems
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn resolves_existing_module() {
+        let dir = tempdir().unwrap();
+        let module_dir = dir.path().join("lib").join("Foo");
+        std::fs::create_dir_all(&module_dir).unwrap();
+        std::fs::write(module_dir.join("Bar.pm"), "1;").unwrap();
+
+        let documents = Arc::new(Mutex::new(HashMap::<String, ()>::new()));
+        let workspace_folders =
+            Arc::new(Mutex::new(vec![format!("file://{}", dir.path().display())]));
+
+        let path = resolve_module_to_path(&documents, &workspace_folders, "Foo::Bar");
+        assert!(path.is_some(), "module should resolve");
+    }
+
+    #[test]
+    fn missing_module_returns_none() {
+        let dir = tempdir().unwrap();
+        let documents = Arc::new(Mutex::new(HashMap::<String, ()>::new()));
+        let workspace_folders =
+            Arc::new(Mutex::new(vec![format!("file://{}", dir.path().display())]));
+
+        let path = resolve_module_to_path(&documents, &workspace_folders, "No::Such::Module");
+        assert!(path.is_none(), "module should not resolve");
+    }
+}

--- a/crates/perl-parser/tests/file_completion_comprehensive_tests.rs
+++ b/crates/perl-parser/tests/file_completion_comprehensive_tests.rs
@@ -46,7 +46,7 @@ fn test_basic_file_completion() {
     let code = "\"test\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("test").unwrap() + "test".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -71,7 +71,7 @@ fn test_directory_traversal() {
     let code = "\"lib/hel\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("hel").unwrap() + "hel".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -87,7 +87,7 @@ fn test_security_path_traversal_blocked() {
     let code = "\"../../../etc/passwd\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("passwd").unwrap() + "passwd".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -101,7 +101,7 @@ fn test_security_absolute_paths_blocked() {
     let code = "\"/etc/passwd\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("passwd").unwrap() + "passwd".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -115,7 +115,7 @@ fn test_security_null_bytes_blocked() {
     let code = "\"test\0\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("test").unwrap() + "test".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -134,7 +134,7 @@ fn test_hidden_files_filtered() {
     let code = "\".h\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find(".h").unwrap() + ".h".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -156,7 +156,7 @@ fn test_file_type_detection() {
     let code = "\"test.p\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("test.p").unwrap() + "test.p".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -179,7 +179,7 @@ fn test_directory_completion_with_slash() {
     let code = "\"lib\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("lib").unwrap() + "lib".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -202,7 +202,7 @@ fn test_empty_prefix_completion() {
     let code = "\"\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = 1; // Inside the empty string
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -229,7 +229,7 @@ fn test_performance_limits() {
     let code = "\"file_\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("file_").unwrap() + "file_".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -253,7 +253,7 @@ fn test_cancellation_support() {
     let code = "\"test\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("test").unwrap() + "test".len();
 
     // Test with immediate cancellation
@@ -281,7 +281,7 @@ fn test_cross_platform_path_handling() {
     let code = "\"lib\\hel\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("hel").unwrap() + "hel".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -298,7 +298,7 @@ fn test_max_path_length_protection() {
     let code = format!("\"{}\"", very_long_path);
     let mut parser = Parser::new(&code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(&code, pos);
 
@@ -319,7 +319,7 @@ fn test_windows_reserved_names_blocked() {
         let code = "\"CON\"";
         let mut parser = Parser::new(code);
         let ast = parser.parse().unwrap();
-        let provider = CompletionProvider::new_with_index(&ast, None);
+        let provider = CompletionProvider::new_with_index(&ast, None, None);
         let pos = code.find("CON").unwrap() + "CON".len();
         let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -341,7 +341,7 @@ fn test_completion_text_edit_range() {
     let code = "\"test.p\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("test.p").unwrap() + "test.p".len();
     let completions = provider.get_completions_with_path(code, pos, Some("."));
 
@@ -374,7 +374,7 @@ fn test_no_symlink_following() {
         let code = "\"dangerous\"";
         let mut parser = Parser::new(code);
         let ast = parser.parse().unwrap();
-        let provider = CompletionProvider::new_with_index(&ast, None);
+        let provider = CompletionProvider::new_with_index(&ast, None, None);
         let pos = code.find("dangerous").unwrap() + "dangerous".len();
         let completions = provider.get_completions_with_path(code, pos, Some("."));
 

--- a/crates/perl-parser/tests/file_completion_tests.rs
+++ b/crates/perl-parser/tests/file_completion_tests.rs
@@ -19,7 +19,7 @@ fn completes_files_in_src_directory() {
     let code = "\"src/com\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("com").unwrap() + "com".len();
     let completions = provider.get_completions(code, pos);
 
@@ -42,7 +42,7 @@ fn completes_files_in_tests_directory() {
     let code = "\"tests/file_comp\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("file_comp").unwrap() + "file_comp".len();
     let completions = provider.get_completions(code, pos);
 
@@ -55,7 +55,7 @@ fn does_complete_current_directory_files() {
     let code = "\"Cargo\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("Cargo").unwrap() + "Cargo".len();
     let completions = provider.get_completions(code, pos);
 
@@ -68,7 +68,7 @@ fn basic_security_test_rejects_path_traversal() {
     let code = "\"../src/completion.rs\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("completion").unwrap() + "completion".len();
     let completions = provider.get_completions(code, pos);
 
@@ -83,7 +83,7 @@ fn security_test_rejects_path_traversal_etc() {
     let code = "\"../etc/passwd\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
     // Should not provide any completions for path traversal attempts
@@ -95,7 +95,7 @@ fn security_test_rejects_null_bytes() {
     let code = "\"src/test\0file\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
     // Should not provide completions for paths with null bytes
@@ -107,7 +107,7 @@ fn security_test_rejects_absolute_paths() {
     let code = "\"/etc/passwd\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
     // Should not provide completions for absolute paths (security)
@@ -119,7 +119,7 @@ fn security_test_allows_root_path() {
     let code = "\"/\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let _completions = provider.get_completions(code, pos);
     // Root path should be allowed, but we expect empty results in this test environment
@@ -132,7 +132,7 @@ fn security_test_rejects_control_characters() {
     let code = "\"src/test\x01file\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
     // Should not provide completions for paths with control characters
@@ -154,7 +154,7 @@ fn security_test_rejects_windows_reserved_names() {
     for code in test_cases {
         let mut parser = Parser::new(code);
         let ast = parser.parse().unwrap();
-        let provider = CompletionProvider::new_with_index(&ast, None);
+        let provider = CompletionProvider::new_with_index(&ast, None, None);
         let pos = code.len() - 1;
         let completions = provider.get_completions(code, pos);
         // Should not provide completions containing Windows reserved names
@@ -179,7 +179,7 @@ fn performance_test_respects_result_limits() {
     let code = "\"src/\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
 
@@ -195,7 +195,7 @@ fn performance_test_cancellation_support() {
     let code = "\"src/\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
 
     // Test with immediate cancellation
@@ -218,7 +218,7 @@ fn performance_test_rejects_very_long_paths() {
     let code = format!("\"{}\"", long_path);
     let mut parser = Parser::new(&code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(&code, pos);
 
@@ -234,7 +234,7 @@ fn edge_case_handles_unicode_filenames() {
     let code = "\"src/test_ü\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let _completions = provider.get_completions(code, pos);
 
@@ -247,7 +247,7 @@ fn edge_case_handles_empty_prefix() {
     let code = "\"\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let _completions = provider.get_completions(code, pos);
 
@@ -260,7 +260,7 @@ fn edge_case_handles_whitespace_in_paths() {
     let code = "\"src/test file\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let _completions = provider.get_completions(code, pos);
 
@@ -275,7 +275,7 @@ fn file_type_recognition_works() {
     let code = "\"Cargo.\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
 
@@ -296,7 +296,7 @@ fn file_type_recognition_rust_files() {
     let code = "\"src/lib.\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
 
@@ -318,7 +318,7 @@ fn no_completions_in_comments() {
     let code = "# \"src/com\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.find("com").unwrap() + "com".len();
     let completions = provider.get_completions(code, pos);
 
@@ -331,7 +331,7 @@ fn no_completions_without_slash() {
     let code = "\"somefile\"";
     let mut parser = Parser::new(code);
     let ast = parser.parse().unwrap();
-    let provider = CompletionProvider::new_with_index(&ast, None);
+    let provider = CompletionProvider::new_with_index(&ast, None, None);
     let pos = code.len() - 1;
     let completions = provider.get_completions(code, pos);
 


### PR DESCRIPTION
## Summary
- extract module resolution into dedicated `module_resolver` module
- use resolver from LSP server and completion provider for package and `use` suggestions
- add resolver unit tests for existing and missing modules

## Testing
- `cargo test -p perl-parser` *(fails: builtin_empty_blocks_tests::test_grep_empty_block, builtin_empty_blocks_tests::test_map_empty_block, builtin_empty_blocks_tests::test_sort_empty_block)*
- `cargo test -p perl-parser --lib resolves_existing_module`
- `cargo test -p perl-parser --lib missing_module_returns_none`


------
https://chatgpt.com/codex/tasks/task_e_68bda7561b8c8333a048f01386f07943