### PR TITLE
⚡ Bolt: Use PHF for builtin detection in semantic analyzer

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic.rs
@@ -7,6 +7,7 @@
 use crate::SourceLocation;
 use crate::ast::{Node, NodeKind};
 use crate::symbol::{ScopeId, ScopeKind, Symbol, SymbolExtractor, SymbolKind, SymbolTable};
+use perl_parser_core::builtin_signatures_phf;
 use regex::Regex;
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -666,8 +667,17 @@ impl SemanticAnalyzer {
                         }
                     };
 
+                    // Try to find exact location of the function name
+                    // Optimization: if the node location is already the same length as the name, use it directly
+                    let location = if node.location.end - node.location.start == name.len() {
+                        node.location
+                    } else {
+                        let name_offset = self.find_substring_in_source(node, name).unwrap_or(node.location.start);
+                        SourceLocation { start: name_offset, end: name_offset + name.len() }
+                    };
+
                     self.semantic_tokens.push(SemanticToken {
-                        location: node.location,
+                        location,
                         token_type,
                         modifiers: if is_builtin_function(name) && !is_control_keyword(name) {
                             vec![SemanticTokenModifier::DefaultLibrary]
@@ -1203,9 +1213,18 @@ impl SemanticAnalyzer {
                 });
             }
 
-            NodeKind::Identifier { .. } => {
+            NodeKind::Identifier { name } => {
                 // Bareword identifiers, usually left to lexical highlighting
                 // but we handle them to avoid the default case.
+
+                // Check if it's a builtin used as a bareword (e.g. mkdir "foo")
+                if is_builtin_function(name) && !is_control_keyword(name) {
+                    self.semantic_tokens.push(SemanticToken {
+                        location: node.location,
+                        token_type: SemanticTokenType::Function,
+                        modifiers: vec![SemanticTokenModifier::DefaultLibrary],
+                    });
+                }
             }
 
             NodeKind::Heredoc { .. } => {
@@ -1515,51 +1534,9 @@ fn is_control_keyword(name: &str) -> bool {
 }
 
 fn is_builtin_function(name: &str) -> bool {
-    matches!(
-        name,
-        "print"
-            | "say"
-            | "printf"
-            | "sprintf"
-            | "open"
-            | "close"
-            | "read"
-            | "write"
-            | "chomp"
-            | "chop"
-            | "split"
-            | "join"
-            | "push"
-            | "pop"
-            | "shift"
-            | "unshift"
-            | "sort"
-            | "reverse"
-            | "map"
-            | "grep"
-            | "length"
-            | "substr"
-            | "index"
-            | "rindex"
-            | "lc"
-            | "uc"
-            | "lcfirst"
-            | "ucfirst"
-            | "defined"
-            | "undef"
-            | "ref"
-            | "blessed"
-            | "die"
-            | "warn"
-            | "eval"
-            | "require"
-            | "use"
-            | "return"
-            | "next"
-            | "last"
-            | "redo"
-            | "goto" // ... many more
-    )
+    // Use the comprehensive PHF map from perl-builtins (via perl-parser-core)
+    // Also include 'blessed' which is often used as a builtin-like function
+    builtin_signatures_phf::is_builtin(name) || name == "blessed"
 }
 
 /// Get documentation for a Perl built-in function.

--- a/crates/perl-semantic-analyzer/tests/builtin_coverage.rs
+++ b/crates/perl-semantic-analyzer/tests/builtin_coverage.rs
@@ -1,0 +1,68 @@
+use perl_parser_core::Parser;
+use perl_semantic_analyzer::analysis::semantic::{SemanticAnalyzer, SemanticTokenModifier, SemanticTokenType};
+
+#[test]
+fn test_builtin_coverage_expansion() {
+    // A mix of built-ins that were previously covered (print), previously missed (mkdir, chmod),
+    // and the special case (blessed).
+    let code = r#"
+print "hello";
+mkdir("dir");
+chmod 0755, "file";
+socket(S, 1, 1, 1);
+blessed($obj);
+"#;
+
+    let mut parser = Parser::new(code);
+    let ast = parser.parse().expect("Failed to parse");
+    let analyzer = SemanticAnalyzer::analyze(&ast);
+    let tokens = analyzer.semantic_tokens();
+
+    // Helper to find token for a given function name
+    let find_token = |name: &str| {
+        tokens.iter().find(|t| {
+            // Find tokens that correspond to the function name in the source
+            let start = t.location.start;
+            let end = t.location.end;
+            if end > code.len() { return false; }
+            let token_text = &code[start..end];
+            // If the token text is exactly the name, good.
+            // If the token text starts with the name and follows with space or parens, maybe that's how it works?
+            // But let's assume strict match first.
+            token_text == name
+        })
+    };
+
+    // 1. Verify 'print' (was already covered)
+    let print_token = find_token("print").expect("print token not found");
+    assert_eq!(print_token.token_type, SemanticTokenType::Function);
+    assert!(print_token.modifiers.contains(&SemanticTokenModifier::DefaultLibrary),
+            "print should have DefaultLibrary modifier");
+
+    // 2. Verify 'mkdir' (was missing)
+    let mkdir_token = find_token("mkdir").expect("mkdir token not found");
+    assert_eq!(mkdir_token.token_type, SemanticTokenType::Function);
+    // This assertion is expected to fail before the fix
+    assert!(mkdir_token.modifiers.contains(&SemanticTokenModifier::DefaultLibrary),
+            "mkdir should have DefaultLibrary modifier");
+
+    // 3. Verify 'chmod' (was missing)
+    let chmod_token = find_token("chmod").expect("chmod token not found");
+    assert_eq!(chmod_token.token_type, SemanticTokenType::Function);
+    // This assertion is expected to fail before the fix
+    assert!(chmod_token.modifiers.contains(&SemanticTokenModifier::DefaultLibrary),
+            "chmod should have DefaultLibrary modifier");
+
+    // 4. Verify 'socket' (was missing)
+    let socket_token = find_token("socket").expect("socket token not found");
+    assert_eq!(socket_token.token_type, SemanticTokenType::Function);
+    // This assertion is expected to fail before the fix
+    assert!(socket_token.modifiers.contains(&SemanticTokenModifier::DefaultLibrary),
+            "socket should have DefaultLibrary modifier");
+
+    // 5. Verify 'blessed' (special case, not in PHF but handled manually)
+    let blessed_token = find_token("blessed").expect("blessed token not found");
+    assert_eq!(blessed_token.token_type, SemanticTokenType::Function);
+    assert!(blessed_token.modifiers.contains(&SemanticTokenModifier::DefaultLibrary),
+            "blessed should have DefaultLibrary modifier");
+}


### PR DESCRIPTION
* 💡 What: Replaced hardcoded `matches!` macro with `perl_parser_core::builtin_signatures_phf` for builtin function detection. Also updated semantic token generation to handle bareword builtins (fixing false negatives) and improve location precision for function calls.
* 🎯 Why: Expands coverage from ~40 to 200+ built-ins (fixing false negatives like `mkdir`, `chmod`) and uses O(1) perfect hash lookup. Fixes inaccurate highlighting for parenthesized function calls.
* 📊 Impact: ~5x increase in recognized built-ins, O(1) lookup.
* 🔬 Measurement: Verified with new test `builtin_coverage.rs` and existing tests.

---
*PR created automatically by Jules for task [8060524682711339741](https://jules.google.com/task/8060524682711339741) started by @EffortlessSteven*