### PR TITLE
fix(vscode): improve context menu visibility for all Perl file types

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Context Menu Visibility for Dynamic File Types
+**Learning:** Using `resourceExtname` for menu `when` clauses excludes valid files (like `.t` tests or scripts without extensions) even if the language mode is correct.
+**Action:** Always prefer `editorLangId` over `resourceExtname` for language-specific commands to ensure availability across all files of that language type.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -195,12 +195,17 @@
       "editor/context": [
         {
           "command": "perl-lsp.extractSubroutine",
-          "when": "resourceExtname == .pl || resourceExtname == .pm",
+          "when": "editorLangId == perl",
           "group": "1_modification"
         },
         {
           "command": "perl-lsp.extractVariable",
-          "when": "resourceExtname == .pl || resourceExtname == .pm",
+          "when": "editorLangId == perl",
+          "group": "1_modification"
+        },
+        {
+          "command": "perl-lsp.inlineVariable",
+          "when": "editorLangId == perl",
           "group": "1_modification"
         }
       ]
@@ -209,7 +214,7 @@
       {
         "command": "perl-lsp.organizeImports",
         "key": "shift+alt+o",
-        "when": "editorTextFocus && resourceExtname == .pl"
+        "when": "editorTextFocus && editorLangId == perl"
       }
     ],
     "snippets": [


### PR DESCRIPTION
## Summary

Improves VS Code extension context menu visibility by switching from file extension matching to language ID detection. This ensures refactoring commands appear for:
- Standard `.pl` and `.pm` files
- Test files (`.t`)
- PSGI applications (`.psgi`)
- Perl scripts without extensions (shebanged files)

Also adds the existing `inlineVariable` command to the context menu (it was registered but not exposed).

### Changes

- **Context menu items**: Use `editorLangId == perl` instead of `resourceExtname == .pl || resourceExtname == .pm`
- **Keybindings**: Use `editorLangId == perl` for organize imports shortcut
- **New menu item**: Add `perl-lsp.inlineVariable` to context menu

---

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `master` @ `b1474bdf` |
| Head ref | `maint/pr-333-context-menu-20260119` @ `02f33d6b` |
| Commits | 1 |
| Files changed | 2 |
| Diffstat | `+11 / -3` |

**Start review here:** `vscode-extension/package.json`

### Blast Radius / Surface Area
- **Public API**: No
- **Protocol/IO boundary**: No
- **Config/flags**: Yes (VS Code menu `when` clauses)
- **Persistence/schema**: No
- **Concurrency**: No

This is a purely declarative change in package.json affecting VS Code menu visibility.

### Hotspot / Churn Context
- `vscode-extension/package.json`: Low churn, configuration file

### Verification Receipts

```bash
# JSON validity check
$ cd vscode-extension && node -e "require('./package.json'); console.log('JSON is valid')"
JSON is valid
```

**What wasn't run**: Full VS Code extension test suite (requires VS Code runtime). Manual testing recommended for context menu visibility.

### Risk + Rollback
- **Risk class**: Low
- **Rationale**: Declarative config change, no code logic
- **Rollback**: Revert commit

---

## Decision Log

1. **Kept `.jules/palette.md`**: Follows existing pattern (`.jules/sentinel.md` exists) for tracking learnings
2. **Used `editorLangId`**: This is the correct VS Code API for language-aware menus (per VS Code docs)
3. **Added `inlineVariable`**: Command was already registered but missing from context menu

---

Supersedes #333

Co-authored-by: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>