### PR TITLE
chore: ignore integration artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ analyze_survivors.sh
 run_mutation_test.sh
 **/temp_*.rs
 **/*_temp.rs
+
+# Integration artifacts
+.base_sha
+benchmark_results_*.txt


### PR DESCRIPTION
### **User description**
Adds .gitignore entries for integration artifacts:
- .base_sha  
- benchmark_results_*.txt

No code changes. CI endpoints are intentionally disabled by repo hook; local validation: N/A (gitignore-only).


___

### **PR Type**
Other


___

### **Description**
• Adds `.gitignore` entries for integration test artifacts
• Ignores `.base_sha` file used for tracking base commit references
• Ignores `benchmark_results_*.txt` files generated during performance testing
• No functional code changes, only repository maintenance


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

