### PR TITLE
UX: Context-aware Status Menu actions

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,37 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? editor.document.languageId === 'perl' : false;
+        const isTestFile = isPerl && editor ? (editor.document.fileName.endsWith('.t') || editor.document.fileName.endsWith('.pl')) : false;
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : (isPerl ? 'Only available for .t or .pl files' : 'Only available for Perl test files'),
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -215,11 +238,16 @@ export async function activate(context: vscode.ExtensionContext) {
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Perl Language Server Actions'
+            placeHolder: 'Perl Language Server Actions',
+            matchOnDetail: true
         });
 
         if (selection && selection.command) {
-            vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+            if (selection.disabled) {
+                vscode.window.showWarningMessage(`This action is currently disabled: ${selection.detail}`);
+            } else {
+                vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+            }
         }
     });
     


### PR DESCRIPTION
This change improves the UX of the `perl-lsp.showStatusMenu` command by making it context-aware.

Previously, all actions were available regardless of the active file, leading to confusion or silent failures.

Now, actions are dynamically disabled based on the active editor:
- **Organize Imports** and **Format Document** are disabled if the current file is not a Perl file.
- **Run Tests** is disabled if the current file is not a Perl test file (`.t` or `.pl`).

When an action is disabled, the detail text explains why (e.g., "Only available for Perl files"). If a user attempts to select a disabled action, a warning message is displayed instead of executing the command.

This follows the project's philosophy of exposing unavailable UI elements with a disabled state rather than hiding them, aiding discoverability.


---
*PR created automatically by Jules for task [1026411033121118100](https://jules.google.com/task/1026411033121118100) started by @EffortlessSteven*