### PR TITLE
⚡ Bolt: Optimize is_known_function lookup

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1190,37 +1190,15 @@ fn is_known_function(name: &str) -> bool {
         return false;
     }
 
+    // Optimization: Check the perfect hash map of built-ins first (O(1))
+    if perl_parser_core::builtin_signatures_phf::is_builtin(name) {
+        return true;
+    }
+
     match name {
-        // I/O functions
-        "print" | "printf" | "say" | "open" | "close" | "read" | "write" | "seek" | "tell"
-        | "eof" | "fileno" | "binmode" | "sysopen" | "sysread" | "syswrite" | "sysclose"
-        | "select" |
-        // String functions
-        "chomp" | "chop" | "chr" | "crypt" | "fc" | "hex" | "index" | "lc" | "lcfirst" | "length"
-        | "oct" | "ord" | "pack" | "q" | "qq" | "qr" | "quotemeta" | "qw" | "qx" | "reverse"
-        | "rindex" | "sprintf" | "substr" | "tr" | "uc" | "ucfirst" | "unpack" |
-        // Array/List functions
-        "pop" | "push" | "shift" | "unshift" | "splice" | "split" | "join" | "grep" | "map"
-        | "sort" |
-        // Hash functions
-        "delete" | "each" | "exists" | "keys" | "values" |
-        // Control flow
-        "die" | "exit" | "return" | "goto" | "last" | "next" | "redo" | "continue" | "break"
-        | "given" | "when" | "default" |
-        // File test operators
-        "stat" | "lstat" | "-r" | "-w" | "-x" | "-o" | "-R" | "-W" | "-X" | "-O" | "-e" | "-z"
-        | "-s" | "-f" | "-d" | "-l" | "-p" | "-S" | "-b" | "-c" | "-t" | "-u" | "-g" | "-k"
-        | "-T" | "-B" | "-M" | "-A" | "-C" |
-        // System functions
-        "system" | "exec" | "fork" | "wait" | "waitpid" | "kill" | "sleep" | "alarm"
-        | "getpgrp" | "getppid" | "getpriority" | "setpgrp" | "setpriority" | "time" | "times"
-        | "localtime" | "gmtime" |
-        // Math functions
-        "abs" | "atan2" | "cos" | "exp" | "int" | "log" | "rand" | "sin" | "sqrt" | "srand" |
-        // Misc functions
-        "defined" | "undef" | "ref" | "bless" | "tie" | "tied" | "untie" | "eval" | "caller"
-        | "import" | "require" | "use" | "do" | "package" | "sub" | "my" | "our" | "local"
-        | "state" | "scalar" | "wantarray" | "warn" => true,
+        // Fallback for syntax keywords and operators not in builtin_signatures_phf
+        "sysclose" | "q" | "qq" | "qr" | "qw" | "qx" | "tr" | "break" | "continue" | "given"
+        | "when" | "default" | "package" | "sub" | "import" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
⚡ Bolt: Optimize is_known_function lookup

💡 What:
Replaced the manual string match in `ScopeAnalyzer::is_known_function` with a lookup in `perl_parser_core::builtin_signatures_phf::is_builtin` (a Perfect Hash Function).

🎯 Why:
1.  **Performance:** PHF provides O(1) lookup, which is generally faster and scales better than a large match statement (though match is also optimized).
2.  **Maintainability:** Removes the need to manually maintain a duplicate list of Perl built-ins in the semantic analyzer.
3.  **Correctness:** The previous list was incomplete (missing functions like `accept`, `bind`, `socket`, etc.), leading to potential false positive "UnquotedBareword" errors. The PHF covers a much comprehensive list of built-ins.

📊 Impact:
- Code size reduction in `scope_analyzer.rs`.
- More robust bareword detection (fewer false positives for obscure built-ins).
- Slight performance improvement in scope analysis (though likely micro-optimization, it's a hot path for every identifier).

🔬 Measurement:
- Verified that `sysclose` and syntax keywords (`my`, `sub`, etc.) are still handled correctly via fallback.
- Verified that previously missing built-ins (`accept`) are now recognized (via script analysis of `BUILTIN_SIGS`).
- `cargo test -p perl-semantic-analyzer` passes.

---
*PR created automatically by Jules for task [16001901593279567602](https://jules.google.com/task/16001901593279567602) started by @EffortlessSteven*