### PR TITLE
Prep crates.io launch validation workflow

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -18,7 +18,8 @@ This is the same path used by the `release-orchestration` workflow.
 1. Create or confirm an account on [crates.io](https://crates.io)
 2. Authenticate locally with `cargo login`
 3. Ensure release checks pass (`just ci-full`, `just security-scan`, `just semver-check`)
-4. Confirm release version and changelog are finalized
+4. Run crates.io dry-run validation (`just prep-crates-io-launch` for launch crates, or `just prep-crates-io-launch all` for full allowlist)
+5. Confirm release version and changelog are finalized
 
 ## Recommended Path (Automated)
 

--- a/justfile
+++ b/justfile
@@ -1125,6 +1125,12 @@ guardrail-run-ignored:
     @echo "Note: Some tests expected to fail pending feature implementation"
     @cargo test -p xtask --test ci_guardrail_ignored_test_monitoring_tests -- --ignored || true
 
+
+# crates.io launch dry-run checks
+prep-crates-io-launch mode='core':
+    @echo "🚀 Running crates.io launch prep (mode={{mode}})..."
+    @bash scripts/prep-crates-io-launch.sh --{{mode}}
+
 # ============================================================================
 # SemVer Breaking Change Detection (Issue #277)
 # ============================================================================

--- a/scripts/prep-crates-io-launch.sh
+++ b/scripts/prep-crates-io-launch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MODE="core"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prep-crates-io-launch.sh [--core|--all]
+
+Runs crates.io launch readiness checks:
+  1) cargo check --locked for selected crates
+  2) cargo package --list validation for selected crates
+
+Options:
+  --core      Validate public launch crates (default)
+  --all       Validate every crate in [workspace.metadata.publish.allow]
+  -h, --help  Show help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --core)
+      MODE="core"
+      ;;
+    --all)
+      MODE="all"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$MODE" == "core" ]]; then
+  mapfile -t CRATES < <(printf '%s\n' \
+    perl-parser \
+    perl-lexer \
+    perl-lsp \
+    perl-dap \
+    perl-corpus)
+else
+  mapfile -t CRATES < <(
+    cd "$ROOT_DIR"
+    python3 - <<'PY'
+from pathlib import Path
+import tomllib
+
+data = tomllib.loads(Path("Cargo.toml").read_text())
+for crate in data["workspace"]["metadata"]["publish"]["allow"]:
+    print(crate)
+PY
+  )
+fi
+
+echo "🚀 crates.io launch prep (${MODE})"
+echo "📦 Running cargo check + cargo package --list for ${#CRATES[@]} crate(s)"
+
+for crate in "${CRATES[@]}"; do
+  echo ""
+  echo "==> ${crate}"
+  (
+    cd "$ROOT_DIR"
+    cargo check --locked -p "$crate"
+    cargo package --list -p "$crate" >/dev/null
+  )
+done
+
+echo ""
+echo "✅ crates.io launch prep completed (${MODE})"


### PR DESCRIPTION
### Motivation

- Provide a simple, repeatable pre-publish validation step to catch package/packaging problems before attempting crates.io publishes. 
- Support both a small launch subset and a full workspace allowlist so release engineers can run light-weight or exhaustive checks depending on context.

### Description

- Add `scripts/prep-crates-io-launch.sh`, a script that supports `--core` (default launch crates) and `--all` modes and runs pre-release-safe checks (`cargo check --locked` and `cargo package --list`) per crate. 
- Add a `just` recipe `prep-crates-io-launch` that invokes the script via `just prep-crates-io-launch` for easy invocation from the project dev flow. 
- Update `docs/PUBLISHING.md` to include the new dry-run validation step in the automated crates.io path and document usage recommendations. 
- The script reads the workspace publish allowlist from `Cargo.toml` when invoked with `--all` and uses `--locked` package checks to avoid requiring dependent crates to already be published.

### Testing

- Ran `bash scripts/prep-crates-io-launch.sh --help` and observed the help output (succeeded). 
- Ran `bash scripts/prep-crates-io-launch.sh --core` which executed `cargo check --locked` and `cargo package --list` for the selected launch crates and completed successfully. 
- The checks exercised packaging/manifest validation paths for the core launch crates with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c40643e4833394f38594e1b4adde)