### PR TITLE
refactor: streamline error handling and assertion formatting

### DIFF
--- a/crates/perl-dap/src/breakpoints.rs
+++ b/crates/perl-dap/src/breakpoints.rs
@@ -700,9 +700,8 @@ print "result: $final\n";
         store
             .breakpoints
             .lock()
-            .map_err(|e| format!("lock failed: {e}"))
-            .ok()
-            .map(|mut bps| bps.insert(source_path.to_string(), vec![record]));
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(source_path.to_string(), vec![record]);
 
         // 1. Add 5 lines at line 5 (shift down)
         store.adjust_breakpoints_for_edit(source_path, 5, 5);

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -2934,17 +2934,13 @@ mod tests {
         let bypasses = [
             "&{'sys'.'tem'}('ls')", // Dynamic function name via concatenation
             "& { 'sys' . 'tem' }",  // Dynamic function name with spaces
-            "<*.txt>",               // Glob operator for filesystem access
+            "<*.txt>",              // Glob operator for filesystem access
             "CORE::print",          // Explicitly blocked by dangerous ops regex
         ];
 
         for expr in bypasses {
             let err = validate_safe_expression(expr);
-            assert!(
-                err.is_some(),
-                "Expression '{}' should be blocked but was allowed",
-                expr
-            );
+            assert!(err.is_some(), "Expression '{}' should be blocked but was allowed", expr);
         }
     }
 

--- a/crates/perl-parser/benches/scope_benchmark.rs
+++ b/crates/perl-parser/benches/scope_benchmark.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::expect_used)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use perl_parser::{Parser, ScopeAnalyzer, PragmaState};
+use perl_parser::{Parser, PragmaState, ScopeAnalyzer};
 use std::hint::black_box;
 
 const BAREWORDS_SCRIPT: &str = r#"
@@ -72,14 +72,10 @@ fn benchmark_strict_barewords(c: &mut Criterion) {
     let analyzer = ScopeAnalyzer::new();
 
     // Enable strict subs to force is_known_function checks
-    let pragma_map = vec![
-        (0..script.len(), PragmaState {
-            strict_subs: true,
-            strict_vars: true,
-            strict_refs: true,
-            warnings: true
-        })
-    ];
+    let pragma_map = vec![(
+        0..script.len(),
+        PragmaState { strict_subs: true, strict_vars: true, strict_refs: true, warnings: true },
+    )];
 
     c.bench_function("scope_analysis_strict_barewords", |b| {
         b.iter(|| {

--- a/crates/perl-parser/tests/parser_depth_limit_test.rs
+++ b/crates/perl-parser/tests/parser_depth_limit_test.rs
@@ -8,7 +8,7 @@
 use perl_parser::{ParseError, Parser};
 use perl_tdd_support::must_err;
 
-/// Test that deeply nested blocks are rejected with RecursionLimit error
+/// Test that deeply nested blocks are rejected with NestingTooDeep error
 #[test]
 #[ignore = "recursion limit behavior changed with error recovery"]
 fn parser_depth_limit_nested_blocks() {
@@ -124,7 +124,7 @@ fn parser_depth_limit_reasonable_nesting() {
 fn parser_depth_limit_mixed_nesting() {
     // Create a mix of blocks and expressions that exceeds the limit.
     // Each { ( pair adds multiple depth increments, so depth=100 should
-    // quickly exceed the limit of 128 and trigger RecursionLimit.
+    // quickly exceed the limit of 128 and trigger NestingTooDeep.
     let depth = 100;
     let mut code = String::new();
 

--- a/crates/perl-parser/tests/scope_analyzer_tests.rs
+++ b/crates/perl-parser/tests/scope_analyzer_tests.rs
@@ -688,8 +688,13 @@ my %h = ();
 print $h; # Should NOT resolve to %h, because it is a scalar usage
 "#;
     let issues = analyze_code(code);
-    assert!(issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$h"),
-        "Expected UndeclaredVariable for $h, but got: {:?}", issues);
+    assert!(
+        issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$h"),
+        "Expected UndeclaredVariable for $h, but got: {:?}",
+        issues
+    );
 }
 
 #[test]
@@ -700,8 +705,13 @@ my @arr = ();
 print $arr; # Should NOT resolve to @arr
 "#;
     let issues = analyze_code(code);
-    assert!(issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$arr"),
-        "Expected UndeclaredVariable for $arr, but got: {:?}", issues);
+    assert!(
+        issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$arr"),
+        "Expected UndeclaredVariable for $arr, but got: {:?}",
+        issues
+    );
 }
 
 #[test]
@@ -713,8 +723,11 @@ my $v = $h{k}; # Should resolve to %h
 print($h{k}); # Should also resolve (FunctionCall -> Binary)
 "#;
     let issues = analyze_code(code);
-    assert!(!issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable)),
-        "Unexpected undeclared variable error for $h{{k}}: {:?}", issues);
+    assert!(
+        !issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable)),
+        "Unexpected undeclared variable error for $h{{k}}: {:?}",
+        issues
+    );
 }
 
 #[test]
@@ -725,6 +738,9 @@ my @a = ();
 print($a[0]); # Should resolve to @a
 "#;
     let issues = analyze_code(code);
-    assert!(!issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable)),
-        "Unexpected undeclared variable error for $a[0]: {:?}", issues);
+    assert!(
+        !issues.iter().any(|i| matches!(i.kind, IssueKind::UndeclaredVariable)),
+        "Unexpected undeclared variable error for $a[0]: {:?}",
+        issues
+    );
 }


### PR DESCRIPTION
## Summary
- Use `unwrap_or_else` for cleaner mutex handling in breakpoints.rs
- Update comments for error name change (RecursionLimit -> NestingTooDeep)
- Format assertion macros for better readability across test files

## Test plan
- [x] Changes are formatting and minor refactoring only
- [ ] CI passes