### PR TITLE
fix(security): remediate minimatch CVEs in vscode-extension lockfile

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -452,7 +452,7 @@
   },
   "pnpm": {
     "overrides": {
-      "minimatch": ">=10.2.1"
+      "minimatch": "10.2.3"
     }
   },
   "devDependencies": {

--- a/vscode-extension/pnpm-lock.yaml
+++ b/vscode-extension/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  minimatch: '>=10.2.1'
+  minimatch: 10.2.3
 
 importers:
 
@@ -799,8 +799,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.2.2:
-    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
@@ -1549,7 +1549,7 @@ snapshots:
       leven: 3.1.0
       markdown-it: 14.1.0
       mime: 1.6.0
-      minimatch: 10.2.2
+      minimatch: 10.2.3
       parse-semver: 1.1.1
       read: 1.0.7
       secretlint: 10.2.2
@@ -1895,7 +1895,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.2.2
+      minimatch: 10.2.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -2114,7 +2114,7 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  minimatch@10.2.2:
+  minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.2
 
@@ -2528,7 +2528,7 @@ snapshots:
 
   vscode-languageclient@9.0.1:
     dependencies:
-      minimatch: 10.2.2
+      minimatch: 10.2.3
       semver: 7.7.3
       vscode-languageserver-protocol: 3.17.5
 


### PR DESCRIPTION
## Summary
- pin `minimatch` override to `10.2.3` in `vscode-extension/package.json`
- refresh `vscode-extension/pnpm-lock.yaml` with the fixed `minimatch` version

## Why
`Trivy Repository Scan` is failing with:
- `CVE-2026-27903`
- `CVE-2026-27904`

Both are reported against `minimatch 10.2.2` and fixed in `10.2.3`.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm install --lockfile-only` (in `vscode-extension`)
- lockfile now resolves `minimatch@10.2.3`
