### PR TITLE
🎨 Palette: Context-aware "Run Tests" in Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-18 - [Context-Aware Status Menu]
+**Learning:** Static menu items for context-specific actions (like "Run Tests") frustrate users when invoked in the wrong context. Dynamic menu items that show "disabled" states with explanations are superior to letting actions fail.
+**Action:** When adding actions to the Status Menu, always check `vscode.window.activeTextEditor` and modify the item's icon/description/command to reflect availability.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,11 +199,19 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isTestFile = editor && editor.document.languageId === 'perl' &&
+                          (editor.document.uri.fsPath.endsWith('.t') || editor.document.uri.fsPath.endsWith('.pl'));
+
+        const runTestsItem: MenuAction = isTestFile
+            ? { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' }
+            : { label: '$(circle-slash) Run Tests', description: '(Only available for .t/.pl files)', detail: 'Open a .t or .pl file to enable this action', command: undefined };
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+            runTestsItem,
             { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },


### PR DESCRIPTION
💡 What: Updated the "Run Tests" item in the `perl-lsp.showStatusMenu` command to be context-aware.
🎯 Why: Users were frustrated by clicking "Run Tests" on non-test files and getting an error.
📸 Before/After:
  - Before: "Run Tests" item was always enabled but failed on non-test files.
  - After: "Run Tests" is disabled (icon `$(circle-slash)`) with an explanatory description if the active file is not a Perl test (`.t` or `.pl`).
♿ Accessibility: Provides clear feedback on action availability without needing to attempt the action first.
Reference: `.Jules/palette.md` updated with learning.

---
*PR created automatically by Jules for task [15770196539487865915](https://jules.google.com/task/15770196539487865915) started by @EffortlessSteven*