### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix relative redirect crash in downloader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-23 - Relative Redirect DoS in Binary Downloader
+**Vulnerability:** The `BinaryDownloader` in `vscode-extension` crashed when receiving a relative `Location` header during an HTTP redirect because it used `new URL(newUrl)` without a base URL.
+**Learning:** `new URL()` in Node.js throws on relative paths if no base is provided. HTTP clients handling redirects manually must resolve relative redirects against the request URL. This also bypassed protocol downgrade checks if the relative path didn't start with `http`.
+**Prevention:** Use `new URL(newUrl, currentUrl).toString()` to properly resolve relative paths before processing them. Always check the resolved URL against security policies (e.g. protocol) rather than the raw header.


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix relative redirect crash in downloader

🚨 Severity: MEDIUM (DoS / Reliability)
💡 Vulnerability: The `BinaryDownloader` used `new URL(newUrl)` on the `Location` header from redirects. If the server returned a relative path (e.g., `/foo`), this would throw an `Invalid URL` error, crashing the extension activation. This also potentially bypassed the protocol downgrade check which expected URLs to start with `http`.
🎯 Impact: Extensions could fail to install the language server if the download server used relative redirects. Potential for infinite redirect loops.
🔧 Fix:
- Implemented `redirectCount` to limit recursion depth to 5.
- Used `new URL(newUrl, url).toString()` to properly resolve relative paths.
- Applied protocol checks to the *resolved* absolute URL.
✅ Verification: Created a reproduction script confirming `new URL()` fails on relative paths and verifying the fix handles them correctly. Extension compiles successfully.

---
*PR created automatically by Jules for task [17514575379094481755](https://jules.google.com/task/17514575379094481755) started by @EffortlessSteven*