### PR TITLE
fix(publish): add perl-dead-code to crates.io publish allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ allow = [
     "perl-refactoring",
 
     # Tier 5 — Application crates
+    "perl-dead-code",
     "perl-parser",
     "perl-corpus",
 


### PR DESCRIPTION
## Summary

`cargo publish --dry-run` was run against all 75 crates in `[workspace.metadata.publish].allow`. One fixable issue was found: `perl-dead-code` was missing from the allowlist despite being a dependency of `perl-parser`.

## Dry-Run Results

### ✅ Passing (23/75 leaf crates — no workspace deps on crates.io)

| Crate | Status |
|-------|--------|
| perl-builtins | ✅ Pass |
| perl-content-length-framing | ✅ Pass |
| perl-dap-platform | ✅ Pass |
| perl-diagnostics-codes | ✅ Pass |
| perl-feature-catalog | ✅ Pass |
| perl-keywords | ✅ Pass |
| perl-lsp-cancellation | ✅ Pass |
| perl-lsp-feature-ids | ✅ Pass |
| perl-lsp-formatting-types | ✅ Pass |
| perl-lsp-limits | ✅ Pass |
| perl-module-name | ✅ Pass |
| perl-module-token-core | ✅ Pass |
| perl-path-security | ✅ Pass |
| perl-position-tracking | ✅ Pass |
| perl-qualified-name | ✅ Pass |
| perl-quote | ✅ Pass |
| perl-regex | ✅ Pass |
| perl-source-file | ✅ Pass |
| perl-subprocess-runtime | ✅ Pass |
| perl-symbol-cursor | ✅ Pass |
| perl-symbol-types | ✅ Pass |
| perl-token | ✅ Pass |
| perl-workspace-index-slo | ✅ Pass |

### ⏳ Expected failures (52/75 — dependency not yet on crates.io)

All 52 remaining crates fail only because their workspace dependencies aren't published yet. This is expected for first-time publish — crates must be published in topological order. No missing fields, license issues, or other errors were found.

### 🔧 Fix Applied

**`perl-dead-code` added to publish allowlist** — `perl-parser` depends on `perl-dead-code`, which depends on `perl-workspace-index`. It was the only crate missing from the allowlist despite being required by an allowlisted crate.

### Key Findings

- **0 missing fields** — all crates have required metadata
- **0 license/readme issues** — all crates properly configured
- **0 unexpected errors** — only dependency-ordering failures
- **1 allowlist gap** — `perl-dead-code` (now fixed)
- **428 informational warnings** — test files not included in published packages (expected, not actionable)