### PR TITLE
feat(dap): expand safe evaluation blocklist

### DIFF
--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -4,11 +4,11 @@
 //! to enable debugging support in VSCode and other DAP-compatible editors.
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{Sender, channel};
+use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread;
 


### PR DESCRIPTION
## Summary
Expands the DAP safe evaluation blocklist to prevent additional potentially dangerous Perl operations from executing when the debugger evaluates expressions with `allowSideEffects=false`. This enhances security by blocking file globbing, low-level I/O, System V IPC, and network operations during hover/watch evaluation.

## Why
When debugging, users may accidentally hover over expressions containing operations that could modify system state, consume resources (semaphores, shared memory), or leak information via network calls. The existing blocklist covered basic operations but missed several categories of potentially harmful Perl built-ins. This change follows the defense-in-depth principle for the debugger's safe evaluation mode.

## Modern dev metrics

### Change shape
- Base: `master` @ `13c4d91c47de2ac713834516a05ff3d08c4ed9a9`
- Head: `maint/pr-529-20260125` @ `e4f950717e15632d40a4b39e9da350558e9b959e`
- Commits: 2
- Files changed: 1

Diffstat:
```
 crates/perl-dap/src/debug_adapter.rs | 41 +++++++++++++++++++++++++++++-------
 1 file changed, 33 insertions(+), 8 deletions(-)
```

Start review here:
- `crates/perl-dap/src/debug_adapter.rs` - the `dangerous_ops_re()` function and new test

### Blast radius / surface area
- Public API: N/A (internal regex blocklist only, no external interface change)
- Protocol / IO boundary: N/A (affects expression validation, not DAP protocol)
- Config / flags: N/A (uses existing `allowSideEffects` flag behavior)
- Persistence / schema: N/A (no state changes)
- Concurrency: N/A (static `OnceLock` initialization, thread-safe)

### Hotspot / churn context
The `debug_adapter.rs` file is the core DAP implementation. The modified `dangerous_ops_re()` function is a self-contained static initializer with no callers outside the safe evaluation path. Low-risk, localized change.

## Verification receipts
- rustfmt: PASS (pre-existing import ordering fixed in maintainer commit)
- cargo check -p perl-dap: PASS
- cargo test -p perl-dap --lib: PASS (84 tests, including new `safe_eval_blocks_extended_ops_v2`)
- See `evidence/verification.md` for full logs

## Risk and rollback
- Risk class: Low - additive blocklist expansion, no behavioral changes to passing expressions
- Rollback plan: Revert the commit; previously-allowed operations will be permitted again in safe mode

## Decision log
- Kept the original Jules commit with expanded blocklist
- Added maintainer commit to fix pre-existing rustfmt import ordering issue
- Verified the new `safe_eval_blocks_extended_ops_v2` test exercises the new blocked operations
- No architectural changes needed; the change is well-scoped
