### PR TITLE
fix(lsp): address unresolved review comments from PRs #881 and #882

### DIFF
--- a/crates/perl-lsp/src/features/document_highlight.rs
+++ b/crates/perl-lsp/src/features/document_highlight.rs
@@ -100,7 +100,7 @@ impl DocumentHighlightProvider {
     /// Find the node at the given byte offset
     fn find_node_at_offset(&self, node: &Node, offset: usize) -> Option<Node> {
         // Check if offset is within this node
-        if offset < node.location.start || offset > node.location.end {
+        if offset < node.location.start || offset >= node.location.end {
             return None;
         }
 
@@ -129,7 +129,7 @@ impl DocumentHighlightProvider {
         source: &str,
         offset: usize,
     ) -> Option<SymbolInfo> {
-        if offset < node.location.start || offset > node.location.end {
+        if offset < node.location.start || offset >= node.location.end {
             return None;
         }
 

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -168,7 +168,7 @@ impl LspServer {
                 let _ = self.notify(
                     "textDocument/publishDiagnostics",
                     json!({
-                        "uri": normalized_uri,
+                        "uri": uri,
                         "version": doc.version,
                         "diagnostics": lsp_diagnostics
                     }),

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -145,8 +145,8 @@ impl LspServer {
                 coordinator.notify_parse_complete(uri);
             }
 
-            // Send diagnostics
-            self.publish_diagnostics(&normalized_uri);
+            // Send diagnostics (use original URI for client notification)
+            self.publish_diagnostics(uri);
         }
 
         Ok(())
@@ -331,8 +331,8 @@ impl LspServer {
                     coordinator.notify_parse_complete(uri);
                 }
 
-                // Send diagnostics
-                self.publish_diagnostics(&normalized_uri);
+                // Send diagnostics (use original URI for client notification)
+                self.publish_diagnostics(uri);
             }
         }
 


### PR DESCRIPTION
## Summary

Addresses two bugs identified by code review bots (Qodo, CodeRabbit) in recently merged PRs that were left unresolved.

**PR #882 — Half-open span boundary bug**: `find_node_at_offset` and `extract_symbol_at_offset` in document highlight used `offset > end` (inclusive end), but `ByteSpan::contains()` defines `[start, end)` with `offset < end` (exclusive end). This inconsistency could return symbols when the cursor is exactly at `end`, and breaks for zero-width spans (`start == end`).

**PR #881 — Normalized URI in diagnostics**: `publishDiagnostics` notifications sent the internally-normalized URI rather than the client's original URI. On Windows, `normalize_uri_key()` lowercases drive letters (e.g., `C:` → `c:`), so clients may fail to match diagnostics to their tracked document URIs.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: bugfix — diagnostics now use client-provided URI
- DAP surface: unchanged
- CLI: unchanged

## What changed

### document_highlight.rs
- `find_node_at_offset`: `offset > node.location.end` → `offset >= node.location.end`
- `extract_symbol_at_offset`: same boundary fix

### diagnostics.rs
- `publish_diagnostics`: JSON payload now uses `uri` parameter instead of `normalized_uri`

### text_sync.rs
- `handle_did_open` and `handle_did_change`: pass original `uri` to `publish_diagnostics()` instead of `&normalized_uri`

## How to review

Start with `document_highlight.rs` (2-line change), then `diagnostics.rs` (1-line change), then `text_sync.rs` (caller updates).

## Evidence

```
cargo build -p perl-lsp          # ✅ compiles clean
cargo clippy -p perl-lsp --lib   # ✅ no warnings
cargo test -p perl-lsp -- highlight diagnostics publish  # ✅ no regressions
```

3 pre-existing test failures in highlight tests confirmed on master (unrelated).

## Risk & rollback

**Low risk**. Both changes align code with documented semantics:
- Span fix matches `ByteSpan::contains()` contract
- URI fix follows LSP spec (client URI should round-trip)

Rollback: revert this single commit.

## Follow-ups

- PR #884: CI benchmark baseline selection uses lexicographic sorting (will break at v0.10+)
- PR #871: duplicate release workflow link (appears already fixed in current code)