### PR TITLE
Improve 'Run Tests' UX in Status Menu

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -327,7 +327,7 @@
       "editor/context": [
         {
           "command": "perl-lsp.runTests",
-          "when": "editorLangId == perl",
+          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl)$/",
           "group": "navigation"
         },
         {


### PR DESCRIPTION
Improved the UX of the "Run Tests" command in the VS Code extension. 
Previously, the "Run Tests" command was visible in the status menu for all Perl files but would fail if executed on non-test files.
Now, the status menu item visually indicates unavailability (using the `$(circle-slash)` icon) and prevents execution for non-test files, providing a helpful message instead.
Additionally, the context menu entry for "Run Tests" is now hidden for non-test files to reduce clutter.

---
*PR created automatically by Jules for task [18010554109795110601](https://jules.google.com/task/18010554109795110601) started by @EffortlessSteven*