### PR TITLE
🎨 Palette: Add missing Test::More snippets

### DIFF
--- a/vscode-extension/snippets/perl.json
+++ b/vscode-extension/snippets/perl.json
@@ -382,6 +382,27 @@
         ],
         "description": "Test if object is of a given class (Test::More)"
     },
+    "Test Can Ok": {
+        "prefix": "tm-can_ok",
+        "body": [
+            "can_ok(${1:$obj}, qw(${2:methods}));"
+        ],
+        "description": "Test if object or class has methods (Test::More)"
+    },
+    "Test Pass": {
+        "prefix": "tm-pass",
+        "body": [
+            "pass('${1:test description}');"
+        ],
+        "description": "Explicitly pass a test (Test::More)"
+    },
+    "Test Fail": {
+        "prefix": "tm-fail",
+        "body": [
+            "fail('${1:test description}');"
+        ],
+        "description": "Explicitly fail a test (Test::More)"
+    },
     "Test Subtest": {
         "prefix": "tm-subtest",
         "body": [


### PR DESCRIPTION
## Summary
Maintained takeover of automated PR #552 (Palette). Adds missing Test::More snippets to VSCode extension.

## Why
Ensuring automated changes are verified and shipped with proper receipts.

## Modern dev metrics

### Change shape
- Base: master
- Commits: 1
- Files changed: 1

Diffstat:
```
 vscode-extension/snippets/perl.json | 21 +++++++++++++++++++++
 1 file changed, 21 insertions(+)
```

### Blast radius
- Configuration/Data only (snippets).

## Verification receipts
- See: `evidence/verification.md`
- JSON syntax validated.

## Risk and rollback
- Risk class: Low. Client-side snippet definition.
- Rollback plan: Revert commit.

## Decision log
- Accepted bot changes after verification.
