### PR TITLE
🛡️ Sentinel: [HIGH] Fix safe evaluation bypass for `use`, `no`, `goto`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-10-26 - Missing Safe Evaluation Blocks for Compile-Time Directives
+**Vulnerability:** The `perl-dap` safe evaluation mode failed to block `use`, `no`, `goto`, and `package`. While `require` was blocked, `use` (which runs at compile-time but can be triggered in eval) allows arbitrary module loading and execution of `import` methods. `goto` allows control flow manipulation.
+**Learning:** Security blocklists for "safe" execution must account for language constructs that operate at different phases (compile-time vs run-time) if the evaluation context (like `eval`) flattens them. Blocking `require` is insufficient if `use` is allowed.
+**Prevention:** Audit all keywords in the language, not just functions. Explicitly block compile-time directives and control flow keywords in safe evaluation contexts.

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -169,7 +169,12 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "link", // Code loading/execution
                 "eval",
                 "require",
-                "do", // Tie mechanism (can execute arbitrary code)
+                "do",
+                "use",
+                "no",
+                "goto",
+                "package",
+                // Tie mechanism (can execute arbitrary code)
                 "tie",
                 "untie", // Network
                 "socket",

--- a/crates/perl-dap/tests/security_gap_test.rs
+++ b/crates/perl-dap/tests/security_gap_test.rs
@@ -1,0 +1,40 @@
+use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
+use serde_json::json;
+
+#[test]
+fn test_security_gaps_are_closed() {
+    let mut adapter = DebugAdapter::new();
+
+    // List of operations that must be blocked
+    let ops = vec![
+        "use Data::Dumper",
+        "no strict",
+        "goto LABEL",
+        "package Foo",
+        "dump",
+    ];
+
+    for op in ops {
+        let args = json!({
+            "expression": op,
+            "allowSideEffects": false
+        });
+
+        let response = adapter.handle_request(1, "evaluate", Some(args));
+
+        if let DapMessage::Response { success, message, .. } = response {
+            let msg = message.unwrap_or_default();
+            println!("Op: '{}' -> Success: {}, Message: '{}'", op, success, msg);
+
+            // Should be success=false and message should indicate it was blocked by safe mode
+            assert!(!success, "Operation '{}' should have failed", op);
+            assert!(
+                msg.contains("Safe evaluation mode"),
+                "Operation '{}' should be blocked by Safe evaluation mode, but got: {}",
+                op, msg
+            );
+        } else {
+             panic!("Unexpected response type");
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a security gap in the `perl-dap` Debug Adapter where certain Perl keywords (`use`, `no`, `goto`, `package`) were not blocked in "Safe Evaluation" mode (e.g., during hover).

**Changes:**
- Updated `dangerous_ops_re` in `crates/perl-dap/src/debug_adapter.rs` to include `use`, `no`, `goto`, and `package`.
- Added `crates/perl-dap/tests/security_gap_test.rs` to verify that these operations are correctly blocked.
- Updated `.jules/sentinel.md` with the security learning.

**Verification:**
- Run `cargo test --test security_gap_test` to confirm the fix.
- Run `cargo test --test safe_evaluation_tests` to ensure no regressions.

---
*PR created automatically by Jules for task [9876930969191273038](https://jules.google.com/task/9876930969191273038) started by @EffortlessSteven*