### PR TITLE
🛡️ Sentinel: [CRITICAL] Enforce fail-closed for empty workspace roots

### DIFF
--- a/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
@@ -31,7 +31,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
 fn test_execute_command_not_default_comprehensive() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Create test files for comprehensive testing
     let test_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'test execution';\n";
@@ -161,7 +161,7 @@ fn test_execute_command_not_default_comprehensive() -> TestResult {
 
 #[test]
 fn test_command_routing_specificity_comprehensive() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Create test file
     let test_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'routing test';\n";
@@ -234,7 +234,7 @@ fn test_command_routing_specificity_comprehensive() -> TestResult {
 
 #[test]
 fn test_unknown_command_handling() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Test unknown command handling (targets command routing mutations)
     let result = provider.execute_command("perl.nonExistentCommand", vec![]);
@@ -275,7 +275,7 @@ fn test_unknown_command_handling() -> TestResult {
 
 #[test]
 fn test_parameter_validation_comprehensive() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Test missing file path arguments for all commands that require them
     let commands_requiring_file_path =
@@ -358,7 +358,7 @@ fn test_parameter_validation_comprehensive() -> TestResult {
 
 #[test]
 fn test_file_path_extraction_validation() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Test that extract_file_path_argument returns actual values, not hardcoded ones
     // We do this indirectly by testing runCritic with different file paths
@@ -404,7 +404,7 @@ fn test_file_path_extraction_validation() -> TestResult {
 
 #[test]
 fn test_response_structure_validation() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Create test file with known content
     let test_content =
@@ -480,7 +480,7 @@ fn test_response_structure_validation() -> TestResult {
 
 #[test]
 fn test_file_not_found_error_structure() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Test with definitely non-existent file
     let result = provider.execute_command(
@@ -518,7 +518,7 @@ fn test_file_not_found_error_structure() -> TestResult {
 
 #[test]
 fn test_command_execution_success_failure_logic() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Create files for testing different execution scenarios
     let valid_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint \"success\";\n";
@@ -560,7 +560,7 @@ fn test_command_execution_success_failure_logic() -> TestResult {
 
 #[test]
 fn test_comprehensive_edge_cases() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Test empty file handling
     let empty_content = "";
@@ -648,7 +648,7 @@ fn test_supported_commands_structure() -> TestResult {
 
 #[test]
 fn test_comprehensive_workflow_validation() -> TestResult {
-    let provider = ExecuteCommandProvider::new();
+    let provider = ExecuteCommandProvider::with_workspace_roots(vec![std::env::temp_dir()]);
 
     // Create comprehensive test file
     let comprehensive_content = r#"#!/usr/bin/perl


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ExecuteCommandProvider` allowed file execution (fail-open) when no workspace roots were configured, potentially allowing execution of arbitrary files if the client failed to provide roots or in single-file mode.
🎯 Impact: An attacker could potentially execute arbitrary files on the system if they could invoke commands like `perl.runFile` with crafted paths when no workspace root was active.
🔧 Fix: Modified `resolve_path_from_args` in `crates/perl-lsp/src/execute_command.rs` to return an error ("Fail-closed") if `workspace_roots` is empty. Updated all unit and integration tests to explicitly configure a workspace root (e.g., `/tmp`) to ensure valid tests pass while enforcing the new security policy.
✅ Verification: Added `test_fail_closed_empty_workspace_roots` which confirms that `ExecuteCommandProvider::new()` (empty roots) now blocks execution. Verified all existing tests pass with proper root configuration.

Note: `ExecuteCommandProvider::with_workspace_roots` was already present in the codebase and is now used extensively in tests.

---
*PR created automatically by Jules for task [12006894551732384751](https://jules.google.com/task/12006894551732384751) started by @EffortlessSteven*