### PR TITLE
Extract DAP frame visibility into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-dap-frame-visibility"
+version = "0.10.0"
+
+[[package]]
 name = "perl-dap-platform"
 version = "0.10.0"
 dependencies = [
@@ -1617,6 +1621,7 @@ name = "perl-dap-stack"
 version = "0.10.0"
 dependencies = [
  "once_cell",
+ "perl-dap-frame-visibility",
  "perl-tdd-support",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "crates/perl-dap",
     "crates/perl-dead-code",
     "crates/perl-dap-breakpoint",
+    "crates/perl-dap-frame-visibility",
     "crates/perl-dap-eval",
     "crates/perl-dap-platform",
     "crates/perl-dap-stack",
@@ -163,6 +164,7 @@ allow = [
 
     # Tier 5 — DAP components
     "perl-dap-breakpoint",
+    "perl-dap-frame-visibility",
     "perl-dap-eval",
     "perl-dap-platform",
     "perl-dap-stack",
@@ -260,6 +262,7 @@ perl-corpus = { path = "crates/perl-corpus", version = "0.10.0" }
 perl-dap = { path = "crates/perl-dap", version = "0.10.0" }
 perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }
 perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.10.0" }
+perl-dap-frame-visibility = { path = "crates/perl-dap-frame-visibility", version = "0.10.0" }
 perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.10.0" }
 perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.10.0" }
 perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.10.0" }

--- a/crates/perl-dap-frame-visibility/Cargo.toml
+++ b/crates/perl-dap-frame-visibility/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "perl-dap-frame-visibility"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Frame visibility classification for Perl DAP stack traces"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-dap-frame-visibility"
+keywords = ["perl", "dap", "debug", "stack-trace"]
+categories = ["development-tools::debugging"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-dap-frame-visibility/README.md
+++ b/crates/perl-dap-frame-visibility/README.md
@@ -1,0 +1,4 @@
+# perl-dap-frame-visibility
+
+Tiny SRP microcrate for classifying whether a Perl DAP stack frame should be
+hidden from user-visible stack traces.

--- a/crates/perl-dap-frame-visibility/src/lib.rs
+++ b/crates/perl-dap-frame-visibility/src/lib.rs
@@ -1,0 +1,30 @@
+//! Frame visibility classification for Perl DAP stack traces.
+
+/// Returns true when a frame belongs to debugger/shim internals.
+#[must_use]
+pub fn is_internal_frame_name_and_path(name: &str, path: Option<&str>) -> bool {
+    name.starts_with("Devel::TSPerlDAP::")
+        || name.starts_with("DB::")
+        || path.is_some_and(|value| value.contains("perl5db.pl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_internal_frame_name_and_path;
+
+    #[test]
+    fn internal_frame_by_name_prefix() {
+        assert!(is_internal_frame_name_and_path("DB::sub", Some("/app/main.pl")));
+        assert!(is_internal_frame_name_and_path("Devel::TSPerlDAP::shim", Some("/app/main.pl")));
+    }
+
+    #[test]
+    fn internal_frame_by_perl5db_path() {
+        assert!(is_internal_frame_name_and_path("helper", Some("/usr/lib/perl5/perl5db.pl")));
+    }
+
+    #[test]
+    fn non_internal_user_frame() {
+        assert!(!is_internal_frame_name_and_path("main::run", Some("/app/main.pl")));
+    }
+}

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["perl", "dap", "debug", "stack-trace", "debugger"]
 categories = ["development-tools::debugging"]
 
 [dependencies]
+perl-dap-frame-visibility = { workspace = true }
+
 # Serialization for DAP protocol
 serde = { version = "1.0", features = ["derive"] }
 

--- a/crates/perl-dap-stack/src/visibility.rs
+++ b/crates/perl-dap-stack/src/visibility.rs
@@ -1,12 +1,6 @@
 use crate::StackFrame;
 
-/// Returns true when a frame belongs to debugger/shim internals.
-#[must_use]
-pub fn is_internal_frame_name_and_path(name: &str, path: Option<&str>) -> bool {
-    name.starts_with("Devel::TSPerlDAP::")
-        || name.starts_with("DB::")
-        || path.is_some_and(|value| value.contains("perl5db.pl"))
-}
+pub use perl_dap_frame_visibility::is_internal_frame_name_and_path;
 
 /// Returns true when a frame belongs to debugger/shim internals.
 #[must_use]


### PR DESCRIPTION
### Motivation
- Separate the low-level stack-frame visibility heuristic from the larger `perl-dap-stack` crate so the small, stable classification logic can be owned, discovered, and reused independently.
- The visibility predicate is a single-responsibility, low-dependency concern that reduces coupling and avoids pulling parser types into consumers that only need the heuristic.

### Description
- Added a new microcrate `crates/perl-dap-frame-visibility` that implements `is_internal_frame_name_and_path` and focused unit tests (`src/lib.rs`) and a short `README.md` for discoverability.
- Updated `crates/perl-dap-stack` to depend on the new crate and `pub use` the classifier symbol while retaining `is_internal_frame` and `filter_user_visible_frames` helper APIs so downstream behavior is unchanged.
- Wired the new crate into the workspace by adding it to `Cargo.toml` workspace `members`, the `workspace.metadata.publish` allowlist, and to `workspace.dependencies` so it is publish-ready and build-integrated.

### Testing
- Ran `cargo fmt --all` successfully to format the workspace.
- Ran `cargo test -p perl-dap-frame-visibility` and all unit tests passed.
- Ran `cargo test -p perl-dap-stack` and `cargo test -p perl-dap --lib` and all tests passed.
- Ran `cargo clippy -p perl-dap-frame-visibility -p perl-dap-stack --all-targets` and the checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e58c213083338bd20bd170d0a4ff)