### PR TITLE
🛡️ Sentinel: Fix command injection in VS Code downloader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 Users hovering over expressions containing these keywords could accidentally trigger dangerous operations even when `allowSideEffects: false`.
 **Learning:** Safe evaluation blocklists must cover ALL categories of dangerous operations. Partial coverage creates a false sense of security. Perl's `tie` mechanism is particularly insidious as it can execute arbitrary code on variable access.
 **Prevention:** Maintain a categorized blocklist with clear documentation of why each operation is blocked. Test each blocked operation explicitly with regression tests.
+
+## 2026-05-27 - Archive Extraction Command Injection
+**Vulnerability:** The `BinaryDownloader` in `vscode-extension` used `exec` with constructed command strings to extract archives (`tar`, `unzip`). Maliciously crafted filenames or paths (e.g., from an internal repo or if the release tag was compromised) could inject shell commands.
+**Learning:** File manipulation operations involving external tools (`tar`, `unzip`, `git`) are frequent targets for injection if paths are interpolated into command strings.
+**Prevention:** Use `execFile` with argument arrays for all external tool invocations. Never interpolate paths into shell commands.

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import { promisify } from 'util';
 import * as child_process from 'child_process';
 
-const exec = promisify(child_process.exec);
+const execFile = promisify(child_process.execFile);
 
 interface ReleaseAsset {
     name: string;
@@ -188,18 +188,23 @@ export class BinaryDownloader {
                 fs.mkdirSync(extractDir);
                 
                 // Choose extraction command based on file extension
-                let extractCmd: string;
+                let cmd: string;
+                let args: string[];
+
                 if (assetName.endsWith('.tar.xz')) {
-                    extractCmd = `tar -xJf "${archivePath}" -C "${extractDir}"`;
+                    cmd = 'tar';
+                    args = ['-xJf', archivePath, '-C', extractDir];
                 } else if (assetName.endsWith('.tar.gz')) {
-                    extractCmd = `tar -xzf "${archivePath}" -C "${extractDir}"`;
+                    cmd = 'tar';
+                    args = ['-xzf', archivePath, '-C', extractDir];
                 } else if (assetName.endsWith('.zip')) {
-                    extractCmd = `unzip -q "${archivePath}" -d "${extractDir}"`;
+                    cmd = 'unzip';
+                    args = ['-q', archivePath, '-d', extractDir];
                 } else {
                     throw new Error(`Unsupported archive format: ${assetName}`);
                 }
                 
-                await exec(extractCmd);
+                await execFile(cmd, args);
                 
                 // Find the binary
                 const binaryName = process.platform === 'win32' ? 'perl-lsp.exe' : 'perl-lsp';


### PR DESCRIPTION
## Summary
Security hardening: Replace shell-interpolated `exec` with `execFile` + argument arrays in the VS Code extension's binary downloader. This prevents command injection if archive filenames or paths ever contain shell metacharacters.

## Why
The old pattern used `exec()` with template literals:
```typescript
await exec(`tar -xJf "${archivePath}" -C "${extractDir}"`);
```
If `archivePath` contained shell metacharacters (e.g., from a compromised release tag or malicious internal URL), arbitrary commands could execute. The fix uses `execFile()` which bypasses the shell entirely:
```typescript
await execFile('tar', ['-xJf', archivePath, '-C', extractDir]);
```

## Modern dev metrics

### Change shape
- Base: `master` @ `13c4d91c47de2ac713834516a05ff3d08c4ed9a9`
- Head: `maint/pr-524-20260125` @ `c8e112ab4eef871438dac350dbeaf1311135c024`
- Commits: 1
- Files changed: 2

Diffstat:
```
 .jules/sentinel.md                 |  5 +++++
 vscode-extension/src/downloader.ts | 17 +++++++++++------
 2 files changed, 16 insertions(+), 6 deletions(-)
```

Start review here:
- `vscode-extension/src/downloader.ts` (security fix)
- `.jules/sentinel.md` (documentation)

### Blast radius / surface area
- Public API: N/A (internal implementation detail)
- Protocol / IO boundary: Process spawning (hardened)
- Config / flags: N/A
- Persistence / schema: N/A
- Concurrency: N/A

### Hotspot / churn context
`downloader.ts` is the binary auto-update mechanism. Low churn, medium criticality (handles downloads from GitHub releases).

## Verification receipts
- Receipts: `evidence/verification.md`
- TypeScript compile: PASS (takeover=0, base=0)
- No behavioral changes to extraction logic; only the subprocess spawning method changes

## Risk and rollback
- Risk class: Low (purely defensive change, identical extraction behavior)
- Rollback plan: Revert commit; original behavior is functionally identical

## Decision log
- Kept Jules's fix as-is: the pattern is correct Node.js security practice
- Added documentation to `.jules/sentinel.md` (Jules did this)
- No additional changes needed: fix is complete and correct
