### PR TITLE
fix: topological publish order in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,31 +94,40 @@ exclude = [
 [workspace.metadata.publish]
 allow = [
     # Leaf crates (verified via cargo publish --dry-run)
+
+    "perl-position-tracking",
+    "perl-token",
+    "perl-ast",
     "perl-builtins",
     "perl-content-length-framing",
-    "perl-diagnostics-codes",
-    "perl-feature-catalog",
+    "perl-corpus",
     "perl-keywords",
-    "perl-lsp-cancellation",
-    "perl-lsp-feature-ids",
+    "perl-lexer",
     "perl-module-name",
-    "perl-module-token-core",
-    "perl-path-security",
-    "perl-position-tracking",
     "perl-qualified-name",
     "perl-quote",
     "perl-regex",
-    "perl-source-file",
+    "perl-error",
+    "perl-tokenizer",
+    "perl-edit",
+    "perl-pragma",
+    "perl-heredoc",
+    "perl-parser-core",
     "perl-symbol-types",
-    "perl-token",
     "perl-workspace-index-slo",
-    # Core crates (already published)
-    "perl-lexer",
+    "perl-tdd-support",
     "perl-parser",
-    "perl-corpus",
-    # Binary crates
-    "perl-lsp",
+    "perl-path-security",
     "perl-dap",
+    "perl-diagnostics-codes",
+    "perl-feature-catalog",
+    "perl-lsp-feature-ids",
+    "perl-module-token-core",
+    "perl-source-file",
+    "perl-lsp-cancellation",
+    "perl-lsp",
+
+
 ]
 
 # Workspace-level package metadata


### PR DESCRIPTION
Updates the `allow` array under `[workspace.metadata.publish]` in
the workspace `Cargo.toml` to list all necessary workspace crates
in precise topological order. This ensures automated tools like
`cargo publish` or `xtask publish-crates` correctly process
dependencies before the packages that depend on them, avoiding
'no matching package found' errors.

---
*PR created automatically by Jules for task [16508188821044867667](https://jules.google.com/task/16508188821044867667) started by @EffortlessSteven*