### PR TITLE
🎨 Palette: Improved Status Menu Organization

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-01-27 - Transient Status Bar Feedback
 **Learning:** For long-running operations like tests where the "Output" panel is too hidden and "Notifications" are too intrusive, temporarily hijacking the Status Bar Item provides excellent, non-disruptive feedback.
 **Action:** When implementing async commands that have a corresponding Status Bar Item, use a `try...finally` block to temporarily update the item's text (e.g., `$(sync~spin) Processing...`) and restore it afterwards.
+
+## 2026-01-27 - Structured Status Bar Menus
+**Learning:** Flat status bar menus can become cluttered as features grow. Using `QuickPickItemKind.Separator` to group actions (Actions, Information, Configuration) significantly reduces cognitive load. Including a direct "Configure Settings" link in the menu bridges the gap between usage and configuration.
+**Action:** When implementing `showStatusMenu` commands, use separators to organize items logically and always include a shortcut to the extension's settings.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -184,22 +184,34 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
         interface MenuAction extends vscode.QuickPickItem {
-            command: string;
+            command?: string;
+            args?: any[];
         }
 
         const items: MenuAction[] = [
+            { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Restart the language server', command: 'perl-lsp.restart' },
+            { label: '$(organization) Organize Use Statements', description: 'Sort and deduplicate imports', command: 'perl-lsp.organizeImports' },
             { label: '$(beaker) Run Tests in Current File', description: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+
+            { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', description: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
-            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' }
+            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+
+            { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
+            { label: '$(gear) Configure Settings', description: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection) {
-            vscode.commands.executeCommand(selection.command);
+        if (selection && selection.command) {
+            if (selection.args) {
+                vscode.commands.executeCommand(selection.command, ...selection.args);
+            } else {
+                vscode.commands.executeCommand(selection.command);
+            }
         }
     });
     


### PR DESCRIPTION
Improved the UX of the `perl-lsp.showStatusMenu` command by organizing items into logical groups with separators and adding a direct shortcut to the extension's configuration. This reduces cognitive load and improves discoverability of key features.

---
*PR created automatically by Jules for task [14469800128975459120](https://jules.google.com/task/14469800128975459120) started by @EffortlessSteven*