### PR TITLE
🛡️ Sentinel: Fix Safe Evaluation Bypass via Package Separator

### DIFF
--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -1823,6 +1823,7 @@ impl DebugAdapter {
 fn is_in_single_quotes(s: &str, idx: usize) -> bool {
     let mut in_sq = false;
     let mut escaped = false;
+    let mut prev_char: Option<char> = None;
 
     for (i, ch) in s.char_indices() {
         if i >= idx {
@@ -1837,8 +1838,15 @@ fn is_in_single_quotes(s: &str, idx: usize) -> bool {
                 in_sq = false;
             }
         } else if ch == '\'' {
-            in_sq = true;
+            // Only start a string if NOT preceded by a word character
+            // This prevents treating package separators (e.g., CORE'system) as string starts
+            let is_package_separator =
+                prev_char.is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+            if !is_package_separator {
+                in_sq = true;
+            }
         }
+        prev_char = Some(ch);
     }
 
     in_sq

--- a/crates/perl-dap/tests/security_repro_test.rs
+++ b/crates/perl-dap/tests/security_repro_test.rs
@@ -1,0 +1,36 @@
+use perl_dap::DapMessage;
+use perl_dap::DebugAdapter;
+use serde_json::json;
+
+#[test]
+fn test_security_repro_core_system_bypass() {
+    let mut adapter = DebugAdapter::new();
+
+    // We try to evaluate CORE'system("ls") which bypasses the current check
+    // because it treats ' as a string delimiter due to is_in_single_quotes logic
+    // seeing ' preceded by 'E' (part of CORE).
+
+    let args = json!({
+        "expression": "CORE'system(\"ls\")",
+        "allowSideEffects": false
+    });
+
+    let response = adapter.handle_request(1, "evaluate", Some(args));
+
+    if let DapMessage::Response { success, message, .. } = response {
+        // success should be false regardless (either security error or no session error)
+        assert!(!success);
+
+        let msg = message.expect("Expected message in response");
+
+        // If the vulnerability exists, the message will be "No debugger session"
+        // If fixed, it will be "Safe evaluation mode: ..."
+        assert!(
+            msg.contains("Safe evaluation mode"),
+            "Security check bypassed! The expression was allowed to proceed to session check. Got message: '{}'",
+            msg
+        );
+    } else {
+        panic!("Expected response");
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Safe Evaluation Bypass

🚨 Severity: HIGH
💡 Vulnerability: Safe Evaluation Bypass via Package Separator
The "Safe Evaluation" mode in the debug adapter could be bypassed using Perl's archaic package separator syntax (e.g., `CORE'system`). The parser incorrectly identified the package separator `'` as the start of a string literal, causing the security filter to ignore the subsequent dangerous function call.

🎯 Impact: Arbitrary Code Execution
An attacker (or a user unknowingly evaluating a malicious expression) could execute arbitrary commands (e.g., `system`, `exec`) even when "Safe Evaluation" is strictly enforced, defeating the purpose of the security feature.

🔧 Fix: Improved String Detection
The `is_in_single_quotes` helper function was updated to recognize that a single quote preceded by a word character is likely a package separator, not a string delimiter. This ensures that expressions like `CORE'system` are correctly parsed as code and blocked.

✅ Verification:
- Added a regression test `crates/perl-dap/tests/security_repro_test.rs` that attempts to evaluate `CORE'system("ls")`.
- Verified that the test fails (bypasses security) without the fix and passes (blocks execution) with the fix.
- Verified that valid single-quoted strings (e.g., `print 'hello'`) are still handled correctly (though `print` itself is blocked, the string parsing logic is sound).

---
*PR created automatically by Jules for task [7605457544879714927](https://jules.google.com/task/7605457544879714927) started by @EffortlessSteven*