### PR TITLE
🎨 Palette: Improve binary downloader UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-01-27 - Transient Status Bar Feedback
 **Learning:** For long-running operations like tests where the "Output" panel is too hidden and "Notifications" are too intrusive, temporarily hijacking the Status Bar Item provides excellent, non-disruptive feedback.
 **Action:** When implementing async commands that have a corresponding Status Bar Item, use a `try...finally` block to temporarily update the item's text (e.g., `$(sync~spin) Processing...`) and restore it afterwards.
+
+## 2026-01-27 - Consistent Status Bar Placement
+**Learning:** Placing temporary status indicators (like downloads) on the opposite side of the main extension indicator creates visual disconnection and confusion.
+**Action:** Always align temporary status items (downloads, initialization) with the main extension status item (usually Right) and provide tooltips/commands for details.

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -48,8 +48,10 @@ export class BinaryDownloader {
         }
         
         // Show status bar while downloading
-        const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+        const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
         statusBar.text = '$(sync~spin) Perl LSP: downloading binary...';
+        statusBar.tooltip = 'Downloading Perl Language Server... Click to show logs';
+        statusBar.command = 'perl-lsp.showOutput';
         statusBar.show();
         
         // Download binary

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,6 +18,12 @@ let testAdapter: PerlTestAdapter | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel('Perl Language Server');
+
+    // Register showOutput command early so it's available during binary download and initialization
+    const showOutputCommand = vscode.commands.registerCommand('perl-lsp.showOutput', () => {
+        outputChannel.show();
+    });
+    context.subscriptions.push(showOutputCommand);
     
     // Get the path to perl-lsp
     const serverPath = await getServerPath(context);
@@ -167,10 +173,6 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
     
-    const showOutputCommand = vscode.commands.registerCommand('perl-lsp.showOutput', () => {
-        outputChannel.show();
-    });
-    
     const showVersionCommand = vscode.commands.registerCommand('perl-lsp.showVersion', async () => {
         const { execFile } = require('child_process');
         execFile(serverPath, ['--version'], (error: any, stdout: string, stderr: string) => {
@@ -203,7 +205,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
     
-    context.subscriptions.push(restartCommand, runTestsCommand, showOutputCommand, showVersionCommand, statusMenuCommand);
+    context.subscriptions.push(restartCommand, runTestsCommand, showVersionCommand, statusMenuCommand);
     
     outputChannel.appendLine('Perl Language Server started successfully');
 }


### PR DESCRIPTION
- Aligned the binary downloader status bar item to the right (consistent with main extension status).
- Added a helpful tooltip: "Downloading Perl Language Server... Click to show logs".
- Enabled click-to-show-logs by linking the `perl-lsp.showOutput` command.
- Moved `perl-lsp.showOutput` registration to the start of `activate` to ensure availability during download.
- Added journal entry to `.jules/palette.md`.

---
*PR created automatically by Jules for task [9508475868388744615](https://jules.google.com/task/9508475868388744615) started by @EffortlessSteven*