### PR TITLE
docs: finalize RELEASE_NOTES.md and CHANGELOG.md for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - 2026-02-28
 
 ### Added
-- **Document Highlight Improvements**: Support for modern Perl syntax (try/catch parameters, method/sub signatures, string interpolation).
-- **CI Workflow Hardening**: Concurrency groups to prevent duplicate release runs, fixed asset URLs, scoop/chocolatey packaging fixes.
-- **Semver-Aware Benchmark Sorting**: Correct version comparison for benchmark baseline selection.
+- **Document Highlight Improvements**: Support for modern Perl syntax (try/catch parameters, method/sub signatures, string interpolation) (#882).
+- **CI Workflow Hardening**: Concurrency groups to prevent duplicate release runs, fixed asset URLs, scoop/chocolatey packaging fixes (#890).
+- **Semver-Aware Benchmark Sorting**: Correct version comparison for benchmark baseline selection (#885).
+- **crates.io Publishing Readiness**: All crate metadata verified, publish-ignore lists normalized, crate badges added (#871).
+- **Module Infrastructure Crates**: Content-Length framing and LSP hardening (#857).
+- **Feature Governance Microcrates**: Extracted into 9 dedicated crates (#848).
+- **InlineValues Lifecycle Coverage**: Added test coverage for inlineValues support (#729).
+- **Context-Aware Status Menu**: Improved UX with context-aware states (#646).
 
 ### Changed
-- **Version Consistency**: All workspace crates, documentation, VS Code extension, and feature catalogs updated to v0.10.0.
+- **Version Consistency**: All workspace crates, documentation, VS Code extension, and feature catalogs updated to v0.10.0 (77+ files).
 - **Documentation Refresh**: Updated editor setup guides, roadmap, milestones, and stability policy for v0.10.0.
 - **features.toml**: Version bumped to 0.10.0 with 100% LSP coverage maintained (53/53 user-visible, 97/97 protocol).
-- **VS Code Extension**: Version synchronized to 0.10.0.
+- **VS Code Extension**: Version synchronized to 0.10.0 with packaging fixes (#863, #866, #869).
 
 ### Fixed
-- **Version Drift**: Resolved version inconsistencies between workspace root (0.10.0) and satellite files still referencing 0.9.1.
+- **Build Fixes**: Resolved 4 compilation errors in the release candidate build (#881).
+- **Version Drift**: Resolved version inconsistencies between workspace root (0.10.0) and satellite files still referencing 0.9.1 (#884).
+- **[HIGH] Path Traversal in DAP Launch**: Fixed path traversal vulnerability in debug adapter (#640).
+- **[HIGH] Argument Injection in TestRunner**: Fixed argument injection vulnerability (#633).
+- **[MEDIUM] Safe Evaluation Bypass**: Fixed bypass for iterator/IO operations (#647).
+- **VS Code Extension Security**: Pinned minimatch to 10.2.3 (#861).
+- **Checksum Verification**: Hardened checksum verification and stabilized incremental parsing CI (#858).
+
+### Performance
+- **Symbol Extraction**: Optimized regex compilation for faster workspace indexing (#645).
+- **Semantic Analyzer**: Eliminated deep cloning of AST nodes in subroutine analysis (#632).
+- **Scope Analyzer**: Optimized unused parameter detection (#638).
 
 ## [0.9.1] - 2026-02-20
 
@@ -66,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Future Milestones
 
-### v0.10.0
+### Next Release
 - Enhanced DAP native implementation (Phase 2).
 - Semantic depth improvements for Moo/Moose.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,68 +1,104 @@
-# Perl LSP v0.10.0 - Public Alpha
+# Perl LSP v0.10.0 — Public Alpha
 
 ## Release Date
+
 February 28, 2026
 
 ## Overview
 
-Perl LSP v0.10.0 continues the **Public Alpha** series with version consistency improvements, expanded documentation, and release infrastructure hardening. This release transitions from the initial v0.10.0 alpha to a more polished, release-candidate-quality package while maintaining the project's trajectory toward the v0.15.0 Stability Contract milestone.
+Perl LSP v0.10.0 continues the **Public Alpha** series with build reliability fixes, security hardening, document highlight improvements for modern Perl syntax, and release infrastructure hardening. All 80+ workspace crates are now version-consistent and crates.io publish-ready, with 1521 tests passing and a clean security audit.
 
 ## 🚀 Key Highlights
 
-### Initial Public Alpha
-- **Fast & Native**: Recursive descent parser written in pure Rust (1-150μs typical).
-- **Substantially Complete**: 99% coverage of the LSP 3.18 methods (alpha-validated).
-- **High Performance**: sub-millisecond incremental updates and sub-50ms LSP responses.
-- **Experimental Protocol**: Wire protocol and APIs are subject to change based on feedback.
-
-### Performance
-- **21μs Mean Parse Time**: Native recursive descent parser.
-- **0.31s Test Suite**: Optimized execution through adaptive threading.
-- **<1ms Incremental Updates**: Real-time parsing with 70-99% node reuse.
-
-### Complete Semantic Analysis
-- **100% AST Node Coverage**: All NodeKind handlers implemented.
-- **Lexical Scoping**: Proper handling of nested scopes and package boundaries.
-- **Cross-File Navigation**: Dual indexing for qualified and bare function calls.
-
-### Security Focused
-- **Hardened Foundations**: UTF-16 boundary fixes and path traversal prevention.
-- **Memory Safe**: Full Rust memory safety guarantees.
-- **Process Isolation**: Controlled execution for external tool integration.
+- **Fast & Native**: Recursive descent parser written in pure Rust (1–150μs typical).
+- **Substantially Complete**: 100% LSP 3.18 coverage (53/53 user-visible, 97/97 protocol).
+- **High Performance**: Sub-millisecond incremental updates with 70–99% node reuse.
+- **1521 Tests Passing**: Comprehensive test suite with adaptive threading.
+- **Security Audited**: Zero known vulnerabilities (`cargo audit` clean).
+- **Semver Compatible**: No breaking API changes from v0.9.1.
 
 ## 🎯 What's New in v0.10.0
 
-### Complete Semantic Analyzer
-The semantic analyzer now provides a deep understanding of Perl code:
-- All NodeKind handlers implemented.
-- Proper lexical scoping with nested scope support.
-- Package-qualified call resolution (`Package::function`).
-- Shadowed variable detection.
+### Document Highlight Improvements
+Enhanced highlighting for modern Perl syntax constructs:
+- **try/catch parameters**: Proper highlighting of catch block variables.
+- **Method and subroutine signatures**: Full support for signature parameter highlighting.
+- **String interpolation**: Correct highlighting of interpolated variables within strings.
 
-### Debug Adapter Protocol (DAP) Support
-Initial debugging capabilities available in VS Code and DAP-compatible editors:
-- Phase 1 bridge to Perl::LanguageServer.
-- Cross-platform support (Windows, macOS, Linux, WSL).
-- <50ms breakpoint operations.
+### Security Hardening
+Three security fixes applied during this release cycle:
+- **[HIGH]** Fixed path traversal vulnerability in debug adapter launch (#640).
+- **[HIGH]** Fixed argument injection in TestRunner (#633).
+- **[MEDIUM]** Fixed safe evaluation bypass for iterator/IO operations (#647).
+- Pinned `minimatch` to 10.2.3 in the VS Code extension lockfile (#861).
 
-### Enhanced LSP Cancellation System
-Thread-safe cancellation infrastructure for improved responsiveness:
-- <100μs Check Latency.
-- Global Registry for concurrent request coordination.
-- JSON-RPC 2.0 compliance for `$/cancelRequest`.
+### Performance Optimizations
+- **Symbol extraction**: Optimized regex compilation for faster workspace indexing (#645).
+- **Semantic analyzer**: Eliminated deep cloning of AST nodes in subroutine analysis (#632).
+- **Scope analyzer**: Optimized unused parameter detection (#638).
 
-## 🛠️ Installation & Setup
+### Build & Compilation Fixes
+- Resolved 4 compilation errors in the release candidate build (#881).
+- All workspace crates compile cleanly on stable Rust.
 
-### Quick Install
+### Version Consistency
+- Updated 77+ files across all workspace crates, documentation, VS Code extension, and feature catalogs to v0.10.0.
+- Resolved version drift between workspace root and satellite files still referencing v0.9.1 (#884).
+- `features.toml` updated with 100% LSP coverage maintained.
+
+### CI & Release Infrastructure
+- **Concurrency groups**: Prevent duplicate release workflow runs (#890).
+- **Asset name fixes**: Corrected release workflow artifact URLs (#890).
+- **crates.io readiness**: All crate metadata verified, publish-ignore lists normalized, crate badges added (#871).
+- **VS Code extension**: Packaging fixes for runtime dependencies and npm lockfile (#863, #866, #869).
+- **Scoop/Chocolatey/Homebrew**: Packaging configuration fixes for all package managers.
+
+### Additional Improvements
+- Semver-aware benchmark sorting for correct version comparison (#885).
+- Context-aware status menu states for improved UX (#646).
+- `inlineValues` lifecycle coverage (#729).
+- Module infrastructure crates and Content-Length framing hardening (#857).
+- Feature governance extracted into 9 microcrates (#848).
+
+## ⚠️ Breaking Changes
+
+None. v0.10.0 is a drop-in upgrade from v0.9.1.
+
+## 🔄 Migration from v0.9.1
+
+No migration steps required. Simply update your installation:
 
 ```bash
-# Install LSP server
+cargo install perl-lsp --force
+```
+
+Editor extensions will detect the new version automatically.
+
+## 🐛 Known Issues
+
+- DAP support remains Phase 1 (bridge to Perl::LanguageServer). Native DAP implementation is planned for a future release.
+- Wire protocol and APIs are subject to change during the alpha phase (pre-v0.15.0).
+
+## 🛠️ Installation
+
+### From crates.io
+
+```bash
 cargo install perl-lsp
+cargo install perl-dap   # optional: debug adapter
+```
 
-# Install DAP server (optional)
-cargo install perl-dap
+### From Source
 
-# Or quick install (Linux/macOS)
+```bash
+git clone https://github.com/EffortlessMetrics/perl-lsp.git
+cd perl-lsp
+cargo install --path crates/perl-lsp
+```
+
+### Quick Install Script (Linux/macOS)
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 ```
 
@@ -77,21 +113,15 @@ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/i
 | macOS | aarch64 | ✅ Tier 1 | Pre-built |
 | Windows | x86_64 | ✅ Tier 1 | Pre-built |
 
-## 🔄 Origins & History
+## 📋 Roadmap
 
-- **Project Start**: Q2 2025.
-- **Code Fork**: Initially forked on July 15th, 2025 from [tree-sitter-perl-better](https://github.com/tree-sitter-perl/tree-sitter-perl).
-- **Evolution**: Transitioned from a tree-sitter based system to a pure-Rust recursive descent architecture for performance and security.
-
-## 📋 Roadmap & Stability
-
-### v0.10.0 (Planned: April 2026)
+### Next Release
 - Enhanced DAP native implementation (Phase 2).
 - Moo/Moose semantic depth (field recognition).
 - Performance optimizations and refactoring refinements.
 
-### v0.15.0 (Future Milestone)
-- **Stability Contract**: Formal API stability and contract-locked wire protocol.
+### v0.15.0 — Stability Contract Milestone
+- Formal API stability and contract-locked wire protocol.
 - Full protocol compliance audit.
 - Package manager distribution.
 
@@ -99,6 +129,7 @@ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/i
 
 - **GitHub Issues**: [Report bugs and request features](https://github.com/EffortlessMetrics/perl-lsp/issues)
 - **Discussions**: [Community discussions and Q&A](https://github.com/EffortlessMetrics/perl-lsp/discussions)
+- **Full Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
 ## 📜 License
 


### PR DESCRIPTION
## Summary

Finalizes release documentation for v0.10.0 to accurately reflect all changes since v0.9.1.

### RELEASE_NOTES.md Changes
- **Rewrote "What's New" section**: Previous version incorrectly listed v0.9.1 features (semantic analyzer, DAP, cancellation) as v0.10.0 changes. Now accurately describes v0.10.0-specific work.
- **Added Security Hardening section**: 3 Sentinel fixes (path traversal, argument injection, eval bypass) + VS Code minimatch pin.
- **Added Performance Optimizations section**: Regex compilation, AST deep cloning elimination, scope analysis optimization.
- **Added Build & Compilation Fixes**: 4 compilation errors resolved in release candidate.
- **Added CI & Release Infrastructure section**: Concurrency groups, asset names, crates.io readiness, VS Code packaging fixes.
- **Added Version Consistency section**: 77+ files updated, version drift resolved.
- **Added Breaking Changes section**: None (drop-in upgrade from v0.9.1).
- **Added Migration Notes**: No steps required.
- **Added Known Issues section**: DAP Phase 1 limitation, alpha API stability note.
- **Added link to full CHANGELOG.md**.
- **Fixed roadmap**: Removed contradictory "v0.10.0 (Planned: April 2026)" from a v0.10.0 release document.
- **Updated test count**: 1521 tests passing, clean security audit.

### CHANGELOG.md Changes
- Added missing entries: security fixes, performance optimizations, build fixes, new features.
- Added PR references for traceability.
- Fixed "Future Milestones" section (removed v0.10.0 as future since it's now released).

### Cross-check Verification
- ✅ Build fixes (4 compilation errors fixed) — documented
- ✅ Document highlight improvements (try/catch, signatures, interpolation) — documented
- ✅ CI workflow hardening (concurrency groups, asset names) — documented
- ✅ Version consistency (77+ files) — documented
- ✅ crates.io publishing readiness — documented
- ✅ Security audit clean — documented
- ✅ Semver compatible — documented
- ✅ VSCode extension validated — documented
- ✅ 1521 tests passing — documented