### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix safe evaluation bypass for regex mutations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-27 - Regex Mutation Bypass in Safe Evaluation
+**Vulnerability:** The regex used to detect mutating operators (`s///`, `tr///`, `y///`) in `perl-dap` failed to account for optional whitespace between the operator and the delimiter (e.g., `s /foo/bar/` was allowed while `s/foo/bar/` was blocked). This allowed users to inadvertently modify state in "safe" evaluation mode.
+**Learning:** Regex-based parsing of flexible languages like Perl is error-prone. Heuristics must account for all syntactic variations allowed by the language parser, especially whitespace which is often permitted but easily overlooked in simple regex patterns.
+**Prevention:** When using regex for security checks, verify against the language's formal grammar or comprehensive documentation to identify valid whitespace or delimiter variations. Use robust parser-based validation where possible, or extensive regression testing for regex patterns.

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -210,7 +210,7 @@ fn regex_mutation_re() -> Option<&'static Regex> {
             // Match s, tr, y followed by a delimiter character (not alphanumeric/underscore/whitespace)
             // Common delimiters: / # | ! { [ ( ' "
             // Note: We filter out escape sequences like \s manually after matching
-            Regex::new(r"\b(?:s|tr|y)[^\w\s]")
+            Regex::new(r"\b(?:s|tr|y)\s*[^\w\s]")
         })
         .as_ref()
         .ok()
@@ -3213,6 +3213,22 @@ DB<1>"#;
         for expr in blocked {
             let err = validate_safe_expression(expr);
             assert!(err.is_some(), "expected block for {expr:?}");
+        }
+    }
+
+    #[test]
+    fn test_safe_eval_bypass_whitespace() {
+        // These patterns use whitespace to bypass the regex check
+        let blocked = [
+            "s /foo/bar/",
+            "tr /a/b/",
+            "y /a/b/",
+            "$x =~ s /foo/bar/",
+        ];
+
+        for expr in blocked {
+            let err = validate_safe_expression(expr);
+            assert!(err.is_some(), "expression '{}' should be blocked", expr);
         }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix safe evaluation bypass for regex mutations

🚨 Severity: MEDIUM
💡 Vulnerability: The "safe" evaluation mode in `perl-dap` relied on a regex `\b(?:s|tr|y)[^\w\s]` to block mutating operators (`s`, `tr`, `y`). This regex failed to match if the operator was followed by whitespace (e.g., `s /foo/bar/`), allowing users to inadvertently mutate state (e.g., modifying `$_`) even when `allowSideEffects` was false.
🎯 Impact: Users relying on "safe" evaluation (e.g., hovering over variables in a debugger) could trigger side effects or state mutations if the expression contained whitespace-separated substitution or transliteration operators. While not arbitrary RCE (as `system` and other dangerous ops are blocked separately), it violates the safety guarantee of the debugger.
🔧 Fix: Updated the regex to `\b(?:s|tr|y)\s*[^\w\s]` to correctly identify these operators even with intervening whitespace.
✅ Verification: Added `test_safe_eval_bypass_whitespace` which confirms `s /foo/bar/` is now correctly blocked. Verified all other tests pass.

---
*PR created automatically by Jules for task [8071274412000102895](https://jules.google.com/task/8071274412000102895) started by @EffortlessSteven*