### PR TITLE
Add SRP microcrate discovery script and just target

### DIFF
--- a/justfile
+++ b/justfile
@@ -550,6 +550,11 @@ ci-lsp-microcrates:
                    -p perl-lsp-launcher
     @echo "✅ LSP microcrate compatibility tests passed"
 
+# Workspace SRP microcrate inventory (family + metadata driven)
+srp-microcrates:
+    @echo "🧭 Discovering SRP microcrates in workspace..."
+    @bash scripts/find_srp_microcrates.sh
+
 # Framework semantic depth receipts (Moo/Moose/Class::Accessor)
 ci-semantic-frameworks:
     @echo "🧠 Running framework semantic tests..."

--- a/scripts/find_srp_microcrates.sh
+++ b/scripts/find_srp_microcrates.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Focused families that intentionally model single-responsibility microcrates.
+readonly srp_prefixes=(
+  "perl-module-"
+  "perl-lsp-feature-"
+  "perl-dap-"
+  "perl-ts-"
+  "perl-workspace-"
+)
+
+mapfile -t crate_dirs < <(find crates -mindepth 1 -maxdepth 1 -type d | sort)
+
+srp_crates=()
+other_crates=()
+
+for dir in "${crate_dirs[@]}"; do
+  crate_name="$(basename "$dir")"
+
+  is_srp=0
+  for prefix in "${srp_prefixes[@]}"; do
+    if [[ "$crate_name" == "$prefix"* ]]; then
+      is_srp=1
+      break
+    fi
+  done
+
+  # Some SRP crates do not use family prefixes; discover by crate metadata.
+  if [[ $is_srp -eq 0 ]] && [[ -f "$dir/Cargo.toml" ]]; then
+    if rg -q --max-count 1 '(?i)single responsibility|srp|microcrate' "$dir/Cargo.toml"; then
+      is_srp=1
+    fi
+  fi
+
+  if [[ $is_srp -eq 0 ]] && [[ -f "$dir/README.md" ]]; then
+    if rg -q --max-count 1 '(?i)single responsibility|srp|microcrate' "$dir/README.md"; then
+      is_srp=1
+    fi
+  fi
+
+  if [[ $is_srp -eq 1 ]]; then
+    srp_crates+=("$crate_name")
+  else
+    other_crates+=("$crate_name")
+  fi
+done
+
+printf 'SRP microcrates (%d):\n' "${#srp_crates[@]}"
+printf '  - %s\n' "${srp_crates[@]}"
+printf '\nNon-SRP/composition crates (%d):\n' "${#other_crates[@]}"
+printf '  - %s\n' "${other_crates[@]}"


### PR DESCRIPTION
### Motivation
- Provide a simple workspace inventory to separate small single-responsibility (SRP) microcrates from composition/application crates for auditing and modularization efforts.
- Enable easy, repeatable discovery using both family-prefix heuristics and lightweight metadata hints to keep the classification up-to-date without changing build behavior.

### Description
- Add an executable script `scripts/find_srp_microcrates.sh` that scans `crates/*` and classifies crates as SRP or non-SRP using family prefixes (`perl-module-*`, `perl-lsp-feature-*`, `perl-dap-*`, `perl-ts-*`, `perl-workspace-*`) and by searching `Cargo.toml`/`README.md` for keywords (`single responsibility`, `srp`, `microcrate`).
- Add a `just` target `srp-microcrates` which runs the script via `just srp-microcrates` to make the inventory accessible as a standard developer command.
- The change is additive and only affects repository tooling; it does not modify build or runtime code paths.

### Testing
- Ran the script locally with `bash scripts/find_srp_microcrates.sh` and it completed successfully (produced an SRP list and a non-SRP list). 
- The command reported the classification output without errors (script executed successfully and exited with status 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366a8992083339d12444295308ca6)