### PR TITLE
🎨 Palette: Improve Status Menu context awareness

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-12 - [Context-Aware Menu Items with Explanations]
+**Learning:** For custom menu interfaces like `showQuickPick`, simply hiding unavailable actions reduces discoverability. Showing them as disabled with a clear explanation (e.g., via `(Not available)` label suffix and warning message on click) helps users understand *why* an action cannot be performed, reducing frustration.
+**Action:** When implementing aggregated menus, modify item labels to reflect availability and intercept selection to provide helpful feedback instead of silently failing or hiding options.


### PR DESCRIPTION
Improved the `perl-lsp.showStatusMenu` command to be context-aware. Instead of showing all commands regardless of whether they work (e.g., showing "Run Tests" for a text file), the menu now dynamically marks actions as disabled based on the active editor (Perl language, Test file). Disabled items show a `(Not available)` suffix and a circle-slash icon. Clicking them triggers a helpful warning message explaining the restriction. This follows the "Context-Aware Menu Items" UX pattern recorded in the journal.

---
*PR created automatically by Jules for task [17164587739700007179](https://jules.google.com/task/17164587739700007179) started by @EffortlessSteven*