### PR TITLE
fix(lsp): standardize request handling and UTF-16 correctness

### DIFF
--- a/crates/perl-parser/src/lsp/protocol/errors.rs
+++ b/crates/perl-parser/src/lsp/protocol/errors.rs
@@ -178,3 +178,62 @@ pub fn document_not_found_error() -> Value {
 pub fn internal_error(message: &str) -> JsonRpcError {
     JsonRpcError { code: INTERNAL_ERROR, message: message.to_string(), data: None }
 }
+
+// ============================================================================
+// Request Parameter Extraction Helpers
+// ============================================================================
+
+/// Extract the required textDocument.uri from LSP request params
+///
+/// Returns INVALID_PARAMS error if the URI is missing or not a string.
+pub fn req_uri(params: &Value) -> Result<&str, JsonRpcError> {
+    params
+        .pointer("/textDocument/uri")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))
+}
+
+/// Extract the required position (line, character) from LSP request params
+///
+/// Returns INVALID_PARAMS error if line or character are missing.
+pub fn req_position(params: &Value) -> Result<(u32, u32), JsonRpcError> {
+    let line = params
+        .pointer("/position/line")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: position.line"))?
+        as u32;
+    let character = params
+        .pointer("/position/character")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: position.character"))?
+        as u32;
+    Ok((line, character))
+}
+
+/// Extract the required range from LSP request params
+///
+/// Returns INVALID_PARAMS error if any range components are missing.
+/// Returns ((start_line, start_char), (end_line, end_char)).
+pub fn req_range(params: &Value) -> Result<((u32, u32), (u32, u32)), JsonRpcError> {
+    let start_line = params
+        .pointer("/range/start/line")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: range.start.line"))?
+        as u32;
+    let start_char = params
+        .pointer("/range/start/character")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: range.start.character"))?
+        as u32;
+    let end_line = params
+        .pointer("/range/end/line")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: range.end.line"))?
+        as u32;
+    let end_char = params
+        .pointer("/range/end/character")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| invalid_params("Missing required parameter: range.end.character"))?
+        as u32;
+    Ok(((start_line, start_char), (end_line, end_char)))
+}

--- a/crates/perl-parser/src/lsp/server_impl/language/completion.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/completion.rs
@@ -77,7 +77,7 @@ impl LspServer {
             #[cfg(not(feature = "workspace"))]
             let index_ready = false;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
 
@@ -319,7 +319,7 @@ impl LspServer {
             let req_version = params["textDocument"]["version"].as_i64().map(|n| n as i32);
             self.ensure_latest(uri, req_version)?;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
 

--- a/crates/perl-parser/src/lsp/server_impl/language/formatting.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/formatting.rs
@@ -23,7 +23,7 @@ impl LspServer {
             let line = pos["line"].as_u64().unwrap_or(0) as u32;
             let col = pos["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
                 code: INVALID_REQUEST,
                 message: format!("Document not open: {}", uri),
@@ -62,7 +62,7 @@ impl LspServer {
 
             eprintln!("Formatting document: {}", uri);
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let formatter = CodeFormatter::new();
                 match formatter.format_document(&doc.text, &options) {
@@ -136,7 +136,7 @@ impl LspServer {
 
             eprintln!("Formatting range in document: {}", uri);
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let formatter = CodeFormatter::new();
                 match formatter.format_range(&doc.text, &range, &options) {

--- a/crates/perl-parser/src/lsp/server_impl/language/hierarchy.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/hierarchy.rs
@@ -16,7 +16,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
 
@@ -150,7 +150,7 @@ impl LspServer {
                 let uri = item["data"]["uri"].as_str().unwrap_or("");
                 let name = item["data"]["name"].as_str().unwrap_or("");
 
-                let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+                let documents = self.documents_guard();
                 if let Some(doc) = documents.get(uri) {
                     if let Some(ref ast) = doc.ast {
                         // Create type hierarchy provider
@@ -262,7 +262,7 @@ impl LspServer {
                 let uri = item["data"]["uri"].as_str().unwrap_or("");
                 let name = item["data"]["name"].as_str().unwrap_or("");
 
-                let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+                let documents = self.documents_guard();
                 if let Some(doc) = documents.get(uri) {
                     if let Some(ref ast) = doc.ast {
                         // Create type hierarchy provider
@@ -382,7 +382,7 @@ impl LspServer {
 
             eprintln!("Preparing call hierarchy at: {} ({}:{})", uri, line, character);
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let provider = CallHierarchyProvider::new(doc.text.clone(), uri.to_string());
@@ -408,7 +408,7 @@ impl LspServer {
 
             eprintln!("Getting incoming calls for: {}", item["name"].as_str().unwrap_or(""));
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     // Reconstruct the CallHierarchyItem from JSON
@@ -437,7 +437,7 @@ impl LspServer {
 
             eprintln!("Getting outgoing calls for: {}", item["name"].as_str().unwrap_or(""));
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     // Reconstruct the CallHierarchyItem from JSON

--- a/crates/perl-parser/src/lsp/server_impl/language/hover.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/hover.rs
@@ -20,7 +20,7 @@ impl LspServer {
             let req_version = params["textDocument"]["version"].as_i64().map(|n| n as i32);
             self.ensure_latest(uri, req_version)?;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ast) = &doc.ast {
                     let offset = self.pos16_to_offset(doc, line, character);
@@ -147,7 +147,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let offset = self.pos16_to_offset(doc, line, character);
 

--- a/crates/perl-parser/src/lsp/server_impl/language/navigation.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/navigation.rs
@@ -30,7 +30,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let offset = self.pos16_to_offset(doc, line, character);
@@ -155,7 +155,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 // First check if we're on a module name in use/require statement
                 let offset = self.pos16_to_offset(doc, line, character);
@@ -447,7 +447,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let provider = TypeDefinitionProvider::new();
@@ -478,7 +478,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     #[cfg(feature = "workspace")]
@@ -585,7 +585,7 @@ impl LspServer {
             // This would need proper traversal - simplified for now
             if self.check_inheritance_in_package(node, base_class) {
                 // Get source text for position conversion
-                let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+                let documents = self.documents_guard();
                 if let Some(doc) = documents.get(uri) {
                     let source_text = &doc.text;
                     // Convert byte offsets to UTF-16 line/column

--- a/crates/perl-parser/src/lsp/server_impl/language/rename.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/rename.rs
@@ -16,7 +16,7 @@ impl LspServer {
             let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
             let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(_ast) = &doc.ast {
                     let offset = self.pos16_to_offset(doc, line, character);
@@ -78,7 +78,7 @@ impl LspServer {
                 });
             }
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let offset = self.pos16_to_offset(doc, line, character);
@@ -135,7 +135,7 @@ impl LspServer {
                 p.get("position").and_then(|p| p.get("character")).and_then(|n| n.as_u64()),
                 p.get("newName").and_then(|s| s.as_str()),
             ) {
-                let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+                let documents = self.documents_guard();
                 if let Some(doc) = documents.get(uri) {
                     if let Some(ref ast) = doc.ast {
                         let offset = self.pos16_to_offset(doc, line as u32, ch as u32);

--- a/crates/perl-parser/src/lsp/server_impl/language/semantic_tokens.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/semantic_tokens.rs
@@ -16,7 +16,7 @@ impl LspServer {
                 message: "Missing textDocument.uri".into(),
                 data: None,
             })?;
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
                 code: INVALID_REQUEST,
                 message: format!("Document not open: {}", uri),
@@ -44,7 +44,7 @@ impl LspServer {
 
             eprintln!("Getting semantic tokens for: {}", uri);
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let provider = SemanticTokensProvider::new(doc.text.clone());
@@ -81,7 +81,7 @@ impl LspServer {
                 uri, start_line, end_line
             );
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let provider = SemanticTokensProvider::new(doc.text.clone());

--- a/crates/perl-parser/src/lsp/server_impl/language/symbols.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/symbols.rs
@@ -13,7 +13,7 @@ impl LspServer {
         if let Some(params) = params {
             let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     // Extract symbols from AST
@@ -142,7 +142,7 @@ impl LspServer {
         if let Some(params) = params {
             let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
 
-            let documents = self.documents.lock().unwrap_or_else(|e| e.into_inner());
+            let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 let mut lsp_ranges = Vec::new();
 


### PR DESCRIPTION
## Summary

Follow-up to PR #242 addressing consistency and correctness issues in the extracted LSP handler modules:

- **Request parameter helpers**: `req_uri()`, `req_position()`, `req_range()` for proper INVALID_PARAMS errors
- **UTF-16 correctness**: Fix regex fallback in references.rs to convert byte offsets to UTF-16 columns
- **Lock standardization**: Add `documents_guard()` helper, applied to all 42 lock patterns in language modules

## Changes

| File | Change |
|------|--------|
| `protocol/errors.rs` | +59 lines: request parameter helpers |
| `server_impl/mod.rs` | +18 lines: `documents_guard()` + public `byte_to_utf16_col()` |
| 11 language modules | Replace inline lock patterns with helper |

## Test plan

- [x] `cargo fmt --check -p perl-parser` passes
- [x] `cargo clippy -p perl-parser --no-deps -- -D warnings` passes  
- [x] `cargo test -p perl-parser --lib` - 287 tests pass
- [x] `cargo test -p perl-lsp` - 14 tests pass

## Notes

This sets the stage for:
1. Gradual adoption of `req_uri()`/`req_position()`/`req_range()` (silent failures → proper errors)
2. Easy `parking_lot` migration if needed (single change point)
3. Correct character positions for non-ASCII Perl code in find-references