### PR TITLE
Extract reusable `perl-lsp-dedup` SRP microcrate and wire diagnostics to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,9 +1791,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-dedup"
+version = "0.10.0"
+
+[[package]]
 name = "perl-lsp-diagnostics"
 version = "0.10.0"
 dependencies = [
+ "perl-lsp-dedup",
  "perl-parser-core",
  "perl-pragma",
  "perl-semantic-analyzer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/perl-lsp-transport",
     "crates/perl-lsp-tooling",
     "crates/perl-lsp-formatting",
+    "crates/perl-lsp-dedup",
     "crates/perl-lsp-diagnostics",
     "crates/perl-lsp-semantic-tokens",
     "crates/perl-lsp-inlay-hints",
@@ -125,6 +126,7 @@ allow = [
     "perl-workspace-index",
     "perl-semantic-analyzer",
     "perl-lsp-diagnostics",
+    "perl-lsp-dedup",
     "perl-lsp-rename",
     "perl-lsp-code-actions",
     "perl-lsp-completion",
@@ -257,6 +259,7 @@ perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
+perl-lsp-dedup = { path = "crates/perl-lsp-dedup", version = "0.10.0" }
 perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }
 perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0" }
 perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.10.0" }

--- a/crates/perl-lsp-dedup/Cargo.toml
+++ b/crates/perl-lsp-dedup/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "perl-lsp-dedup"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for sort-and-dedup utilities used by Perl LSP crates"
+readme = "README.md"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-dedup/README.md
+++ b/crates/perl-lsp-dedup/README.md
@@ -1,0 +1,5 @@
+# perl-lsp-dedup
+
+A single-responsibility utility crate for sorting and de-duplicating LSP collections.
+
+It provides a small generic helper that lets each consumer define its own ordering and duplicate semantics.

--- a/crates/perl-lsp-dedup/src/lib.rs
+++ b/crates/perl-lsp-dedup/src/lib.rs
@@ -1,0 +1,86 @@
+//! Sort-and-dedup helpers shared across Perl LSP crates.
+//!
+//! This microcrate keeps de-duplication policy in one place while allowing each
+//! caller to define domain-specific sort and equality behavior.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::cmp::Ordering;
+
+/// Sort items with `sort_by`, then remove duplicates based on `is_equal`.
+///
+/// Callers define what ordering and equality mean for their domain type.
+pub fn sort_and_dedup_by<T, FSort, FEqual>(
+    items: &mut Vec<T>,
+    mut sort_by: FSort,
+    mut is_equal: FEqual,
+) where
+    FSort: FnMut(&T, &T) -> Ordering,
+    FEqual: FnMut(&T, &T) -> bool,
+{
+    items.sort_by(|left, right| sort_by(left, right));
+    items.dedup_by(|left, right| is_equal(left, right));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_and_dedup_by;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestDiagnostic {
+        range: (usize, usize),
+        severity: u8,
+        code: Option<String>,
+        message: String,
+    }
+
+    #[test]
+    fn removes_exact_duplicates_after_sorting() {
+        let mut diagnostics = vec![
+            TestDiagnostic {
+                range: (10, 11),
+                severity: 1,
+                code: Some("parse-error".to_string()),
+                message: "Issue A".to_string(),
+            },
+            TestDiagnostic {
+                range: (3, 4),
+                severity: 1,
+                code: Some("parse-error".to_string()),
+                message: "Issue B".to_string(),
+            },
+            TestDiagnostic {
+                range: (10, 11),
+                severity: 1,
+                code: Some("parse-error".to_string()),
+                message: "Issue A".to_string(),
+            },
+        ];
+
+        sort_and_dedup_by(
+            &mut diagnostics,
+            |a, b| {
+                a.range
+                    .0
+                    .cmp(&b.range.0)
+                    .then(a.range.1.cmp(&b.range.1))
+                    .then(a.severity.cmp(&b.severity))
+                    .then(a.code.cmp(&b.code))
+                    .then(a.message.cmp(&b.message))
+            },
+            |a, b| {
+                a.range == b.range
+                    && a.severity == b.severity
+                    && a.code == b.code
+                    && a.message == b.message
+            },
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].range, (3, 4));
+        assert_eq!(diagnostics[1].range, (10, 11));
+    }
+}

--- a/crates/perl-lsp-diagnostics/Cargo.toml
+++ b/crates/perl-lsp-diagnostics/Cargo.toml
@@ -21,6 +21,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-pragma = { workspace = true }
+perl-lsp-dedup = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-diagnostics/src/dedup.rs
+++ b/crates/perl-lsp-diagnostics/src/dedup.rs
@@ -4,6 +4,7 @@
 //! to avoid reporting the same issue multiple times.
 
 use super::types::Diagnostic;
+use perl_lsp_dedup::sort_and_dedup_by;
 
 /// De-duplicate diagnostics to avoid reporting the same issue twice
 ///
@@ -11,19 +12,22 @@ use super::types::Diagnostic;
 /// then removes exact duplicates (same range, severity, code, and message).
 #[allow(dead_code)]
 pub fn deduplicate_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
-    // Sort by range, severity, code, and message
-    diagnostics.sort_by(|a, b| {
-        a.range
-            .0
-            .cmp(&b.range.0)
-            .then(a.range.1.cmp(&b.range.1))
-            .then(a.severity.cmp(&b.severity))
-            .then(a.code.cmp(&b.code))
-            .then(a.message.cmp(&b.message))
-    });
-
-    // Remove only exact duplicates (same range, severity, code, and message)
-    diagnostics.dedup_by(|a, b| {
-        a.range == b.range && a.severity == b.severity && a.code == b.code && a.message == b.message
-    });
+    sort_and_dedup_by(
+        diagnostics,
+        |a, b| {
+            a.range
+                .0
+                .cmp(&b.range.0)
+                .then(a.range.1.cmp(&b.range.1))
+                .then(a.severity.cmp(&b.severity))
+                .then(a.code.cmp(&b.code))
+                .then(a.message.cmp(&b.message))
+        },
+        |a, b| {
+            a.range == b.range
+                && a.severity == b.severity
+                && a.code == b.code
+                && a.message == b.message
+        },
+    );
 }


### PR DESCRIPTION
### Motivation
- Isolate the generic sort-and-dedup responsibility from diagnostics so the low-level dedup mechanics can be reused across LSP crates and kept SRP-compliant.
- Reduce code duplication and centralize deterministic sort+dedup semantics in a small focused microcrate.

### Description
- Added a new microcrate `crates/perl-lsp-dedup` exposing `sort_and_dedup_by` for callers to provide domain-specific ordering and equality logic.
- Replaced in-crate dedup logic in `crates/perl-lsp-diagnostics/src/dedup.rs` with a call to `perl_lsp_dedup::sort_and_dedup_by` while preserving the existing diagnostic ordering and equality semantics (range, severity, code, message).
- Wired the new crate into the workspace by adding it to `Cargo.toml` members, the workspace `dependencies` section, and the publish allowlist so it participates in builds and releases.
- Added a unit test in `perl-lsp-dedup` verifying deterministic sort-and-dedup behavior and updated diagnostics crate to depend on the new microcrate.

### Testing
- Ran formatting with `cargo fmt --all`, which completed successfully.
- Ran unit tests with `cargo test -p perl-lsp-dedup -p perl-lsp-diagnostics`, and all tests passed including the new `perl-lsp-dedup` unit test and existing diagnostics tests.
- Ran static checks with `cargo clippy -p perl-lsp-dedup -p perl-lsp-diagnostics --all-targets -- -D warnings`, which completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64e24888333be5493d4a8666bbf)