### PR TITLE
docs: add missing package manager install methods and VS Code Marketplace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,39 @@ cargo install --path crates/perl-lsp
 
 ### Pre-built binaries
 
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), or use the installer script (best-effort / non-canonical) to install `perl-lsp`:
+Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), or use the installer scripts (best-effort / non-canonical):
 
 ```bash
+# Linux / macOS
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
+```
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew install perl-lsp
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop install perl-lsp
+```
+
+### Chocolatey (Windows)
+
+```powershell
+choco install perl-lsp
 ```
 
 ## Editor Setup
 
 ### VS Code
 
-Install the [perl-lsp extension](vscode-extension/) from the included VS Code extension source, or point any LSP-compatible extension at the `perl-lsp` binary.
+Install the **Perl Language Server** extension (`effortlesssteven.perl-lsp`) from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp), or build from [source](vscode-extension/).
 
 ### Neovim (nvim-lspconfig)
 


### PR DESCRIPTION
## Summary

Adds missing installation methods to README.md that already have CI automation but weren't documented:

- **Homebrew** (macOS/Linux) — `brew install perl-lsp` (via `brew-bump.yml` → Homebrew/homebrew-core)
- **Scoop** (Windows) — `scoop install perl-lsp` (via `scoop-bump.yml` → ScoopInstaller/Main)
- **Chocolatey** (Windows) — `choco install perl-lsp` (via `chocolatey-bump.yml` → chocolatey-community)
- **Windows installer script** — `install.ps1` alongside existing `install.sh`
- **VS Code Marketplace** — updated editor setup with extension ID and Marketplace link

No code changes. Documentation only.