### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in single-file mode (fail closed)

### DIFF
--- a/crates/perl-lsp/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_security_tests.rs
@@ -10,6 +10,7 @@ use perl_lsp::execute_command::ExecuteCommandProvider;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
+use std::path::PathBuf;
 use tempfile::TempDir;
 
 /// Test that run_test_sub is protected against code injection via file_path.
@@ -59,11 +60,14 @@ fn test_run_test_sub_file_path_injection() -> Result<(), Box<dyn Error>> {
 /// code will NOT be executed.
 #[test]
 fn test_run_test_sub_subname_injection() -> Result<(), Box<dyn Error>> {
-    let provider = ExecuteCommandProvider::new();
-
     // Create a minimal test file with a marker subroutine
     let test_file = "/tmp/security_test_sub.pl";
     std::fs::write(test_file, "sub safe_sub { print 'SAFE_SUB_EXECUTED'; }").ok();
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![PathBuf::from(test_file).canonicalize()?],
+    );
 
     // This payload would execute code if string interpolation was used.
     // With the fix (using @ARGV), it's treated as a literal subroutine name.
@@ -201,7 +205,10 @@ fn test_valid_file_execution() -> Result<(), Box<dyn Error>> {
     let file_path = temp_dir.path().join("test_valid.pl");
     fs::write(&file_path, "print 'VALID_OUTPUT';")?;
 
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![file_path.canonicalize()?],
+    );
 
     let result = provider.execute_command(
         "perl.runFile",


### PR DESCRIPTION
This PR addresses a security vulnerability in the `ExecuteCommandProvider` where path traversal protection was disabled if `workspace_roots` were empty (e.g., in single-file mode).

### Vulnerability Fix
*   **Fail-Closed by Default:** `ExecuteCommandProvider` now denies execution by default if no security context (workspace roots or trusted files) is provided.
*   **Trusted Files:** Introduced `trusted_files` allowlist for scenarios where workspace roots are unavailable (single-file mode).
*   **Canonicalization:** Both arguments and trusted files are canonicalized before comparison to prevent bypasses.

### Implementation Details
*   Modified `ExecuteCommandProvider` struct and `resolve_path_from_args` logic in `crates/perl-lsp/src/execute_command.rs`.
*   Updated `handle_execute_command` in `crates/perl-lsp/src/runtime/language/misc.rs` to populate `trusted_files` from currently open documents.
*   Updated existing tests to use `with_security_context` instead of `new` (which is now secure/restrictive).
*   Added new security regression tests: `test_execute_command_fail_closed`, `test_execute_command_single_file_trusted`, `test_execute_command_single_file_untrusted`.

### Verification
*   Ran `cargo test -p perl-lsp`.
*   Verified that `execute_command_security_tests.rs` and `execute_command_mutation_hardening_public_api_tests.rs` pass with the new security context.


---
*PR created automatically by Jules for task [11064493943137800311](https://jules.google.com/task/11064493943137800311) started by @EffortlessSteven*