### PR TITLE
🎨 Palette: Improve Status Menu UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-18 - [Unavailable Actions in QuickPick Menus]
+**Learning:** For `QuickPick` menus (like Status Menu), explicitly showing unavailable actions with a disabled state (e.g., "(Not available)" suffix) is better than hiding them, as it aids discoverability and explains *why* an action isn't available via description text.
+**Action:** When implementing context-aware menus, calculate availability upfront and modify the item's label/description to reflect its state, rather than filtering it out.


### PR DESCRIPTION
This PR enhances the UX of the `perl-lsp.showStatusMenu` command by making the "Run Tests" option context-aware. 

Previously, "Run Tests" was always enabled, even if the active file was not a Perl test script (`.t`) or a Perl script (`.pl`). This could lead to confusion or errors when users tried to run it on module files (`.pm`) or non-Perl files.

Now, the menu item checks the active editor's file extension. If it's not a valid test file, the item is visually marked as "(Not available)", the description explains the restriction ("Only available for .t and .pl files"), and selecting it does nothing. This follows the design pattern of exposing unavailable features with a disabled state rather than hiding them, aiding in feature discoverability.

---
*PR created automatically by Jules for task [16453867983794622343](https://jules.google.com/task/16453867983794622343) started by @EffortlessSteven*