### PR TITLE
Extract reusable SLO latency math into dedicated perl-slo-metrics microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-slo-metrics"
+version = "0.10.0"
+
+[[package]]
 name = "perl-source-file"
 version = "0.10.0"
 
@@ -2477,6 +2481,7 @@ name = "perl-workspace-index-slo"
 version = "0.10.0"
 dependencies = [
  "parking_lot",
+ "perl-slo-metrics",
  "proptest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ members = [
     "crates/perl-ts-heredoc-parser",
     "crates/perl-ts-partial-ast",
     "crates/perl-ts-advanced-parsers",
+    "crates/perl-slo-metrics",
     "xtask",
 ]
 
@@ -115,6 +116,7 @@ allow = [
     "perl-regex",
     "perl-error",
     "perl-heredoc",
+    "perl-slo-metrics",
     "perl-pragma",
     "perl-quote",
     "perl-tokenizer",
@@ -227,6 +229,7 @@ perl-lexer = { path = "crates/perl-lexer", version = "0.10.0" }
 perl-ast = { path = "crates/perl-ast", version = "0.10.0" }
 perl-heredoc = { path = "crates/perl-heredoc", version = "0.10.0" }
 perl-error = { path = "crates/perl-error", version = "0.10.0" }
+perl-slo-metrics = { path = "crates/perl-slo-metrics", version = "0.10.0" }
 perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.10.0" }
 perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.10.0" }
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }

--- a/crates/perl-slo-metrics/Cargo.toml
+++ b/crates/perl-slo-metrics/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-slo-metrics"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Reusable percentile and latency summary utilities for SLO tracking"
+readme = "README.md"
+documentation = "https://docs.rs/perl-slo-metrics"
+keywords = ["slo", "metrics", "latency", "percentile"]
+categories = ["development-tools"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-slo-metrics/README.md
+++ b/crates/perl-slo-metrics/README.md
@@ -1,0 +1,3 @@
+# perl-slo-metrics
+
+Reusable percentile and latency summary utilities for SLO tracking crates.

--- a/crates/perl-slo-metrics/src/lib.rs
+++ b/crates/perl-slo-metrics/src/lib.rs
@@ -1,0 +1,76 @@
+//! Reusable percentile and latency summary utilities for SLO tracking.
+
+/// Latency summary derived from a set of durations measured in milliseconds.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct LatencySummary {
+    /// P50 latency (median)
+    pub p50_ms: u64,
+    /// P95 latency
+    pub p95_ms: u64,
+    /// P99 latency
+    pub p99_ms: u64,
+    /// Average latency in milliseconds
+    pub avg_ms: f64,
+}
+
+/// Compute percentile latency and average from millisecond durations.
+///
+/// Returns default values when `durations_ms` is empty.
+pub fn summarize_latencies(durations_ms: &[u64]) -> LatencySummary {
+    if durations_ms.is_empty() {
+        return LatencySummary::default();
+    }
+
+    let mut sorted = durations_ms.to_vec();
+    sorted.sort_unstable();
+
+    let avg_ms = sorted.iter().map(|&d| d as f64).sum::<f64>() / sorted.len() as f64;
+
+    LatencySummary {
+        p50_ms: percentile(&sorted, 50),
+        p95_ms: percentile(&sorted, 95),
+        p99_ms: percentile(&sorted, 99),
+        avg_ms,
+    }
+}
+
+/// Calculate a percentile from a sorted slice of values using the nearest-rank method.
+pub fn percentile(sorted_values: &[u64], pct: u64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+
+    let rank = ((pct as f64 / 100.0) * sorted_values.len() as f64).ceil() as usize;
+    sorted_values[rank.min(sorted_values.len()).saturating_sub(1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_handles_empty_slice() {
+        assert_eq!(percentile(&[], 50), 0);
+    }
+
+    #[test]
+    fn percentile_uses_nearest_rank() {
+        let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        assert_eq!(percentile(&values, 50), 5);
+        assert_eq!(percentile(&values, 95), 10);
+    }
+
+    #[test]
+    fn summarize_latencies_computes_expected_values() {
+        let summary = summarize_latencies(&[10, 1, 7, 2]);
+        assert_eq!(summary.p50_ms, 2);
+        assert_eq!(summary.p95_ms, 10);
+        assert_eq!(summary.p99_ms, 10);
+        assert_eq!(summary.avg_ms, 5.0);
+    }
+
+    #[test]
+    fn summarize_latencies_handles_empty_input() {
+        assert_eq!(summarize_latencies(&[]), LatencySummary::default());
+    }
+}

--- a/crates/perl-workspace-index-slo/Cargo.toml
+++ b/crates/perl-workspace-index-slo/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 parking_lot = "0.12.5"
+perl-slo-metrics = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/crates/perl-workspace-index-slo/src/lib.rs
+++ b/crates/perl-workspace-index-slo/src/lib.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use parking_lot::Mutex;
+use perl_slo_metrics::summarize_latencies;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -253,44 +254,26 @@ impl OperationSloTracker {
         let error_rate =
             if total_count > 0 { failure_count as f64 / total_count as f64 } else { 0.0 };
 
-        // Calculate percentiles
-        let mut durations_ms: Vec<u64> =
+        let durations_ms: Vec<u64> =
             self.samples.iter().map(|s| s.duration.as_millis() as u64).collect();
-        durations_ms.sort_unstable();
-
-        let p50_ms = percentile(&durations_ms, 50);
-        let p95_ms = percentile(&durations_ms, 95);
-        let p99_ms = percentile(&durations_ms, 99);
-
-        let avg_ms =
-            durations_ms.iter().map(|&d| d as f64).sum::<f64>() / durations_ms.len() as f64;
+        let latency_summary = summarize_latencies(&durations_ms);
 
         // Check if SLO is met
-        let slo_met = p95_ms <= self.slo_target_ms && error_rate <= self.max_error_rate;
+        let slo_met =
+            latency_summary.p95_ms <= self.slo_target_ms && error_rate <= self.max_error_rate;
 
         SloStatistics {
             total_count,
             success_count,
             failure_count,
             error_rate,
-            p50_ms,
-            p95_ms,
-            p99_ms,
-            avg_ms,
+            p50_ms: latency_summary.p50_ms,
+            p95_ms: latency_summary.p95_ms,
+            p99_ms: latency_summary.p99_ms,
+            avg_ms: latency_summary.avg_ms,
             slo_met,
         }
     }
-}
-
-/// Calculate a percentile from a sorted slice of values.
-fn percentile(sorted_values: &[u64], pct: u64) -> u64 {
-    if sorted_values.is_empty() {
-        return 0;
-    }
-
-    // Nearest-rank method: ceil(pct/100 * n) gives 1-based rank
-    let rank = ((pct as f64 / 100.0) * sorted_values.len() as f64).ceil() as usize;
-    sorted_values[rank.min(sorted_values.len()).saturating_sub(1)]
 }
 
 /// SLO tracker for workspace index operations.
@@ -597,12 +580,5 @@ mod tests {
     fn test_operation_result() {
         assert!(OperationResult::Success.is_success());
         assert!(!OperationResult::Failure("error".to_string()).is_success());
-    }
-
-    #[test]
-    fn test_percentile() {
-        let values = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        assert_eq!(percentile(&values, 50), 5); // Median
-        assert_eq!(percentile(&values, 95), 10); // P95
     }
 }


### PR DESCRIPTION
### Motivation
- Split out generic latency/percentile math from the workspace SLO tracker to follow SRP and enable reuse by other telemetry components.
- Reduce responsibility of `perl-workspace-index-slo` so it focuses on operation tracking and SLO policy rather than low-level statistics math.

### Description
- Added a new microcrate `crates/perl-slo-metrics` that provides `LatencySummary`, `summarize_latencies`, and `percentile` utilities for computing p50/p95/p99 and averages from millisecond durations.
- Replaced inline percentile/summarization logic in `crates/perl-workspace-index-slo/src/lib.rs` with a call to `perl_slo_metrics::summarize_latencies` and removed the local `percentile` helper.
- Wired the new crate into the workspace by adding it to `Cargo.toml` members, the workspace `publish` allowlist, and `workspace.dependencies` and added `perl-slo-metrics = { workspace = true }` to `crates/perl-workspace-index-slo/Cargo.toml`.
- Added unit tests for the new crate and adjusted tests in the SLO crate to use the extracted logic (tests validating p50/p95/p99, averages, and SLO evaluation remain present).

### Testing
- Ran formatting with `cargo fmt --all` and the workspace formatted cleanly.
- Ran unit and doctests with `cargo test -p perl-slo-metrics -p perl-workspace-index-slo` and all tests (unit/doctests/property/bdd/fuzz tests in these crates) passed.
- Ran linters with `cargo clippy -p perl-slo-metrics -p perl-workspace-index-slo --all-targets` and checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e58d5e2c83339d3d3f125478b163)