### PR TITLE
⚡ Bolt: Optimize symbol extraction for interpolated strings

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -25,6 +25,7 @@ use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 // Re-export the unified symbol types from perl-symbol-types
 /// Symbol kind enums used during Index/Analyze workflows.
@@ -862,10 +863,15 @@ impl SymbolExtractor {
 
     /// Extract variable references from an interpolated string
     fn extract_vars_from_string(&mut self, value: &str, string_location: SourceLocation) {
+        static SCALAR_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
+
         // Simple regex to find scalar variables in strings
         // This handles $var, ${var}, but not arrays/hashes for now
-        let Ok(scalar_re) = Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})") else {
-            return; // Skip variable extraction if regex fails
+        let scalar_re = SCALAR_RE.get_or_init(|| Regex::new(r"\$([a-zA-Z_]\w*|\{[a-zA-Z_]\w*\})"));
+
+        // Skip variable extraction if regex fails
+        let Ok(scalar_re) = scalar_re.as_ref() else {
+            return;
         };
 
         // The value includes quotes, so strip them

--- a/crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs
+++ b/crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs
@@ -1,0 +1,24 @@
+use perl_semantic_analyzer::{Parser, symbol::SymbolExtractor};
+use std::time::Instant;
+
+#[test]
+#[ignore]
+fn benchmark_string_interpolation() {
+    let mut code = String::from("package TestPackage;\n\nsub test {\n");
+
+    // Generate 5000 interpolated strings
+    for i in 0..5000 {
+        code.push_str(&format!("    my $str_{} = \"Hello $name_{}, how are you?\";\n", i, i));
+    }
+    code.push_str("}\n");
+
+    let mut parser = Parser::new(&code);
+    let ast = parser.parse().expect("parse");
+
+    let start = Instant::now();
+    let extractor = SymbolExtractor::new_with_source(&code);
+    let _table = extractor.extract(&ast);
+    let duration = start.elapsed();
+
+    println!("Time to extract symbols from 5000 interpolated strings: {:?}", duration);
+}


### PR DESCRIPTION
⚡ Bolt: Optimize symbol extraction for interpolated strings

Refactors `SymbolExtractor::extract_vars_from_string` in `crates/perl-semantic-analyzer` to use `std::sync::OnceLock` for regex compilation.

This change reduces the execution time for extracting symbols from 5000 interpolated strings from ~15.18s to ~24ms (approx 600x improvement) by avoiding regex recompilation in the loop.

Includes a new benchmark test `crates/perl-semantic-analyzer/tests/string_interpolation_perf.rs`.

---
*PR created automatically by Jules for task [9003045437832264828](https://jules.google.com/task/9003045437832264828) started by @EffortlessSteven*