### PR TITLE
feat(semantic): add uninitialized variable detection and improve type inference

### DIFF
--- a/crates/perl-lsp-providers/src/ide/lsp_compat/diagnostics.rs
+++ b/crates/perl-lsp-providers/src/ide/lsp_compat/diagnostics.rs
@@ -258,7 +258,8 @@ impl DiagnosticsProvider {
                 IssueKind::VariableShadowing
                 | IssueKind::UnusedVariable
                 | IssueKind::ParameterShadowsGlobal
-                | IssueKind::UnusedParameter => DiagnosticSeverity::Warning,
+                | IssueKind::UnusedParameter
+                | IssueKind::UninitializedVariable => DiagnosticSeverity::Warning,
             };
 
             let code = match issue.kind {
@@ -270,6 +271,7 @@ impl DiagnosticsProvider {
                 IssueKind::ParameterShadowsGlobal => "parameter-shadows-global",
                 IssueKind::UnusedParameter => "unused-parameter",
                 IssueKind::UnquotedBareword => "unquoted-bareword",
+                IssueKind::UninitializedVariable => "uninitialized-variable",
             };
 
             diagnostics.push(Diagnostic {

--- a/crates/perl-parser/tests/scope_analysis_test.rs
+++ b/crates/perl-parser/tests/scope_analysis_test.rs
@@ -1,0 +1,123 @@
+use perl_parser::Parser;
+use perl_semantic_analyzer::analysis::scope_analyzer::{IssueKind, ScopeAnalyzer};
+use perl_semantic_analyzer::pragma_tracker::PragmaState;
+
+fn analyze(code: &str) -> Vec<perl_semantic_analyzer::analysis::scope_analyzer::ScopeIssue> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().unwrap();
+    let analyzer = ScopeAnalyzer::new();
+    let pragma_map = vec![]; // We can assume strict/warnings for tests if needed, or pass empty
+    analyzer.analyze(&ast, code, &pragma_map)
+}
+
+fn analyze_strict(code: &str) -> Vec<perl_semantic_analyzer::analysis::scope_analyzer::ScopeIssue> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().unwrap();
+    let analyzer = ScopeAnalyzer::new();
+
+    // Create a pragma map with strict enabled for the whole file
+    let pragma_map = vec![(
+        0..code.len(),
+        PragmaState { strict_refs: true, strict_subs: true, strict_vars: true, warnings: true },
+    )];
+
+    analyzer.analyze(&ast, code, &pragma_map)
+}
+
+#[test]
+fn test_use_before_definition_same_scope() {
+    let code = r#"
+        use strict;
+        print $x;
+        my $x = 10;
+    "#;
+
+    let issues = analyze_strict(code);
+
+    // We expect UndeclaredVariable because at the point of 'print $x', $x is not in scope
+    let undeclared =
+        issues.iter().find(|i| i.kind == IssueKind::UndeclaredVariable && i.variable_name == "$x");
+    assert!(undeclared.is_some(), "Should detect usage before definition as undeclared variable");
+}
+
+#[test]
+fn test_use_before_initialization() {
+    let code = r#"
+        use strict;
+        my $x;
+        print $x;
+    "#;
+
+    let issues = analyze_strict(code);
+
+    let uninitialized = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::UninitializedVariable && i.variable_name == "$x");
+    assert!(uninitialized.is_some(), "Should detect usage before initialization");
+}
+
+#[test]
+fn test_variable_shadowing() {
+    let code = r#"
+        my $x = 10;
+        {
+            my $x = 20;
+            print $x;
+        }
+    "#;
+
+    let issues = analyze(code);
+    let shadowing = issues.iter().find(|i| i.kind == IssueKind::VariableShadowing);
+    assert!(shadowing.is_some(), "Should detect shadowing");
+}
+
+#[test]
+fn test_variable_redeclaration_same_scope() {
+    let code = r#"
+        my $x = 10;
+        my $x = 20;
+    "#;
+
+    let issues = analyze(code);
+    let redecl = issues.iter().find(|i| i.kind == IssueKind::VariableRedeclaration);
+    assert!(redecl.is_some(), "Should detect redeclaration");
+}
+
+#[test]
+fn test_undeclared_assignment() {
+    let code = r#"
+        use strict;
+        $undeclared = 10;
+    "#;
+
+    let issues = analyze_strict(code);
+
+    let undeclared = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::UndeclaredVariable && i.variable_name == "$undeclared");
+    assert!(undeclared.is_some(), "Should detect assignment to undeclared variable");
+}
+
+#[test]
+fn test_list_assignment_initialization() {
+    let code = r#"
+        use strict;
+        my $x;
+        my $y;
+        ($x, $y) = (1, 2);
+        print $x;
+        print $y;
+    "#;
+
+    let issues = analyze_strict(code);
+
+    let uninit_x = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::UninitializedVariable && i.variable_name == "$x");
+    let uninit_y = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::UninitializedVariable && i.variable_name == "$y");
+
+    assert!(uninit_x.is_none(), "List assignment should initialize $x");
+    assert!(uninit_y.is_none(), "List assignment should initialize $y");
+}

--- a/crates/perl-parser/tests/type_inference_test.rs
+++ b/crates/perl-parser/tests/type_inference_test.rs
@@ -1,0 +1,77 @@
+use perl_parser::Parser;
+use perl_semantic_analyzer::analysis::type_inference::{PerlType, ScalarType, TypeInferenceEngine};
+
+fn infer(code: &str) -> TypeInferenceEngine {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().unwrap();
+    let mut engine = TypeInferenceEngine::new();
+    let _ = engine.infer(&ast);
+    engine
+}
+
+#[test]
+fn test_variable_assignment_propagation() {
+    let code = r#"
+        my $x = 42;
+        my $y = $x;
+    "#;
+    let engine = infer(code);
+    assert_eq!(engine.get_type_at("x"), Some(PerlType::Scalar(ScalarType::Integer)));
+    // Currently this might fail or return Any if propagation isn't fully implemented
+    assert_eq!(engine.get_type_at("y"), Some(PerlType::Scalar(ScalarType::Integer)));
+}
+
+#[test]
+fn test_return_type_inference() {
+    let code = r#"
+        sub get_int {
+            return 100;
+        }
+        my $x = get_int();
+    "#;
+    let engine = infer(code);
+
+    // Check subroutine return type
+    if let Some(PerlType::Subroutine { returns, .. }) = engine.get_subroutine("get_int") {
+        assert!(!returns.is_empty());
+        assert_eq!(returns[0], PerlType::Scalar(ScalarType::Integer));
+    } else {
+        panic!("Subroutine get_int not found or wrong type");
+    }
+
+    // Check variable assigned from function call
+    assert_eq!(engine.get_type_at("x"), Some(PerlType::Scalar(ScalarType::Integer)));
+}
+
+#[test]
+fn test_implicit_return_inference() {
+    let code = r#"
+        sub get_str {
+            "hello";
+        }
+    "#;
+    let engine = infer(code);
+
+    if let Some(PerlType::Subroutine { returns, .. }) = engine.get_subroutine("get_str") {
+        assert!(!returns.is_empty());
+        assert_eq!(returns[0], PerlType::Scalar(ScalarType::String));
+    } else {
+        panic!("Subroutine get_str not found");
+    }
+}
+
+#[test]
+fn test_control_flow_union() {
+    let code = r#"
+        my $x;
+        if (1) {
+            $x = 1;
+        } else {
+            $x = "string";
+        }
+    "#;
+    // This test is harder to assert on with current engine because it might just be Any
+    // But ideally it should be Union(Integer, String) or similar.
+    // For now, let's just see what happens.
+    let _engine = infer(code);
+}

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -55,6 +55,7 @@ pub enum IssueKind {
     ParameterShadowsGlobal,
     UnusedParameter,
     UnquotedBareword,
+    UninitializedVariable,
 }
 
 #[derive(Debug, Clone)]
@@ -72,6 +73,7 @@ struct Variable {
     line: usize,
     is_used: RefCell<bool>,
     is_our: bool,
+    is_initialized: RefCell<bool>,
 }
 
 #[derive(Debug)]
@@ -89,7 +91,13 @@ impl Scope {
         Self { variables: RefCell::new(HashMap::new()), parent: Some(parent) }
     }
 
-    fn declare_variable(&self, name: &str, line: usize, is_our: bool) -> Option<IssueKind> {
+    fn declare_variable(
+        &self,
+        name: &str,
+        line: usize,
+        is_our: bool,
+        is_initialized: bool,
+    ) -> Option<IssueKind> {
         // First check if already declared in this scope
         {
             let vars = self.variables.borrow();
@@ -114,6 +122,7 @@ impl Scope {
                 line,
                 is_used: RefCell::new(is_our), // 'our' variables are considered used
                 is_our,
+                is_initialized: RefCell::new(is_initialized),
             }),
         );
 
@@ -128,12 +137,18 @@ impl Scope {
             .or_else(|| self.parent.as_ref()?.lookup_variable(name))
     }
 
-    fn use_variable(&self, name: &str) -> bool {
+    fn use_variable(&self, name: &str) -> (bool, bool) {
         if let Some(var) = self.lookup_variable(name) {
             *var.is_used.borrow_mut() = true;
-            true
+            (true, *var.is_initialized.borrow())
         } else {
-            false
+            (false, false)
+        }
+    }
+
+    fn initialize_variable(&self, name: &str) {
+        if let Some(var) = self.lookup_variable(name) {
+            *var.is_initialized.borrow_mut() = true;
         }
     }
 
@@ -200,14 +215,26 @@ impl ScopeAnalyzer {
         let pragma_state = PragmaTracker::state_for_offset(pragma_map, node.location.start);
         let strict_mode = pragma_state.strict_subs;
         match &node.kind {
-            NodeKind::VariableDeclaration { declarator, variable, .. } => {
+            NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let var_name = self.extract_variable_name(variable);
                 let line = self.get_line_from_node(variable, code);
                 let is_our = declarator == "our";
+                let is_initialized = initializer.is_some();
 
-                if let Some(issue_kind) =
-                    scope.declare_variable(&var_name, variable.location.start, is_our)
-                {
+                // If checking initializer first (e.g. my $x = $x), we need to analyze initializer in
+                // current scope BEFORE declaring the variable (standard Perl behavior)
+                // Actually Perl evaluates RHS before LHS assignment, so usages in initializer refer to OUTER scope.
+                // So we analyze initializer first.
+                if let Some(init) = initializer {
+                    self.analyze_node(init, scope, parent_map, issues, code, pragma_map);
+                }
+
+                if let Some(issue_kind) = scope.declare_variable(
+                    &var_name,
+                    variable.location.start,
+                    is_our,
+                    is_initialized,
+                ) {
                     issues.push(ScopeIssue {
                         kind: issue_kind,
                         variable_name: var_name.clone(),
@@ -226,15 +253,25 @@ impl ScopeAnalyzer {
                 }
             }
 
-            NodeKind::VariableListDeclaration { declarator, variables, .. } => {
+            NodeKind::VariableListDeclaration { declarator, variables, initializer, .. } => {
                 let is_our = declarator == "our";
+                let is_initialized = initializer.is_some();
+
+                // Analyze initializer first
+                if let Some(init) = initializer {
+                    self.analyze_node(init, scope, parent_map, issues, code, pragma_map);
+                }
+
                 for variable in variables {
                     let var_name = self.extract_variable_name(variable);
                     let line = self.get_line_from_node(variable, code);
 
-                    if let Some(issue_kind) =
-                        scope.declare_variable(&var_name, variable.location.start, is_our)
-                    {
+                    if let Some(issue_kind) = scope.declare_variable(
+                        &var_name,
+                        variable.location.start,
+                        is_our,
+                        is_initialized,
+                    ) {
                         issues.push(ScopeIssue {
                             kind: issue_kind,
                             variable_name: var_name.clone(),
@@ -274,7 +311,12 @@ impl ScopeAnalyzer {
                                         || var_name.starts_with('%'))
                                 {
                                     // Declare these variables as globals in the current scope
-                                    scope.declare_variable(var_name, node.location.start, true); // true = is_our (global)
+                                    scope.declare_variable(
+                                        var_name,
+                                        node.location.start,
+                                        true,
+                                        true,
+                                    ); // true = is_our (global), true = initialized (assumed)
                                 }
                             }
                         } else {
@@ -285,7 +327,7 @@ impl ScopeAnalyzer {
                                     || var_name.starts_with('@')
                                     || var_name.starts_with('%'))
                             {
-                                scope.declare_variable(var_name, node.location.start, true);
+                                scope.declare_variable(var_name, node.location.start, true, true);
                             }
                         }
                     }
@@ -305,7 +347,7 @@ impl ScopeAnalyzer {
                 }
 
                 // Try to use the variable
-                let mut variable_used = scope.use_variable(&full_name);
+                let (mut variable_used, mut is_initialized) = scope.use_variable(&full_name);
 
                 // If not found as simple variable, check if this is part of a hash/array access pattern
                 if !variable_used && sigil == "$" {
@@ -313,24 +355,58 @@ impl ScopeAnalyzer {
                     let hash_name = format!("%{}", name);
                     let array_name = format!("@{}", name);
 
-                    if scope.lookup_variable(&hash_name).is_some()
-                        || scope.lookup_variable(&array_name).is_some()
-                    {
-                        // This is likely part of a hash/array access pattern, don't flag as undefined
+                    let (hash_used, hash_init) = scope.use_variable(&hash_name);
+                    let (array_used, array_init) = scope.use_variable(&array_name);
+
+                    if hash_used || array_used {
                         variable_used = true;
+                        is_initialized = hash_init || array_init;
                     }
                 }
 
                 // Variable not found - check if we should report it
-                if !variable_used && strict_mode {
+                if !variable_used {
+                    if strict_mode {
+                        issues.push(ScopeIssue {
+                            kind: IssueKind::UndeclaredVariable,
+                            variable_name: full_name.clone(),
+                            line: self.get_line_from_node(node, code),
+                            range: (node.location.start, node.location.end),
+                            description: format!(
+                                "Variable '{}' is used but not declared",
+                                full_name
+                            ),
+                        });
+                    }
+                } else if !is_initialized {
+                    // Variable found but used before initialization
+                    // Note: This check is rudimentary and doesn't account for flow control
+                    // It only catches: my $x; print $x;
                     issues.push(ScopeIssue {
-                        kind: IssueKind::UndeclaredVariable,
+                        kind: IssueKind::UninitializedVariable,
                         variable_name: full_name.clone(),
                         line: self.get_line_from_node(node, code),
                         range: (node.location.start, node.location.end),
-                        description: format!("Variable '{}' is used but not declared", full_name),
+                        description: format!(
+                            "Variable '{}' is used before being initialized",
+                            full_name
+                        ),
                     });
                 }
+            }
+            NodeKind::Assignment { lhs, rhs, op: _ } => {
+                // Handle assignment: LHS variable becomes initialized
+                // First analyze RHS (usages)
+                self.analyze_node(rhs, scope, parent_map, issues, code, pragma_map);
+
+                // Then analyze LHS
+                // We need to recursively mark variables as initialized in the LHS structure
+                // This handles scalars ($x = 1) and lists (($x, $y) = (1, 2))
+                self.mark_initialized(lhs, scope);
+
+                // Recurse into LHS to trigger UndeclaredVariable checks
+                // Note: 'use_variable' marks as used, which is technically correct for assignment too (write usage)
+                self.analyze_node(lhs, scope, parent_map, issues, code, pragma_map);
             }
 
             NodeKind::Identifier { name } => {
@@ -479,7 +555,7 @@ impl ScopeAnalyzer {
                         }
 
                         // Declare the parameter in subroutine scope
-                        sub_scope.declare_variable(&full_name, param.location.start, false);
+                        sub_scope.declare_variable(&full_name, param.location.start, false, true); // Parameters are initialized
                         // Don't mark parameters as automatically used yet - track their actual usage
                     }
                 }
@@ -530,6 +606,44 @@ impl ScopeAnalyzer {
                 // Recursively analyze children
                 for child in node.children() {
                     self.analyze_node(child, scope, parent_map, issues, code, pragma_map);
+                }
+            }
+        }
+    }
+
+    fn mark_initialized(&self, node: &Node, scope: &Rc<Scope>) {
+        match &node.kind {
+            NodeKind::Variable { sigil, name } => {
+                let full_name = format!("{}{}", sigil, name);
+                if !full_name.contains("::") {
+                    scope.initialize_variable(&full_name);
+                }
+            }
+            NodeKind::VariableListDeclaration { variables, .. } => {
+                for variable in variables {
+                    self.mark_initialized(variable, scope);
+                }
+            }
+            NodeKind::ArrayLiteral { elements } => {
+                for element in elements {
+                    self.mark_initialized(element, scope);
+                }
+            }
+            NodeKind::HashLiteral { pairs } => {
+                for (key, value) in pairs {
+                    self.mark_initialized(key, scope);
+                    self.mark_initialized(value, scope);
+                }
+            }
+            NodeKind::ExpressionStatement { expression } => {
+                self.mark_initialized(expression, scope);
+            }
+            // Add other nodes that can appear on LHS if needed
+            _ => {
+                // For other nodes, we might need to recurse if they can contain assignable variables
+                // e.g. parens, etc. But for now this covers common cases.
+                for child in node.children() {
+                    self.mark_initialized(child, scope);
                 }
             }
         }
@@ -728,6 +842,9 @@ impl ScopeAnalyzer {
                 }
                 IssueKind::UnquotedBareword => {
                     format!("Quote bareword '{}' or declare as filehandle", issue.variable_name)
+                }
+                IssueKind::UninitializedVariable => {
+                    format!("Initialize '{}' before use", issue.variable_name)
                 }
             })
             .collect()

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -236,7 +236,34 @@ impl TypeInferenceEngine {
 
     /// Infer types for an AST
     pub fn infer(&mut self, ast: &Node) -> Result<PerlType, Vec<TypeConstraint>> {
-        let ty = self.infer_node(ast, &mut self.global_env.clone())?;
+        // We need to use a temporary environment that has global_env as parent,
+        // or just use global_env directly if we want to persist top-level declarations?
+        // Usually top-level declarations should persist.
+        // But we can't borrow self.global_env mutably and also self methods easily if they need self.
+        // infer_node takes &mut self and &mut env.
+
+        // Let's create a temporary scope that is a child of the current global env,
+        // OR just use global_env if we want top-level effects (like subs) to be visible.
+        // But wait, `infer_node` modifies `env`. If we pass a clone, modifications are lost.
+        // We WANT modifications to persist for the duration of `infer` call, but do we want them in `self.global_env`?
+        // Yes, if we want to query them later via `get_subroutine`.
+
+        // However, `infer_node` calls `self.infer_node` recursively.
+        // Let's avoid cloning `global_env` inside `infer`.
+
+        // To satisfy borrow checker (if we pass &mut self.global_env to self.infer_node),
+        // we might have issues. `infer_node` takes `&mut self`.
+        // So `self` is borrowed mutably. We can't pass a reference to a field of `self`.
+
+        // Solution: Temporarily take `global_env` out of `self`, use it, then put it back?
+        // Or change `infer_node` signature?
+
+        // For now, let's just make `infer` work by swapping.
+        let mut env = std::mem::take(&mut self.global_env);
+        let result = self.infer_node(ast, &mut env);
+        self.global_env = env;
+
+        let ty = result?;
 
         // Check constraints
         if !self.constraints.is_empty() {
@@ -272,6 +299,9 @@ impl TypeInferenceEngine {
                 }
                 Ok(last_type)
             }
+
+            // Handle expression statements by returning the type of the expression
+            NodeKind::ExpressionStatement { expression } => self.infer_node(expression, env),
 
             NodeKind::Number { value } => {
                 if value.contains('.') || value.contains('e') || value.contains('E') {
@@ -455,6 +485,22 @@ impl TypeInferenceEngine {
                 let param_types = vec![Any];
 
                 // Infer return type from body
+                // In Perl, the return value is the value of the last statement
+                // or explicit return statement.
+                // Our `infer_node` for Block already returns the type of the last statement.
+                // We should also scan for `Return` nodes, but for now we just use the block result
+                // which handles the implicit return of the last statement.
+                // Note: explicit returns inside control flow (if/else) are tricky to unify without
+                // a full control flow graph, but `infer_node` recurses so it should pick up types.
+                // Wait, `infer_node` for `Program`/`Block` returns the type of the *last* statement.
+                // It does NOT unify types from intermediate `return` statements.
+
+                // For better accuracy, we should probably scan the body for `Return` nodes?
+                // But `infer_node(body)` calls `infer_node` recursively.
+                // If we want to support explicit returns not at the end, we need to handle `Return` node
+                // to return a special type or track returns in `TypeInferenceEngine`.
+
+                // For now, let's trust `infer_node(body)` to return the implicit return type of the block.
                 let return_type = self.infer_node(body, &mut sub_env)?;
 
                 let sub_type = Subroutine { params: param_types, returns: vec![return_type] };
@@ -749,6 +795,11 @@ impl TypeInferenceEngine {
     /// Gets the inferred type for a variable by name
     pub fn get_type_at(&self, name: &str) -> Option<PerlType> {
         self.global_env.get_variable(name).cloned()
+    }
+
+    /// Gets the inferred type signature for a subroutine
+    pub fn get_subroutine(&self, name: &str) -> Option<PerlType> {
+        self.global_env.get_subroutine(name).cloned()
     }
 
     /// Returns all type constraint violations as errors


### PR DESCRIPTION
## Summary

Implements enhanced semantic analysis (Phase 2-3) for the Perl LSP:

- **UninitializedVariable detection** - Tracks variable initialization status and reports usage before initialization
- **Improved type inference** - Assignment propagation, implicit return inference, and ExpressionStatement handling
- **LSP integration** - UninitializedVariable diagnostic with Warning severity

Supersedes: #301

## Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `master` @ `8115acba` |
| Head ref | `maint/pr-301-semantic-analyzer-phase2-20260120` @ `0cc85125` |
| Files changed | 5 |
| Lines added | +396 |
| Lines removed | -26 |
| Commits | 1 (squashed) |

**Files (start review here):**
1. `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` (+165/-23) - Core initialization tracking
2. `crates/perl-semantic-analyzer/src/analysis/type_inference.rs` (+53/-1) - Type propagation improvements
3. `crates/perl-lsp-providers/src/ide/lsp_compat/diagnostics.rs` (+4/-1) - LSP integration
4. `crates/perl-parser/tests/scope_analysis_test.rs` (+123 new) - Scope analysis tests
5. `crates/perl-parser/tests/type_inference_test.rs` (+77 new) - Type inference tests

## Blast Radius / Surface Area

| Category | Impact |
|----------|--------|
| Public API | ✅ Yes - `get_subroutine()` added to TypeInferenceEngine |
| Protocol/IO | ✅ Yes - New diagnostic code `uninitialized-variable` |
| Persistence/Schema | ❌ No |
| Concurrency | ❌ No |
| Config/Flags | ❌ No |

## Verification Receipts

```bash
# Format check
$ cargo fmt --all -- --check
✅ PASS (after auto-formatting)

# Clippy
$ cargo clippy --workspace --lib -- -D warnings
✅ PASS

# Semantic analyzer tests
$ cargo test -p perl-semantic-analyzer
✅ 22 passed

# New scope analysis tests
$ cargo test -p perl-parser --test scope_analysis_test
✅ 6 passed

# New type inference tests
$ cargo test -p perl-parser --test type_inference_test
✅ 4 passed

# LSP providers tests
$ cargo test -p perl-lsp-providers
✅ 56 passed

# Workspace build
$ cargo build --workspace
✅ PASS
```

## Risk + Rollback

**Risk class:** Low

- Changes are additive (new diagnostic type, new API method)
- Scope analyzer changes are well-encapsulated
- Existing tests continue to pass
- New functionality has dedicated test coverage

**Rollback:** Revert this commit

## Decision Log

1. **Cherry-pick conflict resolution** - HEAD had a `range` field in ScopeIssue struct (added in recent master). Merged by keeping the `range` field while using the correct description message from the Jules PR.

2. **Squashed commits** - Original PR had 2 duplicate commits with same message. Squashed into single clean commit for cleaner history.

3. **Formatting fixes** - Applied `cargo fmt` to match project style guidelines.

## Test Plan

- [x] Verify UninitializedVariable detection works: `my $x; print $x;` → warning
- [x] Verify list assignment initialization: `($x, $y) = (1, 2)` initializes both
- [x] Verify type propagation: `my $y = $x` inherits type from `$x`
- [x] Verify implicit return inference for subroutines
- [x] All existing tests pass