### PR TITLE
Extract subprocess runtime into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "lsp-types",
  "moka",
  "perl-parser-core",
+ "perl-subprocess-runtime",
  "perl-tdd-support",
  "serde",
 ]
@@ -2268,6 +2269,10 @@ dependencies = [
 
 [[package]]
 name = "perl-source-file"
+version = "0.10.0"
+
+[[package]]
+name = "perl-subprocess-runtime"
 version = "0.10.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/perl-lsp-protocol",
     "crates/perl-lsp-transport",
     "crates/perl-lsp-tooling",
+    "crates/perl-subprocess-runtime",
     "crates/perl-lsp-formatting",
     "crates/perl-lsp-diagnostics",
     "crates/perl-lsp-semantic-tokens",
@@ -103,6 +104,7 @@ allow = [
     "perl-ast",
     "perl-builtins",
     "perl-content-length-framing",
+    "perl-subprocess-runtime",
     "perl-keywords",
     "perl-lexer",
     "perl-regex",
@@ -238,6 +240,7 @@ perl-keywords = { path = "crates/perl-keywords", version = "0.10.0" }
 perl-source-file = { path = "crates/perl-source-file", version = "0.10.0" }
 perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
 perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -21,6 +21,7 @@ default = ["lsp-compat"]
 lsp-compat = ["dep:lsp-types"]
 
 [dependencies]
+perl-subprocess-runtime = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }

--- a/crates/perl-lsp-tooling/src/lib.rs
+++ b/crates/perl-lsp-tooling/src/lib.rs
@@ -31,15 +31,13 @@ pub mod performance;
 pub mod perl_critic;
 /// Perltidy integration for code formatting.
 pub mod perltidy;
-mod subprocess_runtime;
 
-pub use subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
+pub use perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use subprocess_runtime::OsSubprocessRuntime;
+pub use perl_subprocess_runtime::OsSubprocessRuntime;
 
 /// Test mock implementations for subprocess runtimes.
-#[cfg(test)]
 pub mod mock {
-    pub use crate::subprocess_runtime::mock::*;
+    pub use perl_subprocess_runtime::mock::*;
 }

--- a/crates/perl-lsp-tooling/src/perl_critic.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic.rs
@@ -3,11 +3,11 @@
 //! This module provides integration with Perl::Critic for static code analysis
 //! and policy enforcement in Perl code.
 
-use super::subprocess_runtime::SubprocessRuntime;
 use perl_parser_core::{
     Node,
     position::{Position, Range},
 };
+use perl_subprocess_runtime::SubprocessRuntime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -132,7 +132,7 @@ impl CriticAnalyzer {
     /// Creates a new analyzer with the OS subprocess runtime (non-WASM only).
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_os_runtime(config: CriticConfig) -> Self {
-        use super::subprocess_runtime::OsSubprocessRuntime;
+        use perl_subprocess_runtime::OsSubprocessRuntime;
         Self::new(config, Arc::new(OsSubprocessRuntime::new()))
     }
 
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         // Mock perlcritic output format: file:line:column:severity:policy:message
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_caching() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_config_args() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));

--- a/crates/perl-lsp-tooling/src/perltidy.rs
+++ b/crates/perl-lsp-tooling/src/perltidy.rs
@@ -3,7 +3,7 @@
 //! This module provides integration with perltidy for automatic code formatting
 //! and beautification of Perl code.
 
-use super::subprocess_runtime::SubprocessRuntime;
+use perl_subprocess_runtime::SubprocessRuntime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -185,7 +185,7 @@ impl PerlTidyFormatter {
     /// Creates a new formatter with the OS subprocess runtime (non-WASM only).
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_os_runtime(config: PerlTidyConfig) -> Self {
-        use super::subprocess_runtime::OsSubprocessRuntime;
+        use perl_subprocess_runtime::OsSubprocessRuntime;
         Self::new(config, Arc::new(OsSubprocessRuntime::new()))
     }
 
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_formatter_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"my $x = 1;\n".to_vec()));
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_formatter_caching() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"formatted\n".to_vec()));
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_formatter_error_handling() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::failure(b"syntax error".to_vec(), 1));
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_format_file_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));

--- a/crates/perl-subprocess-runtime/Cargo.toml
+++ b/crates/perl-subprocess-runtime/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-subprocess-runtime"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Shared subprocess execution abstraction with OS and mock runtimes"
+readme = "README.md"
+documentation = "https://docs.rs/perl-subprocess-runtime"
+keywords = ["perl", "subprocess", "runtime", "testing"]
+categories = ["development-tools"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-subprocess-runtime/README.md
+++ b/crates/perl-subprocess-runtime/README.md
@@ -1,0 +1,9 @@
+# perl-subprocess-runtime
+
+Shared subprocess execution primitives for Perl LSP ecosystem crates.
+
+Provides:
+
+- `SubprocessRuntime` trait
+- `OsSubprocessRuntime` implementation (non-WASM)
+- `mock` module for deterministic tests

--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -1,7 +1,13 @@
 //! Subprocess execution abstraction for provider purity
 //!
-//! This module provides a trait-based abstraction for subprocess execution,
+//! This crate provides a trait-based abstraction for subprocess execution,
 //! enabling testing with mock implementations and WASM compatibility.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
 
 use std::fmt;
 
@@ -55,24 +61,9 @@ impl fmt::Display for SubprocessError {
 
 impl std::error::Error for SubprocessError {}
 
-/// Abstraction trait for subprocess execution
-///
-/// This trait allows providers to execute external commands without
-/// directly depending on `std::process::Command`, enabling:
-/// - Unit testing with mock implementations
-/// - WASM compatibility with alternative implementations
-/// - Sandboxing and security controls
+/// Abstraction trait for subprocess execution.
 pub trait SubprocessRuntime: Send + Sync {
-    /// Execute a command with the given arguments and optional stdin
-    ///
-    /// # Arguments
-    /// * `program` - The program to execute (e.g., "perltidy", "perlcritic")
-    /// * `args` - Command line arguments
-    /// * `stdin` - Optional data to write to the process's stdin
-    ///
-    /// # Returns
-    /// * `Ok(SubprocessOutput)` - The command completed (check status_code for success)
-    /// * `Err(SubprocessError)` - The command failed to start or other I/O error
+    /// Execute a command with the given arguments and optional stdin.
     fn run_command(
         &self,
         program: &str,
@@ -81,15 +72,13 @@ pub trait SubprocessRuntime: Send + Sync {
     ) -> Result<SubprocessOutput, SubprocessError>;
 }
 
-/// Default implementation using `std::process::Command`
-///
-/// This implementation is only available on non-WASM targets.
+/// Default implementation using `std::process::Command`.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct OsSubprocessRuntime;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl OsSubprocessRuntime {
-    /// Create a new OS subprocess runtime
+    /// Create a new OS subprocess runtime.
     pub fn new() -> Self {
         Self
     }
@@ -116,7 +105,6 @@ impl SubprocessRuntime for OsSubprocessRuntime {
         let mut cmd = Command::new(program);
         cmd.args(args);
 
-        // Configure stdin based on whether we need to write to it
         if stdin.is_some() {
             cmd.stdin(Stdio::piped());
         }
@@ -124,12 +112,10 @@ impl SubprocessRuntime for OsSubprocessRuntime {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        // Spawn the process
         let mut child = cmd
             .spawn()
             .map_err(|e| SubprocessError::new(format!("Failed to start {}: {}", program, e)))?;
 
-        // Write to stdin if provided
         if let Some(input) = stdin
             && let Some(mut child_stdin) = child.stdin.take()
         {
@@ -138,7 +124,6 @@ impl SubprocessRuntime for OsSubprocessRuntime {
             })?;
         }
 
-        // Wait for completion
         let output = child
             .wait_with_output()
             .map_err(|e| SubprocessError::new(format!("Failed to wait for {}: {}", program, e)))?;
@@ -151,62 +136,61 @@ impl SubprocessRuntime for OsSubprocessRuntime {
     }
 }
 
-/// Mock subprocess runtime for testing
-///
-/// This implementation allows tests to define expected command invocations
-/// and their responses without actually executing subprocesses.
-#[cfg(test)]
+/// Mock subprocess runtime for testing.
 pub mod mock {
     use super::*;
-    use perl_tdd_support::must;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, MutexGuard};
 
-    /// A recorded command invocation
+    fn lock<'a, T>(mutex: &'a Mutex<T>) -> MutexGuard<'a, T> {
+        match mutex.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// A recorded command invocation.
     #[derive(Debug, Clone)]
     pub struct CommandInvocation {
-        /// The program that was called
+        /// The program that was called.
         pub program: String,
-        /// The arguments passed
+        /// The arguments passed.
         pub args: Vec<String>,
-        /// The stdin data provided
+        /// The stdin data provided.
         pub stdin: Option<Vec<u8>>,
     }
 
-    /// Builder for mock responses
+    /// Builder for mock responses.
     #[derive(Debug, Clone)]
     pub struct MockResponse {
-        /// Stdout to return
+        /// Stdout to return.
         pub stdout: Vec<u8>,
-        /// Stderr to return
+        /// Stderr to return.
         pub stderr: Vec<u8>,
-        /// Status code to return
+        /// Status code to return.
         pub status_code: i32,
     }
 
     impl MockResponse {
-        /// Create a successful mock response with the given stdout
+        /// Create a successful mock response with the given stdout.
         pub fn success(stdout: impl Into<Vec<u8>>) -> Self {
             Self { stdout: stdout.into(), stderr: Vec::new(), status_code: 0 }
         }
 
-        /// Create a failed mock response with the given stderr
+        /// Create a failed mock response with the given stderr.
         pub fn failure(stderr: impl Into<Vec<u8>>, status_code: i32) -> Self {
             Self { stdout: Vec::new(), stderr: stderr.into(), status_code }
         }
     }
 
-    /// Mock subprocess runtime for testing
+    /// Mock subprocess runtime for testing.
     pub struct MockSubprocessRuntime {
-        /// Recorded invocations
         invocations: Arc<Mutex<Vec<CommandInvocation>>>,
-        /// Responses to return (in order)
         responses: Arc<Mutex<Vec<MockResponse>>>,
-        /// Default response if responses are exhausted
         default_response: MockResponse,
     }
 
     impl MockSubprocessRuntime {
-        /// Create a new mock runtime with a default successful response
+        /// Create a new mock runtime with a default successful response.
         pub fn new() -> Self {
             Self {
                 invocations: Arc::new(Mutex::new(Vec::new())),
@@ -215,24 +199,24 @@ pub mod mock {
             }
         }
 
-        /// Add a response to be returned for the next command
+        /// Add a response to be returned for the next command.
         pub fn add_response(&self, response: MockResponse) {
-            must(self.responses.lock()).push(response);
+            lock(&self.responses).push(response);
         }
 
-        /// Set the default response when no queued responses remain
+        /// Set the default response when no queued responses remain.
         pub fn set_default_response(&mut self, response: MockResponse) {
             self.default_response = response;
         }
 
-        /// Get all recorded invocations
+        /// Get all recorded invocations.
         pub fn invocations(&self) -> Vec<CommandInvocation> {
-            must(self.invocations.lock()).clone()
+            lock(&self.invocations).clone()
         }
 
-        /// Clear recorded invocations
+        /// Clear recorded invocations.
         pub fn clear_invocations(&self) {
-            must(self.invocations.lock()).clear();
+            lock(&self.invocations).clear();
         }
     }
 
@@ -249,16 +233,14 @@ pub mod mock {
             args: &[&str],
             stdin: Option<&[u8]>,
         ) -> Result<SubprocessOutput, SubprocessError> {
-            // Record the invocation
-            must(self.invocations.lock()).push(CommandInvocation {
+            lock(&self.invocations).push(CommandInvocation {
                 program: program.to_string(),
                 args: args.iter().map(|s| s.to_string()).collect(),
                 stdin: stdin.map(|s| s.to_vec()),
             });
 
-            // Get the next response or use default
             let response = {
-                let mut responses = must(self.responses.lock());
+                let mut responses = lock(&self.responses);
                 if responses.is_empty() {
                     self.default_response.clone()
                 } else {
@@ -278,7 +260,6 @@ pub mod mock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perl_tdd_support::must;
 
     #[test]
     fn test_subprocess_output_success() {
@@ -309,7 +290,10 @@ mod tests {
         let result = runtime.run_command("perltidy", &["-st"], Some(b"my $x = 1;"));
 
         assert!(result.is_ok());
-        let output = must(result);
+        let output = match result {
+            Ok(output) => output,
+            Err(_) => panic!("expected ok subprocess output"),
+        };
         assert!(output.success());
         assert_eq!(output.stdout_lossy(), "formatted code");
 
@@ -324,12 +308,13 @@ mod tests {
     #[test]
     fn test_os_runtime_echo() {
         let runtime = OsSubprocessRuntime::new();
-
-        // Test with echo which should be available on most systems
         let result = runtime.run_command("echo", &["hello"], None);
 
         assert!(result.is_ok());
-        let output = must(result);
+        let output = match result {
+            Ok(output) => output,
+            Err(_) => panic!("expected ok subprocess output"),
+        };
         assert!(output.success());
         assert!(output.stdout_lossy().trim() == "hello");
     }


### PR DESCRIPTION
### Motivation

- Reduce coupling and follow single-responsibility by extracting the subprocess execution abstraction out of `perl-lsp-tooling` into a focused microcrate for reuse and cleaner dependency graphs.
- The change improves testability (shared `mock` runtime) and enables other crates to depend on subprocess primitives without pulling the entire `perl-lsp-tooling` surface.

### Description

- Added a new crate `crates/perl-subprocess-runtime` that provides `SubprocessRuntime`, `SubprocessOutput`, `SubprocessError`, `OsSubprocessRuntime` (non-WASM) and a `mock` module for deterministic tests, moving the former implementation out of `perl-lsp-tooling`.
- Updated `crates/perl-lsp-tooling` to depend on and re-export types from `perl_subprocess_runtime` so the public tooling API remains stable while the implementation is split out.
- Updated `perltidy` and `perl_critic` modules to import runtime primitives from `perl_subprocess_runtime` and replaced the old local references.
- Wired the new microcrate into the workspace by adding it to `Cargo.toml` members, the publish allowlist, and `workspace.dependencies`, and removed the duplicated source file from `perl-lsp-tooling`.

### Testing

- Ran `cargo fmt --all` successfully to apply formatting.
- Ran `cargo test -p perl-subprocess-runtime -p perl-lsp-tooling -p perl-lsp-formatting` and all tests passed (6 tests for `perl-subprocess-runtime`, 19 tests for `perl-lsp-tooling`, 3 tests for `perl-lsp-formatting`).
- Ran `cargo test -p perl-lsp-providers --test microcrate_reexports_compatibility` and the compatibility tests passed (3 tests).
- Ran `cargo clippy -p perl-subprocess-runtime -p perl-lsp-tooling --all-targets -- -D warnings` with no warnings reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64d2ba48333bd3b2564272f19c1)