### PR TITLE
fix: resolve cargo doc warnings

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -82,7 +82,7 @@
 //!
 //! ## LSP Integration Example
 //!
-//! ```ignore
+//! ```text
 //! use crate::Node;
 //!
 //! // Parse Perl code and extract symbols for LSP

--- a/crates/perl-lsp-providers/src/ide/lsp_compat/code_actions.rs
+++ b/crates/perl-lsp-providers/src/ide/lsp_compat/code_actions.rs
@@ -34,6 +34,6 @@
 //!
 //! - [`crate::ide::lsp_compat::completion`] for completion support
 //! - [`crate::ide::lsp_compat::diagnostics`] for diagnostic publishing
-//! - [`perl_lsp_code_actions::CodeActionProvider`] for the main implementation
+//! - [`perl_lsp_code_actions::CodeActionsProvider`] for the main implementation
 
 pub use perl_lsp_code_actions::*;

--- a/crates/perl-lsp/src/cancellation.rs
+++ b/crates/perl-lsp/src/cancellation.rs
@@ -1,6 +1,6 @@
 //! Re-exported cancellation microcrate API.
 //!
-//! The cancellation subsystem now lives in [`perl-lsp-cancellation`] and is reused by
+//! The cancellation subsystem now lives in `perl-lsp-cancellation` and is reused by
 //! both LSP internals and external integrations that need explicit API access.
 
 pub use perl_lsp_cancellation::*;

--- a/crates/tree-sitter-perl-rs/src/bin/benchmark_parsers.rs
+++ b/crates/tree-sitter-perl-rs/src/bin/benchmark_parsers.rs
@@ -12,14 +12,14 @@
 //! - Regression detection
 //!
 //! Usage:
-//!   benchmark_parsers [OPTIONS]
+//!   benchmark_parsers \[OPTIONS\]
 //!
 //! Options:
-//!   -o, --output <PATH>    Output file path (default: benchmark_results.json)
+//!   -o, --output `<PATH>`    Output file path (default: benchmark_results.json)
 //!   -s, --save             Save results to file (implied when --output is used)
-//!   -c, --config <PATH>    Configuration file path
-//!   -i, --iterations <N>   Number of benchmark iterations (default: 100)
-//!   -w, --warmup <N>       Number of warmup iterations (default: 10)
+//!   -c, --config `<PATH>`    Configuration file path
+//!   -i, --iterations `<N>`   Number of benchmark iterations (default: 100)
+//!   -w, --warmup `<N>`       Number of warmup iterations (default: 10)
 //!   -h, --help             Print help information
 //!   -V, --version          Print version information
 


### PR DESCRIPTION
## Summary

Fix all documentation warnings found by `cargo doc --workspace --no-deps`.

## Changes

- **perl-ast**: Change ```ignore to ```text for non-Rust code block (fixes `invalid_rust_codeblocks` warning)
- **perl-lsp-providers**: Fix broken intra-doc link `CodeActionProvider` → `CodeActionsProvider` (fixes `broken_intra_doc_links`)
- **perl-lsp**: Remove doc link brackets around `perl-lsp-cancellation` crate name (fixes `broken_intra_doc_links`)
- **tree-sitter-perl**: Escape brackets and angle brackets in CLI usage docs (fixes `broken_intra_doc_links` and `invalid_html_tags`)

## Verification

```bash
cargo doc --workspace --no-deps 2>&1 | grep warning
# No output (zero warnings)
```

Closes the intent of PR #891.