### PR TITLE
🛡️ Sentinel: [HIGH] Enforce Fail-Closed Security in ExecuteCommandProvider

### DIFF
--- a/crates/perl-lsp/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_security_tests.rs
@@ -10,6 +10,7 @@ use perl_lsp::execute_command::ExecuteCommandProvider;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
+use std::path::PathBuf;
 use tempfile::TempDir;
 
 /// Test that run_test_sub is protected against code injection via file_path.
@@ -59,11 +60,15 @@ fn test_run_test_sub_file_path_injection() -> Result<(), Box<dyn Error>> {
 /// code will NOT be executed.
 #[test]
 fn test_run_test_sub_subname_injection() -> Result<(), Box<dyn Error>> {
-    let provider = ExecuteCommandProvider::new();
-
     // Create a minimal test file with a marker subroutine
     let test_file = "/tmp/security_test_sub.pl";
     std::fs::write(test_file, "sub safe_sub { print 'SAFE_SUB_EXECUTED'; }").ok();
+
+    // Security: Must trust the file to execute it
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![PathBuf::from(test_file)]
+    );
 
     // This payload would execute code if string interpolation was used.
     // With the fix (using @ARGV), it's treated as a literal subroutine name.
@@ -201,7 +206,11 @@ fn test_valid_file_execution() -> Result<(), Box<dyn Error>> {
     let file_path = temp_dir.path().join("test_valid.pl");
     fs::write(&file_path, "print 'VALID_OUTPUT';")?;
 
-    let provider = ExecuteCommandProvider::new();
+    // Security: Trust the temp file
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![file_path.clone()]
+    );
 
     let result = provider.execute_command(
         "perl.runFile",


### PR DESCRIPTION
This PR enhances the security of the `ExecuteCommandProvider` by implementing a "Fail Closed" model.

Previously, if `workspace_roots` was empty (e.g., in single-file editing mode), the provider would bypass path traversal checks, potentially allowing execution of arbitrary files if the client requested it.

This change:
1.  Updates `ExecuteCommandProvider` to accept a list of `trusted_files`.
2.  Modifies `resolve_path_from_args` to enforce that if `workspace_roots` is empty, the target file MUST be in `trusted_files`.
3.  If both are empty, execution is strictly blocked.
4.  Updates `LspServer` to populate `trusted_files` from the list of currently open documents.
5.  Updates unit and integration tests to explicitly provide trusted files, ensuring the test suite reflects the secure behavior.

This ensures that even in single-file mode, users (or malicious workspace configurations) cannot trigger execution of files outside the editor's context.

---
*PR created automatically by Jules for task [14064007845133688068](https://jules.google.com/task/14064007845133688068) started by @EffortlessSteven*