### PR TITLE
🎨 Palette: Context-aware status menu actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-14 - [Context-Aware QuickPick Actions]
+**Learning:** VS Code's `QuickPickItem` supports a `disabled` property (in newer APIs), but visually communicating unavailability via label suffixes (e.g., "(Not available)") is clearer for users than relying solely on UI state, especially when the reason for disabling is context-dependent (e.g., wrong file type).
+**Action:** When creating dynamic menus, explicitly mark unavailable actions as disabled and update their labels to explain why, rather than hiding them or letting them fail.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,38 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? editor.document.languageId === 'perl' : false;
+        const fileName = editor ? editor.document.fileName : '';
+        const isTestFile = isPerl && (fileName.endsWith('.t') || fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: isPerl ? '$(organization) Organize Imports' : '$(organization) Organize Imports (Not available)',
+                description: 'Shift+Alt+O',
+                detail: 'Sort and organize use statements',
+                command: isPerl ? 'perl-lsp.organizeImports' : undefined,
+                disabled: !isPerl
+            },
+            {
+                label: isTestFile ? '$(beaker) Run Tests in Current File' : '$(beaker) Run Tests in Current File (Not available)',
+                description: 'Shift+Alt+T',
+                detail: 'Run tests for the active file',
+                command: isTestFile ? 'perl-lsp.runTests' : undefined,
+                disabled: !isTestFile
+            },
+            {
+                label: isPerl ? '$(list-flat) Format Document' : '$(list-flat) Format Document (Not available)',
+                description: 'Shift+Alt+F',
+                detail: 'Format using perltidy',
+                command: isPerl ? 'editor.action.formatDocument' : undefined,
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
💡 What: Added dynamic disabling of "Organize Imports", "Run Tests", and "Format Document" in the Perl LSP Status Menu based on the active file context.
🎯 Why: Users were able to click these actions in non-Perl files, leading to errors or no action. Disabling them proactively prevents frustration.
📸 Before/After: N/A (Dynamic UI behavior)
♿ Accessibility: Added "(Not available)" text to disabled items to clarify status, as standard disabled state might be subtle.

---
*PR created automatically by Jules for task [14169116175179225284](https://jules.google.com/task/14169116175179225284) started by @EffortlessSteven*