### PR TITLE
fix(tree-sitter-perl): repair C binding crate so it builds standalone

### DIFF
--- a/tree-sitter-perl/Cargo.toml
+++ b/tree-sitter-perl/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "perl"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-perl"
-edition.workspace = true
+edition = "2021"
 autoexamples = false
 
 build = "bindings/rust/build.rs"
@@ -18,6 +18,9 @@ path = "bindings/rust/lib.rs"
 
 [dependencies]
 tree-sitter-language = "0.1.5"
+
+[dev-dependencies]
+tree-sitter = "0.25"
 
 [build-dependencies]
 cc = "1.2.46"

--- a/tree-sitter-perl/bindings/rust/build.rs
+++ b/tree-sitter-perl/bindings/rust/build.rs
@@ -13,17 +13,12 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 
     // If your language uses an external scanner written in C++,
     // then include this block of code:

--- a/tree-sitter-perl/bindings/rust/lib.rs
+++ b/tree-sitter-perl/bindings/rust/lib.rs
@@ -6,7 +6,8 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_perl::language()).expect("Error loading perl grammar");
+//! let language: tree_sitter::Language = tree_sitter_perl::language().into();
+//! parser.set_language(&language).expect("Error loading perl grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -15,38 +16,40 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_perl() -> Language;
+    fn tree_sitter_perl() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_perl() }
+/// Get the tree-sitter [LanguageFn][] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_perl) };
+
+/// Get the tree-sitter [LanguageFn][] for this grammar.
+pub fn language() -> LanguageFn {
+    LANGUAGE
 }
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
     #[test]
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
+        let language: tree_sitter::Language = super::language().into();
         parser
-            .set_language(super::language())
+            .set_language(&language)
             .expect("Error loading perl language");
     }
 }

--- a/tree-sitter-perl/src/bsearch.h
+++ b/tree-sitter-perl/src/bsearch.h
@@ -69,7 +69,7 @@ is respectively less than, matching, or greater than the array member.
  * have to make lim 3, then halve, obtaining 1, so that we will only
  * look at item 3.
  */
-static void *bsearch(const void *key, const void *base0, size_t nmemb, size_t size,
+static void *tsp_bsearch(const void *key, const void *base0, size_t nmemb, size_t size,
                      int (*compar)(const void *, const void *)) {
   const char *base = (const char *)base0;
   int lim, cmp;

--- a/tree-sitter-perl/src/tsp_unicode.h
+++ b/tree-sitter-perl/src/tsp_unicode.h
@@ -542,7 +542,7 @@ static const struct TSPRange tsp_id_start[] = {
 };
 
 static bool is_tsp_id_start (int32_t codepoint) {
-  return bsearch(&codepoint, tsp_id_start, sizeof(tsp_id_start) / sizeof(tsp_id_start[0]), sizeof(tsp_id_start[0]), tsprange_contains);
+  return tsp_bsearch(&codepoint, tsp_id_start, sizeof(tsp_id_start) / sizeof(tsp_id_start[0]), sizeof(tsp_id_start[0]), tsprange_contains);
 }
 
 static const struct TSPRange tsp_id_continue[] = {
@@ -1206,7 +1206,7 @@ static const struct TSPRange tsp_id_continue[] = {
 };
 
 static bool is_tsp_id_continue (int32_t codepoint) {
-  return bsearch(&codepoint, tsp_id_continue, sizeof(tsp_id_continue) / sizeof(tsp_id_continue[0]), sizeof(tsp_id_continue[0]), tsprange_contains);
+  return tsp_bsearch(&codepoint, tsp_id_continue, sizeof(tsp_id_continue) / sizeof(tsp_id_continue[0]), sizeof(tsp_id_continue[0]), tsprange_contains);
 }
 
 static const struct TSPRange tsp_whitespace[] = {
@@ -1222,5 +1222,5 @@ static const struct TSPRange tsp_whitespace[] = {
   { 12288, 12289 }
 };
 static bool is_tsp_whitespace (int32_t codepoint) {
-  return bsearch(&codepoint, tsp_whitespace, sizeof(tsp_whitespace) / sizeof(tsp_whitespace[0]), sizeof(tsp_whitespace[0]), tsprange_contains);
+  return tsp_bsearch(&codepoint, tsp_whitespace, sizeof(tsp_whitespace) / sizeof(tsp_whitespace[0]), sizeof(tsp_whitespace[0]), tsprange_contains);
 }


### PR DESCRIPTION
## Summary

The `tree-sitter-perl/` C binding crate (excluded from the workspace) had multiple issues preventing it from compiling. This PR fixes the Rust bindings, build script, and a C symbol conflict so the crate builds and tests pass standalone.

The workspace member `crates/tree-sitter-perl-rs/` was audited and is clean: 138 tests pass, clippy reports no warnings.

## Interface & compatibility

- perl-parser API: **unchanged**
- LSP surface: **unchanged**
- DAP surface: **unchanged**
- CLI: **unchanged**
- tree-sitter-perl C crate: **additive** (new `LANGUAGE` const, `HIGHLIGHTS_QUERY`, `INJECTIONS_QUERY` exports)

## What changed

| File | Fix |
|------|-----|
| `Cargo.toml` | `edition.workspace = true` → `edition = "2021"` (crate is excluded from workspace); added `tree-sitter = "0.25"` dev-dep for tests |
| `bindings/rust/build.rs` | Uncommented scanner.c compilation — parser.c references 39 external scanner tokens that require it |
| `bindings/rust/lib.rs` | Migrated from removed `tree_sitter::Language` API to `tree_sitter_language::LanguageFn`; exported `HIGHLIGHTS_QUERY` and `INJECTIONS_QUERY`; cleaned up redundant `'static` lifetimes |
| `src/bsearch.h` | Renamed `bsearch()` → `tsp_bsearch()` to avoid conflict with `<stdlib.h>` (now pulled in by tree-sitter's `alloc.h`) |
| `src/tsp_unicode.h` | Updated 3 call sites to use `tsp_bsearch()` |

## How to review

Start with `Cargo.toml` and `lib.rs` for the Rust binding modernization, then `build.rs` for the scanner fix, then the C headers for the symbol conflict.

## Evidence

```
# Excluded C crate (standalone build)
$ cd tree-sitter-perl && cargo test
test tests::test_can_load_grammar ... ok
test bindings/rust/lib.rs - (line 6) ... ok
test result: ok. 2 passed; 0 failed

# Workspace member (unchanged)
$ cargo test -p tree-sitter-perl --lib
test result: ok. 138 passed; 0 failed

$ cargo clippy -p tree-sitter-perl
Finished (no warnings)
```

## Risk & rollback

**Blast radius**: Only the excluded `tree-sitter-perl/` C binding crate. No workspace crates are affected.

**Rollback**: Revert this single commit.

## Follow-ups

- The `bsearch.h` rename should be upstreamed to [tree-sitter/tree-sitter-perl](https://github.com/tree-sitter/tree-sitter-perl)
- `locals.scm` and `tags.scm` queries are still missing (commented out in lib.rs)