### PR TITLE
Extract LSP limits into SRP microcrate (perl-lsp-limits)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "perl-lsp-formatting",
  "perl-lsp-inlay-hints",
  "perl-lsp-launcher",
+ "perl-lsp-limits",
  "perl-lsp-navigation",
  "perl-lsp-protocol",
  "perl-lsp-providers",
@@ -1885,6 +1886,13 @@ version = "0.10.0"
 dependencies = [
  "perl-lsp-feature-governance",
  "perl-tdd-support",
+]
+
+[[package]]
+name = "perl-lsp-limits"
+version = "0.10.0"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/perl-lsp-completion",
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
+    "crates/perl-lsp-limits",
     "crates/perl-lsp-feature-policy",
     "crates/perl-diagnostics-codes",
     "crates/perl-position-tracking",
@@ -192,6 +193,7 @@ perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version =
 perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.10.0" }
 perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.10.0" }
 perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.10.0" }
+perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
 perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.10.0" }
 perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.10.0" }
 perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.10.0" }

--- a/crates/perl-lsp-limits/Cargo.toml
+++ b/crates/perl-lsp-limits/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "perl-lsp-limits"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for bounded LSP limits and deadline policy"
+readme = "README.md"
+
+[dependencies]
+serde_json = "1.0.149"
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-limits/README.md
+++ b/crates/perl-lsp-limits/README.md
@@ -1,0 +1,14 @@
+# perl-lsp-limits
+
+Standalone microcrate for LSP operation limits and deadline policy.
+
+## Scope
+
+This crate owns:
+
+- Result caps (`workspace_symbol_cap`, `references_cap`, etc.)
+- Deadlines for bounded request latency
+- Cache and indexing guardrails
+- Global, thread-safe limit state and helper accessors
+
+Keeping these concerns in one place supports SRP and allows other crates to share the same bounded behavior contract.

--- a/crates/perl-lsp-limits/src/lib.rs
+++ b/crates/perl-lsp-limits/src/lib.rs
@@ -14,7 +14,7 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! use perl_parser::lsp::state::LspLimits;
+//! use perl_lsp_limits::LspLimits;
 //!
 //! let limits = LspLimits::default();
 //! let results = my_query().take(limits.references_result_cap);

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -27,6 +27,7 @@ perl-parser = { workspace = true, features = ["test-performance"] }
 perl-lsp-providers = { workspace = true, features = ["lsp-compat"] }
 perl-lsp-formatting = { workspace = true }
 perl-lsp-cancellation = { workspace = true }
+perl-lsp-limits = { workspace = true }
 perl-lsp-feature-governance = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-lsp-protocol = { workspace = true }

--- a/crates/perl-lsp/src/state/mod.rs
+++ b/crates/perl-lsp/src/state/mod.rs
@@ -8,8 +8,7 @@
 
 mod config;
 mod document;
-mod limits;
 
 pub use config::*;
 pub use document::*;
-pub use limits::*;
+pub use perl_lsp_limits::*;


### PR DESCRIPTION
### Motivation

- Isolate LSP limits, deadline policy, and related guardrails behind a single-responsibility microcrate to reduce runtime crate surface and improve ownership of bounded-behavior policy. 

### Description

- Moved `crates/perl-lsp/src/state/limits.rs` into a new microcrate `crates/perl-lsp-limits` at `src/lib.rs` and kept the implementation, singleton, accessors, and tests intact. 
- Added `crates/perl-lsp-limits/Cargo.toml` and `crates/perl-lsp-limits/README.md` to document scope and dependencies. 
- Wired the new microcrate into the workspace and dependency graph by updating the top-level `Cargo.toml` and `crates/perl-lsp/Cargo.toml` to include `perl-lsp-limits`. 
- Preserved existing `crate::state::*` call sites by re-exporting the microcrate from `crates/perl-lsp/src/state/mod.rs` (`pub use perl_lsp_limits::*;`).

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perl-lsp-limits` and all microcrate unit tests passed (4 passed). 
- Ran `cargo test -p perl-lsp --lib` and the library test suite passed (all executed tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366b6ff3c8333a7f8703d7fc23166)