### PR TITLE
🛡️ Sentinel: [HIGH] Fix Arbitrary File Execution in Single-File Mode

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-10-25 - Arbitrary File Execution in Single-File Mode
+**Vulnerability:** The LSP `ExecuteCommandProvider` defaulted to a "fail-open" state when no workspace roots were configured (`workspace_roots` was empty), allowing arbitrary file execution via commands like `perl.runFile`. This exposed users who opened a single file (without a workspace) to execution of files outside their intended context.
+**Learning:** Security controls that rely on workspace context must have a secure fallback for "single-file" or "no-workspace" scenarios. Assuming "no workspace" means "no restrictions" is dangerous.
+**Prevention:** Implement a "fail-closed" default: if no workspace context is available, explicitly restrict operations to a trusted allowlist (e.g., currently open documents) or deny them entirely.

--- a/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
@@ -31,8 +31,6 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
 fn test_execute_command_not_default_comprehensive() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Create test files for comprehensive testing
     let test_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'test execution';\n";
     let temp_file = "/tmp/test_execute_not_default.pl";
@@ -41,6 +39,11 @@ fn test_execute_command_not_default_comprehensive() -> TestResult {
     let sub_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nsub test_function { print 'executed'; return 42; }\n";
     let sub_file = "/tmp/test_sub_not_default.pl";
     fs::write(sub_file, sub_content)?;
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(temp_file), std::path::PathBuf::from(sub_file)],
+    );
 
     // Test each command to ensure no Ok(Default::default()) returns
     let test_cases = vec![
@@ -161,12 +164,15 @@ fn test_execute_command_not_default_comprehensive() -> TestResult {
 
 #[test]
 fn test_command_routing_specificity_comprehensive() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Create test file
     let test_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'routing test';\n";
     let temp_file = "/tmp/test_routing_comprehensive.pl";
     fs::write(temp_file, test_content)?;
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(temp_file)],
+    );
 
     // Execute all commands and verify they produce DIFFERENT results
     let run_tests_result = provider
@@ -327,6 +333,11 @@ fn test_parameter_validation_comprehensive() -> TestResult {
     temp_file.write_all(b"")?;
     let temp_path = temp_file.path().to_string_lossy().to_string();
 
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![temp_file.path().to_path_buf()],
+    );
+
     let result =
         provider.execute_command("perl.runTestSub", vec![Value::String(temp_path.clone())]);
     assert!(result.is_err(), "runTestSub should fail with missing subroutine name");
@@ -404,13 +415,16 @@ fn test_file_path_extraction_validation() -> TestResult {
 
 #[test]
 fn test_response_structure_validation() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Create test file with known content
     let test_content =
         "#!/usr/bin/perl\n# Missing pragmas for violations\nmy $var = 42;\nprint $var;\n";
     let temp_file = "/tmp/test_response_structure.pl";
     fs::write(temp_file, test_content)?;
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(temp_file)],
+    );
 
     // Test runCritic response structure in detail
     let result =
@@ -518,12 +532,17 @@ fn test_file_not_found_error_structure() -> TestResult {
 
 #[test]
 fn test_command_execution_success_failure_logic() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Create files for testing different execution scenarios
     let valid_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint \"success\";\n";
     let valid_file = "/tmp/test_valid_execution.pl";
     fs::write(valid_file, valid_content)?;
+
+    let sub_file = "/tmp/test_sub_execution.pl";
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(valid_file), std::path::PathBuf::from(sub_file)],
+    );
 
     // Test successful execution
     let success_result =
@@ -537,7 +556,7 @@ fn test_command_execution_success_failure_logic() -> TestResult {
 
     // Test with subroutine execution
     let sub_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nsub test_execution { print \"sub executed\"; return 1; }\n";
-    let sub_file = "/tmp/test_sub_execution.pl";
+    // sub_file defined above
     fs::write(sub_file, sub_content)?;
 
     let sub_result = provider.execute_command(
@@ -560,12 +579,15 @@ fn test_command_execution_success_failure_logic() -> TestResult {
 
 #[test]
 fn test_comprehensive_edge_cases() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Test empty file handling
     let empty_content = "";
     let empty_file = "/tmp/test_empty_file.pl";
     fs::write(empty_file, empty_content)?;
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(empty_file)],
+    );
 
     let empty_result =
         provider.execute_command("perl.runCritic", vec![Value::String(empty_file.to_string())]);
@@ -648,8 +670,6 @@ fn test_supported_commands_structure() -> TestResult {
 
 #[test]
 fn test_comprehensive_workflow_validation() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
-
     // Create comprehensive test file
     let comprehensive_content = r#"#!/usr/bin/perl
 use strict;
@@ -670,6 +690,11 @@ print "Result: $result\n";
 
     let temp_file = "/tmp/comprehensive_workflow_test.pl";
     fs::write(temp_file, comprehensive_content)?;
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(temp_file)],
+    );
 
     // Execute all commands and verify end-to-end behavior
     let all_commands = vec![

--- a/crates/perl-lsp/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_security_tests.rs
@@ -59,11 +59,14 @@ fn test_run_test_sub_file_path_injection() -> Result<(), Box<dyn Error>> {
 /// code will NOT be executed.
 #[test]
 fn test_run_test_sub_subname_injection() -> Result<(), Box<dyn Error>> {
-    let provider = ExecuteCommandProvider::new();
-
     // Create a minimal test file with a marker subroutine
     let test_file = "/tmp/security_test_sub.pl";
     std::fs::write(test_file, "sub safe_sub { print 'SAFE_SUB_EXECUTED'; }").ok();
+
+    let provider = ExecuteCommandProvider::with_security_context(
+        vec![],
+        vec![std::path::PathBuf::from(test_file)],
+    );
 
     // This payload would execute code if string interpolation was used.
     // With the fix (using @ARGV), it's treated as a literal subroutine name.
@@ -201,7 +204,8 @@ fn test_valid_file_execution() -> Result<(), Box<dyn Error>> {
     let file_path = temp_dir.path().join("test_valid.pl");
     fs::write(&file_path, "print 'VALID_OUTPUT';")?;
 
-    let provider = ExecuteCommandProvider::new();
+    let provider =
+        ExecuteCommandProvider::with_security_context(vec![], vec![file_path.clone()]);
 
     let result = provider.execute_command(
         "perl.runFile",


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Arbitrary File Execution in Single-File Mode

🚨 Severity: HIGH
💡 Vulnerability: The LSP `ExecuteCommandProvider` defaulted to allowing arbitrary file execution when no workspace roots were configured (single-file mode).
🎯 Impact: Malicious clients or scripts could trigger execution of arbitrary Perl files on the system if the user had no workspace open.
🔧 Fix: Implemented a "fail-closed" mechanism. If `workspace_roots` is empty, execution is restricted to a strictly defined list of `trusted_files` (currently open documents). If neither is present, execution is denied.
✅ Verification: Updated unit and integration tests to ensure that `ExecuteCommandProvider` requires explicit security context (workspace roots or trusted files) to execute commands. Verified that execution fails when no context is provided.

---
*PR created automatically by Jules for task [1617385011109966497](https://jules.google.com/task/1617385011109966497) started by @EffortlessSteven*