### PR TITLE
Extract shared source-context heuristics into a dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-dead-code"
+version = "0.10.0"
+dependencies = [
+ "perl-workspace-index",
+ "serde",
+]
+
+[[package]]
 name = "perl-diagnostics-codes"
 version = "0.10.0"
 dependencies = [
@@ -1767,6 +1775,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-capability-map"
+version = "0.10.0"
+dependencies = [
+ "lsp-types",
+ "perl-lsp-feature-ids",
+]
+
+[[package]]
 name = "perl-lsp-code-actions"
 version = "0.10.0"
 dependencies = [
@@ -1784,6 +1800,7 @@ dependencies = [
  "perl-keywords",
  "perl-parser-core",
  "perl-semantic-analyzer",
+ "perl-source-context",
  "perl-tdd-support",
  "perl-workspace-index",
  "url",
@@ -1807,6 +1824,7 @@ version = "0.10.0"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
+ "perl-lsp-capability-map",
  "perl-lsp-feature-ids",
  "serde",
 ]
@@ -1961,6 +1979,7 @@ dependencies = [
  "perl-keywords",
  "perl-parser-core",
  "perl-semantic-analyzer",
+ "perl-source-context",
  "perl-symbol-cursor",
  "perl-tdd-support",
 ]
@@ -1984,6 +2003,7 @@ dependencies = [
  "lsp-types",
  "moka",
  "perl-parser-core",
+ "perl-subprocess-runtime",
  "perl-tdd-support",
  "serde",
 ]
@@ -2134,6 +2154,7 @@ dependencies = [
  "nix",
  "parking_lot",
  "perl-corpus",
+ "perl-dead-code",
  "perl-incremental-parsing",
  "perl-keywords",
  "perl-lexer",
@@ -2275,7 +2296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-source-context"
+version = "0.10.0"
+
+[[package]]
 name = "perl-source-file"
+version = "0.10.0"
+
+[[package]]
+name = "perl-subprocess-runtime"
 version = "0.10.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
     "crates/perl-text-line",
     "crates/perl-keywords",
     "crates/perl-source-file",
+    "crates/perl-source-context",
     "crates/perl-content-length-framing",
     "crates/perl-uri",
     "crates/perl-path-security",
@@ -194,6 +195,7 @@ allow = [
     "perl-module-resolution-uri",
     "perl-module-resolution",
     "perl-source-file",
+    "perl-source-context",
     "perl-workspace-discovery",
     "perl-diagnostics-codes",
 
@@ -246,6 +248,7 @@ perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", versi
 perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.10.0" }
 perl-keywords = { path = "crates/perl-keywords", version = "0.10.0" }
 perl-source-file = { path = "crates/perl-source-file", version = "0.10.0" }
+perl-source-context = { path = "crates/perl-source-context", version = "0.10.0" }
 perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
 perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }

--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -21,6 +21,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-keywords = { workspace = true }
+perl-source-context = { workspace = true }
 lsp-types = { version = "0.97.0", optional = true }
 url = "2.5.8"
 walkdir = "2.5.0"

--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -107,6 +107,7 @@ pub use self::items::{CompletionItem, CompletionItemKind};
 
 use perl_parser_core::ast::Node;
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
+use perl_source_context::{is_in_comment, is_in_string};
 use perl_workspace_index::workspace_index::WorkspaceIndex;
 use std::sync::Arc;
 
@@ -593,9 +594,9 @@ impl CompletionProvider {
         let trigger_character = if position > 0 { source.chars().nth(position - 1) } else { None };
 
         // Simple heuristics for context detection
-        let in_string = self.is_in_string(source, position);
+        let in_string = is_in_string(source, position);
         let in_regex = self.is_in_regex(source, position);
-        let in_comment = self.is_in_comment(source, position);
+        let in_comment = is_in_comment(source, position);
 
         CompletionContext::new(
             &self.symbol_table,
@@ -816,16 +817,6 @@ impl CompletionProvider {
         false
     }
 
-    /// Simple heuristic to check if position is in a string
-    fn is_in_string(&self, source: &str, position: usize) -> bool {
-        let before = &source[..position];
-        let single_quotes = before.matches('\'').count();
-        let double_quotes = before.matches('"').count();
-
-        // Very simple: odd number of quotes means we're inside
-        single_quotes % 2 == 1 || double_quotes % 2 == 1
-    }
-
     /// Simple heuristic to check if position is in a regex
     fn is_in_regex(&self, source: &str, position: usize) -> bool {
         // Look for regex patterns before position
@@ -840,13 +831,6 @@ impl CompletionProvider {
         } else {
             false
         }
-    }
-
-    /// Simple heuristic to check if position is in a comment
-    fn is_in_comment(&self, source: &str, position: usize) -> bool {
-        let line_start = source[..position].rfind('\n').map(|p| p + 1).unwrap_or(0);
-        let line = &source[line_start..position];
-        line.contains('#')
     }
 
     /// Check if we're in a test context

--- a/crates/perl-lsp-rename/Cargo.toml
+++ b/crates/perl-lsp-rename/Cargo.toml
@@ -21,6 +21,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-keywords = { workspace = true }
 perl-symbol-cursor = { workspace = true }
+perl-source-context = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-rename/src/rename/apply.rs
+++ b/crates/perl-lsp-rename/src/rename/apply.rs
@@ -4,6 +4,7 @@
 
 use perl_parser_core::SourceLocation;
 use perl_semantic_analyzer::symbol::SymbolKind;
+use perl_source_context::{is_in_comment, is_in_string};
 
 use super::types::{RenameOptions, TextEdit};
 
@@ -38,8 +39,8 @@ pub fn find_occurrences_in_text(
         let absolute_pos = search_pos + pos;
 
         // Check if this is in a comment or string
-        let in_comment = is_in_comment(absolute_pos, source);
-        let in_string = is_in_string(absolute_pos, source);
+        let in_comment = is_in_comment(source, absolute_pos);
+        let in_string = is_in_string(source, absolute_pos);
 
         if (in_comment && options.rename_in_comments) || (in_string && options.rename_in_strings) {
             // Make sure it's a whole word
@@ -67,30 +68,6 @@ pub fn find_occurrences_in_text(
     }
 
     edits
-}
-
-/// Check if position is in a comment
-pub fn is_in_comment(position: usize, source: &str) -> bool {
-    let line_start =
-        if position == 0 { 0 } else { source[..position].rfind('\n').map_or(0, |p| p + 1) };
-    let line = &source[line_start..];
-
-    if let Some(comment_pos) = line.find('#') {
-        let comment_absolute = line_start + comment_pos;
-        position >= comment_absolute
-    } else {
-        false
-    }
-}
-
-/// Check if position is in a string
-pub fn is_in_string(position: usize, source: &str) -> bool {
-    // Simple heuristic - count quotes before position
-    let before = &source[..position];
-    let single_quotes = before.matches('\'').count();
-    let double_quotes = before.matches('"').count();
-
-    single_quotes % 2 == 1 || double_quotes % 2 == 1
 }
 
 /// Apply rename edits to source text

--- a/crates/perl-source-context/Cargo.toml
+++ b/crates/perl-source-context/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-source-context"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Shared source text context heuristics for Perl tooling"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-source-context"
+keywords = ["perl", "source", "context", "analysis", "lsp"]
+categories = ["development-tools", "text-editors"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-source-context/LICENSE-APACHE
+++ b/crates/perl-source-context/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/perl-source-context/LICENSE-MIT
+++ b/crates/perl-source-context/LICENSE-MIT
@@ -1,0 +1,7 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/perl-source-context/README.md
+++ b/crates/perl-source-context/README.md
@@ -1,0 +1,10 @@
+# perl-source-context
+
+Shared source-text context heuristics used across Perl tooling crates.
+
+## Features
+
+- String literal context detection
+- Comment context detection
+
+These helpers intentionally provide lightweight heuristics suitable for interactive tooling.

--- a/crates/perl-source-context/src/lib.rs
+++ b/crates/perl-source-context/src/lib.rs
@@ -1,0 +1,52 @@
+//! Shared source-text context heuristics for Perl tooling.
+
+/// Returns `true` when `position` appears inside a quoted string literal.
+///
+/// This uses a lightweight heuristic based on unmatched single or double quotes.
+pub fn is_in_string(source: &str, position: usize) -> bool {
+    let before = &source[..position];
+    let single_quotes = before.matches('\'').count();
+    let double_quotes = before.matches('"').count();
+
+    single_quotes % 2 == 1 || double_quotes % 2 == 1
+}
+
+/// Returns `true` when `position` appears inside a line comment (`# ...`).
+///
+/// This uses a lightweight line-scoped heuristic without full Perl parsing.
+pub fn is_in_comment(source: &str, position: usize) -> bool {
+    let line_start = if position == 0 {
+        0
+    } else {
+        source[..position].rfind('\n').map_or(0, |line_break| line_break + 1)
+    };
+    let line = &source[line_start..position];
+
+    line.contains('#')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_string_context() {
+        let src = "my $x = \"hello\";";
+        let pos = src.find("hello").unwrap_or(0);
+        assert!(is_in_string(src, pos));
+    }
+
+    #[test]
+    fn detects_comment_context() {
+        let src = "my $x = 1; # comment";
+        let pos = src.find("comment").unwrap_or(0);
+        assert!(is_in_comment(src, pos));
+    }
+
+    #[test]
+    fn ignores_non_comment_prefix() {
+        let src = "my $x = 1;\nmy $y = 2;";
+        let pos = src.find("$y").unwrap_or(0);
+        assert!(!is_in_comment(src, pos));
+    }
+}


### PR DESCRIPTION
### Motivation

- `perl-lsp-completion` and `perl-lsp-rename` contained duplicated lightweight heuristics for detecting string/comment contexts, which risks behavioral drift and violates SRP.  
- Extracting these helpers into a focused microcrate centralizes the logic and simplifies future maintenance.

### Description

- Added a new microcrate `crates/perl-source-context` providing `is_in_string` and `is_in_comment` helpers with unit tests and README.  
- Wired the new crate into the workspace by adding it to `members`, the workspace dependency catalog, and the publish allowlist in `Cargo.toml`.  
- Refactored `crates/perl-lsp-completion` and `crates/perl-lsp-rename` to depend on `perl-source-context` and replaced their local `is_in_string`/`is_in_comment` implementations with the shared functions.  
- Removed duplicated code from `perl-lsp-completion` and `perl-lsp-rename` and updated callsites to the shared API; `Cargo.lock` was updated to include the new crate.

### Testing

- Ran `cargo fmt --all`, which completed successfully.  
- Ran `cargo test -p perl-source-context -p perl-lsp-rename -p perl-lsp-completion`, and all unit tests passed (completion: 8 tests, rename: 3 tests, source-context: 3 tests).  
- Ran `cargo clippy --workspace --all-targets` and `cargo clippy -p perl-source-context -p perl-lsp-rename -p perl-lsp-completion --all-targets`; clippy completed with no errors and produced a single non-fatal warning in a test target.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7cdb42558833399c9d7acc8446a1b)