### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Safe Evaluation Bypass via Package Separator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-27 - Safe Evaluation Bypass via Package Separator
+**Vulnerability:** The `perl-dap` safe evaluation mode checks failed to detect dangerous operations when they were prefixed with a package name using the archaic `'` separator (e.g., `main'system('ls')`). The parser treated the `'` as the start of a string literal, causing the dangerous operation `system` to be ignored as "string content".
+**Learning:** Parsing logic that attempts to identify safe constructs (like string literals) using simple state machines must account for all syntactic ambiguities in the language. In Perl, `'` can be a package separator if preceded by an identifier, not just a quote delimiter.
+**Prevention:** Enhanced the string detection logic to check the preceding character. If `'` is preceded by a word character, it is treated as a package separator, ensuring the subsequent code is analyzed for dangerous operations.


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Safe Evaluation Bypass

🚨 Severity: CRITICAL
💡 Vulnerability: The "Safe Evaluation" mode in `perl-dap` could be bypassed by using the archaic Perl package separator `'` (single quote) to prefix dangerous function calls (e.g., `main'system('ls')`). The security validator incorrectly interpreted the single quote as the start of a string literal, causing it to ignore the dangerous function call (`system`) contained within.
🎯 Impact: This allowed attackers (or users mistakenly trusting hover previews) to execute arbitrary commands or dangerous Perl operations even when "Safe Evaluation" (side-effect free mode) was enforced.
🔧 Fix: Enhanced the `is_in_single_quotes` tokenizer logic to check the character preceding a single quote. If the preceding character is alphanumeric or an underscore, the single quote is treated as a package separator rather than a string delimiter. This ensures that the subsequent code is correctly analyzed and blocked by the dangerous operation filter.
✅ Verification: Added a new regression test `test_safe_eval_bypass_package_separator` which explicitly verifies that constructs like `main'system('ls')`, `CORE'system`, and `$x = main'exec` are correctly blocked by the `validate_safe_expression` function. Validated that normal string usage (e.g., `print 'text'`) is unaffected.

---
*PR created automatically by Jules for task [11750188214439031542](https://jules.google.com/task/11750188214439031542) started by @EffortlessSteven*