### PR TITLE
🎨 Palette: Make 'Run Tests' command context-aware

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -97,6 +97,8 @@ All notable changes to the Perl Language Server extension will be documented in 
 ### Changed
 - **Performance**: O(1) symbol lookups, optimized scope analysis
 - **Code Quality**: Unified position/range types, improved code formatting
+- **UX**: "Run Tests" in Status Menu now visually indicates when it's unavailable (non-test files) instead of just failing.
+- **UX**: "Run Tests" context menu item is now hidden for non-test files.
 
 ## [0.9.0] - 2026-01-18
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -327,7 +327,7 @@
       "editor/context": [
         {
           "command": "perl-lsp.runTests",
-          "when": "editorLangId == perl",
+          "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl)$/",
           "group": "navigation"
         },
         {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,11 +199,18 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isTestFile = editor && (editor.document.fileName.endsWith('.t') || editor.document.fileName.endsWith('.pl'));
+
+        const runTestsItem: MenuAction = isTestFile
+            ? { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' }
+            : { label: '$(circle-slash) Run Tests', description: '(Only available for .t and .pl files)', detail: 'Open a test file to run tests', command: undefined };
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+            runTestsItem,
             { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },


### PR DESCRIPTION
Enhanced the UX of the "Run Tests" command in the VS Code extension.

1.  **Context Menu**: Restricted the "Run Tests" command in the editor context menu to only appear for files with `.t` or `.pl` extensions. This prevents the command from cluttering the menu when working on module files (`.pm`) where it is not applicable.
2.  **Status Menu**: Modified the `perl-lsp.showStatusMenu` command to dynamically check the active file type. If the file is not a test file, the "Run Tests" item is now displayed in a disabled state with a clear explanation ("Only available for .t and .pl files") and the action is effectively disabled.

These changes follow the "micro-UX improvement" philosophy by making the interface more intuitive and self-explanatory.

---
*PR created automatically by Jules for task [15875785222061855949](https://jules.google.com/task/15875785222061855949) started by @EffortlessSteven*