### PR TITLE
fix(features): add missing test references for show_message and log_message

### DIFF
--- a/features.toml
+++ b/features.toml
@@ -335,7 +335,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["tests/lsp_comprehensive_3_17_test.rs"]
 description = "Show messages to user"
 
 [[feature]]
@@ -345,7 +345,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["tests/lsp_comprehensive_3_17_test.rs", "tests/lsp_window_progress_test.rs"]
 description = "Log messages"
 
 [[feature]]


### PR DESCRIPTION
## Truth Audit of features.toml

Full audit of all 97 features in `features.toml` against implementation code and tests.

### Discrepancies Found (2)

| Feature | Issue | Fix |
|---------|-------|-----|
| `lsp.show_message` | `tests = []` but `test_show_message_3_17` exists in `lsp_comprehensive_3_17_test.rs` | Added test reference |
| `lsp.log_message` | `tests = []` but `test_log_message_3_17` exists in `lsp_comprehensive_3_17_test.rs` and `test_window_log_message_notification` exists in `lsp_window_progress_test.rs` | Added test references |

### Audit Summary

| Metric | Count |
|--------|-------|
| Total features | 97 |
| Advertised | 96 |
| Not advertised | 1 (`notebook_cell_execution` — correct, sub-feature of notebook sync) |
| GA maturity | 97 |
| With test references | 97 (was 95) |
| All test files exist on disk | ✅ |
| All features have implementation code | ✅ |
| Implemented-but-unclaimed features | 0 |

### Verification

- `python3 scripts/check_features_invariants.py` passes
- TOML parses cleanly
- All referenced test files verified to exist