### PR TITLE
🎨 Palette: Add smart disable states to Status Menu

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,37 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.uri.fsPath.endsWith('.t') || editor?.document.uri.fsPath.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Only available for .t and .pl files',
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -218,7 +241,7 @@ export async function activate(context: vscode.ExtensionContext) {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection && selection.command) {
+        if (selection && selection.command && !selection.disabled) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });


### PR DESCRIPTION
This PR improves the User Experience of the "Perl Language Server Actions" status menu (`perl-lsp.showStatusMenu`).

Previously, all actions were always selectable, leading to error messages if a user clicked "Run Tests" on a non-test file or "Organize Imports" on a non-Perl file.

Changes:
- The menu is now context-aware based on the active text editor.
- "Run Tests in Current File" is disabled and labeled as "(Not available)" if the file is not a `.t` or `.pl` script.
- "Organize Imports" and "Format Document" are disabled if the file is not a Perl file.
- `disabled` property logic was implemented manually since `QuickPickItem` types in use didn't expose it, ensuring commands are not executed if disabled.

This makes the interface more intuitive and prevents "dead end" interactions.

---
*PR created automatically by Jules for task [12651478899406148096](https://jules.google.com/task/12651478899406148096) started by @EffortlessSteven*