### PR TITLE
Add SRP microcrate discovery script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, [CODE_OF_CONDUCT.md](CODE
 - [LSP Implementation Guide](docs/LSP_IMPLEMENTATION_GUIDE.md) -- server architecture
 - [DAP User Guide](docs/DAP_USER_GUIDE.md) -- debugger setup and usage
 - [Stability Policy](docs/STABILITY.md) -- API versioning and compatibility
+- [SRP Microcrates](docs/SRP_MICROCRATES.md) -- inventory of single-responsibility microcrates
 - [features.toml](features.toml) -- canonical LSP feature catalog
 
 ## License

--- a/docs/SRP_MICROCRATES.md
+++ b/docs/SRP_MICROCRATES.md
@@ -1,0 +1,60 @@
+# SRP Microcrates
+
+This workspace uses **single-responsibility (SRP) microcrates** to keep behavior focused and reusable.
+
+To find and separate SRP-style microcrates from broader workspace crates, run:
+
+```bash
+scripts/list-srp-microcrates.py
+```
+
+The script scans each `crates/perl-*` crate for SRP signals (`single responsibility`, `SRP`, `microcrate`) in:
+
+- `Cargo.toml`
+- `README.md`
+- `src/lib.rs`
+
+## Current snapshot
+
+Detected `18` crates with SRP/microcrate signals.
+
+### `perl-module-*` (5)
+
+- `perl-module-name`
+- `perl-module-resolution-path`
+- `perl-module-resolution-uri`
+- `perl-module-token-core`
+- `perl-module-token-parser`
+
+### `perl-lsp-feature-*` (6)
+
+- `perl-lsp-feature-contracts`
+- `perl-lsp-feature-flags`
+- `perl-lsp-feature-grid`
+- `perl-lsp-feature-ids`
+- `perl-lsp-feature-policy`
+- `perl-lsp-feature-profile`
+
+### `perl-lsp-*` (2)
+
+- `perl-lsp-cancellation`
+- `perl-lsp-launcher`
+
+### `perl-workspace-*` (2)
+
+- `perl-workspace-folder`
+- `perl-workspace-index-slo`
+
+### `perl-ts-*` (2)
+
+- `perl-ts-heredoc-parser`
+- `perl-ts-partial-ast`
+
+### Core/misc (1)
+
+- `perl-text-line`
+
+## Notes
+
+- This is an intentionally conservative detector based on explicit SRP wording.
+- Add SRP wording to crate docs when introducing new microcrates so they are discovered by this inventory.

--- a/scripts/list-srp-microcrates.py
+++ b/scripts/list-srp-microcrates.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""List SRP-style microcrates in this workspace.
+
+A crate is classified as an SRP microcrate when at least one of these signals is present:
+- Cargo description contains "single responsibility" or "microcrate".
+- README contains "single responsibility", "SRP", or "microcrate".
+- src/lib.rs module docs contain "single responsibility" or "microcrate".
+
+The output is grouped by crate family prefixes to make extraction and maintenance easier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CRATES_DIR = REPO_ROOT / "crates"
+
+SIGNAL_PATTERNS = [
+    re.compile(r"\bsingle responsibility\b", re.IGNORECASE),
+    re.compile(r"\bmicrocrate\b", re.IGNORECASE),
+    re.compile(r"\bSRP\b", re.IGNORECASE),
+]
+
+FAMILY_PREFIXES = [
+    "perl-module-",
+    "perl-lsp-feature-",
+    "perl-lsp-",
+    "perl-dap-",
+    "perl-workspace-",
+    "perl-ts-",
+    "perl-",
+]
+
+
+@dataclass
+class CrateMatch:
+    name: str
+    signals: list[str]
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _has_signal(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SIGNAL_PATTERNS)
+
+
+def find_srp_microcrates() -> list[CrateMatch]:
+    matches: list[CrateMatch] = []
+
+    for crate_dir in sorted(p for p in CRATES_DIR.iterdir() if p.is_dir()):
+        crate_name = crate_dir.name
+        if not crate_name.startswith("perl-"):
+            continue
+        cargo_toml = _read_text(crate_dir / "Cargo.toml")
+        readme = _read_text(crate_dir / "README.md")
+        lib_rs = _read_text(crate_dir / "src/lib.rs")
+
+        crate_signals: list[str] = []
+        if _has_signal(cargo_toml):
+            crate_signals.append("Cargo.toml")
+        if _has_signal(readme):
+            crate_signals.append("README.md")
+        if _has_signal(lib_rs):
+            crate_signals.append("src/lib.rs")
+
+        if crate_signals:
+            matches.append(CrateMatch(name=crate_name, signals=crate_signals))
+
+    return matches
+
+
+def family_key(crate_name: str) -> tuple[int, str]:
+    for idx, prefix in enumerate(FAMILY_PREFIXES):
+        if crate_name.startswith(prefix):
+            return idx, crate_name
+    return len(FAMILY_PREFIXES), crate_name
+
+
+def main() -> None:
+    matches = find_srp_microcrates()
+    grouped: dict[str, list[CrateMatch]] = {}
+
+    for match in sorted(matches, key=lambda m: family_key(m.name)):
+        family = "core/misc"
+        for prefix in FAMILY_PREFIXES:
+            if prefix != "perl-" and match.name.startswith(prefix):
+                family = prefix
+                break
+        grouped.setdefault(family, []).append(match)
+
+    print("# SRP microcrate inventory")
+    print()
+    print(f"Detected {len(matches)} crates with SRP/microcrate signals.")
+    print()
+
+    for family in sorted(grouped.keys()):
+        crates = grouped[family]
+        print(f"## {family} ({len(crates)})")
+        for crate in crates:
+            sources = ", ".join(crate.signals)
+            print(f"- {crate.name} ({sources})")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a reproducible inventory of single-responsibility (SRP) microcrates so maintainers can identify and separate narrowly-focused crates across the workspace. 
- Make SRP discovery conservative and explicit by detecting crates that already document SRP/microcrate intent. 

### Description
- Add `scripts/list-srp-microcrates.py`, a script that scans `crates/perl-*` for SRP signals in `Cargo.toml`, `README.md`, and `src/lib.rs` and groups matches by family prefixes. 
- Add `docs/SRP_MICROCRATES.md` with a current snapshot, family grouping, and regeneration instructions using `scripts/list-srp-microcrates.py`. 
- Link the SRP inventory from the root `README.md` so the inventory is discoverable from the project landing page. 

### Testing
- Ran `scripts/list-srp-microcrates.py` and redirected its output to `/tmp/srp.out`, which reported `Detected 18 crates with SRP/microcrate signals`, confirming the detector runs successfully. 
- Inspected the generated output via `sed` to verify the produced family grouping and listed crate names match the repository contents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366cc05588333b57c68d143ba7c3c)