### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix safe evaluation bypass via package qualification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-10-25 - Safe Evaluation Bypass via Package Qualification
+**Vulnerability:** The `perl-dap` safe evaluation mode explicitly allowed any package-qualified operation (e.g., `IO::File::open`) unless it was in the `CORE::` namespace. This allowed users to bypass the dangerous operations blocklist by invoking built-ins via standard modules or other packages (e.g., `IO::File::open` executes the blocked `open` operation).
+**Learning:** Allow-listing namespace patterns is dangerous when the underlying language allows aliasing or wrapping dangerous functionality. Assuming that "non-CORE" packages are safe ignores the reality that standard and user modules often wrap dangerous system primitives.
+**Prevention:** In security blocklists, apply checks based on the operation name (e.g., `open`) regardless of its namespace or qualification. Do not assume any namespace is "safe" by default.

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -1844,50 +1844,6 @@ fn is_in_single_quotes(s: &str, idx: usize) -> bool {
     in_sq
 }
 
-/// Check if the match is CORE:: or CORE::GLOBAL:: qualified (must block these)
-fn is_core_qualified(s: &str, op_start: usize) -> bool {
-    let bytes = s.as_bytes();
-
-    // Must have :: immediately before op
-    if op_start < 2 || bytes[op_start - 1] != b':' || bytes[op_start - 2] != b':' {
-        return false;
-    }
-
-    // Extract the identifier right before that ::
-    let end = op_start - 2;
-    let mut start = end;
-    while start > 0 {
-        let b = bytes[start - 1];
-        if b.is_ascii_alphanumeric() || b == b'_' {
-            start -= 1;
-        } else {
-            break;
-        }
-    }
-    let seg = &s[start..end];
-    if seg == "CORE" {
-        return true;
-    }
-    if seg != "GLOBAL" {
-        return false;
-    }
-
-    // If GLOBAL, require CORE::GLOBAL::op
-    if start < 2 || bytes[start - 1] != b':' || bytes[start - 2] != b':' {
-        return false;
-    }
-    let end2 = start - 2;
-    let mut start2 = end2;
-    while start2 > 0 {
-        let b = bytes[start2 - 1];
-        if b.is_ascii_alphanumeric() || b == b'_' {
-            start2 -= 1;
-        } else {
-            break;
-        }
-    }
-    &s[start2..end2] == "CORE"
-}
 
 /// Check if the match is a sigil-prefixed identifier ($print, @say, %exit, *dump)
 /// BUT NOT if it's a dereference call (&$print) or method call (->$print)
@@ -1967,16 +1923,6 @@ fn is_simple_braced_scalar_var(s: &str, op_start: usize, op_end: usize) -> bool 
     j < bytes.len() && bytes[j] == b'}'
 }
 
-/// Check if the match is package-qualified (Foo::print) but not CORE::
-fn is_package_qualified_not_core(s: &str, op_start: usize) -> bool {
-    let bytes = s.as_bytes();
-    if op_start < 2 || bytes[op_start - 1] != b':' || bytes[op_start - 2] != b':' {
-        return false;
-    }
-    // It's qualified, but we need to check it's not CORE::
-    !is_core_qualified(s, op_start)
-}
-
 /// Validate that an expression is safe for evaluation (non-mutating)
 ///
 /// AC10.2: Safe evaluation mode validates expressions don't have side effects
@@ -1985,7 +1931,6 @@ fn is_package_qualified_not_core(s: &str, op_start: usize) -> bool {
 /// context-aware filtering to reduce false positives for:
 /// - Sigil-prefixed identifiers ($print, @say, %exit)
 /// - Simple braced scalar variables ${print}
-/// - Package-qualified names (Foo::print) unless CORE::
 /// - Single-quoted string literals ('print')
 ///
 /// Note: Method calls ($obj->print) are intentionally NOT exempted because
@@ -2058,11 +2003,6 @@ fn validate_safe_expression(expression: &str) -> Option<String> {
 
             // Allow ${print} (simple scalar braced variable form)
             if is_simple_braced_scalar_var(expression, start, end) {
-                continue;
-            }
-
-            // Allow package-qualified names unless it's CORE::
-            if is_package_qualified_not_core(expression, start) {
                 continue;
             }
 
@@ -3213,6 +3153,24 @@ DB<1>"#;
         for expr in blocked {
             let err = validate_safe_expression(expr);
             assert!(err.is_some(), "expected block for {expr:?}");
+        }
+    }
+
+    #[test]
+    fn test_safe_eval_blocks_package_qualified_dangerous_ops() {
+        // These are package-qualified calls to dangerous operations that should be blocked
+        // even if they are not explicitly CORE::
+        let blocked = [
+            "IO::File::open($fh, 'file')",
+            "My::Utils::system('ls')",
+            "Any::Package::exec('rm -rf /')",
+            "Some::Module::eval('die')",
+            "Class::kill(9, $$)",
+        ];
+
+        for expr in blocked {
+            let err = validate_safe_expression(expr);
+            assert!(err.is_some(), "Expression '{}' should be blocked but was allowed", expr);
         }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix safe evaluation bypass via package qualification

🚨 Severity: CRITICAL
💡 Vulnerability: The `perl-dap` safe evaluation mode allowed dangerous operations (like `open`, `system`) if they were invoked with a package qualifier (e.g., `IO::File::open`), bypassing the blocklist which only checked for barewords or `CORE::` calls.
🎯 Impact: Users inspecting variables or expressions via hover (safe evaluation) could inadvertently trigger side effects or command execution if the expression contained a package-qualified call to a dangerous function.
🔧 Fix: Removed the exemption for package-qualified names in `validate_safe_expression`. The blocklist now applies to the operation name regardless of its namespace.
✅ Verification: Added a new test `test_safe_eval_blocks_package_qualified_dangerous_ops` in `crates/perl-dap/src/debug_adapter.rs` which verifies that expressions like `IO::File::open` are correctly blocked.


---
*PR created automatically by Jules for task [2327431829992764457](https://jules.google.com/task/2327431829992764457) started by @EffortlessSteven*