### PR TITLE
🎨 Palette: Make "Run Tests" menu item context-aware

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-03-01 - [Simulated Disabled State in QuickPick]
+**Learning:** VS Code's `QuickPickItem` API lacks a native `disabled` property. Disabled items can be simulated by removing the `command` property and using a distinct icon (e.g., `$(circle-slash)`) with an explanatory description.
+**Action:** Use this pattern to keep unavailable actions visible but non-functional in status menus, providing context on why they are disabled instead of hiding them.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,11 +199,18 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isTestFile = editor && editor.document.languageId === 'perl' && /\.(t|pl)$/.test(editor.document.fileName);
+
+        const runTestsItem: MenuAction = isTestFile
+            ? { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' }
+            : { label: '$(circle-slash) Run Tests in Current File', description: 'Only available for .t and .pl files', detail: 'Open a test file to enable' };
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
             { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
+            runTestsItem,
             { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },


### PR DESCRIPTION
This PR enhances the "Run Tests in Current File" menu item in the Perl LSP status menu to be context-aware.

💡 **What:**
- The menu item now checks the active editor's file extension (`.t` or `.pl`).
- If the file is not a test script, the item is displayed in a disabled state:
    - Icon changes to `$(circle-slash)`.
    - Description explains "Only available for .t and .pl files".
    - No command is executed when selected.

🎯 **Why:**
- Previously, users could select "Run Tests" on any file (e.g., `.pm` modules), which would result in a generic warning or no action, leading to confusion.
- This change provides immediate visual feedback about the action's availability, improving discoverability and reducing frustration.

📸 **Before/After:**
*(Visual description since screenshots are not possible)*
- **Before:** "Run Tests" was always available with `$(beaker)` icon.
- **After (on .pm file):** "Run Tests" shows `$(circle-slash)` and says "Only available for .t and .pl files".

♿ **Accessibility:**
- The menu item remains focusable and screen-reader accessible, with the description providing the context for why it's "disabled" (simulated).


---
*PR created automatically by Jules for task [16329702108204487984](https://jules.google.com/task/16329702108204487984) started by @EffortlessSteven*