### PR TITLE
fix: align asset naming across release workflow chain

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -37,6 +37,10 @@ permissions:
   id-token: write
   attestations: write
 
+concurrency:
+  group: release-orchestration-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
         run: cargo install cargo-release --locked
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 

--- a/Formula/perl-lsp.rb
+++ b/Formula/perl-lsp.rb
@@ -8,28 +8,28 @@ class PerlLsp < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_X86_64__"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_X86_64__"
     end
   end
 
   def install
-    # Expected extracted layout: perl-lsp-v<version>-<target>/perl-lsp
+    # Expected extracted layout: perl-lsp-<version>-<target>/perl-lsp
     # If the release packaging layout changes, update this extraction logic with a follow-up.
-    extracted_dir = Dir.glob("perl-lsp-v*").find { |dir| Dir.exist?(dir) }
+    extracted_dir = Dir.glob("perl-lsp-*").find { |dir| Dir.exist?(dir) }
     if extracted_dir
       bin.install "#{extracted_dir}/perl-lsp"
     else

--- a/distribution/homebrew/perl-lsp.rb
+++ b/distribution/homebrew/perl-lsp.rb
@@ -7,28 +7,28 @@ class PerlLsp < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_X86_64__"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_X86_64__"
     end
   end
 
   def install
-    # Expected extracted layout: perl-lsp-v<version>-<target>/perl-lsp
+    # Expected extracted layout: perl-lsp-<version>-<target>/perl-lsp
     # If the release packaging layout changes, update this extraction logic with a follow-up.
-    extracted_dir = Dir.glob("perl-lsp-v*").find { |dir| Dir.exist?(dir) }
+    extracted_dir = Dir.glob("perl-lsp-*").find { |dir| Dir.exist?(dir) }
     if extracted_dir
       bin.install "#{extracted_dir}/perl-lsp"
     else

--- a/homebrew/perl-lsp.rb
+++ b/homebrew/perl-lsp.rb
@@ -6,27 +6,27 @@ class PerlLsp < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-0.8.3-aarch64-apple-darwin.tar.gz"
       sha256 "PLACEHOLDER_SHA256_AARCH64_DARWIN"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-0.8.3-x86_64-apple-darwin.tar.gz"
       sha256 "PLACEHOLDER_SHA256_X86_64_DARWIN"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-0.8.3-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "PLACEHOLDER_SHA256_AARCH64_LINUX"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-0.8.3-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "8af781a0e0aed47f22517ab15cce80dbf78e7bcafb62e1eed5ab236b481b920d"
     end
   end
 
   def install
     # Find the extracted directory (should be perl-lsp-v0.8.3-{target})
-    extracted_dir = Dir.glob("perl-lsp-v*").first
+    extracted_dir = Dir.glob("perl-lsp-*").first
     if extracted_dir && File.directory?(extracted_dir)
       bin.install "#{extracted_dir}/perl-lsp"
     else

--- a/install.ps1
+++ b/install.ps1
@@ -62,8 +62,10 @@ if ($Version -eq "latest") {
     $Tag = if ($Version.StartsWith("v")) { $Version } else { "v$Version" }
 }
 
+$VersionNum = $Tag.TrimStart("v")
+
 # Construct download URL
-$Asset = "$Name-$Tag-$Target.zip"
+$Asset = "$Name-$VersionNum-$Target.zip"
 $Url = "https://github.com/$Repo/releases/download/$Tag/$Asset"
 
 Write-Info "Downloading $Name $Tag for $Target"
@@ -108,7 +110,7 @@ try {
     Expand-Archive -Path $ZipPath -DestinationPath $ExtractDir -Force
     
     # Find the binary
-    $ExtractedDir = Join-Path $ExtractDir "$Name-$Tag-$Target"
+    $ExtractedDir = Join-Path $ExtractDir "$Name-$VersionNum-$Target"
     if (-not (Test-Path $ExtractedDir)) {
         # Try without nested directory
         $ExtractedDir = $ExtractDir

--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,8 @@ get_version() {
 
 # Download and install binary
 install_binary() {
-    ASSET="$NAME-$TAG-$TARGET.tar.gz"
+    VERSION_NUM="${TAG#v}"
+    ASSET="$NAME-$VERSION_NUM-$TARGET.tar.gz"
     URL="https://github.com/$REPO/releases/download/$TAG/$ASSET"
     
     write_info "Downloading $NAME $TAG for $TARGET"
@@ -153,7 +154,7 @@ install_binary() {
     tar xzf "$ARCHIVE_PATH"
     
     # Find the binary
-    EXTRACTED_DIR="$NAME-$TAG-$TARGET"
+    EXTRACTED_DIR="$NAME-$VERSION_NUM-$TARGET"
     if [ ! -d "$EXTRACTED_DIR" ]; then
         write_error "Extracted directory not found: $EXTRACTED_DIR"
     fi


### PR DESCRIPTION
## Release Workflow Audit — v0.10.0 Readiness

### Critical: Asset naming mismatch (would cause 404s)

`release.yml` creates artifacts named `perl-lsp-{VERSION}-{TARGET}` where VERSION has **no** `v` prefix (e.g., `perl-lsp-0.10.0-x86_64-unknown-linux-gnu.tar.gz`).

However, multiple files expected a `v` prefix in the asset name:

| File | Before (broken) | After (fixed) |
|------|---------|-------|
| `install.sh` | `perl-lsp-v0.10.0-...` | `perl-lsp-0.10.0-...` |
| `install.ps1` | `perl-lsp-v0.10.0-...` | `perl-lsp-0.10.0-...` |
| `Formula/perl-lsp.rb` | `perl-lsp-v#{version}-...` | `perl-lsp-#{version}-...` |
| `distribution/homebrew/perl-lsp.rb` | same | same |
| `homebrew/perl-lsp.rb` | `perl-lsp-v0.8.3-...` | `perl-lsp-0.8.3-...` |

The download URLs use the **tag** (`v0.10.0`) for the path, which is correct. Only the **asset filename** portion was wrong.

### Moderate: download-artifact version mismatch

`release.yml` used `actions/upload-artifact@v6` but `actions/download-artifact@v7`. These must use matching major versions. Fixed to both use `@v6`.

### Moderate: Missing concurrency group

`release-orchestration.yml` had no concurrency group, allowing duplicate orchestration runs. Added `release-orchestration-${{ version }}` group.

### Audit Summary (items NOT requiring fixes)

| Area | Status |
|------|--------|
| Tag validation regex (`^v[0-9]+\.[0-9]+\.[0-9]+...`) | ✅ Matches v0.10.0 |
| Platform matrix (7 targets: linux gnu/musl x86+arm, macOS x86+arm, Windows) | ✅ Complete |
| Concurrency groups on release.yml, publish-crates.yml, ci.yml, ci-security.yml | ✅ All set |
| Scoop manifest asset naming | ✅ Correct (no v prefix) |
| Chocolatey install script asset naming | ✅ Correct (no v prefix) |
| brew-bump.yml downloads | ✅ Correct (no v prefix) |
| Placeholder tokens (`__RELEASE_VERSION__`, `__SHA256_*__`, `__RELEASE_HASH__`) | ✅ Consistent |
| `CARGO_REGISTRY_TOKEN` secret reference | ✅ Correct |
| Topological publish ordering in publish-crates.yml | ✅ Correct |
| Workspace version (Cargo.toml) | ✅ 0.10.0 |
