### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTPS downgrade vulnerability in downloader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The binary downloader for the VS Code extension allowed installation of unverified binaries if the `SHA256SUMS` file was missing from the release assets or if the specific file entry was absent. It treated checksum verification as optional ("if available") and only logged a warning on failure to find the checksum.
 **Learning:** Security controls like checksum verification must be mandatory ("fail-secure"), not optional ("fail-open"). Relying on the presence of a security artifact (like a checksum file) without enforcing it allows attackers to bypass the check by simply omitting the artifact.
 **Prevention:** Always enforce strict verification. If a security check cannot be performed (e.g., missing checksum file), the operation must fail, not proceed with a warning.
+
+## 2026-10-25 - HTTPS Downgrade Vulnerability in Binary Downloader
+**Vulnerability:** The `BinaryDownloader` implemented custom redirect handling that re-evaluated the protocol for the new URL. If an HTTPS URL redirected to an HTTP URL, the downloader would silently downgrade the connection, exposing the download to MITM attacks.
+**Learning:** Manual redirect handling often misses standard security checks (like "Same Protocol" or "Upgrade Only"). Blindly following redirects to any protocol breaks the security promise of the initial HTTPS connection.
+**Prevention:** When handling redirects manually, explicitly check that the new URL's protocol is at least as secure as the original. Reject downgrades from HTTPS to HTTP.

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -381,6 +381,11 @@ export class BinaryDownloader {
                     file.destroy();
                     const newUrl = response.headers.location;
                     if (newUrl) {
+                        // Security check: Prevent downgrade from HTTPS to HTTP
+                        if (isHttps && newUrl.toLowerCase().startsWith('http:') && !newUrl.toLowerCase().startsWith('https:')) {
+                            reject(new Error('Security violation: Redirect from HTTPS to HTTP prevented'));
+                            return;
+                        }
                         this.downloadFile(newUrl, dest, timeoutMs).then(resolve).catch(reject);
                         return;
                     }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix HTTPS downgrade vulnerability in downloader

🚨 Severity: HIGH
💡 Vulnerability: The `BinaryDownloader` allowed redirects from HTTPS URLs to insecure HTTP URLs, enabling potential Man-in-the-Middle (MITM) attacks during binary installation.
🎯 Impact: An attacker could intercept the redirect and serve a malicious binary instead of the legitimate language server.
🔧 Fix: Added a strict protocol check in the redirect handler. If the current connection is HTTPS, redirects to HTTP are explicitly rejected.
✅ Verification: Verified with a reproduction script that mocks the redirect behavior. The script confirmed that the downgrade is now blocked with a security error.

---
*PR created automatically by Jules for task [11462784934681518903](https://jules.google.com/task/11462784934681518903) started by @EffortlessSteven*