### PR TITLE
🛡️ Sentinel: [HIGH] Fix Safe Eval Bypasses and Test Race Conditions

### DIFF
--- a/crates/perl-dap/tests/dap_security_validation_tests.rs
+++ b/crates/perl-dap/tests/dap_security_validation_tests.rs
@@ -18,26 +18,30 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
 fn test_path_validation_safe_relative_paths() -> TestResult {
-    let workspace = std::env::current_dir()?.join("test_workspace");
-    std::fs::create_dir_all(&workspace)?;
+    let tempdir = tempfile::tempdir()?;
+    let workspace = tempdir.path();
 
     // Safe relative paths
     let safe_paths = vec!["src/main.pl", "./lib/Module.pm", "test.pl", ".gitignore"];
 
     for path_str in safe_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
-        assert!(result.is_ok(), "Path '{}' should be valid within workspace", path_str);
+        let result = validate_path(&path, workspace);
+        assert!(
+            result.is_ok(),
+            "Path '{}' should be valid within workspace, got: {:?}",
+            path_str,
+            result
+        );
     }
 
-    std::fs::remove_dir_all(&workspace).ok();
     Ok(())
 }
 
 #[test]
-fn test_path_validation_parent_traversal_attempts() {
-    let workspace = std::env::current_dir().expect("Failed to get cwd").join("test_workspace");
-    std::fs::create_dir_all(&workspace).ok();
+fn test_path_validation_parent_traversal_attempts() -> TestResult {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = tempdir.path();
 
     // Malicious paths with parent directory references
     let malicious_paths =
@@ -45,7 +49,7 @@ fn test_path_validation_parent_traversal_attempts() {
 
     for path_str in malicious_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
 
         if result.is_ok() {
             eprintln!(
@@ -67,26 +71,30 @@ fn test_path_validation_parent_traversal_attempts() {
         // Verify it's the right error type
         if let Err(e) = result {
             match e {
-                SecurityError::PathTraversalAttempt(_) => {}
-                _ => panic!("Expected PathTraversalAttempt error for '{}', got: {:?}", path_str, e),
+                SecurityError::PathTraversalAttempt(_)
+                | SecurityError::PathOutsideWorkspace(_) => {}
+                _ => panic!(
+                    "Expected PathTraversalAttempt or PathOutsideWorkspace error for '{}', got: {:?}",
+                    path_str, e
+                ),
             }
         }
     }
 
-    std::fs::remove_dir_all(&workspace).ok();
+    Ok(())
 }
 
 #[test]
-fn test_path_validation_absolute_paths() {
-    let workspace = std::env::current_dir().expect("Failed to get cwd").join("test_workspace");
-    std::fs::create_dir_all(&workspace).ok();
+fn test_path_validation_absolute_paths() -> TestResult {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = tempdir.path();
 
     // Absolute paths outside workspace should be rejected
     let outside_paths = vec!["/etc/passwd", "/root/.ssh/id_rsa"];
 
     for path_str in outside_paths {
         let path = PathBuf::from(path_str);
-        let result = validate_path(&path, &workspace);
+        let result = validate_path(&path, workspace);
         assert!(
             result.is_err(),
             "Absolute path '{}' outside workspace should be rejected",
@@ -94,7 +102,7 @@ fn test_path_validation_absolute_paths() {
         );
     }
 
-    std::fs::remove_dir_all(&workspace).ok();
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Safe Evaluation Bypasses and Test Flakiness

🚨 Severity: HIGH
💡 Vulnerability:
1. The `perl-dap` safe evaluation mode allowed state-mutating operations like `keys` (resets hash iterator), `rand` (consumes PRNG state), and `package` (switches namespace). This could corrupt the debugged program's state during inspection (hovers).
2. Security integration tests had a race condition using a shared `test_workspace` directory, causing flaky failures during parallel execution.

🎯 Impact:
1. Debugging could silently break the application logic (e.g., infinite loops if `keys` resets an iterator inside a `while(each)` loop).
2. CI/CD instability due to flaky tests.

🔧 Fix:
1. Updated `dangerous_ops_re` in `debug_adapter.rs` to include `chop`, `chomp`, `each`, `keys`, `values`, `rand`, `package`, `use`, `no`, `sysopen`, `chgrp`.
2. Refactored `dap_security_validation_tests.rs` to use `tempfile::tempdir()` for isolated test workspaces.

✅ Verification:
- Added `test_safe_eval_blocks_missing_ops` verifying the new blocks.
- Ran `cargo test -p perl-dap` to verify all tests pass and are stable.

---
*PR created automatically by Jules for task [11453919454635477855](https://jules.google.com/task/11453919454635477855) started by @EffortlessSteven*