### PR TITLE
🎨 Palette: Filter status menu items by context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-02-04 - [Context-Aware Menu Filtering]
+**Learning:** While VS Code QuickPicks support disabled states in newer APIs, relying on them can be risky if type definitions or engine versions are ambiguous. Filtering out inapplicable actions entirely is a robust, fail-safe pattern for "Status Menus" to reduce cognitive load.
+**Action:** When building context-sensitive menus (like Status Menus), prefer filtering out irrelevant items over disabling them if API support for disabled states is uncertain. This ensures a clean, error-free user experience.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,20 +199,56 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
+        const editor = vscode.window.activeTextEditor;
+        const isPerl = editor ? (editor.document.languageId === 'perl') : false;
+        const fileName = editor ? editor.document.fileName : '';
+        const isTestFile = isPerl && (fileName.endsWith('.t') || fileName.endsWith('.pl'));
+
         const items: MenuAction[] = [
             { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+            {
+                label: '$(refresh) Restart Server',
+                description: 'Shift+Alt+R',
+                detail: 'Restart the language server',
+                command: 'perl-lsp.restart'
+            }
+        ];
 
+        if (isPerl) {
+            items.push({
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: 'Sort and organize use statements',
+                command: 'perl-lsp.organizeImports'
+            });
+        }
+
+        if (isTestFile) {
+            items.push({
+                label: '$(beaker) Run Tests in Current File',
+                description: 'Shift+Alt+T',
+                detail: 'Run tests for the active file',
+                command: 'perl-lsp.runTests'
+            });
+        }
+
+        if (isPerl) {
+            items.push({
+                label: '$(list-flat) Format Document',
+                description: 'Shift+Alt+F',
+                detail: 'Format using perltidy',
+                command: 'editor.action.formatDocument'
+            });
+        }
+
+        items.push(
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
-        ];
+        );
 
         const selection = await vscode.window.showQuickPick(items, {
             placeHolder: 'Perl Language Server Actions'


### PR DESCRIPTION
Improved the UX of the "Status Menu" by hiding irrelevant actions.

- **What:** Modified `vscode-extension/src/extension.ts` to conditionally add menu items.
- **Why:** Showing actions that cannot be performed (like running tests on a README file) increases cognitive load and leads to frustrating error messages.
- **How:** Checked `activeTextEditor.document.languageId` and filename extension before populating the QuickPick items.
- **Verification:** Verified via `pnpm run compile` and manual code review.
- **Learnings:** Documented that filtering is a safer alternative to disabled states when API support is ambiguous.

---
*PR created automatically by Jules for task [5929412520490223345](https://jules.google.com/task/5929412520490223345) started by @EffortlessSteven*