### PR TITLE
fix(lexer): mixed-delimiter substitution replacement; enable MUT_002 regression

### DIFF
--- a/crates/perl-parser/tests/moniker_export_import_tests.rs
+++ b/crates/perl-parser/tests/moniker_export_import_tests.rs
@@ -45,117 +45,57 @@ mod moniker_export_import_tests {
     }
 
     // ========================================================================
-    // @EXPORT Detection Tests - qw Delimiter Support
+    // @EXPORT Detection Tests - qw Delimiter Support (Data-Driven)
     // ========================================================================
 
+    /// Data-driven test: verify all qw delimiter variants parse correctly and produce valid AST
     #[test]
-    fn test_export_qw_angle_brackets() {
-        // Tests feature spec: PR #262 - qw<> delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw<foo bar baz>;
-"#;
-        let text = code;
-        let ast = parse_code(code);
+    fn test_export_qw_delimiter_variants_parse() {
+        // Tests feature spec: PR #262 - All qw delimiter forms for @EXPORT
+        let cases = [
+            ("qw<foo bar baz>", "<>"),
+            ("qw(foo bar baz)", "()"),
+            ("qw[foo bar baz]", "[]"),
+            ("qw{foo bar baz}", "{}"),
+            ("qw/foo bar baz/", "//"),
+            ("qw|foo bar baz|", "||"),
+            ("qw!foo bar baz!", "!!"),
+        ];
 
-        // Use the AST to verify parsing succeeds
-        assert!(matches!(ast.kind, NodeKind::Program { .. }));
+        for (qw_form, desc) in cases {
+            let code = format!("package MyModule;\n@EXPORT = {};\n", qw_form);
+            let ast = parse_code(&code);
+            assert!(
+                matches!(ast.kind, NodeKind::Program { .. }),
+                "Parser should produce Program node for qw{} delimiter",
+                desc
+            );
 
-        // Verify the regex pattern would match this format
-        // Pattern: @EXPORT(?:_OK)?\s*=\s*qw[(\[{/<|!]([^)\]}/|!>]+)[)\]}/|!>]
-        assert!(text.contains("qw<foo bar baz>"));
-        assert!(text.contains("@EXPORT"));
+            // Verify we got a valid program with statements
+            if let NodeKind::Program { statements } = &ast.kind {
+                assert!(
+                    !statements.is_empty(),
+                    "Program should have statements for qw{} delimiter",
+                    desc
+                );
+            }
+        }
     }
 
+    /// Data-driven test: verify @EXPORT_OK also works with all delimiter variants
     #[test]
-    fn test_export_qw_parentheses() {
-        // Tests feature spec: PR #262 - qw() delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw(foo bar baz);
-"#;
-        let text = code;
+    fn test_export_ok_qw_delimiter_variants_parse() {
+        let cases = ["qw<foo bar>", "qw(foo bar)", "qw[foo bar]", "qw{foo bar}"];
 
-        assert!(text.contains("qw(foo bar baz)"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_qw_square_brackets() {
-        // Tests feature spec: PR #262 - qw[] delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw[foo bar baz];
-"#;
-        let text = code;
-
-        assert!(text.contains("qw[foo bar baz]"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_qw_curly_braces() {
-        // Tests feature spec: PR #262 - qw{} delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw{foo bar baz};
-"#;
-        let text = code;
-
-        assert!(text.contains("qw{foo bar baz}"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_qw_forward_slashes() {
-        // Tests feature spec: PR #262 - qw// delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw/foo bar baz/;
-"#;
-        let text = code;
-
-        assert!(text.contains("qw/foo bar baz/"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_qw_pipes() {
-        // Tests feature spec: PR #262 - qw|| delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw|foo bar baz|;
-"#;
-        let text = code;
-
-        assert!(text.contains("qw|foo bar baz|"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_qw_exclamations() {
-        // Tests feature spec: PR #262 - qw!! delimiter support for @EXPORT
-        let code = r#"
-package MyModule;
-@EXPORT = qw!foo bar baz!;
-"#;
-        let text = code;
-
-        assert!(text.contains("qw!foo bar baz!"));
-        assert!(text.contains("@EXPORT"));
-    }
-
-    #[test]
-    fn test_export_ok_qw_angle_brackets() {
-        // Tests feature spec: PR #262 - qw<> delimiter support for @EXPORT_OK
-        let code = r#"
-package MyModule;
-@EXPORT_OK = qw<foo bar baz>;
-"#;
-        let text = code;
-
-        assert!(text.contains("qw<foo bar baz>"));
-        assert!(text.contains("@EXPORT_OK"));
+        for qw_form in cases {
+            let code = format!("package MyModule;\n@EXPORT_OK = {};\n", qw_form);
+            let ast = parse_code(&code);
+            assert!(
+                matches!(ast.kind, NodeKind::Program { .. }),
+                "Parser should produce Program node for @EXPORT_OK with {}",
+                qw_form
+            );
+        }
     }
 
     #[test]
@@ -166,40 +106,32 @@ package MyModule;
 @EXPORT = qw<foo bar>;
 @EXPORT_OK = qw(baz qux);
 "#;
-        let text = code;
+        let ast = parse_code(code);
+        assert!(matches!(ast.kind, NodeKind::Program { .. }));
 
-        assert!(text.contains("qw<foo bar>"));
-        assert!(text.contains("qw(baz qux)"));
+        if let NodeKind::Program { statements } = &ast.kind {
+            // Should have package + 2 export assignments
+            assert!(statements.len() >= 2, "Expected at least package and exports");
+        }
     }
 
     #[test]
-    fn test_export_array_assignment_single_quotes() {
+    fn test_export_array_assignment_variants() {
         // Tests feature spec: PR #262 - Array assignment with quoted strings
-        let code = r#"
-package MyModule;
-@EXPORT = ('foo', 'bar', 'baz');
-"#;
-        let text = code;
+        let cases = [
+            ("@EXPORT = ('foo', 'bar', 'baz');", "single quotes"),
+            (r#"@EXPORT = ("foo", "bar", "baz");"#, "double quotes"),
+        ];
 
-        assert!(text.contains("@EXPORT"));
-        assert!(text.contains("'foo'"));
-        assert!(text.contains("'bar'"));
-        assert!(text.contains("'baz'"));
-    }
-
-    #[test]
-    fn test_export_array_assignment_double_quotes() {
-        // Tests feature spec: PR #262 - Array assignment with double quotes
-        let code = r#"
-package MyModule;
-@EXPORT = ("foo", "bar", "baz");
-"#;
-        let text = code;
-
-        assert!(text.contains("@EXPORT"));
-        assert!(text.contains(r#""foo""#));
-        assert!(text.contains(r#""bar""#));
-        assert!(text.contains(r#""baz""#));
+        for (export_stmt, desc) in cases {
+            let code = format!("package MyModule;\n{}\n", export_stmt);
+            let ast = parse_code(&code);
+            assert!(
+                matches!(ast.kind, NodeKind::Program { .. }),
+                "Parser should handle array assignment with {}",
+                desc
+            );
+        }
     }
 
     #[test]
@@ -209,117 +141,51 @@ package MyModule;
 package MyModule;
 @EXPORT    =    qw<  foo   bar   baz  >;
 "#;
-        let text = code;
-
-        assert!(text.contains("@EXPORT"));
-        assert!(text.contains("qw<"));
+        let ast = parse_code(code);
+        assert!(
+            matches!(ast.kind, NodeKind::Program { .. }),
+            "Parser should handle arbitrary whitespace in qw declarations"
+        );
     }
 
     // ========================================================================
-    // Import Source Detection Tests - AST-based Testing
+    // Import Source Detection Tests - AST-based Testing (Data-Driven)
     // ========================================================================
 
+    /// Data-driven test: verify all qw delimiter variants work in use statements
     #[test]
-    fn test_import_source_qw_angle_brackets() {
-        // Tests feature spec: PR #262 - find_import_source with qw<> delimiters
-        let use_node = create_use_node("Data::Dumper", vec!["qw<Dumper DumperX>"]);
-        let program = create_program_with_uses(vec![use_node]);
+    fn test_import_source_qw_delimiter_variants() {
+        // Tests feature spec: PR #262 - find_import_source with all qw delimiter forms
+        let cases = [
+            ("Data::Dumper", "qw<Dumper DumperX>", "qw<"),
+            ("Exporter", "qw(import)", "qw("),
+            ("File::Spec", "qw[catfile catdir]", "qw["),
+            ("List::Util", "qw{first max min}", "qw{"),
+            ("Carp", "qw/croak confess/", "qw/"),
+            ("Test::More", "qw|ok is like|", "qw|"),
+            ("Scalar::Util", "qw!blessed reftype!", "qw!"),
+        ];
 
-        // Verify the AST structure is correct
-        if let NodeKind::Program { statements } = &program.kind {
-            assert_eq!(statements.len(), 1);
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "Data::Dumper");
-                assert_eq!(args.len(), 1);
-                assert_eq!(args[0], "qw<Dumper DumperX>");
+        for (module_name, qw_args, expected_prefix) in cases {
+            let use_node = create_use_node(module_name, vec![qw_args]);
+            let program = create_program_with_uses(vec![use_node]);
+
+            if let NodeKind::Program { statements } = &program.kind {
+                assert_eq!(statements.len(), 1, "Expected 1 statement for {}", module_name);
+                if let NodeKind::Use { module, args } = &statements[0].kind {
+                    assert_eq!(module, module_name, "Module name mismatch");
+                    assert_eq!(args.len(), 1, "Expected 1 arg for {}", module_name);
+                    assert!(
+                        args[0].starts_with(expected_prefix),
+                        "Args should start with {} for {}",
+                        expected_prefix,
+                        module_name
+                    );
+                } else {
+                    panic!("Expected Use node for {}", module_name);
+                }
             } else {
-                panic!("Expected Use node");
-            }
-        } else {
-            panic!("Expected Program node");
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_parentheses() {
-        // Tests feature spec: PR #262 - find_import_source with qw() delimiters
-        let use_node = create_use_node("Exporter", vec!["qw(import)"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "Exporter");
-                assert!(args[0].starts_with("qw("));
-            }
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_square_brackets() {
-        // Tests feature spec: PR #262 - find_import_source with qw[] delimiters
-        let use_node = create_use_node("File::Spec", vec!["qw[catfile catdir]"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "File::Spec");
-                assert!(args[0].starts_with("qw["));
-            }
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_curly_braces() {
-        // Tests feature spec: PR #262 - find_import_source with qw{} delimiters
-        let use_node = create_use_node("List::Util", vec!["qw{first max min}"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "List::Util");
-                assert!(args[0].starts_with("qw{"));
-            }
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_forward_slashes() {
-        // Tests feature spec: PR #262 - find_import_source with qw// delimiters
-        let use_node = create_use_node("Carp", vec!["qw/croak confess/"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "Carp");
-                assert!(args[0].starts_with("qw/"));
-            }
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_pipes() {
-        // Tests feature spec: PR #262 - find_import_source with qw|| delimiters
-        let use_node = create_use_node("Test::More", vec!["qw|ok is like|"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "Test::More");
-                assert!(args[0].starts_with("qw|"));
-            }
-        }
-    }
-
-    #[test]
-    fn test_import_source_qw_exclamations() {
-        // Tests feature spec: PR #262 - find_import_source with qw!! delimiters
-        let use_node = create_use_node("Scalar::Util", vec!["qw!blessed reftype!"]);
-        let program = create_program_with_uses(vec![use_node]);
-
-        if let NodeKind::Program { statements } = &program.kind {
-            if let NodeKind::Use { module, args } = &statements[0].kind {
-                assert_eq!(module, "Scalar::Util");
-                assert!(args[0].starts_with("qw!"));
+                panic!("Expected Program node for {}", module_name);
             }
         }
     }
@@ -340,7 +206,7 @@ package MyModule;
 
     #[test]
     fn test_import_source_multiple_modules() {
-        // Tests feature spec: PR #262 - Multiple use statements in same program
+        // Tests feature spec: PR #262 - Multiple use statements with mixed delimiters
         let uses = vec![
             create_use_node("Data::Dumper", vec!["qw<Dumper>"]),
             create_use_node("List::Util", vec!["qw(first max)"]),
@@ -349,7 +215,7 @@ package MyModule;
         let program = create_program_with_uses(uses);
 
         if let NodeKind::Program { statements } = &program.kind {
-            assert_eq!(statements.len(), 3);
+            assert_eq!(statements.len(), 3, "Expected 3 use statements");
         }
     }
 


### PR DESCRIPTION
## Cover Sheet (added 2026-01-07; original notes below)

- **Issue(s):** #144, #147
- **PR(s):** #260, #264
- **Exhibit ID:** `substitution-operator-correctness`

### What changed
- Fixed MUT_002: Empty replacement with balanced/mixed delimiters (`s{pattern}{}`, `s[pattern]{replacement}`)
- Fixed MUT_005: Invalid modifier characters silently accepted (`s/foo/bar/z`)
- Added `paired_closing()` helper, moved validation from lexer to parser layer

### Why
Mutation testing exposed logic flaws in substitution operator parsing that would have caused silent failures in production - mixed paired delimiters and invalid modifiers were incorrectly handled.

### Review map
- `crates/perl-lexer/src/lib.rs` - Modifier scanning (alphanumeric)
- `crates/perl-lexer/src/quote_handler.rs` - `paired_closing()` helper
- `crates/perl-parser/src/quote_parser.rs` - Strict validation
- `crates/perl-parser/tests/substitution_ac_tests.rs` - Regression tests

### Verification (receipts)
- MUT_002: KILLED (test_ac2_empty_replacement_balanced_delimiters enabled)
- MUT_005: KILLED (test_ac2_invalid_flag_combinations enabled)
- Ignored test baseline: bug=8 -> bug=4 (4 substitution bugs fixed)

### Known limits / follow-ups
- Remaining 4 ignored bugs tracked in IGNORED_TESTS_ROADMAP.md

### How to reproduce trust
```bash
cargo test -p perl-parser --test substitution_ac_tests
```

---

## Archived PR description

## Summary
- **Lexer now detects replacement delimiter independently** (fixes "swallowed trailing code" regression)
- **MUT_002 regression test is no longer ignored**
- Additional moniker export/import test coverage
- Formatting cleanup

## Changes
- Enhanced delimiter detection in `perl-lexer` for substitutions with mixed paired delimiters
- Tightened MUT_002 test cases with comprehensive trailing code validation
- Added moniker export/import tests clarifying coverage

## Verification
```bash
cargo test -p perl-lexer
cargo test -p perl-parser --test substitution_operator_tests
bash scripts/ignored-test-count.sh  # BUG=0, manual=1
```

## Related
- Follow-up to PR #263 (merged)
- Maintains BUG=0 baseline
