### PR TITLE
Split formatting DTOs into dedicated `perl-lsp-formatting-types` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,10 +1881,17 @@ dependencies = [
 name = "perl-lsp-formatting"
 version = "0.10.0"
 dependencies = [
+ "perl-lsp-formatting-types",
  "perl-lsp-tooling",
  "perl-tdd-support",
- "serde",
  "thiserror",
+]
+
+[[package]]
+name = "perl-lsp-formatting-types"
+version = "0.10.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/perl-lsp-transport",
     "crates/perl-lsp-tooling",
     "crates/perl-subprocess-runtime",
+    "crates/perl-lsp-formatting-types",
     "crates/perl-lsp-formatting",
     "crates/perl-lsp-diagnostics",
     "crates/perl-lsp-semantic-tokens",
@@ -145,6 +146,7 @@ allow = [
     # Tier 4 — LSP providers
     "perl-lsp-navigation",
     "perl-lsp-tooling",
+    "perl-lsp-formatting-types",
     "perl-lsp-formatting",
     "perl-lsp-semantic-tokens",
     "perl-lsp-providers",
@@ -264,6 +266,7 @@ perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "
 perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
+perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.10.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
 perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }
 perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0" }

--- a/crates/perl-lsp-formatting-types/Cargo.toml
+++ b/crates/perl-lsp-formatting-types/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "perl-lsp-formatting-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Shared formatting DTOs for perl-lsp formatting workflows"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-formatting-types"
+keywords = ["perl", "lsp", "formatting", "text-edit"]
+categories = ["development-tools", "text-editors"]
+
+[lib]
+doctest = false
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-formatting-types/README.md
+++ b/crates/perl-lsp-formatting-types/README.md
@@ -1,0 +1,12 @@
+# perl-lsp-formatting-types
+
+Shared DTOs for Perl LSP formatting requests/results:
+
+- `FormattingOptions`
+- `FormatPosition`
+- `FormatRange`
+- `FormatTextEdit`
+- `FormattedDocument`
+
+This crate exists to keep transport-safe formatting data structures isolated from
+perltidy process execution logic (`perl-lsp-formatting`).

--- a/crates/perl-lsp-formatting-types/src/lib.rs
+++ b/crates/perl-lsp-formatting-types/src/lib.rs
@@ -1,0 +1,128 @@
+//! Shared formatting types for Perl LSP integrations.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use serde::{Deserialize, Serialize};
+
+/// Text edit for formatting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatTextEdit {
+    /// The range to replace.
+    pub range: FormatRange,
+    /// The new text.
+    #[serde(rename = "newText")]
+    pub new_text: String,
+}
+
+/// Position in a document (UTF-16 based).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatPosition {
+    /// Line position (0-based).
+    pub line: u32,
+    /// Character position (UTF-16, 0-based).
+    pub character: u32,
+}
+
+impl FormatPosition {
+    /// Create a new position.
+    pub fn new(line: u32, character: u32) -> Self {
+        Self { line, character }
+    }
+}
+
+/// Range in a document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatRange {
+    /// Start position.
+    pub start: FormatPosition,
+    /// End position.
+    pub end: FormatPosition,
+}
+
+impl FormatRange {
+    /// Create a range covering the entire document.
+    pub fn whole_document(content: &str) -> Self {
+        let lines: Vec<&str> = content.lines().collect();
+        let last_line = if lines.is_empty() { 0 } else { (lines.len() - 1) as u32 };
+
+        FormatRange {
+            start: FormatPosition { line: 0, character: 0 },
+            end: FormatPosition {
+                line: last_line,
+                character: lines.get(last_line as usize).map(|line| line.len() as u32).unwrap_or(0),
+            },
+        }
+    }
+
+    /// Create a new range from positions.
+    pub fn new(start: FormatPosition, end: FormatPosition) -> Self {
+        Self { start, end }
+    }
+}
+
+/// Formatting options.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FormattingOptions {
+    /// Size of a tab in spaces.
+    #[serde(rename = "tabSize")]
+    pub tab_size: u32,
+    /// Prefer spaces over tabs.
+    #[serde(rename = "insertSpaces")]
+    pub insert_spaces: bool,
+    /// Trim trailing whitespace on a line.
+    #[serde(rename = "trimTrailingWhitespace")]
+    pub trim_trailing_whitespace: Option<bool>,
+    /// Insert a newline character at the end of the file.
+    #[serde(rename = "insertFinalNewline")]
+    pub insert_final_newline: Option<bool>,
+    /// Trim all newlines after the final newline at the end of the file.
+    #[serde(rename = "trimFinalNewlines")]
+    pub trim_final_newlines: Option<bool>,
+}
+
+/// Formatted document result.
+#[derive(Debug, Clone)]
+pub struct FormattedDocument {
+    /// The formatted text.
+    pub text: String,
+    /// Text edits to apply formatting.
+    pub edits: Vec<FormatTextEdit>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_formatting_options() {
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(true),
+            trim_final_newlines: Some(true),
+        };
+
+        assert_eq!(options.tab_size, 4);
+        assert!(options.insert_spaces);
+    }
+
+    #[test]
+    fn test_format_position() {
+        let position = FormatPosition::new(5, 10);
+        assert_eq!(position.line, 5);
+        assert_eq!(position.character, 10);
+    }
+
+    #[test]
+    fn test_format_range() {
+        let start = FormatPosition::new(0, 0);
+        let end = FormatPosition::new(10, 20);
+        let range = FormatRange::new(start, end);
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.end.line, 10);
+    }
+}

--- a/crates/perl-lsp-formatting/Cargo.toml
+++ b/crates/perl-lsp-formatting/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 perl-lsp-tooling = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
+perl-lsp-formatting-types = { workspace = true }
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/crates/perl-lsp-formatting/src/formatting.rs
+++ b/crates/perl-lsp-formatting/src/formatting.rs
@@ -1,139 +1,42 @@
-//! Code formatting support using Perl::Tidy for Perl parsing workflow pipeline
-//!
-//! This module provides integration with perltidy for code formatting of Perl scripts
-//! throughout the LSP workflow, ensuring consistent code style and readability for
-//! large-scale Perl parsing operations.
-//!
-//! # LSP Workflow Integration
-//!
-//! Formatting operations are integrated across LSP workflow stages:
-//! - **Extract**: Format Perl scripts during initial processing for consistency
-//! - **Normalize**: Apply standardized formatting rules to Perl parsing code
-//! - **Thread**: Maintain readable formatting during control flow analysis
-//! - **Render**: Ensure consistent output formatting for processed Perl scripts
-//! - **Index**: Generate consistently formatted code for indexing and search
-//!
-//! # Performance Characteristics
-//!
-//! Optimized for enterprise-scale Perl script formatting:
-//! - **large Perl codebase Support**: Efficient handling of large Perl script collections
-//! - **Incremental Formatting**: Format only changed code sections for performance
-//! - **Graceful Degradation**: Continues operation even when perltidy is unavailable
-//! - **Memory Efficient**: Streams large files to minimize memory usage during formatting
+//! Code formatting support using Perl::Tidy for Perl parsing workflow pipeline.
 
-use serde::{Deserialize, Serialize};
+pub use perl_lsp_formatting_types::{
+    FormatPosition, FormatRange, FormatTextEdit, FormattedDocument, FormattingOptions,
+};
 
-/// Text edit for formatting
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FormatTextEdit {
-    /// The range to replace
-    pub range: FormatRange,
-    /// The new text
-    #[serde(rename = "newText")]
-    pub new_text: String,
-}
-
-/// Position in a document (UTF-16 based)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FormatPosition {
-    /// Line position (0-based)
-    pub line: u32,
-    /// Character position (UTF-16, 0-based)
-    pub character: u32,
-}
-
-/// Range in a document
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FormatRange {
-    /// Start position
-    pub start: FormatPosition,
-    /// End position
-    pub end: FormatPosition,
-}
-
-impl FormatRange {
-    /// Create a range covering the entire document
-    pub fn whole_document(content: &str) -> Self {
-        let lines: Vec<&str> = content.lines().collect();
-        let last_line = if lines.is_empty() { 0 } else { (lines.len() - 1) as u32 };
-
-        FormatRange {
-            start: FormatPosition { line: 0, character: 0 },
-            end: FormatPosition {
-                line: last_line,
-                character: lines.get(last_line as usize).map(|l| l.len() as u32).unwrap_or(0),
-            },
-        }
-    }
-
-    /// Create a new range from positions
-    pub fn new(start: FormatPosition, end: FormatPosition) -> Self {
-        Self { start, end }
-    }
-}
-
-/// Formatting options
-#[derive(Debug, Clone, Deserialize)]
-pub struct FormattingOptions {
-    /// Size of a tab in spaces
-    #[serde(rename = "tabSize")]
-    pub tab_size: u32,
-    /// Prefer spaces over tabs
-    #[serde(rename = "insertSpaces")]
-    pub insert_spaces: bool,
-    /// Trim trailing whitespace on a line
-    #[serde(rename = "trimTrailingWhitespace")]
-    pub trim_trailing_whitespace: Option<bool>,
-    /// Insert a newline character at the end of the file
-    #[serde(rename = "insertFinalNewline")]
-    pub insert_final_newline: Option<bool>,
-    /// Trim all newlines after the final newline at the end of the file
-    #[serde(rename = "trimFinalNewlines")]
-    pub trim_final_newlines: Option<bool>,
-}
-
-/// Formatted document result
-#[derive(Debug, Clone)]
-pub struct FormattedDocument {
-    /// The formatted text
-    pub text: String,
-    /// Text edits to apply formatting
-    pub edits: Vec<FormatTextEdit>,
-}
-
-/// Formatting error
+/// Formatting error.
 #[derive(Debug, thiserror::Error)]
 pub enum FormattingError {
     #[error(
         "perltidy not found: {0}\n\nTo install perltidy:\n  - CPAN: cpan Perl::Tidy\n  - Debian/Ubuntu: apt-get install perltidy\n  - RedHat/Fedora: yum install perltidy\n  - macOS: brew install perltidy\n  - Windows: cpan Perl::Tidy"
     )]
-    /// perltidy executable not found on system PATH
+    /// perltidy executable not found on system PATH.
     PerltidyNotFound(String),
 
-    /// Error occurred during perltidy execution
+    /// Error occurred during perltidy execution.
     #[error("perltidy error: {0}")]
     PerltidyError(String),
 
-    /// I/O error during file operations
+    /// I/O error during file operations.
     #[error("IO error: {0}")]
     IoError(String),
 }
 
-/// Code formatter using perltidy
+/// Code formatter using perltidy.
 pub struct FormattingProvider<R> {
-    /// Subprocess runtime for executing perltidy
+    /// Subprocess runtime for executing perltidy.
     runtime: R,
-    /// Optional custom perltidy path
+    /// Optional custom perltidy path.
     perltidy_path: Option<String>,
 }
 
 impl<R> FormattingProvider<R> {
-    /// Create a new formatting provider with the given runtime
+    /// Create a new formatting provider with the given runtime.
     pub fn new(runtime: R) -> Self {
         Self { runtime, perltidy_path: None }
     }
 
-    /// Set a custom perltidy path
+    /// Set a custom perltidy path.
     pub fn with_perltidy_path(mut self, path: String) -> Self {
         self.perltidy_path = Some(path);
         self
@@ -141,66 +44,18 @@ impl<R> FormattingProvider<R> {
 }
 
 impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
-    /// Format the entire Perl script document with perltidy integration
-    ///
-    /// Performs comprehensive formatting of Perl script content using perltidy
-    /// with graceful fallback handling for environments where perltidy is not
-    /// available. Optimized for Perl parsing workflow development workflows.
-    ///
-    /// # Arguments
-    ///
-    /// * `content` - Perl script source code to format
-    /// * `options` - Formatting configuration including indentation and style preferences
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(FormattedDocument)` - Formatted document with text and edits
-    /// * `Err(FormattingError)` - When formatting fails or perltidy is unavailable
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use perl_lsp_formatting::{FormattingProvider, FormattingOptions};
-    /// use perl_lsp_tooling::OsSubprocessRuntime;
-    ///
-    /// let runtime = OsSubprocessRuntime::new();
-    /// let provider = FormattingProvider::new(runtime);
-    /// let options = FormattingOptions {
-    ///     tab_size: 4,
-    ///     insert_spaces: true,
-    ///     trim_trailing_whitespace: Some(true),
-    ///     insert_final_newline: Some(true),
-    ///     trim_final_newlines: Some(true),
-    /// };
-    ///
-    /// match provider.format_document(script, &options) {
-    ///     Ok(doc) => {
-    ///         println!("Formatted with {} edits", doc.edits.len());
-    ///     }
-    ///     Err(e) => {
-    ///         eprintln!("Formatting failed: {}", e);
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// # Error Recovery
-    ///
-    /// This function provides graceful degradation when perltidy is not available,
-    /// ensuring Perl script development can continue with manual formatting.
+    /// Format the entire Perl script document with perltidy integration.
     pub fn format_document(
         &self,
         content: &str,
         options: &FormattingOptions,
     ) -> Result<FormattedDocument, FormattingError> {
-        // Format using perltidy
         let formatted = self.run_perltidy(content, options)?;
 
-        // If nothing changed, return empty edits
         if formatted == content {
             return Ok(FormattedDocument { text: formatted, edits: vec![] });
         }
 
-        // Return a single edit that replaces the entire document
         Ok(FormattedDocument {
             text: formatted.clone(),
             edits: vec![FormatTextEdit {
@@ -210,14 +65,13 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
         })
     }
 
-    /// Format a specific range in the document
+    /// Format a specific range in the document.
     pub fn format_range(
         &self,
         content: &str,
         range: &FormatRange,
         options: &FormattingOptions,
     ) -> Result<FormattedDocument, FormattingError> {
-        // Extract the lines to format
         let lines: Vec<&str> = content.lines().collect();
         let start_line = range.start.line as usize;
         let end_line = (range.end.line as usize).min(lines.len().saturating_sub(1));
@@ -226,18 +80,13 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
             return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
         }
 
-        // Get the text to format
         let text_to_format = lines[start_line..=end_line].join("\n");
-
-        // Format using perltidy
         let formatted = self.run_perltidy(&text_to_format, options)?;
 
-        // If nothing changed, return empty edits
         if formatted == text_to_format {
             return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
         }
 
-        // Calculate the range to replace
         let start_char = 0;
         let end_char = lines[end_line].len() as u32;
 
@@ -253,40 +102,31 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
         })
     }
 
-    /// Run perltidy on the given text
     fn run_perltidy(
         &self,
         content: &str,
         options: &FormattingOptions,
     ) -> Result<String, FormattingError> {
-        // Build perltidy arguments
-        let mut args = vec![
-            "-st".to_string(), // Output to stdout
-            "-se".to_string(), // Errors to stderr
-        ];
+        let mut args = vec!["-st".to_string(), "-se".to_string()];
 
-        // Add formatting options
         if options.insert_spaces {
-            args.push(format!("-et={}", options.tab_size)); // Expand tabs
-            args.push(format!("-i={}", options.tab_size)); // Indent size
+            args.push(format!("-et={}", options.tab_size));
+            args.push(format!("-i={}", options.tab_size));
         } else {
-            args.push("-dt".to_string()); // Use tabs
-            args.push(format!("-i={}", options.tab_size)); // Tab size
+            args.push("-dt".to_string());
+            args.push(format!("-i={}", options.tab_size));
         }
 
-        // Get perltidy command
-        let default_cmd = "perltidy";
-        let perltidy_cmd = self.perltidy_path.as_deref().unwrap_or(default_cmd);
+        let perltidy_cmd = self.perltidy_path.as_deref().unwrap_or("perltidy");
 
-        // Try to run perltidy
         let output = self
             .runtime
             .run_command(
                 perltidy_cmd,
-                &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                &args.iter().map(String::as_str).collect::<Vec<_>>(),
                 Some(content.as_bytes()),
             )
-            .map_err(|e| FormattingError::PerltidyNotFound(e.message))?;
+            .map_err(|error| FormattingError::PerltidyNotFound(error.message))?;
 
         if !output.success() {
             return Err(FormattingError::PerltidyError(
@@ -295,47 +135,5 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    }
-}
-
-impl FormatPosition {
-    /// Create a new position
-    pub fn new(line: u32, character: u32) -> Self {
-        Self { line, character }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_formatting_options() {
-        let options = FormattingOptions {
-            tab_size: 4,
-            insert_spaces: true,
-            trim_trailing_whitespace: Some(true),
-            insert_final_newline: Some(true),
-            trim_final_newlines: Some(true),
-        };
-
-        assert_eq!(options.tab_size, 4);
-        assert!(options.insert_spaces);
-    }
-
-    #[test]
-    fn test_format_position() {
-        let pos = FormatPosition::new(5, 10);
-        assert_eq!(pos.line, 5);
-        assert_eq!(pos.character, 10);
-    }
-
-    #[test]
-    fn test_format_range() {
-        let start = FormatPosition::new(0, 0);
-        let end = FormatPosition::new(10, 20);
-        let range = FormatRange::new(start, end);
-        assert_eq!(range.start.line, 0);
-        assert_eq!(range.end.line, 10);
     }
 }


### PR DESCRIPTION
### Motivation
- Separate data-shape concerns (transport/DTOs) from process/execution logic to follow SRP and make formatting types reusable without pulling in subprocess/runtime dependencies.
- Reduce coupling so other crates can consume formatting DTOs without depending on `perl-lsp-formatting` runtime machinery.
- Prepare a small, focused microcrate for future extensions and clearer ownership of serde-friendly types.

### Description
- Add a new microcrate `perl-lsp-formatting-types` providing `FormattingOptions`, `FormatPosition`, `FormatRange`, `FormatTextEdit`, `FormattedDocument` and unit tests (new files under `crates/perl-lsp-formatting-types/`).
- Refactor `crates/perl-lsp-formatting` to consume and re-export the DTOs from `perl-lsp-formatting-types` while keeping `FormattingProvider` and `FormattingError` (perltidy orchestration and error mapping) in the provider crate (`crates/perl-lsp-formatting/src/formatting.rs`).
- Wire the new crate into the workspace by adding it to `Cargo.toml` members, the workspace dependency list, and the publish allowlist, and update `crates/perl-lsp-formatting/Cargo.toml` to depend on `perl-lsp-formatting-types`.
- Move unit tests for DTO constructors/shape into the new types crate and keep provider-focused tests in `perl-lsp-formatting`.

### Testing
- Ran `cargo fmt --all` and formatting succeeded.
- Ran `cargo test -p perl-lsp-formatting-types -p perl-lsp-formatting` and all tests passed.
- Ran `cargo test -p perl-lsp-providers --test microcrate_reexports_compatibility` to validate reexports and compatibility, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64e24888333be5493d4a8666bbf)