### PR TITLE
chore: expand crates.io publish allowlist with verified crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,32 @@ exclude = [
 
 [workspace.metadata.publish]
 allow = [
+    # Leaf crates (verified via cargo publish --dry-run)
+    "perl-builtins",
+    "perl-content-length-framing",
+    "perl-diagnostics-codes",
+    "perl-feature-catalog",
+    "perl-keywords",
+    "perl-lsp-cancellation",
+    "perl-lsp-feature-ids",
+    "perl-module-name",
+    "perl-module-token-core",
+    "perl-path-security",
+    "perl-position-tracking",
+    "perl-qualified-name",
+    "perl-quote",
+    "perl-regex",
+    "perl-source-file",
+    "perl-symbol-types",
+    "perl-token",
+    "perl-workspace-index-slo",
+    # Core crates (already published)
     "perl-lexer",
     "perl-parser",
     "perl-corpus",
+    # Binary crates
+    "perl-lsp",
+    "perl-dap",
 ]
 
 # Workspace-level package metadata


### PR DESCRIPTION
## Summary

Expands the workspace publish allowlist from 3 to 23 crates. The 18 new leaf crates all passed `cargo publish --dry-run` and have complete metadata (description, license, repository, readme). Also adds `perl-lsp` and `perl-dap` as the main binary crates.

This is a configuration-only change — no code, no behavior change, no new dependencies.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`Cargo.toml` — expanded `[workspace.metadata.publish].allow` with:

**18 leaf crates** (verified dry-run):
`perl-builtins`, `perl-content-length-framing`, `perl-diagnostics-codes`, `perl-feature-catalog`, `perl-keywords`, `perl-lsp-cancellation`, `perl-lsp-feature-ids`, `perl-module-name`, `perl-module-token-core`, `perl-path-security`, `perl-position-tracking`, `perl-qualified-name`, `perl-quote`, `perl-regex`, `perl-source-file`, `perl-symbol-types`, `perl-token`, `perl-workspace-index-slo`

**2 binary crates**: `perl-lsp`, `perl-dap`

**3 existing**: `perl-lexer`, `perl-parser`, `perl-corpus` (unchanged)

## How to review

Single file change — verify each crate name exists in the workspace and has proper metadata. The allowlist is consumed by `.github/workflows/publish-crates.yml` which filters the topological publish order through it.

## Evidence

```
$ cargo metadata --no-deps --format-version=1 | jq '.metadata.publish.allow | length'
23
```

All 23 crate names resolve to valid workspace members with description, license, repository, and readme fields.

## Risk & rollback

**Blast radius**: Zero runtime impact. Only affects the `publish-crates.yml` workflow when a release is triggered.
**Rollback**: Revert commit or remove entries from the allowlist.

## Follow-ups

- Run full `cargo publish --dry-run` for non-leaf crates once their dependency chain is allowlisted
- Consider automating allowlist validation in CI