### PR TITLE
vscode-extension: add marketplace preflight workflow and publish runbook

### DIFF
--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -1,163 +1,95 @@
 # Publishing the Perl Language Server Extension
 
+This guide is optimized for a **VS Code Marketplace launch** from the repository root.
+
 ## Prerequisites
 
-1. **Node.js and npm** installed
-2. **Visual Studio Code** installed
-3. **vsce** (Visual Studio Code Extension manager) installed:
-   ```bash
-   npm install -g @vscode/vsce
-   ```
-4. **Publisher account** on Visual Studio Marketplace
+1. Node.js + npm installed.
+2. Rust toolchain installed.
+3. `@vscode/vsce` available (already in `devDependencies`).
+4. A Marketplace publisher and PAT with publish rights.
 
-## Build Process
-
-### 1. Build the LSP Binary
-
-First, ensure the perl-lsp binary is built:
+## 0) One-time marketplace auth
 
 ```bash
-# From the project root
-cd ..
-cargo build -p perl-parser --bin perl-lsp --release
+cd vscode-extension
+npx @vscode/vsce login effortlesssteven
 ```
 
-### 2. Build the Extension
+## 1) Preflight checks (recommended before every release)
 
 ```bash
-# From project root
-cargo xtask release <version>
+cd vscode-extension
+npm ci
+npm run marketplace:preflight
 ```
 
-Or manually:
+This preflight command performs:
+- TypeScript compile
+- Package content listing (`vsce ls`)
+- VSIX packaging into `vscode-extension/dist/`
+
+## 2) Build and smoke test the VSIX locally
 
 ```bash
-# Install dependencies
-npm install
-
-# Compile TypeScript
-npm run compile
-
-# Bundle LSP binary
-npm run bundle-lsp
-
-# Package extension
-npm run package
-```
-
-### 3. Test Locally
-
-Install and test the extension locally:
-
-```bash
-# Install the VSIX file
-code --install-extension perl-language-server-*.vsix
-
-# Open test file
+cd vscode-extension
+code --install-extension dist/perl-lsp-0.10.0.vsix --force
 code test/sample.pl
 ```
 
-Test these features:
-- [ ] Syntax highlighting works
-- [ ] Diagnostics appear for syntax errors
-- [ ] Format document (Shift+Alt+F) works (if perltidy installed)
-- [ ] Go to definition (F12) works
-- [ ] Hover shows information
-- [ ] Auto-completion triggers
+Smoke-test checklist:
+- [ ] Extension activates on Perl files
+- [ ] `Perl: Restart Perl Language Server` command works
+- [ ] Hover, completion, and go-to-definition respond
+- [ ] Diagnostics appear for malformed Perl code
+- [ ] Debug configuration snippets are available
 
-### 4. Cross-Platform Binaries
-
-For marketplace release, build for all platforms:
+## 3) Publish to VS Code Marketplace
 
 ```bash
-# Linux x64
-cargo build --target x86_64-unknown-linux-gnu --release
-
-# macOS x64
-cargo build --target x86_64-apple-darwin --release
-
-# macOS ARM64
-cargo build --target aarch64-apple-darwin --release
-
-# Windows x64
-cargo build --target x86_64-pc-windows-msvc --release
+cd vscode-extension
+npx @vscode/vsce publish
 ```
 
-Place binaries in appropriate directories:
-- `bin/linux-x64/perl-lsp`
-- `bin/darwin-x64/perl-lsp`
-- `bin/darwin-arm64/perl-lsp`
-- `bin/win32-x64/perl-lsp.exe`
-
-### 5. Create Publisher
-
-If you haven't already:
-
-1. Go to https://marketplace.visualstudio.com/manage
-2. Create a publisher ID (e.g., "tree-sitter-perl")
-3. Get a Personal Access Token from Azure DevOps
-
-### 6. Login to vsce
+For a specific version (already updated in `package.json`):
 
 ```bash
-vsce login <publisher-id>
-# Enter your Personal Access Token when prompted
+cd vscode-extension
+npx @vscode/vsce publish 0.10.0
 ```
 
-### 7. Publish
+## 4) Post-publish verification
 
-```bash
-# Publish to marketplace
-npm run publish
-
-# Or with version bump
-vsce publish minor  # 0.5.0 -> 0.6.0
-vsce publish major  # 0.5.0 -> 0.9.x
-vsce publish 0.5.1  # Specific version
-```
-
-## Post-Publishing
-
-1. **Verify on Marketplace**
-   - Go to https://marketplace.visualstudio.com/
-   - Search for "Perl Language Server"
-   - Verify description, screenshots, etc.
-
-2. **Update Documentation**
-   - Update main README.md with marketplace link
-   - Add installation instructions
-   - Update CHANGELOG.md
-
-3. **Create GitHub Release**
-   - Tag the release: `git tag vscode-extension-v0.5.0`
-   - Create release on GitHub
-   - Attach the .vsix file
-
-## Maintenance
-
-### Updating the Extension
-
-1. Update version in `package.json`
-2. Update `CHANGELOG.md`
-3. Rebuild and test
-4. Publish update: `vsce publish`
-
-### Monitoring
-
-- Check reviews and ratings on marketplace
-- Monitor GitHub issues
-- Respond to user feedback
+1. Confirm listing metadata, icon, and README render on Marketplace.
+2. Confirm install/update path from a clean VS Code profile.
+3. Confirm release notes in `vscode-extension/CHANGELOG.md` match the published version.
+4. Update top-level docs if install instructions changed.
 
 ## Troubleshooting
 
-### "Missing publisher name"
-Update `package.json` with your publisher ID.
+### Authentication or permission issues
 
-### "Personal Access Token expired"
-Create a new token and login again with `vsce login`.
+```bash
+cd vscode-extension
+npx @vscode/vsce verify-pat effortlesssteven
+```
 
-### Binary not found
-Ensure `bundle-lsp.js` correctly detects platform and copies binaries.
+Then refresh PAT and re-run `vsce login` if needed.
 
-### Large package size
-Check `.vscodeignore` is excluding unnecessary files.
+### Unexpected files in the VSIX
+
+```bash
+cd vscode-extension
+npm run package:list
+```
+
+Tune `.vscodeignore` and rerun preflight.
+
+### Packaging fails during dependency scan
+
+Use the existing script which already sets `--no-yarn` and relies on npm lockfile:
+
+```bash
+cd vscode-extension
+npm run package
+```

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -82,7 +82,9 @@
         "runtime": "node",
         "configurationAttributes": {
           "launch": {
-            "required": ["program"],
+            "required": [
+              "program"
+            ],
             "properties": {
               "program": {
                 "type": "string",
@@ -175,7 +177,11 @@
       "properties": {
         "perl-lsp.channel": {
           "type": "string",
-          "enum": ["latest", "stable", "tag"],
+          "enum": [
+            "latest",
+            "stable",
+            "tag"
+          ],
           "default": "latest",
           "markdownDescription": "Release channel: `latest` for newest release, `stable` for latest stable, `tag` for specific version"
         },
@@ -443,7 +449,10 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "package:list": "npx @vscode/vsce ls --no-yarn",
+    "package": "mkdir -p dist && npx @vscode/vsce package --no-yarn --out dist/perl-lsp-${npm_package_version}.vsix",
+    "marketplace:preflight": "npm run compile && npm run package:list && npm run package"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1",


### PR DESCRIPTION
### Motivation
- Provide a focused, repeatable Marketplace launch runbook for the VS Code extension to reduce manual steps and checklist drift.
- Add deterministic, repository-contained packaging helpers so maintainers can preflight and produce a VSIX from source consistently.

### Description
- Rewrote `vscode-extension/PUBLISHING.md` into a Marketplace-oriented runbook with one-time `vsce login`, a recommended preflight flow, local VSIX smoke-test steps, publish commands, post-publish verification, and troubleshooting tips.
- Added npm scripts to `vscode-extension/package.json`: `package:list` (runs `vsce ls`), `package` (packages a VSIX into `dist/perl-lsp-${npm_package_version}.vsix`), and `marketplace:preflight` (compiles, lists package contents, and packs the VSIX).
- The new `package` script uses `--no-yarn` and writes a deterministic VSIX to `vscode-extension/dist/` to make CI/local checks simpler.

### Testing
- Ran `cd vscode-extension && npm run compile`, which completed successfully (TypeScript build succeeded).
- Ran `cd vscode-extension && npm ci`, which completed successfully and populated `node_modules`.
- Initially `cd vscode-extension && npm run package:list` failed due to a stale/missing `node_modules` tree, but after `npm ci` it succeeded and listed VSIX contents.
- Ran `cd vscode-extension && npm run marketplace:preflight`, which completed end-to-end and produced `dist/perl-lsp-0.10.0.vsix` (packaging succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c412a1508333a29d07f5f97f95a9)