### PR TITLE
🎨 Palette: Improve Perl Language Server Status Menu UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-03-01 - [Disabled States in QuickPick]
+**Learning:** `QuickPickItem` lacks a standard `disabled` property in the older VS Code type definitions used here. A disabled state can be simulated by updating the item's label/detail and manually preventing execution in the handler.
+**Action:** When implementing context-sensitive menus via `showQuickPick`, check if the item is applicable. If not, visually degrade it (remove icon, add "(Not available)") and provide a clear explanation in the `detail` property rather than hiding it entirely, to aid discoverability.


### PR DESCRIPTION
💡 **What:** Enhanced the `perl-lsp.showStatusMenu` command to be context-aware.
🎯 **Why:** Users were presented with "Run Tests", "Organize Imports", and "Format Document" options even when they weren't applicable (e.g. non-Perl files, or "Run Tests" on a non-test file), leading to confusion or errors.
📸 **Before/After:**
*   Before: All menu items were always enabled.
*   After: Items are dynamically disabled with "(Not available)" suffix and explanatory detail text (e.g. "Only available for .t or .pl files") if the context is incorrect.
♿ **Accessibility:** Improved discoverability by explaining *why* an action is disabled instead of hiding it or failing silently. Using `(Not available)` text ensures screen readers announce the state.

---
*PR created automatically by Jules for task [13738635118268824634](https://jules.google.com/task/13738635118268824634) started by @EffortlessSteven*