### PR TITLE
🎨 Palette: Context-aware Status Menu

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,12 +199,32 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? editor.document.languageId === 'perl' : false;
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+
+            {
+                label: '$(organization) Organize Imports',
+                description: isPerl ? 'Shift+Alt+O' : '(Perl file required)',
+                detail: isPerl ? 'Sort and organize use statements' : 'Open a Perl file to enable this action',
+                command: 'perl-lsp.organizeImports'
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: isTestFile ? 'Shift+Alt+T' : '(.t or .pl file required)',
+                detail: isTestFile ? 'Run tests for the active file' : 'Open a test script to enable this action',
+                command: 'perl-lsp.runTests'
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: isPerl ? 'Shift+Alt+F' : '(Perl file required)',
+                detail: isPerl ? 'Format using perltidy' : 'Open a Perl file to enable this action',
+                command: 'editor.action.formatDocument'
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
💡 What: Updated `perl-lsp.showStatusMenu` to dynamically adjust menu items based on the active editor context.
🎯 Why: Users were presented with actions (like "Run Tests") that would fail or show errors if selected in the wrong context (e.g., non-Perl files). This change guides the user by explicitly marking actions as unavailable.
📸 Before/After: The menu now appends explanations like "(Perl file required)" or "(.t or .pl file required)" to unavailable items.
♿ Accessibility: Improves cognitive accessibility by reducing error states and providing clear system status visibility.


---
*PR created automatically by Jules for task [17145103090220102264](https://jules.google.com/task/17145103090220102264) started by @EffortlessSteven*