### PR TITLE
⚡ Bolt: Optimize is_known_function with PHF lookup

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -51,6 +51,7 @@
 
 use crate::ast::{Node, NodeKind};
 use crate::pragma_tracker::{PragmaState, PragmaTracker};
+use perl_parser_core::builtin_signatures_phf;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use std::ops::Range;
@@ -1190,37 +1191,15 @@ fn is_known_function(name: &str) -> bool {
         return false;
     }
 
+    // Optimization: Use perfect hash map for O(1) lookup of most builtins
+    if builtin_signatures_phf::is_builtin(name) {
+        return true;
+    }
+
     match name {
-        // I/O functions
-        "print" | "printf" | "say" | "open" | "close" | "read" | "write" | "seek" | "tell"
-        | "eof" | "fileno" | "binmode" | "sysopen" | "sysread" | "syswrite" | "sysclose"
-        | "select" |
-        // String functions
-        "chomp" | "chop" | "chr" | "crypt" | "fc" | "hex" | "index" | "lc" | "lcfirst" | "length"
-        | "oct" | "ord" | "pack" | "q" | "qq" | "qr" | "quotemeta" | "qw" | "qx" | "reverse"
-        | "rindex" | "sprintf" | "substr" | "tr" | "uc" | "ucfirst" | "unpack" |
-        // Array/List functions
-        "pop" | "push" | "shift" | "unshift" | "splice" | "split" | "join" | "grep" | "map"
-        | "sort" |
-        // Hash functions
-        "delete" | "each" | "exists" | "keys" | "values" |
-        // Control flow
-        "die" | "exit" | "return" | "goto" | "last" | "next" | "redo" | "continue" | "break"
-        | "given" | "when" | "default" |
-        // File test operators
-        "stat" | "lstat" | "-r" | "-w" | "-x" | "-o" | "-R" | "-W" | "-X" | "-O" | "-e" | "-z"
-        | "-s" | "-f" | "-d" | "-l" | "-p" | "-S" | "-b" | "-c" | "-t" | "-u" | "-g" | "-k"
-        | "-T" | "-B" | "-M" | "-A" | "-C" |
-        // System functions
-        "system" | "exec" | "fork" | "wait" | "waitpid" | "kill" | "sleep" | "alarm"
-        | "getpgrp" | "getppid" | "getpriority" | "setpgrp" | "setpriority" | "time" | "times"
-        | "localtime" | "gmtime" |
-        // Math functions
-        "abs" | "atan2" | "cos" | "exp" | "int" | "log" | "rand" | "sin" | "sqrt" | "srand" |
-        // Misc functions
-        "defined" | "undef" | "ref" | "bless" | "tie" | "tied" | "untie" | "eval" | "caller"
-        | "import" | "require" | "use" | "do" | "package" | "sub" | "my" | "our" | "local"
-        | "state" | "scalar" | "wantarray" | "warn" => true,
+        // Syntax keywords and operators not in builtin_signatures_phf
+        "sub" | "package" | "import" | "q" | "qq" | "qr" | "qw" | "qx" | "tr" | "break"
+        | "continue" | "default" | "given" | "when" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
💡 What: Optimized `is_known_function` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` to use `perl_parser_core::builtin_signatures_phf::is_builtin`.

🎯 Why: The previous implementation used a large manual `match` statement with hundreds of string literals, which is less efficient and harder to maintain.

📊 Impact: Reduces the time complexity of built-in function checks to O(1) for most cases. This is a hot path in the semantic analyzer, executed for every identifier in the code.

🔬 Measurement: Verified with `cargo test -p perl-semantic-analyzer` to ensure no regressions. The fallback match correctly handles keywords and operators not present in the PHF map.

---
*PR created automatically by Jules for task [3268481136502879933](https://jules.google.com/task/3268481136502879933) started by @EffortlessSteven*