### PR TITLE
🎨 Palette: Context-aware Status Menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-18 - [Context-Aware Status Menus]
+**Learning:** Users attempt to run commands (like "Run Tests") in invalid contexts (e.g., `.pm` files). VS Code 1.82+ supports `disabled: boolean` on `QuickPickItem`, allowing us to keep the item visible but unselectable, with an explanatory `detail` message. This is better than hiding the item (which can be confusing) or letting it fail.
+**Action:** Use `disabled` and dynamic `detail` properties in QuickPick menus to guide users on why an action is unavailable.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,43 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean; // Explicitly add for older @types/vscode if needed, though 1.82+ supports it
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const fileName = editor?.document.uri.fsPath || '';
+        const isTest = isPerl && (fileName.endsWith('.t') || fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Only available for Perl files',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTest ? 'Run tests for the active file' : 'Only available for .t or .pl files',
+                command: 'perl-lsp.runTests',
+                disabled: !isTest
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Only available for Perl files',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
This PR improves the UX of the "Perl Language Server Actions" menu (`perl-lsp.showStatusMenu`) by making it context-aware.

Previously, all actions were available regardless of the current file, leading to confusion or silent failures (e.g., trying to run tests on a module file).

Changes:
- The menu now checks the active editor's `languageId` and file extension.
- **Run Tests:** Disabled if not a `.t` or `.pl` file. Added detail: "Only available for .t or .pl files".
- **Organize Imports / Format:** Disabled if not a Perl file. Added detail: "Only available for Perl files".
- Technical: Leverages the `disabled` property of `QuickPickItem` (available since VS Code 1.82).

This follows the "Micro-UX" philosophy of guiding the user and preventing errors before they happen.

---
*PR created automatically by Jules for task [15023898307223324512](https://jules.google.com/task/15023898307223324512) started by @EffortlessSteven*