### PR TITLE
ci: harden workflow permissions, concurrency, and secret scoping

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -17,6 +17,10 @@ concurrency:
   group: brew-bump-${{ github.ref }}
   cancel-in-progress: false  # Don't cancel brew bumps
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   bump:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -56,10 +56,10 @@ jobs:
   mutation:
     name: Mutation Testing
     if: |
-      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_mutation != 'false') ||
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'ci:mutation')) ||
-      (github.event_name == 'schedule' && github.event.inputs.run_mutation != 'false')
+       contains(github.event.pull_request.labels.*.name, 'ci:mutation'))
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,7 +27,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
 jobs:
   # Step 1: Compute topological publish order from cargo metadata
@@ -183,6 +182,7 @@ jobs:
 
       - name: Publish all crates
         env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           CRATES_JSON: ${{ needs.compute-order.outputs.crates }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -16,6 +16,9 @@ concurrency:
   group: publish-extension-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
   cancel-in-progress: false  # Don't cancel publishing
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,6 +29,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
 jobs:
   version-bump:
     name: Bump Version & Generate Changelog


### PR DESCRIPTION
## Summary

Systematic audit of all 13 GitHub Actions workflow files, following up on the SHA-pinning work in PR #911. This PR addresses **logic and configuration issues** — missing permissions blocks, missing concurrency guards, over-scoped secrets, and a faulty conditional expression.

Six issues found and fixed across six workflow files. No Rust code changes.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

| Workflow | Issue | Fix |
|---|---|---|
| `publish-extension.yml` | Missing `permissions` block | Added `contents: read` |
| `brew-bump.yml` | Missing `permissions` block | Added `contents: read`, `pull-requests: write` |
| `release.yml` | Missing top-level `permissions` block (only `release` job had one) | Added `contents: read` top-level default |
| `version-bump.yml` | Missing `concurrency` block (parallel bumps possible) | Added `concurrency: group: version-bump` |
| `publish-crates.yml` | `CARGO_REGISTRY_TOKEN` in top-level `env` leaked to all jobs (`compute-order`, `verify`) | Moved to `publish` job step-level `env` only |
| `ci-nightly.yml` | Mutation job condition `github.event.inputs.run_mutation != 'false'` on schedule events (schedule has no `inputs`) | Restructured: schedule always runs, `workflow_dispatch` gates on input, PR gates on label |

### Workflows reviewed and found clean (7)

`ci.yml`, `ci-security.yml`, `docker-publish.yml`, `docs-deploy.yml`, `release-orchestration.yml`, `chocolatey-bump.yml`, `scoop-bump.yml`

## How to review

Each change is a 1-4 line addition/rearrangement in a workflow YAML file. Review the diff file-by-file — all changes are self-contained.

The `ci-nightly.yml` mutation condition change is the most nuanced: the old condition *accidentally* worked (because `null != 'false'` is truthy in GitHub Actions expressions), but the intent was unclear and the logic was wrong.

## Evidence

All YAML files validated with Python yaml.safe_load — no syntax errors.

## Risk & rollback

**Blast radius**: CI/CD workflow behavior only. No source code changes.
**Failure mode**: Worst case, a workflow gets an extra permission denial (immediately visible in Actions logs).
**Rollback**: Revert this single commit.

## Follow-ups

- `brew-bump.yml`, `chocolatey-bump.yml`, `scoop-bump.yml` use `secrets.GITHUB_TOKEN` with `peter-evans/create-pull-request` targeting *external* repos — this won't work without a PAT with cross-repo scope. Tracked separately.