### PR TITLE
Add SRP microcrate discovery script

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ cargo clippy --workspace --lib && cargo fmt --all
 
 # Full local gate (requires Nix)
 nix develop -c just ci-gate
+
+# Find SRP-focused microcrates in the workspace
+scripts/find_srp_microcrates.sh
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for our community standards, [SUPPORT.md](SUPPORT.md) for how to get help, and [CLAUDE.md](CLAUDE.md) for the full command reference.

--- a/scripts/find_srp_microcrates.sh
+++ b/scripts/find_srp_microcrates.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Identify workspace crates that explicitly declare SRP/microcrate intent.
+# A crate qualifies if any of these files mention "single responsibility" or "microcrate":
+#   - README.md
+#   - src/lib.rs
+#   - src/main.rs
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+patterns=('single responsibility' 'microcrate')
+
+printf "%-40s | %s\n" "crate" "matched file"
+printf '%s\n' "$(printf '%.0s-' {1..72})"
+
+for crate_dir in crates/*; do
+    [[ -d "$crate_dir" ]] || continue
+
+    crate_name="$(basename "$crate_dir")"
+    matched_file=""
+
+    for candidate in "README.md" "src/lib.rs" "src/main.rs"; do
+        path="$crate_dir/$candidate"
+        [[ -f "$path" ]] || continue
+
+        for pattern in "${patterns[@]}"; do
+            if rg -q -i "$pattern" "$path"; then
+                matched_file="$candidate"
+                break 2
+            fi
+        done
+    done
+
+    if [[ -n "$matched_file" ]]; then
+        printf "%-40s | %s\n" "$crate_name" "$matched_file"
+    fi
+done | sort


### PR DESCRIPTION
### Motivation

- Provide a simple, fast way to locate workspace crates that explicitly declare single-responsibility / microcrate intent to aid refactoring and microcrate separation efforts.

### Description

- Add `scripts/find_srp_microcrates.sh`, which scans `crates/*` and checks `README.md`, `src/lib.rs`, and `src/main.rs` for the phrases `single responsibility` or `microcrate`, then prints a stable, sorted table of matching crates and the file where the phrase was found.
- Document the new utility in the `README.md` `Development` section by adding the `scripts/find_srp_microcrates.sh` invocation.

### Testing

- Ran a syntax check with `bash -n scripts/find_srp_microcrates.sh`, which succeeded.
- Executed `scripts/find_srp_microcrates.sh | head -n 60` to validate output, which produced the expected list of matching crates and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366c23a188333bf6d5fb0a0102a7f)