### PR TITLE
🎨 Palette: Make status menu context-aware

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-18 - [Context-Aware QuickPick Menus]
+**Learning:** Standard VS Code `QuickPickItem`s lack a native `disabled` state. Users can select any item. To prevent invalid actions, we must manually filter context (e.g., file type) and block execution in the handler, while providing visual feedback (e.g., modified description) to explain unavailability.
+**Action:** When creating custom menus with `showQuickPick`, always implement a custom `disabled` property logic to filter out contextually invalid actions and update their descriptions to guide the user.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,44 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        // Get context
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? editor.document.languageId === 'perl' : false;
+        const fileName = editor ? editor.document.fileName : '';
+        const isTestFile = isPerl && (fileName.endsWith('.t') || fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: '$(organization) Organize Imports',
+                description: isPerl ? 'Shift+Alt+O' : '(Perl files only)',
+                detail: 'Sort and organize use statements',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: isTestFile ? 'Shift+Alt+T' : '(Test/Script files only)',
+                detail: 'Run tests for the active file',
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: isPerl ? 'Shift+Alt+F' : '(Perl files only)',
+                detail: 'Format using perltidy',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -219,7 +249,9 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         if (selection && selection.command) {
-            vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+            if (!selection.disabled) {
+                vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+            }
         }
     });
     


### PR DESCRIPTION
Enhances the 'Perl LSP Actions' menu to dynamically disable actions based on the active file context (e.g., disabling 'Run Tests' for non-test files), improving UX and preventing invalid command execution.

---
*PR created automatically by Jules for task [2894012431693698841](https://jules.google.com/task/2894012431693698841) started by @EffortlessSteven*