### PR TITLE
⚡ Bolt: Optimize unused variable allocation in ScopeAnalyzer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@ This journal tracks critical performance learnings for the `tree-sitter-perl-rs`
 ## 2024-05-22 - [Initial Setup]
 **Learning:** Performance benchmarks are available in `crates/perl-parser/benches/`. The `ast_to_sexp` benchmark currently emits many parse errors, which might noise up the results.
 **Action:** When running benchmarks, ensure valid input or filter out known noisy benchmarks if they obscure the target optimization.
+
+## 2026-01-23 - [Iterator Callback vs Vector Allocation]
+**Learning:** Returning `Vec<String>` from hot loops (like unused variable collection in `ScopeAnalyzer`) forces allocation even for items that will be immediately filtered out. Using an iterator pattern or callback (`for_each_unused_variable`) allows filtering *before* allocation.
+**Action:** Prefer passing closures to inner scopes/loops instead of collecting results into temporary vectors, especially when filtering logic is available in the caller.


### PR DESCRIPTION
## Summary
Optimizes unused variable collection in `ScopeAnalyzer` by replacing a vector-returning method with a callback-based approach, eliminating intermediate allocations.

## Why
The original `get_unused_variables()` method allocated a `Vec<(String, usize)>` for every scope and allocated a `String` for every unused variable, even those starting with `_` that would be immediately filtered out. By switching to a callback pattern (`for_each_unused_variable`), we:
- Eliminate one Vec allocation per scope
- Avoid String allocation for underscore-prefixed variables (filtered before `format!()`)
- Reduce memory pressure during scope analysis of large Perl files

This is a semantic no-op - the same variables are reported as unused, with less allocation overhead.

## Modern dev metrics

### Change shape
- Base: `master` @ `1d4d1e2f50c06b9793d41fa8584084a2af31fd2a`
- Head: `maint/pr-541_20260125_064805` @ `44d247b2f98ce395847b7613bc5a4792f70c52d5`
- Commits: 1
- Files changed: 2

Diffstat:
```
 .jules/bolt.md                                     |  4 ++++
 .../src/analysis/scope_analyzer.rs                 | 26 +++++++++-------------
 2 files changed, 15 insertions(+), 15 deletions(-)
```

Start review here:
```
.jules/bolt.md
crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
```

### Blast radius / surface area
- Public API: None - `for_each_unused_variable` is private to `Scope`
- Protocol / IO boundary: None
- Config / flags: None
- Persistence / schema: None
- Concurrency: None - single-threaded RefCell-based scope analysis

### Hotspot / churn context
## Churn context (last 90 days; approximate)
- .jules/bolt.md : 3 commits
- crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs : 18 commits

## Verification receipts
- See: `evidence/verification.md`

| Gate | Result |
|------|--------|
| cargo clippy --workspace --lib | PASS |
| cargo test --workspace --lib | PASS |
| cargo test -p perl-semantic-analyzer | PASS |

Note: Pre-existing format issue in `parser_benchmark.rs` (unrelated file) fails on both base and takeover.

## Risk and rollback
- Risk class: Low - pure refactor with no behavioral change, no API changes, no IO
- Rollback plan: Revert commit - no data migration needed

## Decision log
- **Considered**: Keeping the Vec-based API but using `with_capacity()` - rejected because callback pattern is cleaner and avoids allocation entirely
- **Chose**: Callback-based `for_each_unused_variable` pattern matching idiomatic Rust iterator patterns
- **Explicitly not included**: Performance benchmarks proving the optimization (not in scope for this takeover - the allocation reduction is structurally obvious)
