### PR TITLE
Context-Aware Perl Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-17 - [Context-Aware QuickPick Menus]
+**Learning:** In "Status Menus" (QuickPicks acting as dashboards), users prefer seeing unavailable actions disabled with an explanation (e.g., "(Not available)") rather than having them hidden entirely. This improves learnability by showing what *could* be done in the right context.
+**Action:** When building QuickPick menus, dynamically set the `disabled` property and modify the label/detail to indicate unavailability based on the current context (e.g., file type), instead of filtering the items out.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,42 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: `$(organization) Organize Imports${isPerl ? '' : ' (Not available)'}`,
+                description: 'Shift+Alt+O',
+                detail: 'Sort and organize use statements',
+                command: isPerl ? 'perl-lsp.organizeImports' : undefined,
+                disabled: !isPerl
+            },
+            {
+                label: `$(beaker) Run Tests in Current File${isTestFile ? '' : ' (Not available)'}`,
+                description: 'Shift+Alt+T',
+                detail: 'Run tests for the active file',
+                command: isTestFile ? 'perl-lsp.runTests' : undefined,
+                disabled: !isTestFile
+            },
+            {
+                label: `$(list-flat) Format Document${isPerl ? '' : ' (Not available)'}`,
+                description: 'Shift+Alt+F',
+                detail: 'Format using perltidy',
+                command: isPerl ? 'editor.action.formatDocument' : undefined,
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
Implements a UX improvement for the Perl LSP Status Menu. Previously, all actions were selectable regardless of context, leading to potential errors. Now, unavailable actions (like running tests on a non-Perl file) are visually indicated as "(Not available)" and disabled in the menu, improving discoverability and preventing user error.

---
*PR created automatically by Jules for task [14019484033863768913](https://jules.google.com/task/14019484033863768913) started by @EffortlessSteven*