### PR TITLE
Context-Aware Status Menu for Perl LSP

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2025-05-24 - [Context-Aware QuickPick Menus]
+**Learning:** VS Code's QuickPickItem lacks a native 'disabled' state. Hiding unavailable items reduces discoverability, while showing them as fully clickable leads to error messages. A 'soft disable' pattern (appending '(Not available)', removing the command, and explaining why in the description) provides better UX by educating users about feature requirements without cluttering the interface with errors.
+**Action:** When implementing QuickPick menus involving context-sensitive actions, use the 'soft disable' pattern instead of hiding items or allowing them to fail.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,20 +199,58 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerlDocument = editor ? editor.document.languageId === 'perl' : false;
+        let isTestFile = false;
+
+        if (isPerlDocument && editor) {
+            const filePath = editor.document.uri.fsPath;
+            isTestFile = filePath.endsWith('.t') || filePath.endsWith('.pl');
+        }
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' }
+        ];
 
+        if (isPerlDocument) {
+            items.push(
+                { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' }
+            );
+        } else {
+            items.push(
+                { label: '$(organization) Organize Imports (Not available)', description: 'Only available for Perl files', detail: '' }
+            );
+        }
+
+        if (isTestFile) {
+            items.push(
+                { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' }
+            );
+        } else {
+            items.push(
+                { label: '$(beaker) Run Tests (Not available)', description: 'Only available for .t and .pl files', detail: '' }
+            );
+        }
+
+        if (isPerlDocument) {
+            items.push(
+                { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' }
+            );
+        } else {
+            items.push(
+                { label: '$(list-flat) Format Document (Not available)', description: 'Only available for Perl files', detail: '' }
+            );
+        }
+
+        items.push(
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
-        ];
+        );
 
         const selection = await vscode.window.showQuickPick(items, {
             placeHolder: 'Perl Language Server Actions'


### PR DESCRIPTION
🎨 Palette Enhancement: Context-Aware Status Menu

💡 **What:**
The "Perl Language Server Actions" menu (accessed via status bar) now intelligently adapts to the current file.
- "Organize Imports" and "Format Document" are now marked as "Not available" when viewing non-Perl files.
- "Run Tests in Current File" is marked as "Not available" when viewing files that are not Perl scripts (`.pl`) or tests (`.t`).

🎯 **Why:**
Previously, clicking these actions in an unsupported file (e.g., a JSON config) would trigger an error message ("No active Perl file to test"). This update prevents that frustration by clearly indicating availability upfront, while still keeping the options visible to aid feature discoverability.

📸 **Before/After (Conceptual):**
*Before (in `config.json`):*
`$(beaker) Run Tests in Current File` -> [Click] -> ❌ "Error: No active Perl file"

*After (in `config.json`):*
`$(beaker) Run Tests (Not available)`
`Only available for .t and .pl files` -> [Click] -> (Nothing happens, no error)

♿ **Accessibility:**
- Unavailable items include a description explaining *why* they are unavailable.
- Prevents users from navigating to and activating dead links.

---
*PR created automatically by Jules for task [7325803571739122618](https://jules.google.com/task/7325803571739122618) started by @EffortlessSteven*