### PR TITLE
Split diagnostic data model into dedicated `perl-lsp-diagnostic-types` microcrate

### DIFF
--- a/crates/perl-lsp-diagnostic-types/Cargo.toml
+++ b/crates/perl-lsp-diagnostic-types/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "perl-lsp-diagnostic-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Shared diagnostic data types for Perl LSP crates"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-diagnostic-types"
+keywords = ["perl", "lsp", "diagnostics", "types"]
+categories = ["development-tools", "text-editors"]
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-diagnostic-types/README.md
+++ b/crates/perl-lsp-diagnostic-types/README.md
@@ -1,0 +1,6 @@
+# perl-lsp-diagnostic-types
+
+Shared diagnostic model types used across Perl LSP crates.
+
+This crate contains only the data model (`Diagnostic`, severity, tags, and related information),
+allowing crates that only need these shared structures to avoid depending on the full diagnostics engine.

--- a/crates/perl-lsp-diagnostic-types/src/lib.rs
+++ b/crates/perl-lsp-diagnostic-types/src/lib.rs
@@ -1,0 +1,63 @@
+//! Shared diagnostic model types for Perl LSP crates.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+/// Severity level for diagnostics.
+///
+/// Represents the importance and type of a diagnostic message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DiagnosticSeverity {
+    /// Critical error that prevents successful parsing or execution.
+    Error = 1,
+    /// Non-critical issue that should be addressed.
+    Warning = 2,
+    /// Informational message.
+    Information = 3,
+    /// Subtle suggestion for improvement.
+    Hint = 4,
+}
+
+/// A diagnostic message.
+///
+/// Represents an issue found during code analysis with location,
+/// severity, and additional context information.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// Source code range (start, end) where the issue occurs.
+    pub range: (usize, usize),
+    /// Severity level of the diagnostic.
+    pub severity: DiagnosticSeverity,
+    /// Optional diagnostic code for categorization.
+    pub code: Option<String>,
+    /// Human-readable description of the issue.
+    pub message: String,
+    /// Additional context and related information.
+    pub related_information: Vec<RelatedInformation>,
+    /// Tags for categorizing the diagnostic.
+    pub tags: Vec<DiagnosticTag>,
+}
+
+/// Related information for a diagnostic.
+///
+/// Additional context that helps understand or resolve the main diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelatedInformation {
+    /// Location in source code for the related information.
+    pub location: (usize, usize),
+    /// Description of the related information.
+    pub message: String,
+}
+
+/// Tags for diagnostics.
+///
+/// Additional metadata about the nature of a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    /// Code that is not needed and can be removed.
+    Unnecessary,
+    /// Code that uses deprecated features.
+    Deprecated,
+}


### PR DESCRIPTION
### Motivation
- Isolate the pure diagnostic data model (`Diagnostic`, `DiagnosticSeverity`, `DiagnosticTag`, `RelatedInformation`) from the diagnostics engine to follow SRP and reduce coupling for consumers that only need the model.
- Allow downstream crates to depend only on the shared types instead of the full `perl-lsp-diagnostics` crate, simplifying dependency graphs and improving compilation and reuse.

### Description
- Added a new microcrate `crates/perl-lsp-diagnostic-types` containing the shared model types (moved the former `types.rs` into `perl-lsp-diagnostic-types/src/lib.rs`).
- Rewired `crates/perl-lsp-diagnostics` to depend on `perl-lsp-diagnostic-types` and re-export the model while keeping diagnostic generation logic local to `perl-lsp-diagnostics` (`pub use perl_lsp_diagnostic_types::{...}`).
- Updated `crates/perl-lsp-code-actions` to depend on `perl-lsp-diagnostic-types` and replaced imports to use the new crate where only the model is required.
- Integrated the new crate into the workspace by adding it to `Cargo.toml` members, workspace dependencies/publish allowlist entries, and updated `Cargo.lock`/dependency references accordingly.

### Testing
- Ran `cargo fmt --all` to format changes (succeeded).
- Ran `cargo test -p perl-lsp-diagnostic-types -p perl-lsp-diagnostics -p perl-lsp-code-actions` and all tests passed for the targeted crates (succeeded).
- Ran `cargo clippy -p perl-lsp-diagnostic-types -p perl-lsp-diagnostics -p perl-lsp-code-actions --all-targets -- -D warnings` and the targeted crates passed with no warnings (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64f99b0833388dd7e79c1022b16)