### PR TITLE
refactor(dap): extract frame visibility classifier into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-dap-frame-visibility"
+version = "0.10.0"
+
+[[package]]
 name = "perl-dap-platform"
 version = "0.10.0"
 dependencies = [
@@ -1617,6 +1621,7 @@ name = "perl-dap-stack"
 version = "0.10.0"
 dependencies = [
  "once_cell",
+ "perl-dap-frame-visibility",
  "perl-tdd-support",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "crates/perl-dap-breakpoint",
     "crates/perl-dap-eval",
     "crates/perl-dap-platform",
+    "crates/perl-dap-frame-visibility",
     "crates/perl-dap-stack",
     "crates/perl-dap-variables",
     "crates/perl-feature-catalog",
@@ -165,6 +166,7 @@ allow = [
     "perl-dap-breakpoint",
     "perl-dap-eval",
     "perl-dap-platform",
+    "perl-dap-frame-visibility",
     "perl-dap-stack",
     "perl-dap-variables",
     "perl-path-security",
@@ -262,6 +264,7 @@ perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }
 perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.10.0" }
 perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.10.0" }
 perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.10.0" }
+perl-dap-frame-visibility = { path = "crates/perl-dap-frame-visibility", version = "0.10.0" }
 perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.10.0" }
 perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.10.0" }
 perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.10.0" }

--- a/crates/perl-dap-frame-visibility/Cargo.toml
+++ b/crates/perl-dap-frame-visibility/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "perl-dap-frame-visibility"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for identifying internal Perl DAP stack frames"
+readme = "README.md"
+
+[lints]
+workspace = true

--- a/crates/perl-dap-frame-visibility/README.md
+++ b/crates/perl-dap-frame-visibility/README.md
@@ -1,0 +1,5 @@
+# perl-dap-frame-visibility
+
+Single-responsibility crate for determining whether stack-frame metadata should be
+considered internal to the Perl debugger bridge and therefore hidden from user-facing
+stack traces.

--- a/crates/perl-dap-frame-visibility/src/lib.rs
+++ b/crates/perl-dap-frame-visibility/src/lib.rs
@@ -1,0 +1,37 @@
+//! Frame visibility primitives for Perl DAP stack traces.
+//!
+//! This crate intentionally contains only name/path classification helpers that
+//! can be shared across DAP crates without coupling to a concrete `StackFrame`
+//! type.
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Returns true when a frame belongs to debugger/shim internals.
+#[must_use]
+pub fn is_internal_frame_name_and_path(name: &str, path: Option<&str>) -> bool {
+    name.starts_with("Devel::TSPerlDAP::")
+        || name.starts_with("DB::")
+        || path.is_some_and(|value| value.contains("perl5db.pl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_internal_frame_name_and_path;
+
+    #[test]
+    fn internal_frame_detected_by_name_prefix() {
+        assert!(is_internal_frame_name_and_path("DB::sub", Some("/app/main.pl")));
+        assert!(is_internal_frame_name_and_path("Devel::TSPerlDAP::shim", Some("/app/main.pl")));
+    }
+
+    #[test]
+    fn internal_frame_detected_by_debugger_path() {
+        assert!(is_internal_frame_name_and_path("helper", Some("/usr/lib/perl5/perl5db.pl")));
+    }
+
+    #[test]
+    fn user_frame_remains_visible() {
+        assert!(!is_internal_frame_name_and_path("main::run", Some("/app/main.pl")));
+    }
+}

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["perl", "dap", "debug", "stack-trace", "debugger"]
 categories = ["development-tools::debugging"]
 
 [dependencies]
+perl-dap-frame-visibility = { workspace = true }
 # Serialization for DAP protocol
 serde = { version = "1.0", features = ["derive"] }
 

--- a/crates/perl-dap-stack/src/visibility.rs
+++ b/crates/perl-dap-stack/src/visibility.rs
@@ -1,12 +1,5 @@
 use crate::StackFrame;
-
-/// Returns true when a frame belongs to debugger/shim internals.
-#[must_use]
-pub fn is_internal_frame_name_and_path(name: &str, path: Option<&str>) -> bool {
-    name.starts_with("Devel::TSPerlDAP::")
-        || name.starts_with("DB::")
-        || path.is_some_and(|value| value.contains("perl5db.pl"))
-}
+pub use perl_dap_frame_visibility::is_internal_frame_name_and_path;
 
 /// Returns true when a frame belongs to debugger/shim internals.
 #[must_use]


### PR DESCRIPTION
### Motivation

- Reduce coupling by isolating the simple name/path classifier used to decide whether a stack frame is internal to the debugger bridge into its own SRP microcrate.
- Enable reuse of the classification logic by other DAP components without pulling in `StackFrame`/parser types.

### Description

- Added new crate `crates/perl-dap-frame-visibility` with `Cargo.toml`, `README.md`, and `src/lib.rs` containing `is_internal_frame_name_and_path(name, path)` and unit tests.
- Moved the original `is_internal_frame_name_and_path` implementation out of `crates/perl-dap-stack/src/visibility.rs` and replaced it with `pub use perl_dap_frame_visibility::is_internal_frame_name_and_path;` so existing call sites keep working.
- Wired the new crate into the workspace by adding it to `Cargo.toml` members, the workspace `publish.allow` list, and the workspace dependency table, and updated `crates/perl-dap-stack/Cargo.toml` to depend on the new crate.
- Updated `Cargo.lock` to reflect the new package and dependency edge from `perl-dap-stack` to `perl-dap-frame-visibility` and committed the changes.

### Testing

- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-dap-frame-visibility -p perl-dap-stack -p perl-dap --lib` and all tests passed.
- Ran `cargo clippy -p perl-dap-frame-visibility -p perl-dap-stack --all-targets -- -D warnings` and there were no clippy warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e52142608333a159a286d68bfd53)