### PR TITLE
Extract workspace skip-directory policy into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ name = "perl-workspace-discovery"
 version = "0.10.0"
 dependencies = [
  "perl-source-file",
+ "perl-workspace-skip",
  "proptest",
  "tempfile",
  "walkdir",
@@ -2435,6 +2436,10 @@ dependencies = [
  "parking_lot",
  "proptest",
 ]
+
+[[package]]
+name = "perl-workspace-skip"
+version = "0.10.0"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/perl-text-line",
     "crates/perl-keywords",
     "crates/perl-source-file",
+    "crates/perl-workspace-skip",
     "crates/perl-content-length-framing",
     "crates/perl-uri",
     "crates/perl-path-security",
@@ -185,6 +186,7 @@ allow = [
     "perl-module-resolution-uri",
     "perl-module-resolution",
     "perl-source-file",
+    "perl-workspace-skip",
     "perl-workspace-discovery",
     "perl-diagnostics-codes",
 
@@ -236,6 +238,7 @@ perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", versi
 perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.10.0" }
 perl-keywords = { path = "crates/perl-keywords", version = "0.10.0" }
 perl-source-file = { path = "crates/perl-source-file", version = "0.10.0" }
+perl-workspace-skip = { path = "crates/perl-workspace-skip", version = "0.10.0" }
 perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }

--- a/crates/perl-workspace-discovery/Cargo.toml
+++ b/crates/perl-workspace-discovery/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-source-file = { workspace = true }
+perl-workspace-skip = { workspace = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -8,7 +8,8 @@
 //! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`).
 
 use perl_source_file::is_perl_source_path;
-use std::path::{Component, Path, PathBuf};
+use perl_workspace_skip::{path_contains_skipped_component, should_skip_dir_name};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
 
@@ -145,20 +146,7 @@ fn should_skip_dir(entry: &DirEntry) -> bool {
     }
 
     let name = entry.file_name().to_string_lossy();
-    matches!(name.as_ref(), ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-}
-
-fn path_contains_skipped_component(path: &Path) -> bool {
-    for component in path.components() {
-        if let Component::Normal(name) = component
-            && let Some(value) = name.to_str()
-            && matches!(value, ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-        {
-            return true;
-        }
-    }
-
-    false
+    should_skip_dir_name(name.as_ref())
 }
 
 fn log_discovery(result: &DiscoveryResult) {

--- a/crates/perl-workspace-skip/Cargo.toml
+++ b/crates/perl-workspace-skip/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-workspace-skip"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-workspace-skip"
+description = "Shared workspace skip-directory policy helpers"
+readme = "README.md"
+keywords = ["perl", "workspace", "lsp", "filesystem"]
+categories = ["development-tools", "filesystem"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-skip/README.md
+++ b/crates/perl-workspace-skip/README.md
@@ -1,0 +1,6 @@
+# perl-workspace-skip
+
+Shared helpers for consistent workspace directory skip policies.
+
+This crate centralizes conventional non-source directory filtering used by
+workspace traversal components.

--- a/crates/perl-workspace-skip/src/lib.rs
+++ b/crates/perl-workspace-skip/src/lib.rs
@@ -1,0 +1,50 @@
+//! Shared skip-directory policy for workspace scanning.
+//!
+//! Consumers can use these helpers to apply the same conservative filtering
+//! rules for non-source directories across git output parsing and filesystem walking.
+
+use std::path::{Component, Path};
+
+const SKIPPED_DIRECTORIES: [&str; 6] = [".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+
+/// Returns true when `name` is one of the conventional non-source directory names.
+#[must_use]
+pub fn should_skip_dir_name(name: &str) -> bool {
+    SKIPPED_DIRECTORIES.contains(&name)
+}
+
+/// Returns true when any path component should be skipped.
+#[must_use]
+pub fn path_contains_skipped_component(path: &Path) -> bool {
+    for component in path.components() {
+        if let Component::Normal(name) = component
+            && let Some(value) = name.to_str()
+            && should_skip_dir_name(value)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{path_contains_skipped_component, should_skip_dir_name};
+    use std::path::Path;
+
+    #[test]
+    fn skipped_names_are_recognized() {
+        assert!(should_skip_dir_name(".git"));
+        assert!(should_skip_dir_name("node_modules"));
+        assert!(should_skip_dir_name("target"));
+        assert!(!should_skip_dir_name("src"));
+    }
+
+    #[test]
+    fn path_components_are_scanned() {
+        assert!(path_contains_skipped_component(Path::new("/repo/target/build/Foo.pm")));
+        assert!(path_contains_skipped_component(Path::new("/repo/node_modules/pkg.pm")));
+        assert!(!path_contains_skipped_component(Path::new("/repo/lib/Foo.pm")));
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication by separating the workspace skip-directory policy from discovery logic so multiple traversal/indexing components can share a single canonical implementation.
- Improve SRP boundaries: keep discovery orchestration (git/WalkDir strategy, timing, reporting) separate from the simple rule-set that decides which directories to skip.
- Make the skip policy discoverable and testable independently to avoid future drift between consumers.

### Description

- Added a new microcrate `crates/perl-workspace-skip` providing `should_skip_dir_name(&str) -> bool` and `path_contains_skipped_component(&Path) -> bool` as the canonical skip-policy helpers in `src/lib.rs`.
- Updated `crates/perl-workspace-discovery` to consume `perl_workspace_skip::{path_contains_skipped_component, should_skip_dir_name}` and removed the previous inline skip logic (`should_skip_dir` / `path_contains_skipped_component`) while preserving behavior.
- Wired the new crate into the workspace by adding `crates/perl-workspace-skip` to the workspace `members`, adding `perl-workspace-skip` to the publish allowlist and `workspace.dependencies` in the root `Cargo.toml`, and adding a workspace dependency entry in `crates/perl-workspace-discovery/Cargo.toml`.
- Local lockfile now includes the new package entry (updated `Cargo.lock`).

### Testing

- Ran formatting: `cargo fmt --all`, which completed successfully.
- Ran unit/integration tests for the modified area: `cargo test -p perl-workspace-skip -p perl-workspace-discovery`, and all tests passed.
- Ran linting: `cargo clippy --workspace`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64befa48333be756bb871cd9dc2)