### PR TITLE
docs: fix NodeKind coverage accuracy in corpus gap tracking

### DIFF
--- a/docs/issues/corpus/gaps/README.md
+++ b/docs/issues/corpus/gaps/README.md
@@ -2,17 +2,19 @@
 
 This directory contains documented gaps in the parser's corpus coverage.
 
-**Status**: These gaps need closure before v0.9.0 release.
+**Status**: Most gaps have been addressed. Remaining items tracked below.
 
 ---
 
 ## Summary
 
-| Category | Count | Priority |
-|----------|-------|----------|
-| GA Feature Missing Coverage | 4 | P0 |
-| NodeKind Never Seen | 4 | P1 |
-| Timeout/Hang Risks | 13 | P0-P2 |
+| Category | Count | Priority | Status |
+|----------|-------|----------|--------|
+| GA Feature Missing Coverage | 2 | P0 | 2 resolved, 2 remaining |
+| NodeKind Coverage Status | 2 | P1 | 2 resolved, 2 clarified |
+| Timeout/Hang Risks | 13 | P0-P2 | tracking |
+
+**Note**: The parser has 55 NodeKind variants (not 68 as previously stated).
 
 ---
 
@@ -21,24 +23,24 @@ This directory contains documented gaps in the parser's corpus coverage.
 Features advertised as GA but lacking test fixtures:
 
 - [continue-redo-statements](ga-feature-missing-coverage/continue-redo-statements.md)
-- [format-statements](ga-feature-missing-coverage/format-statements.md)
-- [glob-expressions](ga-feature-missing-coverage/glob-expressions.md)
-- [tie-interface](ga-feature-missing-coverage/tie-interface.md)
+- ~~[format-statements](ga-feature-missing-coverage/format-statements.md)~~ ✅ RESOLVED - corpus added
+- ~~[glob-expressions](ga-feature-missing-coverage/glob-expressions.md)~~ ✅ RESOLVED - corpus added
+- [tie-interface](ga-feature-missing-coverage/tie-interface.md) - NodeKind not yet implemented
 
 **Required action**: Add fixtures/tests that exercise these features.
 
 ---
 
-## NodeKind Never Seen (P1)
+## NodeKind Coverage Status (P1)
 
-NodeKinds defined in the parser but never encountered in corpus:
+Status of NodeKinds previously flagged as "never seen":
 
-- [format](nodekind-never-seen/format.md)
-- [glob](nodekind-never-seen/glob.md)
-- [sigil](nodekind-never-seen/sigil.md)
-- [tie](nodekind-never-seen/tie.md)
+- ~~[format](nodekind-never-seen/format.md)~~ ✅ RESOLVED - NodeKind exists, corpus added (`test_corpus/format_statements.pl`)
+- ~~[glob](nodekind-never-seen/glob.md)~~ ✅ RESOLVED - NodeKind exists, corpus added (`test_corpus/glob_expressions.pl`)
+- [sigil](nodekind-never-seen/sigil.md) - ⚠️ NOT A NODEKIND - sigils are fields in `Variable` nodes (intentional design)
+- [tie](nodekind-never-seen/tie.md) - ⚠️ NOT A NODEKIND - `Tie` not yet implemented in parser
 
-**Required action**: Determine if intentional (retire/alias) or coverage gap (add fixtures).
+**Required action**: For Sigil, document design decision. For Tie, implement NodeKind if needed.
 
 ---
 

--- a/docs/issues/corpus/gaps/ga-feature-missing-coverage/format-statements.md
+++ b/docs/issues/corpus/gaps/ga-feature-missing-coverage/format-statements.md
@@ -1,16 +1,19 @@
 # Issue: Format Statements - No Corpus Coverage
 
-## Problem Description
+> **STATUS: ✅ RESOLVED** - Corpus coverage has been added.
+>
+> - Test corpus: `test_corpus/format_statements.pl` (4+ test cases)
+> - Additional coverage: `test_corpus/legacy_syntax.pl`
+> - Added in PR #404 (commit 28552903)
 
-### What We Found
+## Original Problem Description (Historical)
 
-Format statements have **zero coverage** in the corpus despite being a P0 critical feature in the GA (Grammar Analyzer) feature list:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 test cases
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 test cases
-- Test corpus (`test_corpus/`): 0 test cases
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Now Outdated)
 
-This represents a critical gap in test coverage for a feature that is still widely used in legacy Perl codebases.
+~~Format statements have **zero coverage** in the corpus.~~
+
+**Current status**: Corpus coverage was added. The parser supports format statements
+via `NodeKind::Format { name, body }` and test fixtures now exercise this feature.
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/ga-feature-missing-coverage/glob-expressions.md
+++ b/docs/issues/corpus/gaps/ga-feature-missing-coverage/glob-expressions.md
@@ -1,16 +1,19 @@
 # Issue: Glob Expressions - No Corpus Coverage
 
-## Problem Description
+> **STATUS: ✅ RESOLVED** - Corpus coverage has been added.
+>
+> - Test corpus: `test_corpus/glob_expressions.pl` (8+ test cases)
+> - Additional coverage: `test_corpus/legacy_syntax.pl`, `test_corpus/advanced_regex.pl`
+> - Added in PR #404 (commit 28552903)
 
-### What We Found
+## Original Problem Description (Historical)
 
-Glob expressions have **zero coverage** in the corpus despite being a P0 critical feature in the GA (Grammar Analyzer) feature list:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 test cases
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 test cases
-- Test corpus (`test_corpus/`): 0 test cases
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Now Outdated)
 
-This represents a critical gap in test coverage for file pattern matching, a commonly used Perl feature.
+~~Glob expressions have **zero coverage** in the corpus.~~
+
+**Current status**: Corpus coverage was added. The parser supports glob expressions
+via `NodeKind::Glob { pattern }` and test fixtures now exercise this feature.
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/ga-feature-missing-coverage/tie-interface.md
+++ b/docs/issues/corpus/gaps/ga-feature-missing-coverage/tie-interface.md
@@ -1,16 +1,22 @@
 # Issue: Tie Interface - No Corpus Coverage
 
+> **STATUS: ⚠️ OPEN** - Parser enhancement needed.
+>
+> The parser does not have a dedicated `NodeKind::Tie` variant. Currently, `tie`
+> and `untie` are parsed as regular function calls (`NodeKind::FunctionCall`).
+> This limits semantic analysis capabilities for tie operations.
+>
+> **Related**: Issue #437, nodekind-never-seen/tie.md
+
 ## Problem Description
 
 ### What We Found
 
-Tie interface has **zero coverage** in the corpus despite being a P0 critical feature in the GA (Grammar Analyzer) feature list:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 test cases
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 test cases
-- Test corpus (`test_corpus/`): 0 test cases
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
-
-This represents a critical gap in test coverage for an important Perl feature that enables binding variables to objects.
+Tie interface has **limited support** in the parser:
+- `tie` parsed as: `NodeKind::FunctionCall { name: "tie", args: [...] }`
+- No dedicated `NodeKind::Tie` variant exists
+- Semantic analysis for tie operations is limited
+- Test corpus coverage: none (would exercise function call path only)
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/nodekind-never-seen/format.md
+++ b/docs/issues/corpus/gaps/nodekind-never-seen/format.md
@@ -1,16 +1,19 @@
 # Issue: Format NodeKind Never Seen in Corpus
 
-## Problem Description
+> **STATUS: ✅ RESOLVED** - Format NodeKind exists and has corpus coverage.
+>
+> - `NodeKind::Format` implemented in `crates/perl-parser-core/src/engine/ast.rs`
+> - Parser support in `crates/perl-parser-core/src/engine/parser/declarations.rs`
+> - Test corpus: `test_corpus/format_statements.pl` (added in PR #404)
+> - Also covered in: `test_corpus/legacy_syntax.pl`
 
-### What We Found
+## Original Problem Description (Historical)
 
-The `Format` NodeKind is **never seen** in any corpus test fixture across all four corpus layers:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 occurrences
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 occurrences
-- Test corpus (`test_corpus/`): 0 occurrences
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Now Outdated)
 
-This represents a **6% gap** in NodeKind coverage (4 of 68 NodeKinds never seen).
+~~The `Format` NodeKind is **never seen** in any corpus test fixture.~~
+
+**Current status**: `NodeKind::Format { name, body }` exists and is actively used. Test corpus coverage was added in commit 28552903.
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/nodekind-never-seen/glob.md
+++ b/docs/issues/corpus/gaps/nodekind-never-seen/glob.md
@@ -1,16 +1,19 @@
 # Issue: Glob NodeKind Never Seen in Corpus
 
-## Problem Description
+> **STATUS: ✅ RESOLVED** - Glob NodeKind exists and has corpus coverage.
+>
+> - `NodeKind::Glob { pattern }` implemented in `crates/perl-parser-core/src/engine/ast.rs`
+> - Parser support in `crates/perl-parser-core/src/engine/parser/expressions/primary.rs`
+> - Test corpus: `test_corpus/glob_expressions.pl` (added in PR #404)
+> - Also covered in: `test_corpus/legacy_syntax.pl`, `test_corpus/advanced_regex.pl`
 
-### What We Found
+## Original Problem Description (Historical)
 
-The `Glob` NodeKind is **never seen** in any corpus test fixture across all four corpus layers:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 occurrences
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 occurrences
-- Test corpus (`test_corpus/`): 0 occurrences
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Now Outdated)
 
-This represents a **6% gap** in NodeKind coverage (4 of 68 NodeKinds never seen).
+~~The `Glob` NodeKind is **never seen** in any corpus test fixture.~~
+
+**Current status**: `NodeKind::Glob { pattern }` exists and is actively used. Test corpus coverage was added in commit 28552903.
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/nodekind-never-seen/sigil.md
+++ b/docs/issues/corpus/gaps/nodekind-never-seen/sigil.md
@@ -1,16 +1,27 @@
 # Issue: Sigil NodeKind Never Seen in Corpus
 
-## Problem Description
+> **STATUS: ⚠️ NOT A NODEKIND** - This is intentional design, not a coverage gap.
+>
+> The parser does NOT have a `NodeKind::Sigil` variant. Sigils are captured as a
+> `String` field within `NodeKind::Variable { sigil, name }`. This design was chosen
+> because sigils are inherently part of variable constructs in Perl, not standalone
+> semantic units.
+>
+> **Design decision**: Option 2 (Keep Sigils as Part of Other Nodes) - see below.
 
-### What We Found
+## Original Problem Description (Now Clarified)
 
-The `Sigil` NodeKind is **never seen** in any corpus test fixture across all four corpus layers:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 occurrences
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 occurrences
-- Test corpus (`test_corpus/`): 0 occurrences
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Clarification)
 
-This represents a **6% gap** in NodeKind coverage (4 of 68 NodeKinds never seen).
+~~The `Sigil` NodeKind is **never seen** in any corpus test fixture.~~
+
+**Clarification**: There is no `NodeKind::Sigil` variant in the parser. The parser
+has 55 NodeKind variants (not 68 as previously stated), and `Sigil` is not among them.
+
+Sigils (`$`, `@`, `%`, `&`, `*`) are represented as the `sigil: String` field in:
+- `NodeKind::Variable { sigil, name }` - for variables like `$foo`, `@array`, `%hash`
+
+This is intentional - sigils are intrinsically part of the variable identifier in Perl.
 
 ### Minimal Reproduction
 

--- a/docs/issues/corpus/gaps/nodekind-never-seen/tie.md
+++ b/docs/issues/corpus/gaps/nodekind-never-seen/tie.md
@@ -1,16 +1,26 @@
 # Issue: Tie NodeKind Never Seen in Corpus
 
-## Problem Description
+> **STATUS: ⚠️ NOT YET IMPLEMENTED** - This is a real feature gap, not a coverage gap.
+>
+> The parser does NOT have a `NodeKind::Tie` variant. The `tie` builtin is currently
+> parsed as a regular function call (`NodeKind::FunctionCall`), not as a distinct
+> construct. Implementing a dedicated `Tie` NodeKind would require parser enhancements.
+>
+> **Current behavior**: `tie %hash, 'Package', @args` → `FunctionCall { name: "tie", args: [...] }`
+>
+> **Related issue**: #437 (Corpus Coverage: Add tie-interface test fixtures)
 
-### What We Found
+## Problem Description (Updated)
 
-The `Tie` NodeKind is **never seen** in any corpus test fixture across all four corpus layers:
-- Tree-sitter corpus (`tree-sitter-perl/test/corpus/`): 0 occurrences
-- Highlight fixtures (`tree-sitter-perl/test/highlight/`): 0 occurrences
-- Test corpus (`test_corpus/`): 0 occurrences
-- Perl-corpus generators (`crates/perl-corpus/src/gen/`): 0 generators
+### What We Found (Clarification)
 
-This represents a **6% gap** in NodeKind coverage (4 of 68 NodeKinds never seen).
+~~The `Tie` NodeKind is **never seen** in any corpus test fixture.~~
+
+**Clarification**: There is no `NodeKind::Tie` variant in the parser. The parser
+has 55 NodeKind variants (not 68 as previously stated), and `Tie` is not among them.
+
+The `tie` and `untie` builtins are currently parsed as regular function calls. This
+means semantic analysis for tie operations is limited.
 
 ### Minimal Reproduction
 


### PR DESCRIPTION
## Summary

Corrects multiple inaccuracies in the corpus gap documentation that were causing confusion about parser coverage status.

**Key corrections:**
- Fix NodeKind count: **55 variants exist** (not 68 as previously documented)
- Mark Format and Glob gaps as **RESOLVED** (corpus added in PR #404)
- Clarify Sigil is **NOT a NodeKind** (intentional design - sigils are fields in Variable nodes)
- Clarify Tie is **NOT a NodeKind** (real feature gap, not coverage gap)

## Modern Dev Metrics

### Change Shape

| Metric | Value |
|--------|-------|
| Base ref | master @ e04faa72 |
| Head ref | docs/fix-nodekind-coverage-accuracy-20260122 @ 5b46b08d |
| Files changed | 8 |
| Lines added | ~112 |
| Lines removed | ~71 |
| Commits | 1 |

### Files Changed

- `docs/issues/corpus/gaps/README.md` - Summary table and status updates
- `docs/issues/corpus/gaps/ga-feature-missing-coverage/format-statements.md` - Mark RESOLVED
- `docs/issues/corpus/gaps/ga-feature-missing-coverage/glob-expressions.md` - Mark RESOLVED
- `docs/issues/corpus/gaps/ga-feature-missing-coverage/tie-interface.md` - Clarify status
- `docs/issues/corpus/gaps/nodekind-never-seen/format.md` - Mark RESOLVED
- `docs/issues/corpus/gaps/nodekind-never-seen/glob.md` - Mark RESOLVED
- `docs/issues/corpus/gaps/nodekind-never-seen/sigil.md` - Clarify NOT a NodeKind
- `docs/issues/corpus/gaps/nodekind-never-seen/tie.md` - Clarify NOT a NodeKind

### Blast Radius / Surface Area

| Area | Impact |
|------|--------|
| Public API | ❌ None |
| Protocol/IO boundary | ❌ None |
| Config/flags | ❌ None |
| Persistence/schema | ❌ None |
| Concurrency | ❌ None |

**This is a documentation-only change** with no code impact.

### Hotspot / Churn Context

The `docs/issues/corpus/gaps/` directory was added recently (PR #404) and contained outdated information about parser state before the comprehensive corpus expansion was completed.

### Verification Receipts

| Check | Status | Notes |
|-------|--------|-------|
| File validation | ✅ | All 8 markdown files modified successfully |
| Git status | ✅ | Clean working tree after commit |
| Build impact | N/A | Documentation-only (no Rust code changes) |

**What wasn't run and why:**
- `cargo test` - Not applicable (no Rust changes)
- `cargo clippy` - Not applicable (no Rust changes)
- Pre-existing clippy issues in codebase unrelated to this PR

### Risk + Rollback

| Aspect | Assessment |
|--------|------------|
| Risk class | **Minimal** |
| Rationale | Documentation-only changes; no code impact |
| Rollback plan | `git revert <commit>` |

## Decision Log

### Investigation Findings

Analyzed the NodeKind enum in `crates/perl-parser-core/src/engine/ast.rs`:
- Counted **55 actual NodeKind variants** (not 68)
- Found `NodeKind::Format { name, body }` EXISTS and is used
- Found `NodeKind::Glob { pattern }` EXISTS and is used
- Confirmed **no `NodeKind::Sigil`** exists - sigils are `String` field in `Variable`
- Confirmed **no `NodeKind::Tie`** exists - tie parsed as `FunctionCall`

### Why This Approach

1. **Accuracy over speculation** - Verified actual codebase state rather than accepting documentation at face value
2. **Preserve history** - Kept original problem descriptions as "historical" rather than deleting
3. **Clear status banners** - Added prominent status indicators at top of each document
4. **Actionable remaining items** - Distinguished between resolved issues vs. actual feature gaps

### What Was NOT Changed

- Did not implement `NodeKind::Tie` (out of scope for doc fix)
- Did not close GitHub issues #432, #434, #437, #446 (maintainer decision)
- Did not modify any Rust code

## Related Issues

- Issue #446: NodeKind Coverage Gaps tracking (should be updated to reflect findings)
- Issue #437: Corpus Coverage: tie-interface (clarified as feature gap not coverage gap)

## Test Plan

- [x] Documentation renders correctly on GitHub
- [x] All relative links in README.md work
- [x] Status banners are visible and clear