### PR TITLE
style(vscode): use markdownDescription for settings with code references

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -122,7 +122,7 @@
         "perl-lsp.enableFormatting": {
           "type": "boolean",
           "default": true,
-          "description": "Enable document formatting using perltidy. Requires perltidy to be installed on your system."
+          "markdownDescription": "Enable document formatting using `perltidy`. Requires `perltidy` to be installed on your system."
         },
         "perl-lsp.formatOnSave": {
           "type": "boolean",
@@ -137,7 +137,7 @@
         "perl-lsp.perltidyConfig": {
           "type": "string",
           "default": "",
-          "description": "Path to your `.perltidyrc` configuration file. If omitted, searches workspace and home directory."
+          "markdownDescription": "Path to your `.perltidyrc` configuration file. If omitted, searches workspace and home directory."
         },
         "perl-lsp.includePaths": {
           "type": "array",
@@ -145,12 +145,12 @@
             "lib",
             "local/lib/perl5"
           ],
-          "description": "Additional library paths (like `use lib`) to search for Perl modules. Relative paths resolve from workspace root."
+          "markdownDescription": "Additional library paths (like `use lib`) to search for Perl modules. Relative paths resolve from workspace root."
         },
         "perl-lsp.enableTestIntegration": {
           "type": "boolean",
           "default": true,
-          "description": "Enable Test::More and Test2 integration"
+          "markdownDescription": "Enable `Test::More` and `Test2` integration"
         }
       }
     },


### PR DESCRIPTION
## Summary

Update VS Code configuration settings that contain code-formatted text (`perltidy`, `Test::More`, `Test2`, `.perltidyrc`, `use lib`) to use `markdownDescription` instead of plain `description`. This allows inline code blocks to render properly in VS Code's settings UI.

**Supersedes:** #414

## Changes

- `perl-lsp.enableFormatting`: backtick `perltidy` references
- `perl-lsp.perltidyConfig`: already had `.perltidyrc` backticked, now renders properly
- `perl-lsp.includePaths`: already had `use lib` backticked, now renders properly  
- `perl-lsp.enableTestIntegration`: backtick `Test::More` and `Test2` references

## Maintainer Improvements

- Rebased onto latest master (28552903)
- Converted commit message from Jules emoji style to conventional commits (`style(vscode):`)

---

## Glass Cockpit

### Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `master` @ `28552903` |
| Head ref | `maint/pr-414-20260121` @ `26462b52` |
| Diffstat | 1 file changed, 4 insertions(+), 4 deletions(-) |
| Files changed | 1 |
| Commits | 1 |
| Start review here | `vscode-extension/package.json` |

### Blast Radius

| Surface | Affected? | Notes |
|---------|-----------|-------|
| Public API | No | Extension config only |
| Protocol/IO boundary | No | |
| Config/flags | **Yes** | VS Code settings (4 descriptions) |
| Persistence/schema | No | |
| Concurrency | No | |

### Hotspot / Churn Context

- `vscode-extension/package.json`: Low churn, configuration file
- No load-bearing code paths affected

### Verification Receipts

```
✓ JSON validation: package.json is valid JSON
✓ TypeScript compile: tsc -p ./ succeeded
✓ Rust format check: Pre-existing issues on master (unrelated to this PR)
✓ Clippy: No new warnings from this change
```

**What wasn't run:** Full `ci-gate` - this PR only touches VS Code extension metadata (JSON), not Rust code. The relevant gates for this change are JSON validation and TypeScript compilation, both of which passed.

### Risk + Rollback

- **Risk class:** Low
- **Why:** Cosmetic change to VS Code settings UI rendering; no functional impact
- **Rollback:** Revert single commit, redeploy extension

### Decision Log

1. **Scoped to settings with code references**: Settings like `formatOnSave` and `enableDiagnostics` don't contain code-formatted text, so they remain as plain `description` (no benefit from markdown)
2. **Conventional commit style**: Converted Jules emoji prefix to `style(vscode):` to match project conventions
3. **Did not address pre-existing format issues**: Master has some `cargo fmt` differences in `perl-corpus` - out of scope for this UX improvement