### PR TITLE
Fix crates publish workflow for workspace dev-dependency verification cycles

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -150,11 +150,13 @@ jobs:
               continue
             fi
 
-            # Publish with retries
+            # Publish with retries.
+            # Use --no-verify because workspace dev-dependency cycles can fail
+            # verification before all crates are indexed on crates.io.
             PUBLISHED=false
             for attempt in 1 2 3; do
-              echo "Attempt $attempt/3: cargo publish -p $CRATE"
-              if cargo publish -p "$CRATE" 2>&1; then
+              echo "Attempt $attempt/3: cargo publish -p $CRATE --no-verify"
+              if cargo publish -p "$CRATE" --no-verify 2>&1; then
                 PUBLISHED=true
                 break
               fi


### PR DESCRIPTION
## Summary
- switch crates publish step in `.github/workflows/publish-crates.yml` to `cargo publish -p "$CRATE" --no-verify`
- keep dry-run path unchanged (`scripts/cargo-package-workspace-dry-run.sh`) as the publish preflight verification signal
- add inline workflow rationale documenting workspace dev-dependency verification-cycle failures

## Why
`cargo publish` verification can fail for workspace crates when dev-dependencies reference sibling crates that are not indexed yet. Publishing in topological order by non-dev dependencies does not eliminate those verify-time cycles.

## Validation Evidence
- `bash scripts/cargo-package-workspace-dry-run.sh perl-lexer perl-corpus perl-parser` ✅
- `cargo publish -p perl-parser --dry-run --no-verify` fails pre-release with `no matching package named 'perl-incremental-parsing' found` (expected before dependencies are published/indexed; this is the index timing risk mitigated in real publish by `--no-verify`)

## Residual Risk
- `--no-verify` skips local verification during publish, so packaging/compile regressions must be caught by CI and dry-run preflight.
- crates.io index propagation latency still exists after upload (workflow already waits and checks index with retries).
