### PR TITLE
Add local publish preflight docs and update tree-sitter Go metadata

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,6 +40,23 @@ cargo metadata --no-deps --format-version=1 |\
 
 To inspect the exact publish order used by the workflow, read the "Compute topological order" output in the workflow run.
 
+## Local Preflight (Recommended Before Dispatch)
+
+For a workspace launch, use packaging preflight before any `cargo publish` step. This validates crate contents
+and manifest metadata while patching workspace dependencies to local paths (so checks do not depend on crates
+already being available in the registry).
+
+```bash
+# Core launch crates
+scripts/cargo-package-workspace-dry-run.sh perl-parser perl-lsp perl-dap
+
+# Optional: run full allowlist from workspace metadata
+cargo metadata --no-deps --format-version=1 | jq -r '.metadata.publish.allow[]' |
+  xargs scripts/cargo-package-workspace-dry-run.sh
+```
+
+If any crate fails packaging, resolve the error before triggering the `publish-crates` workflow.
+
 ## Manual Fallback (Use with caution)
 
 If automated publish fails and needs recovery, publish remaining crates one-by-one using the workflow summary order:

--- a/tree-sitter-perl/go.mod
+++ b/tree-sitter-perl/go.mod
@@ -1,5 +1,5 @@
 module github.com/tree-sitter/tree-sitter-perl
 
-go 1.22
+go 1.23
 
 require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/tree-sitter-perl/go.sum
+++ b/tree-sitter-perl/go.sum
@@ -1,0 +1,1 @@
+github.com/tree-sitter/go-tree-sitter v0.23.1/go.mod h1:EvIVhMvvPNvhu9x+ddSPxSnUEU5AnsSwi1LMqXIVE3A=


### PR DESCRIPTION
### Motivation

- `cargo publish --dry-run` for a single crate can fail when workspace dependency crates are not yet available on crates.io, which causes false negatives at launch time. 
- Provide a lightweight local preflight that packages target crates while patching workspace dependencies to local paths so packaging and manifest metadata are validated in a launch-like context. 
- Ensure tree-sitter metadata is up-to-date for tooling that relies on the embedded Go module information.

### Description

- Add a **Local Preflight** section to `docs/PUBLISHING.md` that documents using `scripts/cargo-package-workspace-dry-run.sh` for core launch crates and an optional full-allowlist path via `cargo metadata | jq` and `xargs` to run the packaging preflight for the entire publish allowlist. 
- Update `tree-sitter-perl/go.mod` to `go 1.23` and add `tree-sitter-perl/go.sum` with the checksum for `github.com/tree-sitter/go-tree-sitter v0.23.1`. 
- Files changed: `docs/PUBLISHING.md`, `tree-sitter-perl/go.mod`, and `tree-sitter-perl/go.sum`.

### Testing

- Ran the packaging preflight: `scripts/cargo-package-workspace-dry-run.sh perl-parser perl-lsp perl-dap`, and all three crates were packaged and verified successfully. 
- The packaging run produced expected warnings about excluded tests/examples and `patch`-not-used warnings for crates outside each package graph, which are acceptable for the workspace patch strategy. 
- The preflight reproduces and prevents the prior `cargo publish --dry-run -p perl-lsp` failure that can happen when dependent workspace crates are not present on crates.io.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c40643e4833394f38594e1b4adde)