### PR TITLE
🛡️ Sentinel: Fix potential arbitrary code execution via subroutine name injection

### DIFF
--- a/crates/perl-lsp/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_security_tests.rs
@@ -77,29 +77,16 @@ fn test_run_test_sub_subname_injection() -> Result<(), Box<dyn Error>> {
     // Clean up
     std::fs::remove_file(test_file).ok();
 
-    assert!(result.is_ok(), "Command should not fail to spawn");
-    let val = result?;
-    let output = val["output"].as_str().ok_or("Missing 'output' field")?;
+    // With enhanced validation, this should be rejected BEFORE execution
+    assert!(result.is_err(), "Malicious sub_name should be rejected by validation");
 
-    // Key assertions:
-    // 1. The injected print statement should NOT have executed
+    let err = result.unwrap_err();
     assert!(
-        !output.contains("INJECTED_CODE_RAN"),
-        "Vulnerability: code injection via sub_name succeeded! Output: {}",
-        output
+        err.contains("Invalid subroutine name"),
+        "Error should be about validation: {}",
+        err
     );
 
-    // 2. The safe_sub should NOT have been called either (the malicious name
-    //    includes "safe_sub()" but that should be treated literally, not executed)
-    assert!(
-        !output.contains("SAFE_SUB_EXECUTED"),
-        "Unexpected: safe_sub was called despite malicious sub_name. Output: {}",
-        output
-    );
-
-    // 3. The command should have failed because no subroutine with that literal name exists
-    let success = val["success"].as_bool().ok_or("Missing 'success' field")?;
-    assert!(!success, "Command should have failed (subroutine not found)");
     Ok(())
 }
 

--- a/crates/perl-lsp/tests/execute_command_subname_validation.rs
+++ b/crates/perl-lsp/tests/execute_command_subname_validation.rs
@@ -1,0 +1,50 @@
+use perl_lsp::execute_command::ExecuteCommandProvider;
+use serde_json::Value;
+use std::error::Error;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_run_test_sub_invalid_names() -> Result<(), Box<dyn Error>> {
+    let provider = ExecuteCommandProvider::new();
+    let temp_dir = TempDir::new()?;
+    let file_path = temp_dir.path().join("test_sub_validation.pl");
+    fs::write(&file_path, "sub safe_sub { print 'SAFE'; }")?;
+
+    let file_arg = Value::String(file_path.to_string_lossy().to_string());
+
+    // List of invalid subroutine names that should be rejected
+    let invalid_names = vec![
+        "system('calc')",       // Code injection attempt (though blocked by @ARGV, validation should reject it)
+        "CORE::system",         // Built-in
+        "CORE::GLOBAL::system", // Global override
+        "Foo'Bar",              // Old package separator (we enforce ::)
+        "123sub",               // Starts with digit
+        "-flag",                // Starts with hyphen
+        "sub; rm -rf /",        // Shell injection attempt chars
+        "",                     // Empty
+        "   ",                  // Whitespace
+        "Foo::Bar::",           // Trailing ::
+        "::Foo",                // Leading ::
+    ];
+
+    for name in invalid_names {
+        let result = provider.execute_command(
+            "perl.runTestSub",
+            vec![file_arg.clone(), Value::String(name.to_string())],
+        );
+
+        // Expect an error about invalid subroutine name
+        assert!(result.is_err(), "Should have blocked invalid subroutine name: '{}'", name);
+
+        let error = result.unwrap_err();
+        assert!(
+            error.contains("Invalid subroutine name") ||
+            error.contains("Subroutine name cannot be empty") ||
+            error.contains("CORE:: subroutines are not allowed"),
+            "Unexpected error message for '{}': {}", name, error
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Implemented strict input validation for subroutine names in `perl.runTestSub` command to prevent execution of unintended functions (like `CORE::system`) and mitigate potential injection risks. Validation uses a regex whitelist for valid Perl identifiers and explicitly blocks `CORE::` namespace. Verified with comprehensive unit and regression tests.

---
*PR created automatically by Jules for task [10250681623746147808](https://jules.google.com/task/10250681623746147808) started by @EffortlessSteven*