### PR TITLE
refactor: move code-action statement/indent helpers into perl-text-line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ dependencies = [
  "perl-lsp-rename",
  "perl-parser-core",
  "perl-tdd-support",
+ "perl-text-line",
 ]
 
 [[package]]

--- a/crates/perl-lsp-code-actions/Cargo.toml
+++ b/crates/perl-lsp-code-actions/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 perl-parser-core = { workspace = true }
 perl-lsp-rename = { workspace = true }
 perl-lsp-diagnostics = { workspace = true }
+perl-text-line = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-code-actions/src/ast_utils.rs
+++ b/crates/perl-lsp-code-actions/src/ast_utils.rs
@@ -4,6 +4,7 @@
 //! nodes and positions for code actions.
 
 use perl_parser_core::{Node, NodeKind};
+use perl_text_line::{leading_indent_at, statement_start_before};
 
 /// Find the best position to insert a declaration
 pub fn find_declaration_position(source: &str, error_pos: usize) -> usize {
@@ -13,15 +14,7 @@ pub fn find_declaration_position(source: &str, error_pos: usize) -> usize {
 
 /// Find the start of the current statement
 pub fn find_statement_start(source: &str, pos: usize) -> usize {
-    // Look backwards for statement boundary
-    let mut i = pos.saturating_sub(1);
-    while i > 0 {
-        if source.chars().nth(i) == Some(';') || source.chars().nth(i) == Some('\n') {
-            return i + 1;
-        }
-        i = i.saturating_sub(1);
-    }
-    0
+    statement_start_before(source, pos)
 }
 
 /// Find a good position to insert a function
@@ -89,16 +82,5 @@ pub fn find_node_at_range(node: &Node, range: (usize, usize)) -> Option<&Node> {
 
 /// Get indentation at a position
 pub fn get_indent_at(source: &str, pos: usize) -> String {
-    let line_start = source[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
-
-    let line = &source[line_start..];
-    let mut indent = String::new();
-    for ch in line.chars() {
-        if ch == ' ' || ch == '\t' {
-            indent.push(ch);
-        } else {
-            break;
-        }
-    }
-    indent
+    leading_indent_at(source, pos)
 }

--- a/crates/perl-lsp-code-actions/src/enhanced/helpers.rs
+++ b/crates/perl-lsp-code-actions/src/enhanced/helpers.rs
@@ -1,5 +1,7 @@
 //! Helper methods for enhanced code actions
 
+use perl_text_line::{leading_indent_at, statement_start_before};
+
 /// Helper methods for enhanced code actions
 pub struct Helpers<'a> {
     pub source: &'a str,
@@ -14,14 +16,7 @@ impl<'a> Helpers<'a> {
 
     /// Find statement start
     pub fn find_statement_start(&self, pos: usize) -> usize {
-        let mut i = pos.saturating_sub(1);
-        while i > 0 {
-            if self.source.chars().nth(i) == Some(';') || self.source.chars().nth(i) == Some('\n') {
-                return i + 1;
-            }
-            i = i.saturating_sub(1);
-        }
-        0
+        statement_start_before(self.source, pos)
     }
 
     /// Find subroutine insertion position
@@ -69,18 +64,7 @@ impl<'a> Helpers<'a> {
 
     /// Get indentation at position
     pub fn get_indent_at(&self, pos: usize) -> String {
-        let line_start = self.source[..pos].rfind('\n').map(|p| p + 1).unwrap_or(0);
-
-        let line = &self.source[line_start..];
-        let mut indent = String::new();
-        for ch in line.chars() {
-            if ch == ' ' || ch == '\t' {
-                indent.push(ch);
-            } else {
-                break;
-            }
-        }
-        indent
+        leading_indent_at(self.source, pos)
     }
 
     /// Truncate expression for display

--- a/crates/perl-text-line/src/lib.rs
+++ b/crates/perl-text-line/src/lib.rs
@@ -51,11 +51,61 @@ pub fn is_keyword_boundary(bytes: &[u8], start: usize, len: usize) -> bool {
     true
 }
 
-/// Advance `idx` while bytes at the cursor are ASCII whitespace.
+/// Advance `idx` while bytes at the cursor are horizontal ASCII whitespace (` ` or `\t`).
 #[must_use]
 pub fn skip_ascii_whitespace(bytes: &[u8], mut idx: usize) -> usize {
-    while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+    while idx < bytes.len() && (bytes[idx] == b' ' || bytes[idx] == b'\t') {
         idx += 1;
     }
     idx
+}
+
+/// Return the insertion offset at the start of the statement containing `pos`.
+///
+/// A statement boundary is considered to be either `;` or a newline.
+#[must_use]
+pub fn statement_start_before(text: &str, pos: usize) -> usize {
+    let cursor = pos.min(text.len());
+    if cursor == 0 {
+        return 0;
+    }
+
+    let bytes = text.as_bytes();
+    let mut idx = cursor.saturating_sub(1);
+    while idx > 0 {
+        if bytes[idx] == b';' || bytes[idx] == b'\n' {
+            return idx + 1;
+        }
+        idx = idx.saturating_sub(1);
+    }
+
+    0
+}
+
+/// Return the leading whitespace prefix for the line containing `pos`.
+#[must_use]
+pub fn leading_indent_at(text: &str, pos: usize) -> String {
+    let (line_start, line_end) = line_bounds_at(text, pos);
+    let line = &text[line_start..line_end];
+    let indent_len = line.as_bytes().iter().take_while(|b| **b == b' ' || **b == b'\t').count();
+    line[..indent_len].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{leading_indent_at, statement_start_before};
+
+    #[test]
+    fn statement_start_detects_statement_boundaries() {
+        let source = "my $x = 1;\n  say $x;\n";
+        assert_eq!(statement_start_before(source, source.len()), 21);
+        assert_eq!(statement_start_before(source, 8), 0);
+    }
+
+    #[test]
+    fn leading_indent_returns_spaces_and_tabs() {
+        let source = "first\n\t  second\nthird";
+        assert_eq!(leading_indent_at(source, 9), "\t  ");
+        assert_eq!(leading_indent_at(source, source.len()), "");
+    }
 }


### PR DESCRIPTION
### Motivation

- Centralize single-responsibility text/line helpers used by code actions to avoid duplicated logic across crates. 
- Make statement/indent primitives reusable and easier to test by moving them into the existing `perl-text-line` microcrate.

### Description

- Added two reusable APIs to `crates/perl-text-line/src/lib.rs`: `statement_start_before(text, pos)` and `leading_indent_at(text, pos)`, and included focused unit tests for them.
- Adjusted `skip_ascii_whitespace` to treat only horizontal whitespace (`' '` and `\t`) as skippable to align with existing BDD expectations.
- Updated `crates/perl-lsp-code-actions` to consume the new utilities instead of duplicating logic by importing `perl-text-line::{leading_indent_at, statement_start_before}` and replacing local implementations in `src/ast_utils.rs` and `src/enhanced/helpers.rs`.
- Added `perl-text-line` as a dependency in `crates/perl-lsp-code-actions/Cargo.toml` and wired tests accordingly.

### Testing

- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-text-line` and all unit and integration tests for that crate passed.
- Ran `cargo test -p perl-lsp-code-actions` and all tests for that crate passed.
- Ran `cargo clippy -p perl-text-line -p perl-lsp-code-actions --all-targets -- -D warnings` and linting completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e58d5e2c83339d3d3f125478b163)