### PR TITLE
refactor: extract subprocess runtime into standalone workspace microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "lsp-types",
  "moka",
  "perl-parser-core",
+ "perl-subprocess-runtime",
  "perl-tdd-support",
  "serde",
 ]
@@ -2269,6 +2270,13 @@ dependencies = [
 [[package]]
 name = "perl-source-file"
 version = "0.10.0"
+
+[[package]]
+name = "perl-subprocess-runtime"
+version = "0.10.0"
+dependencies = [
+ "perl-tdd-support",
+]
 
 [[package]]
 name = "perl-symbol-table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/perl-lsp-protocol",
     "crates/perl-lsp-transport",
     "crates/perl-lsp-tooling",
+    "crates/perl-subprocess-runtime",
     "crates/perl-lsp-formatting",
     "crates/perl-lsp-diagnostics",
     "crates/perl-lsp-semantic-tokens",
@@ -140,6 +141,7 @@ allow = [
 
     # Tier 4 — LSP providers
     "perl-lsp-navigation",
+    "perl-subprocess-runtime",
     "perl-lsp-tooling",
     "perl-lsp-formatting",
     "perl-lsp-semantic-tokens",
@@ -256,6 +258,7 @@ perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.10.0
 perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
 perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }
 perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-description = "Tooling integration for Perl LSP (perltidy, perlcritic, subprocess abstraction)"
+description = "Tooling integration for Perl LSP (perltidy and perlcritic)"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository.workspace = true
@@ -21,7 +21,7 @@ default = ["lsp-compat"]
 lsp-compat = ["dep:lsp-types"]
 
 [dependencies]
-perl-tdd-support = { workspace = true }
+perl-subprocess-runtime = { workspace = true }
 perl-parser-core = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
 lsp-types = { version = "0.97.0", optional = true }
@@ -29,6 +29,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
+perl-subprocess-runtime = { workspace = true, features = ["mock"] }
 criterion = "0.8"
 
 [[bench]]

--- a/crates/perl-lsp-tooling/src/lib.rs
+++ b/crates/perl-lsp-tooling/src/lib.rs
@@ -31,15 +31,13 @@ pub mod performance;
 pub mod perl_critic;
 /// Perltidy integration for code formatting.
 pub mod perltidy;
-mod subprocess_runtime;
-
-pub use subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
+pub use perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use subprocess_runtime::OsSubprocessRuntime;
+pub use perl_subprocess_runtime::OsSubprocessRuntime;
 
 /// Test mock implementations for subprocess runtimes.
 #[cfg(test)]
 pub mod mock {
-    pub use crate::subprocess_runtime::mock::*;
+    pub use perl_subprocess_runtime::mock::*;
 }

--- a/crates/perl-lsp-tooling/src/perl_critic.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic.rs
@@ -3,7 +3,7 @@
 //! This module provides integration with Perl::Critic for static code analysis
 //! and policy enforcement in Perl code.
 
-use super::subprocess_runtime::SubprocessRuntime;
+use super::SubprocessRuntime;
 use perl_parser_core::{
     Node,
     position::{Position, Range},
@@ -132,7 +132,7 @@ impl CriticAnalyzer {
     /// Creates a new analyzer with the OS subprocess runtime (non-WASM only).
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_os_runtime(config: CriticConfig) -> Self {
-        use super::subprocess_runtime::OsSubprocessRuntime;
+        use super::OsSubprocessRuntime;
         Self::new(config, Arc::new(OsSubprocessRuntime::new()))
     }
 
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         // Mock perlcritic output format: file:line:column:severity:policy:message
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_caching() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_config_args() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));

--- a/crates/perl-lsp-tooling/src/perltidy.rs
+++ b/crates/perl-lsp-tooling/src/perltidy.rs
@@ -3,7 +3,7 @@
 //! This module provides integration with perltidy for automatic code formatting
 //! and beautification of Perl code.
 
-use super::subprocess_runtime::SubprocessRuntime;
+use super::SubprocessRuntime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -185,7 +185,7 @@ impl PerlTidyFormatter {
     /// Creates a new formatter with the OS subprocess runtime (non-WASM only).
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_os_runtime(config: PerlTidyConfig) -> Self {
-        use super::subprocess_runtime::OsSubprocessRuntime;
+        use super::OsSubprocessRuntime;
         Self::new(config, Arc::new(OsSubprocessRuntime::new()))
     }
 
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_formatter_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"my $x = 1;\n".to_vec()));
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_formatter_caching() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"formatted\n".to_vec()));
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_formatter_error_handling() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::failure(b"syntax error".to_vec(), 1));
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_format_file_with_mock_runtime() {
-        use super::super::subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
+        use super::super::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
         runtime.add_response(MockResponse::success(b"".to_vec()));

--- a/crates/perl-subprocess-runtime/Cargo.toml
+++ b/crates/perl-subprocess-runtime/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "perl-subprocess-runtime"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Subprocess runtime abstraction for Perl tooling crates"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-subprocess-runtime"
+keywords = ["perl", "subprocess", "runtime", "testing"]
+categories = ["development-tools"]
+
+[features]
+default = []
+mock = ["dep:perl-tdd-support"]
+
+[dependencies]
+perl-tdd-support = { workspace = true, optional = true }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+perl-tdd-support = { workspace = true }

--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -1,47 +1,57 @@
-//! Subprocess execution abstraction for provider purity
+//! Subprocess execution abstraction for provider purity.
 //!
-//! This module provides a trait-based abstraction for subprocess execution,
+//! This crate provides a trait-based abstraction for subprocess execution,
 //! enabling testing with mock implementations and WASM compatibility.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
 
 use std::fmt;
 
-/// Output from a subprocess execution
+/// Output from a subprocess execution.
 #[derive(Debug, Clone)]
 pub struct SubprocessOutput {
-    /// Standard output bytes
+    /// Standard output bytes.
     pub stdout: Vec<u8>,
-    /// Standard error bytes
+    /// Standard error bytes.
     pub stderr: Vec<u8>,
-    /// Exit status code (0 typically indicates success)
+    /// Exit status code (0 typically indicates success).
     pub status_code: i32,
 }
 
 impl SubprocessOutput {
-    /// Returns true if the subprocess exited successfully (status code 0)
+    /// Returns true if the subprocess exited successfully (status code 0).
+    #[must_use]
     pub fn success(&self) -> bool {
         self.status_code == 0
     }
 
-    /// Returns stdout as a UTF-8 string, lossy converting invalid bytes
+    /// Returns stdout as a UTF-8 string, lossy converting invalid bytes.
+    #[must_use]
     pub fn stdout_lossy(&self) -> String {
         String::from_utf8_lossy(&self.stdout).into_owned()
     }
 
-    /// Returns stderr as a UTF-8 string, lossy converting invalid bytes
+    /// Returns stderr as a UTF-8 string, lossy converting invalid bytes.
+    #[must_use]
     pub fn stderr_lossy(&self) -> String {
         String::from_utf8_lossy(&self.stderr).into_owned()
     }
 }
 
-/// Error type for subprocess execution failures
+/// Error type for subprocess execution failures.
 #[derive(Debug, Clone)]
 pub struct SubprocessError {
-    /// Human-readable error message
+    /// Human-readable error message.
     pub message: String,
 }
 
 impl SubprocessError {
-    /// Create a new subprocess error with the given message
+    /// Create a new subprocess error with the given message.
+    #[must_use]
     pub fn new(message: impl Into<String>) -> Self {
         Self { message: message.into() }
     }
@@ -55,24 +65,9 @@ impl fmt::Display for SubprocessError {
 
 impl std::error::Error for SubprocessError {}
 
-/// Abstraction trait for subprocess execution
-///
-/// This trait allows providers to execute external commands without
-/// directly depending on `std::process::Command`, enabling:
-/// - Unit testing with mock implementations
-/// - WASM compatibility with alternative implementations
-/// - Sandboxing and security controls
+/// Abstraction trait for subprocess execution.
 pub trait SubprocessRuntime: Send + Sync {
-    /// Execute a command with the given arguments and optional stdin
-    ///
-    /// # Arguments
-    /// * `program` - The program to execute (e.g., "perltidy", "perlcritic")
-    /// * `args` - Command line arguments
-    /// * `stdin` - Optional data to write to the process's stdin
-    ///
-    /// # Returns
-    /// * `Ok(SubprocessOutput)` - The command completed (check status_code for success)
-    /// * `Err(SubprocessError)` - The command failed to start or other I/O error
+    /// Execute a command with the given arguments and optional stdin.
     fn run_command(
         &self,
         program: &str,
@@ -81,15 +76,14 @@ pub trait SubprocessRuntime: Send + Sync {
     ) -> Result<SubprocessOutput, SubprocessError>;
 }
 
-/// Default implementation using `std::process::Command`
-///
-/// This implementation is only available on non-WASM targets.
+/// Default implementation using `std::process::Command`.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct OsSubprocessRuntime;
 
 #[cfg(not(target_arch = "wasm32"))]
 impl OsSubprocessRuntime {
-    /// Create a new OS subprocess runtime
+    /// Create a new OS subprocess runtime.
+    #[must_use]
     pub fn new() -> Self {
         Self
     }
@@ -116,7 +110,6 @@ impl SubprocessRuntime for OsSubprocessRuntime {
         let mut cmd = Command::new(program);
         cmd.args(args);
 
-        // Configure stdin based on whether we need to write to it
         if stdin.is_some() {
             cmd.stdin(Stdio::piped());
         }
@@ -124,12 +117,10 @@ impl SubprocessRuntime for OsSubprocessRuntime {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
-        // Spawn the process
         let mut child = cmd
             .spawn()
             .map_err(|e| SubprocessError::new(format!("Failed to start {}: {}", program, e)))?;
 
-        // Write to stdin if provided
         if let Some(input) = stdin
             && let Some(mut child_stdin) = child.stdin.take()
         {
@@ -138,7 +129,6 @@ impl SubprocessRuntime for OsSubprocessRuntime {
             })?;
         }
 
-        // Wait for completion
         let output = child
             .wait_with_output()
             .map_err(|e| SubprocessError::new(format!("Failed to wait for {}: {}", program, e)))?;
@@ -151,62 +141,59 @@ impl SubprocessRuntime for OsSubprocessRuntime {
     }
 }
 
-/// Mock subprocess runtime for testing
-///
-/// This implementation allows tests to define expected command invocations
-/// and their responses without actually executing subprocesses.
-#[cfg(test)]
+/// Mock subprocess runtime for testing.
+#[cfg(any(test, feature = "mock"))]
 pub mod mock {
     use super::*;
     use perl_tdd_support::must;
     use std::sync::{Arc, Mutex};
 
-    /// A recorded command invocation
+    /// A recorded command invocation.
     #[derive(Debug, Clone)]
     pub struct CommandInvocation {
-        /// The program that was called
+        /// The program that was called.
         pub program: String,
-        /// The arguments passed
+        /// The arguments passed.
         pub args: Vec<String>,
-        /// The stdin data provided
+        /// The stdin data provided.
         pub stdin: Option<Vec<u8>>,
     }
 
-    /// Builder for mock responses
+    /// Builder for mock responses.
     #[derive(Debug, Clone)]
     pub struct MockResponse {
-        /// Stdout to return
+        /// Stdout to return.
         pub stdout: Vec<u8>,
-        /// Stderr to return
+        /// Stderr to return.
         pub stderr: Vec<u8>,
-        /// Status code to return
+        /// Status code to return.
         pub status_code: i32,
     }
 
     impl MockResponse {
-        /// Create a successful mock response with the given stdout
+        /// Create a successful mock response with the given stdout.
+        #[must_use]
         pub fn success(stdout: impl Into<Vec<u8>>) -> Self {
             Self { stdout: stdout.into(), stderr: Vec::new(), status_code: 0 }
         }
 
-        /// Create a failed mock response with the given stderr
+        /// Create a failed mock response with the given stderr.
+        #[must_use]
         pub fn failure(stderr: impl Into<Vec<u8>>, status_code: i32) -> Self {
             Self { stdout: Vec::new(), stderr: stderr.into(), status_code }
         }
     }
 
-    /// Mock subprocess runtime for testing
+    /// Mock subprocess runtime for testing.
     pub struct MockSubprocessRuntime {
-        /// Recorded invocations
         invocations: Arc<Mutex<Vec<CommandInvocation>>>,
-        /// Responses to return (in order)
         responses: Arc<Mutex<Vec<MockResponse>>>,
-        /// Default response if responses are exhausted
         default_response: MockResponse,
     }
 
     impl MockSubprocessRuntime {
-        /// Create a new mock runtime with a default successful response
+        /// Create a new mock runtime with a default successful response.
+        #[must_use]
         pub fn new() -> Self {
             Self {
                 invocations: Arc::new(Mutex::new(Vec::new())),
@@ -215,22 +202,23 @@ pub mod mock {
             }
         }
 
-        /// Add a response to be returned for the next command
+        /// Add a response to be returned for the next command.
         pub fn add_response(&self, response: MockResponse) {
             must(self.responses.lock()).push(response);
         }
 
-        /// Set the default response when no queued responses remain
+        /// Set the default response when no queued responses remain.
         pub fn set_default_response(&mut self, response: MockResponse) {
             self.default_response = response;
         }
 
-        /// Get all recorded invocations
+        /// Get all recorded invocations.
+        #[must_use]
         pub fn invocations(&self) -> Vec<CommandInvocation> {
             must(self.invocations.lock()).clone()
         }
 
-        /// Clear recorded invocations
+        /// Clear recorded invocations.
         pub fn clear_invocations(&self) {
             must(self.invocations.lock()).clear();
         }
@@ -249,14 +237,12 @@ pub mod mock {
             args: &[&str],
             stdin: Option<&[u8]>,
         ) -> Result<SubprocessOutput, SubprocessError> {
-            // Record the invocation
             must(self.invocations.lock()).push(CommandInvocation {
                 program: program.to_string(),
                 args: args.iter().map(|s| s.to_string()).collect(),
                 stdin: stdin.map(|s| s.to_vec()),
             });
 
-            // Get the next response or use default
             let response = {
                 let mut responses = must(self.responses.lock());
                 if responses.is_empty() {
@@ -281,26 +267,26 @@ mod tests {
     use perl_tdd_support::must;
 
     #[test]
-    fn test_subprocess_output_success() {
+    fn subprocess_output_success() {
         let output = SubprocessOutput { stdout: vec![1, 2, 3], stderr: vec![], status_code: 0 };
         assert!(output.success());
     }
 
     #[test]
-    fn test_subprocess_output_failure() {
+    fn subprocess_output_failure() {
         let output = SubprocessOutput { stdout: vec![], stderr: b"error".to_vec(), status_code: 1 };
         assert!(!output.success());
         assert_eq!(output.stderr_lossy(), "error");
     }
 
     #[test]
-    fn test_subprocess_error_display() {
+    fn subprocess_error_display() {
         let error = SubprocessError::new("test error");
         assert_eq!(format!("{}", error), "test error");
     }
 
     #[test]
-    fn test_mock_runtime() {
+    fn mock_runtime_records_and_replays() {
         use mock::*;
 
         let runtime = MockSubprocessRuntime::new();
@@ -322,25 +308,21 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_os_runtime_echo() {
+    fn os_runtime_echo() {
         let runtime = OsSubprocessRuntime::new();
-
-        // Test with echo which should be available on most systems
         let result = runtime.run_command("echo", &["hello"], None);
 
         assert!(result.is_ok());
         let output = must(result);
         assert!(output.success());
-        assert!(output.stdout_lossy().trim() == "hello");
+        assert_eq!(output.stdout_lossy().trim(), "hello");
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_os_runtime_nonexistent() {
+    fn os_runtime_nonexistent() {
         let runtime = OsSubprocessRuntime::new();
-
         let result = runtime.run_command("nonexistent_program_xyz", &[], None);
-
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
### Motivation
- `perl-lsp-tooling` mixed tooling-specific integrations (perltidy/perlcritic) with a generic subprocess execution abstraction, violating SRP and preventing reuse. 
- Extracting the runtime into its own microcrate enables reuse, simpler ownership, and cleaner testing surface for tooling providers.

### Description
- Added a new workspace crate `perl-subprocess-runtime` that exposes the `SubprocessRuntime` trait and types `SubprocessOutput` and `SubprocessError`, plus `OsSubprocessRuntime` and a feature-gated `mock` module for tests. 
- Moved the former `subprocess_runtime.rs` implementation into `crates/perl-subprocess-runtime/src/lib.rs` and added `crates/perl-subprocess-runtime/Cargo.toml`. 
- Updated workspace wiring by adding the new member, workspace dependency entry, and publish allowlist entries in `Cargo.toml` and updating `Cargo.lock`. 
- Updated `perl-lsp-tooling` to depend on and re-export `perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime}` and `OsSubprocessRuntime`, and adjusted `perltidy.rs` and `perl_critic.rs` imports and tests to use the new re-exports and mock paths. 
- Performed code formatting with `cargo fmt --all` to keep style consistent. 

### Testing
- Ran `cargo test -p perl-subprocess-runtime` and all tests passed (6 passed). 
- Ran `cargo test -p perl-lsp-tooling` and all tests passed (19 passed). 
- Ran `cargo test -p perl-lsp-formatting` and all tests passed (3 passed). 
- Ran `CARGO_TARGET_DIR=target-clippy-split cargo clippy -p perl-subprocess-runtime -p perl-lsp-tooling -p perl-lsp-formatting --all-targets` and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c19c0af483338b2ff5f433d93aeb)