### PR TITLE
feat(vscode): filter command palette to show Perl commands only in Perl files

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -199,6 +199,32 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "perl-lsp.restart",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.organizeImports",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.runTests",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.extractSubroutine",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.extractVariable",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.inlineVariable",
+          "when": "editorLangId == perl"
+        }
+      ],
       "editor/context": [
         {
           "command": "perl-lsp.runTests",


### PR DESCRIPTION
## Summary

Add `commandPalette` menu contribution to filter Perl-specific commands to only appear when editing Perl files. This reduces visual noise in polyglot workspaces.

**Scoped from:** #410 (commandPalette portion only; markdownDescription changes handled by #468)

## Changes

- Add `commandPalette` menu entries with `when: "editorLangId == perl"` for:
  - `perl-lsp.restart`
  - `perl-lsp.organizeImports`
  - `perl-lsp.runTests`
  - `perl-lsp.extractSubroutine`
  - `perl-lsp.extractVariable`
  - `perl-lsp.inlineVariable`

## Maintainer Improvements

1. **Scoped to unique value**: Original #410 bundled commandPalette filtering with markdownDescription changes. This PR extracts only the commandPalette filtering since #468 already handles markdownDescription.
2. **Conventional commit style**: Changed from Jules emoji prefix to `feat(vscode):` per project conventions.
3. **Rebased onto latest master**: Fresh branch from `28552903`.

---

## Glass Cockpit

### Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `master` @ `28552903` |
| Head ref | `maint/pr-410-commandpalette-20260121` @ `9dc0e8f3` |
| Diffstat | 1 file changed, 26 insertions(+) |
| Files changed | 1 |
| Commits | 1 |
| Start review here | `vscode-extension/package.json` |

### Blast Radius

| Surface | Affected? | Notes |
|---------|-----------|-------|
| Public API | No | Extension UI only |
| Protocol/IO boundary | No | |
| Config/flags | No | Settings unchanged |
| Persistence/schema | No | |
| Concurrency | No | |
| **UI/UX** | **Yes** | Command palette visibility |

### Hotspot / Churn Context

- `vscode-extension/package.json`: Low churn, configuration file
- No load-bearing code paths affected

### Verification Receipts

```
✓ JSON validation: python3 -c "import json; json.load(open('package.json'))"
✓ TypeScript compile: tsc -p ./ succeeded (no output = success)
✓ cargo fmt --all -- --check: passed
✓ cargo clippy --workspace --lib: passed (no warnings)
✓ cargo test --workspace --lib: passed
```

**What wasn't run:** Full `nix develop -c just ci-gate` — this PR only touches VS Code extension metadata (JSON), not Rust code. The relevant gates for this change are JSON validation and TypeScript compilation, both passed.

### Risk + Rollback

- **Risk class:** Low
- **Why:** Cosmetic change to VS Code command palette visibility; no functional impact to LSP operations
- **Rollback:** Revert single commit, redeploy extension

### Decision Log

1. **Scoped to commandPalette only**: Original #410 bundled two unrelated changes. Separated them so #468 handles markdownDescription and this PR handles commandPalette filtering.
2. **Conventional commit style**: Converted from Jules `🎨 Palette:` to `feat(vscode):` to match project conventions.
3. **Commands filtered**: All 6 Perl-specific commands now require `editorLangId == perl`. `showVersion` intentionally left visible globally (useful for debugging without a Perl file open).