### PR TITLE
Extract workspace ignore logic into a dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ name = "perl-workspace-discovery"
 version = "0.10.0"
 dependencies = [
  "perl-source-file",
+ "perl-workspace-ignore",
  "proptest",
  "tempfile",
  "walkdir",
@@ -2408,6 +2409,10 @@ dependencies = [
  "tempfile",
  "url",
 ]
+
+[[package]]
+name = "perl-workspace-ignore"
+version = "0.10.0"
 
 [[package]]
 name = "perl-workspace-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/perl-text-line",
     "crates/perl-keywords",
     "crates/perl-source-file",
+    "crates/perl-workspace-ignore",
     "crates/perl-content-length-framing",
     "crates/perl-uri",
     "crates/perl-path-security",
@@ -118,6 +119,7 @@ allow = [
     "perl-edit",
     "perl-incremental-parsing",
     "perl-symbol-types",
+    "perl-workspace-ignore",
     "perl-uri",
     "perl-workspace-index-slo",
 
@@ -218,6 +220,7 @@ perl-error = { path = "crates/perl-error", version = "0.10.0" }
 perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.10.0" }
 perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.10.0" }
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
 perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
 perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }

--- a/crates/perl-workspace-discovery/Cargo.toml
+++ b/crates/perl-workspace-discovery/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-source-file = { workspace = true }
+perl-workspace-ignore = { workspace = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -8,7 +8,10 @@
 //! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`).
 
 use perl_source_file::is_perl_source_path;
-use std::path::{Component, Path, PathBuf};
+use perl_workspace_ignore::{
+    is_ignored_workspace_dir_name, path_contains_ignored_workspace_component,
+};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
 
@@ -87,7 +90,7 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
         }
 
         let relative_path = Path::new(entry);
-        if path_contains_skipped_component(relative_path) {
+        if path_contains_ignored_workspace_component(relative_path) {
             excluded_count += 1;
             continue;
         }
@@ -145,20 +148,7 @@ fn should_skip_dir(entry: &DirEntry) -> bool {
     }
 
     let name = entry.file_name().to_string_lossy();
-    matches!(name.as_ref(), ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-}
-
-fn path_contains_skipped_component(path: &Path) -> bool {
-    for component in path.components() {
-        if let Component::Normal(name) = component
-            && let Some(value) = name.to_str()
-            && matches!(value, ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-        {
-            return true;
-        }
-    }
-
-    false
+    is_ignored_workspace_dir_name(name.as_ref())
 }
 
 fn log_discovery(result: &DiscoveryResult) {
@@ -173,10 +163,7 @@ fn log_discovery(result: &DiscoveryResult) {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DiscoveryMethod, parse_git_ls_files_output, path_contains_skipped_component,
-        should_skip_dir, walk_discovery,
-    };
+    use super::{DiscoveryMethod, parse_git_ls_files_output, should_skip_dir, walk_discovery};
     use std::fs;
     use std::path::Path;
     use std::time::Instant;
@@ -203,13 +190,6 @@ mod tests {
         assert!(files.iter().any(|path| path.ends_with("lib/Foo.pm")));
         assert!(files.iter().any(|path| path.ends_with("script.pl")));
         assert_eq!(excluded_count, 2);
-    }
-
-    #[test]
-    fn skipped_component_detection_is_consistent() {
-        assert!(path_contains_skipped_component(Path::new("/repo/node_modules/pkg.pm")));
-        assert!(path_contains_skipped_component(Path::new("/repo/target/build/generated.pm")));
-        assert!(!path_contains_skipped_component(Path::new("/repo/lib/My/Module.pm")));
     }
 
     #[test]

--- a/crates/perl-workspace-ignore/Cargo.toml
+++ b/crates/perl-workspace-ignore/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-workspace-ignore"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-workspace-ignore"
+description = "Shared workspace ignore rules for discovery/indexing crates"
+readme = "README.md"
+keywords = ["perl", "workspace", "ignore", "lsp"]
+categories = ["development-tools", "filesystem"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-ignore/LICENSE-APACHE
+++ b/crates/perl-workspace-ignore/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/perl-workspace-ignore/LICENSE-MIT
+++ b/crates/perl-workspace-ignore/LICENSE-MIT
@@ -1,0 +1,7 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/perl-workspace-ignore/README.md
+++ b/crates/perl-workspace-ignore/README.md
@@ -1,0 +1,8 @@
+# perl-workspace-ignore
+
+Shared ignore rules for workspace walking/discovery crates.
+
+## API
+
+- `is_ignored_workspace_dir_name` checks if a directory name should be pruned.
+- `path_contains_ignored_workspace_component` checks if any path component is ignored.

--- a/crates/perl-workspace-ignore/src/lib.rs
+++ b/crates/perl-workspace-ignore/src/lib.rs
@@ -1,0 +1,50 @@
+//! Shared workspace ignore rules used by filesystem discovery/indexing crates.
+
+use std::path::{Component, Path};
+
+const IGNORED_WORKSPACE_DIRS: [&str; 6] =
+    [".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+
+/// Returns `true` when `name` matches a conventional workspace noise directory.
+#[must_use]
+pub fn is_ignored_workspace_dir_name(name: &str) -> bool {
+    IGNORED_WORKSPACE_DIRS.contains(&name)
+}
+
+/// Returns `true` if any normal path component is an ignored workspace directory.
+#[must_use]
+pub fn path_contains_ignored_workspace_component(path: &Path) -> bool {
+    for component in path.components() {
+        if let Component::Normal(name) = component
+            && let Some(value) = name.to_str()
+            && is_ignored_workspace_dir_name(value)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_ignored_workspace_dir_name, path_contains_ignored_workspace_component};
+    use std::path::Path;
+
+    #[test]
+    fn known_noise_dirs_are_ignored() {
+        assert!(is_ignored_workspace_dir_name(".git"));
+        assert!(is_ignored_workspace_dir_name("target"));
+        assert!(is_ignored_workspace_dir_name("node_modules"));
+        assert!(!is_ignored_workspace_dir_name("src"));
+    }
+
+    #[test]
+    fn path_component_detection_only_checks_normal_components() {
+        assert!(path_contains_ignored_workspace_component(Path::new("/repo/node_modules/pkg.pm")));
+        assert!(path_contains_ignored_workspace_component(Path::new(
+            "/repo/target/build/generated.pm"
+        )));
+        assert!(!path_contains_ignored_workspace_component(Path::new("/repo/lib/My/Module.pm")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce responsibility of the discovery crate by extracting workspace ignore rules so they can be reused by other indexing/discovery components.
- Centralize the list of conventional noise directories (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`) and the path/component checks behind a focused API.
- Improve single-responsibility and testability of the workspace discovery code by removing duplicated helper logic.

### Description
- Add a new microcrate `perl-workspace-ignore` exposing `is_ignored_workspace_dir_name` and `path_contains_ignored_workspace_component` with unit tests.
- Update `perl-workspace-discovery` to depend on `perl-workspace-ignore` and replace local helper logic (`path_contains_skipped_component` / inline matches) with calls to `path_contains_ignored_workspace_component` and `is_ignored_workspace_dir_name`.
- Wire the new crate into the workspace by adding it to `members`, `workspace.dependencies`, and the publish `allow` list, and update the lockfile to reflect the new package dependency.

### Testing
- Ran `cargo test -p perl-workspace-ignore -p perl-workspace-discovery` and all tests passed successfully.
- Ran `cargo clippy -p perl-workspace-ignore -p perl-workspace-discovery --all-targets -- -D warnings` with no warnings reported.
- Ran `cargo fmt --all` to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64d2ba48333bd3b2564272f19c1)