### PR TITLE
fix(perl-corpus): use valid crates.io category slug

### DIFF
--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 documentation = "https://docs.rs/perl-corpus"
 homepage.workspace = true
 keywords = ["perl", "corpus", "proptest", "testing", "parser"]
-categories = ["development-tools", "testing"]
+categories = ["development-tools", "development-tools::testing"]
 include = ["src/**", "README.md", "LICENSE*", "Cargo.toml"]
 
 [lib]


### PR DESCRIPTION
## Summary

Audited all 23 publishable crates' `Cargo.toml` metadata for crates.io completeness. Every crate was checked for: `description`, `license`, `repository`, `keywords`, `categories`, `readme`, and `homepage`.

Found one issue: `perl-corpus` used `"testing"` as a category slug, which is not a valid top-level crates.io category. Changed it to `"development-tools::testing"`, which is the correct subcategory slug.

All other 22 publishable crates have complete and correct metadata.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-corpus/Cargo.toml`: `categories` field changed from `["development-tools", "testing"]` to `["development-tools", "development-tools::testing"]`.

The bare `testing` slug returns 404 from the crates.io API (`/api/v1/categories/testing`), while `development-tools::testing` is a valid subcategory.

## How to review

Single-line change in `crates/perl-corpus/Cargo.toml` line 14.

## Evidence

```
$ cargo check -p perl-corpus
Finished `dev` profile [optimized + debuginfo] target(s) in 25.89s

$ curl -s https://crates.io/api/v1/categories/testing
{"errors":[{"detail":"Not Found"}]}

$ curl -s https://crates.io/api/v1/categories/development-tools::testing | head -c 100
{"category":{"id":"development-tools::testing","category":"Testing","slug":"development-tools::testing"...
```

## Risk & rollback

Zero runtime risk — metadata-only change affecting only crate publishing. Rollback: revert the single line.

## Follow-ups

None.