### PR TITLE
🎨 Palette: Context-aware Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-05-21 - [Context-Aware QuickPick Menus]
+**Learning:** Users can feel frustrated when selecting a seemingly valid option from a menu only to be told it's invalid for the current context. Pre-validating options and using `disabled` states with explanatory `detail` text significantly reduces cognitive load and frustration.
+**Action:** When creating QuickPick menus, always check the current editor context (language, file type) and dynamically disable/annotate items that are not currently applicable, rather than failing on execution.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,37 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && editor && (editor.document.uri.fsPath.endsWith('.t') || editor.document.uri.fsPath.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : (isPerl ? 'Only available for .t and .pl files' : 'Only available for Perl files'),
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -215,10 +238,11 @@ export async function activate(context: vscode.ExtensionContext) {
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Perl Language Server Actions'
+            placeHolder: 'Perl Language Server Actions',
+            matchOnDetail: true
         });
 
-        if (selection && selection.command) {
+        if (selection && !selection.disabled && selection.command) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });


### PR DESCRIPTION
💡 What: Enhanced the 'Perl Language Server Actions' status menu (perl-lsp.showStatusMenu) to be context-aware.
🎯 Why: Users were presented with actions (like 'Run Tests' or 'Organize Imports') that were invalid for the current file context, leading to errors or confusion.
♿ Accessibility: Actions are now clearly annotated with explanations when unavailable, reducing cognitive load and preventing error states.

Changes:
- Disables 'Run Tests' if active file is not a test script (.t/.pl).
- Disables 'Organize Imports' and 'Format Document' if active file is not Perl.
- Adds explanatory detail text to disabled items.

---
*PR created automatically by Jules for task [8606241344116400481](https://jules.google.com/task/8606241344116400481) started by @EffortlessSteven*