### PR TITLE
🛡️ Sentinel: [HIGH] Block `sysopen` in safe evaluation

### DIFF
--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -128,6 +128,7 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "readpipe",
                 "syscall",
                 "open",
+                "sysopen",
                 "close",
                 "print",
                 "say",
@@ -2676,6 +2677,22 @@ mod tests {
             "CORE::GLOBAL::exit",
             "$obj->print",
             "$obj->system('ls')",
+        ];
+
+        for expr in blocked {
+            let err = validate_safe_expression(expr);
+            assert!(err.is_some(), "expected block for {expr:?}");
+        }
+    }
+
+    #[test]
+    fn safe_eval_blocks_sysopen() {
+        // Verify sysopen is blocked as it can truncate files (O_TRUNC) or overwrite them
+        // This is a reproduction test case for a missing security check
+        let blocked = [
+            "sysopen $fh, 'file', 1",
+            "sysopen($fh, 'file', 1)",
+            "CORE::sysopen $fh, 'file', 1",
         ];
 
         for expr in blocked {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix unsafe `sysopen` in safe evaluation

🚨 Severity: HIGH
💡 Vulnerability: The `sysopen` function was not blocked in safe evaluation mode, allowing potential file creation, truncation, or overwriting during debugging if the user evaluates an expression containing `sysopen`.
🎯 Impact: An attacker or careless user could unintentionally or maliciously modify the file system (e.g., truncate `/etc/passwd` or critical project files) by evaluating a crafted expression in the debugger, bypassing the "safe" evaluation intent.
🔧 Fix: Added `sysopen` to the `dangerous_ops_re` regex deny-list in `crates/perl-dap/src/debug_adapter.rs`.
✅ Verification: Added a new test `safe_eval_blocks_sysopen` in `crates/perl-dap/src/debug_adapter.rs` which verifies that `sysopen`, `sysopen(...)`, and `CORE::sysopen` are correctly rejected. The test passes.


---
*PR created automatically by Jules for task [11400947483794253638](https://jules.google.com/task/11400947483794253638) started by @EffortlessSteven*