### PR TITLE
chore: v0.10.0 release polish — lockfile sync and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2026-02-28
 
+### Added
+- **Document Highlight Improvements**: Support for modern Perl syntax (try/catch parameters, method/sub signatures, string interpolation).
+- **CI Workflow Hardening**: Concurrency groups to prevent duplicate release runs, fixed asset URLs, scoop/chocolatey packaging fixes.
+- **Semver-Aware Benchmark Sorting**: Correct version comparison for benchmark baseline selection.
+
 ### Changed
 - **Version Consistency**: All workspace crates, documentation, VS Code extension, and feature catalogs updated to v0.10.0.
 - **Documentation Refresh**: Updated editor setup guides, roadmap, milestones, and stability policy for v0.10.0.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",


### PR DESCRIPTION
## Summary
- Sync vscode-extension/package-lock.json version to 0.10.0
- Add missing 'Added' section to CHANGELOG.md v0.10.0 entry

## Changes
- **package-lock.json**: Regenerated to match package.json 0.10.0
- **CHANGELOG.md**: Added entries for document highlight improvements, CI hardening, benchmark sorting fix