### PR TITLE
⚡ Bolt: Optimize interpolated string variable extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,7 @@ A simple swap to prioritize `is_known_function` (string match) over `is_in_hash_
 ## 2026-06-01 - [Cross-Crate Closure Inlining Regression]
 **Learning:** Replacing `node.children()` (allocates `Vec`) with `node.for_each_child(|child| recursive_fn(child))` caused a 45% regression in recursive AST traversal. This is likely due to the overhead of passing a large closure (capturing recursive state) to a non-inlined method in another crate. Adding `#[inline]` helped slightly but did not fully recover performance.
 **Action:** Use specialized helpers like `first_child()` to avoid vector allocation for simple queries, but stick to vector iteration (which is cache-friendly and well-optimized) for full traversals unless the traversal method is guaranteed to be inlined and specialized.
+
+## 2026-08-07 - [Regex Compilation in Loop]
+**Learning:** Compiling a `Regex` inside a frequently called method (e.g., `extract_vars_from_string` for every interpolated string) is catastrophic for performance.
+**Action:** Always use `std::sync::OnceLock` or `lazy_static` to compile regexes once. In this case, moving the regex to `OnceLock` improved interpolated string processing time by ~1000x (13.3s -> 12.6ms).

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -25,6 +25,7 @@ use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 // Re-export the unified symbol types from perl-symbol-types
 /// Symbol kind enums used during Index/Analyze workflows.
@@ -864,9 +865,11 @@ impl SymbolExtractor {
     fn extract_vars_from_string(&mut self, value: &str, string_location: SourceLocation) {
         // Simple regex to find scalar variables in strings
         // This handles $var, ${var}, but not arrays/hashes for now
-        let Ok(scalar_re) = Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})") else {
-            return; // Skip variable extraction if regex fails
-        };
+        static SCALAR_VAR_REGEX: OnceLock<Regex> = OnceLock::new();
+        let scalar_re = SCALAR_VAR_REGEX.get_or_init(|| {
+            #[allow(clippy::expect_used)]
+            Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})").expect("Invalid regex")
+        });
 
         // The value includes quotes, so strip them
         let content = if value.len() >= 2 { &value[1..value.len() - 1] } else { value };

--- a/crates/perl-semantic-analyzer/tests/symbol_perf_test.rs
+++ b/crates/perl-semantic-analyzer/tests/symbol_perf_test.rs
@@ -123,3 +123,30 @@ sub documented_sub {
     assert_eq!(sub_symbols.len(), 1);
     assert!(sub_symbols[0].documentation.is_some());
 }
+
+#[test]
+#[ignore]
+fn benchmark_interpolated_string_extraction() {
+    // Generate code with many interpolated strings
+    let count = 5000;
+    let mut code = String::from("sub test {\n");
+    for i in 0..count {
+        code.push_str(&format!("    my $v{} = \"Hello $name{}\";\n", i, i));
+    }
+    code.push_str("}\n");
+
+    let mut parser = Parser::new(&code);
+    let ast = parser.parse().expect("parse");
+
+    // Warm up
+    let extractor = SymbolExtractor::new_with_source(&code);
+    let _ = extractor.extract(&ast);
+
+    let start = Instant::now();
+    let extractor = SymbolExtractor::new_with_source(&code);
+    let table = extractor.extract(&ast);
+    let duration = start.elapsed();
+
+    println!("Interpolated string extraction ({} strings): {:?}", count, duration);
+    println!("References extracted: {}", table.references.len());
+}


### PR DESCRIPTION
⚡ Bolt: Optimize interpolated string variable extraction

💡 What:
Replaced the inline compilation of `Regex::new` in `SymbolExtractor::extract_vars_from_string` with a `static OnceLock<Regex>`.

🎯 Why:
The original implementation compiled the regex anew for every single interpolated string in the source code. For files with many interpolated strings, this was a massive performance bottleneck ($O(N \times M)$ vs $O(N + M)$).

📊 Impact:
- **~1000x speedup** for variable extraction in interpolated strings.
- Benchmark (5000 interpolated strings):
  - Before: **13.29s**
  - After: **12.66ms**

🔬 Measurement:
Run the new benchmark test:
`cargo test -p perl-semantic-analyzer --test symbol_perf_test benchmark_interpolated_string_extraction -- --nocapture --ignored`

---
*PR created automatically by Jules for task [4480141832619128705](https://jules.google.com/task/4480141832619128705) started by @EffortlessSteven*