### PR TITLE
docs: expand crate-level documentation for mid-tier crates

### DIFF
--- a/crates/perl-builtins/src/lib.rs
+++ b/crates/perl-builtins/src/lib.rs
@@ -1,4 +1,9 @@
-//! Builtin function signatures and metadata.
+//! Builtin function signatures and metadata for Perl.
+//!
+//! Provides [`BuiltinSignature`](builtin_signatures::BuiltinSignature) entries
+//! covering Perl's built-in functions, including signature variants and
+//! documentation strings. Used by the LSP completion, hover, and signature-help
+//! providers to surface accurate information without an external Perl runtime.
 
 pub mod builtin_signatures;
 pub mod builtin_signatures_phf;

--- a/crates/perl-keywords/src/lib.rs
+++ b/crates/perl-keywords/src/lib.rs
@@ -1,4 +1,9 @@
 //! Canonical Perl keyword inventories and allocation-free lookup helpers.
+//!
+//! Exports a single [`KEYWORDS`] constant containing the full set of Perl
+//! reserved words, pragmas, and special tokens. The list is used by the lexer,
+//! completion provider, and semantic-token highlighter to distinguish keywords
+//! from user-defined identifiers.
 
 /// Canonical union of keyword inventories used by the workspace.
 pub const KEYWORDS: &[&str] = &[

--- a/crates/perl-lsp-feature-contracts/src/lib.rs
+++ b/crates/perl-lsp-feature-contracts/src/lib.rs
@@ -1,4 +1,9 @@
 //! Shared feature contracts for profile parsing, BDD-grid rows, and capability mapping.
+//!
+//! This crate defines the canonical [`FeatureProfileKind`] enum and associated
+//! [`FeatureProfileSpec`] metadata used for feature-coverage reporting. It sits
+//! between `perl-lsp-feature-ids` (raw identifiers) and
+//! `perl-lsp-feature-policy` (runtime capability selection).
 
 use perl_lsp_feature_ids::*;
 use serde::Serialize;

--- a/crates/perl-refactoring/src/lib.rs
+++ b/crates/perl-refactoring/src/lib.rs
@@ -1,4 +1,8 @@
 //! Refactoring and modernization helpers for Perl.
+//!
+//! Provides AST-driven refactoring operations including import optimization,
+//! code modernization, and workspace-wide symbol rename. These are consumed by
+//! the LSP code-action and rename providers to offer automated transformations.
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -1,4 +1,9 @@
 //! Semantic analysis, symbol extraction, and type inference for Perl.
+//!
+//! Walks a parsed AST to build scoped symbol tables, resolve declarations and
+//! references, and perform lightweight type inference. The resulting semantic
+//! model powers go-to-definition, find-references, and diagnostic providers
+//! in the LSP server.
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]

--- a/crates/perl-tokenizer/src/lib.rs
+++ b/crates/perl-tokenizer/src/lib.rs
@@ -1,4 +1,9 @@
 //! Token stream and trivia utilities for the parser.
+//!
+//! Wraps the raw token output of `perl-lexer` into a position-aware
+//! [`TokenStream`] and preserves whitespace/comment trivia via the
+//! [`TriviaPreservingParser`]. Used by the parser and formatting provider
+//! to maintain lossless round-trip fidelity.
 
 #![deny(unsafe_code)]
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]

--- a/crates/perl-workspace-index/src/lib.rs
+++ b/crates/perl-workspace-index/src/lib.rs
@@ -1,4 +1,9 @@
 //! Workspace indexing and refactoring orchestration for Perl.
+//!
+//! Maintains an in-memory index of all symbols, references, and module
+//! declarations across a Perl workspace. Provides incremental update, a
+//! document store for open files, and coordinates cross-file operations
+//! such as workspace-wide rename and symbol search.
 
 #![deny(unsafe_code)]
 #![deny(unreachable_pub)]


### PR DESCRIPTION
## Summary


Each expanded block describes the crate's purpose, key types, and relationship to the broader workspace.

### Crates updated

| Crate | Previous | Now |
|-------|----------|-----|
| `perl-lsp-feature-contracts` | 1 line | 5 lines — adds type/layer context |
| `perl-builtins` | 1 line | 5 lines — describes LSP integration |
| `perl-keywords` | 1 line | 5 lines — explains consumer crates |
| `perl-refactoring` | 1 line | 4 lines — lists key operations |
| `perl-semantic-analyzer` | 1 line | 5 lines — explains semantic model |
| `perl-tokenizer` | 1 line | 5 lines — describes trivia fidelity |
| `perl-workspace-index` | 1 line | 5 lines — covers index capabilities |

### Verification

- `cargo doc --no-deps` passes with zero warnings for all seven crates
- Documentation-only change — no logic modified