### PR TITLE
🛡️ Sentinel: Fix Infinite Redirect DoS in BinaryDownloader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@ Users hovering over expressions containing these keywords could accidentally tri
 **Vulnerability:** The VS Code extension settings `perl-lsp.serverPath` and `perl-lsp.downloadBaseUrl` lacked `scope: "machine"`, allowing them to be defined in a workspace's `.vscode/settings.json`. An attacker could create a malicious repository that, when opened, executes an arbitrary binary or downloads a compromised one.
 **Learning:** VS Code extension settings default to `window` scope (which includes Workspace), making them vulnerable to configuration injection attacks if they control executable paths or download URLs.
 **Prevention:** Always explicitly set `scope: "machine"` (or `application`) in `package.json` for any setting that controls executable paths, command arguments, or sensitive URLs.
+
+## 2026-05-27 - Infinite Redirect DoS in Binary Downloader
+**Vulnerability:** The `BinaryDownloader` implemented manual redirect following recursively without a recursion limit. An attacker could set up a server that redirects infinitely (or to a very large depth), causing the extension to consume resources indefinitely (DoS) or crash. Additionally, relative `Location` headers caused a crash due to improper URL resolution.
+**Learning:** Manual implementation of HTTP features (like redirects) often misses standard safeguards present in mature libraries. `http.get` in Node.js does not follow redirects automatically, leading developers to implement it manually, where edge cases like infinite loops and relative URLs are easily overlooked.
+**Prevention:** Always implement a maximum redirect count (e.g., 5) when manually following redirects. Use `new URL(newLocation, previousUrl)` to robustly resolve relative redirects.

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -349,7 +349,7 @@ export class BinaryDownloader {
         };
     }
     
-    private async downloadFile(url: string, dest: string, timeoutMs = 30000): Promise<void> {
+    private async downloadFile(url: string, dest: string, timeoutMs = 30000, redirects = 5): Promise<void> {
         return new Promise((resolve, reject) => {
             // Security check: Enforce HTTPS for remote URLs to prevent MITM attacks
             try {
@@ -407,12 +407,27 @@ export class BinaryDownloader {
                     file.destroy();
                     const newUrl = response.headers.location;
                     if (newUrl) {
+                        // Check redirect limit
+                        if (redirects <= 0) {
+                            reject(new Error('Too many redirects'));
+                            return;
+                        }
+
+                        // Resolve relative URLs
+                        let resolvedUrl: string;
+                        try {
+                            resolvedUrl = new URL(newUrl, url).toString();
+                        } catch (e) {
+                            reject(new Error(`Invalid redirect URL: ${newUrl}`));
+                            return;
+                        }
+
                         // Security check: Prevent downgrade from HTTPS to HTTP
-                        if (isHttps && newUrl.toLowerCase().startsWith('http:') && !newUrl.toLowerCase().startsWith('https:')) {
+                        if (isHttps && resolvedUrl.toLowerCase().startsWith('http:') && !resolvedUrl.toLowerCase().startsWith('https:')) {
                             reject(new Error('Security violation: Redirect from HTTPS to HTTP prevented'));
                             return;
                         }
-                        this.downloadFile(newUrl, dest, timeoutMs).then(resolve).catch(reject);
+                        this.downloadFile(resolvedUrl, dest, timeoutMs, redirects - 1).then(resolve).catch(reject);
                         return;
                     }
                 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Infinite Redirect DoS in BinaryDownloader

🚨 Severity: HIGH
💡 Vulnerability: The `BinaryDownloader` recursively followed HTTP redirects without a limit, allowing a malicious server to cause infinite recursion (DoS) or resource exhaustion. Additionally, relative `Location` headers caused the extension to crash due to improper URL parsing.
🎯 Impact: An attacker controlling the update server or a compromised release could cause the VS Code extension host to hang or crash.
🔧 Fix:
- Added `redirects` parameter to `downloadFile` with a default limit of 5.
- Implemented relative URL resolution using `new URL(newUrl, url)`.
- Enforced strict HTTPS checks on resolved redirect URLs.
✅ Verification:
- Created reproduction script `reproduce_issue.js` demonstrating the infinite loop (1458 redirects/2s).
- Verified fix with `verify_fix.js` confirming it stops after 5 redirects and handles relative URLs correctly.
- Verified TypeScript compilation with `pnpm run compile`.

---
*PR created automatically by Jules for task [9558619138843453052](https://jules.google.com/task/9558619138843453052) started by @EffortlessSteven*