### PR TITLE
Extract DAP stack-frame visibility filtering into perl-dap-stack

### DIFF
--- a/crates/perl-dap-stack/src/lib.rs
+++ b/crates/perl-dap-stack/src/lib.rs
@@ -28,9 +28,13 @@
 
 mod classifier;
 mod parser;
+mod visibility;
 
 pub use classifier::{FrameCategory, FrameClassifier, PerlFrameClassifier};
 pub use parser::{PerlStackParser, StackParseError};
+pub use visibility::{
+    filter_user_visible_frames, is_internal_frame, is_internal_frame_name_and_path,
+};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/perl-dap-stack/src/visibility.rs
+++ b/crates/perl-dap-stack/src/visibility.rs
@@ -1,0 +1,66 @@
+use crate::StackFrame;
+
+/// Returns true when a frame belongs to debugger/shim internals.
+#[must_use]
+pub fn is_internal_frame_name_and_path(name: &str, path: Option<&str>) -> bool {
+    name.starts_with("Devel::TSPerlDAP::")
+        || name.starts_with("DB::")
+        || path.is_some_and(|value| value.contains("perl5db.pl"))
+}
+
+/// Returns true when a frame belongs to debugger/shim internals.
+#[must_use]
+pub fn is_internal_frame(frame: &StackFrame) -> bool {
+    is_internal_frame_name_and_path(
+        &frame.name,
+        frame.source.as_ref().and_then(|source| source.path.as_deref()),
+    )
+}
+
+/// Filter out internal debugger and shim frames from user-visible stack traces.
+#[must_use]
+pub fn filter_user_visible_frames(frames: Vec<StackFrame>) -> Vec<StackFrame> {
+    frames.into_iter().filter(|frame| !is_internal_frame(frame)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_user_visible_frames, is_internal_frame, is_internal_frame_name_and_path};
+    use crate::{Source, StackFrame};
+
+    fn frame(id: i64, name: &str, path: &str) -> StackFrame {
+        StackFrame::new(id, name.to_string(), Some(Source::new(path)), 1)
+    }
+
+    #[test]
+    fn internal_frame_by_name_prefix() {
+        assert!(is_internal_frame(&frame(1, "DB::sub", "/app/main.pl")));
+        assert!(is_internal_frame(&frame(2, "Devel::TSPerlDAP::shim", "/app/main.pl")));
+    }
+
+    #[test]
+    fn internal_frame_by_perl5db_path() {
+        assert!(is_internal_frame(&frame(3, "helper", "/usr/lib/perl5/perl5db.pl")));
+    }
+
+    #[test]
+    fn classification_from_name_and_path() {
+        assert!(is_internal_frame_name_and_path("DB::sub", Some("/app/main.pl")));
+        assert!(is_internal_frame_name_and_path("helper", Some("/usr/lib/perl5/perl5db.pl")));
+        assert!(!is_internal_frame_name_and_path("main::run", Some("/app/main.pl")));
+    }
+
+    #[test]
+    fn filter_keeps_only_user_frames_preserving_order() {
+        let frames = vec![
+            frame(1, "main::start", "/app/main.pl"),
+            frame(2, "DB::sub", "/usr/lib/perl5/perl5db.pl"),
+            frame(3, "Utils::run", "/app/lib/Utils.pm"),
+        ];
+
+        let filtered = filter_user_visible_frames(frames);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].name, "main::start");
+        assert_eq!(filtered[1].name, "Utils::run");
+    }
+}

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -24,7 +24,7 @@ use crate::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
 use perl_content_length_framing::{ContentLengthFramer, frame};
 use perl_dap_breakpoint::{AstBreakpointValidator, BreakpointValidator};
 use perl_dap_eval::SafeEvaluator;
-use perl_dap_stack::PerlStackParser;
+use perl_dap_stack::{PerlStackParser, is_internal_frame_name_and_path};
 use perl_dap_variables::{
     PerlVariableRenderer, RenderedVariable, VariableParser, VariableRenderer,
 };
@@ -1054,10 +1054,8 @@ impl DebugAdapter {
     fn filter_user_visible_frames(frames: Vec<StackFrame>) -> Vec<StackFrame> {
         frames
             .into_iter()
-            .filter(|f| {
-                !f.name.starts_with("Devel::TSPerlDAP::")
-                    && !f.name.starts_with("DB::")
-                    && !f.source.path.contains("perl5db.pl")
+            .filter(|frame| {
+                !is_internal_frame_name_and_path(&frame.name, Some(frame.source.path.as_str()))
             })
             .collect()
     }
@@ -6042,14 +6040,7 @@ mod tests {
 
     /// Test helper: Filter frames using the same logic as handle_stack_trace (AC8.2.1)
     fn filter_internal_frames(frames: Vec<StackFrame>) -> Vec<StackFrame> {
-        frames
-            .into_iter()
-            .filter(|f| {
-                !f.name.starts_with("Devel::TSPerlDAP::")
-                    && !f.name.starts_with("DB::")
-                    && !f.source.path.contains("perl5db.pl")
-            })
-            .collect()
+        DebugAdapter::filter_user_visible_frames(frames)
     }
 
     #[test]

--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 1396 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 1400 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -83,7 +83,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 1396 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 1400 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
### Motivation
- Consolidate duplicated stack-frame visibility logic and keep stack parsing and visibility concerns together by moving the predicate into the stack microcrate.

### Description
- Added a new `visibility` module in `crates/perl-dap-stack/src/visibility.rs` exposing `is_internal_frame_name_and_path`, `is_internal_frame`, and `filter_user_visible_frames` with unit tests.
- Re-exported the new helpers from `crates/perl-dap-stack/src/lib.rs` so downstream crates can consume the functionality via `perl_dap_stack`.
- Updated `crates/perl-dap/src/debug_adapter.rs` to call the extracted `is_internal_frame_name_and_path` predicate in `DebugAdapter::filter_user_visible_frames`, removing inline duplicated filtering logic.
- Adjusted adapter test helpers to delegate to the adapter filtering path so behavior remains consistent and covered by tests.

### Testing
- Formatted code with `cargo fmt --all` and ran unit tests for the modified crates with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-dap-stack --lib` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-dap --lib`.
- All executed test suites completed successfully: `perl-dap-stack` tests passed and `perl-dap` tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d64f99b0833388dd7e79c1022b16)