### PR TITLE
🛡️ Sentinel: [HIGH] Fix Safe Evaluation Bypass via sysopen

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-02-01 - Safe Evaluation Bypass via sysopen
+**Vulnerability:** The `perl-dap` safe evaluation mode failed to block `sysopen`, allowing side effects (file creation/truncation) in debug expressions.
+**Learning:** Security blocklists for "safe evaluation" must be exhaustive. When multiple variants of an operation exist (e.g., `open` vs `sysopen`), blocking one is insufficient.
+**Prevention:** Audit all related built-ins when blocking a category of operations. If `open` is blocked, `sysopen` must also be blocked.

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -128,6 +128,7 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "readpipe",
                 "syscall",
                 "open",
+                "sysopen",
                 "close",
                 "print",
                 "say",
@@ -2775,6 +2776,7 @@ mod tests {
             "opendir $dh, '.'",
             "closedir $dh",
             "seek $fh, 0, 0",
+            "sysopen $fh, 'file', 1",
             "sysseek $fh, 0, 0",
             "setpgrp",
             "setpriority 0, 0, 10",
@@ -3215,4 +3217,5 @@ DB<1>"#;
             assert!(err.is_some(), "expected block for {expr:?}");
         }
     }
+
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Safe Evaluation Bypass via sysopen

🚨 Severity: HIGH
💡 Vulnerability: The `sysopen` function was not included in the `dangerous_ops_re` blocklist for safe evaluation in `perl-dap`. This allowed users (or the IDE) to execute expressions like `sysopen($fh, 'file', 1)` during hover or watch, potentially truncating or overwriting files even when `allowSideEffects` was false.
🎯 Impact: Unintended file system modification or data loss during debugging sessions.
🔧 Fix: Added `sysopen` to the `dangerous_ops_re` regex in `crates/perl-dap/src/debug_adapter.rs`.
✅ Verification: Verified that `sysopen` is now rejected by `validate_safe_expression` using the updated regression test `safe_eval_blocks_mutation_and_resource_ops`. Ran `cargo test -p perl-dap --lib`.

---
*PR created automatically by Jules for task [955170972320742320](https://jules.google.com/task/955170972320742320) started by @EffortlessSteven*