### PR TITLE
docs: improve crate-level documentation for LSP protocol and feature-policy crates

### DIFF
--- a/crates/perl-lsp-feature-policy/src/lib.rs
+++ b/crates/perl-lsp-feature-policy/src/lib.rs
@@ -1,7 +1,10 @@
 //! LSP feature policy and capability profile helpers.
 //!
 //! This microcrate centralizes capability set selection, turning high-level profile
-//! decisions into runtime `BuildFlags` and catalog-oriented feature IDs.
+//! decisions (e.g. `ga-lock`, `production`, `all`) into runtime [`BuildFlags`] and
+//! catalog-oriented feature IDs. It bridges [`FeatureProfileKind`] to the
+//! [`AdvertisedFeatures`] projection consumed by server startup and the
+//! `initialize` response.
 
 use perl_lsp_feature_contracts::advertised_features;
 use perl_lsp_feature_flags::{AdvertisedFeatures, BuildFlags};

--- a/crates/perl-lsp-protocol/src/lib.rs
+++ b/crates/perl-lsp-protocol/src/lib.rs
@@ -1,7 +1,12 @@
 //! JSON-RPC protocol types, error handling, and capabilities for perl-lsp.
 //!
 //! This crate isolates protocol types from the LSP runtime so they can be
-//! shared across binaries and provider layers.
+//! shared across binaries and provider layers. Key modules:
+//!
+//! - `jsonrpc` — Core JSON-RPC 2.0 request, response, and error message types
+//! - `errors` — Standard and LSP-specific JSON-RPC error codes and builders
+//! - [`methods`] — LSP 3.17 method name constants for request/notification routing
+//! - [`capabilities`] — Server capability configuration advertised during `initialize`
 
 #![deny(unsafe_code)]
 #![warn(missing_docs)]


### PR DESCRIPTION
## Summary


### Changes

- **`perl-lsp-protocol`** (4 → 9 lines): enumerate the four key modules (`jsonrpc`, `errors`, `methods`, `capabilities`) so readers can discover the crate's structure at a glance.
- **`perl-lsp-feature-policy`** (4 → 7 lines): mention concrete profile names (`ga-lock`, `production`, `all`), link to `BuildFlags`/`AdvertisedFeatures`/`FeatureProfileKind` types, and note the `initialize` response as the downstream consumer.

### Audit


### Verification

- `cargo check -p perl-lsp-protocol -p perl-lsp-feature-policy` passes cleanly
- No logic changes — documentation only