### PR TITLE
test(lsp-feature-compliance): add comprehensive unit tests

### DIFF
--- a/crates/perl-lsp-feature-contracts/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-feature-contracts/tests/comprehensive_unit_tests.rs
@@ -525,3 +525,468 @@ fn caps_roundtrip_multiple_features() {
         assert!(ids.contains(&feat), "missing feature {feat} after roundtrip");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Spec ↔ FeatureProfileKind consistency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn spec_canonical_matches_kind_as_str() {
+    for &kind in FeatureProfileKind::all() {
+        let spec = FEATURE_PROFILE_SPECS.iter().find(|s| s.canonical == kind.as_str());
+        assert!(spec.is_some(), "no spec found for profile {:?}", kind);
+    }
+}
+
+#[test]
+fn spec_aliases_match_kind_aliases() {
+    for &kind in FeatureProfileKind::all() {
+        let spec = FEATURE_PROFILE_SPECS.iter().find(|s| s.canonical == kind.as_str());
+        if let Some(spec) = spec {
+            let kind_aliases = kind.aliases();
+            for &alias in spec.aliases {
+                assert!(
+                    kind_aliases.contains(&alias),
+                    "spec alias '{alias}' not in kind aliases for {:?}",
+                    kind
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn spec_count_matches_kind_count() {
+    assert_eq!(FEATURE_PROFILE_SPECS.len(), FeatureProfileKind::all().len());
+}
+
+// ---------------------------------------------------------------------------
+// FeatureProfileKind — edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_str_name_rejects_whitespace_variants() {
+    assert!(FeatureProfileKind::from_str_name(" all").is_none());
+    assert!(FeatureProfileKind::from_str_name("all ").is_none());
+    assert!(FeatureProfileKind::from_str_name(" ga-lock ").is_none());
+}
+
+#[test]
+fn from_str_name_rejects_mixed_case() {
+    assert!(FeatureProfileKind::from_str_name("Ga-Lock").is_none());
+    assert!(FeatureProfileKind::from_str_name("PROD").is_none());
+    assert!(FeatureProfileKind::from_str_name("Auto").is_none());
+}
+
+#[test]
+fn all_variants_are_distinct() {
+    let all = FeatureProfileKind::all();
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "variants at index {i} and {j} are equal");
+            }
+        }
+    }
+}
+
+#[test]
+fn all_variants_have_distinct_as_str() {
+    let strs: Vec<&str> = FeatureProfileKind::all().iter().map(|k| k.as_str()).collect();
+    let mut deduped = strs.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(strs.len(), deduped.len());
+}
+
+// ---------------------------------------------------------------------------
+// catalog — advertised_features consistency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn advertised_features_subset_of_all_features() {
+    let all_ids: Vec<&str> = all_features().iter().map(|f| f.id).collect();
+    for &feat in catalog::advertised_features() {
+        assert!(all_ids.contains(&feat), "advertised feature '{feat}' not in all_features()");
+    }
+}
+
+#[test]
+fn advertised_features_match_advertised_flag() {
+    let advertised_from_flag: Vec<&str> =
+        all_features().iter().filter(|f| f.advertised).map(|f| f.id).collect();
+    let advertised = catalog::advertised_features();
+    assert_eq!(
+        advertised.len(),
+        advertised_from_flag.len(),
+        "advertised_features() count mismatch with advertised flag count"
+    );
+}
+
+#[test]
+fn compliance_percent_agrees_with_catalog() {
+    let grid_pct = compliance_percent_for_grid();
+    let catalog_pct = catalog::compliance_percent();
+    // Both should be in valid range; catalog may use different formula
+    assert!((0.0..=100.0).contains(&grid_pct));
+    assert!((0.0..=100.0).contains(&catalog_pct));
+}
+
+// ---------------------------------------------------------------------------
+// BddFeatureRow — field mapping fidelity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bdd_rows_preserve_all_feature_fields() {
+    let features = all_features();
+    let rows = bdd_feature_rows();
+    for feature in features {
+        let row = rows.iter().find(|r| r.id == feature.id);
+        assert!(row.is_some(), "no BDD row for feature {}", feature.id);
+        if let Some(row) = row {
+            assert_eq!(row.spec, feature.spec, "spec mismatch for {}", feature.id);
+            assert_eq!(row.area, feature.area, "area mismatch for {}", feature.id);
+            assert_eq!(row.maturity, feature.maturity, "maturity mismatch for {}", feature.id);
+            assert_eq!(
+                row.advertised, feature.advertised,
+                "advertised mismatch for {}",
+                feature.id
+            );
+            assert_eq!(
+                row.counts_in_coverage, feature.counts_in_coverage,
+                "counts_in_coverage mismatch for {}",
+                feature.id
+            );
+            assert_eq!(
+                row.description, feature.description,
+                "description mismatch for {}",
+                feature.id
+            );
+            assert_eq!(row.tests, feature.tests, "tests mismatch for {}", feature.id);
+        }
+    }
+}
+
+#[test]
+fn bdd_rows_serialize_all_rows() -> Result<(), Box<dyn std::error::Error>> {
+    for row in bdd_feature_rows() {
+        let json = serde_json::to_string(&row)?;
+        assert!(json.contains(row.id), "JSON for {} missing id", row.id);
+        assert!(json.contains(row.area), "JSON for {} missing area", row.id);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Capability map roundtrip — individual features
+// ---------------------------------------------------------------------------
+
+#[test]
+fn caps_roundtrip_signature_help() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.signature_help"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.signature_help"));
+}
+
+#[test]
+fn caps_roundtrip_declaration() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.declaration"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.declaration"));
+}
+
+#[test]
+fn caps_roundtrip_type_definition() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.type_definition"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.type_definition"));
+}
+
+#[test]
+fn caps_roundtrip_implementation() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.implementation"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.implementation"));
+}
+
+#[test]
+fn caps_roundtrip_document_symbol() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.document_symbol"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.document_symbol"));
+}
+
+#[test]
+fn caps_roundtrip_code_action() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.code_action"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.code_action"));
+}
+
+#[test]
+fn caps_roundtrip_code_lens() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.code_lens"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.code_lens"));
+}
+
+#[test]
+fn caps_roundtrip_formatting() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.formatting"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.formatting"));
+}
+
+#[test]
+fn caps_roundtrip_range_formatting() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.range_formatting"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.range_formatting"));
+}
+
+#[test]
+fn caps_roundtrip_on_type_formatting() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.on_type_formatting"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.on_type_formatting"));
+}
+
+#[test]
+fn caps_roundtrip_rename() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.rename"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.rename"));
+}
+
+#[test]
+fn caps_roundtrip_document_link() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.document_link"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.document_link"));
+}
+
+#[test]
+fn caps_roundtrip_folding_range() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.folding_range"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.folding_range"));
+}
+
+#[test]
+fn caps_roundtrip_selection_range() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.selection_range"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.selection_range"));
+}
+
+#[test]
+fn caps_roundtrip_semantic_tokens() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.semantic_tokens"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.semantic_tokens"));
+}
+
+#[test]
+fn caps_roundtrip_inlay_hint() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.inlay_hint"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.inlay_hint"));
+}
+
+#[test]
+fn caps_roundtrip_call_hierarchy() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.call_hierarchy"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.call_hierarchy"));
+}
+
+#[test]
+fn caps_roundtrip_pull_diagnostics() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.pull_diagnostics"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.pull_diagnostics"));
+}
+
+#[test]
+fn caps_roundtrip_inline_value() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.inline_value"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.inline_value"));
+}
+
+#[test]
+fn caps_roundtrip_document_color() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.document_color"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.document_color"));
+}
+
+#[test]
+fn caps_roundtrip_linked_editing_range() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.linked_editing_range"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.linked_editing_range"));
+}
+
+#[test]
+fn caps_roundtrip_moniker() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.moniker"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.moniker"));
+}
+
+#[test]
+fn caps_roundtrip_workspace_symbol() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.workspace_symbol"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.workspace_symbol"));
+}
+
+#[test]
+fn caps_roundtrip_execute_command() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.execute_command"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.execute_command"));
+}
+
+#[test]
+fn caps_roundtrip_document_highlight() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.document_highlight"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.document_highlight"));
+}
+
+#[test]
+fn caps_roundtrip_notebook_document_sync() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.notebook_document_sync"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.contains(&"lsp.notebook_document_sync"));
+}
+
+#[test]
+fn caps_from_feature_ids_unknown_feature_ignored() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let caps = caps_from_feature_ids(&["lsp.nonexistent_xyz"]);
+    let ids = feature_ids_from_caps(&caps);
+    assert!(ids.is_empty());
+}
+
+#[test]
+fn caps_roundtrip_all_advertised_features() {
+    use perl_lsp_feature_contracts::{caps_from_feature_ids, feature_ids_from_caps};
+    let advertised = catalog::advertised_features();
+    let caps = caps_from_feature_ids(advertised);
+    let ids = feature_ids_from_caps(&caps);
+    // Every advertised feature that has a capability mapping should roundtrip
+    for &feat in advertised {
+        if ids.contains(&feat) {
+            // Feature survived the roundtrip — good
+        }
+        // Some features (e.g. lsp.progress) don't map to ServerCapabilities fields,
+        // so we don't assert all features must roundtrip.
+    }
+    // At least some features should survive
+    assert!(!ids.is_empty(), "no features survived roundtrip");
+}
+
+// ---------------------------------------------------------------------------
+// Compliance math — edge-case validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trackable_plus_planned_equals_countable_total() {
+    let total_countable = all_features().iter().filter(|f| f.counts_in_coverage).count();
+    let planned_countable =
+        all_features().iter().filter(|f| f.maturity == "planned" && f.counts_in_coverage).count();
+    assert_eq!(trackable_feature_count_for_grid(), total_countable - planned_countable);
+}
+
+#[test]
+fn compliance_percent_for_grid_is_whole_number() {
+    let pct = compliance_percent_for_grid();
+    assert!(
+        (pct - pct.round()).abs() < f32::EPSILON,
+        "compliance_percent_for_grid should be rounded: got {pct}"
+    );
+}
+
+#[test]
+fn compliance_monotonic_with_advertised() {
+    // If all trackable features were advertised, compliance would be 100%
+    let trackable = trackable_feature_count_for_grid();
+    let advertised = advertised_trackable_feature_count_for_grid();
+    if trackable > 0 && advertised == trackable {
+        let pct = compliance_percent_for_grid();
+        assert!((pct - 100.0).abs() < f32::EPSILON);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Feature catalog — VERSION / LSP_VERSION format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_version_looks_like_semver() {
+    let v = catalog::VERSION;
+    let parts: Vec<&str> = v.split('.').collect();
+    assert!(parts.len() >= 2, "VERSION '{v}' doesn't look like semver");
+}
+
+#[test]
+fn catalog_lsp_version_has_dot_separator() {
+    let v = catalog::LSP_VERSION;
+    assert!(v.contains('.'), "LSP_VERSION '{v}' should contain a dot separator");
+}
+
+// ---------------------------------------------------------------------------
+// FeatureProfileKind — supported_cli_profiles exhaustive
+// ---------------------------------------------------------------------------
+
+#[test]
+fn supported_cli_profiles_covers_all_aliases() {
+    let cli = FeatureProfileKind::supported_cli_profiles();
+    for &kind in FeatureProfileKind::all() {
+        for &alias in kind.aliases() {
+            assert!(
+                cli.contains(&alias),
+                "alias '{alias}' for {:?} not in supported_cli_profiles",
+                kind
+            );
+        }
+    }
+}
+
+#[test]
+fn supported_cli_profiles_no_duplicates() {
+    let cli = FeatureProfileKind::supported_cli_profiles();
+    let mut deduped = cli.to_vec();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(cli.len(), deduped.len(), "duplicate entries in supported_cli_profiles");
+}


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests for perl-lsp-feature-contracts crate, expanding coverage from 59 to 106 tests.

## New test areas
- Spec ↔ FeatureProfileKind consistency checks
- Edge cases: whitespace, mixed case, distinct variant validation
- Advertised features consistency with all_features
- BddFeatureRow field mapping fidelity and serialization
- Individual capability map roundtrips for 26 LSP features
- Unknown feature handling in caps_from_feature_ids
- Compliance math edge cases and whole-number validation
- VERSION/LSP_VERSION format validation
- CLI profiles alias exhaustiveness and uniqueness

## Evidence
All 106 tests pass locally, cargo fmt clean, clippy clean.