### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent RCE via workspace settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -65,3 +65,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The LSP server's `ExecuteCommandProvider` enforced security boundaries using a single `workspace_root`, but the server initialization logic failed to populate this root when multiple `workspaceFolders` were provided by the client. This resulted in the provider being initialized with no root, bypassing the path traversal check entirely.
 **Learning:** Security controls that rely on optional configuration (like `Option<PathBuf>`) can fail open if the configuration is not derived correctly from all available sources (single root vs multi-root).
 **Prevention:** Always default to "fail closed" or "deny all" when configuration is missing, rather than skipping checks. Ensure security contexts support the full range of client capabilities (e.g., multiple roots).
+
+## 2026-01-29 - Workspace Configuration RCE
+**Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
+**Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
+**Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -157,6 +157,7 @@
         "perl-lsp.serverPath": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "markdownDescription": "Absolute path to `perl-lsp` binary. Leave empty to auto-download latest release."
         },
         "perl-lsp.autoDownload": {
@@ -167,6 +168,7 @@
         "perl-lsp.downloadBaseUrl": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "markdownDescription": "Internal base URL hosting perl-lsp archives and SHA256SUMS (bypasses GitHub releases). Example: `https://internal.example.com/perl-lsp/`"
         },
         "perl-lsp.trace.server": {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Remote Code Execution (RCE) via Workspace Configuration Injection
Target: `vscode-extension`
Type: Configuration Injection / Insecure Defaults

**Details:**
The VS Code extension configuration settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked an explicit `scope` definition in `package.json`, defaulting to `window` (which includes Workspace scope).
This allowed an attacker to create a malicious repository containing a `.vscode/settings.json` file that defines:
1. `perl-lsp.serverPath`: pointing to a malicious script inside the repository.
2. `perl-lsp.downloadBaseUrl`: pointing to a malicious server serving compromised binaries.

When a victim opens this repository (even in Restricted Mode in some older versions, or if they trust the workspace), the extension would automatically execute the specified binary on startup or download a malicious binary.

**Fix:**
Explicitly set `"scope": "machine"` for both `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl`. This restricts these settings to User Settings or Remote Machine Settings, preventing them from being set via workspace configuration files checked into source control.

**Verification:**
- Verified `package.json` contains `"scope": "machine"` for the affected settings.
- Verified extension compiles successfully with `pnpm run compile`.
- Documented learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15448215177515868514](https://jules.google.com/task/15448215177515868514) started by @EffortlessSteven*