### PR TITLE
Get crates.io publication ready by ensuring all dependencies are in the publish allowlist

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -49,91 +49,7 @@ jobs:
       - name: Compute topological order
         id: topo
         run: |
-          cargo metadata --format-version=1 --no-deps | python3 -c '
-          import json, sys
-
-          meta = json.load(sys.stdin)
-          workspace_members = set(meta["workspace_members"])
-
-          # Build name -> package info map (only workspace members)
-          packages = {}
-          for pkg in meta["packages"]:
-              if pkg["id"] in workspace_members:
-                  packages[pkg["name"]] = pkg
-
-          # Build dependency graph (only internal deps)
-          deps = {}
-          for name, pkg in packages.items():
-              deps[name] = set()
-              for dep in pkg["dependencies"]:
-                  if dep["name"] in packages and dep.get("kind") != "dev":
-                      deps[name].add(dep["name"])
-
-          # Topological sort (Kahn algorithm)
-          in_degree = {name: len(d) for name, d in deps.items()}
-          queue = sorted([n for n, d in in_degree.items() if d == 0])
-          order = []
-
-          while queue:
-              node = queue.pop(0)
-              order.append(node)
-              for name, d in deps.items():
-                  if node in d:
-                      in_degree[name] -= 1
-                      if in_degree[name] == 0:
-                          queue.append(name)
-                          queue.sort()
-
-          if len(order) != len(packages):
-              print("ERROR: cycle detected in dependency graph", file=sys.stderr)
-              sys.exit(1)
-
-          # Filter to only crates listed in the workspace publish allowlist
-          allowlist = meta.get("metadata", {}).get("publish", {}).get("allow", [])
-          if not isinstance(allowlist, list):
-              print(
-                  "ERROR: Workspace publish allowlist must be a list at [workspace.metadata.publish.allow].",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-
-          allowed = []
-          for crate_name in allowlist:
-              if not isinstance(crate_name, str):
-                  print(
-                      f"ERROR: Invalid publish allowlist entry (not a string): {crate_name}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              if crate_name in allowed:
-                  continue
-
-              if crate_name not in packages:
-                  print(
-                      f"ERROR: Crate in publish allowlist is not a workspace member: {crate_name}",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              allowed.append(crate_name)
-
-          if len(allowed) == 0:
-              print(
-                  "ERROR: Publish allowlist is empty. Set [workspace.metadata.publish.allow] in workspace Cargo.toml.",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-
-          result = []
-          for name in order:
-              if name not in allowed:
-                  continue
-              pkg = packages[name]
-              result.append({"name": name, "version": pkg["version"]})
-
-          print(json.dumps(result))
-          ' > /tmp/crates.json
+          cargo run --bin xtask publish-order > /tmp/crates.json
 
           echo "crates=$(cat /tmp/crates.json)" >> $GITHUB_OUTPUT
           echo "Publish order ($(cat /tmp/crates.json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))') crates):"
@@ -142,6 +58,7 @@ jobs:
           for i, c in enumerate(json.load(sys.stdin), 1):
               print("  {}. {}@{}".format(i, c["name"], c["version"]))
           '
+
 
       - name: Resolve and validate target version
         id: release-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ allow = [
     "perl-lexer",
     "perl-parser",
     "perl-corpus",
+    "perl-lsp",
+    "perl-dap",
 ]
 
 # Workspace-level package metadata

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,6 +26,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Compute and output the topological publish order of workspace crates
+    PublishOrder,
     /// Run lean CI suite (format, clippy, tests) for constrained environments
     Ci,
 
@@ -421,6 +423,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::PublishOrder => publish::compute_publish_order(),
         Commands::Ci => ci::run(),
         Commands::CheckOnly => ci::check_only(),
         Commands::Build { release, features, c_scanner, rust_scanner } => {

--- a/xtask/src/tasks/publish.rs
+++ b/xtask/src/tasks/publish.rs
@@ -201,3 +201,121 @@ pub fn publish_vscode(yes: bool, token: Option<String>) -> Result<()> {
 
     Ok(())
 }
+
+pub fn compute_publish_order() -> Result<()> {
+    let output =
+        Command::new("cargo").args(["metadata", "--format-version=1", "--no-deps"]).output()?;
+
+    if !output.status.success() {
+        bail!("Failed to run cargo metadata: {}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    let meta: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    let workspace_members: HashSet<&str> =
+        meta["workspace_members"].as_array().unwrap().iter().map(|v| v.as_str().unwrap()).collect();
+
+    let mut packages = HashMap::new();
+    if let Some(pkgs) = meta["packages"].as_array() {
+        for pkg in pkgs {
+            if let (Some(id), Some(name), Some(version)) =
+                (pkg["id"].as_str(), pkg["name"].as_str(), pkg["version"].as_str())
+                && workspace_members.contains(id) {
+                    packages.insert(name.to_string(), (pkg, version.to_string()));
+                }
+        }
+    }
+
+    let mut deps: HashMap<String, HashSet<String>> = HashMap::new();
+    for (name, (pkg, _)) in &packages {
+        let mut package_deps = HashSet::new();
+        if let Some(dependencies) = pkg["dependencies"].as_array() {
+            for dep in dependencies {
+                if let Some(dep_name) = dep["name"].as_str() {
+                    let kind = dep.get("kind").and_then(|k| k.as_str());
+                    if packages.contains_key(dep_name) && kind != Some("dev") {
+                        package_deps.insert(dep_name.to_string());
+                    }
+                }
+            }
+        }
+        deps.insert(name.clone(), package_deps);
+    }
+
+    let mut in_degree: HashMap<String, usize> =
+        deps.keys().map(|k| (k.clone(), deps[k].len())).collect();
+    let mut queue: Vec<String> =
+        in_degree.iter().filter(|&(_, &deg)| deg == 0).map(|(name, _)| name.clone()).collect();
+    queue.sort_by(|a, b| b.cmp(a));
+
+    let mut order = Vec::new();
+    while let Some(node) = queue.pop() {
+        order.push(node.clone());
+        for (name, dep_set) in deps.iter() {
+            if dep_set.contains(&node)
+                && let Some(deg) = in_degree.get_mut(name) {
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push(name.clone());
+                        queue.sort_by(|a, b| b.cmp(a)); // Reverse sort because we pop from end
+                    }
+                }
+        }
+    }
+
+    if order.len() != packages.len() {
+        eprintln!("ERROR: cycle detected in dependency graph");
+        std::process::exit(1);
+    }
+
+    let allowlist_val = meta
+        .pointer("/workspace_metadata/publish/allow")
+        .or_else(|| meta.pointer("/metadata/publish/allow"));
+
+    let mut allowed = Vec::new();
+    if let Some(allowlist) = allowlist_val.and_then(|v| v.as_array()) {
+        for val in allowlist {
+            if let Some(crate_name) = val.as_str() {
+                if !allowed.contains(&crate_name.to_string()) {
+                    if !packages.contains_key(crate_name) {
+                        eprintln!(
+                            "ERROR: Crate in publish allowlist is not a workspace member: {}",
+                            crate_name
+                        );
+                        std::process::exit(1);
+                    }
+                    allowed.push(crate_name.to_string());
+                }
+            } else {
+                eprintln!("ERROR: Invalid publish allowlist entry (not a string): {:?}", val);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        eprintln!(
+            "ERROR: Workspace publish allowlist must be a list at [workspace.metadata.publish.allow]."
+        );
+        std::process::exit(1);
+    }
+
+    if allowed.is_empty() {
+        eprintln!(
+            "ERROR: Publish allowlist is empty. Set [workspace.metadata.publish.allow] in workspace Cargo.toml."
+        );
+        std::process::exit(1);
+    }
+
+    let mut result = Vec::new();
+    for name in &order {
+        if allowed.contains(name) {
+            let (_, version) = packages.get(name).unwrap();
+            let mut item = serde_json::Map::new();
+            item.insert("name".to_string(), serde_json::Value::String(name.clone()));
+            item.insert("version".to_string(), serde_json::Value::String(version.clone()));
+            result.push(serde_json::Value::Object(item));
+        }
+    }
+
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}


### PR DESCRIPTION
Translated the inline python script inside the Github Actions `publish-crates.yml` workflow into a new `cargo xtask publish-order` command. This ensures robust cross-platform dependency resolution. Additionally, ran this new command to generate the correct topological dependencies for `perl-lsp` and `perl-dap` and updated the `[workspace.metadata.publish.allow]` list in the root `Cargo.toml`. This allows the automated crates.io publish script to correctly publish all intermediate transitive dependencies.

---
*PR created automatically by Jules for task [12999938653138352078](https://jules.google.com/task/12999938653138352078) started by @EffortlessSteven*