### PR TITLE
Extract symbol lookup logic into perl-symbol-index microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "moka",
  "perl-parser-core",
  "perl-subprocess-runtime",
+ "perl-symbol-index",
  "perl-tdd-support",
  "serde",
 ]
@@ -2312,6 +2313,10 @@ version = "0.10.0"
 
 [[package]]
 name = "perl-symbol-cursor"
+version = "0.10.0"
+
+[[package]]
+name = "perl-symbol-index"
 version = "0.10.0"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "crates/perl-symbol-types",
     "crates/perl-symbol-cursor",
     "crates/perl-symbol-table",
+    "crates/perl-symbol-index",
     "crates/perl-module-boundary",
     "crates/perl-module-token-core",
     "crates/perl-module-token",
@@ -127,6 +128,7 @@ allow = [
     "perl-symbol-types",
 "perl-symbol-cursor",
 "perl-symbol-table",
+    "perl-symbol-index",
     "perl-uri",
     "perl-workspace-index-slo",
 
@@ -232,6 +234,7 @@ perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
 perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.10.0" }
 perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
 perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }
 perl-module-token = { path = "crates/perl-module-token", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -24,6 +24,7 @@ lsp-compat = ["dep:lsp-types"]
 perl-subprocess-runtime = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
+perl-symbol-index = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
 lsp-types = { version = "0.97.0", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp-tooling/src/performance.rs
+++ b/crates/perl-lsp-tooling/src/performance.rs
@@ -7,9 +7,10 @@
 
 use moka::sync::Cache;
 use perl_parser_core::Node;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+pub use perl_symbol_index::SymbolIndex;
 
 /// Cache for parsed ASTs with TTL.
 ///
@@ -216,149 +217,6 @@ pub mod parallel {
     use super::*;
 }
 
-/// Symbol index for fast lookups.
-///
-/// Supports both prefix and fuzzy matching using a trie and inverted index.
-pub struct SymbolIndex {
-    /// Trie structure for prefix matching
-    trie: SymbolTrie,
-    /// Inverted index for fuzzy matching
-    inverted_index: HashMap<String, Vec<String>>,
-}
-
-/// Trie data structure for efficient prefix matching
-struct SymbolTrie {
-    /// Child nodes indexed by character
-    children: HashMap<char, Box<SymbolTrie>>,
-    /// Symbols stored at this node
-    symbols: Vec<String>,
-}
-
-impl Default for SymbolIndex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SymbolIndex {
-    /// Create a new empty symbol index
-    pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
-    }
-
-    /// Add a symbol to the index.
-    ///
-    /// Indexes the symbol for both prefix and fuzzy matching.
-    pub fn add_symbol(&mut self, symbol: String) {
-        // Add to trie for prefix matching
-        self.trie.insert(&symbol);
-
-        // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
-        for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
-        }
-    }
-
-    /// Search symbols with prefix.
-    ///
-    /// Returns all symbols starting with the given prefix.
-    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        self.trie.search_prefix(prefix)
-    }
-
-    /// Fuzzy search symbols.
-    ///
-    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
-    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
-        let tokens = Self::tokenize(query);
-        let mut results = HashMap::new();
-
-        for token in tokens {
-            if let Some(symbols) = self.inverted_index.get(&token) {
-                for symbol in symbols {
-                    *results.entry(symbol.clone()).or_insert(0) += 1;
-                }
-            }
-        }
-
-        // Sort by relevance (number of matching tokens)
-        let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
-
-        sorted.into_iter().map(|(symbol, _)| symbol).collect()
-    }
-
-    fn tokenize(s: &str) -> Vec<String> {
-        // Split on word boundaries and case changes
-        let mut tokens = Vec::new();
-        let mut current = String::new();
-        let mut prev_upper = false;
-
-        for ch in s.chars() {
-            if ch.is_uppercase() && !prev_upper && !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-            }
-
-            if ch.is_alphanumeric() {
-                current.push(ch);
-                prev_upper = ch.is_uppercase();
-            } else if !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-                prev_upper = false;
-            }
-        }
-
-        if !current.is_empty() {
-            tokens.push(current.to_lowercase());
-        }
-
-        tokens
-    }
-}
-
-impl SymbolTrie {
-    fn new() -> Self {
-        Self { children: HashMap::new(), symbols: Vec::new() }
-    }
-
-    fn insert(&mut self, symbol: &str) {
-        let mut node = self;
-
-        for ch in symbol.chars() {
-            node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
-        }
-
-        node.symbols.push(symbol.to_string());
-    }
-
-    fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        let mut node = self;
-
-        for ch in prefix.chars() {
-            match node.children.get(&ch) {
-                Some(child) => node = child,
-                None => return Vec::new(),
-            }
-        }
-
-        // Collect all symbols from this node and descendants
-        let mut results = Vec::new();
-        Self::collect_all(node, &mut results);
-        results
-    }
-
-    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
-        results.extend(node.symbols.clone());
-
-        for child in node.children.values() {
-            Self::collect_all(child, results);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,25 +274,6 @@ mod tests {
         parser.mark_changed(18, 35);
         assert_eq!(parser.changed_regions.len(), 1);
         assert_eq!(parser.changed_regions[0], (10, 40));
-    }
-
-    #[test]
-    fn test_symbol_index() {
-        let mut index = SymbolIndex::new();
-
-        index.add_symbol("calculate_total".to_string());
-        index.add_symbol("calculate_average".to_string());
-        index.add_symbol("get_user_name".to_string());
-
-        // Prefix search
-        let results = index.search_prefix("calc");
-        assert_eq!(results.len(), 2);
-        assert!(results.contains(&"calculate_total".to_string()));
-        assert!(results.contains(&"calculate_average".to_string()));
-
-        // Fuzzy search
-        let results = index.search_fuzzy("user name");
-        assert!(results.contains(&"get_user_name".to_string()));
     }
 
     #[test]

--- a/crates/perl-symbol-index/Cargo.toml
+++ b/crates/perl-symbol-index/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-symbol-index"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Symbol indexing utilities for prefix and fuzzy lookup"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-symbol-index"
+keywords = ["perl", "lsp", "symbol", "index"]
+categories = ["text-editors", "development-tools"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-symbol-index/README.md
+++ b/crates/perl-symbol-index/README.md
@@ -1,0 +1,3 @@
+# perl-symbol-index
+
+Microcrate providing symbol indexing with prefix and fuzzy lookups.

--- a/crates/perl-symbol-index/src/lib.rs
+++ b/crates/perl-symbol-index/src/lib.rs
@@ -1,0 +1,167 @@
+//! Symbol indexing utilities for fast symbol lookup.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+#![allow(clippy::empty_line_after_outer_attr)]
+
+use std::collections::HashMap;
+
+/// Symbol index for fast lookups.
+///
+/// Supports both prefix and fuzzy matching using a trie and inverted index.
+pub struct SymbolIndex {
+    /// Trie structure for prefix matching
+    trie: SymbolTrie,
+    /// Inverted index for fuzzy matching
+    inverted_index: HashMap<String, Vec<String>>,
+}
+
+/// Trie data structure for efficient prefix matching.
+#[derive(Default)]
+struct SymbolTrie {
+    /// Child nodes indexed by character
+    children: HashMap<char, Box<SymbolTrie>>,
+    /// Symbols stored at this node
+    symbols: Vec<String>,
+}
+
+impl Default for SymbolIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SymbolIndex {
+    /// Create a new empty symbol index.
+    pub fn new() -> Self {
+        Self { trie: SymbolTrie::default(), inverted_index: HashMap::new() }
+    }
+
+    /// Add a symbol to the index.
+    ///
+    /// Indexes the symbol for both prefix and fuzzy matching.
+    pub fn add_symbol(&mut self, symbol: String) {
+        self.trie.insert(&symbol);
+
+        let tokens = Self::tokenize(&symbol);
+        for token in tokens {
+            self.inverted_index.entry(token).or_default().push(symbol.clone());
+        }
+    }
+
+    /// Search symbols with prefix.
+    ///
+    /// Returns all symbols starting with the given prefix.
+    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        self.trie.search_prefix(prefix)
+    }
+
+    /// Fuzzy search symbols.
+    ///
+    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
+    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
+        let tokens = Self::tokenize(query);
+        let mut results = HashMap::new();
+
+        for token in tokens {
+            if let Some(symbols) = self.inverted_index.get(&token) {
+                for symbol in symbols {
+                    *results.entry(symbol.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let mut sorted: Vec<_> = results.into_iter().collect();
+        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+        sorted.into_iter().map(|(symbol, _)| symbol).collect()
+    }
+
+    fn tokenize(s: &str) -> Vec<String> {
+        let mut tokens = Vec::new();
+        let mut current = String::new();
+        let mut prev_upper = false;
+
+        for ch in s.chars() {
+            if ch.is_uppercase() && !prev_upper && !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+            }
+
+            if ch.is_alphanumeric() {
+                current.push(ch);
+                prev_upper = ch.is_uppercase();
+            } else if !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+                prev_upper = false;
+            }
+        }
+
+        if !current.is_empty() {
+            tokens.push(current.to_lowercase());
+        }
+
+        tokens
+    }
+}
+
+impl SymbolTrie {
+    fn insert(&mut self, symbol: &str) {
+        let mut node = self;
+
+        for ch in symbol.chars() {
+            node = node.children.entry(ch).or_default();
+        }
+
+        node.symbols.push(symbol.to_string());
+    }
+
+    fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        let mut node = self;
+
+        for ch in prefix.chars() {
+            match node.children.get(&ch) {
+                Some(child) => node = child,
+                None => return Vec::new(),
+            }
+        }
+
+        let mut results = Vec::new();
+        Self::collect_all(node, &mut results);
+        results
+    }
+
+    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
+        results.extend(node.symbols.clone());
+
+        for child in node.children.values() {
+            Self::collect_all(child, results);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolIndex;
+
+    #[test]
+    fn test_symbol_index() {
+        let mut index = SymbolIndex::new();
+
+        index.add_symbol("calculate_total".to_string());
+        index.add_symbol("calculate_average".to_string());
+        index.add_symbol("get_user_name".to_string());
+
+        let results = index.search_prefix("calc");
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&"calculate_total".to_string()));
+        assert!(results.contains(&"calculate_average".to_string()));
+
+        let results = index.search_fuzzy("user name");
+        assert!(results.contains(&"get_user_name".to_string()));
+    }
+}


### PR DESCRIPTION
### Motivation

- Isolate the symbol lookup responsibility (prefix/fuzzy search) from general performance utilities to follow SRP and reduce coupling. 
- Make symbol indexing easier to maintain and reuse across crates without pulling in unrelated performance code. 
- Preserve existing public APIs for consumers while moving implementation into a focused microcrate.

### Description

- Added a new microcrate `crates/perl-symbol-index` that implements `SymbolIndex` with a trie for prefix lookup and an inverted-token index for fuzzy lookup, plus a focused unit test (`crates/perl-symbol-index/src/lib.rs`).
- Removed the in-file `SymbolIndex` implementation from `crates/perl-lsp-tooling/src/performance.rs` and replaced it with a stable re-export via `pub use perl_symbol_index::SymbolIndex;` so downstream call sites remain unchanged.
- Wired the new crate into the workspace by adding it to `Cargo.toml` members, the workspace `publish` allowlist, and `workspace.dependencies`, and added `perl-symbol-index` as a dependency in `crates/perl-lsp-tooling/Cargo.toml`.
- Removed the duplicate `test_symbol_index` from the original performance tests and kept related unit coverage in the new microcrate; applied formatting changes with `cargo fmt`.

### Testing

- Ran `cargo fmt --all` to ensure formatting; the command completed successfully. 
- Ran `cargo test -p perl-symbol-index -p perl-lsp-tooling` and all tests passed (new crate tests and existing tooling tests). 
- Ran `cargo clippy -p perl-symbol-index -p perl-lsp-tooling --all-targets -- -D warnings` and the lint check completed with no warnings (treating warnings as errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e52142608333a159a286d68bfd53)