### PR TITLE
UX: Improve Status Menu with Separators and Settings

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -184,22 +184,29 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
         interface MenuAction extends vscode.QuickPickItem {
-            command: string;
+            command?: string;
+            args?: any[];
         }
 
         const items: MenuAction[] = [
+            { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(beaker) Run Tests in Current File', description: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+
+            { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', description: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
-            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' }
+            { label: '$(info) Show Version', description: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+
+            { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
+            { label: '$(gear) Configure Settings', description: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection) {
-            vscode.commands.executeCommand(selection.command);
+        if (selection && selection.command) {
+            vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });
     


### PR DESCRIPTION
Improved the `perl-lsp.showStatusMenu` command in the VS Code extension by:
- Grouping menu items into logical sections (Actions, Information, Configuration) using `vscode.QuickPickItemKind.Separator`.
- Adding a "Configure Settings" option that deep-links directly to the `perl-lsp` extension settings.
- Adding a `$(gear)` icon for the settings command.
- Updating the `MenuAction` interface to support optional commands and arguments.

This makes the status menu more scannable and provides quicker access to frequently used actions and configuration.

---
*PR created automatically by Jules for task [7799715166304757207](https://jules.google.com/task/7799715166304757207) started by @EffortlessSteven*