### PR TITLE
🎨 Palette: Context-aware Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-05 - [Context-Aware QuickPick Menus]
+**Learning:** Custom menus built with `QuickPick` (like Status Menus) do not automatically respect VS Code's `when` clauses used in `package.json`. They must be manually filtered or updated at runtime to reflect the current editor context.
+**Action:** When creating custom menu commands, explicitly check `activeTextEditor`, `languageId`, and other context variables to enable/disable or hide items dynamically.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,12 +199,43 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const docUri = editor?.document.uri;
+        const isTestFile = isPerl && docUri && (docUri.fsPath.endsWith('.t') || docUri.fsPath.endsWith('.pl'));
+
+        const createAction = (
+            label: string,
+            icon: string,
+            command: string,
+            description: string,
+            detail: string,
+            enabled: boolean
+        ): MenuAction => {
+            if (enabled) {
+                return {
+                    label: `$(${icon}) ${label}`,
+                    description,
+                    detail,
+                    command
+                };
+            } else {
+                return {
+                    label: `$(${icon}) ${label} (Not available)`,
+                    description: '',
+                    detail: 'Not available in current context',
+                    // No command property, so it won't execute
+                };
+            }
+        };
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+
+            createAction('Organize Imports', 'organization', 'perl-lsp.organizeImports', 'Shift+Alt+O', 'Sort and organize use statements', !!isPerl),
+            createAction('Run Tests in Current File', 'beaker', 'perl-lsp.runTests', 'Shift+Alt+T', 'Run tests for the active file', !!isTestFile),
+            createAction('Format Document', 'list-flat', 'editor.action.formatDocument', 'Shift+Alt+F', 'Format using perltidy', !!isPerl),
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
Implemented context-aware filtering for the `perl-lsp.showStatusMenu` command.
Menu items that are not applicable to the current active editor (e.g. running tests on a non-test file) are now visually marked as "(Not available)" and their execution is prevented. This improves UX by guiding users to valid actions and preventing confusion or errors.

---
*PR created automatically by Jules for task [8115372984491367074](https://jules.google.com/task/8115372984491367074) started by @EffortlessSteven*