### PR TITLE
fix(vscode): include runtime node deps in VSIX packaging

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Package extension
         working-directory: vscode-extension
         run: |
-          vsce package --no-dependencies
+          vsce package
           echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_ENV
 
       - name: Publish to VSCode Marketplace

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -8,8 +8,6 @@ src/**
 **/.eslintrc.json
 **/*.map
 **/*.ts
-node_modules/**
-!node_modules/vscode-languageclient/**
 scripts/**
 *.vsix
 *.tgz


### PR DESCRIPTION
## Summary
- remove blanket `node_modules/**` exclusion from `vscode-extension/.vscodeignore`
- stop using `vsce package --no-dependencies` in publish workflow
- keep scope limited to extension packaging/publish files

## Why
The previous combination of `.vscodeignore` + `--no-dependencies` could produce VSIX artifacts missing required runtime Node modules, causing runtime activation/download failures.

## Validation
Executed in `vscode-extension/`:

```bash
npm install
npm run compile
npx vsce package
```

Observed successful packaging:
- `DONE  Packaged: .../vscode-extension/perl-lsp-0.9.1.vsix (324 files, 569.07 KB)`
- VSIX includes `node_modules/ (303 files)`

Verified required runtime deps are inside VSIX:
```bash
unzip -l perl-lsp-0.9.1.vsix | rg "extension/node_modules/(adm-zip|tar|vscode-languageclient)/"
```
Matches found for all three required modules, plus transitive runtime modules (e.g. `minizlib`, `vscode-jsonrpc`, `vscode-languageserver-protocol`).