### PR TITLE
perf: Cache built-in function signatures with OnceLock

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,11 @@
+# Bolt's Journal
+
+This journal tracks critical performance learnings for the `tree-sitter-perl-rs` repository.
+
 ## 2026-01-21 - [Allocation in Hot Path Analysis]
 **Learning:** `format!` in recursive AST traversal (like `ScopeAnalyzer`) causes significant memory churn. Checking properties of composite values (like variable sigil + name) should be done on components before allocation.
 **Action:** When filtering or checking nodes in hot paths, pass references to components (`&str`, `&str`) instead of constructing owned `String`s just for the check.
+
+## 2024-05-22 - [Initial Setup]
+**Learning:** Performance benchmarks are available in `crates/perl-parser/benches/`. The `ast_to_sexp` benchmark currently emits many parse errors, which might noise up the results.
+**Action:** When running benchmarks, ensure valid input or filter out known noisy benchmarks if they obscure the target optimization.

--- a/crates/perl-lsp-providers/src/ide/lsp_compat/signature_help.rs
+++ b/crates/perl-lsp-providers/src/ide/lsp_compat/signature_help.rs
@@ -47,7 +47,7 @@ pub struct SignatureHelp {
 pub struct SignatureHelpProvider {
     ast: Node,
     symbol_table: SymbolTable,
-    builtin_signatures: HashMap<&'static str, ImportedBuiltinSignature>,
+    builtin_signatures: &'static HashMap<&'static str, ImportedBuiltinSignature>,
 }
 
 impl SignatureHelpProvider {

--- a/crates/perl-parser-core/src/builtins/builtin_signatures.rs
+++ b/crates/perl-parser-core/src/builtins/builtin_signatures.rs
@@ -14,6 +14,7 @@
 //! - **Index**: Powers search and matching operations with regex functions
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 /// Built-in function signature with documentation for Perl script development
 ///
@@ -26,1142 +27,1169 @@ pub struct BuiltinSignature {
     pub documentation: &'static str,
 }
 
+static SIGNATURES_CACHE: OnceLock<HashMap<&'static str, BuiltinSignature>> = OnceLock::new();
+
 /// Create comprehensive built-in function signatures
-pub fn create_builtin_signatures() -> HashMap<&'static str, BuiltinSignature> {
-    let mut signatures = HashMap::new();
-
-    // ===== I/O Functions =====
-    signatures.insert(
-        "print",
-        BuiltinSignature {
-            signatures: vec!["print FILEHANDLE LIST", "print FILEHANDLE", "print LIST", "print"],
-            documentation: "Prints a string or list of strings to a filehandle",
-        },
-    );
-
-    signatures.insert(
-        "printf",
-        BuiltinSignature {
-            signatures: vec!["printf FILEHANDLE FORMAT, LIST", "printf FORMAT, LIST"],
-            documentation: "Prints a formatted string",
-        },
-    );
-
-    signatures.insert(
-        "say",
-        BuiltinSignature {
-            signatures: vec!["say FILEHANDLE LIST", "say FILEHANDLE", "say LIST", "say"],
-            documentation: "Prints with a newline",
-        },
-    );
-
-    signatures.insert(
-        "open",
-        BuiltinSignature {
-            signatures: vec![
-                "open FILEHANDLE, MODE, FILENAME",
-                "open FILEHANDLE, EXPR",
-                "open FILEHANDLE",
-            ],
-            documentation: "Opens a file",
-        },
-    );
-
-    signatures.insert(
-        "close",
-        BuiltinSignature {
-            signatures: vec!["close FILEHANDLE", "close"],
-            documentation: "Closes a filehandle",
-        },
-    );
-
-    signatures.insert(
-        "read",
-        BuiltinSignature {
-            signatures: vec![
-                "read FILEHANDLE, SCALAR, LENGTH, OFFSET",
-                "read FILEHANDLE, SCALAR, LENGTH",
-            ],
-            documentation: "Reads from a filehandle into a scalar",
-        },
-    );
-
-    signatures.insert(
-        "sysread",
-        BuiltinSignature {
-            signatures: vec![
-                "sysread FILEHANDLE, SCALAR, LENGTH, OFFSET",
-                "sysread FILEHANDLE, SCALAR, LENGTH",
-            ],
-            documentation: "Reads from a filehandle bypassing stdio",
-        },
-    );
-
-    signatures.insert(
-        "write",
-        BuiltinSignature {
-            signatures: vec!["write FILEHANDLE", "write"],
-            documentation: "Writes a formatted record",
-        },
-    );
-
-    signatures.insert(
-        "syswrite",
-        BuiltinSignature {
-            signatures: vec![
-                "syswrite FILEHANDLE, SCALAR, LENGTH, OFFSET",
-                "syswrite FILEHANDLE, SCALAR, LENGTH",
-                "syswrite FILEHANDLE, SCALAR",
-            ],
-            documentation: "Writes to a filehandle bypassing stdio",
-        },
-    );
-
-    signatures.insert(
-        "seek",
-        BuiltinSignature {
-            signatures: vec!["seek FILEHANDLE, POSITION, WHENCE"],
-            documentation: "Sets file pointer position",
-        },
-    );
-
-    signatures.insert(
-        "tell",
-        BuiltinSignature {
-            signatures: vec!["tell FILEHANDLE", "tell"],
-            documentation: "Returns current file position",
-        },
-    );
-
-    signatures.insert(
-        "eof",
-        BuiltinSignature {
-            signatures: vec!["eof FILEHANDLE", "eof"],
-            documentation: "Tests for end of file",
-        },
-    );
-
-    // ===== String Functions =====
-    signatures.insert(
-        "chomp",
-        BuiltinSignature {
-            signatures: vec!["chomp VARIABLE", "chomp LIST", "chomp"],
-            documentation: "Removes trailing newline from string",
-        },
-    );
-
-    signatures.insert(
-        "chop",
-        BuiltinSignature {
-            signatures: vec!["chop VARIABLE", "chop LIST", "chop"],
-            documentation: "Removes last character from string",
-        },
-    );
-
-    signatures.insert(
-        "chr",
-        BuiltinSignature {
-            signatures: vec!["chr NUMBER", "chr"],
-            documentation: "Returns character for a number",
-        },
-    );
-
-    signatures.insert(
-        "ord",
-        BuiltinSignature {
-            signatures: vec!["ord EXPR", "ord"],
-            documentation: "Returns numeric value of character",
-        },
-    );
-
-    signatures.insert(
-        "hex",
-        BuiltinSignature {
-            signatures: vec!["hex EXPR", "hex"],
-            documentation: "Converts hex string to number",
-        },
-    );
-
-    signatures.insert(
-        "oct",
-        BuiltinSignature {
-            signatures: vec!["oct EXPR", "oct"],
-            documentation: "Converts octal string to number",
-        },
-    );
-
-    signatures.insert(
-        "length",
-        BuiltinSignature {
-            signatures: vec!["length EXPR", "length"],
-            documentation: "Returns length of string",
-        },
-    );
-
-    signatures.insert(
-        "substr",
-        BuiltinSignature {
-            signatures: vec![
-                "substr EXPR, OFFSET, LENGTH, REPLACEMENT",
-                "substr EXPR, OFFSET, LENGTH",
-                "substr EXPR, OFFSET",
-            ],
-            documentation: "Extracts or replaces substring",
-        },
-    );
-
-    signatures.insert(
-        "index",
-        BuiltinSignature {
-            signatures: vec!["index STR, SUBSTR, POSITION", "index STR, SUBSTR"],
-            documentation: "Finds position of substring",
-        },
-    );
-
-    signatures.insert(
-        "rindex",
-        BuiltinSignature {
-            signatures: vec!["rindex STR, SUBSTR, POSITION", "rindex STR, SUBSTR"],
-            documentation: "Finds position of substring from end",
-        },
-    );
-
-    signatures.insert(
-        "sprintf",
-        BuiltinSignature {
-            signatures: vec!["sprintf FORMAT, LIST"],
-            documentation: "Returns formatted string",
-        },
-    );
-
-    signatures.insert(
-        "lc",
-        BuiltinSignature {
-            signatures: vec!["lc EXPR", "lc"],
-            documentation: "Returns lowercase version",
-        },
-    );
-
-    signatures.insert(
-        "lcfirst",
-        BuiltinSignature {
-            signatures: vec!["lcfirst EXPR", "lcfirst"],
-            documentation: "Returns string with first char lowercase",
-        },
-    );
-
-    signatures.insert(
-        "uc",
-        BuiltinSignature {
-            signatures: vec!["uc EXPR", "uc"],
-            documentation: "Returns uppercase version",
-        },
-    );
-
-    signatures.insert(
-        "ucfirst",
-        BuiltinSignature {
-            signatures: vec!["ucfirst EXPR", "ucfirst"],
-            documentation: "Returns string with first char uppercase",
-        },
-    );
-
-    signatures.insert(
-        "quotemeta",
-        BuiltinSignature {
-            signatures: vec!["quotemeta EXPR", "quotemeta"],
-            documentation: "Quotes metacharacters",
-        },
-    );
-
-    signatures.insert(
-        "split",
-        BuiltinSignature {
-            signatures: vec![
-                "split /PATTERN/, EXPR, LIMIT",
-                "split /PATTERN/, EXPR",
-                "split /PATTERN/",
-                "split",
-            ],
-            documentation: "Splits string into list",
-        },
-    );
-
-    signatures.insert(
-        "join",
-        BuiltinSignature {
-            signatures: vec!["join EXPR, LIST"],
-            documentation: "Joins list into string",
-        },
-    );
-
-    signatures.insert(
-        "reverse",
-        BuiltinSignature {
-            signatures: vec!["reverse LIST"],
-            documentation: "Reverses list or string",
-        },
-    );
-
-    // ===== Array Functions =====
-    signatures.insert(
-        "push",
-        BuiltinSignature {
-            signatures: vec!["push ARRAY, LIST"],
-            documentation: "Appends values to array",
-        },
-    );
-
-    signatures.insert(
-        "pop",
-        BuiltinSignature {
-            signatures: vec!["pop ARRAY", "pop"],
-            documentation: "Removes and returns last element",
-        },
-    );
-
-    signatures.insert(
-        "shift",
-        BuiltinSignature {
-            signatures: vec!["shift ARRAY", "shift"],
-            documentation: "Removes and returns first element",
-        },
-    );
-
-    signatures.insert(
-        "unshift",
-        BuiltinSignature {
-            signatures: vec!["unshift ARRAY, LIST"],
-            documentation: "Prepends values to array",
-        },
-    );
-
-    signatures.insert(
-        "splice",
-        BuiltinSignature {
-            signatures: vec![
-                "splice ARRAY, OFFSET, LENGTH, LIST",
-                "splice ARRAY, OFFSET, LENGTH",
-                "splice ARRAY, OFFSET",
-                "splice ARRAY",
-            ],
-            documentation: "Removes and replaces array elements",
-        },
-    );
-
-    signatures.insert(
-        "map",
-        BuiltinSignature {
-            signatures: vec!["map BLOCK LIST", "map EXPR, LIST"],
-            documentation: "Transforms a list",
-        },
-    );
-
-    signatures.insert(
-        "grep",
-        BuiltinSignature {
-            signatures: vec!["grep BLOCK LIST", "grep EXPR, LIST"],
-            documentation: "Filters a list",
-        },
-    );
-
-    signatures.insert(
-        "sort",
-        BuiltinSignature {
-            signatures: vec!["sort BLOCK LIST", "sort SUBNAME LIST", "sort LIST"],
-            documentation: "Sorts a list",
-        },
-    );
-
-    // ===== Hash Functions =====
-    signatures.insert(
-        "each",
-        BuiltinSignature {
-            signatures: vec!["each HASH", "each ARRAY"],
-            documentation: "Returns key-value pair",
-        },
-    );
-
-    signatures.insert(
-        "keys",
-        BuiltinSignature {
-            signatures: vec!["keys HASH", "keys ARRAY"],
-            documentation: "Returns list of keys",
-        },
-    );
-
-    signatures.insert(
-        "values",
-        BuiltinSignature {
-            signatures: vec!["values HASH", "values ARRAY"],
-            documentation: "Returns list of values",
-        },
-    );
-
-    signatures.insert(
-        "exists",
-        BuiltinSignature {
-            signatures: vec!["exists EXPR"],
-            documentation: "Tests whether key exists",
-        },
-    );
-
-    signatures.insert(
-        "delete",
-        BuiltinSignature { signatures: vec!["delete EXPR"], documentation: "Deletes hash element" },
-    );
-
-    // ===== File Test Operators =====
-    signatures.insert(
-        "stat",
-        BuiltinSignature {
-            signatures: vec!["stat FILEHANDLE", "stat EXPR", "stat"],
-            documentation: "Returns file statistics",
-        },
-    );
-
-    signatures.insert(
-        "lstat",
-        BuiltinSignature {
-            signatures: vec!["lstat FILEHANDLE", "lstat EXPR", "lstat"],
-            documentation: "Returns symbolic link statistics",
-        },
-    );
-
-    // ===== Directory Functions =====
-    signatures.insert(
-        "opendir",
-        BuiltinSignature {
-            signatures: vec!["opendir DIRHANDLE, EXPR"],
-            documentation: "Opens a directory",
-        },
-    );
-
-    signatures.insert(
-        "readdir",
-        BuiltinSignature {
-            signatures: vec!["readdir DIRHANDLE"],
-            documentation: "Reads directory entries",
-        },
-    );
-
-    signatures.insert(
-        "closedir",
-        BuiltinSignature {
-            signatures: vec!["closedir DIRHANDLE"],
-            documentation: "Closes a directory handle",
-        },
-    );
-
-    signatures.insert(
-        "rewinddir",
-        BuiltinSignature {
-            signatures: vec!["rewinddir DIRHANDLE"],
-            documentation: "Resets directory handle",
-        },
-    );
-
-    signatures.insert(
-        "telldir",
-        BuiltinSignature {
-            signatures: vec!["telldir DIRHANDLE"],
-            documentation: "Returns directory position",
-        },
-    );
-
-    signatures.insert(
-        "seekdir",
-        BuiltinSignature {
-            signatures: vec!["seekdir DIRHANDLE, POS"],
-            documentation: "Sets directory position",
-        },
-    );
-
-    // ===== File Operations =====
-    signatures.insert(
-        "chmod",
-        BuiltinSignature {
-            signatures: vec!["chmod MODE, LIST"],
-            documentation: "Changes file permissions",
-        },
-    );
-
-    signatures.insert(
-        "chown",
-        BuiltinSignature {
-            signatures: vec!["chown UID, GID, LIST"],
-            documentation: "Changes file ownership",
-        },
-    );
-
-    signatures.insert(
-        "link",
-        BuiltinSignature {
-            signatures: vec!["link OLDFILE, NEWFILE"],
-            documentation: "Creates hard link",
-        },
-    );
-
-    signatures.insert(
-        "symlink",
-        BuiltinSignature {
-            signatures: vec!["symlink OLDFILE, NEWFILE"],
-            documentation: "Creates symbolic link",
-        },
-    );
-
-    signatures.insert(
-        "readlink",
-        BuiltinSignature {
-            signatures: vec!["readlink EXPR", "readlink"],
-            documentation: "Reads symbolic link",
-        },
-    );
-
-    signatures.insert(
-        "rename",
-        BuiltinSignature {
-            signatures: vec!["rename OLDNAME, NEWNAME"],
-            documentation: "Renames a file",
-        },
-    );
-
-    signatures.insert(
-        "unlink",
-        BuiltinSignature {
-            signatures: vec!["unlink LIST", "unlink"],
-            documentation: "Deletes files",
-        },
-    );
-
-    signatures.insert(
-        "mkdir",
-        BuiltinSignature {
-            signatures: vec!["mkdir FILENAME, MODE", "mkdir FILENAME"],
-            documentation: "Creates directory",
-        },
-    );
-
-    signatures.insert(
-        "rmdir",
-        BuiltinSignature {
-            signatures: vec!["rmdir FILENAME", "rmdir"],
-            documentation: "Removes directory",
-        },
-    );
-
-    // ===== Process Functions =====
-    signatures.insert(
-        "system",
-        BuiltinSignature {
-            signatures: vec!["system LIST", "system PROGRAM LIST"],
-            documentation: "Executes system command",
-        },
-    );
-
-    signatures.insert(
-        "exec",
-        BuiltinSignature {
-            signatures: vec!["exec LIST", "exec PROGRAM LIST"],
-            documentation: "Executes system command (never returns)",
-        },
-    );
-
-    signatures.insert(
-        "fork",
-        BuiltinSignature { signatures: vec!["fork"], documentation: "Creates a child process" },
-    );
-
-    signatures.insert(
-        "wait",
-        BuiltinSignature { signatures: vec!["wait"], documentation: "Waits for child process" },
-    );
-
-    signatures.insert(
-        "waitpid",
-        BuiltinSignature {
-            signatures: vec!["waitpid PID, FLAGS"],
-            documentation: "Waits for specific child process",
-        },
-    );
-
-    signatures.insert(
-        "kill",
-        BuiltinSignature {
-            signatures: vec!["kill SIGNAL, LIST"],
-            documentation: "Sends signal to processes",
-        },
-    );
-
-    signatures.insert(
-        "getpid",
-        BuiltinSignature { signatures: vec!["getpid"], documentation: "Returns process ID" },
-    );
-
-    signatures.insert(
-        "getppid",
-        BuiltinSignature {
-            signatures: vec!["getppid"],
-            documentation: "Returns parent process ID",
-        },
-    );
-
-    // ===== Time Functions =====
-    signatures.insert(
-        "time",
-        BuiltinSignature { signatures: vec!["time"], documentation: "Returns current time" },
-    );
-
-    signatures.insert(
-        "localtime",
-        BuiltinSignature {
-            signatures: vec!["localtime EXPR", "localtime"],
-            documentation: "Converts time to local time",
-        },
-    );
-
-    signatures.insert(
-        "gmtime",
-        BuiltinSignature {
-            signatures: vec!["gmtime EXPR", "gmtime"],
-            documentation: "Converts time to GMT",
-        },
-    );
-
-    signatures.insert(
-        "sleep",
-        BuiltinSignature {
-            signatures: vec!["sleep EXPR", "sleep"],
-            documentation: "Sleeps for seconds",
-        },
-    );
-
-    signatures.insert(
-        "alarm",
-        BuiltinSignature {
-            signatures: vec!["alarm SECONDS", "alarm"],
-            documentation: "Sets alarm signal",
-        },
-    );
-
-    // ===== Mathematical Functions =====
-    signatures.insert(
-        "abs",
-        BuiltinSignature {
-            signatures: vec!["abs VALUE", "abs"],
-            documentation: "Returns absolute value",
-        },
-    );
-
-    signatures.insert(
-        "atan2",
-        BuiltinSignature { signatures: vec!["atan2 Y, X"], documentation: "Returns arctangent" },
-    );
-
-    signatures.insert(
-        "cos",
-        BuiltinSignature { signatures: vec!["cos EXPR", "cos"], documentation: "Returns cosine" },
-    );
-
-    signatures.insert(
-        "sin",
-        BuiltinSignature { signatures: vec!["sin EXPR", "sin"], documentation: "Returns sine" },
-    );
-
-    signatures.insert(
-        "exp",
-        BuiltinSignature {
-            signatures: vec!["exp EXPR", "exp"],
-            documentation: "Returns e raised to power",
-        },
-    );
-
-    signatures.insert(
-        "log",
-        BuiltinSignature {
-            signatures: vec!["log EXPR", "log"],
-            documentation: "Returns natural logarithm",
-        },
-    );
-
-    signatures.insert(
-        "sqrt",
-        BuiltinSignature {
-            signatures: vec!["sqrt EXPR", "sqrt"],
-            documentation: "Returns square root",
-        },
-    );
-
-    signatures.insert(
-        "int",
-        BuiltinSignature {
-            signatures: vec!["int EXPR", "int"],
-            documentation: "Returns integer portion",
-        },
-    );
-
-    signatures.insert(
-        "rand",
-        BuiltinSignature {
-            signatures: vec!["rand EXPR", "rand"],
-            documentation: "Returns random number",
-        },
-    );
-
-    signatures.insert(
-        "srand",
-        BuiltinSignature {
-            signatures: vec!["srand EXPR", "srand"],
-            documentation: "Seeds random number generator",
-        },
-    );
-
-    // ===== Type and Reference Functions =====
-    signatures.insert(
-        "ref",
-        BuiltinSignature {
-            signatures: vec!["ref EXPR", "ref"],
-            documentation: "Returns type of reference",
-        },
-    );
-
-    signatures.insert(
-        "bless",
-        BuiltinSignature {
-            signatures: vec!["bless REF, CLASSNAME", "bless REF"],
-            documentation: "Blesses reference into class",
-        },
-    );
-
-    signatures.insert(
-        "defined",
-        BuiltinSignature {
-            signatures: vec!["defined EXPR", "defined"],
-            documentation: "Tests whether value is defined",
-        },
-    );
-
-    signatures.insert(
-        "undef",
-        BuiltinSignature {
-            signatures: vec!["undef EXPR", "undef"],
-            documentation: "Undefines a value",
-        },
-    );
-
-    signatures.insert(
-        "scalar",
-        BuiltinSignature {
-            signatures: vec!["scalar EXPR"],
-            documentation: "Forces scalar context",
-        },
-    );
-
-    signatures.insert(
-        "wantarray",
-        BuiltinSignature {
-            signatures: vec!["wantarray"],
-            documentation: "Returns context of subroutine call",
-        },
-    );
-
-    // ===== Control Flow =====
-    signatures.insert(
-        "die",
-        BuiltinSignature {
-            signatures: vec!["die LIST", "die"],
-            documentation: "Raises an exception",
-        },
-    );
-
-    signatures.insert(
-        "warn",
-        BuiltinSignature {
-            signatures: vec!["warn LIST", "warn"],
-            documentation: "Prints warning message",
-        },
-    );
-
-    signatures.insert(
-        "exit",
-        BuiltinSignature {
-            signatures: vec!["exit EXPR", "exit"],
-            documentation: "Exits the program",
-        },
-    );
-
-    signatures.insert(
-        "return",
-        BuiltinSignature {
-            signatures: vec!["return LIST", "return"],
-            documentation: "Returns from subroutine",
-        },
-    );
-
-    signatures.insert(
-        "next",
-        BuiltinSignature {
-            signatures: vec!["next LABEL", "next"],
-            documentation: "Starts next iteration of loop",
-        },
-    );
-
-    signatures.insert(
-        "last",
-        BuiltinSignature { signatures: vec!["last LABEL", "last"], documentation: "Exits loop" },
-    );
-
-    signatures.insert(
-        "redo",
-        BuiltinSignature {
-            signatures: vec!["redo LABEL", "redo"],
-            documentation: "Restarts current iteration",
-        },
-    );
-
-    signatures.insert(
-        "goto",
-        BuiltinSignature {
-            signatures: vec!["goto LABEL", "goto EXPR", "goto &NAME"],
-            documentation: "Goes to label or subroutine",
-        },
-    );
-
-    // ===== Module Functions =====
-    signatures.insert(
-        "require",
-        BuiltinSignature {
-            signatures: vec!["require VERSION", "require MODULE", "require EXPR", "require"],
-            documentation: "Loads module or file",
-        },
-    );
-
-    signatures.insert(
-        "use",
-        BuiltinSignature {
-            signatures: vec![
-                "use MODULE VERSION LIST",
-                "use MODULE VERSION",
-                "use MODULE LIST",
-                "use MODULE",
-                "use VERSION",
-            ],
-            documentation: "Imports module",
-        },
-    );
-
-    signatures.insert(
-        "no",
-        BuiltinSignature {
-            signatures: vec![
-                "no MODULE VERSION LIST",
-                "no MODULE VERSION",
-                "no MODULE LIST",
-                "no MODULE",
-                "no VERSION",
-            ],
-            documentation: "Unimports module",
-        },
-    );
-
-    signatures.insert(
-        "import",
-        BuiltinSignature {
-            signatures: vec!["import MODULE LIST"],
-            documentation: "Imports symbols from module",
-        },
-    );
-
-    signatures.insert(
-        "unimport",
-        BuiltinSignature {
-            signatures: vec!["unimport MODULE LIST"],
-            documentation: "Unimports symbols from module",
-        },
-    );
-
-    // ===== Package Functions =====
-    signatures.insert(
-        "package",
-        BuiltinSignature {
-            signatures: vec!["package NAMESPACE VERSION", "package NAMESPACE"],
-            documentation: "Declares package namespace",
-        },
-    );
-
-    signatures.insert(
-        "caller",
-        BuiltinSignature {
-            signatures: vec!["caller EXPR", "caller"],
-            documentation: "Returns context of current subroutine call",
-        },
-    );
-
-    // ===== Eval and Do =====
-    signatures.insert(
-        "eval",
-        BuiltinSignature {
-            signatures: vec!["eval EXPR", "eval BLOCK"],
-            documentation: "Evaluates code",
-        },
-    );
-
-    signatures.insert(
-        "do",
-        BuiltinSignature {
-            signatures: vec!["do FILENAME", "do BLOCK"],
-            documentation: "Executes file or block",
-        },
-    );
-
-    // ===== Tied Variables =====
-    signatures.insert(
-        "tie",
-        BuiltinSignature {
-            signatures: vec!["tie VARIABLE, CLASSNAME, LIST"],
-            documentation: "Binds variable to class",
-        },
-    );
-
-    signatures.insert(
-        "tied",
-        BuiltinSignature {
-            signatures: vec!["tied VARIABLE"],
-            documentation: "Returns object tied to variable",
-        },
-    );
-
-    signatures.insert(
-        "untie",
-        BuiltinSignature {
-            signatures: vec!["untie VARIABLE"],
-            documentation: "Breaks binding on variable",
-        },
-    );
-
-    // ===== Socket Functions =====
-    signatures.insert(
-        "socket",
-        BuiltinSignature {
-            signatures: vec!["socket SOCKET, DOMAIN, TYPE, PROTOCOL"],
-            documentation: "Creates a socket",
-        },
-    );
-
-    signatures.insert(
-        "bind",
-        BuiltinSignature {
-            signatures: vec!["bind SOCKET, NAME"],
-            documentation: "Binds address to socket",
-        },
-    );
-
-    signatures.insert(
-        "listen",
-        BuiltinSignature {
-            signatures: vec!["listen SOCKET, QUEUESIZE"],
-            documentation: "Listens for connections",
-        },
-    );
-
-    signatures.insert(
-        "accept",
-        BuiltinSignature {
-            signatures: vec!["accept NEWSOCKET, GENERICSOCKET"],
-            documentation: "Accepts socket connection",
-        },
-    );
-
-    signatures.insert(
-        "connect",
-        BuiltinSignature {
-            signatures: vec!["connect SOCKET, NAME"],
-            documentation: "Connects to socket",
-        },
-    );
-
-    signatures.insert(
-        "shutdown",
-        BuiltinSignature {
-            signatures: vec!["shutdown SOCKET, HOW"],
-            documentation: "Shuts down socket",
-        },
-    );
-
-    signatures.insert(
-        "send",
-        BuiltinSignature {
-            signatures: vec!["send SOCKET, MSG, FLAGS, TO", "send SOCKET, MSG, FLAGS"],
-            documentation: "Sends message on socket",
-        },
-    );
-
-    signatures.insert(
-        "recv",
-        BuiltinSignature {
-            signatures: vec!["recv SOCKET, SCALAR, LENGTH, FLAGS"],
-            documentation: "Receives message from socket",
-        },
-    );
-
-    signatures.insert(
-        "getsockopt",
-        BuiltinSignature {
-            signatures: vec!["getsockopt SOCKET, LEVEL, OPTNAME"],
-            documentation: "Gets socket options",
-        },
-    );
-
-    signatures.insert(
-        "setsockopt",
-        BuiltinSignature {
-            signatures: vec!["setsockopt SOCKET, LEVEL, OPTNAME, OPTVAL"],
-            documentation: "Sets socket options",
-        },
-    );
-
-    // ===== Pack/Unpack =====
-    signatures.insert(
-        "pack",
-        BuiltinSignature {
-            signatures: vec!["pack TEMPLATE, LIST"],
-            documentation: "Packs list into binary",
-        },
-    );
-
-    signatures.insert(
-        "unpack",
-        BuiltinSignature {
-            signatures: vec!["unpack TEMPLATE, EXPR"],
-            documentation: "Unpacks binary into list",
-        },
-    );
-
-    // ===== Regular Expression =====
-    signatures.insert(
-        "study",
-        BuiltinSignature {
-            signatures: vec!["study SCALAR", "study"],
-            documentation: "Optimizes string for pattern matching",
-        },
-    );
-
-    signatures.insert(
-        "pos",
-        BuiltinSignature {
-            signatures: vec!["pos SCALAR", "pos"],
-            documentation: "Returns or sets match position",
-        },
-    );
-
-    signatures.insert(
-        "reset",
-        BuiltinSignature {
-            signatures: vec!["reset EXPR", "reset"],
-            documentation: "Resets variables and searches",
-        },
-    );
-
-    // ===== Format Functions =====
-    signatures.insert(
-        "formline",
-        BuiltinSignature {
-            signatures: vec!["formline PICTURE, LIST"],
-            documentation: "Internal function for formats",
-        },
-    );
-
-    signatures.insert(
-        "format",
-        BuiltinSignature { signatures: vec!["format NAME ="], documentation: "Declares format" },
-    );
-
-    // ===== File Test Operators =====
-    macro_rules! file_test {
-        ($op:literal) => {
-            signatures.insert(
-                $op,
-                BuiltinSignature {
-                    signatures: vec![concat!($op, " FILE"), $op],
-                    documentation: "File test operator",
-                },
-            );
-        };
-    }
-
-    file_test!("-e");
-    file_test!("-f");
-    file_test!("-d");
-    file_test!("-r");
-    file_test!("-w");
-    file_test!("-x");
-    file_test!("-o");
-    file_test!("-R");
-    file_test!("-W");
-    file_test!("-X");
-    file_test!("-O");
-    file_test!("-z");
-    file_test!("-s");
-    file_test!("-l");
-    file_test!("-p");
-    file_test!("-S");
-    file_test!("-b");
-    file_test!("-c");
-    file_test!("-t");
-    file_test!("-u");
-    file_test!("-g");
-    file_test!("-k");
-    file_test!("-T");
-    file_test!("-B");
-    file_test!("-M");
-    file_test!("-A");
-    file_test!("-C");
-
-    // ===== Miscellaneous =====
-    signatures.insert(
-        "dump",
-        BuiltinSignature {
-            signatures: vec!["dump LABEL", "dump"],
-            documentation: "Creates core dump",
-        },
-    );
-
-    signatures.insert(
-        "dbmopen",
-        BuiltinSignature {
-            signatures: vec!["dbmopen HASH, DBNAME, MASK"],
-            documentation: "Opens DBM file (deprecated, use tie instead)",
-        },
-    );
-
-    signatures.insert(
-        "dbmclose",
-        BuiltinSignature {
-            signatures: vec!["dbmclose HASH"],
-            documentation: "Closes DBM file (deprecated, use untie instead)",
-        },
-    );
-
-    signatures.insert(
-        "vec",
-        BuiltinSignature {
-            signatures: vec!["vec EXPR, OFFSET, BITS"],
-            documentation: "Accesses bit vector",
-        },
-    );
-
-    signatures.insert(
-        "prototype",
-        BuiltinSignature {
-            signatures: vec!["prototype FUNCTION"],
-            documentation: "Returns function prototype",
-        },
-    );
-
-    signatures.insert(
-        "lock",
-        BuiltinSignature { signatures: vec!["lock THING"], documentation: "Locks shared variable" },
-    );
-
-    signatures
+pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSignature> {
+    SIGNATURES_CACHE.get_or_init(|| {
+        let mut signatures = HashMap::new();
+
+        // ===== I/O Functions =====
+        signatures.insert(
+            "print",
+            BuiltinSignature {
+                signatures: vec![
+                    "print FILEHANDLE LIST",
+                    "print FILEHANDLE",
+                    "print LIST",
+                    "print",
+                ],
+                documentation: "Prints a string or list of strings to a filehandle",
+            },
+        );
+
+        signatures.insert(
+            "printf",
+            BuiltinSignature {
+                signatures: vec!["printf FILEHANDLE FORMAT, LIST", "printf FORMAT, LIST"],
+                documentation: "Prints a formatted string",
+            },
+        );
+
+        signatures.insert(
+            "say",
+            BuiltinSignature {
+                signatures: vec!["say FILEHANDLE LIST", "say FILEHANDLE", "say LIST", "say"],
+                documentation: "Prints with a newline",
+            },
+        );
+
+        signatures.insert(
+            "open",
+            BuiltinSignature {
+                signatures: vec![
+                    "open FILEHANDLE, MODE, FILENAME",
+                    "open FILEHANDLE, EXPR",
+                    "open FILEHANDLE",
+                ],
+                documentation: "Opens a file",
+            },
+        );
+
+        signatures.insert(
+            "close",
+            BuiltinSignature {
+                signatures: vec!["close FILEHANDLE", "close"],
+                documentation: "Closes a filehandle",
+            },
+        );
+
+        signatures.insert(
+            "read",
+            BuiltinSignature {
+                signatures: vec![
+                    "read FILEHANDLE, SCALAR, LENGTH, OFFSET",
+                    "read FILEHANDLE, SCALAR, LENGTH",
+                ],
+                documentation: "Reads from a filehandle into a scalar",
+            },
+        );
+
+        signatures.insert(
+            "sysread",
+            BuiltinSignature {
+                signatures: vec![
+                    "sysread FILEHANDLE, SCALAR, LENGTH, OFFSET",
+                    "sysread FILEHANDLE, SCALAR, LENGTH",
+                ],
+                documentation: "Reads from a filehandle bypassing stdio",
+            },
+        );
+
+        signatures.insert(
+            "write",
+            BuiltinSignature {
+                signatures: vec!["write FILEHANDLE", "write"],
+                documentation: "Writes a formatted record",
+            },
+        );
+
+        signatures.insert(
+            "syswrite",
+            BuiltinSignature {
+                signatures: vec![
+                    "syswrite FILEHANDLE, SCALAR, LENGTH, OFFSET",
+                    "syswrite FILEHANDLE, SCALAR, LENGTH",
+                    "syswrite FILEHANDLE, SCALAR",
+                ],
+                documentation: "Writes to a filehandle bypassing stdio",
+            },
+        );
+
+        signatures.insert(
+            "seek",
+            BuiltinSignature {
+                signatures: vec!["seek FILEHANDLE, POSITION, WHENCE"],
+                documentation: "Sets file pointer position",
+            },
+        );
+
+        signatures.insert(
+            "tell",
+            BuiltinSignature {
+                signatures: vec!["tell FILEHANDLE", "tell"],
+                documentation: "Returns current file position",
+            },
+        );
+
+        signatures.insert(
+            "eof",
+            BuiltinSignature {
+                signatures: vec!["eof FILEHANDLE", "eof"],
+                documentation: "Tests for end of file",
+            },
+        );
+
+        // ===== String Functions =====
+        signatures.insert(
+            "chomp",
+            BuiltinSignature {
+                signatures: vec!["chomp VARIABLE", "chomp LIST", "chomp"],
+                documentation: "Removes trailing newline from string",
+            },
+        );
+
+        signatures.insert(
+            "chop",
+            BuiltinSignature {
+                signatures: vec!["chop VARIABLE", "chop LIST", "chop"],
+                documentation: "Removes last character from string",
+            },
+        );
+
+        signatures.insert(
+            "chr",
+            BuiltinSignature {
+                signatures: vec!["chr NUMBER", "chr"],
+                documentation: "Returns character for a number",
+            },
+        );
+
+        signatures.insert(
+            "ord",
+            BuiltinSignature {
+                signatures: vec!["ord EXPR", "ord"],
+                documentation: "Returns numeric value of character",
+            },
+        );
+
+        signatures.insert(
+            "hex",
+            BuiltinSignature {
+                signatures: vec!["hex EXPR", "hex"],
+                documentation: "Converts hex string to number",
+            },
+        );
+
+        signatures.insert(
+            "oct",
+            BuiltinSignature {
+                signatures: vec!["oct EXPR", "oct"],
+                documentation: "Converts octal string to number",
+            },
+        );
+
+        signatures.insert(
+            "length",
+            BuiltinSignature {
+                signatures: vec!["length EXPR", "length"],
+                documentation: "Returns length of string",
+            },
+        );
+
+        signatures.insert(
+            "substr",
+            BuiltinSignature {
+                signatures: vec![
+                    "substr EXPR, OFFSET, LENGTH, REPLACEMENT",
+                    "substr EXPR, OFFSET, LENGTH",
+                    "substr EXPR, OFFSET",
+                ],
+                documentation: "Extracts or replaces substring",
+            },
+        );
+
+        signatures.insert(
+            "index",
+            BuiltinSignature {
+                signatures: vec!["index STR, SUBSTR, POSITION", "index STR, SUBSTR"],
+                documentation: "Finds position of substring",
+            },
+        );
+
+        signatures.insert(
+            "rindex",
+            BuiltinSignature {
+                signatures: vec!["rindex STR, SUBSTR, POSITION", "rindex STR, SUBSTR"],
+                documentation: "Finds position of substring from end",
+            },
+        );
+
+        signatures.insert(
+            "sprintf",
+            BuiltinSignature {
+                signatures: vec!["sprintf FORMAT, LIST"],
+                documentation: "Returns formatted string",
+            },
+        );
+
+        signatures.insert(
+            "lc",
+            BuiltinSignature {
+                signatures: vec!["lc EXPR", "lc"],
+                documentation: "Returns lowercase version",
+            },
+        );
+
+        signatures.insert(
+            "lcfirst",
+            BuiltinSignature {
+                signatures: vec!["lcfirst EXPR", "lcfirst"],
+                documentation: "Returns string with first char lowercase",
+            },
+        );
+
+        signatures.insert(
+            "uc",
+            BuiltinSignature {
+                signatures: vec!["uc EXPR", "uc"],
+                documentation: "Returns uppercase version",
+            },
+        );
+
+        signatures.insert(
+            "ucfirst",
+            BuiltinSignature {
+                signatures: vec!["ucfirst EXPR", "ucfirst"],
+                documentation: "Returns string with first char uppercase",
+            },
+        );
+
+        signatures.insert(
+            "quotemeta",
+            BuiltinSignature {
+                signatures: vec!["quotemeta EXPR", "quotemeta"],
+                documentation: "Quotes metacharacters",
+            },
+        );
+
+        signatures.insert(
+            "split",
+            BuiltinSignature {
+                signatures: vec![
+                    "split /PATTERN/, EXPR, LIMIT",
+                    "split /PATTERN/, EXPR",
+                    "split /PATTERN/",
+                    "split",
+                ],
+                documentation: "Splits string into list",
+            },
+        );
+
+        signatures.insert(
+            "join",
+            BuiltinSignature {
+                signatures: vec!["join EXPR, LIST"],
+                documentation: "Joins list into string",
+            },
+        );
+
+        signatures.insert(
+            "reverse",
+            BuiltinSignature {
+                signatures: vec!["reverse LIST"],
+                documentation: "Reverses list or string",
+            },
+        );
+
+        // ===== Array Functions =====
+        signatures.insert(
+            "push",
+            BuiltinSignature {
+                signatures: vec!["push ARRAY, LIST"],
+                documentation: "Appends values to array",
+            },
+        );
+
+        signatures.insert(
+            "pop",
+            BuiltinSignature {
+                signatures: vec!["pop ARRAY", "pop"],
+                documentation: "Removes and returns last element",
+            },
+        );
+
+        signatures.insert(
+            "shift",
+            BuiltinSignature {
+                signatures: vec!["shift ARRAY", "shift"],
+                documentation: "Removes and returns first element",
+            },
+        );
+
+        signatures.insert(
+            "unshift",
+            BuiltinSignature {
+                signatures: vec!["unshift ARRAY, LIST"],
+                documentation: "Prepends values to array",
+            },
+        );
+
+        signatures.insert(
+            "splice",
+            BuiltinSignature {
+                signatures: vec![
+                    "splice ARRAY, OFFSET, LENGTH, LIST",
+                    "splice ARRAY, OFFSET, LENGTH",
+                    "splice ARRAY, OFFSET",
+                    "splice ARRAY",
+                ],
+                documentation: "Removes and replaces array elements",
+            },
+        );
+
+        signatures.insert(
+            "map",
+            BuiltinSignature {
+                signatures: vec!["map BLOCK LIST", "map EXPR, LIST"],
+                documentation: "Transforms a list",
+            },
+        );
+
+        signatures.insert(
+            "grep",
+            BuiltinSignature {
+                signatures: vec!["grep BLOCK LIST", "grep EXPR, LIST"],
+                documentation: "Filters a list",
+            },
+        );
+
+        signatures.insert(
+            "sort",
+            BuiltinSignature {
+                signatures: vec!["sort BLOCK LIST", "sort SUBNAME LIST", "sort LIST"],
+                documentation: "Sorts a list",
+            },
+        );
+
+        // ===== Hash Functions =====
+        signatures.insert(
+            "each",
+            BuiltinSignature {
+                signatures: vec!["each HASH", "each ARRAY"],
+                documentation: "Returns key-value pair",
+            },
+        );
+
+        signatures.insert(
+            "keys",
+            BuiltinSignature {
+                signatures: vec!["keys HASH", "keys ARRAY"],
+                documentation: "Returns list of keys",
+            },
+        );
+
+        signatures.insert(
+            "values",
+            BuiltinSignature {
+                signatures: vec!["values HASH", "values ARRAY"],
+                documentation: "Returns list of values",
+            },
+        );
+
+        signatures.insert(
+            "exists",
+            BuiltinSignature {
+                signatures: vec!["exists EXPR"],
+                documentation: "Tests whether key exists",
+            },
+        );
+
+        signatures.insert(
+            "delete",
+            BuiltinSignature {
+                signatures: vec!["delete EXPR"],
+                documentation: "Deletes hash element",
+            },
+        );
+
+        // ===== File Test Operators =====
+        signatures.insert(
+            "stat",
+            BuiltinSignature {
+                signatures: vec!["stat FILEHANDLE", "stat EXPR", "stat"],
+                documentation: "Returns file statistics",
+            },
+        );
+
+        signatures.insert(
+            "lstat",
+            BuiltinSignature {
+                signatures: vec!["lstat FILEHANDLE", "lstat EXPR", "lstat"],
+                documentation: "Returns symbolic link statistics",
+            },
+        );
+
+        // ===== Directory Functions =====
+        signatures.insert(
+            "opendir",
+            BuiltinSignature {
+                signatures: vec!["opendir DIRHANDLE, EXPR"],
+                documentation: "Opens a directory",
+            },
+        );
+
+        signatures.insert(
+            "readdir",
+            BuiltinSignature {
+                signatures: vec!["readdir DIRHANDLE"],
+                documentation: "Reads directory entries",
+            },
+        );
+
+        signatures.insert(
+            "closedir",
+            BuiltinSignature {
+                signatures: vec!["closedir DIRHANDLE"],
+                documentation: "Closes a directory handle",
+            },
+        );
+
+        signatures.insert(
+            "rewinddir",
+            BuiltinSignature {
+                signatures: vec!["rewinddir DIRHANDLE"],
+                documentation: "Resets directory handle",
+            },
+        );
+
+        signatures.insert(
+            "telldir",
+            BuiltinSignature {
+                signatures: vec!["telldir DIRHANDLE"],
+                documentation: "Returns directory position",
+            },
+        );
+
+        signatures.insert(
+            "seekdir",
+            BuiltinSignature {
+                signatures: vec!["seekdir DIRHANDLE, POS"],
+                documentation: "Sets directory position",
+            },
+        );
+
+        // ===== File Operations =====
+        signatures.insert(
+            "chmod",
+            BuiltinSignature {
+                signatures: vec!["chmod MODE, LIST"],
+                documentation: "Changes file permissions",
+            },
+        );
+
+        signatures.insert(
+            "chown",
+            BuiltinSignature {
+                signatures: vec!["chown UID, GID, LIST"],
+                documentation: "Changes file ownership",
+            },
+        );
+
+        signatures.insert(
+            "link",
+            BuiltinSignature {
+                signatures: vec!["link OLDFILE, NEWFILE"],
+                documentation: "Creates hard link",
+            },
+        );
+
+        signatures.insert(
+            "symlink",
+            BuiltinSignature {
+                signatures: vec!["symlink OLDFILE, NEWFILE"],
+                documentation: "Creates symbolic link",
+            },
+        );
+
+        signatures.insert(
+            "readlink",
+            BuiltinSignature {
+                signatures: vec!["readlink EXPR", "readlink"],
+                documentation: "Reads symbolic link",
+            },
+        );
+
+        signatures.insert(
+            "rename",
+            BuiltinSignature {
+                signatures: vec!["rename OLDNAME, NEWNAME"],
+                documentation: "Renames a file",
+            },
+        );
+
+        signatures.insert(
+            "unlink",
+            BuiltinSignature {
+                signatures: vec!["unlink LIST", "unlink"],
+                documentation: "Deletes files",
+            },
+        );
+
+        signatures.insert(
+            "mkdir",
+            BuiltinSignature {
+                signatures: vec!["mkdir FILENAME, MODE", "mkdir FILENAME"],
+                documentation: "Creates directory",
+            },
+        );
+
+        signatures.insert(
+            "rmdir",
+            BuiltinSignature {
+                signatures: vec!["rmdir FILENAME", "rmdir"],
+                documentation: "Removes directory",
+            },
+        );
+
+        // ===== Process Functions =====
+        signatures.insert(
+            "system",
+            BuiltinSignature {
+                signatures: vec!["system LIST", "system PROGRAM LIST"],
+                documentation: "Executes system command",
+            },
+        );
+
+        signatures.insert(
+            "exec",
+            BuiltinSignature {
+                signatures: vec!["exec LIST", "exec PROGRAM LIST"],
+                documentation: "Executes system command (never returns)",
+            },
+        );
+
+        signatures.insert(
+            "fork",
+            BuiltinSignature { signatures: vec!["fork"], documentation: "Creates a child process" },
+        );
+
+        signatures.insert(
+            "wait",
+            BuiltinSignature { signatures: vec!["wait"], documentation: "Waits for child process" },
+        );
+
+        signatures.insert(
+            "waitpid",
+            BuiltinSignature {
+                signatures: vec!["waitpid PID, FLAGS"],
+                documentation: "Waits for specific child process",
+            },
+        );
+
+        signatures.insert(
+            "kill",
+            BuiltinSignature {
+                signatures: vec!["kill SIGNAL, LIST"],
+                documentation: "Sends signal to processes",
+            },
+        );
+
+        signatures.insert(
+            "getpid",
+            BuiltinSignature { signatures: vec!["getpid"], documentation: "Returns process ID" },
+        );
+
+        signatures.insert(
+            "getppid",
+            BuiltinSignature {
+                signatures: vec!["getppid"],
+                documentation: "Returns parent process ID",
+            },
+        );
+
+        // ===== Time Functions =====
+        signatures.insert(
+            "time",
+            BuiltinSignature { signatures: vec!["time"], documentation: "Returns current time" },
+        );
+
+        signatures.insert(
+            "localtime",
+            BuiltinSignature {
+                signatures: vec!["localtime EXPR", "localtime"],
+                documentation: "Converts time to local time",
+            },
+        );
+
+        signatures.insert(
+            "gmtime",
+            BuiltinSignature {
+                signatures: vec!["gmtime EXPR", "gmtime"],
+                documentation: "Converts time to GMT",
+            },
+        );
+
+        signatures.insert(
+            "sleep",
+            BuiltinSignature {
+                signatures: vec!["sleep EXPR", "sleep"],
+                documentation: "Sleeps for seconds",
+            },
+        );
+
+        signatures.insert(
+            "alarm",
+            BuiltinSignature {
+                signatures: vec!["alarm SECONDS", "alarm"],
+                documentation: "Sets alarm signal",
+            },
+        );
+
+        // ===== Mathematical Functions =====
+        signatures.insert(
+            "abs",
+            BuiltinSignature {
+                signatures: vec!["abs VALUE", "abs"],
+                documentation: "Returns absolute value",
+            },
+        );
+
+        signatures.insert(
+            "atan2",
+            BuiltinSignature {
+                signatures: vec!["atan2 Y, X"],
+                documentation: "Returns arctangent",
+            },
+        );
+
+        signatures.insert(
+            "cos",
+            BuiltinSignature {
+                signatures: vec!["cos EXPR", "cos"],
+                documentation: "Returns cosine",
+            },
+        );
+
+        signatures.insert(
+            "sin",
+            BuiltinSignature { signatures: vec!["sin EXPR", "sin"], documentation: "Returns sine" },
+        );
+
+        signatures.insert(
+            "exp",
+            BuiltinSignature {
+                signatures: vec!["exp EXPR", "exp"],
+                documentation: "Returns e raised to power",
+            },
+        );
+
+        signatures.insert(
+            "log",
+            BuiltinSignature {
+                signatures: vec!["log EXPR", "log"],
+                documentation: "Returns natural logarithm",
+            },
+        );
+
+        signatures.insert(
+            "sqrt",
+            BuiltinSignature {
+                signatures: vec!["sqrt EXPR", "sqrt"],
+                documentation: "Returns square root",
+            },
+        );
+
+        signatures.insert(
+            "int",
+            BuiltinSignature {
+                signatures: vec!["int EXPR", "int"],
+                documentation: "Returns integer portion",
+            },
+        );
+
+        signatures.insert(
+            "rand",
+            BuiltinSignature {
+                signatures: vec!["rand EXPR", "rand"],
+                documentation: "Returns random number",
+            },
+        );
+
+        signatures.insert(
+            "srand",
+            BuiltinSignature {
+                signatures: vec!["srand EXPR", "srand"],
+                documentation: "Seeds random number generator",
+            },
+        );
+
+        // ===== Type and Reference Functions =====
+        signatures.insert(
+            "ref",
+            BuiltinSignature {
+                signatures: vec!["ref EXPR", "ref"],
+                documentation: "Returns type of reference",
+            },
+        );
+
+        signatures.insert(
+            "bless",
+            BuiltinSignature {
+                signatures: vec!["bless REF, CLASSNAME", "bless REF"],
+                documentation: "Blesses reference into class",
+            },
+        );
+
+        signatures.insert(
+            "defined",
+            BuiltinSignature {
+                signatures: vec!["defined EXPR", "defined"],
+                documentation: "Tests whether value is defined",
+            },
+        );
+
+        signatures.insert(
+            "undef",
+            BuiltinSignature {
+                signatures: vec!["undef EXPR", "undef"],
+                documentation: "Undefines a value",
+            },
+        );
+
+        signatures.insert(
+            "scalar",
+            BuiltinSignature {
+                signatures: vec!["scalar EXPR"],
+                documentation: "Forces scalar context",
+            },
+        );
+
+        signatures.insert(
+            "wantarray",
+            BuiltinSignature {
+                signatures: vec!["wantarray"],
+                documentation: "Returns context of subroutine call",
+            },
+        );
+
+        // ===== Control Flow =====
+        signatures.insert(
+            "die",
+            BuiltinSignature {
+                signatures: vec!["die LIST", "die"],
+                documentation: "Raises an exception",
+            },
+        );
+
+        signatures.insert(
+            "warn",
+            BuiltinSignature {
+                signatures: vec!["warn LIST", "warn"],
+                documentation: "Prints warning message",
+            },
+        );
+
+        signatures.insert(
+            "exit",
+            BuiltinSignature {
+                signatures: vec!["exit EXPR", "exit"],
+                documentation: "Exits the program",
+            },
+        );
+
+        signatures.insert(
+            "return",
+            BuiltinSignature {
+                signatures: vec!["return LIST", "return"],
+                documentation: "Returns from subroutine",
+            },
+        );
+
+        signatures.insert(
+            "next",
+            BuiltinSignature {
+                signatures: vec!["next LABEL", "next"],
+                documentation: "Starts next iteration of loop",
+            },
+        );
+
+        signatures.insert(
+            "last",
+            BuiltinSignature {
+                signatures: vec!["last LABEL", "last"],
+                documentation: "Exits loop",
+            },
+        );
+
+        signatures.insert(
+            "redo",
+            BuiltinSignature {
+                signatures: vec!["redo LABEL", "redo"],
+                documentation: "Restarts current iteration",
+            },
+        );
+
+        signatures.insert(
+            "goto",
+            BuiltinSignature {
+                signatures: vec!["goto LABEL", "goto EXPR", "goto &NAME"],
+                documentation: "Goes to label or subroutine",
+            },
+        );
+
+        // ===== Module Functions =====
+        signatures.insert(
+            "require",
+            BuiltinSignature {
+                signatures: vec!["require VERSION", "require MODULE", "require EXPR", "require"],
+                documentation: "Loads module or file",
+            },
+        );
+
+        signatures.insert(
+            "use",
+            BuiltinSignature {
+                signatures: vec![
+                    "use MODULE VERSION LIST",
+                    "use MODULE VERSION",
+                    "use MODULE LIST",
+                    "use MODULE",
+                    "use VERSION",
+                ],
+                documentation: "Imports module",
+            },
+        );
+
+        signatures.insert(
+            "no",
+            BuiltinSignature {
+                signatures: vec![
+                    "no MODULE VERSION LIST",
+                    "no MODULE VERSION",
+                    "no MODULE LIST",
+                    "no MODULE",
+                    "no VERSION",
+                ],
+                documentation: "Unimports module",
+            },
+        );
+
+        signatures.insert(
+            "import",
+            BuiltinSignature {
+                signatures: vec!["import MODULE LIST"],
+                documentation: "Imports symbols from module",
+            },
+        );
+
+        signatures.insert(
+            "unimport",
+            BuiltinSignature {
+                signatures: vec!["unimport MODULE LIST"],
+                documentation: "Unimports symbols from module",
+            },
+        );
+
+        // ===== Package Functions =====
+        signatures.insert(
+            "package",
+            BuiltinSignature {
+                signatures: vec!["package NAMESPACE VERSION", "package NAMESPACE"],
+                documentation: "Declares package namespace",
+            },
+        );
+
+        signatures.insert(
+            "caller",
+            BuiltinSignature {
+                signatures: vec!["caller EXPR", "caller"],
+                documentation: "Returns context of current subroutine call",
+            },
+        );
+
+        // ===== Eval and Do =====
+        signatures.insert(
+            "eval",
+            BuiltinSignature {
+                signatures: vec!["eval EXPR", "eval BLOCK"],
+                documentation: "Evaluates code",
+            },
+        );
+
+        signatures.insert(
+            "do",
+            BuiltinSignature {
+                signatures: vec!["do FILENAME", "do BLOCK"],
+                documentation: "Executes file or block",
+            },
+        );
+
+        // ===== Tied Variables =====
+        signatures.insert(
+            "tie",
+            BuiltinSignature {
+                signatures: vec!["tie VARIABLE, CLASSNAME, LIST"],
+                documentation: "Binds variable to class",
+            },
+        );
+
+        signatures.insert(
+            "tied",
+            BuiltinSignature {
+                signatures: vec!["tied VARIABLE"],
+                documentation: "Returns object tied to variable",
+            },
+        );
+
+        signatures.insert(
+            "untie",
+            BuiltinSignature {
+                signatures: vec!["untie VARIABLE"],
+                documentation: "Breaks binding on variable",
+            },
+        );
+
+        // ===== Socket Functions =====
+        signatures.insert(
+            "socket",
+            BuiltinSignature {
+                signatures: vec!["socket SOCKET, DOMAIN, TYPE, PROTOCOL"],
+                documentation: "Creates a socket",
+            },
+        );
+
+        signatures.insert(
+            "bind",
+            BuiltinSignature {
+                signatures: vec!["bind SOCKET, NAME"],
+                documentation: "Binds address to socket",
+            },
+        );
+
+        signatures.insert(
+            "listen",
+            BuiltinSignature {
+                signatures: vec!["listen SOCKET, QUEUESIZE"],
+                documentation: "Listens for connections",
+            },
+        );
+
+        signatures.insert(
+            "accept",
+            BuiltinSignature {
+                signatures: vec!["accept NEWSOCKET, GENERICSOCKET"],
+                documentation: "Accepts socket connection",
+            },
+        );
+
+        signatures.insert(
+            "connect",
+            BuiltinSignature {
+                signatures: vec!["connect SOCKET, NAME"],
+                documentation: "Connects to socket",
+            },
+        );
+
+        signatures.insert(
+            "shutdown",
+            BuiltinSignature {
+                signatures: vec!["shutdown SOCKET, HOW"],
+                documentation: "Shuts down socket",
+            },
+        );
+
+        signatures.insert(
+            "send",
+            BuiltinSignature {
+                signatures: vec!["send SOCKET, MSG, FLAGS, TO", "send SOCKET, MSG, FLAGS"],
+                documentation: "Sends message on socket",
+            },
+        );
+
+        signatures.insert(
+            "recv",
+            BuiltinSignature {
+                signatures: vec!["recv SOCKET, SCALAR, LENGTH, FLAGS"],
+                documentation: "Receives message from socket",
+            },
+        );
+
+        signatures.insert(
+            "getsockopt",
+            BuiltinSignature {
+                signatures: vec!["getsockopt SOCKET, LEVEL, OPTNAME"],
+                documentation: "Gets socket options",
+            },
+        );
+
+        signatures.insert(
+            "setsockopt",
+            BuiltinSignature {
+                signatures: vec!["setsockopt SOCKET, LEVEL, OPTNAME, OPTVAL"],
+                documentation: "Sets socket options",
+            },
+        );
+
+        // ===== Pack/Unpack =====
+        signatures.insert(
+            "pack",
+            BuiltinSignature {
+                signatures: vec!["pack TEMPLATE, LIST"],
+                documentation: "Packs list into binary",
+            },
+        );
+
+        signatures.insert(
+            "unpack",
+            BuiltinSignature {
+                signatures: vec!["unpack TEMPLATE, EXPR"],
+                documentation: "Unpacks binary into list",
+            },
+        );
+
+        // ===== Regular Expression =====
+        signatures.insert(
+            "study",
+            BuiltinSignature {
+                signatures: vec!["study SCALAR", "study"],
+                documentation: "Optimizes string for pattern matching",
+            },
+        );
+
+        signatures.insert(
+            "pos",
+            BuiltinSignature {
+                signatures: vec!["pos SCALAR", "pos"],
+                documentation: "Returns or sets match position",
+            },
+        );
+
+        signatures.insert(
+            "reset",
+            BuiltinSignature {
+                signatures: vec!["reset EXPR", "reset"],
+                documentation: "Resets variables and searches",
+            },
+        );
+
+        // ===== Format Functions =====
+        signatures.insert(
+            "formline",
+            BuiltinSignature {
+                signatures: vec!["formline PICTURE, LIST"],
+                documentation: "Internal function for formats",
+            },
+        );
+
+        signatures.insert(
+            "format",
+            BuiltinSignature {
+                signatures: vec!["format NAME ="],
+                documentation: "Declares format",
+            },
+        );
+
+        // ===== File Test Operators =====
+        macro_rules! file_test {
+            ($op:literal) => {
+                signatures.insert(
+                    $op,
+                    BuiltinSignature {
+                        signatures: vec![concat!($op, " FILE"), $op],
+                        documentation: "File test operator",
+                    },
+                );
+            };
+        }
+
+        file_test!("-e");
+        file_test!("-f");
+        file_test!("-d");
+        file_test!("-r");
+        file_test!("-w");
+        file_test!("-x");
+        file_test!("-o");
+        file_test!("-R");
+        file_test!("-W");
+        file_test!("-X");
+        file_test!("-O");
+        file_test!("-z");
+        file_test!("-s");
+        file_test!("-l");
+        file_test!("-p");
+        file_test!("-S");
+        file_test!("-b");
+        file_test!("-c");
+        file_test!("-t");
+        file_test!("-u");
+        file_test!("-g");
+        file_test!("-k");
+        file_test!("-T");
+        file_test!("-B");
+        file_test!("-M");
+        file_test!("-A");
+        file_test!("-C");
+
+        // ===== Miscellaneous =====
+        signatures.insert(
+            "dump",
+            BuiltinSignature {
+                signatures: vec!["dump LABEL", "dump"],
+                documentation: "Creates core dump",
+            },
+        );
+
+        signatures.insert(
+            "dbmopen",
+            BuiltinSignature {
+                signatures: vec!["dbmopen HASH, DBNAME, MASK"],
+                documentation: "Opens DBM file (deprecated, use tie instead)",
+            },
+        );
+
+        signatures.insert(
+            "dbmclose",
+            BuiltinSignature {
+                signatures: vec!["dbmclose HASH"],
+                documentation: "Closes DBM file (deprecated, use untie instead)",
+            },
+        );
+
+        signatures.insert(
+            "vec",
+            BuiltinSignature {
+                signatures: vec!["vec EXPR, OFFSET, BITS"],
+                documentation: "Accesses bit vector",
+            },
+        );
+
+        signatures.insert(
+            "prototype",
+            BuiltinSignature {
+                signatures: vec!["prototype FUNCTION"],
+                documentation: "Returns function prototype",
+            },
+        );
+
+        signatures.insert(
+            "lock",
+            BuiltinSignature {
+                signatures: vec!["lock THING"],
+                documentation: "Locks shared variable",
+            },
+        );
+
+        signatures
+    })
 }


### PR DESCRIPTION
## Summary

- Cache `create_builtin_signatures()` result using `std::sync::OnceLock` for zero-cost repeated lookups
- Change `SignatureHelpProvider` to hold a `&'static` reference instead of owned `HashMap`
- Fix pre-existing format and clippy warnings in `perl-corpus` crate

Supersedes #400 (Jules PR).

---

## Modern Dev Metrics

### Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `master` @ `28552903` |
| Head ref | `maint/pr-400-20260121` @ `69b9019b` |
| Commits | 2 |
| Files changed | 8 |
| Lines | +1,194 / -1,167 |

**Start review here:**
1. `crates/perl-parser-core/src/builtins/builtin_signatures.rs` - main OnceLock caching
2. `crates/perl-lsp-providers/src/ide/lsp_compat/signature_help.rs` - consumer update

### Blast Radius

| Surface | Affected? | Notes |
|---------|-----------|-------|
| Public API | No | Internal function return type change only |
| Protocol/IO | No | No LSP protocol changes |
| Config/Flags | No | No configuration changes |
| Persistence/Schema | No | No state changes |
| Concurrency | Yes (positive) | Thread-safe static caching via OnceLock |

### Hotspot / Churn Context

- `builtin_signatures.rs` - low churn (3 commits), foundational module
- `signature_help.rs` - low churn (2 commits), stable LSP provider
- `perl-corpus/*` - format/clippy fixes (pre-existing, not from Jules PR)

### Verification Receipts

| Gate | Command | Result |
|------|---------|--------|
| Format | `cargo fmt --all -- --check` | ✅ Pass (after fixes) |
| Clippy | `cargo clippy --workspace --lib -- -D warnings` | ✅ Pass (after fixes) |
| Tests (core) | `cargo test -p perl-parser-core` | ✅ 60/60 pass |
| Tests (providers) | `cargo test -p perl-lsp-providers` | ✅ 56/56 pass |
| Tests (workspace) | `cargo test --workspace --lib -- --test-threads=2` | ✅ All pass |

**Not run:** `nix develop -c just ci-gate` (individual gates run instead)

### Risk + Rollback

- **Risk class:** Low
- **Rationale:** Pure performance optimization using stable Rust patterns (`OnceLock`). No behavior change, just avoids repeated allocation of ~130-entry HashMap on each `create_builtin_signatures()` call.
- **Rollback:** Revert this PR

---

## Decision Log

**What was considered:**
1. Keep original implementation (allocate on every call)
2. Use `lazy_static!` crate for caching
3. Use `std::sync::OnceLock` (chosen)

**Why OnceLock:**
- No external dependency (in std since Rust 1.70)
- Thread-safe initialization
- Returns `&'static` reference, eliminating clone overhead
- Standard pattern for this use case

**What was explicitly done beyond Jules PR:**
- Fixed pre-existing format drift in `perl-corpus` (5 files)
- Fixed 4 clippy warnings in `perl-corpus` (manual_contains, field_reassign_with_default, collapsible_if)

**What was not done:**
- No benchmark added (perf improvement is straightforward allocation avoidance)
- No API changes to signature help public interface