### PR TITLE
fix: harden installer scripts for security and reliability

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -98,7 +98,7 @@ try {
         if ($ExpectedHash -eq $ActualHash) {
             Write-Success "Checksum verified"
         } else {
-            Write-Warn "Checksum mismatch - expected: $ExpectedHash, got: $ActualHash"
+            Write-Error "Checksum mismatch - expected: $ExpectedHash, got: $ActualHash"
         }
     } catch {
         Write-Warn "Could not download or verify checksums"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # Perl LSP installer for Linux and macOS
 # Usage: curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -82,8 +82,7 @@ get_version() {
             write_error "curl is required but not installed"
         fi
         
-        RELEASE_INFO=$(curl -s "$RELEASE_API")
-        if [ $? -ne 0 ]; then
+        if ! RELEASE_INFO=$(curl -s "$RELEASE_API"); then
             write_error "Failed to fetch release information"
         fi
         
@@ -111,7 +110,7 @@ install_binary() {
     
     # Create temporary directory
     TEMP_DIR=$(mktemp -d)
-    trap "rm -rf $TEMP_DIR" EXIT
+    trap 'rm -rf "$TEMP_DIR"' EXIT
     
     # Download archive
     ARCHIVE_PATH="$TEMP_DIR/$ASSET"
@@ -141,7 +140,7 @@ install_binary() {
             if [ -n "$ACTUAL_HASH" ] && [ "$EXPECTED_HASH" = "$ACTUAL_HASH" ]; then
                 write_success "Checksum verified"
             elif [ -n "$ACTUAL_HASH" ]; then
-                write_warn "Checksum mismatch - expected: $EXPECTED_HASH, got: $ACTUAL_HASH"
+                write_error "Checksum mismatch - expected: $EXPECTED_HASH, got: $ACTUAL_HASH"
             fi
         fi
     else
@@ -206,10 +205,10 @@ check_path() {
         echo
         echo "To add it to your PATH permanently, run:"
         echo
-        if [ -n "$BASH_VERSION" ]; then
+        if [ -n "${BASH_VERSION:-}" ]; then
             echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.bashrc"
             echo "  source ~/.bashrc"
-        elif [ -n "$ZSH_VERSION" ]; then
+        elif [ -n "${ZSH_VERSION:-}" ]; then
             echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.zshrc"
             echo "  source ~/.zshrc"
         else


### PR DESCRIPTION
## Summary

Audit and harden both installer scripts (`install.sh` and `install.ps1`) for security and reliability.

### Changes

**install.sh (bash installer)**
- Add `set -u` and `set -o pipefail` for strict error handling (`set -e` alone is insufficient)
- **Security fix**: Promote checksum mismatch from warning to fatal error — prevents installing tampered binaries
- Fix `trap` quoting: use single quotes so `$TEMP_DIR` is evaluated at trap execution, not definition, and is properly quoted for paths with spaces
- Guard `$BASH_VERSION` / `$ZSH_VERSION` with `${VAR:-}` default to avoid errors under `set -u`
- Replace indirect `$?` check with direct exit code check (shellcheck SC2181)
- Passes shellcheck cleanly

**install.ps1 (PowerShell installer)**
- **Security fix**: Promote checksum mismatch from warning to fatal error

### Verification

- [x] `install.sh` passes `shellcheck` with zero findings
- [x] Download URLs match release.yml asset naming pattern (`perl-lsp-{VERSION}-{TARGET}`, no v-prefix on version)
- [x] Checksum validated against `SHA256SUMS` file
- [x] All HTTPS URLs confirmed
- [x] Temp file cleanup via `trap` (bash) and `try/finally` (PowerShell)
- [x] Handles all target platforms: linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64, windows-x86_64