### PR TITLE
Prep VS Code extension for Marketplace launch

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Perl Language Server extension will be documented in 
 
 ## [Unreleased]
 
+### Added
+- Marketplace readiness workflow via `npm run verify:marketplace` for compile + bundle + package validation.
+- VS Marketplace badges and installation link in extension README.
+
+### Changed
+- Publishing guide refreshed with a launch checklist and pre-release recommendation for initial rollout.
+
 ## [0.10.0] - 2026-02-28
 
 ### Changed

--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -19,31 +19,18 @@ First, ensure the perl-lsp binary is built:
 ```bash
 # From the project root
 cd ..
-cargo build -p perl-parser --bin perl-lsp --release
+cargo build -p perl-lsp --release
 ```
 
-### 2. Build the Extension
+### 2. Build and Validate the Extension
 
 ```bash
-# From project root
-cargo xtask release <version>
-```
-
-Or manually:
-
-```bash
-# Install dependencies
+# From vscode-extension/
 npm install
-
-# Compile TypeScript
-npm run compile
-
-# Bundle LSP binary
-npm run bundle-lsp
-
-# Package extension
-npm run package
+npm run verify:marketplace
 ```
+
+`verify:marketplace` runs TypeScript compilation, bundles the local platform binary, and generates a `.vsix` package suitable for pre-release validation.
 
 ### 3. Test Locally
 
@@ -107,7 +94,7 @@ vsce login <publisher-id>
 ### 7. Publish
 
 ```bash
-# Publish to marketplace
+# Publish to marketplace (already logged in via vsce)
 npm run publish
 
 # Or with version bump
@@ -161,3 +148,14 @@ Ensure `bundle-lsp.js` correctly detects platform and copies binaries.
 
 ### Large package size
 Check `.vscodeignore` is excluding unnecessary files.
+## Marketplace Launch Checklist
+
+Before first public launch:
+
+- [ ] Confirm `package.json` metadata is complete (`publisher`, `icon`, repository links, categories, keywords).
+- [ ] Ensure `README.md` has clear install + configuration guidance.
+- [ ] Ensure `CHANGELOG.md` includes release notes for the exact published version.
+- [ ] Run `npm run verify:marketplace` and install the generated `.vsix` locally.
+- [ ] Validate extension activation in a clean profile (`code --user-data-dir <tmpdir>`).
+- [ ] Verify binary download fallback works when no bundled binary exists for the host platform.
+- [ ] Publish as pre-release first (recommended for initial alpha), then promote to stable after validation feedback.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,9 @@
 # Perl Language Server
 
-Lightning-fast Perl language support with 26+ IDE features powered by tree-sitter-perl.
+[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/effortlesssteven.perl-lsp?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/effortlesssteven.perl-lsp)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
+
+Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
 
 ## ✨ Features
 
@@ -44,6 +47,8 @@ Lightning-fast Perl language support with 26+ IDE features powered by tree-sitte
 - **Sub-millisecond** position conversions (v0.8.0)
 
 ## 📦 Installation
+
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp).
 
 The extension automatically downloads the correct language server for your platform:
 - Windows (x64, ARM64)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -4,6 +4,8 @@
   "description": "Comprehensive Perl language support powered by perl-lsp",
   "version": "0.10.0",
   "publisher": "effortlesssteven",
+  "preview": true,
+  "markdown": "github",
   "engines": {
     "vscode": "^1.88.0"
   },
@@ -443,7 +445,11 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "bundle-lsp": "node ./scripts/bundle-lsp.js",
+    "package": "npx @vscode/vsce package",
+    "publish": "npx @vscode/vsce publish",
+    "verify:marketplace": "npm run compile && npm run bundle-lsp && npm run package"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1",

--- a/vscode-extension/scripts/build-release-local.sh
+++ b/vscode-extension/scripts/build-release-local.sh
@@ -44,7 +44,7 @@ echo "📦 Building for ${TARGET}"
 
 # Build the binary
 echo "🔨 Building perl-lsp..."
-cargo build --release -p perl-parser --bin perl-lsp
+cargo build --release -p perl-lsp
 
 # Create package
 PKG_NAME="${NAME}-${VERSION}-${TARGET}"

--- a/vscode-extension/scripts/bundle-lsp.js
+++ b/vscode-extension/scripts/bundle-lsp.js
@@ -38,7 +38,7 @@ if (!platform) {
 try {
     // Build the binary
     console.log('Building perl-lsp binary...');
-    const buildCmd = `cargo build -p perl-parser --bin perl-lsp --release`;
+    const buildCmd = `cargo build -p perl-lsp --release`;
     execSync(buildCmd, { 
         cwd: projectRoot,
         stdio: 'inherit'


### PR DESCRIPTION
### Motivation
- Prepare the VS Code extension for a Marketplace pre-release by adding metadata, validation scripts, and documentation so packaging and publishing are repeatable and discoverable.
- Provide a single verification command that compiles the extension, bundles a locally-built `perl-lsp` binary, and produces a `.vsix` for pre-release validation.
- Fix an incorrect build target in the bundling/release scripts that attempted to build a `perl-parser` bin instead of the `perl-lsp` crate to ensure the bundled binary is correct.

### Description
- Add `preview` and `markdown` metadata to `vscode-extension/package.json` and add marketplace helper scripts `bundle-lsp`, `package`, `publish`, and `verify:marketplace` to `scripts`.
- Update `vscode-extension/scripts/bundle-lsp.js` to call `cargo build -p perl-lsp --release` so the `perl-lsp` crate is built and its binary is copied into `vscode-extension/bin`.
- Fix `vscode-extension/scripts/build-release-local.sh` to build the `perl-lsp` crate (`cargo build --release -p perl-lsp`) for local release packaging.
- Refresh `vscode-extension/PUBLISHING.md` to document the new `verify:marketplace` flow and add a Marketplace launch checklist, and add Marketplace badges and an install link to `vscode-extension/README.md`.
- Document the changes under the `Unreleased` section in `vscode-extension/CHANGELOG.md`.

### Testing
- Ran `npm install` in `vscode-extension` which completed successfully with no vulnerabilities reported.
- Ran `npm run verify:marketplace` which compiles TypeScript, builds the `perl-lsp` binary, copies it into `vscode-extension/bin`, and packages a `.vsix`; the final run succeeded and produced `/workspace/perl-lsp/vscode-extension/perl-lsp-0.10.0.vsix`.
- Ran `npm run compile` (TypeScript compile) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c412a1508333a29d07f5f97f95a9)