### PR TITLE
ci: add budget guardrails (concurrency + path filters) and local nix gate

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,9 +3,22 @@ name: Benchmarks
 on:
   push:
     branches: [ master, main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ master, main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   workflow_dispatch:
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/check-ignored.yml
+++ b/.github/workflows/check-ignored.yml
@@ -15,6 +15,11 @@ on:
       - 'ci/ignored_baseline.txt'
       - 'ci/check_ignored.sh'
 
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-ignored:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-expensive.yml
+++ b/.github/workflows/ci-expensive.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
 
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [ ci-pilot/** ]
 
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/comprehensive_tests.yml
+++ b/.github/workflows/comprehensive_tests.yml
@@ -3,8 +3,21 @@ name: Comprehensive Test Suite
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -3,6 +3,11 @@ name: docs-truth
 on:
   pull_request:
 
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-docs:
     if: |

--- a/.github/workflows/lsp-tests.yml
+++ b/.github/workflows/lsp-tests.yml
@@ -15,6 +15,11 @@ on:
       - 'crates/perl-lexer/**'
       - 'crates/perl-lsp/**'
 
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full

--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -3,11 +3,24 @@ name: Property Tests
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   schedule:
     # Run nightly at 3 AM UTC
     - cron: '0 3 * * *'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   property-tests-standard:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -3,8 +3,21 @@ name: Quality Checks
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,8 +3,21 @@ name: Rust CI
 on:
   push:
     branches: [ main, develop, rust-conversion ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main, develop, rust-conversion ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-strict.yml
+++ b/.github/workflows/rust-strict.yml
@@ -3,8 +3,21 @@ name: Rust Strict Quality Checks
 on:
   push:
     branches: [ master, main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ master, main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -123,15 +136,15 @@ jobs:
     - name: Dependency Security Check
       run: cargo deny check
 
-  - name: Assert lockfile unchanged
-    if: ${{ always() }}
-    shell: bash
-    run: |
-      if ! git diff --quiet -- Cargo.lock; then
-        echo "::error::Cargo.lock changed during this job. Run 'cargo update' locally and commit the result."
-        git --no-pager diff -- Cargo.lock | sed -n '1,200p'
-        exit 1
-      fi
+    - name: Assert lockfile unchanged
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if ! git diff --quiet -- Cargo.lock; then
+          echo "::error::Cargo.lock changed during this job. Run 'cargo update' locally and commit the result."
+          git --no-pager diff -- Cargo.lock | sed -n '1,200p'
+          exit 1
+        fi
 
   # Optional: Semver checks for published crates
   semver:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,21 @@ name: Rust CI
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,21 @@ name: Tests
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+
+# Cancel in-flight runs on new pushes (saves minutes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/CI_TEST_LANES.md
+++ b/docs/CI_TEST_LANES.md
@@ -1,0 +1,197 @@
+# CI Test Lanes
+
+This document describes the test lane architecture for the Perl LSP project. Understanding these lanes is critical for maintaining CI budget discipline.
+
+## Quick Reference
+
+| Lane | Feature Flag | Default | Purpose |
+|------|-------------|---------|---------|
+| Core | (none) | ✅ PR | Fast, essential tests |
+| LSP | (none) | ✅ PR | LSP integration tests |
+| Stress | `stress-tests` | ❌ Label | Long-running stability tests |
+| Extras | `lsp-extras` | ❌ Label | Optional LSP features |
+| Security | `stress-tests` | ❌ Label | Security edge cases (can hang) |
+
+## Local-First Workflow
+
+**IMPORTANT**: CI should be a confirmation step, not your iteration loop.
+
+### Before Any Push
+
+```bash
+# Fast merge gate (~2-5 min) - REQUIRED
+just ci-gate
+
+# Full CI pipeline (~10-20 min) - RECOMMENDED for large changes
+just ci-full
+
+# Nix users (deterministic, reproducible)
+nix flake check -L
+```
+
+### What `just ci-gate` Runs
+
+1. `cargo fmt --check --all` - Format check
+2. `cargo clippy --workspace --lib --locked -- -D warnings -A missing_docs` - Lint
+3. `cargo test --workspace --lib --locked` - Library tests
+4. `.ci/scripts/check-from-raw.sh` - Policy checks
+5. LSP semantic definition tests
+
+### What `just ci-full` Adds
+
+1. Full clippy (all targets)
+2. Core tests (lib + bins)
+3. LSP integration tests (thread-constrained)
+4. Documentation build
+
+## Test Lane Details
+
+### Core Lane (Default)
+
+**Runs on**: Every PR
+**Command**: `cargo test --workspace --lib --locked`
+
+Fast, essential tests that must always pass. This is the minimum bar for any merge.
+
+### LSP Lane (Default)
+
+**Runs on**: Every PR with code changes
+**Command**: `RUST_TEST_THREADS=2 cargo test -p perl-lsp --locked`
+
+LSP integration tests with adaptive threading. Uses thread constraints to prevent resource exhaustion on CI runners.
+
+### Stress Lane (Label-Gated)
+
+**Runs on**: PRs with `ci:stress` label
+**Command**: `cargo test -p perl-lsp --features stress-tests --locked`
+
+Long-running stability tests, memory pressure tests, and performance benchmarks. Gated because they can take 10+ minutes and burn CI minutes.
+
+Tests in this lane:
+- `lsp_stress_tests.rs`
+- `lsp_memory_pressure.rs`
+- `lsp_performance_benchmarks.rs`
+
+### Extras Lane (Label-Gated)
+
+**Runs on**: PRs with `ci:extras` label
+**Command**: `cargo test -p perl-lsp --features lsp-extras --locked`
+
+Optional LSP features that aren't part of the core protocol. These tests are informational.
+
+Tests in this lane:
+- `lsp_new_features_tests.rs`
+- `lsp_advanced_features_test.rs`
+
+### Security Lane (Label-Gated)
+
+**Runs on**: PRs with `ci:stress` label
+**Reason**: Some security tests can hang on malformed input
+
+Tests in this lane:
+- `lsp_security_edge_cases.rs`
+- `lsp_protocol_violations.rs`
+
+**Known Issue**: The test harness `read_response()` can block forever on malformed requests. Until we add `read_response_timeout()` handling, these tests are gated.
+
+## CI Budget Controls
+
+### Concurrency Cancellation
+
+All workflows now include:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+This means pushing 5 times only pays for the last run, not all 5.
+
+### Path Filters
+
+Most workflows exclude docs-only changes:
+
+```yaml
+paths-ignore:
+  - 'docs/**'
+  - '**/*.md'
+  - '.claude/**'
+```
+
+### Label-Gating
+
+Expensive jobs require explicit labels:
+
+- `ci:bench` - Performance benchmarks
+- `ci:coverage` - Code coverage analysis
+- `ci:mutation` - Mutation testing
+- `ci:semver` - API compatibility checks
+- `ci:strict` - Strict quality checks
+- `ci:stress` - Stress/security tests
+- `ci:extras` - Extra LSP features
+- `ci:all-tests` - Comprehensive test suite
+
+## Adding New Tests
+
+### Default Lane (Always Runs)
+
+Place test in the appropriate crate's `tests/` directory. No feature flag needed.
+
+```rust
+#[test]
+fn test_my_feature() {
+    // This runs on every PR
+}
+```
+
+### Gated Lane (Opt-In)
+
+Add feature flag to `Cargo.toml`:
+
+```toml
+[features]
+stress-tests = []
+```
+
+Guard your test:
+
+```rust
+#[test]
+#[cfg(feature = "stress-tests")]
+fn test_stress_scenario() {
+    // Only runs with ci:stress label
+}
+```
+
+## Troubleshooting
+
+### CI Hangs
+
+1. Check if test is in security/protocol lane
+2. Add explicit timeout: `read_response_timeout(server, Duration::from_secs(5))`
+3. Consider gating under `stress-tests` feature
+
+### CI Minutes Burning
+
+1. Check for missing `concurrency` block
+2. Check for missing `paths-ignore`
+3. Consider if test needs to be in default lane
+
+### Flaky Tests
+
+1. Use `RUST_TEST_THREADS=2` for LSP tests
+2. Use adaptive timeouts from `common/mod.rs`
+3. Consider moving to stress lane if inherently unstable
+
+## Workflow Reference
+
+| Workflow | Trigger | Lane |
+|----------|---------|------|
+| `ci.yml` | PR to master | Core + LSP |
+| `lsp-tests.yml` | Code changes | LSP (matrix) |
+| `test.yml` | Code changes | Core (matrix) |
+| `property-tests.yml` | Code changes | Property tests |
+| `ci-expensive.yml` | Labels | Bench, Mutation |
+| `quality-checks.yml` | Code changes | Quality gates |
+| `nightly.yml` | Schedule | Deep tests |

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767667566,
+        "narHash": "sha256-COy+yxZGuhQRVD1r4bWVgeFt1GB+IB1k5WRpDKbLfI8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "056ce5b125ab32ffe78c7d3e394d9da44733c95e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,167 @@
+{
+  description = "Perl LSP - Lightning-fast Language Server Protocol implementation for Perl";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        # Use Rust 1.89 (MSRV) from rust-overlay
+        rustToolchain = pkgs.rust-bin.stable."1.89.0".default.override {
+          extensions = [ "rust-src" "clippy" "rustfmt" ];
+        };
+
+        # Common build inputs
+        buildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          openssl
+        ] ++ lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+
+        nativeBuildInputs = with pkgs; [
+          just
+          cargo-nextest
+        ];
+
+      in {
+        # Development shell
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs;
+          nativeBuildInputs = nativeBuildInputs ++ [ rustToolchain ];
+
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+          shellHook = ''
+            echo "🦀 Perl LSP development environment"
+            echo "   Rust: $(rustc --version)"
+            echo ""
+            echo "Commands:"
+            echo "  just ci-gate      # Fast merge gate (~2-5 min)"
+            echo "  just ci-full      # Full CI pipeline (~10-20 min)"
+            echo "  nix flake check   # Run all checks"
+          '';
+        };
+
+        # Checks - the single source of truth before pushing
+        checks = {
+          # Format check (fast fail)
+          format = pkgs.runCommand "check-format" {
+            buildInputs = [ rustToolchain ];
+            src = self;
+          } ''
+            cd $src
+            cargo fmt --check --all
+            touch $out
+          '';
+
+          # Clippy lint (catches common issues)
+          clippy = pkgs.runCommand "check-clippy" {
+            buildInputs = buildInputs ++ [ rustToolchain ];
+            src = self;
+          } ''
+            cd $src
+            cargo clippy --workspace --lib --locked -- -D warnings -A missing_docs
+            touch $out
+          '';
+
+          # Library tests (fast, essential) - uses nextest for consistency with CI
+          test-lib = pkgs.runCommand "check-test-lib" {
+            buildInputs = buildInputs ++ [ rustToolchain pkgs.cargo-nextest ];
+            src = self;
+          } ''
+            cd $src
+            cargo nextest run --workspace --lib --locked --hide-progress-bar
+            touch $out
+          '';
+
+          # WASM32 determinism check
+          wasm-check = pkgs.runCommand "check-wasm" {
+            buildInputs = buildInputs ++ [
+              (rustToolchain.override { targets = [ "wasm32-unknown-unknown" ]; })
+            ];
+            src = self;
+          } ''
+            cd $src
+            RUSTFLAGS="-D warnings" cargo check --locked -p perl-parser --target wasm32-unknown-unknown
+            touch $out
+          '';
+
+          # LSP integration tests (thread-constrained, matches CI)
+          test-lsp = pkgs.runCommand "check-test-lsp" {
+            buildInputs = buildInputs ++ [ rustToolchain pkgs.cargo-nextest ];
+            src = self;
+            RUST_TEST_THREADS = "2";
+          } ''
+            cd $src
+            cargo nextest run -p perl-lsp --locked --hide-progress-bar --test-threads=2
+            touch $out
+          '';
+
+          # Policy checks (simplified for nix sandbox - no git available)
+          policy = pkgs.runCommand "check-policy" {
+            buildInputs = [ pkgs.bash pkgs.gnugrep pkgs.findutils ];
+            src = self;
+          } ''
+            cd $src
+            # Check for direct ExitStatus::from_raw() usage (without helper)
+            # This is the same policy as .ci/scripts/check-from-raw.sh but without git
+            viol=$(find crates xtask -name '*.rs' -exec grep -l 'ExitStatus::from_raw(' {} \; 2>/dev/null \
+              | xargs -r grep -nE 'ExitStatus::from_raw\(' 2>/dev/null \
+              | grep -Ev '::from_raw\([[:space:]]*raw[_ ]?exit[[:space:]]*\(' || true)
+            if [ -n "$viol" ]; then
+              echo "Policy violation: direct ExitStatus::from_raw() usage found:"
+              echo "$viol"
+              exit 1
+            fi
+            echo "✅ Policy check passed"
+            touch $out
+          '';
+        };
+
+        # Packages
+        packages = {
+          default = self.packages.${system}.perl-lsp;
+
+          perl-lsp = pkgs.rustPlatform.buildRustPackage {
+            pname = "perl-lsp";
+            version = "0.8.8";
+            src = self;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            inherit buildInputs;
+            nativeBuildInputs = with pkgs; [ pkg-config ];
+
+            buildAndTestSubdir = "crates/perl-lsp";
+
+            # Skip tests during package build (run via checks)
+            doCheck = false;
+
+            meta = with pkgs.lib; {
+              description = "Lightning-fast Perl LSP server";
+              homepage = "https://github.com/EffortlessMetrics/tree-sitter-perl-rs";
+              license = licenses.mit;
+              mainProgram = "perl-lsp";
+            };
+          };
+        };
+
+        # Apps
+        apps.default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.perl-lsp;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

This PR establishes CI budget discipline through three mechanisms:

### 1. Concurrency Cancellation
All 13 PR-triggered workflows now include:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
**Impact**: Pushing 5 times only pays for the last run, not all 5.

### 2. Path Filters  
Heavy workflows exclude docs-only changes via `paths-ignore`:
- benchmark.yml, comprehensive_tests.yml, property-tests.yml
- quality-checks.yml, rust-ci.yml, rust-strict.yml  
- rust.yml, test.yml

### 3. Nix Flake (Local Pre-Push Gate)
New `flake.nix` provides single-command validation:
```bash
nix flake check -L
```

**Checks included**:
- `format`: cargo fmt --check
- `clippy`: cargo clippy --workspace --lib --locked
- `test-lib`: cargo nextest run --workspace --lib --locked
- `test-lsp`: cargo nextest run -p perl-lsp --locked --test-threads=2
- `wasm-check`: cargo check -p perl-parser --target wasm32-unknown-unknown
- `policy`: ExitStatus::from_raw() usage validation

### 4. Documentation
Added `docs/CI_TEST_LANES.md` explaining:
- Test lane architecture (Core, LSP, Stress, Extras, Security)
- Local-first workflow with `just ci-gate` and `nix flake check`
- Budget controls and troubleshooting guidance

## Test plan

- [ ] Verify `nix flake check -L` passes locally
- [ ] Verify `just ci-gate` still works
- [ ] Confirm concurrency cancellation works by pushing twice quickly
- [ ] Confirm docs-only changes skip heavy workflows

Addresses Issue #211 (CI Pipeline Cleanup)