### PR TITLE
UX: Make status menu context-aware

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-01-29 - [Placeholder UI Elements]
 **Learning:** Exposing placeholder or "coming soon" features in main UI menus (like Status Menu) is considered a UX regression if the commands are not fully functional, even if they provide a "roadmap" message.
 **Action:** Only add commands to high-visibility menus (like Status Menu) if they perform a functional action immediately; avoid "dead" or "informational only" interaction points for core tasks.
+
+## 2026-01-29 - [QuickPick Menu Context Awareness]
+**Learning:** The `vscode.window.showQuickPick` API does not support declarative `when` clauses like `package.json` menus. To prevent clutter in custom menus (like "Status Menu"), you must programmatically filter the `items` array based on the current editor context (e.g., `activeTextEditor.document.languageId`).
+**Action:** When implementing custom menus via QuickPick, always check `activeTextEditor` and filter out irrelevant actions to reduce cognitive load.

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -199,23 +199,33 @@ export async function activate(context: vscode.ExtensionContext) {
             args?: any[];
         }
 
-        const items: MenuAction[] = [
-            { label: 'Actions', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' },
-            { label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' },
-            { label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' },
-            { label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' },
+        const editor = vscode.window.activeTextEditor;
+        const isPerlFile = editor?.document.languageId === 'perl';
+        const isTestFile = isPerlFile && (editor!.document.uri.fsPath.endsWith('.t') || editor!.document.uri.fsPath.endsWith('.pl'));
 
-            { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
-            { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+        const items: MenuAction[] = [];
 
-            { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
-        ];
+        items.push({ label: 'Actions', kind: vscode.QuickPickItemKind.Separator });
+        items.push({ label: '$(refresh) Restart Server', description: 'Shift+Alt+R', detail: 'Restart the language server', command: 'perl-lsp.restart' });
+
+        if (isPerlFile) {
+            items.push({ label: '$(organization) Organize Imports', description: 'Shift+Alt+O', detail: 'Sort and organize use statements', command: 'perl-lsp.organizeImports' });
+            items.push({ label: '$(list-flat) Format Document', description: 'Shift+Alt+F', detail: 'Format using perltidy', command: 'editor.action.formatDocument' });
+
+            if (isTestFile) {
+                items.push({ label: '$(beaker) Run Tests in Current File', description: 'Shift+Alt+T', detail: 'Run tests for the active file', command: 'perl-lsp.runTests' });
+            }
+        }
+
+        items.push({ label: 'Information', kind: vscode.QuickPickItemKind.Separator });
+        items.push({ label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' });
+        items.push({ label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' });
+
+        items.push({ label: 'Configuration', kind: vscode.QuickPickItemKind.Separator });
+        items.push({ label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] });
 
         const selection = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Perl Language Server Actions'
+            placeHolder: isPerlFile ? 'Perl Language Server Actions' : 'Perl Language Server (Global Actions)'
         });
 
         if (selection && selection.command) {


### PR DESCRIPTION
This PR updates the "Perl Status Menu" command to be context-aware. Previously, it showed a static list of all possible actions, even if they were irrelevant to the current file (e.g., "Run Tests" on a JSON file).

**Changes:**
- Checks `vscode.window.activeTextEditor` to determine the current file type.
- Filters out "Organize Imports" and "Format Document" if the file is not a Perl file.
- Filters out "Run Tests" if the file is not a Perl test script (`.t` or `.pl`).
- Updates the menu placeholder text to be more descriptive.

**UX Impact:**
- Reduced cognitive load by hiding irrelevant options.
- Improved discoverability of valid actions.
- Cleaner interface consistent with VS Code patterns.

---
*PR created automatically by Jules for task [10816078177881042150](https://jules.google.com/task/10816078177881042150) started by @EffortlessSteven*