### PR TITLE
⚡ Bolt: Refactor perl-dap-eval to use std::sync::OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,7 +1503,6 @@ dependencies = [
 name = "perl-dap-eval"
 version = "0.1.0"
 dependencies = [
- "once_cell",
  "perl-tdd-support",
  "regex",
  "thiserror",

--- a/crates/perl-dap-eval/Cargo.toml
+++ b/crates/perl-dap-eval/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["development-tools"]
 [dependencies]
 # Regex for pattern matching
 regex = "1.12.2"
-once_cell = "1.21.3"
 
 # Error handling
 thiserror = "2.0.18"

--- a/crates/perl-dap-eval/src/validator.rs
+++ b/crates/perl-dap-eval/src/validator.rs
@@ -3,7 +3,7 @@
 //! This module provides the core validation logic for detecting dangerous
 //! operations in Perl expressions during debug evaluation.
 
-use crate::patterns::{ASSIGNMENT_OPERATORS, DANGEROUS_OPS_RE, REGEX_MUTATION_RE};
+use crate::patterns::{ASSIGNMENT_OPERATORS, dangerous_ops_re, regex_mutation_re};
 
 /// Error type for unsafe expression detection
 #[derive(Debug, Clone, thiserror::Error)]
@@ -104,10 +104,7 @@ impl SafeEvaluator {
 
     /// Check for dangerous operations in the expression
     fn check_dangerous_operations(&self, expression: &str) -> ValidationResult {
-        let Some(re) = DANGEROUS_OPS_RE.as_ref().ok() else {
-            // If regex failed to compile, be conservative and allow
-            return Ok(());
-        };
+        let re = dangerous_ops_re();
 
         for mat in re.find_iter(expression) {
             let op = mat.as_str();
@@ -143,9 +140,7 @@ impl SafeEvaluator {
 
     /// Check for regex mutation operators (s///, tr///, y///)
     fn check_regex_mutation(&self, expression: &str) -> ValidationResult {
-        let Some(re) = REGEX_MUTATION_RE.as_ref().ok() else {
-            return Ok(());
-        };
+        let re = regex_mutation_re();
 
         if let Some(mat) = re.find(expression) {
             let op = mat.as_str();


### PR DESCRIPTION
⚡ Bolt: Refactor perl-dap-eval to use std::sync::OnceLock

💡 What:
Replaced the `once_cell` crate with `std::sync::OnceLock` in `perl-dap-eval` for static regex compilation.

🎯 Why:
- **Dependency Reduction:** Removes an external dependency (`once_cell`) in favor of the standard library.
- **Modernization:** Aligns with the project's standard of using `OnceLock` (Rust 1.70+).
- **Security:** Changed error handling for regex compilation from "fail open" (ignoring errors and allowing operations) to "fail fast" (panicking on invalid hardcoded regexes). This prevents potential security bypasses if the regex configuration is ever broken.

📊 Impact:
- **Build Time:** Slightly reduced due to one less dependency.
- **Runtime:** Negligible performance difference, but slightly cleaner access patterns.
- **Safety:** Improved robusteness against configuration errors.

🔬 Measurement:
Verified by running `cargo test -p perl-dap-eval`. All tests passed.
Verified `cargo clippy -p perl-dap-eval` passed with no warnings.

---
*PR created automatically by Jules for task [4588659236075603643](https://jules.google.com/task/4588659236075603643) started by @EffortlessSteven*