### PR TITLE
tests(refactoring): isolate cleanup_no_backups backup root

### DIFF
--- a/crates/perl-refactoring/src/refactor/refactoring.rs
+++ b/crates/perl-refactoring/src/refactor/refactoring.rs
@@ -2732,7 +2732,12 @@ sub complex {
 
         #[test]
         fn test_cleanup_no_backups() {
-            let mut engine = RefactoringEngine::new();
+            let temp_dir = must(tempfile::tempdir());
+            let config = RefactoringConfig {
+                backup_root: Some(temp_dir.path().to_path_buf()),
+                ..RefactoringConfig::default()
+            };
+            let mut engine = RefactoringEngine::with_config(config);
             let result = must(engine.clear_history());
             assert_eq!(result.directories_removed, 0);
             assert_eq!(result.space_reclaimed, 0);


### PR DESCRIPTION
## Summary
- Isolate `test_cleanup_no_backups` from shared temp state by configuring a test-local `backup_root`.
- Keep gate hardening scoped to the failing test path only.

## Validation
- cargo fmt --all -- --check
- cargo test --workspace --lib
- cargo clippy --workspace --lib -q

All commands pass in this branch.
