### PR TITLE
Split perltidy argument construction into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-dead-code"
+version = "0.10.0"
+dependencies = [
+ "perl-workspace-index",
+ "serde",
+]
+
+[[package]]
 name = "perl-diagnostics-codes"
 version = "0.10.0"
 dependencies = [
@@ -1767,6 +1775,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-capability-map"
+version = "0.10.0"
+dependencies = [
+ "lsp-types",
+ "perl-lsp-feature-ids",
+]
+
+[[package]]
 name = "perl-lsp-code-actions"
 version = "0.10.0"
 dependencies = [
@@ -1807,6 +1823,7 @@ version = "0.10.0"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
+ "perl-lsp-capability-map",
  "perl-lsp-feature-ids",
  "serde",
 ]
@@ -1864,10 +1881,18 @@ dependencies = [
 name = "perl-lsp-formatting"
 version = "0.10.0"
 dependencies = [
+ "perl-lsp-formatting-cli",
  "perl-lsp-formatting-types",
  "perl-lsp-tooling",
  "perl-tdd-support",
  "thiserror",
+]
+
+[[package]]
+name = "perl-lsp-formatting-cli"
+version = "0.10.0"
+dependencies = [
+ "perl-lsp-formatting-types",
 ]
 
 [[package]]
@@ -1984,6 +2009,7 @@ dependencies = [
  "lsp-types",
  "moka",
  "perl-parser-core",
+ "perl-subprocess-runtime",
  "perl-tdd-support",
  "serde",
 ]
@@ -2134,6 +2160,7 @@ dependencies = [
  "nix",
  "parking_lot",
  "perl-corpus",
+ "perl-dead-code",
  "perl-incremental-parsing",
  "perl-keywords",
  "perl-lexer",
@@ -2276,6 +2303,10 @@ dependencies = [
 
 [[package]]
 name = "perl-source-file"
+version = "0.10.0"
+
+[[package]]
+name = "perl-subprocess-runtime"
 version = "0.10.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/perl-lsp-tooling",
     "crates/perl-subprocess-runtime",
     "crates/perl-lsp-formatting-types",
+    "crates/perl-lsp-formatting-cli",
     "crates/perl-lsp-formatting",
     "crates/perl-lsp-diagnostics",
     "crates/perl-lsp-semantic-tokens",
@@ -149,6 +150,7 @@ allow = [
     "perl-lsp-navigation",
     "perl-lsp-tooling",
     "perl-lsp-formatting-types",
+    "perl-lsp-formatting-cli",
     "perl-lsp-formatting",
     "perl-lsp-semantic-tokens",
     "perl-lsp-providers",
@@ -270,6 +272,7 @@ perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
 perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.10.0" }
+perl-lsp-formatting-cli = { path = "crates/perl-lsp-formatting-cli", version = "0.10.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
 perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }
 perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0" }

--- a/crates/perl-lsp-formatting-cli/Cargo.toml
+++ b/crates/perl-lsp-formatting-cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "perl-lsp-formatting-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Perltidy CLI argument construction for perl-lsp formatting"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+perl-lsp-formatting-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-formatting-cli/src/lib.rs
+++ b/crates/perl-lsp-formatting-cli/src/lib.rs
@@ -1,0 +1,59 @@
+//! Perltidy command-line argument construction.
+//!
+//! This crate has a single responsibility: transform [`FormattingOptions`]
+//! into deterministic `perltidy` CLI arguments used by LSP formatters.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use perl_lsp_formatting_types::FormattingOptions;
+
+/// Build perltidy CLI arguments from formatting options.
+#[must_use]
+pub fn build_perltidy_args(options: &FormattingOptions) -> Vec<String> {
+    let mut args = vec!["-st".to_string(), "-se".to_string()];
+
+    if options.insert_spaces {
+        args.push(format!("-et={}", options.tab_size));
+        args.push(format!("-i={}", options.tab_size));
+    } else {
+        args.push("-dt".to_string());
+        args.push(format!("-i={}", options.tab_size));
+    }
+
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_perltidy_args;
+    use perl_lsp_formatting_types::FormattingOptions;
+
+    #[test]
+    fn builds_space_indentation_args() {
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: Some(true),
+        };
+
+        assert_eq!(build_perltidy_args(&options), vec!["-st", "-se", "-et=4", "-i=4"]);
+    }
+
+    #[test]
+    fn builds_tab_indentation_args() {
+        let options = FormattingOptions {
+            tab_size: 2,
+            insert_spaces: false,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: Some(true),
+        };
+
+        assert_eq!(build_perltidy_args(&options), vec!["-st", "-se", "-dt", "-i=2"]);
+    }
+}

--- a/crates/perl-lsp-formatting/Cargo.toml
+++ b/crates/perl-lsp-formatting/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 [dependencies]
 perl-lsp-tooling = { workspace = true }
 perl-lsp-formatting-types = { workspace = true }
+perl-lsp-formatting-cli = { workspace = true }
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/crates/perl-lsp-formatting/src/formatting.rs
+++ b/crates/perl-lsp-formatting/src/formatting.rs
@@ -1,5 +1,6 @@
 //! Code formatting support using Perl::Tidy for Perl parsing workflow pipeline.
 
+use perl_lsp_formatting_cli::build_perltidy_args;
 pub use perl_lsp_formatting_types::{
     FormatPosition, FormatRange, FormatTextEdit, FormattedDocument, FormattingOptions,
 };
@@ -107,15 +108,7 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
         content: &str,
         options: &FormattingOptions,
     ) -> Result<String, FormattingError> {
-        let mut args = vec!["-st".to_string(), "-se".to_string()];
-
-        if options.insert_spaces {
-            args.push(format!("-et={}", options.tab_size));
-            args.push(format!("-i={}", options.tab_size));
-        } else {
-            args.push("-dt".to_string());
-            args.push(format!("-i={}", options.tab_size));
-        }
+        let args = build_perltidy_args(options);
 
         let perltidy_cmd = self.perltidy_path.as_deref().unwrap_or("perltidy");
 


### PR DESCRIPTION
### Motivation

- Reduce coupling by extracting CLI argument policy for `perltidy` from the formatter runtime into a single-responsibility microcrate.  
- Make perltidy argument construction easier to reason about, test, and evolve independently of subprocess execution and edit generation.  
- Improve testability by isolating deterministic argument-building logic behind a small API.

### Description

- Added a new crate `perl-lsp-formatting-cli` that exposes `build_perltidy_args(&FormattingOptions) -> Vec<String>` and includes focused unit tests for spaces and tabs modes.  
- Rewired `perl-lsp-formatting` to depend on the new crate and replaced the inline perltidy arg assembly with a call to `build_perltidy_args`.  
- Registered the new crate in the workspace members, dependency table, and publish allowlist (`Cargo.toml` updates).  
- Updated and formatted code (`cargo fmt`) and added the new crate's `Cargo.toml` and tests under `crates/perl-lsp-formatting-cli`.

### Testing

- Ran `cargo test -p perl-lsp-formatting-cli -p perl-lsp-formatting` and all tests completed successfully.  
- Verified unit tests in the new microcrate passed (2 tests for argument building).  
- Ran `cargo fmt --all` to ensure workspace formatting, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7cdb42558833399c9d7acc8446a1b)