### PR TITLE
⚡ Bolt: Optimize regex compilation in SymbolExtractor

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -25,6 +25,7 @@ use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 // Re-export the unified symbol types from perl-symbol-types
 /// Symbol kind enums used during Index/Analyze workflows.
@@ -864,9 +865,12 @@ impl SymbolExtractor {
     fn extract_vars_from_string(&mut self, value: &str, string_location: SourceLocation) {
         // Simple regex to find scalar variables in strings
         // This handles $var, ${var}, but not arrays/hashes for now
-        let Ok(scalar_re) = Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})") else {
-            return; // Skip variable extraction if regex fails
-        };
+        static SCALAR_RE: OnceLock<Regex> = OnceLock::new();
+        let scalar_re = SCALAR_RE.get_or_init(|| {
+            #[allow(clippy::expect_used)]
+            Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})")
+                .expect("Failed to compile scalar regex")
+        });
 
         // The value includes quotes, so strip them
         let content = if value.len() >= 2 { &value[1..value.len() - 1] } else { value };


### PR DESCRIPTION
Optimizes the `extract_vars_from_string` method in `SymbolExtractor` by moving the regex compilation to a `static OnceLock`. This ensures the regex is compiled only once and reused, avoiding the overhead of recompilation on every call.

This follows the existing pattern used in `semantic.rs` and adheres to the project's `clippy::expect-used` lint requirements for static regexes.

---
*PR created automatically by Jules for task [5880568614810025491](https://jules.google.com/task/5880568614810025491) started by @EffortlessSteven*