### PR TITLE
🎨 Palette: Context-aware Status Menu Actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-03-02 - [Context-Aware Disabled States]
+**Learning:** Showing all commands in a menu, even those irrelevant to the current context, clutters the interface and can confuse users. Using the `disabled` property on `QuickPickItem` (available in VS Code 1.82+) combined with a helpful `detail` explanation is a superior pattern to hiding items or letting them fail.
+**Action:** When designing command menus, always check the current editor context (language, file type) and disable irrelevant actions with a clear explanation in the `detail` property.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -197,14 +197,37 @@ export async function activate(context: vscode.ExtensionContext) {
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
             args?: any[];
+            disabled?: boolean;
         }
+
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor?.document.languageId === 'perl';
+        const isTestFile = isPerl && (editor?.document.fileName.endsWith('.t') || editor?.document.fileName.endsWith('.pl'));
 
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: isPerl ? 'Sort and organize use statements' : 'Available for Perl files only',
+                command: 'perl-lsp.organizeImports',
+                disabled: !isPerl
+            },
+            {
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: isTestFile ? 'Run tests for the active file' : 'Available for Perl test files (.t, .pl) only',
+                command: 'perl-lsp.runTests',
+                disabled: !isTestFile
+            },
+            {
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: isPerl ? 'Format using perltidy' : 'Available for Perl files only',
+                command: 'editor.action.formatDocument',
+                disabled: !isPerl
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },


### PR DESCRIPTION
💡 **What:**
Updated the `perl-lsp.showStatusMenu` command to dynamically check the active editor context (language and file extension). It now disables actions that are not relevant to the current file (e.g., "Run Tests" is disabled for non-test files, "Organize Imports" is disabled for non-Perl files) and provides a clear explanation in the menu item detail.

🎯 **Why:**
Users were previously presented with a list of commands that might not work in the current context, leading to confusion or errors. This change guides the user by clearly indicating which actions are available and why, improving the overall developer experience.

📸 **Before:**
All commands were always enabled, regardless of the file type.

📸 **After:**
- "Organize Imports" and "Format Document" are disabled if the active file is not Perl.
- "Run Tests" is disabled if the active file is not a Perl test file (`.t` or `.pl`).
- Disabled items show a detail message like "Available for Perl files only".

♿ **Accessibility:**
Used the `disabled` property on `QuickPickItem` (supported in VS Code 1.82+) to make irrelevant items unselectable and visually distinct, providing better guidance for all users.


---
*PR created automatically by Jules for task [14752442993380913445](https://jules.google.com/task/14752442993380913445) started by @EffortlessSteven*