### PR TITLE
fix(lsp): improve error logging in LSP providers

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -165,14 +165,16 @@ impl LspServer {
             if !self.client_supports_pull_diags.load(Ordering::Relaxed) {
                 // Send diagnostics notification with version
                 // This ensures diagnostics are cleared when all errors are fixed
-                let _ = self.notify(
+                if let Err(e) = self.notify(
                     "textDocument/publishDiagnostics",
                     json!({
                         "uri": uri,
                         "version": doc.version,
                         "diagnostics": lsp_diagnostics
                     }),
-                );
+                ) {
+                    eprintln!("Failed to publish diagnostics for {}: {}", uri, e);
+                }
             }
         }
     }

--- a/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
@@ -68,7 +68,9 @@ impl LspServer {
                 params["verbose"] = json!(v);
             }
         }
-        let _ = self.notify("$/logTrace", params);
+        if let Err(e) = self.notify("$/logTrace", params) {
+            eprintln!("Failed to send logTrace notification: {}", e);
+        }
     }
 
     /// Handle initialized notification
@@ -86,7 +88,9 @@ impl LspServer {
         self.start_workspace_indexing();
 
         // Send index-ready notification
-        let _ = self.send_index_ready_notification();
+        if let Err(e) = self.send_index_ready_notification() {
+            eprintln!("Failed to send index-ready notification: {}", e);
+        }
 
         Ok(None)
     }

--- a/crates/perl-lsp/src/runtime/language/virtual_content.rs
+++ b/crates/perl-lsp/src/runtime/language/virtual_content.rs
@@ -55,9 +55,21 @@ fn fetch_perldoc(module: &str) -> Option<String> {
     // Run perldoc -T Module::Name to get plain text documentation
     // Use -- to prevent argument injection if module starts with -
     let output =
-        std::process::Command::new("perldoc").arg("-T").arg("--").arg(module).output().ok()?;
+        match std::process::Command::new("perldoc").arg("-T").arg("--").arg(module).output() {
+            Ok(output) => output,
+            Err(e) => {
+                eprintln!("Failed to run perldoc for module {}: {}", module, e);
+                return None;
+            }
+        };
 
-    if output.status.success() { String::from_utf8(output.stdout).ok() } else { None }
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map_err(|e| eprintln!("Invalid UTF-8 in perldoc output for {}: {}", module, e))
+            .ok()
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -377,13 +377,15 @@ impl LspServer {
             }
 
             // Clear diagnostics for this file using centralized notify
-            let _ = self.notify(
+            if let Err(e) = self.notify(
                 "textDocument/publishDiagnostics",
                 json!({
                     "uri": normalized_uri,
                     "diagnostics": []
                 }),
-            );
+            ) {
+                eprintln!("Failed to clear diagnostics for {}: {}", normalized_uri, e);
+            }
         }
 
         Ok(())
@@ -437,13 +439,15 @@ impl LspServer {
                         .collect();
 
                     // Send diagnostics notification
-                    let _ = self.notify(
+                    if let Err(e) = self.notify(
                         "textDocument/publishDiagnostics",
                         json!({
                             "uri": normalized_uri,
                             "diagnostics": lsp_diagnostics
                         }),
-                    );
+                    ) {
+                        eprintln!("Failed to publish diagnostics for {}: {}", normalized_uri, e);
+                    }
                 }
             }
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -61,7 +61,9 @@ fn send_index_ready_notification(output: &Arc<Mutex<Box<dyn Write + Send>>>, rea
         let mut out = output.lock();
         let framed = frame(&payload);
         if out.write_all(&framed).is_ok() {
-            let _ = out.flush();
+            if let Err(e) = out.flush() {
+                eprintln!("Failed to flush index-ready notification: {}", e);
+            }
         }
     }
 }
@@ -437,7 +439,9 @@ impl LspServer {
                     }
 
                     // Trigger client refresh for configuration-dependent features
-                    let _ = self.refresh_controller.refresh_all(self);
+                    if let Err(e) = self.refresh_controller.refresh_all(self) {
+                        eprintln!("Failed to refresh client after config change: {}", e);
+                    }
                 }
             }
         }
@@ -497,8 +501,12 @@ impl LspServer {
                             if let Some(path) = uri_to_fs_path(&uri) {
                                 if let Ok(content) = std::fs::read_to_string(&path) {
                                     if let Ok(url) = url::Url::parse(&uri) {
-                                        let _ = workspace_index.index_file(url, content);
-                                        eprintln!("Indexed new file: {}", uri);
+                                        match workspace_index.index_file(url, content) {
+                                            Ok(()) => eprintln!("Indexed new file: {}", uri),
+                                            Err(e) => {
+                                                eprintln!("Failed to index new file {}: {}", uri, e)
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -518,7 +526,10 @@ impl LspServer {
                                     // Clear old index data
                                     workspace_index.clear_file(&uri);
                                     // Re-index with new content
-                                    let _ = workspace_index.index_file(url, content.clone());
+                                    if let Err(e) = workspace_index.index_file(url, content.clone())
+                                    {
+                                        eprintln!("Failed to re-index changed file {}: {}", uri, e);
+                                    }
                                 }
                             }
                         }
@@ -678,7 +689,13 @@ impl LspServer {
                         if let Some(path) = uri_to_fs_path(new_uri) {
                             if let Ok(content) = std::fs::read_to_string(&path) {
                                 if let Ok(url) = url::Url::parse(new_uri) {
-                                    let _ = workspace_index.index_file(url, content.clone());
+                                    if let Err(e) = workspace_index.index_file(url, content.clone())
+                                    {
+                                        eprintln!(
+                                            "Failed to index renamed file {}: {}",
+                                            new_uri, e
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -726,7 +743,9 @@ impl LspServer {
                 }
 
                 // Trigger client refresh after file deletions
-                let _ = self.refresh_controller.refresh_all(self);
+                if let Err(e) = self.refresh_controller.refresh_all(self) {
+                    eprintln!("Failed to refresh client after file deletions: {}", e);
+                }
             }
         }
 
@@ -799,8 +818,12 @@ impl LspServer {
                                 if let Ok(content) = std::fs::read_to_string(&path) {
                                     coordinator.notify_change(uri);
                                     if let Ok(url) = url::Url::parse(uri) {
-                                        let _ = coordinator.index().index_file(url, content);
-                                        eprintln!("Indexed new file: {}", uri);
+                                        match coordinator.index().index_file(url, content) {
+                                            Ok(()) => eprintln!("Indexed new file: {}", uri),
+                                            Err(e) => {
+                                                eprintln!("Failed to index new file {}: {}", uri, e)
+                                            }
+                                        }
                                     }
                                     coordinator.notify_parse_complete(uri);
                                 }
@@ -810,7 +833,9 @@ impl LspServer {
                 }
 
                 // Trigger client refresh after file creations
-                let _ = self.refresh_controller.refresh_all(self);
+                if let Err(e) = self.refresh_controller.refresh_all(self) {
+                    eprintln!("Failed to refresh client after file creations: {}", e);
+                }
             }
         }
 
@@ -850,8 +875,15 @@ impl LspServer {
                             if let Some(path) = uri_to_fs_path(new_uri) {
                                 if let Ok(content) = std::fs::read_to_string(&path) {
                                     if let Ok(url) = url::Url::parse(new_uri) {
-                                        let _ = coordinator.index().index_file(url, content);
-                                        eprintln!("Indexed renamed file: {}", new_uri);
+                                        match coordinator.index().index_file(url, content) {
+                                            Ok(()) => {
+                                                eprintln!("Indexed renamed file: {}", new_uri)
+                                            }
+                                            Err(e) => eprintln!(
+                                                "Failed to index renamed file {}: {}",
+                                                new_uri, e
+                                            ),
+                                        }
                                     }
                                 }
                             }
@@ -871,7 +903,9 @@ impl LspServer {
                 }
 
                 // Trigger client refresh after file renames
-                let _ = self.refresh_controller.refresh_all(self);
+                if let Err(e) = self.refresh_controller.refresh_all(self) {
+                    eprintln!("Failed to refresh client after file renames: {}", e);
+                }
             }
         }
 
@@ -922,7 +956,9 @@ impl LspServer {
                 }
 
                 // Trigger client refresh after workspace folder changes
-                let _ = self.refresh_controller.refresh_all(self);
+                if let Err(e) = self.refresh_controller.refresh_all(self) {
+                    eprintln!("Failed to refresh client after workspace folder changes: {}", e);
+                }
 
                 // Rebuild workspace index after folder changes
                 #[cfg(feature = "workspace")]
@@ -1128,7 +1164,11 @@ impl LspServer {
                             if let Some(coordinator) = self.coordinator() {
                                 coordinator.notify_change(uri);
                                 if let Ok(url) = url::Url::parse(uri) {
-                                    let _ = coordinator.index().index_file(url, doc.text.clone());
+                                    if let Err(e) =
+                                        coordinator.index().index_file(url, doc.text.clone())
+                                    {
+                                        eprintln!("Failed to re-index file {}: {}", uri, e);
+                                    }
                                 }
                                 coordinator.notify_parse_complete(uri);
                             }


### PR DESCRIPTION
## Summary

Replace silent error discarding (`let _ = ...`) with contextual error logging across the LSP server's workspace indexing, diagnostics, text synchronization, and lifecycle management.

## Changes

### workspace.rs (12 sites)
- Log errors from `index_file()` calls (6 sites) instead of silently discarding with `let _ =`
- Log errors from `refresh_controller.refresh_all()` calls (5 sites) 
- Log flush errors for index-ready notifications (1 site)

### diagnostics.rs (1 site)
- Log failures when publishing diagnostics notifications to the client

### text_sync.rs (2 sites)
- Log failures when clearing diagnostics on document close
- Log failures when publishing diagnostics on document save

### dispatch/lifecycle.rs (2 sites)
- Log failures for `$/logTrace` notifications
- Log failures for index-ready notifications during initialization

### virtual_content.rs (1 site)
- Log perldoc execution failures with module name context
- Log UTF-8 decode errors in perldoc output

## Design decisions
- All error messages include relevant context (URI, module name, etc.)
- No control flow changes — only adds logging on existing error paths
- Does not modify intentional suppressions (cancellation tokens, test cleanup, unused variable markers)

## Verification
- `cargo fmt --all` ✅
- `cargo clippy -p perl-lsp --lib` ✅  
- `cargo test -p perl-lsp --lib -- --test-threads=2` ✅ (138 tests pass)