### PR TITLE
Context-Aware Status Menu Improvements

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -194,6 +194,11 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const filename = editor?.document.uri.fsPath || '';
+        const isTest = isPerl && (filename.endsWith('.t') || filename.endsWith('.pl'));
+
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
@@ -202,9 +207,24 @@ export async function activate(context: vscode.ExtensionContext) {
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: isPerl ? 'Shift+Alt+O' : undefined,
+                detail: isPerl ? 'Sort and organize use statements' : 'Sort and organize use statements (Active Perl file required)',
+                command: 'perl-lsp.organizeImports'
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: isTest ? 'Shift+Alt+T' : undefined,
+                detail: isTest ? 'Run tests for the active file' : 'Run tests for the active file (Active .t or .pl file required)',
+                command: 'perl-lsp.runTests'
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: isPerl ? 'Shift+Alt+F' : undefined,
+                detail: isPerl ? 'Format using perltidy' : 'Format using perltidy (Active Perl file required)',
+                command: 'editor.action.formatDocument'
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
🎨 Palette: Context-Aware Status Menu

💡 **What:**
Updated the `perl-lsp.showStatusMenu` command to be context-aware. It now checks the active editor's language ID and file extension.

🎯 **Why:**
Previously, the status menu showed all actions as available, even if they wouldn't work (e.g., running tests on a non-test file). Users would have to click the command to find out it failed. This change provides immediate visual feedback in the menu itself.

**Changes:**
- "Run Tests" now shows `(Active .t or .pl file required)` in the detail if not in a test file.
- "Organize Imports" and "Format Document" show `(Active Perl file required)` if not in a Perl file.
- Keybinding hints are hidden when the action is not available to visually demote the option.

♿ **Accessibility:**
- Improved clarity of action availability for all users.
- Uses text descriptions in `detail` fields which are screen-reader accessible.

---
*PR created automatically by Jules for task [16727238770517934090](https://jules.google.com/task/16727238770517934090) started by @EffortlessSteven*