### PR TITLE
docs: add public API documentation to leaf crates

### DIFF
--- a/crates/perl-error/src/lib.rs
+++ b/crates/perl-error/src/lib.rs
@@ -429,7 +429,9 @@ pub enum ParseError {
     },
 }
 
+/// Error classification and diagnostic generation for parsed Perl code.
 pub mod classifier;
+/// Error recovery strategies and traits for the Perl parser.
 pub mod recovery;
 
 use perl_ast::Node;

--- a/crates/perl-quote/src/lib.rs
+++ b/crates/perl-quote/src/lib.rs
@@ -1,9 +1,10 @@
-/// Uniform quote operator parsing for the parser
-///
-/// This module provides consistent parsing for quote-like operators,
-/// properly extracting patterns, bodies, and modifiers.
+//! Uniform quote operator parsing for the Perl parser.
+//!
+//! This module provides consistent parsing for quote-like operators,
+//! properly extracting patterns, bodies, and modifiers.
+
 use std::borrow::Cow;
-///
+
 /// Extract pattern and modifiers from a regex-like token (qr, m, or bare //)
 pub fn extract_regex_parts(text: &str) -> (String, String, String) {
     // Handle different prefixes

--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -5,13 +5,21 @@
 
 use thiserror::Error;
 
+/// Error type for Perl regex validation failures.
 #[derive(Error, Debug, Clone, PartialEq)]
 pub enum RegexError {
+    /// Syntax error at a specific byte offset in the regex pattern.
     #[error("{message} at offset {offset}")]
-    Syntax { message: String, offset: usize },
+    Syntax {
+        /// Human-readable description of the syntax issue.
+        message: String,
+        /// Byte offset where the error was detected.
+        offset: usize,
+    },
 }
 
 impl RegexError {
+    /// Create a new syntax error with a message and byte offset.
     pub fn syntax(message: impl Into<String>, offset: usize) -> Self {
         RegexError::Syntax { message: message.into(), offset }
     }


### PR DESCRIPTION
Add missing doc comments to public items in perl-quote, perl-regex, and perl-error leaf crates that will be published to crates.io.

## Changes

- **perl-regex**: Add doc comments to `RegexError` enum, `Syntax` variant fields, and `syntax()` constructor
- **perl-error**: Add doc comments to `pub mod classifier` and `pub mod recovery` module declarations

## Verification

- `cargo fmt --all` — clean
- `cargo test -p perl-quote -p perl-regex -p perl-error` — all passing
- `cargo doc --no-deps` — no missing doc warnings for these crates

The remaining leaf crates (perl-token, perl-ast, perl-heredoc) already had complete public API documentation.