### PR TITLE
fix(lsp): adopt strict params and UTF-16 correctness across handlers

### DIFF
--- a/crates/perl-parser/src/lsp/protocol/errors.rs
+++ b/crates/perl-parser/src/lsp/protocol/errors.rs
@@ -195,45 +195,51 @@ pub fn req_uri(params: &Value) -> Result<&str, JsonRpcError> {
 
 /// Extract the required position (line, character) from LSP request params
 ///
-/// Returns INVALID_PARAMS error if line or character are missing.
+/// Returns INVALID_PARAMS error if line or character are missing or overflow u32.
 pub fn req_position(params: &Value) -> Result<(u32, u32), JsonRpcError> {
-    let line = params
+    let line_u64 = params
         .pointer("/position/line")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: position.line"))?
-        as u32;
-    let character = params
+        .ok_or_else(|| invalid_params("Missing required parameter: position.line"))?;
+    let line =
+        u32::try_from(line_u64).map_err(|_| invalid_params("position.line exceeds u32::MAX"))?;
+    let character_u64 = params
         .pointer("/position/character")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: position.character"))?
-        as u32;
+        .ok_or_else(|| invalid_params("Missing required parameter: position.character"))?;
+    let character = u32::try_from(character_u64)
+        .map_err(|_| invalid_params("position.character exceeds u32::MAX"))?;
     Ok((line, character))
 }
 
 /// Extract the required range from LSP request params
 ///
-/// Returns INVALID_PARAMS error if any range components are missing.
+/// Returns INVALID_PARAMS error if any range components are missing or overflow u32.
 /// Returns ((start_line, start_char), (end_line, end_char)).
 pub fn req_range(params: &Value) -> Result<((u32, u32), (u32, u32)), JsonRpcError> {
-    let start_line = params
+    let start_line_u64 = params
         .pointer("/range/start/line")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: range.start.line"))?
-        as u32;
-    let start_char = params
+        .ok_or_else(|| invalid_params("Missing required parameter: range.start.line"))?;
+    let start_line = u32::try_from(start_line_u64)
+        .map_err(|_| invalid_params("range.start.line exceeds u32::MAX"))?;
+    let start_char_u64 = params
         .pointer("/range/start/character")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: range.start.character"))?
-        as u32;
-    let end_line = params
+        .ok_or_else(|| invalid_params("Missing required parameter: range.start.character"))?;
+    let start_char = u32::try_from(start_char_u64)
+        .map_err(|_| invalid_params("range.start.character exceeds u32::MAX"))?;
+    let end_line_u64 = params
         .pointer("/range/end/line")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: range.end.line"))?
-        as u32;
-    let end_char = params
+        .ok_or_else(|| invalid_params("Missing required parameter: range.end.line"))?;
+    let end_line = u32::try_from(end_line_u64)
+        .map_err(|_| invalid_params("range.end.line exceeds u32::MAX"))?;
+    let end_char_u64 = params
         .pointer("/range/end/character")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| invalid_params("Missing required parameter: range.end.character"))?
-        as u32;
+        .ok_or_else(|| invalid_params("Missing required parameter: range.end.character"))?;
+    let end_char = u32::try_from(end_char_u64)
+        .map_err(|_| invalid_params("range.end.character exceeds u32::MAX"))?;
     Ok(((start_line, start_char), (end_line, end_char)))
 }

--- a/crates/perl-parser/src/lsp/server_impl/language/completion.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/completion.rs
@@ -10,7 +10,7 @@
 use crate::{
     CompletionItemKind, CompletionProvider,
     cancellation::{GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, RequestCleanupGuard},
-    lsp::protocol::{JsonRpcError, REQUEST_CANCELLED},
+    lsp::protocol::{JsonRpcError, REQUEST_CANCELLED, req_position, req_uri},
     type_inference::TypeInferenceEngine,
 };
 use lazy_static::lazy_static;
@@ -62,9 +62,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             // Reject stale requests
             let req_version = params["textDocument"]["version"].as_i64().map(|n| n as i32);
@@ -311,9 +310,8 @@ impl LspServer {
             }
 
             // Use cancellable provider method instead of delegating
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             // Reject stale requests
             let req_version = params["textDocument"]["version"].as_i64().map(|n| n as i32);

--- a/crates/perl-parser/src/lsp/server_impl/language/hierarchy.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/hierarchy.rs
@@ -4,6 +4,7 @@
 //! prepareCallHierarchy, callHierarchy/incomingCalls, and callHierarchy/outgoingCalls.
 
 use super::super::*;
+use crate::lsp::protocol::{req_position, req_uri};
 
 impl LspServer {
     /// Handle textDocument/prepareTypeHierarchy request
@@ -12,9 +13,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -375,10 +375,8 @@ impl LspServer {
         }
 
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let position = &params["position"];
-            let line = position["line"].as_u64().unwrap_or(0) as u32;
-            let character = position["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             eprintln!("Preparing call hierarchy at: {} ({}:{})", uri, line, character);
 

--- a/crates/perl-parser/src/lsp/server_impl/language/hover.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/hover.rs
@@ -4,6 +4,7 @@
 
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
+use crate::lsp::protocol::{req_position, req_uri};
 
 impl LspServer {
     /// Handle hover request
@@ -12,9 +13,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             // Reject stale requests
             let req_version = params["textDocument"]["version"].as_i64().map(|n| n as i32);
@@ -143,9 +143,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {

--- a/crates/perl-parser/src/lsp/server_impl/language/references.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/references.rs
@@ -3,6 +3,7 @@
 //! Handles textDocument/references and textDocument/documentHighlight requests.
 
 use super::super::{byte_to_utf16_col, *};
+use crate::lsp::protocol::{req_position, req_uri};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -19,9 +20,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
             let include_declaration = if let Some(context) = params.get("context") {
                 context["includeDeclaration"].as_bool().unwrap_or(true)
             } else {
@@ -299,9 +299,8 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-            let line = params["position"]["line"].as_u64().unwrap_or(0) as u32;
-            let character = params["position"]["character"].as_u64().unwrap_or(0) as u32;
+            let uri = req_uri(&params)?;
+            let (line, character) = req_position(&params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {

--- a/crates/perl-parser/src/lsp/server_impl/language/symbols.rs
+++ b/crates/perl-parser/src/lsp/server_impl/language/symbols.rs
@@ -2,7 +2,8 @@
 //!
 //! Handles textDocument/documentSymbol and textDocument/foldingRange requests.
 
-use super::super::*;
+use super::super::{byte_to_utf16_col, *};
+use crate::lsp::protocol::req_uri;
 
 impl LspServer {
     /// Handle textDocument/documentSymbol request
@@ -11,7 +12,7 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+            let uri = req_uri(&params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -140,7 +141,7 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+            let uri = req_uri(&params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -238,15 +239,17 @@ impl LspServer {
             if let Some(captures) = sub_regex.captures(line) {
                 if let Some(name_match) = captures.get(1) {
                     let name = name_match.as_str().to_string();
-                    let start_char = name_match.start();
-                    let end_char = name_match.end();
+                    // Convert byte positions to UTF-16 code units for LSP compliance
+                    let start_char = byte_to_utf16_col(line, name_match.start());
+                    let end_char = byte_to_utf16_col(line, name_match.end());
+                    let line_end_utf16 = byte_to_utf16_col(line, line.len());
 
                     symbols.push(json!({
                         "name": name,
                         "kind": 12, // Function
                         "range": {
                             "start": { "line": line_num, "character": 0 },
-                            "end": { "line": line_num, "character": line.len() }
+                            "end": { "line": line_num, "character": line_end_utf16 }
                         },
                         "selectionRange": {
                             "start": { "line": line_num, "character": start_char },
@@ -260,15 +263,17 @@ impl LspServer {
             if let Some(captures) = package_regex.captures(line) {
                 if let Some(name_match) = captures.get(1) {
                     let name = name_match.as_str().to_string();
-                    let start_char = name_match.start();
-                    let end_char = name_match.end();
+                    // Convert byte positions to UTF-16 code units for LSP compliance
+                    let start_char = byte_to_utf16_col(line, name_match.start());
+                    let end_char = byte_to_utf16_col(line, name_match.end());
+                    let line_end_utf16 = byte_to_utf16_col(line, line.len());
 
                     symbols.push(json!({
                         "name": name,
                         "kind": 4, // Module
                         "range": {
                             "start": { "line": line_num, "character": 0 },
-                            "end": { "line": line_num, "character": line.len() }
+                            "end": { "line": line_num, "character": line_end_utf16 }
                         },
                         "selectionRange": {
                             "start": { "line": line_num, "character": start_char },


### PR DESCRIPTION
## Summary

Follow-up to #243 - adopts the strict parameter helpers and UTF-16 correctness across all LSP handlers.

### Changes

- **Strict params everywhere**: Use `req_uri`/`req_position`/`req_range` helpers with `try_from` overflow protection
- **UTF-16 correctness**: Fix character positions in fallback regex paths using `byte_to_utf16_col()`
  - `symbols.rs` - document symbols fallback
  - `references.rs` - find references fallback  
  - `misc.rs` - inlineValue fallback
- **Proper range ends**: Use `location.end` instead of computing `start + name.len()`
- **INVALID_PARAMS errors**: All handlers return proper LSP errors for missing required fields

### Bug Classes Eliminated

1. **Silent missing param behavior** - no more empty URI defaults or 0/0 position fallbacks
2. **UTF-16 incorrect positions** - fallback paths now properly convert byte offsets to UTF-16 code units

### Testing

- ✅ `cargo fmt --check -p perl-parser`
- ✅ `cargo clippy -p perl-parser --no-deps -- -D warnings`
- ✅ `cargo build -p perl-lsp`
- ✅ `cargo test -p perl-parser --lib` (287 passed)

### Design Decision

**Strict-by-default**: Missing required params return `INVALID_PARAMS` (-32602). Exceptions are explicitly documented where the LSP ecosystem is messy (e.g., optional inlayHint range).