### PR TITLE
Release: unblock crates.io dry-run packaging for workspace crates

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -145,8 +145,8 @@ jobs:
             fi
 
             if [ "$DRY_RUN" = "true" ]; then
-              echo "Dry run: cargo package -p $CRATE"
-              cargo package -p "$CRATE"
+              echo "Dry run: scripts/cargo-package-workspace-dry-run.sh $CRATE"
+              bash scripts/cargo-package-workspace-dry-run.sh "$CRATE"
               continue
             fi
 

--- a/scripts/cargo-package-workspace-dry-run.sh
+++ b/scripts/cargo-package-workspace-dry-run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <crate> [crate ...]" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${WORKSPACE_ROOT}"
+
+PATCH_OUTPUT="$(
+  cargo metadata --format-version=1 --no-deps | python3 -c '
+import json
+import os
+import sys
+
+meta = json.load(sys.stdin)
+workspace_members = set(meta["workspace_members"])
+workspace_root = meta["workspace_root"]
+
+for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
+    if pkg["id"] not in workspace_members:
+        continue
+    publish = pkg.get("publish")
+    if publish is not None and len(publish) == 0:
+        continue
+    crate_dir = os.path.dirname(pkg["manifest_path"])
+    rel_path = os.path.relpath(crate_dir, workspace_root)
+    print("--config=patch.crates-io.{}.path=\"{}\"".format(pkg["name"], rel_path))
+'
+)"
+
+mapfile -t PATCH_ARGS <<< "${PATCH_OUTPUT}"
+
+for crate in "$@"; do
+  echo "==> cargo package -p ${crate}"
+  cargo package -p "${crate}" "${PATCH_ARGS[@]}"
+done


### PR DESCRIPTION
## Summary
- Fix crates.io dry-run packaging for workspace crates that depend on yet-to-be-published internal crates.
- Add `scripts/cargo-package-workspace-dry-run.sh` to run `cargo package` with temporary `patch.crates-io` mappings generated from `cargo metadata`.
- Update `.github/workflows/publish-crates.yml` dry-run path to use that helper.

## Why
`cargo package -p <dependent-crate>` failed in dry-run mode before publish order completion because Cargo resolved internal deps against crates.io index and could not find them yet.

## Evidence
Executed from workspace root:

```bash
bash scripts/cargo-package-workspace-dry-run.sh perl-parser perl-lsp perl-dap 2>&1 | rg '^(==>|\s+Packaged|\s+Finished .*profile)'
```

Output:

```text
==> cargo package -p perl-parser
    Packaged 37 files, 305.5KiB (64.2KiB compressed)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.25s
==> cargo package -p perl-lsp
    Packaged 104 files, 1.1MiB (217.0KiB compressed)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.60s
==> cargo package -p perl-dap
    Packaged 23 files, 550.7KiB (105.3KiB compressed)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.75s
```

## Scope
Publish-readiness only. No crate runtime/feature code changes.
