### PR TITLE
ci: skip docs deploy when GitHub Pages is disabled

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -74,6 +74,25 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
+      - name: Check whether GitHub Pages is enabled
+        id: pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          status_code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pages")"
+
+          if [ "${status_code}" = "200" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub Pages is not enabled (HTTP ${status_code}); skipping deployment."
+          fi
+
       - name: Deploy to GitHub Pages
+        if: steps.pages.outputs.enabled == 'true'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a pre-check in the docs deploy workflow to detect whether GitHub Pages is enabled via GitHub API
- run `actions/deploy-pages@v4` only when Pages is enabled
- when Pages is disabled, emit a clear skip message instead of failing the workflow

## Validation
- `nix develop -c just ci-workflow-audit`