### PR TITLE
⚡ Bolt: Optimize indirect call check with O(1) builtin lookup

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -24,15 +24,30 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Known builtins that commonly use indirect object syntax
-        let indirect_builtins = [
-            "print", "printf", "say", "open", "close", "pipe", "sysopen", "sysread", "syswrite",
-            "truncate", "fcntl", "ioctl", "flock", "seek", "tell", "select", "binmode", "exec",
-            "system",
-        ];
-
-        // Check if it's a known builtin
-        if indirect_builtins.contains(&name) {
+        // Check if it's a known builtin that commonly uses indirect object syntax
+        // Use a match expression for O(1) lookup instead of iterating over an array
+        if matches!(
+            name,
+            "print"
+                | "printf"
+                | "say"
+                | "open"
+                | "close"
+                | "pipe"
+                | "sysopen"
+                | "sysread"
+                | "syswrite"
+                | "truncate"
+                | "fcntl"
+                | "ioctl"
+                | "flock"
+                | "seek"
+                | "tell"
+                | "select"
+                | "binmode"
+                | "exec"
+                | "system"
+        ) {
             // Peek at the token AFTER the function name (use peek_second since peek is the function name)
             let next_token = if let Ok(next) = self.tokens.peek_second() {
                 next


### PR DESCRIPTION
⚡ Bolt: Optimize indirect call check with O(1) builtin lookup

💡 What:
Replaced the `indirect_builtins` array creation and linear scan in `is_indirect_call_pattern` with a `matches!` macro.

🎯 Why:
The `is_indirect_call_pattern` function is called for every identifier that starts a statement (and potentially in expression contexts, though currently limited). The previous implementation allocated an array of 19 strings on the stack and performed a linear search (O(N)). The `matches!` macro compiles to a more efficient jump table or series of comparisons (O(1)).

📊 Impact:
Micro-optimization for parser throughput. Reduces overhead for every statement starting with an identifier.

🔬 Measurement:
No regressions in `cargo test -p perl-parser-core`.
Verified via manual testing that indirect object syntax support remains unchanged (supported at statement level, unsupported in expressions as before).


---
*PR created automatically by Jules for task [2745221640714654772](https://jules.google.com/task/2745221640714654772) started by @EffortlessSteven*