### PR TITLE
🎨 Palette: Make "Run Tests" menu item context-aware

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-04 - [Context-Aware QuickPick Menu]
+**Learning:** VS Code's `QuickPickItem` API (in older versions or for simple implementation) lacks a native `disabled` property. Simulating this by changing the icon (e.g., `$(circle-slash)`) and removing the `command` property is an effective way to communicate unavailability without hiding the option entirely, maintaining discoverability while preventing error states.
+**Action:** Use conditional logic to swap actionable items with "disabled" informational items in `showStatusMenu` when the context (e.g., active file type) is invalid.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,11 +199,24 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerlTest = editor &&
+                          editor.document.languageId === 'perl' &&
+                          (editor.document.uri.fsPath.endsWith('.t') || editor.document.uri.fsPath.endsWith('.pl'));
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+        ];
+
+        if (isPerlTest) {
+            items.push({ label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' });
+        } else {
+            items.push({ label: '$(circle-slash) Run Tests in Current File', description: '(Only available for .t/.pl files)', detail: 'Active file is not a supported Perl test script' });
+        }
+
+        items.push(
             { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
@@ -212,7 +225,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
-        ];
+        );
 
         const selection = await vscode.window.showQuickPick(items, {
             placeHolder: 'Perl Language Server Actions'


### PR DESCRIPTION
This PR improves the UX of the "Status Menu" by making the "Run Tests in Current File" option context-aware.

previously, the option was always available, potentially leading to errors or confusion if clicked when a non-test file was active.

Now:
- If the active file is a Perl test (`.t` or `.pl`), the option appears as normal.
- If not, the option is shown with a disabled icon (`$(circle-slash)`) and a description explaining that it is only available for test files. The command is removed from the item so it cannot be triggered.

This follows the "Good UX is invisible - it just works" philosophy by preventing invalid actions while maintaining discoverability.

---
*PR created automatically by Jules for task [15854774168245311666](https://jules.google.com/task/15854774168245311666) started by @EffortlessSteven*