### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in inlineValues request

### DIFF
--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -155,6 +155,16 @@ fn test_dap_inline_values() -> TestResult {
     write(&script_path, "my $x = 1;\nmy $y = $x + 2;\nmy $z = $y + 3;\n")?;
 
     let mut adapter = DebugAdapter::new();
+
+    // Initialize with workspace root to pass security validation
+    adapter.handle_request(
+        0,
+        "initialize",
+        Some(json!({
+            "rootPath": dir.path().to_str().unwrap()
+        })),
+    );
+
     let response = adapter.handle_request(
         1,
         "inlineValues",

--- a/crates/perl-dap/tests/security_inline_values_tests.rs
+++ b/crates/perl-dap/tests/security_inline_values_tests.rs
@@ -1,0 +1,61 @@
+use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
+use serde_json::json;
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+
+#[test]
+fn test_inline_values_path_traversal_vulnerability() {
+    // 1. Setup directories
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let workspace_dir = temp_dir.path().join("workspace");
+    std::fs::create_dir(&workspace_dir).expect("Failed to create workspace dir");
+
+    // 2. Create a "secret" file OUTSIDE the workspace
+    let secret_file_path = temp_dir.path().join("secret.txt");
+    let mut secret_file = File::create(&secret_file_path).expect("Failed to create secret file");
+    writeln!(secret_file, "my $secret_var = 'pwned';").expect("Failed to write to secret file");
+
+    // 3. Create DebugAdapter and initialize with workspace
+    let mut adapter = DebugAdapter::new();
+    let init_args = json!({
+        "rootPath": workspace_dir.to_str().unwrap(),
+        "adapterID": "perl-dap"
+    });
+    adapter.handle_request(1, "initialize", Some(init_args));
+
+    // 4. Construct inlineValues request pointing to the secret file (outside workspace)
+    let args = json!({
+        "frameId": 1,
+        "text": "doesn't matter",
+        "stoppedLocation": {
+            "startLine": 1,
+            "endLine": 1,
+            "column": 0
+        },
+        "startLine": 1,
+        "endLine": 2,
+        "source": {
+            "path": secret_file_path.to_str().unwrap()
+        }
+    });
+
+    // 5. Send request
+    let response = adapter.handle_request(2, "inlineValues", Some(args));
+
+    // 6. Check response - SHOULD FAIL NOW
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            if success {
+                panic!("Vulnerability NOT fixed: Successfully read file outside workspace!");
+            } else {
+                println!("Security fix verified: Request failed as expected.");
+                let msg = message.unwrap_or_default();
+                assert!(msg.contains("Security Error"), "Should report security error, got: {}", msg);
+                assert!(msg.contains("Path attempts to escape workspace") || msg.contains("Path outside workspace"),
+                        "Should fail with path traversal error, got: {}", msg);
+            }
+        }
+        _ => panic!("Expected Response"),
+    }
+}


### PR DESCRIPTION
This PR fixes a critical Path Traversal (LFI) vulnerability in the DAP `inlineValues` request. Previously, `handle_inline_values` read arbitrary files specified in `source.path` without validation.

Changes:
1.  `crates/perl-dap/src/debug_adapter.rs`:
    *   Added `workspace_root` to `DebugAdapter` struct.
    *   Initialize `workspace_root` from `initialize` request (`rootPath`/`rootUri`) or `launch` request (`cwd`).
    *   Validate `source.path` in `handle_inline_values` against the `workspace_root` (or CWD if unset).
2.  `crates/perl-dap/tests/dap_security_validation_tests.rs`:
    *   Refactored tests to use `tempfile::tempdir()` instead of a shared `test_workspace` directory to prevent race conditions during parallel test execution.
3.  `crates/perl-dap/tests/dap_comprehensive_test.rs`:
    *   Updated `test_dap_inline_values` to initialize the adapter with a workspace root, satisfying the new security check.
4.  `crates/perl-dap/tests/security_inline_values_tests.rs`:
    *   Added a new regression test that explicitly attempts to access a file outside the workspace and asserts failure.

This vulnerability allowed reading any file readable by the debug adapter process. The fix ensures only files within the workspace (or current working directory) can be read.

---
*PR created automatically by Jules for task [2840061444291078248](https://jules.google.com/task/2840061444291078248) started by @EffortlessSteven*