### PR TITLE
🎨 Palette: Fix Organize Imports command and add to Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Broken Command Registration]
+**Learning:** UX commands defined in package.json must have corresponding registrations in code to be discoverable/functional, even if they proxy to built-in actions.
+**Action:** When auditing commands, check package.json against registered commands in extension.ts to ensure no "dead" UI elements exist.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -138,6 +138,10 @@ export async function activate(context: vscode.ExtensionContext) {
         await restartServer(context);
     });
 
+    const organizeImportsCommand = vscode.commands.registerCommand('perl-lsp.organizeImports', async () => {
+        await vscode.commands.executeCommand('editor.action.organizeImports');
+    });
+
     const runTestsCommand = vscode.commands.registerCommand('perl-lsp.runTests', async () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor || editor.document.languageId !== 'perl') {
@@ -193,6 +197,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
+            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
             { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
@@ -212,7 +217,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
     
-    context.subscriptions.push(restartCommand, runTestsCommand, showVersionCommand, statusMenuCommand);
+    context.subscriptions.push(restartCommand, organizeImportsCommand, runTestsCommand, showVersionCommand, statusMenuCommand);
     
     outputChannel.appendLine('Perl Language Server started successfully');
 }


### PR DESCRIPTION
💡 **What:** Implemented the `perl-lsp.organizeImports` command and added it to the Status Menu.
🎯 **Why:** The command was defined in `package.json` but not registered in the code, causing it to be non-functional. Adding it to the Status Menu improves discoverability.
♿ **Accessibility:** Added descriptions and details to the new menu item to explain the shortcut and purpose.

---
*PR created automatically by Jules for task [12639605358337467582](https://jules.google.com/task/12639605358337467582) started by @EffortlessSteven*