### PR TITLE
🎨 Palette: Add context-aware states to Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-01-29 - [Context-Aware QuickPick Menus]
+**Learning:** Standard QuickPickItems lack native "disabled" states in some API versions, but users expect context-sensitive menus. Using visual cues (e.g., `$(circle-slash)`) and updating `detail` text to explain unavailability is a powerful pattern to guide users without confusing dead clicks.
+**Action:** When building custom menus, dynamically update labels and descriptions based on active editor context to prevent invalid actions and explain why they are unavailable.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,43 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const docUri = editor?.document.uri;
+        const isTestFile = isPerl && docUri && (docUri.fsPath.endsWith('.t') || docUri.fsPath.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: isPerl ? '$(organization) Organize Imports' : '$(circle-slash) Organize Imports (Disabled)',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Action not available for non-Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: isTestFile ? '$(beaker) Run Tests in Current File' : '$(circle-slash) Run Tests in Current File (Disabled)',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : (isPerl ? 'Only available for .t/.pl files' : 'Action not available for non-Perl files'),
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: isPerl ? '$(list-flat) Format Document' : '$(circle-slash) Format Document (Disabled)',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Action not available for non-Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -218,7 +247,7 @@ export async function activate(context: vscode.ExtensionContext) {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection && selection.command) {
+        if (selection && selection.command && !selection.disabled) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });


### PR DESCRIPTION
💡 **What:**
Enhanced the `perl-lsp.showStatusMenu` command to be context-aware. It now checks the active editor's language and file extension to determine which actions are valid.

🎯 **Why:**
Users could previously select actions like "Run Tests" or "Organize Imports" in non-Perl files, which would either fail silently or show an error message. This change provides immediate visual feedback about what actions are available, improving discoverability and reducing frustration.

♿ **Accessibility/UX:**
- **Visual Cues:** Uses `$(circle-slash)` icon to indicate disabled state.
- **Context:** Updates `detail` text to explain *why* an action is disabled (e.g., "Active file is not Perl").
- **Prevention:** Blocks execution of disabled commands, preventing error states.

**Verification:**
- Verified TypeScript compilation passes (`pnpm run compile` in `vscode-extension`).
- Logic review confirms correct handling of `isPerl` and `isTestFile` states.

---
*PR created automatically by Jules for task [5256997621535044062](https://jules.google.com/task/5256997621535044062) started by @EffortlessSteven*