### PR TITLE
🎨 Palette: Context-aware Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-01-29 - [Context-Aware QuickPick Menus]
+**Learning:** `vscode.QuickPickItem` in extension API may not support `disabled` property natively in types, but robust UX requires preventing execution of contextually invalid actions.
+**Action:** When creating custom menus, extend `QuickPickItem` with a `disabled` state, visually indicate unavailability (e.g. "(Not available)"), and explicitly prevent command execution in the handler.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,42 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: isPerl ? '$(organization) Organize Imports' : '$(organization) Organize Imports (Not available)',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: isPerl ? 'perl-lsp.organizeImports' : undefined,
+                disabled: !isPerl
+            },
+            {
+                label: isTestFile ? '$(beaker) Run Tests in Current File' : '$(beaker) Run Tests (Not available)',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Open a .t or .pl file to run tests',
+                command: isTestFile ? 'perl-lsp.runTests' : undefined,
+                disabled: !isTestFile
+            },
+            {
+                label: isPerl ? '$(list-flat) Format Document' : '$(list-flat) Format Document (Not available)',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: isPerl ? 'editor.action.formatDocument' : undefined,
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
Implemented a micro-UX improvement for the Perl LSP Status Menu. The menu now checks the active editor's language and filename to determine if actions like "Run Tests" or "Organize Imports" are valid. If not, they are visually marked as unavailable and cannot be executed, preventing user frustration and unnecessary error messages. This aligns with the "Palette" philosophy of intuitive, context-aware interfaces.

---
*PR created automatically by Jules for task [8219141391862212664](https://jules.google.com/task/8219141391862212664) started by @EffortlessSteven*