### PR TITLE
refactor(dap): extract launch config utilities into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,10 +1606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-dap-launch-config"
+version = "0.10.0"
+
+[[package]]
 name = "perl-dap-platform"
 version = "0.10.0"
 dependencies = [
  "anyhow",
+ "perl-dap-launch-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "crates/perl-dap-breakpoint",
     "crates/perl-dap-eval",
     "crates/perl-dap-platform",
+    "crates/perl-dap-launch-config",
     "crates/perl-dap-stack",
     "crates/perl-dap-variables",
     "crates/perl-feature-catalog",
@@ -165,6 +166,7 @@ allow = [
     "perl-dap-breakpoint",
     "perl-dap-eval",
     "perl-dap-platform",
+    "perl-dap-launch-config",
     "perl-dap-stack",
     "perl-dap-variables",
     "perl-path-security",
@@ -258,6 +260,7 @@ perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }
 perl-corpus = { path = "crates/perl-corpus", version = "0.10.0" }
 perl-dap = { path = "crates/perl-dap", version = "0.10.0" }
+perl-dap-launch-config = { path = "crates/perl-dap-launch-config", version = "0.10.0" }
 perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }
 perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.10.0" }
 perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.10.0" }

--- a/crates/perl-dap-launch-config/Cargo.toml
+++ b/crates/perl-dap-launch-config/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "perl-dap-launch-config"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Launch argument and environment preparation for perl-dap"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-dap-launch-config"
+readme = "README.md"
+keywords = ["perl", "dap", "launch", "debugger", "environment"]
+categories = ["development-tools::debugging", "config"]
+include = [
+  "src/**",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE*"
+]
+
+[lib]
+name = "perl_dap_launch_config"
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/perl-dap-launch-config/README.md
+++ b/crates/perl-dap-launch-config/README.md
@@ -1,0 +1,8 @@
+# perl-dap-launch-config
+
+Launch argument and environment preparation utilities extracted from `perl-dap-platform`.
+
+## Responsibilities
+
+- Build `PERL5LIB` from include paths.
+- Quote/escape command arguments for platform-specific shell invocation.

--- a/crates/perl-dap-launch-config/src/lib.rs
+++ b/crates/perl-dap-launch-config/src/lib.rs
@@ -1,0 +1,81 @@
+//! Launch argument and environment preparation for perl-dap.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[cfg(windows)]
+const PATH_SEPARATOR: char = ';';
+#[cfg(not(windows))]
+const PATH_SEPARATOR: char = ':';
+
+/// Setup environment variables for Perl execution.
+pub fn setup_environment(include_paths: &[PathBuf]) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    if !include_paths.is_empty() {
+        let perl5lib = include_paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .join(&PATH_SEPARATOR.to_string());
+
+        env.insert("PERL5LIB".to_string(), perl5lib);
+    }
+
+    env
+}
+
+/// Format command-line arguments for platform-specific shells.
+pub fn format_command_args(args: &[String]) -> Vec<String> {
+    args.iter()
+        .map(|arg| {
+            if arg.contains(' ') {
+                #[cfg(windows)]
+                {
+                    format!("\"{}\"", arg.replace('"', "\\\""))
+                }
+                #[cfg(not(windows))]
+                {
+                    if arg.contains('\'') {
+                        format!("\"{}\"", arg.replace('"', "\\\""))
+                    } else {
+                        format!("'{}'", arg)
+                    }
+                }
+            } else {
+                arg.clone()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_setup_environment_empty() {
+        let env = setup_environment(&[]);
+        assert!(!env.contains_key("PERL5LIB"));
+    }
+
+    #[test]
+    fn test_setup_environment_with_paths() {
+        let env =
+            setup_environment(&[PathBuf::from("/workspace/lib"), PathBuf::from("/custom/lib")]);
+        assert!(env.contains_key("PERL5LIB"));
+    }
+
+    #[test]
+    fn test_format_command_args_with_spaces() {
+        let args = vec!["file with spaces.txt".to_string()];
+        let formatted = format_command_args(&args);
+        assert_eq!(formatted.len(), 1);
+        assert!(formatted[0].contains("file with spaces.txt"));
+    }
+}

--- a/crates/perl-dap-platform/Cargo.toml
+++ b/crates/perl-dap-platform/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.102"
+perl-dap-launch-config = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/perl-dap-platform/src/lib.rs
+++ b/crates/perl-dap-platform/src/lib.rs
@@ -1,7 +1,6 @@
 //! Cross-platform utilities for Perl path resolution and environment setup.
 
 use anyhow::{Context, Result};
-use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 
@@ -76,46 +75,7 @@ pub fn normalize_path(path: &std::path::Path) -> PathBuf {
     path.to_path_buf()
 }
 
-/// Setup environment variables for Perl execution.
-pub fn setup_environment(include_paths: &[PathBuf]) -> HashMap<String, String> {
-    let mut env = HashMap::new();
-
-    if !include_paths.is_empty() {
-        let perl5lib = include_paths
-            .iter()
-            .map(|p| p.to_string_lossy().to_string())
-            .collect::<Vec<_>>()
-            .join(&PATH_SEPARATOR.to_string());
-
-        env.insert("PERL5LIB".to_string(), perl5lib);
-    }
-
-    env
-}
-
-/// Format command-line arguments for platform-specific shells.
-pub fn format_command_args(args: &[String]) -> Vec<String> {
-    args.iter()
-        .map(|arg| {
-            if arg.contains(' ') {
-                #[cfg(windows)]
-                {
-                    format!("\"{}\"", arg.replace('"', "\\\""))
-                }
-                #[cfg(not(windows))]
-                {
-                    if arg.contains('\'') {
-                        format!("\"{}\"", arg.replace('"', "\\\""))
-                    } else {
-                        format!("'{}'", arg)
-                    }
-                }
-            } else {
-                arg.clone()
-            }
-        })
-        .collect()
-}
+pub use perl_dap_launch_config::{format_command_args, setup_environment};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
### Motivation

- Separate launch/argument/env shaping responsibilities from platform path logic to follow SRP and make launch-related code easier to test and reuse.
- Reduce the surface area of `perl-dap-platform` so it only focuses on path resolution and normalization while preserving its public API for callers.

### Description

- Add a new microcrate `crates/perl-dap-launch-config` that implements `setup_environment` (build `PERL5LIB`) and `format_command_args` (platform-aware argument quoting) with unit tests and package metadata (`Cargo.toml`, `README.md`).
- Update `crates/perl-dap-platform` to depend on and re-export `perl_dap_launch_config::{format_command_args, setup_environment}` so callers keep the same API while the implementation is moved out.
- Wire the new crate into the workspace by adding it to `members`, the workspace dependency map, and the `workspace.metadata.publish` allowlist in `Cargo.toml`.
- Run `cargo fmt` to normalize formatting and keep lints consistent.

### Testing

- Ran `cargo fmt --all` successfully.
- Ran unit tests for the new microcrate and the platform crate with `cargo test -p perl-dap-launch-config -p perl-dap-platform`, and all tests passed.
- Ran integration/unit tests for the DAP component with `cargo test -p perl-dap --lib`, and the test suite passed.
- Ran `cargo clippy -p perl-dap-launch-config -p perl-dap-platform --all-targets -- -D warnings` with no warnings or errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e52142608333a159a286d68bfd53)