### PR TITLE
feat(#182b): thread statement tracker through parser pipeline

### DIFF
--- a/crates/tree-sitter-perl-rs/src/heredoc_parser.rs
+++ b/crates/tree-sitter-perl-rs/src/heredoc_parser.rs
@@ -31,6 +31,7 @@ pub struct HeredocDeclaration {
 }
 
 /// Phase 1: Heredoc Detection Scanner
+/// Enhanced in #219 (Issue #182) to thread StatementTracker for future block-aware processing
 pub struct HeredocScanner<'a> {
     input: &'a str,
     position: usize,
@@ -38,11 +39,22 @@ pub struct HeredocScanner<'a> {
     heredoc_counter: usize,
     /// Track which lines should be skipped (heredoc content lines)
     skip_lines: std::collections::HashSet<usize>,
+    /// Issue #182/#219: Statement tracker for block-aware heredoc handling (used in #220)
+    #[allow(dead_code)]
+    statement_tracker: crate::statement_tracker::StatementTracker,
 }
 
 impl<'a> HeredocScanner<'a> {
     pub fn new(input: &'a str) -> Self {
-        Self { input, position: 0, line_number: 1, heredoc_counter: 0, skip_lines: HashSet::new() }
+        Self {
+            input,
+            position: 0,
+            line_number: 1,
+            heredoc_counter: 0,
+            skip_lines: HashSet::new(),
+            // Issue #182/#219: Initialize tracker (no-op for now, used in #220)
+            statement_tracker: crate::statement_tracker::StatementTracker::new(),
+        }
     }
 
     /// Scan input for heredoc declarations and mark their positions
@@ -257,14 +269,23 @@ impl<'a> HeredocScanner<'a> {
 }
 
 /// Phase 2: Heredoc Content Collector
+/// Enhanced in #219 (Issue #182) to thread StatementTracker for future block-aware processing
 pub struct HeredocCollector<'a> {
     _input: &'a str,
     lines: Vec<&'a str>,
+    /// Issue #182/#219: Statement tracker for block-aware heredoc handling (used in #220)
+    #[allow(dead_code)]
+    statement_tracker: crate::statement_tracker::StatementTracker,
 }
 
 impl<'a> HeredocCollector<'a> {
     pub fn new(input: &'a str) -> Self {
-        Self { _input: input, lines: input.lines().collect() }
+        Self {
+            _input: input,
+            lines: input.lines().collect(),
+            // Issue #182/#219: Initialize tracker (no-op for now, used in #220)
+            statement_tracker: crate::statement_tracker::StatementTracker::new(),
+        }
     }
 
     /// Collect content for all heredoc declarations

--- a/crates/tree-sitter-perl-rs/src/statement_tracker.rs
+++ b/crates/tree-sitter-perl-rs/src/statement_tracker.rs
@@ -194,6 +194,57 @@ impl StatementTracker {
         self.heredoc_contexts.clear();
         self.block_boundaries.clear();
     }
+
+    // ===== Issue #182/#219: Stub methods for #220 semantics =====
+    // These methods provide the API for block-aware heredoc handling
+    // but are no-ops in #219 (plumbing only). Semantics filled in #220.
+
+    /// Note that a code block is opening (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn note_block_open(&mut self, _line: usize, _block_type: BlockType) {
+        // No-op for #219; implementation in #220
+    }
+
+    /// Note that a code block is closing (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn note_block_close(&mut self, _line: usize) {
+        // No-op for #219; implementation in #220
+    }
+
+    /// Record a heredoc declaration with its context (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn note_heredoc_declaration(
+        &mut self,
+        _line: usize,
+        _terminator: &str,
+        _statement_end_line: usize,
+    ) {
+        // No-op for #219; implementation in #220
+    }
+
+    /// Get the current block depth (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn current_block_depth(&self) -> usize {
+        self.block_depth
+    }
+
+    /// Get heredoc contexts for processing (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn heredoc_contexts(&self) -> &[HeredocContext] {
+        &self.heredoc_contexts
+    }
+
+    /// Get block boundaries for analysis (Issue #182/#220)
+    #[inline]
+    #[allow(dead_code)]
+    pub fn block_boundaries(&self) -> &[BlockBoundary] {
+        &self.block_boundaries
+    }
 }
 
 /// Find the line where a statement containing a heredoc actually ends


### PR DESCRIPTION
### **User description**
## Issue
Implements #219 (part of #182 Sprint A statement tracker implementation)

**Depends on**: #218 (data structures) ✅ merged

## Scope
Threads `StatementTracker` through the parser pipeline with **zero behavioral changes**:

### Changes Made

1. **HeredocScanner Enhancement**
   - Added `statement_tracker: StatementTracker` field
   - Initialized in constructor (no-op for now)
   - Prepared for block-aware heredoc processing in #220

2. **HeredocCollector Enhancement**
   - Added `statement_tracker: StatementTracker` field
   - Initialized in constructor (no-op for now)
   - Ready for future content collection improvements

3. **StatementTracker API Extension**
   - Added stub methods for block tracking:
     - `note_block_open(line, block_type)` - Records block opening
     - `note_block_close(line)` - Records block closing
     - `current_block_depth()` - Returns current nesting level
     - `block_boundaries()` - Returns block boundary records
   - Added stub methods for heredoc context:
     - `note_heredoc_declaration(line, terminator, statement_end)` - Records heredoc info
     - `heredoc_contexts()` - Returns heredoc context records
   - **All methods are no-ops in #219** - implementation deferred to #220

### Design Pattern

This follows the **incremental refactoring pattern**:
- **#218**: Data structures only ✅
- **#219**: Plumbing only (this PR) ← **pure infrastructure, zero semantics**
- **#220**: Semantics implementation (actual behavior changes)
- **#221**: Tests, metrics, cleanup

### Validation

```bash
just ci-gate  # ✅ All 274 tests pass
cargo fmt --all  # ✅ Clean formatting
cargo clippy  # ✅ Zero warnings
```

### Zero Behavioral Changes

- No changes to statement boundary detection
- No changes to heredoc content collection
- No changes to when/how heredocs are processed
- New fields are `#[allow(dead_code)]` - used in #220
- New methods are no-ops - filled in #220

### What This Enables

After this PR merges, #220 can:
- Implement block-aware heredoc handling
- Use tracker state for content association
- Add actual semantics without touching infrastructure

## Local CI

- `just ci-gate` ✅ 274 tests passing
- Zero regressions, zero new warnings
- Ready for merge

## Sprint A Progress

- #218 (data structures) ✅ merged
- #219 (plumbing) ← **this PR** (50% complete after merge)
- #220 (semantics) - next
- #221 (tests/cleanup) - final

---

**Next Steps**: Implement actual block-aware semantics in #220 using this infrastructure.


___

### **PR Type**
Enhancement


___

### **Description**
- Thread `StatementTracker` through parser pipeline infrastructure

- Add `statement_tracker` field to `HeredocScanner` and `HeredocCollector`

- Implement stub API methods for block tracking and heredoc context management

- Zero behavioral changes; all 274 tests pass


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HS["HeredocScanner"] -->|"add statement_tracker field"| ST["StatementTracker"]
  HC["HeredocCollector"] -->|"add statement_tracker field"| ST
  ST -->|"stub methods"| API["Block/Heredoc API"]
  API -->|"ready for #220"| IMPL["Future Semantics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>heredoc_parser.rs</strong><dd><code>Add StatementTracker fields to heredoc parser structs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/tree-sitter-perl-rs/src/heredoc_parser.rs

<ul><li>Add <code>statement_tracker</code> field to <code>HeredocScanner</code> struct with <br><code>#[allow(dead_code)]</code> annotation<br> <li> Initialize <code>statement_tracker</code> in <code>HeredocScanner::new()</code> constructor<br> <li> Add <code>statement_tracker</code> field to <code>HeredocCollector</code> struct with <br><code>#[allow(dead_code)]</code> annotation<br> <li> Initialize <code>statement_tracker</code> in <code>HeredocCollector::new()</code> constructor<br> <li> Add documentation comments referencing Issue #182/#219 for future <br>block-aware processing</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/tree-sitter-perl-rs/pull/223/files#diff-8a2a3e554ad55554a134602d33172d3d32c4cd2b9faf7084f903a11612d8e2da">+23/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statement_tracker.rs</strong><dd><code>Add stub API methods for block-aware heredoc tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/tree-sitter-perl-rs/src/statement_tracker.rs

<ul><li>Add stub method <code>note_block_open()</code> to record block opening events<br> <li> Add stub method <code>note_block_close()</code> to record block closing events<br> <li> Add stub method <code>note_heredoc_declaration()</code> to record heredoc context <br>information<br> <li> Add getter method <code>current_block_depth()</code> returning current nesting <br>level<br> <li> Add getter method <code>heredoc_contexts()</code> returning slice of heredoc <br>context records<br> <li> Add getter method <code>block_boundaries()</code> returning slice of block boundary <br>records<br> <li> All methods marked with <code>#[allow(dead_code)]</code> and documented as no-ops <br>for #219</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/tree-sitter-perl-rs/pull/223/files#diff-450cd5d7e7e06d56747a2a27659a0e03f93448c44f26c338333ee06c06250989">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).