### PR TITLE
feat(vscode): improve Status Menu UX with context-aware disabled states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-01-30 - [Context-Aware Menus]
+**Learning:** `QuickPick` menus can mimic a disabled state by checking context (like file extensions) and updating the item's `detail` property with an explanation, while programmatically blocking execution.
+**Action:** When creating custom menus, always validate the current context and provide feedback (via `detail` text) instead of hiding items or letting them fail silently.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,37 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? editor.document.languageId === 'perl' : false;
+        const isTestFile = isPerl && editor ? /\.(t|pl)$/.test(editor.document.uri.fsPath) : false;
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Only available for .t and .pl files',
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -218,7 +241,7 @@ export async function activate(context: vscode.ExtensionContext) {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection && selection.command) {
+        if (selection && selection.command && !selection.disabled) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
         }
     });


### PR DESCRIPTION
This PR improves the UX of the "Status Menu" (accessed via the status bar item) by making it context-aware.

## Changes
- Modified `perl-lsp.showStatusMenu` in `vscode-extension/src/extension.ts`.
- Added logic to detect if the active editor is a Perl file and if it is a test file (`.t` or `.pl`).
- Updated the menu items to be "disabled" (programmatically blocked and visually annotated in `detail`) when they are not applicable.
  - **Run Tests**: Only enabled for `.t` and `.pl` files.
  - **Organize Imports**: Only enabled for Perl files.
  - **Format Document**: Only enabled for Perl files.
- Added `disabled` property to the local `MenuAction` interface to satisfy TypeScript and enable the logic.

## UX Improvements
- **Before:** Users would see all commands. Clicking "Run Tests" on a non-test file would show an error message.
- **After:** Users see which commands are available. "Run Tests" shows "Only available for .t and .pl files" in the detail text when unavailable. Clicking it does nothing (blocked).

## Verification
- Verified `pnpm compile` passes in `vscode-extension`.
- Verified logic handles `activeTextEditor` being undefined.

---
*PR created automatically by Jules for task [3367517774485001079](https://jules.google.com/task/3367517774485001079) started by @EffortlessSteven*