### PR TITLE
chore: polish docs + workflow manifest; tighten moniker qw parsing

### DIFF
--- a/.ci/WORKFLOW_MANIFEST.md
+++ b/.ci/WORKFLOW_MANIFEST.md
@@ -105,7 +105,7 @@ These workflows provide deeper test coverage beyond the merge gate.
 |-----------|-------|
 | **Name** | Check Ignored Tests |
 | **Purpose** | Tracks ignored test count baseline to prevent regression |
-| **Trigger** | Push/PR to main/master (path-filtered: tests, src, ci/ignored_baseline.txt) |
+| **Trigger** | Push/PR to main/master (path-filtered: tests, src, scripts/.ignored-baseline) |
 | **Estimated Runtime** | 2-3 minutes |
 | **Cost Tier** | Low |
 | **Recommendation** | **KEEP** - Cheap, valuable hygiene check |
@@ -198,21 +198,23 @@ These workflows provide deeper test coverage beyond the merge gate.
 | **Cost Tier** | Low (runs only on release) |
 | **Recommendation** | **MERGE** - Duplicate with vscode-publish.yml |
 
-### vscode-publish.yml
+### `vscode-publish.yml`
 | Attribute | Value |
 |-----------|-------|
 | **Name** | Publish VS Code Extension |
 | **Purpose** | Publishes VS Code extension to Marketplace (nearly identical to publish-extension.yml) |
-| **Trigger** | Push tag v*.*.*, manual dispatch |
+| **Trigger** | Push tag `v*.*.*`, manual dispatch |
 | **Estimated Runtime** | 5-10 minutes |
 | **Cost Tier** | Low (runs only on release) |
 | **Recommendation** | **MERGE** - Duplicate with publish-extension.yml; consolidate into one |
+
+> **⚠️ Trigger Mismatch Note**: `publish-extension.yml` uses `v*` while `vscode-publish.yml` uses `v*.*.*`. Recommend standardizing on `v*` to include prerelease tags (e.g., `v0.9.0-beta.1`).
 
 ---
 
 ## 5. Deprecated/Candidates for Removal
 
-### rust-ci.yml
+### `rust-ci.yml`
 | Attribute | Value |
 |-----------|-------|
 | **Name** | Rust CI |
@@ -222,7 +224,7 @@ These workflows provide deeper test coverage beyond the merge gate.
 | **Cost Tier** | High |
 | **Recommendation** | **ARCHIVE** - References non-existent branches (develop, rust-conversion), uses xtask commands that may not work, overlaps heavily with ci.yml and test.yml |
 
-### rust.yml
+### `rust.yml`
 | Attribute | Value |
 |-----------|-------|
 | **Name** | Rust CI |

--- a/docs/PARSER_LIMITATIONS.md
+++ b/docs/PARSER_LIMITATIONS.md
@@ -1,376 +1,154 @@
-# Parser Limitations - Known Issues in Test Suite
+# Parser Limitations
 
-This document details known parser limitations that are tracked through ignored tests in the perl-parser test suite. These represent edge cases that require significant parser refactoring to resolve properly.
+This document details intentional parser boundaries and historically resolved issues in the perl-parser.
 
 ## Overview
 
-The perl-parser (v3 Native) has ~100% Perl syntax coverage, but contains three known limitations that cause test failures. Each limitation is documented with:
+The perl-parser (v3 Native) has **~100% Perl syntax coverage** for static Perl code. This document distinguishes between:
 
-- Clear description of the problem
-- Root cause (parser architecture constraints)
-- Impact on users
-- Available workarounds
-- Estimated fix complexity
+1. **Intentional Boundaries**: Features that require runtime evaluation or are explicitly out of scope
+2. **Resolved Issues**: Previously tracked parser limitations that have been fixed
 
 ---
 
-## 1. Return Statement After Word Operators
+## 1. Intentional Boundaries (Non-Goals)
 
-### Test Reference
-- **File**: `crates/perl-parser/tests/comprehensive_operator_precedence_test.rs`
-- **Test**: `test_complex_precedence_combinations` (line 122-148)
-- **Ignore Annotation**: `#[ignore = "BUG: 'return' after 'or' needs deeper parser refactoring - return as expression"]`
+These are not bugs—they represent fundamental limits of static analysis for a dynamic language.
 
-### Description
+### Source Filters
 
-The parser fails to correctly handle `return` statements when they appear as the right-hand side of word operators (`or`, `and`, `xor`). Specifically, patterns like:
+**Scope**: Out of scope for static parsing
 
+**Description**: Source filters (`Filter::Simple`, `Filter::Util::Call`, etc.) transform Perl source code at compile time before parsing. This requires actually executing Perl code.
+
+**Examples**:
 ```perl
-open $fh, $file or return;
+use Switch;      # Modifies source before parsing
+use Perl6::Say;  # Adds 'say' keyword via source filter
 ```
 
-do not parse correctly because the parser treats `return` as a statement rather than as an expression in this context.
+**Workaround**: Users should review files using source filters manually or with Perl's own tools.
 
-### Root Cause
+### eval STRING
 
-**Parser Architecture Constraint**: The recursive descent parser currently treats `return` as a statement-level construct rather than as a general expression. This architectural decision creates a precedence conflict when `return` appears after low-precedence word operators.
+**Scope**: Cannot analyze dynamically-constructed code
 
-In Perl's grammar, word operators (`or`, `and`, `xor`) have very low precedence (levels 22-24), lower than assignment (level 19). The `return` keyword can function as both:
-- **Statement form**: `return $value;` (top-level statement)
-- **Expression form**: `$a or return` (returns from expression context)
+**Description**: `eval STRING` compiles and executes Perl code at runtime. The parser cannot know what code will be generated.
 
-The parser's current statement/expression separation doesn't account for `return` as an expression, causing it to fail when parsing patterns like:
-
+**Examples**:
 ```perl
-$a = func() or die 'error';     # ✅ Works - die is recognized as expression
-open $fh, $file or return;       # ❌ Fails - return not recognized as expression
+my $code = build_code();  # Dynamic code construction
+eval $code;                # Cannot be statically analyzed
 ```
 
-### Impact on Users
+**What We Do**: We parse the `eval` statement itself correctly, but cannot analyze the evaluated code.
 
-**Affected Code Patterns**:
-1. Error handling idioms: `open(...) or return`
-2. Guard clauses: `$condition or return $default`
-3. Complex precedence chains: `$a = $b or $c = $d and return $e`
+### Dynamic Symbol Table Manipulation
 
-**Real-World Impact**: **Medium**
-- Common Perl idiom for error handling
-- Affects approximately 1% of production Perl codebases based on corpus analysis
-- Primarily impacts error handling patterns in subroutines
+**Scope**: Runtime behavior cannot be predicted
 
-### Workarounds
+**Description**: Perl allows dynamic manipulation of symbol tables, stash entries, and glob assignments. These change program behavior at runtime.
 
-**Option 1: Use Parentheses** (Recommended)
+**Examples**:
 ```perl
-# Instead of:
-open $fh, $file or return;
-
-# Use:
-open($fh, $file) or return;
+*foo = sub { ... };              # Dynamic sub definition
+no strict 'refs'; *{$name} = 1;  # Dynamic variable creation
 ```
 
-**Option 2: Separate Statements**
+**What We Do**: We parse these constructs syntactically but cannot determine their runtime effects.
+
+### BEGIN Block Side Effects
+
+**Scope**: Compile-time effects require execution
+
+**Description**: `BEGIN` blocks execute during compilation and can modify the compilation environment in arbitrary ways.
+
+**Examples**:
 ```perl
-# Instead of:
-$result = func() or return $default;
-
-# Use:
-$result = func();
-return $default unless $result;
-```
-
-**Option 3: Use High-Precedence Operators**
-```perl
-# Instead of:
-$value or return;
-
-# Use:
-$value || return;  # C-style || has higher precedence
-```
-
-### Fix Estimate
-
-**Complexity**: High (3-4 weeks)
-
-**Required Changes**:
-1. Refactor expression parser to recognize `return` as a valid expression
-2. Update precedence climbing to handle statement-like expressions
-3. Modify AST to represent `return` in expression contexts
-4. Add comprehensive test coverage for all word operator + return combinations
-5. Ensure backward compatibility with existing `return` statement handling
-
-**Blocked By**:
-- Issue #188 (Semantic Analyzer Phase 2) - Requires expression context analysis
-- ADR-002 API Documentation Infrastructure - New parser interfaces must be documented
-
----
-
-## 2. Indirect Object Syntax Detection
-
-### Test Reference
-- **File**: `crates/perl-parser/tests/parser_regressions.rs`
-- **Test**: `print_filehandle_then_variable_is_indirect` (line 85-100)
-- **Ignore Annotation**: `#[ignore = "BUG: Indirect object detection requires deeper parser refactoring"]`
-
-### Description
-
-The parser cannot reliably distinguish between indirect object syntax and regular function calls when both forms use variables. Specifically:
-
-```perl
-print $fh $x;        # ❌ Should be: print(filehandle=$fh, args=[$x]) - indirect object
-                     # Actually parsed as: print($fh, $x) - regular function call
-```
-
-The parser correctly handles:
-- Bareword filehandles: `print STDOUT "hello"`
-- Single variable print: `print $x`
-- Explicit indirect syntax: `print $fh "text"`
-
-But fails when the argument after the filehandle is also a variable.
-
-### Root Cause
-
-**Semantic Analysis Requirement**: Indirect object syntax detection requires semantic analysis to distinguish between:
-
-1. **Indirect object form**: `method $object @args` or `print $filehandle $data`
-2. **Regular function call**: `func($arg1, $arg2)`
-
-The ambiguity arises because both forms have identical token sequences:
-
-```perl
-print $fh $x;
-# Could be: print(filehandle=$fh, data=$x)  [indirect object]
-# Could be: print($fh, $x)                   [two arguments]
-```
-
-**Why This Is Hard**: Resolving this requires:
-- **Type inference**: Knowing if `$fh` is a filehandle or regular scalar
-- **Context analysis**: Understanding whether `print` expects a filehandle
-- **Lookahead analysis**: Examining subsequent tokens to determine syntax form
-
-This goes beyond pure syntactic parsing and requires semantic analysis (variable types, scoping, context).
-
-### Impact on Users
-
-**Affected Code Patterns**:
-1. Filehandle-based I/O: `print $fh $data`
-2. Indirect method calls: `new Class @args`
-3. Legacy OOP patterns: `method $object @params`
-
-**Real-World Impact**: **Low-Medium**
-- Indirect object syntax is discouraged in modern Perl (PBP §15.1)
-- Affects legacy codebases using old-style OOP
-- Modern code uses arrow notation: `$object->method(@args)`
-- Approximately 0.5% of production code based on corpus analysis
-
-**LSP Functionality**: The parser currently handles this conservatively:
-- **Go-to-definition**: May provide multiple candidates
-- **Hover information**: Shows generic function call signature
-- **Diagnostics**: No false positives (conservative approach)
-
-### Workarounds
-
-**Option 1: Use Arrow Notation** (Recommended for OOP)
-```perl
-# Instead of:
-new Class @args;
-
-# Use:
-Class->new(@args);
-```
-
-**Option 2: Use Parentheses** (Recommended for I/O)
-```perl
-# Instead of:
-print $fh $data;
-
-# Use:
-print($fh $data);      # Explicit function call with 2 args
-# Or:
-print {$fh} $data;     # Explicit indirect object syntax
-```
-
-**Option 3: Use Bareword Filehandles**
-```perl
-# Instead of:
-print $fh "text";
-
-# Use:
-open(FH, '>', 'file.txt');
-print FH "text";
-```
-
-### Fix Estimate
-
-**Complexity**: Very High (6-8 weeks)
-
-**Required Changes**:
-1. Implement semantic analyzer Phase 2 (variable type tracking)
-2. Add filehandle type inference
-3. Implement context-sensitive parsing for indirect objects
-4. Update AST to distinguish indirect object calls from function calls
-5. Add heuristics for ambiguous cases (e.g., check if first arg is opened filehandle)
-6. Comprehensive testing with real-world legacy codebases
-
-**Blocked By**:
-- Issue #188 Phase 2 - Type inference system
-- Issue #188 Phase 3 - Advanced semantic analysis
-- Symbol table infrastructure for tracking filehandle types
-
-**Alternative Approach**:
-Could implement heuristic-based detection (80% accuracy):
-- Check if first argument matches an opened filehandle pattern
-- Detect common filehandle names (STDOUT, STDERR, FH, etc.)
-- Analyze calling context for I/O operations
-
----
-
-## 3. Whitespace Insertion Algorithm Inconsistencies
-
-### Test Reference
-- **File**: `crates/perl-parser/tests/prop_whitespace_idempotence.rs`
-- **Test**: `insertion_safe_is_consistent` (line 38-86)
-- **Ignore Annotation**: `#[ignore = "insertion_safe algorithm has known inconsistencies"]`
-
-### Description
-
-The `insertion_safe` algorithm, which determines where whitespace can be safely inserted without changing token boundaries, has edge cases where it incorrectly marks positions as "safe" when whitespace insertion would actually alter the token stream.
-
-This is a **property-based test failure**, meaning the algorithm works correctly for most inputs but fails on certain edge cases discovered through fuzzing.
-
-### Root Cause
-
-**Algorithmic Complexity**: The whitespace insertion algorithm uses a 3-token sliding window to determine if inserting whitespace between two tokens would change the lexical structure:
-
-```rust
-// From prop_test_utils.rs, line 505-530
-pub fn insertion_safe(original: &str, toks: &[CoreTok], i: usize, ws: &str) -> bool {
-    // Check if pair is breakable (would stay as 2 tokens)
-    if !pair_breakable(&toks[i], &toks[i + 1]) {
-        return false;
-    }
-
-    // Build a 3-token window to check context
-    let start = if i > 0 { toks[i - 1].start } else { toks[i].start };
-    let end = if i + 2 < toks.len() { toks[i + 2].end } else { toks[i + 1].end };
-
-    // Compare original window vs window with whitespace
-    // ...
+BEGIN {
+    require Some::Module;    # Loads module at compile time
+    *func = \&Some::func;    # Modifies symbol table
 }
 ```
 
-**Known Edge Cases**:
-1. **Context-dependent tokens**: Tokens that change meaning based on surrounding context
-   - Example: `${X}` vs `$ {X}` (variable dereference vs separate tokens)
-
-2. **Multi-character operators**: Operators composed of multiple characters
-   - Example: `::` package separator can split into `:` + `:`
-
-3. **Lookahead requirements**: Some tokens require >3 token lookahead
-   - Example: Regex delimiters, quote operators with custom delimiters
-
-The 3-token window is insufficient for all edge cases, but expanding it significantly increases algorithmic complexity (O(n²) → O(n³) or worse).
-
-### Impact on Users
-
-**Affected Functionality**: **Very Low**
-
-This limitation only affects:
-1. **Property-based testing**: Internal test quality, not user-facing features
-2. **Code formatting edge cases**: Rare whitespace preservation scenarios
-3. **Incremental parsing**: Theoretical edge cases in whitespace-sensitive updates
-
-**Real-World Impact**: **None**
-- Does not affect LSP functionality
-- Does not affect parsing accuracy
-- Does not affect code completion, navigation, or diagnostics
-- Only impacts internal code quality testing
-
-**Why This Is Ignored**:
-- The algorithm works correctly for >99.9% of real-world code
-- Property-based testing is designed to find rare edge cases
-- Fixing this would require algorithmic redesign with minimal user benefit
-
-### Workarounds
-
-**For Internal Development**:
-- Use more conservative whitespace insertion heuristics
-- Expand test case corpus to identify specific failure patterns
-- Implement special case handlers for known problematic patterns
-
-**For Users**:
-No workarounds needed - this does not affect user-facing features.
-
-### Fix Estimate
-
-**Complexity**: Medium-High (2-3 weeks)
-
-**Required Changes**:
-1. Expand sliding window from 3 tokens to 5 tokens for better context
-2. Add special case handlers for:
-   - Package separators (`::`)
-   - Variable dereferences (`${}`, `@{}`, `%{}`)
-   - Multi-character operators with potential splits
-3. Implement comprehensive token context analysis
-4. Optimize performance to handle larger windows efficiently
-5. Add regression tests for all discovered edge cases
-
-**Priority**: Low
-- Internal test quality improvement
-- No user-facing impact
-- Can be addressed during general parser refactoring
-
-**Alternative Approach**:
-- Accept the limitation and document known edge cases
-- Use targeted fixes for specific patterns rather than algorithmic redesign
-- Focus on real-world code patterns rather than theoretical completeness
+**What We Do**: We parse `BEGIN` blocks but don't execute them.
 
 ---
 
-## Summary Table
+## 2. Resolved Issues (Historical)
 
-| Limitation | Severity | Real-World Impact | Fix Complexity | Estimated Timeline | Blocked By |
-|------------|----------|-------------------|----------------|-------------------|------------|
-| Return after word operators | Medium | ~1% of codebases | High | 3-4 weeks | Issue #188 Phase 2 |
-| Indirect object detection | Low-Medium | ~0.5% of codebases | Very High | 6-8 weeks | Issue #188 Phase 2/3 |
-| Whitespace insertion algorithm | Very Low | None (internal) | Medium-High | 2-3 weeks | None |
+These were previously tracked as parser limitations and have been fixed.
 
-## Testing Commands
+### Return Statement After Word Operators - RESOLVED ✅
 
-Verify current status of ignored tests:
+**PR**: #261
+**Previous Issue**: `$a = 1 or return` didn't parse correctly because `return` was treated as a statement rather than expression.
 
+**Resolution**: Improved operator precedence handling to recognize `return` as valid expression in low-precedence operator contexts.
+
+**Validation**:
 ```bash
-# Show all ignored tests in operator precedence suite
-cargo test -p perl-parser --test comprehensive_operator_precedence_test -- --ignored --nocapture
-
-# Show ignored indirect object test
-cargo test -p perl-parser --test parser_regressions -- --ignored --nocapture
-
-# Show ignored whitespace property test
-cargo test -p perl-parser --test prop_whitespace_idempotence -- --ignored --nocapture
-
-# Run all ignored tests (will fail)
-cargo test -p perl-parser -- --ignored
+cargo test -p perl-parser --test comprehensive_operator_precedence_test -- test_complex_precedence_combinations
 ```
+
+---
+
+### Indirect Object Syntax Detection - RESOLVED ✅
+
+**PR**: #261
+**Previous Issue**: `print $fh $x;` was not recognized as indirect object form.
+
+**Resolution**: Improved heuristics for detecting indirect object syntax in common patterns (`print`, `say`, `new`, `open`).
+
+**Validation**:
+```bash
+cargo test -p perl-parser --test parser_regressions -- print_filehandle_then_variable_is_indirect
+```
+
+---
+
+### Whitespace Insertion Algorithm - RESOLVED ✅
+
+**PR**: #261
+**Previous Issue**: The `insertion_safe` algorithm had non-deterministic edge cases discovered through property-based testing.
+
+**Resolution**: Made the algorithm deterministic by defining stable ordering for iteration.
+
+**Validation**:
+```bash
+cargo test -p perl-parser --test prop_whitespace_idempotence -- insertion_safe_is_consistent
+```
+
+---
+
+### Malformed Substitution Strictness - RESOLVED ✅
+
+**PR**: #261
+**Previous Issue**: Malformed substitution operators (`s/pattern/`) didn't consistently produce errors.
+
+**Resolution**: Improved substitution operator validation to properly reject malformed patterns.
+
+**Validation**:
+```bash
+cargo test -p perl-parser --test substitution_ac_tests -- test_ac5_negative_malformed
+```
+
+---
+
+## Summary
+
+| Category | Count | Notes |
+|----------|-------|-------|
+| **Intentional Boundaries** | 4 | Source filters, eval STRING, dynamic symbols, BEGIN effects |
+| **Resolved (PR #261)** | 4 | Return precedence, indirect objects, whitespace, substitution |
 
 ## Related Documentation
 
-- **[KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md)**: General parser limitations across all parser versions
-- **[Issue #188](https://github.com/EffortlessMetrics/tree-sitter-perl-rs/issues/188)**: Semantic Analyzer implementation (Phases 1-3)
-- **[ADR-002](ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md)**: API Documentation Infrastructure requirements
-- **[LSP_IMPLEMENTATION_GUIDE.md](LSP_IMPLEMENTATION_GUIDE.md)**: LSP server feature matrix and limitations
-
-## Contributing
-
-If you encounter code that fails to parse due to these limitations:
-
-1. **Check workarounds** - Use recommended alternatives for production code
-2. **Report patterns** - Open an issue with specific code examples
-3. **Vote on priority** - Comment on Issue #188 if these affect your workflow
-4. **Contribute fixes** - See [CONTRIBUTING.md](../CONTRIBUTING.md) for parser development guidelines
+- **[IGNORED_TESTS_ROADMAP.md](IGNORED_TESTS_ROADMAP.md)**: Test tracking and resolution status
+- **[Issue #188](https://github.com/EffortlessMetrics/tree-sitter-perl-rs/issues/188)**: Semantic Analyzer (for deeper analysis needs)
+- **[LSP_IMPLEMENTATION_GUIDE.md](LSP_IMPLEMENTATION_GUIDE.md)**: LSP feature coverage
 
 ## Version History
 
-- **v0.8.8** (2025-01-31): Initial documentation of known parser limitations
-- Test infrastructure uses `#[ignore]` annotations with descriptive reasons
-- All limitations tracked and documented for transparency
+- **v0.8.8** (2025-01-31): Initial documentation
+- **v0.8.9** (2025-12-31): Refactored to show resolved issues (PR #261)

--- a/docs/TEST_INFRASTRUCTURE_GUIDE.md
+++ b/docs/TEST_INFRASTRUCTURE_GUIDE.md
@@ -849,12 +849,14 @@ jobs:
       CARGO_NET_RETRY: 4
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Supply-chain security: Pin third-party actions by commit SHA
+      # Keep version tags in comments for readability; update SHAs on a schedule
+      - uses: actions/checkout@<COMMIT_SHA> # v4
+      - uses: dtolnay/rust-toolchain@<COMMIT_SHA> # stable
         with:
           toolchain: 1.90.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@<COMMIT_SHA> # v2
         with:
           cache-on-failure: true
 
@@ -886,7 +888,7 @@ jobs:
             --junit target/nextest/ci/junit.xml
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@<COMMIT_SHA> # v2
         if: always()
         with:
           junit_files: target/nextest/ci/junit.xml


### PR DESCRIPTION
## Summary

Post-merge polish for PR #261 addressing review comments.

### Changes

**`.ci/WORKFLOW_MANIFEST.md`**:
- Fix ignored-baseline path (`ci/ignored_baseline.txt` → `scripts/.ignored-baseline`)
- Normalize workflow names with extensions (`rust-ci.yml`, `rust.yml`, `vscode-publish.yml`)
- Add trigger mismatch note for `v*` vs `v*.*.*` tags

**`docs/TEST_INFRASTRUCTURE_GUIDE.md`**:
- Add supply-chain security guidance for pinning actions by commit SHA

**`docs/IGNORED_TESTS_ROADMAP.md`**:
- Update Wave C to FIXED status (PR #261)
- Reflect current state: BUG=0, MANUAL=1, total=1

**`docs/PARSER_LIMITATIONS.md`**:
- Refactor into "Intentional Boundaries" vs "Resolved (Historical)"
- Move fixed issues to Resolved section with PR #261 reference

**`crates/perl-parser/src/lsp/server_impl/language/misc.rs`**:
- Add `qw<>` delimiter support to `@EXPORT` regex
- Deduplicate `is_symbol_imported` and `find_import_source`

## Test plan

- [x] `cargo fmt` - passes
- [x] `cargo test -p perl-parser --lib` - 324 tests pass
- [x] `cargo test -p perl-parser --test substitution_ac_tests` - 16 tests pass
- [x] `cargo test -p perl-parser --test prop_whitespace_idempotence` - 3 tests pass
- [x] `cargo test -p perl-parser --test parser_regressions` - 26 tests pass
- [x] `bash scripts/ignored-test-count.sh` - BUG=0, MANUAL=1, total=1