### PR TITLE
Split Perl keyword snippet templates into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ version = "0.10.0"
 dependencies = [
  "lsp-types",
  "perl-keywords",
+ "perl-lsp-keyword-snippets",
  "perl-parser-core",
  "perl-semantic-analyzer",
  "perl-tdd-support",
@@ -1880,6 +1881,10 @@ dependencies = [
  "perl-tdd-support",
  "serde_json",
 ]
+
+[[package]]
+name = "perl-lsp-keyword-snippets"
+version = "0.10.0"
 
 [[package]]
 name = "perl-lsp-launcher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
     "crates/perl-lsp-limits",
+    "crates/perl-lsp-keyword-snippets",
     "crates/perl-lsp-feature-policy",
     "crates/perl-diagnostics-codes",
     "crates/perl-position-tracking",
@@ -171,6 +172,7 @@ allow = [
     "perl-lsp-feature-governance",
     "perl-lsp-launcher",
     "perl-lsp-limits",
+    "perl-lsp-keyword-snippets",
     "perl-lsp-protocol",
     "perl-lsp-transport",
 
@@ -264,6 +266,7 @@ perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.10.0
 perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.10.0" }
 perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.10.0" }
 perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
+perl-lsp-keyword-snippets = { path = "crates/perl-lsp-keyword-snippets", version = "0.10.0" }
 perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.10.0" }
 perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.10.0" }
 perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.10.0" }

--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -21,6 +21,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-keywords = { workspace = true }
+perl-lsp-keyword-snippets = { workspace = true }
 lsp-types = { version = "0.97.0", optional = true }
 url = "2.5.8"
 walkdir = "2.5.0"

--- a/crates/perl-lsp-completion/src/completion/keywords.rs
+++ b/crates/perl-lsp-completion/src/completion/keywords.rs
@@ -4,6 +4,7 @@
 
 use super::{context::CompletionContext, items::CompletionItem};
 use perl_keywords::LSP_COMPLETION_KEYWORDS;
+use perl_lsp_keyword_snippets::template_for_keyword;
 
 /// Canonical Perl keywords for completion.
 #[must_use]
@@ -19,19 +20,9 @@ pub fn add_keyword_completions(
 ) {
     for &keyword in keywords {
         if keyword.starts_with(&context.prefix) {
-            let (insert_text, snippet) = match keyword {
-                "sub" => ("sub ${1:name} {\n    $0\n}", true),
-                "if" => ("if ($1) {\n    $0\n}", true),
-                "elsif" => ("elsif ($1) {\n    $0\n}", true),
-                "else" => ("else {\n    $0\n}", true),
-                "unless" => ("unless ($1) {\n    $0\n}", true),
-                "while" => ("while ($1) {\n    $0\n}", true),
-                "for" => ("for (my $i = 0; $i < $1; $i++) {\n    $0\n}", true),
-                "foreach" => ("foreach my $${1:item} (@${2:array}) {\n    $0\n}", true),
-                "package" => ("package ${1:Name};\n\n$0", true),
-                "use" => ("use ${1:Module};\n$0", true),
-                _ => (keyword, false),
-            };
+            let template = template_for_keyword(keyword);
+            let (insert_text, snippet) =
+                if template.is_snippet { (template.insert_text, true) } else { (keyword, false) };
 
             completions.push(CompletionItem {
                 label: keyword.to_string(),

--- a/crates/perl-lsp-keyword-snippets/Cargo.toml
+++ b/crates/perl-lsp-keyword-snippets/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "perl-lsp-keyword-snippets"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for Perl keyword completion templates and snippet metadata"
+readme = "README.md"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-keyword-snippets/README.md
+++ b/crates/perl-lsp-keyword-snippets/README.md
@@ -1,0 +1,3 @@
+# perl-lsp-keyword-snippets
+
+Centralized snippet templates and snippet/keyword classification for Perl LSP keyword completion.

--- a/crates/perl-lsp-keyword-snippets/src/lib.rs
+++ b/crates/perl-lsp-keyword-snippets/src/lib.rs
@@ -1,0 +1,53 @@
+//! Snippet templates for Perl keyword completion.
+
+/// Completion template metadata for a Perl keyword.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeywordTemplate {
+    /// Text inserted into the document when the keyword is accepted.
+    pub insert_text: &'static str,
+    /// Whether `insert_text` is an LSP snippet.
+    pub is_snippet: bool,
+}
+
+/// Returns completion template metadata for a Perl keyword.
+#[must_use]
+pub fn template_for_keyword(keyword: &str) -> KeywordTemplate {
+    match keyword {
+        "sub" => KeywordTemplate { insert_text: "sub ${1:name} {\n    $0\n}", is_snippet: true },
+        "if" => KeywordTemplate { insert_text: "if ($1) {\n    $0\n}", is_snippet: true },
+        "elsif" => KeywordTemplate { insert_text: "elsif ($1) {\n    $0\n}", is_snippet: true },
+        "else" => KeywordTemplate { insert_text: "else {\n    $0\n}", is_snippet: true },
+        "unless" => KeywordTemplate { insert_text: "unless ($1) {\n    $0\n}", is_snippet: true },
+        "while" => KeywordTemplate { insert_text: "while ($1) {\n    $0\n}", is_snippet: true },
+        "for" => KeywordTemplate {
+            insert_text: "for (my $i = 0; $i < $1; $i++) {\n    $0\n}",
+            is_snippet: true,
+        },
+        "foreach" => KeywordTemplate {
+            insert_text: "foreach my $${1:item} (@${2:array}) {\n    $0\n}",
+            is_snippet: true,
+        },
+        "package" => KeywordTemplate { insert_text: "package ${1:Name};\n\n$0", is_snippet: true },
+        "use" => KeywordTemplate { insert_text: "use ${1:Module};\n$0", is_snippet: true },
+        _ => KeywordTemplate { insert_text: "", is_snippet: false },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::template_for_keyword;
+
+    #[test]
+    fn returns_snippet_templates_for_structured_keywords() {
+        let template = template_for_keyword("sub");
+        assert!(template.is_snippet);
+        assert_eq!(template.insert_text, "sub ${1:name} {\n    $0\n}");
+    }
+
+    #[test]
+    fn returns_non_snippet_for_plain_keywords() {
+        let template = template_for_keyword("return");
+        assert!(!template.is_snippet);
+        assert_eq!(template.insert_text, "");
+    }
+}


### PR DESCRIPTION
### Motivation

- Separate the keyword snippet/template policy from the completion orchestration to follow SRP and make snippet templates reusable and easier to maintain.

### Description

- Add a new microcrate `perl-lsp-keyword-snippets` that exports `KeywordTemplate` and `template_for_keyword` and includes focused unit tests.
- Replace the inline keyword->snippet match table in `perl-lsp-completion::completion::keywords` with calls to `template_for_keyword` and preserve existing completion assembly.
- Wire the new crate into the workspace by adding it to `members`, the workspace `publish.allow` list, and `workspace.dependencies`, and add `perl-lsp-keyword-snippets` as a dependency of `perl-lsp-completion`.
- Add unit tests for snippet and non-snippet behavior in the new crate and update `perl-lsp-completion` to use the microcrate.

### Testing

- Ran formatting with `cargo fmt --all`, which completed successfully.
- Executed unit tests with `cargo test -p perl-lsp-keyword-snippets -p perl-lsp-completion`, and all tests passed (`perl-lsp-completion` tests and `perl-lsp-keyword-snippets` tests succeeded).
- Ran lint checks with `cargo clippy -p perl-lsp-keyword-snippets -p perl-lsp-completion --all-targets -- -D warnings`, which completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64befa48333be756bb871cd9dc2)