### PR TITLE
fix(tests): test harness hardening + BrokenPipe sweep (29 tests unignored)

### DIFF
--- a/crates/perl-lsp/tests/lsp_document_symbols_test.rs
+++ b/crates/perl-lsp/tests/lsp_document_symbols_test.rs
@@ -1,20 +1,12 @@
 //! Tests for textDocument/documentSymbol LSP feature
 //!
-//! ## Test Status (Phase 1 Stabilization)
-//! These tests are currently IGNORED due to flaky BrokenPipe errors during LSP
-//! initialization in CI environments. The errors are environmental/timing related,
-//! not functional bugs in the document symbol provider.
-//!
-//! **Resolution Strategy:**
-//! - Phase 2: Port to stable harness (spawn_lsp, handshake_initialize, barriers)
-//! - Phase 3: Re-enable after demonstrating 100% pass rate with nextest retries
-//!
-//! **Technical Context:**
-//! BrokenPipe errors occur when test infrastructure tears down the LSP server
-//! before all async operations complete. The stable harness addresses this with
-//! proper shutdown sequencing and synchronization barriers.
-
-#![cfg_attr(test, allow(unused))] // Tests currently ignored, will be re-enabled in Phase 2
+//! These tests validate the document symbol provider functionality including:
+//! - Basic symbol extraction (packages, subroutines, variables)
+//! - Nested symbol structures (closures, multiple packages)
+//! - Empty document handling
+//! - Constants and labels
+//! - All variable types (scalar, array, hash, our, local, state)
+//! - Hierarchical symbol structures
 
 use perl_parser::lsp_server::{JsonRpcRequest, LspServer};
 use serde_json::json;
@@ -66,7 +58,6 @@ fn open_document(server: &mut LspServer, uri: &str, content: &str) {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_basic() {
     let mut server = setup_server();
 
@@ -138,7 +129,6 @@ sub calculate {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_nested() {
     let mut server = setup_server();
 
@@ -200,7 +190,6 @@ sub another_sub {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_empty_document() {
     let mut server = setup_server();
 
@@ -227,7 +216,6 @@ fn test_document_symbols_empty_document() {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_with_constants() {
     let mut server = setup_server();
 
@@ -269,7 +257,6 @@ sub area {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_with_labels() {
     let mut server = setup_server();
 
@@ -312,7 +299,6 @@ sub process {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_all_variable_types() {
     let mut server = setup_server();
 
@@ -374,7 +360,6 @@ state $persistent = 0;
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_document_symbols_hierarchical_structure() {
     let mut server = setup_server();
 

--- a/crates/perl-lsp/tests/lsp_error_recovery_behavioral_tests.rs
+++ b/crates/perl-lsp/tests/lsp_error_recovery_behavioral_tests.rs
@@ -51,7 +51,6 @@
 /// - AC9: LSP graceful degradation
 /// - LSP Workflow: Parse → Diagnostics → Continue
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_lsp_server_session_continuity_on_parse_error() {
     // AC:9
     // Test LSP server session continuity with parse errors
@@ -72,7 +71,6 @@ fn test_lsp_server_session_continuity_on_parse_error() {
 /// - Threading: RUST_TEST_THREADS=2 compatibility
 /// - Timeout: 500ms for ≤2 threads
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_lsp_graceful_degradation_with_adaptive_threading() {
     // AC:9
     // Test with RUST_TEST_THREADS=2 environment (CI constraint)
@@ -92,7 +90,6 @@ fn test_lsp_graceful_degradation_with_adaptive_threading() {
 /// - AC9: LSP graceful degradation
 /// - Diagnostic Collection: Multiple errors
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_multiple_parse_errors_diagnostic_collection() {
     // AC:9
     // Test multiple parse errors in single document
@@ -112,7 +109,6 @@ fn test_multiple_parse_errors_diagnostic_collection() {
 /// - AC9: LSP graceful degradation
 /// - Lexer Integration: Error token to diagnostic conversion
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_lexer_error_diagnostic_publication() {
     // AC:9
     // Test lexer error token to diagnostic conversion
@@ -132,7 +128,6 @@ fn test_lexer_error_diagnostic_publication() {
 /// - AC9: LSP graceful degradation
 /// - Partial AST: LSP features on valid portions
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_partial_ast_lsp_feature_availability() {
     // AC:9
     // Test LSP features with partial AST (some parse errors)
@@ -152,7 +147,6 @@ fn test_partial_ast_lsp_feature_availability() {
 /// - AC9: LSP graceful degradation
 /// - JSON-RPC 2.0: Error response format
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_jsonrpc_error_response_compliance() {
     // AC:9
     // Test JSON-RPC error response format
@@ -172,7 +166,6 @@ fn test_jsonrpc_error_response_compliance() {
 /// - AC9: LSP graceful degradation
 /// - Severity Mapping: Error types to LSP severity
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_lsp_diagnostic_severity_mapping() {
     // AC:9
     // Test diagnostic severity mapping from errors
@@ -192,7 +185,6 @@ fn test_lsp_diagnostic_severity_mapping() {
 /// - AC9: LSP graceful degradation
 /// - Performance: <1ms LSP update target
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_error_recovery_performance_budget() {
     // AC:9, Performance
     // Test error recovery performance
@@ -212,7 +204,6 @@ fn test_error_recovery_performance_budget() {
 /// - Threading: Adaptive timeout scaling
 /// - LSP Harness: Thread-aware timeouts
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_adaptive_threading_lsp_harness_timeout_validation() {
     // Adaptive Threading
     // Test LSP harness timeout adaptation
@@ -232,7 +223,6 @@ fn test_adaptive_threading_lsp_harness_timeout_validation() {
 /// - Threading: Optimized idle detection
 /// - Performance: 1000ms → 200ms cycles
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_adaptive_threading_optimized_idle_detection() {
     // Adaptive Threading
     // Test optimized idle detection
@@ -252,7 +242,6 @@ fn test_adaptive_threading_optimized_idle_detection() {
 /// - AC9: LSP graceful degradation
 /// - Session Continuity: Multiple recovery cycles
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_session_continuity_multiple_error_recovery_cycles() {
     // AC:9, Session Continuity
     // Test multiple error recovery cycles
@@ -276,7 +265,6 @@ fn test_session_continuity_multiple_error_recovery_cycles() {
 /// - AC9: LSP graceful degradation
 /// - Session Continuity: Errors during operations
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_session_continuity_error_during_lsp_operation() {
     // AC:9, Session Continuity
     // Test errors during active LSP operations
@@ -300,7 +288,6 @@ fn test_session_continuity_error_during_lsp_operation() {
 /// - AC9: LSP graceful degradation
 /// - Incremental Updates: Diagnostic publication
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_diagnostic_publication_incremental_updates() {
     // AC:9, Diagnostics
     // Test incremental diagnostic updates
@@ -320,7 +307,6 @@ fn test_diagnostic_publication_incremental_updates() {
 /// - AC9: LSP graceful degradation
 /// - Cross-File: Error correlation
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_diagnostic_publication_cross_file_error_correlation() {
     // AC:9, Diagnostics
     // Test cross-file error correlation
@@ -340,7 +326,6 @@ fn test_diagnostic_publication_cross_file_error_correlation() {
 /// - AC9: LSP graceful degradation
 /// - Workspace Indexing: Continuity with errors
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_error_recovery_workspace_indexing_continuity() {
     // AC:9, Workspace
     // Test workspace indexing with parse errors
@@ -360,7 +345,6 @@ fn test_error_recovery_workspace_indexing_continuity() {
 /// - AC9: LSP graceful degradation
 /// - Semantic Tokens: Error handling
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_error_recovery_semantic_tokens_with_errors() {
     // AC:9, Semantic Tokens
     // Test semantic tokens with parse errors
@@ -380,7 +364,6 @@ fn test_error_recovery_semantic_tokens_with_errors() {
 /// - AC9: LSP graceful degradation
 /// - Performance: <50ms error response
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_performance_error_path_lsp_response_time() {
     // AC:9, Performance
     // Test LSP response time during errors
@@ -400,7 +383,6 @@ fn test_performance_error_path_lsp_response_time() {
 /// - AC9: LSP graceful degradation
 /// - Edge Case: Empty document
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_edge_case_empty_document_with_errors() {
     // AC:9, Edge Cases
     // Test empty document error handling
@@ -420,7 +402,6 @@ fn test_edge_case_empty_document_with_errors() {
 /// - AC9: LSP graceful degradation
 /// - Edge Case: Very large files
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_edge_case_very_large_file_with_errors() {
     // AC:9, Edge Cases
     // Test large file error handling
@@ -440,7 +421,6 @@ fn test_edge_case_very_large_file_with_errors() {
 /// - AC9: LSP graceful degradation
 /// - Edge Case: Unicode in diagnostics
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_edge_case_unicode_in_error_diagnostics() {
     // AC:9, Edge Cases
     // Test Unicode in error diagnostics
@@ -460,7 +440,6 @@ fn test_edge_case_unicode_in_error_diagnostics() {
 /// - AC9: LSP graceful degradation
 /// - Integration: Parser + Lexer errors
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_integration_parser_and_lexer_error_combination() {
     // AC:9, Integration
     // Test combined parser and lexer errors

--- a/crates/perl-lsp/tests/lsp_protocol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_protocol_tests.rs
@@ -70,7 +70,6 @@ fn parse_messages(data: &[u8]) -> Vec<Value> {
 }
 
 #[test]
-#[ignore] // Flaky BrokenPipe errors in CI during LSP initialization (environmental/timing)
 fn test_diagnostics_clear_protocol_framing() {
     // Buffer to capture all output from the server
     let buffer = Arc::new(Mutex::new(Vec::new()));
@@ -99,6 +98,9 @@ fn test_diagnostics_clear_protocol_framing() {
             "capabilities": {}
         }),
     );
+
+    // Send initialized notification (required by LSP protocol)
+    send("initialized", None, json!({}));
 
     // Open document
     send(

--- a/scripts/.ignored-baseline
+++ b/scripts/.ignored-baseline
@@ -1,0 +1,9 @@
+# Ignored test baseline - 2025-12-30T03:00:20-05:00
+# Updated by: ignored-test-count.sh --update
+brokenpipe=386
+feature=12
+infra=13
+protocol=1
+bare=11
+other=157
+total=580

--- a/scripts/ignored-test-count.sh
+++ b/scripts/ignored-test-count.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Counts ignored tests by category and tracks delta
+#
+# Usage:
+#   ./scripts/ignored-test-count.sh           # Show current counts
+#   ./scripts/ignored-test-count.sh --update  # Update baseline
+#   ./scripts/ignored-test-count.sh --check   # CI gate (exit 1 if increased)
+#
+# Categories tracked:
+#   - brokenpipe: BrokenPipe/transport flakes
+#   - feature: Feature-gated/not implemented
+#   - infra: Infrastructure/TODO items
+#   - protocol: Protocol compliance issues
+#   - bare: No reason given
+#   - other: Everything else
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASELINE_FILE="$SCRIPT_DIR/.ignored-baseline"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Counters
+declare -A counts
+declare -A baseline
+counts[brokenpipe]=0
+counts[feature]=0
+counts[infra]=0
+counts[protocol]=0
+counts[bare]=0
+counts[other]=0
+
+# Parse command line args
+MODE="show"
+if [[ "${1:-}" == "--update" ]]; then
+    MODE="update"
+elif [[ "${1:-}" == "--check" ]]; then
+    MODE="check"
+elif [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Usage: $0 [--update|--check|--help]"
+    echo ""
+    echo "Options:"
+    echo "  --update  Update the baseline file with current counts"
+    echo "  --check   CI gate mode: exit 1 if total ignores increased"
+    echo "  --help    Show this help message"
+    exit 0
+fi
+
+# Function to categorize an ignore based on reason text
+categorize_ignore() {
+    local reason="$1"
+    local context="$2"
+
+    # Convert to lowercase for matching
+    local lower_reason="${reason,,}"
+    local lower_context="${context,,}"
+
+    # Check for BrokenPipe/transport issues
+    if [[ "$lower_reason" =~ brokenpipe|broken.pipe|transport|flak|timeout|race|intermittent ]]; then
+        echo "brokenpipe"
+    # Check for feature-gated/not implemented
+    elif [[ "$lower_reason" =~ feature|not.implemented|unimplemented|wip|work.in.progress|pending ]]; then
+        echo "feature"
+    # Check for infrastructure/TODO
+    elif [[ "$lower_reason" =~ infra|todo|fixme|needs|requires|setup|config|environment ]]; then
+        echo "infra"
+    # Check for protocol compliance
+    elif [[ "$lower_reason" =~ protocol|lsp|dap|compliance|spec|specification ]]; then
+        echo "protocol"
+    # Bare ignore (no reason)
+    elif [[ -z "$reason" || "$reason" == "ignore" ]]; then
+        echo "bare"
+    else
+        echo "other"
+    fi
+}
+
+# Function to extract reason from ignore attribute
+extract_reason() {
+    local line="$1"
+
+    # Match #[ignore = "reason"] or #[ignore = 'reason']
+    if [[ "$line" =~ \#\[ignore[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+        echo "${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ \#\[ignore[[:space:]]*=[[:space:]]*\'([^\']+)\' ]]; then
+        echo "${BASH_REMATCH[1]}"
+    # Match #[ignore] with comment on same or next line
+    elif [[ "$line" =~ //[[:space:]]*(.+)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo ""
+    fi
+}
+
+# Find all Rust test files and scan for ignores
+echo -e "${BLUE}Scanning for ignored tests in $REPO_ROOT/crates...${NC}"
+echo ""
+
+# Temporary file for detailed output
+DETAILS_FILE=$(mktemp)
+trap "rm -f $DETAILS_FILE" EXIT
+
+# Find all #[ignore] attributes in Rust files
+while IFS= read -r file; do
+    # Get relative path for cleaner output
+    rel_path="${file#$REPO_ROOT/}"
+
+    # Use grep to find ignore lines with context
+    while IFS= read -r match; do
+        if [[ -z "$match" ]]; then
+            continue
+        fi
+
+        # Extract line number and content
+        line_num=$(echo "$match" | cut -d: -f1)
+        line_content=$(echo "$match" | cut -d: -f2-)
+
+        # Get surrounding context (next 3 lines for function name)
+        context=$(sed -n "$((line_num)),$(( line_num + 3 ))p" "$file" 2>/dev/null || echo "")
+
+        # Extract the reason
+        reason=$(extract_reason "$line_content")
+
+        # If no reason in the ignore line, check the context
+        if [[ -z "$reason" ]]; then
+            # Look for comment in context
+            if [[ "$context" =~ //[[:space:]]*(.+) ]]; then
+                reason="${BASH_REMATCH[1]}"
+            fi
+        fi
+
+        # Categorize
+        category=$(categorize_ignore "$reason" "$context")
+        ((counts[$category]++)) || true
+
+        # Extract test function name if possible
+        test_name=""
+        if [[ "$context" =~ fn[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*) ]]; then
+            test_name="${BASH_REMATCH[1]}"
+        fi
+
+        # Record details
+        echo "$category|$rel_path:$line_num|$test_name|$reason" >> "$DETAILS_FILE"
+
+    done < <(grep -n '#\[ignore' "$file" 2>/dev/null || true)
+
+done < <(find "$REPO_ROOT/crates" -name "*.rs" -type f 2>/dev/null)
+
+# Calculate total
+total=0
+for cat in brokenpipe feature infra protocol bare other; do
+    ((total += counts[$cat])) || true
+done
+
+# Load baseline if exists
+baseline_total=0
+if [[ -f "$BASELINE_FILE" ]]; then
+    while IFS='=' read -r key value; do
+        if [[ -n "$key" && -n "$value" ]]; then
+            baseline[$key]=$value
+            if [[ "$key" == "total" ]]; then
+                baseline_total=$value
+            fi
+        fi
+    done < "$BASELINE_FILE"
+fi
+
+# Function to format delta
+format_delta() {
+    local current=$1
+    local base=${2:-0}
+    local delta=$((current - base))
+
+    if [[ $delta -gt 0 ]]; then
+        echo -e "${RED}+$delta${NC}"
+    elif [[ $delta -lt 0 ]]; then
+        echo -e "${GREEN}$delta${NC}"
+    else
+        echo "0"
+    fi
+}
+
+# Print summary table
+echo "==============================================="
+echo "        Ignored Tests Summary"
+echo "==============================================="
+printf "%-12s %8s %8s %8s\n" "Category" "Count" "Baseline" "Delta"
+echo "-----------------------------------------------"
+
+for cat in brokenpipe feature infra protocol bare other; do
+    base_val=${baseline[$cat]:-0}
+    delta=$(format_delta ${counts[$cat]} $base_val)
+    printf "%-12s %8d %8d %8b\n" "$cat" "${counts[$cat]}" "$base_val" "$delta"
+done
+
+echo "-----------------------------------------------"
+base_total=${baseline[total]:-0}
+delta=$(format_delta $total $base_total)
+printf "%-12s %8d %8d %8b\n" "TOTAL" "$total" "$base_total" "$delta"
+echo "==============================================="
+echo ""
+
+# Show details by category if verbose
+if [[ "${VERBOSE:-}" == "1" ]]; then
+    echo ""
+    echo "Detailed breakdown by category:"
+    echo ""
+    for cat in brokenpipe feature infra protocol bare other; do
+        if [[ ${counts[$cat]} -gt 0 ]]; then
+            echo -e "${YELLOW}=== $cat (${counts[$cat]}) ===${NC}"
+            grep "^$cat|" "$DETAILS_FILE" | while IFS='|' read -r _ loc name reason; do
+                printf "  %s\n" "$loc"
+                if [[ -n "$name" ]]; then
+                    printf "    fn: %s\n" "$name"
+                fi
+                if [[ -n "$reason" ]]; then
+                    printf "    reason: %s\n" "$reason"
+                fi
+            done
+            echo ""
+        fi
+    done
+fi
+
+# Handle modes
+case "$MODE" in
+    update)
+        echo "Updating baseline file: $BASELINE_FILE"
+        {
+            echo "# Ignored test baseline - $(date -Iseconds)"
+            echo "# Updated by: ignored-test-count.sh --update"
+            for cat in brokenpipe feature infra protocol bare other; do
+                echo "$cat=${counts[$cat]}"
+            done
+            echo "total=$total"
+        } > "$BASELINE_FILE"
+        echo -e "${GREEN}Baseline updated successfully.${NC}"
+        ;;
+    check)
+        if [[ $total -gt $baseline_total ]]; then
+            echo -e "${RED}ERROR: Ignored test count increased from $baseline_total to $total${NC}"
+            echo ""
+            echo "New ignores must be justified. If intentional, run:"
+            echo "  ./scripts/ignored-test-count.sh --update"
+            echo ""
+            exit 1
+        else
+            echo -e "${GREEN}OK: Ignored test count ($total) is not higher than baseline ($baseline_total)${NC}"
+            exit 0
+        fi
+        ;;
+    show)
+        # Just show the summary (already done above)
+        if [[ $total -gt 0 ]]; then
+            echo "Run with VERBOSE=1 for detailed breakdown:"
+            echo "  VERBOSE=1 $0"
+            echo ""
+            echo "To update baseline:"
+            echo "  $0 --update"
+        fi
+        ;;
+esac


### PR DESCRIPTION
## Summary

This PR hardens the test transport layer and begins the systematic burn-down of BrokenPipe-related ignored tests.

### Transport Hardening (`common/mod.rs`)
- Add `send_message_inner()` helper for graceful write error handling
- Handle `BrokenPipe` errors with proper JSON-RPC error responses (`-32600` Connection closed)
- Convert panicking `unwrap()` patterns to error-returning patterns
- Notifications/raw sends now silently ignore write errors (appropriate for teardown scenarios)

### BrokenPipe Sweep (29 tests unignored)
| File | Tests Unignored | Status |
|------|-----------------|--------|
| `lsp_error_recovery_behavioral_tests.rs` | 21 | ✅ All pass |
| `lsp_document_symbols_test.rs` | 7 | ✅ All pass |
| `lsp_protocol_tests.rs` | 1 | ✅ Fixed (missing `initialized` notification) |

### Infrastructure
- Add `scripts/ignored-test-count.sh` for tracking ignored test counts by category
- Add `scripts/.ignored-baseline` for ratchet enforcement (prevents backsliding)

### Current Baseline

```
Category        Count
-----------------------------------------------
brokenpipe        386 (-29)
feature            12
infra              13
protocol            1
bare               11
other             157
-----------------------------------------------
TOTAL             580 (down from 609)
```

## Test Plan

- [x] Run unignored tests: `RUST_TEST_THREADS=2 cargo test -p perl-lsp --test lsp_error_recovery_behavioral_tests --test lsp_document_symbols_test --test lsp_protocol_tests`
- [x] All 29 previously-ignored tests pass
- [x] Baseline script validates counts

## Next Steps (Future PRs)

This is PR 1 of the test harness stabilization effort:
- **PR 2**: Burn down more BrokenPipe ignores (`lsp_behavioral_tests`, `lsp_filesystem_failures`, etc.)
- **PR 3**: Protocol compliance fixes (4 remaining real issues)
- **Goal**: Get to <100 ignored tests with documented reasons