### PR TITLE
🎨 Palette: Context-Aware Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-05 - [Context-Aware QuickPick Menus]
+**Learning:** Standard QuickPick items don't have a disabled state. Instead of hiding unavailable actions (which reduces discoverability), showing them with a suffix like '(Not available)' and removing the command action provides better feedback.
+**Action:** When building custom menus with QuickPick, dynamically calculate availability and modify label/command properties to indicate disabled states without removing items entirely.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,12 +199,31 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports' + (isPerl ? '' : ' (Not available)'),
+                description: 'Shift+Alt+O',
+                detail: 'Sort and organize use statements',
+                command: isPerl ? 'perl-lsp.organizeImports' : undefined
+            },
+            {
+                label: '$(beaker) Run Tests in Current File' + (isTestFile ? '' : ' (Not available)'),
+                description: 'Shift+Alt+T',
+                detail: 'Run tests for the active file',
+                command: isTestFile ? 'perl-lsp.runTests' : undefined
+            },
+            {
+                label: '$(list-flat) Format Document' + (isPerl ? '' : ' (Not available)'),
+                description: 'Shift+Alt+F',
+                detail: 'Format using perltidy',
+                command: isPerl ? 'editor.action.formatDocument' : undefined
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
Implemented context-aware filtering for the "Perl LSP" status menu. Instead of showing all actions at all times, the menu now checks the active editor's language and file extension. Unavailable actions are visually marked as "(Not available)" and their execution is disabled, preventing users from attempting invalid operations like running tests on non-Perl files. This improves the overall polish and usability of the extension.


---
*PR created automatically by Jules for task [17339549441600369742](https://jules.google.com/task/17339549441600369742) started by @EffortlessSteven*