### PR TITLE
chore: add local-first guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,18 @@ RUST_TEST_THREADS=2 cargo test -p perl-lsp --test lsp_comprehensive_e2e_test -- 
 
 ### Development Workflow (Enhanced)
 
+**Local-First Development** - All gates run locally before CI:
+```bash
+# Canonical local gate (REQUIRED before push)
+nix develop -c just ci-gate
+
+# Install pre-push hook (runs gate automatically)
+bash scripts/install-githooks.sh
+
+# Gate checks: format, clippy, tests, policy, LSP semantic tests
+# Includes nested Cargo.lock detection (prevents subcrate footgun)
+```
+
 **Development Server** - Automatic LSP reload on file changes:
 ```bash
 # Start development server with file watching and hot-reload

--- a/justfile
+++ b/justfile
@@ -24,9 +24,20 @@ ci-full-msrv:
     @echo "🚀 Running full CI on MSRV (Rust 1.89)..."
     @RUSTUP_TOOLCHAIN=1.89.0 just ci-full
 
+# Check for nested Cargo.lock files (footgun prevention)
+ci-check-no-nested-lock:
+    @echo "🔒 Checking for nested Cargo.lock files..."
+    @if find . -name 'Cargo.lock' -type f 2>/dev/null | grep -v '^\./Cargo\.lock$' | grep -q .; then \
+        echo "❌ ERROR: Nested Cargo.lock detected! Run gates from repo root only."; \
+        find . -name 'Cargo.lock' -type f 2>/dev/null | grep -v '^\./Cargo\.lock$'; \
+        exit 1; \
+    fi
+    @echo "✅ No nested lockfiles"
+
 # Fast merge gate (~2-5 min) - REQUIRED for all merges
 ci-gate:
     @echo "🚪 Running fast merge gate..."
+    @just ci-check-no-nested-lock
     @just ci-format
     @just ci-clippy-lib
     @just ci-test-lib

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Install git hooks for perl-lsp development
+# Usage: bash scripts/install-githooks.sh
+set -euo pipefail
+
+mkdir -p .git/hooks
+
+cat > .git/hooks/pre-push <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🚪 Running local gate before push: nix develop -c just ci-gate"
+echo "   (Skip with: git push --no-verify)"
+echo ""
+
+# Try nix develop first, fall back to just alone
+if command -v nix &>/dev/null && [ -f flake.nix ]; then
+    nix develop -c just ci-gate
+elif command -v just &>/dev/null; then
+    just ci-gate
+else
+    echo "⚠️  Neither 'nix develop' nor 'just' available, skipping pre-push gate"
+    echo "   Install just: cargo install just"
+    exit 0
+fi
+EOF
+
+chmod +x .git/hooks/pre-push
+echo "✅ Installed pre-push hook"
+echo "   The hook runs 'nix develop -c just ci-gate' before each push"
+echo "   Skip with: git push --no-verify"


### PR DESCRIPTION
## Summary

Adds guardrails to prevent push-churn-debug cycles and the nested Cargo.lock footgun.

## Changes

- Add `ci-check-no-nested-lock` to `ci-gate` (prevents subcrate footgun)
- Add `scripts/install-githooks.sh` for pre-push hook installation
- Update CLAUDE.md with local-first workflow documentation

## What it prevents

The nested lockfile check fails fast if someone accidentally runs `cargo build` from a subcrate directory, creating a nested `Cargo.lock` that causes confusing dependency conflicts.

## Local receipts

- ✅ `just ci-check-no-nested-lock` (verified)
- ✅ Hook script works with both nix and standalone just