### PR TITLE
🛡️ Sentinel: Block 'use', 'no', 'goto' in DAP safe evaluation

### DIFF
--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -169,7 +169,11 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "link", // Code loading/execution
                 "eval",
                 "require",
-                "do", // Tie mechanism (can execute arbitrary code)
+                "do",
+                "use",
+                "no",
+                "goto",
+                // Tie mechanism (can execute arbitrary code)
                 "tie",
                 "untie", // Network
                 "socket",


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix safe evaluation bypass in Debug Adapter

**Vulnerability:**
The `safe_evaluation_mode` in the Perl Debug Adapter (used for "Watch" expressions and Hovers) failed to block `use`, `no`, and `goto` statements.
- `use Module;` executes `Module->import()` at compile-time (or immediate runtime in `eval`), allowing arbitrary code execution and state mutation (loading modules).
- `no Module;` executes `Module->unimport()`.
- `goto` allows control flow manipulation.

**Impact:**
A user inspecting variables (e.g., hovering) could unintentionally trigger module loading or code execution if the expression contained these keywords, bypassing the intended "side-effect free" guarantee of the safe evaluation mode.

**Fix:**
Updated `dangerous_ops_re` in `crates/perl-dap/src/debug_adapter.rs` to include `use`, `no`, and `goto`.

**Verification:**
- Validated with a reproduction test case `crates/perl-dap/tests/security_use_bypass.rs` (deleted before submit) which confirmed `use` and `no` are now blocked.
- Ran existing regression tests `crates/perl-dap/tests/safe_evaluation_tests.rs`.

---
*PR created automatically by Jules for task [6706321074535774212](https://jules.google.com/task/6706321074535774212) started by @EffortlessSteven*