### PR TITLE
Run LSP cancellation tests and clean test helpers

### DIFF
--- a/crates/perl-lsp/tests/lsp_cancel_test.rs
+++ b/crates/perl-lsp/tests/lsp_cancel_test.rs
@@ -13,7 +13,6 @@ use common::*;
 /// endpoint, it uses a slow operation; otherwise it uses hover which
 /// may or may not be cancelled in time.
 #[test]
-#[cfg_attr(ci, ignore = "flaky timing on CI; tracked in cancellation test deflaking")]
 fn test_cancel_request_handling() {
     let mut server = start_lsp_server();
     let init_resp = initialize_lsp(&mut server);
@@ -134,7 +133,6 @@ fn test_cancel_request_handling() {
 
 /// Test that $/cancelRequest itself doesn't produce a response
 #[test]
-#[cfg_attr(ci, ignore = "flaky timing on CI; tracked in cancellation test deflaking")]
 fn test_cancel_request_no_response() {
     let mut server = start_lsp_server();
     let init_resp = initialize_lsp(&mut server);
@@ -194,7 +192,6 @@ fn test_cancel_request_no_response() {
 
 /// Test cancelling multiple requests
 #[test]
-#[cfg_attr(ci, ignore = "flaky timing on CI; tracked in cancellation test deflaking")]
 fn test_cancel_multiple_requests() {
     let mut server = start_lsp_server();
     let init_resp = initialize_lsp(&mut server);

--- a/crates/perl-lsp/tests/support/test_helpers.rs
+++ b/crates/perl-lsp/tests/support/test_helpers.rs
@@ -16,7 +16,7 @@
 //! use support::test_helpers::*;
 //! ```
 
-#![allow(dead_code)] // Test infrastructure - functions may not be used by all tests
+#![allow(dead_code)]
 
 use serde_json::Value;
 
@@ -107,23 +107,9 @@ fn assert_position_valid(position: &Value, context: &str) {
 
 /// Assert references are found with validation
 pub fn assert_references_found(v: &Option<Value>) {
-    assert_references_found_with_min(v, None);
-}
-
-/// Assert references are found with minimum count validation
-pub fn assert_references_found_with_min(v: &Option<Value>, min_refs: Option<usize>) {
     if let Some(refs_val) = v {
         if !refs_val.is_null() {
             let refs = refs_val.as_array().expect("references should be array");
-
-            if let Some(min) = min_refs {
-                assert!(
-                    refs.len() >= min,
-                    "expected at least {} references, found {}",
-                    min,
-                    refs.len()
-                );
-            }
 
             // Validate each reference has required fields
             for reference in refs {


### PR DESCRIPTION
## Summary
- enable $/cancelRequest tests by removing CI ignore guards
- drop unused `assert_references_found_with_min` helper
- silence warnings in test helpers with module-level `#![allow(dead_code)]`

## Testing
- `cargo test -p perl-lsp --no-run`
- `cargo test -p perl-lsp --test lsp_cancel_test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68c0812d9ebc83338487ae1716f70066