### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unsound raw pointer usage in DeclarationProvider

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-27 - Unsound Raw Pointer Exposure in Public API
+**Vulnerability:** The `DeclarationProvider::with_parent_map` function in `perl-parser` was a safe public function that accepted a map containing raw pointers (`*const Node`) and dereferenced them internally using `unsafe`. This allowed safe Rust code to trigger Undefined Behavior (segfaults, UAF) by passing invalid pointers.
+**Learning:** Functions that accept raw pointers and dereference them MUST be marked `unsafe`, or the pointers must be encapsulated in a safe abstraction that guarantees validity. Raw pointers have no lifetime guarantees, so the compiler cannot prevent use-after-free or invalid access.
+**Prevention:** If an API requires raw pointers for performance, mark the function as `unsafe` and document the safety contracts clearly. Better yet, use safe abstractions (like indices or `Rc`) if the performance cost is acceptable.

--- a/crates/perl-parser/tests/declaration_micro_tests.rs
+++ b/crates/perl-parser/tests/declaration_micro_tests.rs
@@ -35,10 +35,11 @@ mod declaration_micro_tests {
 
         // Create provider - we need to leak to satisfy lifetime
         let leaked_map = Box::leak(Box::new(parent_map));
-        let provider =
+        let provider = unsafe {
             DeclarationProvider::new(ast_arc.clone(), code.to_string(), "test.pl".to_string())
                 .with_parent_map(leaked_map)
-                .with_doc_version(0);
+                .with_doc_version(0)
+        };
 
         Ok((provider, leaked_map.clone(), ast_arc))
     }
@@ -189,10 +190,11 @@ mod constant_advanced_tests {
         DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
 
         let leaked_map = Box::leak(Box::new(parent_map));
-        let provider =
+        let provider = unsafe {
             DeclarationProvider::new(ast_arc.clone(), code.to_string(), "test.pl".to_string())
                 .with_parent_map(leaked_map)
-                .with_doc_version(0);
+                .with_doc_version(0)
+        };
 
         Ok((provider, leaked_map.clone(), ast_arc))
     }
@@ -326,10 +328,11 @@ mod qw_variants_tests {
         DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
 
         let leaked_map = Box::leak(Box::new(parent_map));
-        let provider =
+        let provider = unsafe {
             DeclarationProvider::new(ast_arc.clone(), code.to_string(), "test.pl".to_string())
                 .with_parent_map(leaked_map)
-                .with_doc_version(0);
+                .with_doc_version(0)
+        };
 
         Ok((provider, leaked_map.clone(), ast_arc))
     }
@@ -392,10 +395,11 @@ mod parser_extras_tests {
         DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
 
         let leaked_map = Box::leak(Box::new(parent_map));
-        let provider =
+        let provider = unsafe {
             DeclarationProvider::new(ast_arc.clone(), code.to_string(), "test.pl".to_string())
                 .with_parent_map(leaked_map)
-                .with_doc_version(0);
+                .with_doc_version(0)
+        };
 
         Ok((provider, leaked_map.clone(), ast_arc))
     }

--- a/crates/perl-parser/tests/provider_version_guard.rs
+++ b/crates/perl-parser/tests/provider_version_guard.rs
@@ -20,9 +20,11 @@ mod provider_version_guard {
         DeclarationProvider::build_parent_map(&ast, &mut pm, None);
 
         // Construct provider with version 1…
-        let prov = DeclarationProvider::new(ast.clone(), code.to_string(), "file:///x".into())
-            .with_parent_map(&pm)
-            .with_doc_version(1);
+        let prov = unsafe {
+            DeclarationProvider::new(ast.clone(), code.to_string(), "file:///x".into())
+                .with_parent_map(&pm)
+                .with_doc_version(1)
+        };
 
         // …but call it with a newer doc version => should panic in debug.
         let off = match code.find("FOO") {

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -106,6 +106,11 @@ impl<'a> DeclarationProvider<'a> {
     /// - Root node has a parent (cycle detection)
     /// - Cycles detected in parent relationships
     ///
+    /// # Safety
+    /// The `parent_map` must contain valid pointers to nodes within the `ast` provided
+    /// to this provider. Using pointers to dropped nodes or nodes from a different AST
+    /// will result in Undefined Behavior (use-after-free or invalid memory access).
+    ///
     /// # Examples
     /// ```rust
     /// use perl_parser::declaration::{DeclarationProvider, ParentMap};
@@ -118,9 +123,12 @@ impl<'a> DeclarationProvider<'a> {
     ///
     /// let provider = DeclarationProvider::new(
     ///     ast, "content".to_string(), "uri".to_string()
-    /// ).with_parent_map(&parent_map);
+    /// );
+    /// unsafe {
+    ///     provider.with_parent_map(&parent_map);
+    /// }
     /// ```
-    pub fn with_parent_map(mut self, parent_map: &'a ParentMap) -> Self {
+    pub unsafe fn with_parent_map(mut self, parent_map: &'a ParentMap) -> Self {
         #[cfg(debug_assertions)]
         {
             // If the AST has more than the root node, an empty map is suspicious.


### PR DESCRIPTION
Mark `DeclarationProvider::with_parent_map` as `unsafe` to prevent potential Undefined Behavior when using raw pointers to AST nodes.

**Vulnerability Fixed:**
The `DeclarationProvider::with_parent_map` function in `crates/perl-semantic-analyzer` accepted a map of raw pointers (`*const Node`) and dereferenced them internally. As a safe public API, this allowed callers to pass invalid pointers (e.g., from a dropped AST) and trigger segfaults or use-after-free in safe code.

**Changes:**
*   `crates/perl-semantic-analyzer/src/analysis/declaration.rs`: Marked `with_parent_map` as `unsafe` and added safety documentation.
*   `crates/perl-lsp/src/runtime/language/navigation.rs`: Updated call sites to use `unsafe` blocks (safe because `DocumentState` owns both AST and map). Added `#![allow(unsafe_code)]`.
*   `crates/perl-parser/tests/declaration_micro_tests.rs`: Updated tests to use `unsafe`.
*   `crates/perl-parser/tests/provider_version_guard.rs`: Updated tests to use `unsafe`.

**Verification:**
*   Created a reproduction test case that successfully triggered a panic (misaligned pointer dereference) when compiling safe code (before fix) and failed to compile (after fix), confirming the soundness check.
*   Verified that all `perl-parser` tests pass.
*   Verified that `perl-lsp` compiles successfully.

---
*PR created automatically by Jules for task [2253316438882346425](https://jules.google.com/task/2253316438882346425) started by @EffortlessSteven*