### PR TITLE
Prep crates.io launch dry-run workflow for allowlist-based packaging

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,6 +40,16 @@ cargo metadata --no-deps --format-version=1 |\
 
 To inspect the exact publish order used by the workflow, read the "Compute topological order" output in the workflow run.
 
+For local packaging dry-runs with workspace path patching, use:
+
+```bash
+# package every crate in [workspace.metadata.publish.allow]
+scripts/cargo-package-workspace-dry-run.sh
+
+# package specific crates
+scripts/cargo-package-workspace-dry-run.sh perl-parser perl-lsp perl-dap
+```
+
 ## Manual Fallback (Use with caution)
 
 If automated publish fails and needs recovery, publish remaining crates one-by-one using the workflow summary order:

--- a/scripts/cargo-package-workspace-dry-run.sh
+++ b/scripts/cargo-package-workspace-dry-run.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <crate> [crate ...]" >&2
-  exit 1
-fi
-
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
@@ -35,9 +30,36 @@ for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
 
 mapfile -t PATCH_ARGS <<< "${PATCH_OUTPUT}"
 
+ALLOWLIST_OUTPUT="$(
+  cargo metadata --format-version=1 --no-deps | python3 -c '
+import json
+import sys
+
+meta = json.load(sys.stdin)
+allowlist = meta.get("metadata", {}).get("publish", {}).get("allow")
+
+if not isinstance(allowlist, list) or not allowlist:
+    raise SystemExit("[workspace.metadata.publish.allow] is missing or empty in Cargo.toml")
+
+for crate in allowlist:
+    if not isinstance(crate, str):
+        raise SystemExit("publish allowlist contains a non-string value")
+    print(crate)
+'
+)"
+
+mapfile -t ALLOWLIST_CRATES <<< "${ALLOWLIST_OUTPUT}"
+
+if [[ $# -eq 0 ]]; then
+  echo "No crates provided. Using [workspace.metadata.publish.allow] from Cargo.toml."
+  CRATES=("${ALLOWLIST_CRATES[@]}")
+else
+  CRATES=("$@")
+fi
+
 NO_VERIFY="${CARGO_PACKAGE_NO_VERIFY:-0}"
 
-for crate in "$@"; do
+for crate in "${CRATES[@]}"; do
   echo "==> cargo package -p ${crate}"
   CMD=(cargo package -p "${crate}" "${PATCH_ARGS[@]}")
   if [[ "${NO_VERIFY}" == "1" ]]; then


### PR DESCRIPTION
### Motivation
- Make local crates.io dry-run packaging consistent with the workspace publish automation by using the canonical `[workspace.metadata.publish.allow]` list.
- Reduce manual errors when selecting crates to `cargo package` during release preparation by supporting an automatic no-argument mode.
- Fail early on invalid publish allowlist entries so packaging does not start with a malformed workspace configuration.

### Description
- Updated `scripts/cargo-package-workspace-dry-run.sh` to support a no-argument mode that reads the publish allowlist from `cargo metadata` and packages every crate listed in `[workspace.metadata.publish.allow]`.
- Added validation logic that errors when the publish allowlist is missing, empty, or contains non-string entries, and preserved explicit crate-argument behavior via the same packaging loop.
- Documented the new usage examples in `docs/PUBLISHING.md` showing both the all-allowlist invocation and specifying explicit crates.

### Testing
- Ran a syntax check with `bash -n scripts/cargo-package-workspace-dry-run.sh` which succeeded.
- Executed a local dry-run packaging command `CARGO_PACKAGE_NO_VERIFY=1 scripts/cargo-package-workspace-dry-run.sh perl-content-length-framing` which completed successfully and produced a packaged crate output without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c40643e4833394f38594e1b4adde)