### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in DAP launch request

### DIFF
--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -91,7 +91,9 @@ fn test_dap_launch_with_invalid_program() {
             assert!(!success);
             assert_eq!(command, "launch");
             assert!(message.is_some());
-            assert!(must_some(message).contains("Failed to launch debugger"));
+            let msg = must_some(message);
+            // Now returns Security Error because path is absolute and outside workspace
+            assert!(msg.contains("Security Error") || msg.contains("Failed to launch debugger"));
         }
         _ => panic!("Expected response message"),
     }

--- a/crates/perl-dap/tests/security_path_traversal.rs
+++ b/crates/perl-dap/tests/security_path_traversal.rs
@@ -1,0 +1,36 @@
+use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
+use serde_json::json;
+
+#[test]
+fn test_launch_blocks_arbitrary_absolute_path() {
+    let mut adapter = DebugAdapter::new();
+
+    // Create a temporary file outside the current directory
+    let temp_dir = tempfile::tempdir().unwrap();
+    let outside_file = temp_dir.path().join("evil.pl");
+    std::fs::write(&outside_file, "print 'evil'").unwrap();
+
+    // Launch with absolute path to outside file
+    let args = json!({
+        "program": outside_file.to_str().unwrap(),
+        "cwd": std::env::current_dir().unwrap().to_str().unwrap()
+    });
+
+    // We are mocking the "launch" request
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    if let DapMessage::Response { success, message, .. } = response {
+        // Now we expect it to fail with a security error
+        assert!(!success, "Launch should fail due to security validation");
+
+        if let Some(msg) = message {
+            println!("Message: {}", msg);
+            assert!(msg.contains("Security Error"), "Expected Security Error, got: {}", msg);
+            assert!(msg.contains("Path outside workspace") || msg.contains("Path resolves outside workspace"), "Expected path traversal/workspace error");
+        } else {
+            panic!("Expected error message");
+        }
+    } else {
+        panic!("Expected response");
+    }
+}

--- a/crates/perl-dap/tests/security_regression_tests.rs
+++ b/crates/perl-dap/tests/security_regression_tests.rs
@@ -31,8 +31,9 @@ fn test_command_injection_via_program_argument() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail because file '-e' does not exist");
             let msg = message.ok_or("Expected error message")?;
+            // Strict path validation catches this first
             assert!(
-                msg.contains("Could not access program file"),
+                msg.contains("Could not access program file") || msg.contains("Security Error"),
                 "Should fail with access error: {}",
                 msg
             );
@@ -78,8 +79,9 @@ fn test_launch_with_nonexistent_file_errors_gracefully() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail for nonexistent file");
             let msg = message.ok_or("Expected error message")?;
+            // Strict path validation catches this first
             assert!(
-                msg.contains("Could not access program file"),
+                msg.contains("Could not access program file") || msg.contains("Security Error"),
                 "Should return meaningful error: {}",
                 msg
             );
@@ -165,9 +167,10 @@ fn test_launch_with_directory_rejected() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail for directory path");
             let msg = message.ok_or("Expected error message")?;
+            // Security check may catch this first if outside workspace, or file check if inside
             assert!(
-                msg.contains("not a regular file"),
-                "Should indicate path is not a file: {}",
+                msg.contains("not a regular file") || msg.contains("Security Error"),
+                "Should indicate path is not a file or security error: {}",
                 msg
             );
         }

--- a/crates/perl-dap/tests/session_lifecycle_tests.rs
+++ b/crates/perl-dap/tests/session_lifecycle_tests.rs
@@ -163,8 +163,8 @@ fn test_session_lifecycle_launch_nonexistent_program() {
             assert!(message.is_some());
             let msg = must_some(message);
             assert!(
-                msg.contains("Could not access") || msg.contains("not a regular file"),
-                "Error should mention access issue: {}",
+                msg.contains("Could not access") || msg.contains("not a regular file") || msg.contains("Security Error"),
+                "Error should mention access issue or security error: {}",
                 msg
             );
         }


### PR DESCRIPTION
Implemented path traversal prevention in `perl-dap`. The debug adapter now validates that the program to be launched resides within the workspace root (determined via `initialize` request or defaulting to CWD). This prevents malicious `launch.json` configurations or client requests from executing arbitrary files on the system.

Also fixed race conditions in security tests and updated existing tests to reflect the stricter security posture.

---
*PR created automatically by Jules for task [12060595711923735416](https://jules.google.com/task/12060595711923735416) started by @EffortlessSteven*