### PR TITLE
🎨 Palette: Add 'Configure Settings' to Status Bar Menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-01-27 - Transient Status Bar Feedback
 **Learning:** For long-running operations like tests where the "Output" panel is too hidden and "Notifications" are too intrusive, temporarily hijacking the Status Bar Item provides excellent, non-disruptive feedback.
 **Action:** When implementing async commands that have a corresponding Status Bar Item, use a `try...finally` block to temporarily update the item's text (e.g., `$(sync~spin) Processing...`) and restore it afterwards.
+
+## 2026-01-28 - Deep Linking Settings
+**Learning:** Users often need to tweak extension settings (like paths or flags) but digging through the generic Settings UI is high friction. Providing a direct link to the extension's filtered settings (`@ext:publisher.name`) from a context menu (like the Status Bar) is a massive quality-of-life improvement.
+**Action:** For extensions with complex configuration, add a "Configure Settings" item to the main entry point menu that triggers `workbench.action.openSettings` with the extension ID as an argument.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -185,13 +185,15 @@ export async function activate(context: vscode.ExtensionContext) {
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
         interface MenuAction extends vscode.QuickPickItem {
             command: string;
+            args?: any[];
         }
 
         const items: MenuAction[] = [
             { label: '$(refresh) Restart Server', description: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(beaker) Run Tests in Current File', description: 'Run tests for the active file', command: 'perl-lsp.runTests' },
             { label: '$(output) Show Output', description: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
-            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' }
+            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+            { label: '$(gear) Configure Settings', description: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
@@ -199,7 +201,11 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         if (selection) {
-            vscode.commands.executeCommand(selection.command);
+            if (selection.args) {
+                vscode.commands.executeCommand(selection.command, ...selection.args);
+            } else {
+                vscode.commands.executeCommand(selection.command);
+            }
         }
     });
     


### PR DESCRIPTION
This PR adds a "Configure Settings" option to the Perl LSP status bar menu (accessed by clicking the status bar item). This new option uses a `$(gear)` icon and deep-links directly to the extension's settings page, filtering by the extension ID. This improves UX by providing a quick, discoverable way to access configuration without navigating through the main VS Code settings menu.

Testing:
- Verified TypeScript compilation (`pnpm run compile`).
- Reviewed code changes for correctness.
- Added documentation to `.jules/palette.md`.

---
*PR created automatically by Jules for task [198690090032120359](https://jules.google.com/task/198690090032120359) started by @EffortlessSteven*