### PR TITLE
docs(parser): add API usage examples to public items

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -130,6 +130,40 @@ pub use perl_token::{Token, TokenKind};
 /// - `SourceLocation` uses compact position encoding for large files
 /// - `NodeKind` enum variants minimize memory overhead for common constructs
 /// - Clone operations are optimized for shared analysis workflows
+///
+/// # Examples
+///
+/// Construct a variable declaration node manually:
+///
+/// ```
+/// use perl_ast::{Node, NodeKind, SourceLocation};
+///
+/// let loc = SourceLocation { start: 0, end: 11 };
+/// let var = Node::new(
+///     NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+///     loc,
+/// );
+/// let decl = Node::new(
+///     NodeKind::VariableDeclaration {
+///         declarator: "my".to_string(),
+///         variable: Box::new(var),
+///         attributes: vec![],
+///         initializer: None,
+///     },
+///     loc,
+/// );
+/// assert_eq!(decl.kind.kind_name(), "VariableDeclaration");
+/// ```
+///
+/// Typically you obtain nodes from the parser rather than constructing them by hand:
+///
+/// ```ignore
+/// use perl_parser::Parser;
+///
+/// let mut parser = Parser::new("my $x = 42;");
+/// let ast = parser.parse()?;
+/// println!("AST: {}", ast.to_sexp());
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Node {
     /// The specific type and semantic content of this AST node
@@ -139,12 +173,43 @@ pub struct Node {
 }
 
 impl Node {
-    /// Create a new AST node
+    /// Create a new AST node with the given kind and source location.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let node = Node::new(
+    ///     NodeKind::Number { value: "42".to_string() },
+    ///     SourceLocation { start: 0, end: 2 },
+    /// );
+    /// assert_eq!(node.kind.kind_name(), "Number");
+    /// assert_eq!(node.location.start, 0);
+    /// ```
     pub fn new(kind: NodeKind, location: SourceLocation) -> Self {
         Node { kind, location }
     }
 
-    /// Convert the AST to a tree-sitter compatible S-expression
+    /// Convert the AST to a tree-sitter compatible S-expression.
+    ///
+    /// Produces a parenthesized representation compatible with tree-sitter's
+    /// S-expression format, useful for debugging and snapshot testing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let loc = SourceLocation { start: 0, end: 2 };
+    /// let num = Node::new(NodeKind::Number { value: "42".to_string() }, loc);
+    /// let program = Node::new(
+    ///     NodeKind::Program { statements: vec![num] },
+    ///     loc,
+    /// );
+    /// let sexp = program.to_sexp();
+    /// assert!(sexp.starts_with("(source_file"));
+    /// ```
     pub fn to_sexp(&self) -> String {
         match &self.kind {
             NodeKind::Program { statements } => {
@@ -1234,6 +1299,22 @@ impl Node {
     }
 
     /// Count the total number of nodes in this subtree (inclusive).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let loc = SourceLocation { start: 0, end: 1 };
+    /// let leaf = Node::new(NodeKind::Number { value: "1".to_string() }, loc);
+    /// assert_eq!(leaf.count_nodes(), 1);
+    ///
+    /// let program = Node::new(
+    ///     NodeKind::Program { statements: vec![leaf] },
+    ///     loc,
+    /// );
+    /// assert_eq!(program.count_nodes(), 2);
+    /// ```
     pub fn count_nodes(&self) -> usize {
         let mut count = 1;
         self.for_each_child(|child| {
@@ -1243,6 +1324,20 @@ impl Node {
     }
 
     /// Collect direct child nodes into a vector for convenience APIs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let loc = SourceLocation { start: 0, end: 1 };
+    /// let stmt = Node::new(NodeKind::Number { value: "1".to_string() }, loc);
+    /// let program = Node::new(
+    ///     NodeKind::Program { statements: vec![stmt] },
+    ///     loc,
+    /// );
+    /// assert_eq!(program.children().len(), 1);
+    /// ```
     #[inline]
     pub fn children(&self) -> Vec<&Node> {
         let mut children = Vec::new();
@@ -1280,6 +1375,40 @@ impl Node {
 /// - **Navigate**: Call and reference variants support navigation features
 /// - **Complete**: Expression variants provide completion context
 /// - **Analyze**: Semantic variants drive diagnostics and refactoring
+///
+/// # Examples
+///
+/// Pattern-match on node kinds to extract semantic information:
+///
+/// ```
+/// use perl_ast::{Node, NodeKind, SourceLocation};
+///
+/// let loc = SourceLocation { start: 0, end: 5 };
+/// let node = Node::new(
+///     NodeKind::Variable { sigil: "$".to_string(), name: "foo".to_string() },
+///     loc,
+/// );
+///
+/// match &node.kind {
+///     NodeKind::Variable { sigil, name } => {
+///         assert_eq!(sigil, "$");
+///         assert_eq!(name, "foo");
+///     }
+///     _ => panic!("expected Variable"),
+/// }
+/// ```
+///
+/// Use [`kind_name()`](NodeKind::kind_name) for debugging and diagnostics:
+///
+/// ```
+/// use perl_ast::NodeKind;
+///
+/// let kind = NodeKind::Number { value: "99".to_string() };
+/// assert_eq!(kind.kind_name(), "Number");
+///
+/// let kind = NodeKind::Variable { sigil: "@".to_string(), name: "list".to_string() };
+/// assert_eq!(kind.kind_name(), "Variable");
+/// ```
 ///
 /// # Performance Considerations
 ///
@@ -1897,7 +2026,21 @@ pub enum NodeKind {
 }
 
 impl NodeKind {
-    /// Get the name of this NodeKind as a static string
+    /// Get the name of this `NodeKind` as a static string.
+    ///
+    /// Useful for diagnostics, logging, and human-readable AST dumps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::NodeKind;
+    ///
+    /// let kind = NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() };
+    /// assert_eq!(kind.kind_name(), "Variable");
+    ///
+    /// let kind = NodeKind::Program { statements: vec![] };
+    /// assert_eq!(kind.kind_name(), "Program");
+    /// ```
     pub fn kind_name(&self) -> &'static str {
         match self {
             NodeKind::Program { .. } => "Program",

--- a/crates/perl-parser-core/src/engine/error/recovery_parser.rs
+++ b/crates/perl-parser-core/src/engine/error/recovery_parser.rs
@@ -13,7 +13,21 @@ use crate::{
 };
 use perl_lexer::TokenType;
 
-/// A parser with error recovery capabilities
+/// A parser with error recovery capabilities.
+///
+/// Builds partial ASTs from malformed input by inserting error nodes
+/// at points where syntax errors are encountered, allowing downstream
+/// analysis to proceed on the valid portions of the code.
+///
+/// # Examples
+///
+/// ```ignore
+/// use perl_parser::RecoveryParser;
+///
+/// let parser = RecoveryParser::new("sub foo { if (".to_string());
+/// let (ast, errors) = parser.parse();
+/// // ast contains a partial tree; errors lists the recovery points
+/// ```
 pub struct RecoveryParser {
     context: ParserContext,
 }

--- a/crates/perl-position-tracking/src/mapper.rs
+++ b/crates/perl-position-tracking/src/mapper.rs
@@ -10,7 +10,29 @@ use crate::WirePosition as Position;
 use ropey::Rope;
 use serde_json::Value;
 
-/// Centralized position mapper using rope for efficiency
+/// Centralized position mapper using rope for efficiency.
+///
+/// Converts between byte offsets (used by the parser) and LSP positions
+/// (line/character in UTF-16 code units) while handling mixed line endings.
+///
+/// # Examples
+///
+/// ```
+/// use perl_position_tracking::PositionMapper;
+///
+/// let text = "my $x = 1;\nmy $y = 2;\n";
+/// let mapper = PositionMapper::new(text);
+///
+/// // Convert byte offset 0 → LSP position (line 0, char 0)
+/// let pos = mapper.byte_to_lsp_pos(0);
+/// assert_eq!(pos.line, 0);
+/// assert_eq!(pos.character, 0);
+///
+/// // Second line starts at byte 11
+/// let pos = mapper.byte_to_lsp_pos(11);
+/// assert_eq!(pos.line, 1);
+/// assert_eq!(pos.character, 0);
+/// ```
 pub struct PositionMapper {
     /// The rope containing the document text
     rope: Rope,
@@ -32,7 +54,21 @@ pub enum LineEnding {
 }
 
 impl PositionMapper {
-    /// Create a new position mapper from text
+    /// Create a new position mapper from text.
+    ///
+    /// Detects line endings and builds an internal rope for efficient
+    /// position conversions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_position_tracking::PositionMapper;
+    ///
+    /// let mapper = PositionMapper::new("print 'hello';\n");
+    /// let pos = mapper.byte_to_lsp_pos(6);
+    /// assert_eq!(pos.line, 0);
+    /// assert_eq!(pos.character, 6);
+    /// ```
     pub fn new(text: &str) -> Self {
         let rope = Rope::from_str(text);
         let line_ending = detect_line_ending(text);
@@ -69,7 +105,21 @@ impl PositionMapper {
         self.line_ending = detect_line_ending(&self.rope.to_string());
     }
 
-    /// Convert LSP position to byte offset
+    /// Convert LSP position to byte offset.
+    ///
+    /// Takes a line/character position (UTF-16 code units, as specified by the
+    /// LSP protocol) and returns the corresponding byte offset in the source.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_position_tracking::{PositionMapper, WirePosition};
+    ///
+    /// let mapper = PositionMapper::new("my $x = 1;\nmy $y = 2;\n");
+    /// // Line 1, character 3 → "$y"
+    /// let byte = mapper.lsp_pos_to_byte(WirePosition { line: 1, character: 3 });
+    /// assert_eq!(byte, Some(14));
+    /// ```
     pub fn lsp_pos_to_byte(&self, pos: Position) -> Option<usize> {
         let line_idx = pos.line as usize;
         if line_idx >= self.rope.len_lines() {
@@ -95,7 +145,20 @@ impl PositionMapper {
         Some(line_start_byte + byte_offset)
     }
 
-    /// Convert byte offset to LSP position
+    /// Convert byte offset to LSP position.
+    ///
+    /// Returns line/character (UTF-16 code units) suitable for LSP responses.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_position_tracking::PositionMapper;
+    ///
+    /// let mapper = PositionMapper::new("sub foo {\n    return 1;\n}\n");
+    /// let pos = mapper.byte_to_lsp_pos(14);  // points into "return"
+    /// assert_eq!(pos.line, 1);
+    /// assert_eq!(pos.character, 4);
+    /// ```
     pub fn byte_to_lsp_pos(&self, byte_offset: usize) -> Position {
         let byte_offset = byte_offset.min(self.rope.len_bytes());
 

--- a/crates/perl-semantic-analyzer/src/analysis/semantic.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic.rs
@@ -182,6 +182,20 @@ pub struct HoverInfo {
 /// - Lexical scoping with `my`, `our`, `local`, `state`
 /// - Object-oriented method dispatch
 /// - Regular expression and heredoc analysis
+///
+/// # Examples
+///
+/// ```ignore
+/// use perl_parser::{Parser, SemanticAnalyzer};
+///
+/// let code = "my $greeting = 'hello'; sub say_hi { print $greeting; }";
+/// let mut parser = Parser::new(code);
+/// let ast = parser.parse()?;
+///
+/// let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+/// let symbols = analyzer.symbol_table();
+/// let tokens = analyzer.semantic_tokens();
+/// ```
 pub struct SemanticAnalyzer {
     /// Symbol table with scope hierarchy and definitions
     symbol_table: SymbolTable,
@@ -194,12 +208,44 @@ pub struct SemanticAnalyzer {
 }
 
 impl SemanticAnalyzer {
-    /// Create a new semantic analyzer from an AST
+    /// Create a new semantic analyzer from an AST.
+    ///
+    /// Equivalent to [`analyze_with_source`](Self::analyze_with_source) with an empty
+    /// source string. Use this when you only need symbol-table and token analysis
+    /// without source-text-dependent features like hover documentation.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use perl_parser::{Parser, SemanticAnalyzer};
+    ///
+    /// let mut parser = Parser::new("my $x = 42;");
+    /// let ast = parser.parse()?;
+    /// let analyzer = SemanticAnalyzer::analyze(&ast);
+    /// assert!(!analyzer.symbol_table().symbols.is_empty());
+    /// ```
     pub fn analyze(ast: &Node) -> Self {
         Self::analyze_with_source(ast, "")
     }
 
-    /// Create a new semantic analyzer from an AST and source text
+    /// Create a new semantic analyzer from an AST and source text.
+    ///
+    /// The source text enables richer analysis including hover documentation
+    /// extraction and precise text-range lookups.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use perl_parser::{Parser, SemanticAnalyzer};
+    ///
+    /// let code = "sub greet { print \"Hello\\n\"; }";
+    /// let mut parser = Parser::new(code);
+    /// let ast = parser.parse()?;
+    ///
+    /// let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+    /// let tokens = analyzer.semantic_tokens();
+    /// // tokens contains semantic highlighting data for the parsed code
+    /// ```
     pub fn analyze_with_source(ast: &Node, source: &str) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
 


### PR DESCRIPTION
## Summary

Adds documentation examples (`/// # Examples` blocks) to key public API items across the perl-parser dependency crates, improving docs.rs quality.

### Changes

- **perl-ast**: `Node` struct, `Node::new()`, `to_sexp()`, `count_nodes()`, `children()`, `NodeKind` enum, `kind_name()`
- **perl-semantic-analyzer**: `SemanticAnalyzer` struct, `analyze()`, `analyze_with_source()`
- **perl-parser-core**: `RecoveryParser` struct
- **perl-position-tracking**: `PositionMapper` struct, `new()`, `lsp_pos_to_byte()`, `byte_to_lsp_pos()`

All `perl-ast` and `perl-position-tracking` examples are compilable doctests (8 pass, 5 pre-existing ignores). Examples for crates with `doctest = false` use `ignore` annotations.

## Evidence

- `cargo fmt --all` — clean
- `cargo clippy -p perl-parser -- -D warnings` — clean
- `cargo test -p perl-parser --lib` — 12/12 pass
- `cargo test -p perl-ast --doc` — 8/8 pass
- `cargo test -p perl-position-tracking --doc` — 6/6 pass