### PR TITLE
🛡️ Sentinel: Fix command injection in debug adapter discovery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -50,3 +50,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The `perl-dap` safe evaluation logic exempted variables (e.g., `$system`) from the dangerous operations blacklist, but failed to check if those variables were being used in an execution context (e.g., `&$system` or `&{$system}`). This allowed invoking blocked builtins (like `system`) indirectly via variable dereference.
 **Learning:** Allow-listing variables based on sigils alone is insufficient for languages where sigils are also used for dereference calls. Context matters: `$var` is safe, `&$var` is a function call.
 **Prevention:** When exempting identifiers from a blacklist based on syntax (like sigils), explicitly verify that the surrounding syntax does not imply execution (e.g., preceding `&` or `->`).
+
+## 2026-10-26 - Command Injection via execSync which
+**Vulnerability:** The debugger discovery logic used `execSync('which ' + command)` to locate the debug adapter. Although the command input was currently static, this pattern is inherently unsafe as `execSync` spawns a shell, allowing command injection if the input ever becomes dynamic.
+**Learning:** Utility functions that wrap shell commands (like `which`) using `exec` or `execSync` are common sources of vulnerabilities. Developers often forget that `exec` invokes a shell.
+**Prevention:** Replace shell-based utility wrappers with native Node.js implementations. For finding executables, manually iterating `process.env.PATH` is safer, more efficient, and better for cross-platform compatibility (avoiding reliance on the existence of `which` or `where`).


### PR DESCRIPTION
🛡️ Sentinel: Fix command injection in debug adapter discovery

🚨 Severity: MEDIUM (Potential HIGH if input becomes dynamic)
💡 Vulnerability: The `which` method in `PerlDebugAdapterDescriptorFactory` used `execSync` with a string argument, which spawns a shell. Although currently used with a hardcoded string ('perl-dap'), this pattern is unsafe and could lead to Remote Code Execution (RCE) if the argument were ever derived from user input (e.g., config).
🎯 Impact: Prevention of future RCE vulnerabilities and removal of unsafe shell execution patterns.
🔧 Fix: Replaced `execSync` with a manual iteration over `process.env.PATH` using `fs.existsSync` and `fs.statSync`. Added executable permission checks for correctness.
✅ Verification: Confirmed via `pnpm run compile` and manual verification script `vuln_check_secure.js` that the new logic correctly finds binaries (like `ls`) but returns `undefined` for malicious inputs (like `ls; echo "FAIL"`).

---
*PR created automatically by Jules for task [18145726268091814267](https://jules.google.com/task/18145726268091814267) started by @EffortlessSteven*