### PR TITLE
🛡️ Sentinel: [HIGH] Block control flow and package keywords in safe eval

### DIFF
--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -169,7 +169,12 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "link", // Code loading/execution
                 "eval",
                 "require",
-                "do", // Tie mechanism (can execute arbitrary code)
+                "do",
+                "use",
+                "no",
+                "package",
+                "goto",
+                // Tie mechanism (can execute arbitrary code)
                 "tie",
                 "untie", // Network
                 "socket",
@@ -3213,6 +3218,22 @@ DB<1>"#;
         for expr in blocked {
             let err = validate_safe_expression(expr);
             assert!(err.is_some(), "expected block for {expr:?}");
+        }
+    }
+
+    #[test]
+    fn test_safe_eval_blocks_control_flow_and_packages() {
+        // These are currently allowed but SHOULD be blocked
+        let blocked = [
+            "use Socket",
+            "no strict",
+            "package Evil",
+            "goto LABEL",
+        ];
+
+        for expr in blocked {
+            let err = validate_safe_expression(expr);
+            assert!(err.is_some(), "Expression '{}' should be blocked but was allowed", expr);
         }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Block control flow and package keywords in safe eval

Added `use`, `no`, `package`, and `goto` to the list of blocked operations in `dangerous_ops_re` within `crates/perl-dap/src/debug_adapter.rs`. These keywords can execute arbitrary code (e.g. `use Module`) or alter global state/control flow, which violates the "Safe Evaluation" (side-effect free) contract.

**Vulnerability:** The debug adapter's "Safe Evaluation" mode blocked many dangerous operations but missed compile-time keywords (`use`, `no`) and control flow modifiers (`package`, `goto`). This allowed users (or malicious expressions in a shared workspace) to execute arbitrary code or change namespace context even when "allowSideEffects" was false.

**Impact:** High. Code execution during "safe" inspection.

**Fix:** Added these keywords to the regex blocklist.

**Verification:** Added `test_safe_eval_blocks_control_flow_and_packages` which asserts these keywords are rejected. Ran full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [12296170219316878850](https://jules.google.com/task/12296170219316878850) started by @EffortlessSteven*