### PR TITLE
⚡ Bolt: Optimize documentation extraction (O(N) -> O(1))

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic.rs
@@ -7,9 +7,7 @@
 use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use crate::symbol::{ScopeId, ScopeKind, Symbol, SymbolExtractor, SymbolKind, SymbolTable};
-use regex::Regex;
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Semantic token types for syntax highlighting in the Parse/Complete workflow.
@@ -1245,43 +1243,142 @@ impl SemanticAnalyzer {
 
     /// Extract documentation (POD or comments) preceding a position
     fn extract_documentation(&self, start: usize) -> Option<String> {
-        static POD_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
-        static COMMENT_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
-
         if self.source.is_empty() {
             return None;
         }
-        let before = &self.source[..start];
 
-        // Check for POD blocks ending with =cut
-        let pod_re = POD_RE
-            .get_or_init(|| Regex::new(r"(?ms)(=[a-zA-Z0-9].*?\n=cut\n?)\s*$"))
-            .as_ref()
-            .ok()?;
-        if let Some(caps) = pod_re.captures(before) {
-            if let Some(pod_text) = caps.get(1) {
-                return Some(pod_text.as_str().trim().to_string());
-            }
+        if let Some(pod) = self.scan_backward_for_pod(start) {
+            return Some(pod);
         }
 
-        // Check for consecutive comment lines
-        let comment_re =
-            COMMENT_RE.get_or_init(|| Regex::new(r"(?m)(#.*\n)+\s*$")).as_ref().ok()?;
-        if let Some(caps) = comment_re.captures(before) {
-            if let Some(comment_match) = caps.get(0) {
-                // Strip the # prefix from each comment line
-                let doc = comment_match
-                    .as_str()
-                    .lines()
-                    .map(|line| line.trim_start_matches('#').trim())
-                    .filter(|line| !line.is_empty())
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                return Some(doc);
-            }
+        if let Some(comment) = self.scan_backward_for_comments(start) {
+            return Some(comment);
         }
 
         None
+    }
+
+    fn scan_backward_for_pod(&self, start: usize) -> Option<String> {
+        if start > self.source.len() {
+            return None;
+        }
+        let before = &self.source[..start];
+        let mut lines = before.lines().rev();
+
+        let mut pod_lines = Vec::new();
+        let mut found_cut = false;
+        let mut lines_scanned = 0;
+
+        // 1. Find =cut
+        // The regex `\s*$` implies we match even if there are blank lines between =cut and start.
+        for line in lines.by_ref() {
+            lines_scanned += 1;
+            if lines_scanned > 500 {
+                return None;
+            } // Limit scan
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if trimmed == "=cut" {
+                found_cut = true;
+                pod_lines.push(line); // Keep original formatting
+                break;
+            } else {
+                // If we see code before =cut, then no POD immediately preceding?
+                return None;
+            }
+        }
+
+        if !found_cut {
+            return None;
+        }
+
+        // 2. Collect POD content
+        for line in lines {
+            lines_scanned += 1;
+            if lines_scanned > 500 {
+                break;
+            }
+
+            let trimmed = line.trim();
+            if trimmed == "=cut" {
+                // End of previous block. Stop.
+                break;
+            }
+
+            pod_lines.push(line);
+        }
+
+        // 3. Process collected lines (which are in reverse order)
+        pod_lines.reverse();
+
+        // 4. Find the first command line (=...)
+        // Everything before it is considered "garbage" (code/comments between blocks?) and ignored
+        if let Some(start_idx) = pod_lines.iter().position(|line| line.starts_with('=')) {
+            let doc = pod_lines[start_idx..].join("\n");
+            return Some(doc);
+        }
+
+        None
+    }
+
+    fn scan_backward_for_comments(&self, start: usize) -> Option<String> {
+        if start > self.source.len() {
+            return None;
+        }
+        let before = &self.source[..start];
+        let mut lines = before.lines().rev();
+
+        let mut comment_lines = Vec::new();
+        let mut lines_scanned = 0;
+
+        // 1. Skip current line prefix if we are not at the start of a line
+        // If 'before' does not end with a newline, the first item from lines() is the
+        // partial content of the current line (e.g. indentation). We skip it.
+        // We use is_whitespace check on the last char to be safe about \n or \r.
+        // Actually simplest is: does lines() return a "line" that corresponds to current line?
+        // Yes, always, unless string ends with \n.
+        let ends_with_newline = before.ends_with('\n') || before.ends_with('\r');
+
+        if !ends_with_newline {
+            if lines.next().is_some() {
+                lines_scanned += 1;
+            }
+        }
+
+        // 2. Collect contiguous comments
+        for line in lines {
+            lines_scanned += 1;
+            if lines_scanned > 100 {
+                break;
+            }
+
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() {
+                // Blank line breaks the comment block
+                break;
+            }
+
+            if trimmed.starts_with('#') {
+                // Extract comment content
+                let content = trimmed.trim_start_matches('#').trim();
+                comment_lines.push(content);
+            } else {
+                // Non-comment code line. Stop.
+                break;
+            }
+        }
+
+        if comment_lines.is_empty() {
+            return None;
+        }
+
+        // Reverse to get original order
+        comment_lines.reverse();
+        Some(comment_lines.join(" "))
     }
 
     /// Get scope id for a node by consulting the symbol table

--- a/crates/perl-semantic-analyzer/tests/doc_extraction_test.rs
+++ b/crates/perl-semantic-analyzer/tests/doc_extraction_test.rs
@@ -1,0 +1,60 @@
+use perl_semantic_analyzer::semantic::SemanticAnalyzer;
+use perl_parser_core::Parser;
+
+#[test]
+fn test_doc_extraction_performance() {
+    let mut code = String::new();
+    // Generate a large file with many POD blocks
+    for i in 0..1000 {
+        code.push_str(&format!("=head1 Section {}\nThis is some documentation for section {}.\n=cut\n\nsub func_{} {{}}\n\n", i, i, i));
+    }
+
+    let start = std::time::Instant::now();
+    let mut parser = Parser::new(&code);
+    let ast = parser.parse().unwrap();
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, &code);
+
+    // Measure time to access hover info (which triggers extraction if not cached,
+    // but wait, extract_documentation is called during analyze_node and stored in hover_info map!)
+
+    // Ah, analyze_node calls extract_documentation eagerly for every declaration.
+    // So analyze_with_source effectively benchmarks it.
+
+    let duration = start.elapsed();
+    println!("Analysis took: {:?}", duration);
+
+    // Verify some documentation
+    let symbol_table = analyzer.symbol_table();
+    let symbols = symbol_table.find_symbol("func_500", 0, perl_semantic_analyzer::symbol::SymbolKind::Subroutine);
+    assert!(!symbols.is_empty());
+
+    let hover = analyzer.hover_at(symbols[0].location).unwrap();
+    // With the fix, we expect correct documentation for section 500
+    // Currently (with bug), it returns Section 0 because of greedy regex matching from start
+    assert!(hover.documentation.as_ref().unwrap().contains("This is some documentation for section 500."));
+}
+
+#[test]
+fn test_comment_extraction_edge_cases() {
+    let code = r#"
+# Comment 1
+# Comment 2
+
+sub foo {}
+
+# Comment 3
+sub bar {}
+"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().unwrap();
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+    let foo = analyzer.symbol_table().find_symbol("foo", 0, perl_semantic_analyzer::symbol::SymbolKind::Subroutine)[0].clone();
+    let hover_foo = analyzer.hover_at(foo.location).unwrap();
+    // Should NOT have comments because there is a blank line separating them
+    assert!(hover_foo.documentation.is_none());
+
+    let bar = analyzer.symbol_table().find_symbol("bar", 0, perl_semantic_analyzer::symbol::SymbolKind::Subroutine)[0].clone();
+    let hover_bar = analyzer.hover_at(bar.location).unwrap();
+    assert_eq!(hover_bar.documentation.as_deref(), Some("Comment 3"));
+}


### PR DESCRIPTION
- Replaced regex-based documentation extraction with manual backward scanning.
- Fixed a bug where POD extraction greedily consumed the entire file content up to the declaration.
- Enforced strict adjacency for comment documentation (blank lines break the comment block).
- Added bounded limits (500 lines for POD, 100 lines for comments) to ensure O(1) performance.
- Removed unused `regex` and `OnceLock` imports in `crates/perl-semantic-analyzer/src/analysis/semantic.rs`.
- Added regression test `crates/perl-semantic-analyzer/tests/doc_extraction_test.rs`.

---
*PR created automatically by Jules for task [9332257988232768847](https://jules.google.com/task/9332257988232768847) started by @EffortlessSteven*