### PR TITLE
Add SRP microcrate inventory command

### DIFF
--- a/justfile
+++ b/justfile
@@ -550,6 +550,10 @@ ci-lsp-microcrates:
                    -p perl-lsp-launcher
     @echo "✅ LSP microcrate compatibility tests passed"
 
+# Enumerate SRP-focused microcrates by responsibility family
+list-srp-microcrates:
+    @bash scripts/find-srp-microcrates.sh
+
 # Framework semantic depth receipts (Moo/Moose/Class::Accessor)
 ci-semantic-frameworks:
     @echo "🧠 Running framework semantic tests..."

--- a/scripts/find-srp-microcrates.sh
+++ b/scripts/find-srp-microcrates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -d crates ]]; then
+  echo "error: crates/ directory not found" >&2
+  exit 1
+fi
+
+collect() {
+  local label="$1"
+  shift
+  local -a matches=()
+
+  while IFS= read -r dir; do
+    matches+=("${dir#crates/}")
+  done < <(find crates -maxdepth 1 -mindepth 1 -type d "$@" | sort)
+
+  echo "$label (${#matches[@]})"
+  for crate in "${matches[@]}"; do
+    echo "  - $crate"
+  done
+  echo
+}
+
+echo "SRP microcrate inventory"
+echo "========================"
+echo
+
+collect "Module microcrates" -name 'perl-module-*'
+collect "LSP feature governance microcrates" -name 'perl-lsp-feature-*'
+collect "LSP support microcrates" \( -name 'perl-lsp-cancellation' -o -name 'perl-lsp-launcher' \)
+collect "DAP microcrates" \( -name 'perl-dap-breakpoint' -o -name 'perl-dap-eval' -o -name 'perl-dap-stack' -o -name 'perl-dap-variables' \)
+collect "Workspace/index microcrates" \( -name 'perl-workspace-discovery' -o -name 'perl-workspace-index-slo' \)
+collect "Cross-cutting utility microcrates" \( -name 'perl-content-length-framing' -o -name 'perl-path-security' -o -name 'perl-position-tracking' -o -name 'perl-qualified-name' -o -name 'perl-source-file' -o -name 'perl-text-line' -o -name 'perl-uri' \)


### PR DESCRIPTION
### Motivation
- Provide a quick way to discover and group single-responsibility (SRP) microcrates by responsibility family to aid refactoring and review. 
- Make the inventory callable from the repo root as a standard developer task.

### Description
- Add `scripts/find-srp-microcrates.sh`, an executable helper that enumerates microcrates under `crates/` and groups them into responsibility families (module microcrates, LSP feature governance/support, DAP, workspace/index, cross-cutting utilities). 
- Add a `just` target `list-srp-microcrates` that runs `bash scripts/find-srp-microcrates.sh` for a one-command workflow. 
- Changes are limited to `scripts/find-srp-microcrates.sh` (new, executable) and `justfile` (new target).

### Testing
- Ran `bash scripts/find-srp-microcrates.sh` and verified it prints grouped microcrate lists (success). 
- Attempted `just list-srp-microcrates` in this environment but `just` is not installed so the target could not be executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366c7547483339c66188fd37fe11a)