### PR TITLE
fix(#221): block-aware statement end for heredocs

### DIFF
--- a/crates/tree-sitter-perl-rs/src/heredoc_parser.rs
+++ b/crates/tree-sitter-perl-rs/src/heredoc_parser.rs
@@ -514,24 +514,13 @@ EOF
         assert_eq!(ctx.declaration_line, 2);
         assert_eq!(ctx.block_depth_at_declaration, 0); // Scanner doesn't track block depth yet
         assert_eq!(ctx.terminator, "EOF");
-        // NOTE: find_statement_end_line currently returns 7 (end of block)
-        // because it tracks the opening { from line 1 and waits for closing }
-        // This will be fixed in future PR to handle block-aware statement detection
-        assert_eq!(ctx.statement_end_line, 7); // TODO: Should be 2 once block-aware
-        assert_eq!(ctx.content_start_line, 8); // TODO: Should be 3 once block-aware
+        // #221: Correct block-aware behavior
+        assert_eq!(ctx.statement_end_line, 2);
+        assert_eq!(ctx.content_start_line, 3);
 
-        // BASELINE (#220a): Current buggy behavior - skip_lines is empty
-        // because find_statement_end_line returns 7 (end of block) instead of 2
-        // This will be fixed in #221 (edge cases) to handle block-scoped heredocs
-        let expected_buggy: BTreeSet<usize> = BTreeSet::new(); // Empty - bug!
-        assert_eq!(
-            skips, expected_buggy,
-            "Baseline: skip_lines empty due to find_statement_end_line bug"
-        );
-
-        // Expected correct behavior (will pass after #221):
-        // let expected: BTreeSet<_> = [3_usize, 4, 5].into_iter().collect();
-        // assert_eq!(skips, expected, "skip_lines for heredoc in if block");
+        // #221: Correct skip_lines for heredoc in if block
+        let expected: BTreeSet<_> = [3_usize, 4, 5].into_iter().collect();
+        assert_eq!(skips, expected, "skip_lines for heredoc in if block");
     }
 
     #[test]
@@ -555,17 +544,13 @@ DATA
         assert_eq!(ctx.declaration_line, 3);
         assert_eq!(ctx.block_depth_at_declaration, 0); // Scanner doesn't track block depth yet
         assert_eq!(ctx.terminator, "DATA");
-        // BASELINE (#220a): find_statement_end_line returns 7 (end of outer block)
-        assert_eq!(ctx.statement_end_line, 7); // TODO: Should be 3 once block-aware
-        assert_eq!(ctx.content_start_line, 8); // TODO: Should be 4 once block-aware
+        // #221: Correct block-aware behavior
+        assert_eq!(ctx.statement_end_line, 3);
+        assert_eq!(ctx.content_start_line, 4);
 
-        // BASELINE (#220a): skip_lines is empty due to bug
-        let expected_buggy: BTreeSet<usize> = BTreeSet::new();
-        assert_eq!(skips, expected_buggy, "Baseline: skip_lines empty");
-
-        // Expected correct behavior (will pass after #221):
-        // let expected: BTreeSet<_> = [4_usize, 5].into_iter().collect();
-        // assert_eq!(skips, expected, "skip_lines for heredoc in nested blocks");
+        // #221: Correct skip_lines for heredoc in nested blocks
+        let expected: BTreeSet<_> = [4_usize, 5].into_iter().collect();
+        assert_eq!(skips, expected, "skip_lines for heredoc in nested blocks");
     }
 
     #[test]
@@ -590,24 +575,20 @@ EOF2
         assert_eq!(ctx1.declaration_line, 2);
         assert_eq!(ctx1.block_depth_at_declaration, 0); // Scanner doesn't track block depth yet
         assert_eq!(ctx1.terminator, "EOF1");
-        // BASELINE (#220a): find_statement_end_line returns 8 (closing brace)
-        assert_eq!(ctx1.statement_end_line, 8); // TODO: Should be 2 once block-aware
-        assert_eq!(ctx1.content_start_line, 9); // TODO: Should be 3 once block-aware
+        // #221: Correct block-aware behavior
+        assert_eq!(ctx1.statement_end_line, 2);
+        assert_eq!(ctx1.content_start_line, 3);
 
         let ctx2 = &contexts[1];
         assert_eq!(ctx2.declaration_line, 5);
         assert_eq!(ctx2.block_depth_at_declaration, 0); // Scanner doesn't track block depth yet
         assert_eq!(ctx2.terminator, "EOF2");
-        assert_eq!(ctx2.statement_end_line, 8); // TODO: Should be 5 once block-aware
-        assert_eq!(ctx2.content_start_line, 9); // TODO: Should be 6 once block-aware
+        assert_eq!(ctx2.statement_end_line, 5);
+        assert_eq!(ctx2.content_start_line, 6);
 
-        // BASELINE (#220a): skip_lines is empty due to bug
-        let expected_buggy: BTreeSet<usize> = BTreeSet::new();
-        assert_eq!(skips, expected_buggy, "Baseline: skip_lines empty");
-
-        // Expected correct behavior (will pass after #221):
-        // let expected: BTreeSet<_> = [3_usize, 4, 6, 7].into_iter().collect();
-        // assert_eq!(skips, expected, "skip_lines for two heredocs in same block");
+        // #221: Correct skip_lines for two heredocs in same block
+        let expected: BTreeSet<_> = [3_usize, 4, 6, 7].into_iter().collect();
+        assert_eq!(skips, expected, "skip_lines for two heredocs in same block");
     }
 
     // ===== Original Tests (Preserved) =====


### PR DESCRIPTION
## Cover Sheet (added 2026-01-07; original notes below)

- **Issue(s):** #182
- **PR(s):** #225, #226, #229
- **Exhibit ID:** `statement-tracker-heredoc`

### What changed
- Created StatementTracker API for block depth and heredoc context tracking
- Implemented block-aware statement end detection (semicolon vs. expression heredocs)
- Added F1-F6 test fixtures covering top-level, nested, and multi-heredoc scenarios

### Why
Heredocs inside code blocks were incorrectly parsed because the parser lacked awareness of block boundaries and could not distinguish semicolon-terminated statements from expression heredocs.

### Review map
- `crates/tree-sitter-perl-rs/src/statement_tracker.rs` (566 lines) - Core tracking logic
- `crates/tree-sitter-perl-rs/src/heredoc_parser.rs` (665 lines) - Scanner integration
- `crates/perl-parser/tests/sprint_a_heredoc_ast_tests.rs` (236 lines) - AST validation

### Verification (receipts)
- statement_tracker.rs unit tests: 14 passing
- heredoc_parser.rs integration tests: 8 passing (F1-F4 fixtures)
- sprint_a_heredoc_ast_tests: 6 passing (F5, F6 fixtures)
- Total: 28 combined heredoc/tracker tests

### Known limits / follow-ups
- StatementTracker fields marked `#[allow(dead_code)]` pending full integration (P3)
- Scanner doesn't track block depth yet (documented in test comments, P3)

### How to reproduce trust
```bash
cargo test -p perl-parser --test sprint_a_heredoc_ast_tests
```

---

## Archived PR description

### **User description**
## Summary

Implements block-aware statement end detection to correctly handle heredocs inside code blocks vs. data structures.

### Problem

After #220a integration, F2-F4 fixtures revealed a bug in `find_statement_end_line`:
- Heredocs inside code blocks (`if { my $x = <<EOF; }`) incorrectly returned the closing `}` as statement end
- This caused `skip_lines` to be empty because `content_start_line` was beyond actual heredoc content

### Solution

Smart detection based on semicolon presence:
1. **Heredoc line ends with `;`** → Statement is complete on that line
   - Example: `my $x = <<EOF;` inside `if { ... }`
   - No pre-scan needed, prevents block delimiters from affecting detection
2. **No semicolon** → Part of larger expression
   - Example: `key => <<EOF` inside `( ... )`
   - Pre-scan to track data structure brackets

### Implementation

Modified `find_statement_end_line` in `statement_tracker.rs`:
```rust
// Check if heredoc line ends with semicolon
if ends_with_semicolon {
    return heredoc_line;  // Complete statement, ignore blocks
}
// Otherwise pre-scan for data structure brackets
```

### Test Results

**F1-F4 Fixtures** (now asserting correct behavior):
- ✅ F1: Top-level heredoc
- ✅ F2: Heredoc in if block
- ✅ F3: Heredoc in nested blocks  
- ✅ F4: Two heredocs in same block

**Existing Tests** (preserved):
- ✅ `test_multi_line_hash` - heredoc in hash construction
- ✅ `test_array_ref` - heredoc in array
- ✅ `test_nested_parens` - heredoc in function call
- ✅ `test_simple_statement` - basic case

**CI Gate:**
- ✅ 274 tests passing
- ✅ No regressions

## Related

- Fixes #221
- Builds on #220a (PR #225)
- Part of #182 (Sprint A: 75% complete)
- Sets foundation for heredoc AST integration


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implements block-aware statement end detection for heredocs

- Distinguishes heredocs in code blocks vs. data structures

- Adds StatementTracker integration with HeredocScanner

- Introduces test fixtures validating correct heredoc placement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Heredoc Declaration"] --> B{"Ends with semicolon?"}
  B -->|Yes| C["Return heredoc line<br/>Complete statement"]
  B -->|No| D["Pre-scan for brackets<br/>Part of expression"]
  C --> E["Correct skip_lines<br/>Block-aware"]
  D --> E
  E --> F["StatementTracker<br/>Records context"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>heredoc_parser.rs</strong><dd><code>Integrate StatementTracker and add heredoc integration tests</code></dd></summary>
<hr>

crates/tree-sitter-perl-rs/src/heredoc_parser.rs

<ul><li>Added <code>scan_for_test()</code> method to expose skip_lines and tracker contexts <br>for testing<br> <li> Refactored <code>scan()</code> to call internal <code>do_scan()</code> implementation<br> <li> Integrated <code>StatementTracker.note_heredoc_declaration()</code> calls for each <br>heredoc<br> <li> Added four integration test fixtures (F1-F4) validating block-aware <br>heredoc handling<br> <li> Tests verify correct <code>statement_end_line</code>, <code>content_start_line</code>, and <br><code>skip_lines</code> for heredocs in various contexts</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/tree-sitter-perl-rs/pull/226/files#diff-8a2a3e554ad55554a134602d33172d3d32c4cd2b9faf7084f903a11612d8e2da">+168/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>statement_tracker.rs</strong><dd><code>Implement block-aware statement end detection for heredocs</code></dd></summary>
<hr>

crates/tree-sitter-perl-rs/src/statement_tracker.rs

<ul><li>Implemented <code>note_block_open()</code> to track block depth and record block <br>boundaries<br> <li> Implemented <code>note_block_close()</code> to decrement depth and mark block end <br>lines<br> <li> Implemented <code>note_heredoc_declaration()</code> to record HeredocContext with <br>block depth<br> <li> Modified <code>find_statement_end_line()</code> to check if heredoc line ends with <br>semicolon<br> <li> If semicolon present, returns heredoc line immediately (complete <br>statement)<br> <li> If no semicolon, pre-scans for bracket tracking (part of larger <br>expression)</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/tree-sitter-perl-rs/pull/226/files#diff-450cd5d7e7e06d56747a2a27659a0e03f93448c44f26c338333ee06c06250989">+68/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).
