### PR TITLE
fix: PR #236 review follow-up - dead code and dependency cleanup

### DIFF
--- a/crates/perl-lsp/tests/binary_version_test.rs
+++ b/crates/perl-lsp/tests/binary_version_test.rs
@@ -51,7 +51,8 @@ fn lsp_server_version_matches_crate_version() {
 
     // Assert version matches
     assert_eq!(
-        server_version, EXPECTED_VERSION,
+        server_version,
+        EXPECTED_VERSION,
         "\n\
         ╔════════════════════════════════════════════════════════════════════╗\n\
         ║ WRONG BINARY VERSION DETECTED!                                     ║\n\

--- a/crates/perl-lsp/tests/common/mod.rs
+++ b/crates/perl-lsp/tests/common/mod.rs
@@ -201,15 +201,32 @@ pub fn start_lsp_server() -> LspServer {
             eprintln!("║ Resolution order tried:                                            ║");
             eprintln!("║  1. PERL_LSP_BIN env var: {:?}", std::env::var("PERL_LSP_BIN").ok());
             eprintln!("║  2. Compile-time CARGO_BIN_EXE: {:?}", CARGO_BIN_EXE);
-            eprintln!("║  3. Runtime CARGO_BIN_EXE_perl-lsp: {:?}", std::env::var("CARGO_BIN_EXE_perl-lsp").ok());
-            eprintln!("║  4. Runtime CARGO_BIN_EXE_perl_lsp: {:?}", std::env::var("CARGO_BIN_EXE_perl_lsp").ok());
+            eprintln!(
+                "║  3. Runtime CARGO_BIN_EXE_perl-lsp: {:?}",
+                std::env::var("CARGO_BIN_EXE_perl-lsp").ok()
+            );
+            eprintln!(
+                "║  4. Runtime CARGO_BIN_EXE_perl_lsp: {:?}",
+                std::env::var("CARGO_BIN_EXE_perl_lsp").ok()
+            );
             if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
                 let crate_dir = std::path::Path::new(&manifest_dir);
-                let workspace_root = crate_dir.ancestors().find(|p| p.join("Cargo.lock").exists()).unwrap_or(crate_dir);
+                let workspace_root = crate_dir
+                    .ancestors()
+                    .find(|p| p.join("Cargo.lock").exists())
+                    .unwrap_or(crate_dir);
                 let debug_binary = workspace_root.join("target/debug/perl-lsp");
                 let release_binary = workspace_root.join("target/release/perl-lsp");
-                eprintln!("║  5. Debug binary exists: {} ({})", debug_binary.exists(), debug_binary.display());
-                eprintln!("║  6. Release binary exists: {} ({})", release_binary.exists(), release_binary.display());
+                eprintln!(
+                    "║  5. Debug binary exists: {} ({})",
+                    debug_binary.exists(),
+                    debug_binary.display()
+                );
+                eprintln!(
+                    "║  6. Release binary exists: {} ({})",
+                    release_binary.exists(),
+                    release_binary.display()
+                );
             }
             eprintln!("║  7. perl-lsp in PATH: {:?}", which::which("perl-lsp").ok());
             eprintln!("║  8. cargo run fallback");

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 tree-sitter = "0.26.3"
 serde = { version = "1.0.228", features = ["derive"] }
-bincode = "3.0.0"
+# bincode removed - was unused (v3.0.0 doesn't exist on crates.io)
 proptest = "1.9.0"
 walkdir = "2.5.0"
 thiserror = "2.0.17"


### PR DESCRIPTION
## Summary

Addresses review feedback from Gemini and Codex on PR #236:

- **bincode 3.0.0 typo**: Removed unused bincode dependency from tree-sitter-perl-c (v3.0.0 doesn't exist on crates.io)
- **Dead cfg blocks**: Cleaned up `handle_workspace_symbols` - removed 104 lines of unreachable `#[cfg(feature = "workspace")]` blocks inside a `#[cfg(not(feature = "workspace"))]` function
- **diagnosticProvider**: Already correctly implemented in `capabilities.rs` with `pull_diagnostics: true` in both `production()` and `ga_lock()` - no changes needed
- **Formatting**: Applied `cargo fmt` to test files

## Test plan

- [x] `cargo metadata` validates cleanly
- [x] `cargo check -p perl-parser` passes
- [x] Local gate passes (`CARGO_BUILD_JOBS=2 RUST_TEST_THREADS=1 ./scripts/gate-local.sh`)
- [x] 279 lib tests + integration tests pass