### PR TITLE
🎨 Palette: Improve Status Menu organization

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -185,13 +185,20 @@ export async function activate(context: vscode.ExtensionContext) {
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
         interface MenuAction extends vscode.QuickPickItem {
             command: string;
+            args?: any[];
         }
 
         const items: MenuAction[] = [
+            { label: 'Actions', kind: vscode.QuickPickItemKind.Separator, command: '' },
             { label: '$(refresh) Restart Server', description: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(beaker) Run Tests in Current File', description: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+
+            { label: 'Information', kind: vscode.QuickPickItemKind.Separator, command: '' },
             { label: '$(output) Show Output', description: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
-            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' }
+            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+
+            { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator, command: '' },
+            { label: '$(gear) Configure Settings', description: 'Open extension settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
@@ -199,7 +206,11 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         if (selection) {
-            vscode.commands.executeCommand(selection.command);
+            if (selection.args) {
+                vscode.commands.executeCommand(selection.command, ...selection.args);
+            } else {
+                vscode.commands.executeCommand(selection.command);
+            }
         }
     });
     


### PR DESCRIPTION
Improved the `perl-lsp.showStatusMenu` command by organizing items into logical groups using separators and adding a direct link to the extension settings. This enhances the usability and scanability of the menu.

---
*PR created automatically by Jules for task [15711034754546335178](https://jules.google.com/task/15711034754546335178) started by @EffortlessSteven*