### PR TITLE
Advertise call hierarchy and test prepare

### DIFF
--- a/crates/perl-parser/src/lsp_server.rs
+++ b/crates/perl-parser/src/lsp_server.rs
@@ -898,6 +898,9 @@ impl LspServer {
         if build_flags.type_hierarchy {
             capabilities["typeHierarchyProvider"] = json!(true);
         }
+        if build_flags.call_hierarchy {
+            capabilities["callHierarchyProvider"] = json!(true);
+        }
 
         // Override text document sync with more detailed options
         capabilities["textDocumentSync"] = json!({
@@ -5855,6 +5858,11 @@ impl LspServer {
 
     /// Handle incoming calls request
     fn handle_incoming_calls(&self, params: Option<Value>) -> Result<Option<Value>, JsonRpcError> {
+        // Gate unadvertised feature
+        if !self.advertised_features.lock().unwrap().call_hierarchy {
+            return Err(crate::lsp_errors::method_not_advertised());
+        }
+
         if let Some(params) = params {
             let item = &params["item"];
             let uri = item["uri"].as_str().unwrap_or("");
@@ -5881,6 +5889,11 @@ impl LspServer {
 
     /// Handle outgoing calls request
     fn handle_outgoing_calls(&self, params: Option<Value>) -> Result<Option<Value>, JsonRpcError> {
+        // Gate unadvertised feature
+        if !self.advertised_features.lock().unwrap().call_hierarchy {
+            return Err(crate::lsp_errors::method_not_advertised());
+        }
+
         if let Some(params) = params {
             let item = &params["item"];
             let uri = item["uri"].as_str().unwrap_or("");

--- a/crates/perl-parser/tests/lsp_call_hierarchy_tests.rs
+++ b/crates/perl-parser/tests/lsp_call_hierarchy_tests.rs
@@ -1,0 +1,83 @@
+mod support;
+
+use perl_parser::lsp_server::LspServer;
+use serde_json::json;
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+use support::assert_call_hierarchy_items;
+
+#[test]
+fn test_call_hierarchy_prepare() {
+    let mut server = LspServer::with_output(Arc::new(Mutex::new(
+        Box::new(Cursor::new(Vec::new())) as Box<dyn std::io::Write + Send>,
+    )));
+
+    // Initialize
+    let _ = server.handle_request(
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "processId": null,
+                "rootUri": null,
+                "capabilities": {}
+            }
+        }))
+        .unwrap(),
+    );
+    let _ = server.handle_request(
+        serde_json::from_value(json!({"jsonrpc":"2.0","method":"initialized","params":{}}))
+            .unwrap(),
+    );
+
+    // Open document
+    let _ = server.handle_request(
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": "file:///test_hierarchy.pl",
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": r#"
+sub main {
+    helper();
+    process_data();
+}
+
+sub helper {
+    print "Helper\n";
+}
+
+sub process_data {
+    helper();
+    $obj->helper();
+}
+1;
+"#
+                }
+            }
+        }))
+        .unwrap(),
+    );
+
+    // Prepare call hierarchy at main
+    let result = server
+        .handle_request(
+            serde_json::from_value(json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "textDocument/prepareCallHierarchy",
+                "params": {
+                    "textDocument": {"uri": "file:///test_hierarchy.pl"},
+                    "position": {"line": 1, "character": 4}
+                }
+            }))
+            .unwrap(),
+        )
+        .and_then(|r| r.result);
+
+    assert_call_hierarchy_items(&result, Some("main"));
+}


### PR DESCRIPTION
## Summary
- expose callHierarchyProvider capability during initialization
- gate incoming/outgoing call hierarchy requests behind advertised feature
- add minimal call hierarchy prepare end-to-end test

## Testing
- `cargo +nightly test -p perl-parser --test lsp_call_hierarchy_tests -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68bda7593d308333ac53971737cc87b4