### PR TITLE
🛡️ Sentinel: [HIGH] Fix incomplete safe evaluation blacklist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-28 - Incomplete Dangerous Operations Blacklist
+**Vulnerability:** The `perl-dap` safe evaluation mode failed to block `sysopen`, `chop`, `chomp`, and `package`. `sysopen` allows file creation/overwriting, `chop`/`chomp` allow in-place string mutation, and `package` changes the namespace state.
+**Learning:** Blacklists are prone to omissions, especially for aliases (`sysopen` vs `open`) and mutating operations that don't look like "system" calls.
+**Prevention:** Regularly audit language keywords and built-ins. Consider grouping aliases (IO, FileSystem) and ensure all variants are covered.

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -128,12 +128,15 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "readpipe",
                 "syscall",
                 "open",
+                "sysopen",
                 "close",
                 "print",
                 "say",
                 "printf",
                 "sysread",
                 "syswrite",
+                "chop",
+                "chomp",
                 "glob",
                 "readline",
                 "ioctl",
@@ -169,7 +172,8 @@ fn dangerous_ops_re() -> Option<&'static Regex> {
                 "link", // Code loading/execution
                 "eval",
                 "require",
-                "do", // Tie mechanism (can execute arbitrary code)
+                "do",
+                "package", // Tie mechanism (can execute arbitrary code)
                 "tie",
                 "untie", // Network
                 "socket",

--- a/crates/perl-dap/tests/safe_eval_extended_tests.rs
+++ b/crates/perl-dap/tests/safe_eval_extended_tests.rs
@@ -1,0 +1,91 @@
+
+use perl_dap::debug_adapter::{DebugAdapter, DapMessage};
+use serde_json::json;
+
+#[test]
+fn test_safe_eval_repro_sysopen_blocked() {
+    let mut adapter = DebugAdapter::new();
+    let request_seq = 1;
+
+    // Request with allowSideEffects: false (safe mode)
+    // sysopen is dangerous as it can create/overwrite files
+    let args = json!({
+        "expression": "sysopen($fh, 'file.txt', 0x0200)",
+        "allowSideEffects": false
+    });
+
+    let response = adapter.handle_request(request_seq, "evaluate", Some(args));
+
+    if let DapMessage::Response { success: _, message, .. } = response {
+        if let Some(msg) = message {
+            if msg.contains("Safe evaluation mode") {
+                // Correctly blocked
+            } else if msg.contains("No debugger session") {
+                panic!("sysopen passed security check (reached session check) but should be blocked");
+            } else {
+                panic!("sysopen failed with unexpected error: {}", msg);
+            }
+        } else {
+            // If success is true and no message, it definitely passed security check
+            panic!("sysopen passed security check (success=true) but should be blocked");
+        }
+    } else {
+        panic!("Unexpected response type");
+    }
+}
+
+#[test]
+fn test_safe_eval_repro_chomp_blocked() {
+    let mut adapter = DebugAdapter::new();
+    let request_seq = 1;
+
+    // chomp mutates the string in place
+    let args = json!({
+        "expression": "chomp($str)",
+        "allowSideEffects": false
+    });
+
+    let response = adapter.handle_request(request_seq, "evaluate", Some(args));
+
+    if let DapMessage::Response { success: _, message, .. } = response {
+        if let Some(msg) = message {
+            if msg.contains("Safe evaluation mode") {
+                // Correctly blocked
+            } else if msg.contains("No debugger session") {
+                panic!("chomp passed security check (reached session check) but should be blocked");
+            } else {
+                panic!("chomp failed with unexpected error: {}", msg);
+            }
+        } else {
+            panic!("chomp passed security check (success=true) but should be blocked");
+        }
+    }
+}
+
+#[test]
+fn test_safe_eval_repro_package_blocked() {
+    let mut adapter = DebugAdapter::new();
+    let request_seq = 1;
+
+    // package changes the current package context
+    let args = json!({
+        "expression": "package Foo;",
+        "allowSideEffects": false
+    });
+
+    let response = adapter.handle_request(request_seq, "evaluate", Some(args));
+
+    if let DapMessage::Response { success: _, message, .. } = response {
+        if let Some(msg) = message {
+            if msg.contains("Safe evaluation mode") {
+                // Correctly blocked
+            } else if msg.contains("No debugger session") {
+                panic!("package passed security check (reached session check) but should be blocked");
+            } else {
+                panic!("package failed with unexpected error: {}", msg);
+            }
+        } else {
+            panic!("package passed security check (success=true) but should be blocked");
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a security vulnerability in the `perl-dap` crate where certain dangerous Perl operations were missing from the "safe evaluation" blacklist.

**Changes:**
- Modified `crates/perl-dap/src/debug_adapter.rs`:
    - Added `sysopen` to the I/O blocklist.
    - Added `chop` and `chomp` to the I/O blocklist (mutating ops).
    - Added `package` to the Code Loading blocklist (state mutation).
- Added `crates/perl-dap/tests/safe_eval_extended_tests.rs`:
    - Validates that `sysopen`, `chomp`, and `package` are correctly blocked by the security check.

**Verification:**
- Ran `cargo test -p perl-dap`
- Verified new tests pass.
- Acknowledged pre-existing failure in `test_path_validation_parent_traversal_attempts` (unrelated).

**Sentinel Journal:**
- Added entry to `.jules/sentinel.md` documenting the vulnerability and learning.

---
*PR created automatically by Jules for task [15282864192239023906](https://jules.google.com/task/15282864192239023906) started by @EffortlessSteven*