### PR TITLE
UX: Make status menu context-aware and improve feedback

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,46 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
+            disabledReason?: string;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerlFile = editor?.document.languageId === 'perl';
+        const isTestFile = isPerlFile && (editor?.document.uri.fsPath.endsWith('.t') || editor?.document.uri.fsPath.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: isPerlFile ? '$(organization) Organize Imports' : '$(organization) Organize Imports (Not available)',
+                description: 'Shift+Alt+O',
+                detail: isPerlFile ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerlFile,
+                disabledReason: 'This command requires an active Perl file.'
+            },
+            {
+                label: isTestFile ? '$(beaker) Run Tests in Current File' : '$(beaker) Run Tests (Not available)',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Only available for .t or .pl files',
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile,
+                disabledReason: 'Run Tests is only available for .t and .pl files.'
+            },
+            {
+                label: isPerlFile ? '$(list-flat) Format Document' : '$(list-flat) Format Document (Not available)',
+                description: 'Shift+Alt+F',
+                detail: isPerlFile ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerlFile,
+                disabledReason: 'Formatting requires an active Perl file.'
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -218,8 +250,12 @@ export async function activate(context: vscode.ExtensionContext) {
             placeHolder: 'Perl Language Server Actions'
         });
 
-        if (selection && selection.command) {
-            vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+        if (selection) {
+            if (selection.disabled) {
+                vscode.window.showWarningMessage(selection.disabledReason || 'This action is not available in the current context.');
+            } else if (selection.command) {
+                vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+            }
         }
     });
     


### PR DESCRIPTION
Enhanced `perl-lsp.showStatusMenu` to be context-aware. Added logic to disable irrelevant commands based on the active file (e.g., "Run Tests" only for .t/.pl files) and provide visual feedback ("(Not available)") and warning messages when selected. Updated `MenuAction` interface to support disabled states.

---
*PR created automatically by Jules for task [5735143524279019682](https://jules.google.com/task/5735143524279019682) started by @EffortlessSteven*