### PR TITLE
🎨 Palette: Make status menu actions context-aware

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,40 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+
+            {
+                label: `$(organization) Organize Imports${!isPerl ? ' (Not available)' : ''}`,
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available in Perl files',
+                command: isPerl ? 'perl-lsp.organizeImports' : undefined,
+                disabled: !isPerl
+            },
+
+            {
+                label: `$(beaker) Run Tests in Current File${!isTestFile ? ' (Not available)' : ''}`,
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Only available for .t and .pl files',
+                command: isTestFile ? 'perl-lsp.runTests' : undefined,
+                disabled: !isTestFile
+            },
+
+            {
+                label: `$(list-flat) Format Document${!isPerl ? ' (Not available)' : ''}`,
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available in Perl files',
+                command: isPerl ? 'editor.action.formatDocument' : undefined,
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -218,7 +244,7 @@ export async function activate(context: vscode.ExtensionContext) {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection && selection.command) {
+        if (selection && selection.command && !selection.disabled) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });


### PR DESCRIPTION
🎨 Palette: Make status menu actions context-aware

💡 What:
Updated the `perl-lsp.showStatusMenu` command to dynamically disable and label actions based on the current active editor context.

🎯 Why:
Users were previously presented with actions like "Run Tests" or "Format Document" even when editing non-Perl files or when no editor was active. Selecting these would either do nothing or potentially cause errors. This change guides the user by clearly indicating which actions are available.

📸 Before/After:
(No visual artifacts available in this environment, but logically: "Run Tests" now says "Run Tests (Not available)" when on a `.txt` file).

♿ Accessibility:
Improved cognitive accessibility by reducing confusion and clearly communicating state via labels and descriptions.


---
*PR created automatically by Jules for task [17602648619493270362](https://jules.google.com/task/17602648619493270362) started by @EffortlessSteven*