### PR TITLE
fix(release): add perl-dap to distribution templates and fix build-packages crate name

### DIFF
--- a/Formula/perl-lsp.rb
+++ b/Formula/perl-lsp.rb
@@ -27,13 +27,15 @@ class PerlLsp < Formula
   end
 
   def install
-    # Expected extracted layout: perl-lsp-<version>-<target>/perl-lsp
+    # Expected extracted layout: perl-lsp-<version>-<target>/{perl-lsp,perl-dap}
     # If the release packaging layout changes, update this extraction logic with a follow-up.
     extracted_dir = Dir.glob("perl-lsp-*").find { |dir| Dir.exist?(dir) }
     if extracted_dir
       bin.install "#{extracted_dir}/perl-lsp"
+      bin.install "#{extracted_dir}/perl-dap" if File.exist?("#{extracted_dir}/perl-dap")
     else
       bin.install "perl-lsp"
+      bin.install "perl-dap" if File.exist?("perl-dap")
     end
   end
 

--- a/distribution/build-packages.sh
+++ b/distribution/build-packages.sh
@@ -25,7 +25,7 @@ fi
 
 # Build the release binary
 echo -e "${YELLOW}Building release binary...${NC}"
-cargo build --release --bin perl-lsp -p perl-parser
+cargo build --release --bin perl-lsp -p perl-lsp
 
 # Create temporary directory for packaging
 TEMP_DIR=$(mktemp -d)

--- a/distribution/chocolatey/tools/chocolateyinstall.ps1
+++ b/distribution/chocolatey/tools/chocolateyinstall.ps1
@@ -34,8 +34,17 @@ if (-not (Test-Path $binaryPath)) {
   exit 1
 }
 
-# Create shim
+# Create shims
 Install-BinFile -Name "perl-lsp" -Path $binaryPath
+
+$dapPath = $installPaths |
+  ForEach-Object { Join-Path $_ "perl-dap.exe" } |
+  Where-Object { Test-Path $_ } |
+  Select-Object -First 1
+
+if ($dapPath -and (Test-Path $dapPath)) {
+  Install-BinFile -Name "perl-dap" -Path $dapPath
+}
 
 Write-Host "perl-lsp has been installed successfully."
 Write-Host "To use with your editor, configure it to use 'perl-lsp --stdio'"

--- a/distribution/chocolatey/tools/chocolateyuninstall.ps1
+++ b/distribution/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,6 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
-# Remove shim
+# Remove shims
 Uninstall-BinFile -Name "perl-lsp" -ErrorAction SilentlyContinue
+Uninstall-BinFile -Name "perl-dap" -ErrorAction SilentlyContinue
 
 Write-Host "perl-lsp has been uninstalled successfully."

--- a/distribution/homebrew/perl-lsp.rb
+++ b/distribution/homebrew/perl-lsp.rb
@@ -26,13 +26,15 @@ class PerlLsp < Formula
   end
 
   def install
-    # Expected extracted layout: perl-lsp-<version>-<target>/perl-lsp
+    # Expected extracted layout: perl-lsp-<version>-<target>/{perl-lsp,perl-dap}
     # If the release packaging layout changes, update this extraction logic with a follow-up.
     extracted_dir = Dir.glob("perl-lsp-*").find { |dir| Dir.exist?(dir) }
     if extracted_dir
       bin.install "#{extracted_dir}/perl-lsp"
+      bin.install "#{extracted_dir}/perl-dap" if File.exist?("#{extracted_dir}/perl-dap")
     else
       bin.install "perl-lsp"
+      bin.install "perl-dap" if File.exist?("perl-dap")
     end
   end
 

--- a/distribution/scoop/perl-lsp.json
+++ b/distribution/scoop/perl-lsp.json
@@ -9,7 +9,7 @@
       "hash": "__RELEASE_HASH__"
     }
   },
-  "bin": "perl-lsp.exe",
+  "bin": ["perl-lsp.exe", "perl-dap.exe"],
   "checkver": "github",
   "autoupdate": {
     "architecture": {

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,19 @@ install_binary() {
     chmod +x "$DEST_PATH"
     
     write_success "Installed $NAME to $DEST_PATH"
+    
+    # Install perl-dap if present in the archive
+    DAP_BINARY_PATH="$EXTRACTED_DIR/perl-dap"
+    if [ -f "$DAP_BINARY_PATH" ]; then
+        DAP_DEST_PATH="$INSTALL_DIR/perl-dap"
+        write_info "Installing perl-dap to $DAP_DEST_PATH"
+        if [ -f "$DAP_DEST_PATH" ]; then
+            rm -f "$DAP_DEST_PATH"
+        fi
+        cp "$DAP_BINARY_PATH" "$DAP_DEST_PATH"
+        chmod +x "$DAP_DEST_PATH"
+        write_success "Installed perl-dap to $DAP_DEST_PATH"
+    fi
 }
 
 # Verify installation


### PR DESCRIPTION
## Summary

The release workflow (`release.yml`) correctly builds and packages **both** `perl-lsp` and `perl-dap` into release tarballs for all 7 platform targets. However, all downstream distribution templates only installed `perl-lsp`, leaving `perl-dap` inaccessible to users installing via package managers or the shell installer.

## Audit Findings

### ✅ Release workflow (`release.yml`) — No issues
- **7 platform targets** in build matrix: all correct
  - `x86_64-unknown-linux-gnu` (ubuntu-22.04, native)
  - `aarch64-unknown-linux-gnu` (ubuntu-22.04, cross)
  - `x86_64-unknown-linux-musl` (ubuntu-22.04, cross)
  - `aarch64-unknown-linux-musl` (ubuntu-22.04, cross)
  - `x86_64-apple-darwin` (macos-13, native)
  - `aarch64-apple-darwin` (macos-14, native)
  - `x86_64-pc-windows-msvc` (windows-2022, native)
- **Binary naming**: Correct (`.exe` suffix on Windows, `.zip` vs `.tar.gz`)
- **Cross-compilation**: `cross` used for aarch64-linux and musl targets; stripping correctly skipped for cross builds
- **Both binaries** (`perl-lsp` + `perl-dap`) built and packaged

### ✅ Cross-compilation verification
- `cargo check -p perl-lsp --target x86_64-unknown-linux-musl` — passes
- `cargo check -p perl-dap --target x86_64-unknown-linux-musl` — passes

### ✅ `rust-toolchain.toml` — No issues
No `targets` key needed; the release workflow uses `dtolnay/rust-toolchain@stable` with explicit per-matrix targets.

### ✅ `Cargo.toml` — No issues
Target-specific deps only in `perl-dap` (`nix` for unix, `winapi` for windows) — correctly handled by `cfg()` attributes.

### 🔧 Fixed: Distribution templates missing `perl-dap`

| File | Issue |
|------|-------|
| `distribution/build-packages.sh` | Wrong crate: `-p perl-parser` → `-p perl-lsp` |
| `install.sh` | Only installed `perl-lsp`; now also installs `perl-dap` |
| `Formula/perl-lsp.rb` | Only installed `perl-lsp` binary |
| `distribution/homebrew/perl-lsp.rb` | Only installed `perl-lsp` binary |
| `distribution/scoop/perl-lsp.json` | Only shimmed `perl-lsp.exe` |
| `distribution/chocolatey/tools/chocolateyinstall.ps1` | Only shimmed `perl-lsp` |
| `distribution/chocolatey/tools/chocolateyuninstall.ps1` | Only removed `perl-lsp` shim |

All fixes use graceful fallback — `perl-dap` is installed only when present in the archive.

### ℹ️ Noted (not fixed, out of scope)
- `distribution/build-packages.sh` has hardcoded `VERSION="1.0.0"` and man page version — this script is a local helper, not used by CI
- No `aarch64-pc-windows-msvc` target (Windows ARM) — acceptable for now
- `distribution/build-packages.sh` only builds `perl-lsp` (not `perl-dap`) for .deb/.rpm — separate concern