### PR TITLE
chore: remove unused dependencies flagged by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,6 @@ dependencies = [
  "anyhow",
  "clap",
  "criterion",
- "lsp-types",
  "nix",
  "once_cell",
  "perl-content-length-framing",
@@ -1569,12 +1568,10 @@ dependencies = [
  "perl-feature-catalog",
  "perl-keywords",
  "perl-module-path",
- "perl-parser",
  "perl-path-security",
  "perl-tdd-support",
  "proptest",
  "regex",
- "ropey",
  "serde",
  "serde_json",
  "tempfile",
@@ -1614,7 +1611,6 @@ dependencies = [
  "perl-tdd-support",
  "regex",
  "serde",
- "serde_json",
  "thiserror",
 ]
 
@@ -1626,7 +1622,6 @@ dependencies = [
  "perl-tdd-support",
  "regex",
  "serde",
- "serde_json",
  "thiserror",
 ]
 
@@ -1720,7 +1715,6 @@ dependencies = [
  "perl-content-length-framing",
  "perl-dap",
  "perl-keywords",
- "perl-lexer",
  "perl-lsp-cancellation",
  "perl-lsp-code-actions",
  "perl-lsp-completion",
@@ -1777,13 +1771,7 @@ dependencies = [
  "perl-lsp-diagnostics",
  "perl-lsp-rename",
  "perl-parser-core",
- "perl-position-tracking",
- "perl-refactoring",
- "perl-semantic-analyzer",
  "perl-tdd-support",
- "perl-workspace-index",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -1796,8 +1784,6 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",
- "serde",
- "thiserror",
  "url",
  "walkdir",
 ]
@@ -1806,16 +1792,11 @@ dependencies = [
 name = "perl-lsp-diagnostics"
 version = "0.10.0"
 dependencies = [
- "lsp-types",
- "perl-diagnostics-codes",
  "perl-parser-core",
- "perl-position-tracking",
  "perl-pragma",
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -1881,9 +1862,7 @@ dependencies = [
 name = "perl-lsp-formatting"
 version = "0.10.0"
 dependencies = [
- "lsp-types",
  "perl-lsp-tooling",
- "perl-parser-core",
  "perl-tdd-support",
  "serde",
  "thiserror",
@@ -1893,12 +1872,10 @@ dependencies = [
 name = "perl-lsp-inlay-hints"
 version = "0.10.0"
 dependencies = [
- "lsp-types",
  "perl-parser-core",
  "perl-position-tracking",
  "perl-semantic-analyzer",
  "perl-tdd-support",
- "serde",
  "serde_json",
 ]
 
@@ -1921,10 +1898,8 @@ dependencies = [
  "perl-position-tracking",
  "perl-semantic-analyzer",
  "perl-tdd-support",
- "perl-workspace-index",
  "serde",
  "serde_json",
- "thiserror",
  "url",
 ]
 
@@ -1944,9 +1919,7 @@ name = "perl-lsp-providers"
 version = "0.10.0"
 dependencies = [
  "lsp-types",
- "md5",
  "nix",
- "perl-incremental-parsing",
  "perl-lexer",
  "perl-lsp-code-actions",
  "perl-lsp-completion",
@@ -1958,17 +1931,10 @@ dependencies = [
  "perl-lsp-semantic-tokens",
  "perl-lsp-tooling",
  "perl-parser-core",
- "perl-position-tracking",
- "perl-refactoring",
  "perl-semantic-analyzer",
  "perl-tdd-support",
- "perl-workspace-index",
- "regex",
  "rustc-hash",
- "serde",
  "serde_json",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -1985,14 +1951,11 @@ dependencies = [
 name = "perl-lsp-semantic-tokens"
 version = "0.10.0"
 dependencies = [
- "lsp-types",
  "perl-lexer",
  "perl-parser-core",
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "rustc-hash",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -2200,7 +2163,6 @@ dependencies = [
  "perl-quote",
  "perl-regex",
  "perl-tdd-support",
- "perl-token",
  "perl-tokenizer",
  "tracing-subscriber",
 ]
@@ -2238,7 +2200,6 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -2373,7 +2334,6 @@ dependencies = [
  "encoding_rs",
  "perl-tdd-support",
  "regex",
- "serde",
  "thiserror",
 ]
 
@@ -2453,7 +2413,6 @@ dependencies = [
  "perl-tdd-support",
  "perl-uri",
  "perl-workspace-index-slo",
- "regex",
  "serde",
  "tempfile",
  "url",

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["development-tools::debugging"]
 [dependencies]
 # Serialization for DAP protocol
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 # Regex for parsing debugger output
 regex = "1.12"

--- a/crates/perl-dap-variables/Cargo.toml
+++ b/crates/perl-dap-variables/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["development-tools::debugging", "development-tools"]
 [dependencies]
 # Serialization for DAP protocol
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 # Regex for parsing debugger output
 regex = "1.12"

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -30,9 +30,6 @@ name = "perl_dap"
 path = "src/lib.rs"
 
 [dependencies]
-# LSP types reuse (Position, Range, Location, etc.)
-lsp-types = "0.97.0"
-
 # JSON serialization
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -55,11 +52,6 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 # Command-line argument parsing
 clap = { version = "4.5.60", features = ["derive"] }
 
-# Rope for position mapping (reuse from perl-parser)
-ropey = "1.6.1"
-
-# Perl parser for AST breakpoint validation
-perl-parser = { path = "../perl-parser", version = "0.10.0" }
 perl-dap-breakpoint = { workspace = true }
 perl-dap-eval = { workspace = true }
 perl-dap-variables = { workspace = true }

--- a/crates/perl-lsp-code-actions/Cargo.toml
+++ b/crates/perl-lsp-code-actions/Cargo.toml
@@ -18,14 +18,8 @@ doctest = false
 
 [dependencies]
 perl-parser-core = { workspace = true }
-perl-position-tracking = { workspace = true }
-perl-refactoring = { workspace = true }
-perl-workspace-index = { workspace = true }
-perl-semantic-analyzer = { workspace = true }
 perl-lsp-rename = { workspace = true }
 perl-lsp-diagnostics = { workspace = true }
-serde = "1.0.228"
-thiserror = "2.0.18"
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -22,8 +22,6 @@ perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-keywords = { workspace = true }
 lsp-types = { version = "0.97.0", optional = true }
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
 url = "2.5.8"
 walkdir = "2.5.0"
 

--- a/crates/perl-lsp-diagnostics/Cargo.toml
+++ b/crates/perl-lsp-diagnostics/Cargo.toml
@@ -20,12 +20,7 @@ doctest = false
 perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
-perl-diagnostics-codes = { workspace = true }
 perl-pragma = { workspace = true }
-perl-position-tracking = { workspace = true }
-lsp-types = "0.97.0"
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-formatting/Cargo.toml
+++ b/crates/perl-lsp-formatting/Cargo.toml
@@ -18,8 +18,6 @@ doctest = false
 
 [dependencies]
 perl-lsp-tooling = { workspace = true }
-perl-parser-core = { workspace = true }
-lsp-types = "0.97.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0"
 

--- a/crates/perl-lsp-inlay-hints/Cargo.toml
+++ b/crates/perl-lsp-inlay-hints/Cargo.toml
@@ -20,8 +20,6 @@ doctest = false
 perl-semantic-analyzer = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-parser-core = { workspace = true }
-lsp-types = "0.97.0"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 
 [dev-dependencies]

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -19,10 +19,8 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
-perl-workspace-index = { workspace = true }
 lsp-types = { version = "0.97.0" }
 serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
 serde_json = "1.0.149"
 url = "2.5.8"
 perl-position-tracking = { workspace = true }

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -25,9 +25,6 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
-perl-workspace-index = { workspace = true }
-perl-refactoring = { workspace = true }
-perl-incremental-parsing = { workspace = true }
 perl-lexer = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-lsp-formatting = { workspace = true }
@@ -38,15 +35,9 @@ perl-lsp-rename = { workspace = true }
 perl-lsp-navigation = { workspace = true }
 perl-lsp-completion = { workspace = true }
 perl-lsp-code-actions = { workspace = true }
-perl-position-tracking = { workspace = true }
 rustc-hash = "2.1.1"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-regex = "1.12.2"
 lsp-types = { version = "0.97.0", optional = true }
-url = "2.5.8"
-md5 = "0.8.0"
-walkdir = "2.5.0"
 
 # Unix-only dependency for signal handling in debug adapter
 [target.'cfg(unix)'.dependencies]

--- a/crates/perl-lsp-semantic-tokens/Cargo.toml
+++ b/crates/perl-lsp-semantic-tokens/Cargo.toml
@@ -21,9 +21,6 @@ perl-parser-core = { workspace = true }
 perl-lexer = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 rustc-hash = "2.1.1"
-lsp-types = "0.97.0"
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -39,7 +39,6 @@ perl-lsp-navigation = { workspace = true, features = ["lsp-compat"] }
 perl-lsp-rename = { workspace = true }
 perl-lsp-semantic-tokens = { workspace = true }
 perl-lsp-launcher = { workspace = true }
-perl-lexer = { workspace = true }
 perl-position-tracking = { workspace = true, features = ["lsp-compat"] }
 perl-module-path = { workspace = true }
 perl-module-reference = { workspace = true }

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -24,7 +24,6 @@ doctest = false
 
 [dependencies]
 perl-lexer = { workspace = true }
-perl-token = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-ast = { workspace = true }
 perl-quote = { workspace = true }

--- a/crates/perl-position-tracking/Cargo.toml
+++ b/crates/perl-position-tracking/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 [dependencies]
 serde_json = "1.0"
 ropey = "1.6.1"
-thiserror = "2.0"
 serde = { version = "1.0.228", features = ["derive"] }
 
 [features]

--- a/crates/perl-ts-heredoc-analysis/Cargo.toml
+++ b/crates/perl-ts-heredoc-analysis/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["parsing", "development-tools", "text-processing"]
 [dependencies]
 regex = "1.12.2"
 encoding_rs = "0.8.35"
-serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"
 
 [dev-dependencies]

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -29,7 +29,6 @@ perl-symbol-types = { workspace = true }
 perl-uri = { workspace = true }
 perl-workspace-index-slo = { workspace = true }
 parking_lot = "0.12.5"
-regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 url = "2.5.8"
 lsp-types = { version = "0.97.0", optional = true }


### PR DESCRIPTION
## Summary

Remove 37 unused dependency declarations across 16 crates to slim down the dependency tree.

## Changes

Removed unused deps from:
- **perl-dap-stack**: serde_json
- **perl-dap-variables**: serde_json
- **perl-dap**: lsp-types, perl-parser, ropey
- **perl-lsp**: perl-lexer
- **perl-lsp-formatting**: lsp-types, perl-parser-core
- **perl-lsp-navigation**: perl-workspace-index, thiserror
- **perl-lsp-inlay-hints**: lsp-types, serde
- **perl-lsp-completion**: serde, thiserror
- **perl-lsp-semantic-tokens**: lsp-types, serde, thiserror
- **perl-lsp-code-actions**: perl-position-tracking, perl-refactoring, perl-semantic-analyzer, perl-workspace-index, serde, thiserror
- **perl-lsp-providers**: md5, perl-incremental-parsing, perl-position-tracking, perl-refactoring, perl-workspace-index, regex, serde, url, walkdir
- **perl-lsp-diagnostics**: lsp-types, perl-diagnostics-codes, perl-position-tracking, serde, thiserror
- **perl-parser-core**: perl-token
- **perl-position-tracking**: thiserror
- **perl-workspace-index**: regex
- **perl-ts-heredoc-analysis**: serde

## Verification

- Each dependency verified unused via source code grep (no `use`, no derive macros, no build.rs usage)
- Skipped uncertain cases: optional/feature-gated deps, tree-sitter crates with complex feature flags
- `cargo build --workspace` ✅
- `cargo test --workspace --lib` — 0 failures ✅