### PR TITLE
fix(security): replace exec with execFile in VS Code extension version check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The "safe" evaluation mode in `perl-dap` failed to block `qx` (quoted execution) and backticks, allowing potential command injection or side effects when the user (or IDE) expected read-only evaluation.
 **Learning:** Blocklists for "safe" execution must be comprehensive. When wrapping a language like Perl where `qx` and backticks are first-class execution mechanisms, simply blocking `system` and `exec` is insufficient.
 **Prevention:** Use a deny-default approach if possible, or ensure the deny-list covers all language constructs that trigger external processes or state mutations (including `qx`, `readpipe`, `syscall`, and backticks).
+
+## 2025-05-23 - Command Injection in VS Code Extension Version Check
+**Vulnerability:** The `perl-lsp.showVersion` command in `vscode-extension` used `exec` with a user-configurable `serverPath` string. If an attacker controlled this setting (e.g., via workspace settings), they could inject shell commands.
+**Learning:** In Node.js, `exec` spawns a shell (`/bin/sh` or `cmd.exe`) and parses the command string, making it vulnerable to injection if any part of the string is untrusted. `execFile` spawns the executable directly without a shell.
+**Prevention:** Always use `execFile` (or `spawn`) instead of `exec` when invoking binaries where arguments or paths might be influenced by user input. Avoid string interpolation for shell commands.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -82,8 +82,8 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     
     const showVersionCommand = vscode.commands.registerCommand('perl-lsp.showVersion', async () => {
-        const { exec } = require('child_process');
-        exec(`${serverPath} --version`, (error: any, stdout: string, stderr: string) => {
+        const { execFile } = require('child_process');
+        execFile(serverPath, ['--version'], (error: any, stdout: string, stderr: string) => {
             if (error) {
                 vscode.window.showErrorMessage(`Failed to get version: ${error.message}`);
             } else {


### PR DESCRIPTION
## Summary

Fixes command injection vulnerability in the `perl-lsp.showVersion` VS Code command by replacing `child_process.exec` with `child_process.execFile`.

**Vulnerability:** The `perl-lsp.serverPath` setting could contain shell metacharacters that would be executed when running `--version`.

**Fix:** Use `execFile` which spawns the binary directly without a shell, preventing command injection.

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `master` @ `4cd61166` |
| Head ref | `maint/pr-512-20260124` |
| Files changed | 2 |
| Insertions | +7 |
| Deletions | -2 |
| Commits | 1 |

**Key file:** `vscode-extension/src/extension.ts:84-86`

### Blast Radius
| Surface | Impact |
|---------|--------|
| Public API | ❌ None |
| Protocol/IO boundary | ✅ Shell command execution changed |
| Config/flags | ❌ None (serverPath still works) |
| Persistence/schema | ❌ None |
| Concurrency | ❌ None |

### Hotspot Context
- `extension.ts` is a stable, low-churn file (core extension entrypoint)
- Change is localized to a single command handler

### Verification Receipts

```bash
# TypeScript compilation
$ cd vscode-extension && npx tsc --noEmit
✅ Passed (no errors)

# NPM dependency check  
$ npm install
✅ Passed (209 packages, no new vulnerabilities from this change)

# Diff verification
$ git diff --stat origin/master HEAD
 .jules/sentinel.md                | 5 +++++
 vscode-extension/src/extension.ts | 4 ++--
 2 files changed, 7 insertions(+), 2 deletions(-)
```

**Not run:**
- Rust tests: Not applicable (no Rust changes)
- Extension E2E tests: Not configured in this repo

### Risk + Rollback
| Aspect | Assessment |
|--------|------------|
| Risk class | LOW |
| Rationale | Direct API replacement (`exec` → `execFile`), no behavior change for valid paths |
| Rollback | Revert commit |

## Decision Log

1. **Kept original Jules fix approach** - The `exec` → `execFile` replacement is the correct fix for this class of vulnerability
2. **Did not expand scope** - Identified similar pattern in `downloader.ts` (line 202) but left as follow-up since:
   - Different data flow (more controlled paths from `os.tmpdir()`)
   - Lower severity (user controls their own workspace settings)
   - Scope creep would complicate review
3. **Cherry-picked onto latest master** - Ensured no merge conflicts and rebased on `4cd61166`

---

Supersedes: #512