### PR TITLE
⚡ Bolt: Optimize ScopeAnalyzer::is_known_function with PHF

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1190,37 +1190,15 @@ fn is_known_function(name: &str) -> bool {
         return false;
     }
 
+    // Optimization: Check the perfect hash map first (O(1))
+    if perl_parser_core::builtin_signatures_phf::is_builtin(name) {
+        return true;
+    }
+
     match name {
-        // I/O functions
-        "print" | "printf" | "say" | "open" | "close" | "read" | "write" | "seek" | "tell"
-        | "eof" | "fileno" | "binmode" | "sysopen" | "sysread" | "syswrite" | "sysclose"
-        | "select" |
-        // String functions
-        "chomp" | "chop" | "chr" | "crypt" | "fc" | "hex" | "index" | "lc" | "lcfirst" | "length"
-        | "oct" | "ord" | "pack" | "q" | "qq" | "qr" | "quotemeta" | "qw" | "qx" | "reverse"
-        | "rindex" | "sprintf" | "substr" | "tr" | "uc" | "ucfirst" | "unpack" |
-        // Array/List functions
-        "pop" | "push" | "shift" | "unshift" | "splice" | "split" | "join" | "grep" | "map"
-        | "sort" |
-        // Hash functions
-        "delete" | "each" | "exists" | "keys" | "values" |
-        // Control flow
-        "die" | "exit" | "return" | "goto" | "last" | "next" | "redo" | "continue" | "break"
-        | "given" | "when" | "default" |
-        // File test operators
-        "stat" | "lstat" | "-r" | "-w" | "-x" | "-o" | "-R" | "-W" | "-X" | "-O" | "-e" | "-z"
-        | "-s" | "-f" | "-d" | "-l" | "-p" | "-S" | "-b" | "-c" | "-t" | "-u" | "-g" | "-k"
-        | "-T" | "-B" | "-M" | "-A" | "-C" |
-        // System functions
-        "system" | "exec" | "fork" | "wait" | "waitpid" | "kill" | "sleep" | "alarm"
-        | "getpgrp" | "getppid" | "getpriority" | "setpgrp" | "setpriority" | "time" | "times"
-        | "localtime" | "gmtime" |
-        // Math functions
-        "abs" | "atan2" | "cos" | "exp" | "int" | "log" | "rand" | "sin" | "sqrt" | "srand" |
-        // Misc functions
-        "defined" | "undef" | "ref" | "bless" | "tie" | "tied" | "untie" | "eval" | "caller"
-        | "import" | "require" | "use" | "do" | "package" | "sub" | "my" | "our" | "local"
-        | "state" | "scalar" | "wantarray" | "warn" => true,
+        // Syntax keywords and operators not in builtin_signatures_phf
+        "sub" | "package" | "import" | "break" | "continue" | "given" | "when" | "default"
+        | "sysclose" | "q" | "qq" | "qr" | "qw" | "qx" | "tr" | "y" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Implemented O(1) PHF lookup for `ScopeAnalyzer::is_known_function` to improve performance of scope analysis.

- Imported `perl_parser_core::builtin_signatures_phf`.
- Modified `is_known_function` to check PHF first.
- Kept manual match for non-PHF keywords (checked against `BUILTIN_SIGS`).
- Verified with existing tests and a temporary verification test covering builtins, fallbacks, and unknown words.


---
*PR created automatically by Jules for task [15840257673501769762](https://jules.google.com/task/15840257673501769762) started by @EffortlessSteven*