### PR TITLE
fix(test): update snapshot for lsp.declaration capability

### DIFF
--- a/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
@@ -8,6 +8,7 @@ caps:
   - lsp.code_action
   - lsp.code_lens
   - lsp.completion
+  - lsp.declaration
   - lsp.definition
   - lsp.document_color
   - lsp.document_highlight


### PR DESCRIPTION
## Summary

Update the advertised-vs-caps snapshot to include `lsp.declaration` which was added by the capability-map tests in PR #1063.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Single snapshot file update — adds `lsp.declaration` to the expected capabilities list.

## Evidence

```
cargo test -p perl-lsp --test lsp_features_snapshot_test -- test_advertised_features_match_capabilities
  → PASSED
cargo test --workspace -- --skip dap_smoke_e2e
  → 3001 passed, 0 relevant failures (1 pre-existing flaky BDD race)
```

## Risk & rollback
Zero risk — test-only change, single line addition to snapshot.