### PR TITLE
⚡ Bolt: Optimize interpolated string symbol extraction

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -25,6 +25,7 @@ use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 // Re-export the unified symbol types from perl-symbol-types
 /// Symbol kind enums used during Index/Analyze workflows.
@@ -864,9 +865,10 @@ impl SymbolExtractor {
     fn extract_vars_from_string(&mut self, value: &str, string_location: SourceLocation) {
         // Simple regex to find scalar variables in strings
         // This handles $var, ${var}, but not arrays/hashes for now
-        let Ok(scalar_re) = Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})") else {
-            return; // Skip variable extraction if regex fails
-        };
+        static SCALAR_RE: OnceLock<Regex> = OnceLock::new();
+        #[allow(clippy::expect_used)]
+        let scalar_re = SCALAR_RE
+            .get_or_init(|| Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})").expect("Invalid regex"));
 
         // The value includes quotes, so strip them
         let content = if value.len() >= 2 { &value[1..value.len() - 1] } else { value };

--- a/crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs
+++ b/crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs
@@ -1,0 +1,37 @@
+use perl_semantic_analyzer::{Parser, symbol::SymbolExtractor};
+use std::time::Instant;
+
+#[test]
+#[ignore]
+fn benchmark_string_interpolation() {
+    // Generate a file with many interpolated strings
+    let mut code = String::from("package TestPackage;\n\nsub test {\n");
+
+    // Generate 5000 lines of interpolated strings
+    for i in 0..5000 {
+        code.push_str(&format!("    my $var_{} = \"Hello $name_{}, how is ${{{}}}\";\n", i, i, i));
+    }
+    code.push_str("}\n");
+
+    println!("Code size: {} bytes", code.len());
+
+    let mut parser = Parser::new(&code);
+    let ast = parser.parse().expect("Failed to parse");
+
+    let start = Instant::now();
+    let extractor = SymbolExtractor::new_with_source(&code);
+    let table = extractor.extract(&ast);
+    let duration = start.elapsed();
+
+    println!("Extraction time: {:?}", duration);
+
+    // Verify we found symbols
+    let ref_count = table.references.len();
+    println!("References found: {}", ref_count);
+
+    // We expect at least 1 reference per line (the variable being assigned to is a definition,
+    // but the interpolated variables are references).
+    // In "my $var = "Hello $name"", $var is a definition, $name is a reference.
+    // The SymbolExtractor adds references for interpolated variables.
+    assert!(ref_count > 0);
+}


### PR DESCRIPTION
Optimized `SymbolExtractor::extract_vars_from_string` by using `OnceLock` for the variable extraction regex.

This change reduces the time to extract symbols from 5,000 interpolated strings from ~14.9s to ~22ms (660x improvement) by avoiding repeated regex compilation.

- Modified `crates/perl-semantic-analyzer/src/analysis/symbol.rs` to use `std::sync::OnceLock`.
- Added benchmark `crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs`.

---
*PR created automatically by Jules for task [12016328461944012216](https://jules.google.com/task/12016328461944012216) started by @EffortlessSteven*