### PR TITLE
⚡ Bolt: Optimize bareword detection for class methods

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -903,6 +903,19 @@ impl ScopeAnalyzer {
             let parent = ancestors[i];
 
             match &parent.kind {
+                // Method call: Class->method (Class is bareword)
+                NodeKind::Binary { op, left, right: _ } if op == "->" => {
+                    // Check if current node is the class name (left side of the -> operation)
+                    if std::ptr::eq(left.as_ref(), current) {
+                        return true;
+                    }
+                }
+                NodeKind::MethodCall { object, .. } => {
+                    // Check if current node is the class name (object)
+                    if std::ptr::eq(object.as_ref(), current) {
+                        return true;
+                    }
+                }
                 // Hash subscript: $hash{key} or %hash{key}
                 NodeKind::Binary { op, left: _, right } if op == "{}" => {
                     // Check if current node is the key (right side of the {} operation)


### PR DESCRIPTION
- **crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs**: Updated `is_in_hash_key_context` to handle `NodeKind::MethodCall` and `NodeKind::Binary` with `op == "->"`, preventing false positive bareword errors for class names.
- **crates/perl-parser/benches/scope_benchmark.rs**: Added `benchmark_strict_barewords` to measure performance of bareword analysis under strict mode.

---
*PR created automatically by Jules for task [2523330781998446663](https://jules.google.com/task/2523330781998446663) started by @EffortlessSteven*