### PR TITLE
chore(ci): add --locked to BDD gate and timing receipts

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,6 +63,7 @@ merge-gate: _check-tools-basic pr-fast
     just _timed "clippy-full" "just clippy-full" && \
     just _timed "test-full" "just test-full" && \
     just _timed "lsp-smoke" "just lsp-smoke" && \
+    just _timed "lsp-bdd" "just ci-lsp-bdd" && \
     just _timed "security-audit" "just security-audit" && \
     just _timed "ci-policy" "just ci-policy" && \
     just _timed "ci-v2-bundle-sync" "just ci-v2-bundle-sync" && \
@@ -371,6 +372,7 @@ ci-gate:
     just ci-v2-parity && \
     just ci-lsp-def && \
     just ci-lsp-smoke-e2e && \
+    just ci-lsp-bdd && \
     just ci-semantic-frameworks && \
     just ci-dap-smoke-e2e && \
     just ci-parser-features-check && \
@@ -523,7 +525,7 @@ ci-lsp-smoke-e2e:
 ci-lsp-bdd:
     @echo "🎭 Running LSP BDD workflow tests..."
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
-        cargo test -p perl-lsp --test lsp_bdd_workflows -- --test-threads=1
+        cargo test -p perl-lsp --locked --test lsp_bdd_workflows -- --test-threads=1
     @echo "✅ LSP BDD workflow tests passed"
 
 # Framework semantic depth receipts (Moo/Moose/Class::Accessor)

--- a/scripts/build-timing-receipt.sh
+++ b/scripts/build-timing-receipt.sh
@@ -139,28 +139,28 @@ measure_time() {
 
 # Run clean build measurement
 if [[ "$RUN_CLEAN" == true ]]; then
-  measure_time "clean_build_workspace" "cargo build --workspace" "cargo clean"
+  measure_time "clean_build_workspace" "cargo build --workspace --locked" "cargo clean"
 fi
 
 # Run incremental build measurement
 if [[ "$RUN_INCREMENTAL" == true ]]; then
   # First ensure we have a clean build to measure from
-  cargo build --workspace > /dev/null 2>&1 || true
+  cargo build --workspace --locked > /dev/null 2>&1 || true
 
   # Touch a file in perl-lsp-providers to trigger incremental rebuild
   if [[ -d "${PROJECT_ROOT}/crates/perl-lsp-providers" ]]; then
     touch "${PROJECT_ROOT}/crates/perl-lsp-providers/src/lib.rs" 2>/dev/null || true
-    measure_time "incremental_build_providers" "cargo build -p perl-lsp-providers"
+    measure_time "incremental_build_providers" "cargo build -p perl-lsp-providers --locked"
   else
     # If perl-lsp-providers doesn't exist yet, measure incremental on perl-parser
     touch "${PROJECT_ROOT}/crates/perl-parser/src/lib.rs" 2>/dev/null || true
-    measure_time "incremental_build_parser" "cargo build -p perl-parser"
+    measure_time "incremental_build_parser" "cargo build -p perl-parser --locked"
   fi
 fi
 
 # Run test build measurement
 if [[ "$RUN_TESTS" == true ]]; then
-  measure_time "test_build_workspace" "cargo test --workspace --lib"
+  measure_time "test_build_workspace" "cargo test --workspace --lib --locked"
 fi
 
 # Read measurements from temp file and build final JSON


### PR DESCRIPTION
## Summary

- Add `--locked` flag to `ci-lsp-bdd` recipe for reproducible builds
- Add `--locked` to all cargo commands in `scripts/build-timing-receipt.sh`
- Wire `ci-lsp-bdd` into `merge-gate` and `ci-gate` targets so BDD tests run as part of the standard gate

## Test plan

- [x] `just ci-lsp-bdd` — passes with `--locked` flag against master's `Cargo.lock`
- [x] No microcrate references in diff
- [ ] CI green