### PR TITLE
🛡️ Sentinel: Fix safe evaluation bypass via unblocked keywords

### DIFF
--- a/crates/perl-dap/tests/dap_security_validation_tests.rs
+++ b/crates/perl-dap/tests/dap_security_validation_tests.rs
@@ -18,26 +18,25 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
 fn test_path_validation_safe_relative_paths() -> TestResult {
-    let workspace = std::env::current_dir()?.join("test_workspace");
-    std::fs::create_dir_all(&workspace)?;
+    let temp_dir = tempfile::tempdir()?;
+    let workspace = temp_dir.path();
 
     // Safe relative paths
     let safe_paths = vec!["src/main.pl", "./lib/Module.pm", "test.pl", ".gitignore"];
 
     for path_str in safe_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
         assert!(result.is_ok(), "Path '{}' should be valid within workspace", path_str);
     }
 
-    std::fs::remove_dir_all(&workspace).ok();
     Ok(())
 }
 
 #[test]
 fn test_path_validation_parent_traversal_attempts() {
-    let workspace = std::env::current_dir().expect("Failed to get cwd").join("test_workspace");
-    std::fs::create_dir_all(&workspace).ok();
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let workspace = temp_dir.path();
 
     // Malicious paths with parent directory references
     let malicious_paths =
@@ -45,7 +44,7 @@ fn test_path_validation_parent_traversal_attempts() {
 
     for path_str in malicious_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
 
         if result.is_ok() {
             eprintln!(
@@ -67,34 +66,30 @@ fn test_path_validation_parent_traversal_attempts() {
         // Verify it's the right error type
         if let Err(e) = result {
             match e {
-                SecurityError::PathTraversalAttempt(_) => {}
-                _ => panic!("Expected PathTraversalAttempt error for '{}', got: {:?}", path_str, e),
+                SecurityError::PathTraversalAttempt(_) | SecurityError::PathOutsideWorkspace(_) => {}
+                _ => panic!("Expected PathTraversalAttempt or PathOutsideWorkspace error for '{}', got: {:?}", path_str, e),
             }
         }
     }
-
-    std::fs::remove_dir_all(&workspace).ok();
 }
 
 #[test]
 fn test_path_validation_absolute_paths() {
-    let workspace = std::env::current_dir().expect("Failed to get cwd").join("test_workspace");
-    std::fs::create_dir_all(&workspace).ok();
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let workspace = temp_dir.path();
 
     // Absolute paths outside workspace should be rejected
     let outside_paths = vec!["/etc/passwd", "/root/.ssh/id_rsa"];
 
     for path_str in outside_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
         assert!(
             result.is_err(),
             "Absolute path '{}' outside workspace should be rejected",
             path_str
         );
     }
-
-    std::fs::remove_dir_all(&workspace).ok();
 }
 
 #[test]
@@ -204,15 +199,12 @@ fn test_security_comprehensive_path_traversal_matrix() {
         ("./.gitignore", false),
     ];
 
-    let workspace =
-        std::env::current_dir().expect("Failed to get cwd").join("test_workspace_comprehensive");
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let workspace = temp_dir.path();
 
     for (path_str, should_reject) in test_cases {
-        // Ensure workspace exists for each test case
-        std::fs::create_dir_all(&workspace).expect("Failed to create workspace");
-
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
 
         if should_reject {
             assert!(result.is_err(), "Path '{}' should be rejected but was allowed", path_str);
@@ -226,8 +218,6 @@ fn test_security_comprehensive_path_traversal_matrix() {
             );
         }
     }
-
-    std::fs::remove_dir_all(&workspace).ok();
 }
 
 #[test]


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix safe evaluation bypass via unblocked keywords

🚨 Severity: HIGH
💡 Vulnerability: The "Safe Evaluation" mode in the debug adapter (used for hover and watch expressions) relied on a regex deny-list that missed several dangerous keywords: `use`, `no`, `package`, `goto`, `chop`, `chomp`, and `each`. This allowed users (or malicious repositories) to execute arbitrary code (via module loading) or mutate global state (package switching, iterator consumption) during what should be side-effect-free evaluation.
🎯 Impact: Code execution or state corruption during debugging sessions.
🔧 Fix: Added the missing keywords to the `dangerous_ops_re` regex.
✅ Verification: Added `test_safe_eval_repro_missing_keywords` which confirms these keywords are now blocked. Verified all tests pass. Also fixed flaky `dap_security_validation_tests.rs` using `tempfile`.

---
*PR created automatically by Jules for task [9432774431455452347](https://jules.google.com/task/9432774431455452347) started by @EffortlessSteven*