### PR TITLE
test(regex): add comprehensive unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "perl-tdd-support",
  "regex",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -2285,6 +2286,7 @@ dependencies = [
 name = "perl-regex"
 version = "0.10.0"
 dependencies = [
+ "perl-tdd-support",
  "thiserror",
 ]
 

--- a/crates/perl-regex/Cargo.toml
+++ b/crates/perl-regex/Cargo.toml
@@ -16,5 +16,8 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 thiserror = "2.0.18"
 
+[dev-dependencies]
+perl-tdd-support = { path = "../perl-tdd-support" }
+
 [lints]
 workspace = true

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -1,0 +1,678 @@
+//! Comprehensive unit tests for the perl-regex crate.
+//!
+//! Covers: RegexError, RegexValidator (validate, detects_code_execution,
+//! detect_nested_quantifiers), Default impl, and edge cases.
+
+use perl_regex::{RegexError, RegexValidator};
+
+// ── RegexError ──────────────────────────────────────────────────────────
+
+#[test]
+fn regex_error_syntax_constructor() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("bad pattern", 42);
+    match &err {
+        RegexError::Syntax { message, offset } => {
+            assert_eq!(message, "bad pattern");
+            assert_eq!(*offset, 42);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn regex_error_display_format() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("unmatched paren", 7);
+    let display = format!("{err}");
+    assert_eq!(display, "unmatched paren at offset 7");
+    Ok(())
+}
+
+#[test]
+fn regex_error_clone_and_eq() -> Result<(), Box<dyn std::error::Error>> {
+    let a = RegexError::syntax("x", 0);
+    let b = a.clone();
+    assert_eq!(a, b);
+    Ok(())
+}
+
+#[test]
+fn regex_error_debug_contains_variant() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("msg", 1);
+    let dbg = format!("{err:?}");
+    assert!(dbg.contains("Syntax"));
+    Ok(())
+}
+
+#[test]
+fn regex_error_syntax_zero_offset() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("at start", 0);
+    assert_eq!(format!("{err}"), "at start at offset 0");
+    Ok(())
+}
+
+#[test]
+fn regex_error_syntax_large_offset() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("far away", usize::MAX);
+    match &err {
+        RegexError::Syntax { offset, .. } => assert_eq!(*offset, usize::MAX),
+    }
+    Ok(())
+}
+
+#[test]
+fn regex_error_empty_message() -> Result<(), Box<dyn std::error::Error>> {
+    let err = RegexError::syntax("", 5);
+    assert_eq!(format!("{err}"), " at offset 5");
+    Ok(())
+}
+
+#[test]
+fn regex_error_accepts_string_owned() -> Result<(), Box<dyn std::error::Error>> {
+    let msg = String::from("owned message");
+    let err = RegexError::syntax(msg, 10);
+    match &err {
+        RegexError::Syntax { message, .. } => assert_eq!(message, "owned message"),
+    }
+    Ok(())
+}
+
+// ── RegexValidator construction ─────────────────────────────────────────
+
+#[test]
+fn validator_new_returns_instance() -> Result<(), Box<dyn std::error::Error>> {
+    let _v = RegexValidator::new();
+    Ok(())
+}
+
+#[test]
+fn validator_default_matches_new() -> Result<(), Box<dyn std::error::Error>> {
+    // Both should behave identically on the same input
+    let v1 = RegexValidator::new();
+    let v2 = RegexValidator::default();
+    let pattern = "(a+)+";
+    let r1 = v1.validate(pattern, 0);
+    let r2 = v2.validate(pattern, 0);
+    assert_eq!(r1.is_err(), r2.is_err());
+    Ok(())
+}
+
+// ── validate() — safe patterns ──────────────────────────────────────────
+
+#[test]
+fn validate_empty_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_simple_literal() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("hello", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_single_quantifier() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("a+", 0)?;
+    v.validate("b*", 0)?;
+    v.validate("c?", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_character_class() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("[a-z]+", 0)?;
+    v.validate("[^0-9]", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_alternation() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("foo|bar|baz", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_anchors() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("^start$", 0)?;
+    v.validate(r"\bhello\b", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_non_capturing_group_without_outer_quantifier() -> Result<(), Box<dyn std::error::Error>>
+{
+    let v = RegexValidator::new();
+    // Non-capturing group without an outer quantifier is fine
+    v.validate("(?:abc)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_non_capturing_group_with_outer_quantifier_flagged()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Heuristic treats ? in (?:...) as a quantifier, so (?:abc)+ is flagged
+    assert!(v.validate("(?:abc)+", 0).is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_named_capture() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("(?<name>\\w+)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_lookahead() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("foo(?=bar)", 0)?;
+    v.validate("foo(?!bar)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_lookbehind_simple() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("(?<=foo)bar", 0)?;
+    v.validate("(?<!foo)bar", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_escaped_special_chars() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate(r"\(\)\[\]\{\}\+\*\?", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_unicode_literal_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("café", 0)?;
+    v.validate("日本語", 0)?;
+    v.validate("🦀+", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_single_unicode_property() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate(r"\p{Latin}", 0)?;
+    v.validate(r"\P{Digit}", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_start_pos_propagates_to_error() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    let result = v.validate("(a+)+", 100);
+    match result {
+        Err(RegexError::Syntax { offset, .. }) => {
+            assert_eq!(offset, 100);
+        }
+        Ok(()) => return Err("expected error for nested quantifiers".into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn validate_group_without_quantifier_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("(abc)(def)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_quantifier_on_group_without_inner_quantifier() -> Result<(), Box<dyn std::error::Error>>
+{
+    let v = RegexValidator::new();
+    v.validate("(abc)+", 0)?;
+    v.validate("(abc)*", 0)?;
+    v.validate("(abc)?", 0)?;
+    Ok(())
+}
+
+// ── validate() — nested quantifiers (should fail) ───────────────────────
+
+#[test]
+fn validate_rejects_nested_plus() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    let result = v.validate("(a+)+", 0);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("catastrophic backtracking"));
+    Ok(())
+}
+
+#[test]
+fn validate_rejects_nested_star() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.validate("(a*)*", 0).is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_rejects_star_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.validate("(a+)*", 0).is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_rejects_plus_on_star_group() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.validate("(a*)+", 0).is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_rejects_question_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.validate("(a+)?", 0).is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_rejects_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn std::error::Error>>
+{
+    let v = RegexValidator::new();
+    assert!(v.validate("(a+){2,5}", 0).is_err());
+    Ok(())
+}
+
+// ── detect_nested_quantifiers() direct tests ────────────────────────────
+
+#[test]
+fn nested_quantifiers_false_for_empty() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers(""));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_false_for_simple() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers("abc"));
+    assert!(!v.detect_nested_quantifiers("a+"));
+    assert!(!v.detect_nested_quantifiers("[a-z]+"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_true_classic_cases() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.detect_nested_quantifiers("(a+)+"));
+    assert!(v.detect_nested_quantifiers("(a*)*"));
+    assert!(v.detect_nested_quantifiers("(a?)*"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_escaped_paren_not_group() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Escaped parens are literal, not groups
+    assert!(!v.detect_nested_quantifiers(r"\(a+\)+"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_non_capturing_group() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.detect_nested_quantifiers("(?:a+)+"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_multiple_groups_only_last_nested() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // first group is safe, second has nested quantifiers
+    assert!(v.detect_nested_quantifiers("(abc)(a+)+"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_group_without_outer_quantifier() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // inner quantifier but no outer quantifier on the group
+    assert!(!v.detect_nested_quantifiers("(a+)b"));
+    Ok(())
+}
+
+// ── detects_code_execution() ────────────────────────────────────────────
+
+#[test]
+fn code_execution_empty_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detects_code_execution(""));
+    Ok(())
+}
+
+#[test]
+fn code_execution_safe_patterns() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detects_code_execution("hello"));
+    assert!(!v.detects_code_execution("(abc)"));
+    assert!(!v.detects_code_execution("(?:abc)"));
+    assert!(!v.detects_code_execution("(?=abc)"));
+    assert!(!v.detects_code_execution("(?!abc)"));
+    assert!(!v.detects_code_execution("(?<=abc)"));
+    assert!(!v.detects_code_execution("(?<!abc)"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_detects_eval_block() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.detects_code_execution("(?{ print 'hi' })"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_detects_deferred_eval() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.detects_code_execution("(??{ $code })"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_detects_embedded_in_larger_pattern() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(v.detects_code_execution("abc(?{ die })def"));
+    assert!(v.detects_code_execution("^(\\w+)(??{ gen_re() })$"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_escaped_paren_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Escaped open paren: literal, not a group start
+    assert!(!v.detects_code_execution(r"\(?{ code }"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_brace_without_question_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detects_code_execution("({stuff})"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_question_without_brace_is_safe() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detects_code_execution("(?:abc)"));
+    assert!(!v.detects_code_execution("(?=abc)"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_double_question_without_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // (?? followed by something other than { is not code execution
+    assert!(!v.detects_code_execution("(??x)"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_multiple_code_blocks() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Returns true on first one found
+    assert!(v.detects_code_execution("(?{ a })(?{ b })"));
+    Ok(())
+}
+
+// ── Unicode property limits ─────────────────────────────────────────────
+
+#[test]
+fn validate_under_unicode_property_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // 50 properties should be exactly at the limit
+    let pattern: String = (0..50).map(|_| r"\p{L}").collect::<Vec<_>>().join("");
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_exceeds_unicode_property_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // 51 properties should exceed the limit of 50
+    let pattern: String = (0..51).map(|_| r"\p{L}").collect::<Vec<_>>().join("");
+    let result = v.validate(&pattern, 0);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("Too many Unicode properties"));
+    Ok(())
+}
+
+#[test]
+fn validate_uppercase_p_counted_same() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // \P{...} should also count toward the limit
+    let pattern: String = (0..51).map(|_| r"\P{Digit}").collect::<Vec<_>>().join("");
+    let result = v.validate(&pattern, 0);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn validate_unicode_p_without_brace_not_counted() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // \pL (shorthand without braces) should not count
+    let pattern: String = (0..100).map(|_| r"\pL").collect::<Vec<_>>().join("");
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+// ── Lookbehind nesting limits ───────────────────────────────────────────
+
+#[test]
+fn validate_shallow_lookbehind_nesting() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Single lookbehind is fine
+    v.validate("(?<=a)b", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_deep_lookbehind_nesting_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Build 11 nested lookbehinds (exceeds max_nesting=10)
+    let mut pattern = String::from("x");
+    for _ in 0..11 {
+        pattern = format!("(?<={})", pattern);
+    }
+    let result = v.validate(&pattern, 0);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("lookbehind nesting too deep"));
+    Ok(())
+}
+
+#[test]
+fn validate_exactly_max_lookbehind_nesting_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Build exactly 10 nested lookbehinds (at limit, not over)
+    let mut pattern = String::from("x");
+    for _ in 0..10 {
+        pattern = format!("(?<={})", pattern);
+    }
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+// ── Branch reset nesting limits ─────────────────────────────────────────
+
+#[test]
+fn validate_single_branch_reset() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("(?|a|b|c)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_deep_branch_reset_nesting_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Build 11 nested branch resets (exceeds max_nesting=10)
+    let mut pattern = String::from("x");
+    for _ in 0..11 {
+        pattern = format!("(?|{})", pattern);
+    }
+    let result = v.validate(&pattern, 0);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("branch reset nesting too deep"));
+    Ok(())
+}
+
+#[test]
+fn validate_branch_reset_too_many_branches() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // 51 branches in a branch reset (exceeds max of 50)
+    let branches: String = (0..51).map(|i| format!("a{i}")).collect::<Vec<_>>().join("|");
+    let pattern = format!("(?|{branches})");
+    let result = v.validate(&pattern, 0);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("Too many branches"));
+    Ok(())
+}
+
+#[test]
+fn validate_branch_reset_at_limit_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Exactly 50 branches (at limit), the group starts with one branch and | adds more
+    // So 50 pipes = 51 branches total. We need 49 pipes for 50 branches.
+    let branches: String = (0..50).map(|i| format!("a{i}")).collect::<Vec<_>>().join("|");
+    let pattern = format!("(?|{branches})");
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+// ── Character class handling ────────────────────────────────────────────
+
+#[test]
+fn validate_character_class_with_escaped_bracket() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate(r"[\]]", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_character_class_with_special_chars() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate(r"[+*?{}()]", 0)?;
+    Ok(())
+}
+
+// ── Misc edge cases ────────────────────────────────────────────────────
+
+#[test]
+fn validate_only_backslash() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Trailing backslash — no char to escape, but shouldn't panic
+    v.validate("\\", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_unmatched_parens_does_not_panic() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Unbalanced parens: the validator doesn't check balance, just safety
+    v.validate("((((", 0)?;
+    v.validate("))))", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_deeply_nested_safe_groups() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Deep nesting of normal groups is OK
+    let open: String = "(".repeat(50);
+    let close: String = ")".repeat(50);
+    let pattern = format!("{open}abc{close}");
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_mixed_safe_constructs() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate(r"^(?:(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2}))$", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_alternation_in_branch_reset() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    v.validate("(?|foo|bar|baz)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_pipe_outside_branch_reset_ok() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Many alternations in a normal group should not trigger branch limit
+    let branches: String = (0..100).map(|i| format!("x{i}")).collect::<Vec<_>>().join("|");
+    let pattern = format!("({branches})");
+    v.validate(&pattern, 0)?;
+    Ok(())
+}
+
+#[test]
+fn validate_start_pos_offset_in_unicode_error() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    let pattern: String = (0..51).map(|_| r"\p{L}").collect::<Vec<_>>().join("");
+    let result = v.validate(&pattern, 200);
+    match result {
+        Err(RegexError::Syntax { offset, .. }) => {
+            // Offset should be start_pos + byte index within pattern
+            assert!(offset >= 200);
+        }
+        Ok(()) => return Err("expected error".into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn detect_nested_quantifiers_with_interleaved_literal() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Literal chars between group close and quantifier break the nesting
+    assert!(!v.detect_nested_quantifiers("(a+)b+"));
+    Ok(())
+}
+
+#[test]
+fn code_execution_escaped_backslash_before_paren() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // \\ followed by ( — the backslash escapes the next backslash, so ( is a real group
+    // "\\(?{...})" — the \\ is an escaped backslash, then (?{ is code execution
+    assert!(v.detects_code_execution("\\\\(?{ code })"));
+    Ok(())
+}
+
+#[test]
+fn validate_complex_safe_perl_regex_without_noncapturing() -> Result<(), Box<dyn std::error::Error>>
+{
+    let v = RegexValidator::new();
+    // A realistic Perl regex with no quantifier-on-quantified-group patterns
+    v.validate(r"([a-zA-Z]+)://([a-zA-Z0-9.-]+)/(\S+)", 0)?;
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_lazy_modifier_still_detected() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // (a+?)+ — the ? here makes the inner + lazy, but the outer + still nests
+    // The ? after ) is the outer quantifier on a group with inner +
+    assert!(v.detect_nested_quantifiers("(a+?)+"));
+    Ok(())
+}


### PR DESCRIPTION
Adds 74 comprehensive unit tests for perl-regex crate. All tests pass, fmt clean, clippy clean.