### PR TITLE
Populate advertised features from capabilities

### DIFF
--- a/crates/perl-parser/src/lsp_server.rs
+++ b/crates/perl-parser/src/lsp_server.rs
@@ -4,13 +4,10 @@
 //! that can be used with any LSP-compatible editor.
 
 use crate::{
-    CodeActionKind as InternalCodeActionKind, CodeActionKindV2 as InternalCodeActionKindV2,
-    CodeActionsProvider, CodeActionsProviderV2, CompletionItemKind, CompletionProvider,
-    DiagnosticSeverity as InternalDiagnosticSeverity, DiagnosticsProvider, Parser,
     ast::{Node, NodeKind},
     call_hierarchy_provider::CallHierarchyProvider,
     code_actions_enhanced::EnhancedCodeActionsProvider,
-    code_lens_provider::{CodeLensProvider, get_shebang_lens, resolve_code_lens},
+    code_lens_provider::{get_shebang_lens, resolve_code_lens, CodeLensProvider},
     declaration::ParentMap,
     document_highlight::DocumentHighlightProvider,
     formatting::{CodeFormatter, FormattingOptions},
@@ -19,30 +16,33 @@ use crate::{
     performance::{AstCache, SymbolIndex},
     perl_critic::BuiltInAnalyzer,
     positions::LineStartsCache,
-    semantic_tokens_provider::{SemanticTokensProvider, encode_semantic_tokens},
+    semantic_tokens_provider::{encode_semantic_tokens, SemanticTokensProvider},
     tdd_basic::TestGenerator,
     test_runner::{TestKind, TestRunner},
     type_hierarchy::TypeHierarchyProvider,
     type_inference::TypeInferenceEngine,
+    CodeActionKind as InternalCodeActionKind, CodeActionKindV2 as InternalCodeActionKindV2,
+    CodeActionsProvider, CodeActionsProviderV2, CompletionItemKind, CompletionProvider,
+    DiagnosticSeverity as InternalDiagnosticSeverity, DiagnosticsProvider, Parser,
 };
 use lsp_types::Location;
 use md5;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, Mutex,
     atomic::{AtomicBool, AtomicU32, Ordering},
+    Arc, Mutex,
 };
 use url::Url;
 
 use crate::uri::parse_uri;
 #[cfg(feature = "workspace")]
-use crate::workspace_index::{LspWorkspaceSymbol, WorkspaceIndex, WorkspaceSymbol, uri_to_fs_path};
+use crate::workspace_index::{uri_to_fs_path, LspWorkspaceSymbol, WorkspaceIndex, WorkspaceSymbol};
 
 // JSON-RPC Error Codes
 const ERR_METHOD_NOT_FOUND: i32 = -32601;
@@ -125,7 +125,6 @@ pub struct LspServer {
     /// Root path for module resolution
     root_path: Arc<Mutex<Option<PathBuf>>>,
     /// Advertised server capabilities
-    #[allow(dead_code)]
     advertised_features: std::sync::Mutex<crate::capabilities::AdvertisedFeatures>,
     /// Client supports pull diagnostics
     client_supports_pull_diags: Arc<AtomicBool>,
@@ -190,7 +189,11 @@ pub(crate) struct DocumentState {
 
 /// Normalize legacy package separator ' to ::
 fn norm_pkg<'a>(s: &'a str) -> Cow<'a, str> {
-    if s.contains('\'') { Cow::Owned(s.replace('\'', "::")) } else { Cow::Borrowed(s) }
+    if s.contains('\'') {
+        Cow::Owned(s.replace('\'', "::"))
+    } else {
+        Cow::Borrowed(s)
+    }
 }
 
 /// Server configuration
@@ -263,6 +266,15 @@ impl LspServer {
         #[cfg(feature = "workspace")]
         let workspace_index = Some(Arc::new(WorkspaceIndex::new()));
 
+        let default_features = {
+            let flags = if cfg!(feature = "lsp-ga-lock") {
+                crate::capabilities::BuildFlags::ga_lock()
+            } else {
+                crate::capabilities::BuildFlags::production()
+            };
+            flags.to_advertised_features()
+        };
+
         Self {
             documents: Arc::new(Mutex::new(HashMap::new())),
             initialized: false,
@@ -277,9 +289,7 @@ impl LspServer {
             cancelled: Arc::new(Mutex::new(HashSet::new())),
             workspace_folders: Arc::new(Mutex::new(Vec::new())),
             root_path: Arc::new(Mutex::new(None)),
-            advertised_features: std::sync::Mutex::new(
-                crate::capabilities::AdvertisedFeatures::default(),
-            ),
+            advertised_features: std::sync::Mutex::new(default_features),
             client_supports_pull_diags: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -289,6 +299,15 @@ impl LspServer {
         // Initialize workspace indexing (always enabled when workspace feature is on)
         #[cfg(feature = "workspace")]
         let workspace_index = Some(Arc::new(WorkspaceIndex::new()));
+
+        let default_features = {
+            let flags = if cfg!(feature = "lsp-ga-lock") {
+                crate::capabilities::BuildFlags::ga_lock()
+            } else {
+                crate::capabilities::BuildFlags::production()
+            };
+            flags.to_advertised_features()
+        };
 
         Self {
             documents: Arc::new(Mutex::new(HashMap::new())),
@@ -303,9 +322,7 @@ impl LspServer {
             cancelled: Arc::new(Mutex::new(HashSet::new())),
             workspace_folders: Arc::new(Mutex::new(Vec::new())),
             root_path: Arc::new(Mutex::new(None)),
-            advertised_features: std::sync::Mutex::new(
-                crate::capabilities::AdvertisedFeatures::default(),
-            ),
+            advertised_features: std::sync::Mutex::new(default_features),
             client_supports_pull_diags: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -472,7 +489,11 @@ impl LspServer {
 
     /// Check if a request has been cancelled
     fn is_cancelled(&self, id: &Value) -> bool {
-        if let Ok(set) = self.cancelled.lock() { set.contains(id) } else { false }
+        if let Ok(set) = self.cancelled.lock() {
+            set.contains(id)
+        } else {
+            false
+        }
     }
 
     /// Handle a JSON-RPC request
@@ -891,18 +912,22 @@ impl LspServer {
             build_flags.range_formatting = true;
         }
 
+        // Persist advertised features for gating
+        let features = build_flags.to_advertised_features();
+        *self.advertised_features.lock().unwrap() = features.clone();
+
         // Generate capabilities from build flags
-        let server_caps = crate::capabilities::capabilities_for(build_flags.clone());
+        let server_caps = crate::capabilities::capabilities_for(build_flags);
         let mut capabilities = serde_json::to_value(&server_caps).unwrap();
 
         // Add fields not yet in lsp-types 0.97
         capabilities["positionEncoding"] = json!("utf-16");
         capabilities["declarationProvider"] = json!(true);
         capabilities["documentHighlightProvider"] = json!(true);
-        if build_flags.type_hierarchy {
+        if features.type_hierarchy {
             capabilities["typeHierarchyProvider"] = json!(true);
         }
-        if build_flags.call_hierarchy {
+        if features.call_hierarchy {
             capabilities["callHierarchyProvider"] = json!(true);
         }
 
@@ -914,9 +939,6 @@ impl LspServer {
             "willSaveWaitUntil": false,
             "save": { "includeText": true }
         });
-
-        // Store advertised features for gating
-        *self.advertised_features.lock().unwrap() = build_flags.to_advertised_features();
 
         Ok(Some(json!({
             "capabilities": capabilities,
@@ -1065,7 +1087,7 @@ impl LspServer {
                 let target_version = version;
 
                 // Apply incremental changes with UTF-16 aware mapping
-                use crate::textdoc::{Doc, PosEnc, apply_changes};
+                use crate::textdoc::{apply_changes, Doc, PosEnc};
                 use lsp_types::TextDocumentContentChangeEvent;
 
                 let mut doc = Doc { rope: doc_state.rope.clone(), version };
@@ -6363,7 +6385,7 @@ impl LspServer {
                 };
 
                 // Add named argument hints for => pairs
-                use crate::builtin_signatures_phf::{BUILTIN_SIGS, get_param_names};
+                use crate::builtin_signatures_phf::{get_param_names, BUILTIN_SIGS};
                 use regex::Regex;
                 use std::collections::HashSet;
                 lazy_static::lazy_static! {
@@ -7442,10 +7464,14 @@ impl LspServer {
     /// Register file watchers for Perl files
     fn register_file_watchers_async(&self) {
         use lsp_types::{
+            notification::{DidChangeWatchedFiles, Notification},
             DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration,
             RegistrationParams, WatchKind,
-            notification::{DidChangeWatchedFiles, Notification},
         };
+
+        if !self.advertised_features.lock().unwrap().workspace_symbol {
+            return;
+        }
 
         let watchers = vec![
             FileSystemWatcher {


### PR DESCRIPTION
## Summary
- initialize `advertised_features` during construction
- drive initialization response from stored features
- gate file watcher registration on advertised workspace support

## Testing
- `cargo test -p perl-parser --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a5f01f0833385bd310d3a9d1b05