### PR TITLE
fix(test): add barrier to flaky rename BDD test

### DIFF
--- a/crates/perl-lsp/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp/tests/lsp_bdd_workflows.rs
@@ -710,6 +710,7 @@ my $result = Foo::process_data();
     harness.open(&module_uri, module)?;
     harness.open(&main_uri, main)?;
     harness.wait_for_symbol("process_data", Some(&module_uri), Duration::from_secs(2)).ok();
+    harness.barrier();
 
     let (line, character) = find_position(main, "process_data()");
 


### PR DESCRIPTION
## Summary

Fixes intermittent failure of `bdd_prepare_rename_then_rename_from_call_site` when run as part of the full BDD test suite.

The test renames a symbol **from a call site** in `main.pl`, which requires the server to have completed cross-file reference indexing (not just symbol indexing). The existing `wait_for_symbol` call only confirms the symbol appears in `workspace/symbol` results, but doesn't guarantee the reference mapping between files is ready. Adding `harness.barrier()` forces the server to process all pending work—including reference indexing—before the test issues `prepareRename`/`rename` requests.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Added a single `harness.barrier()` call in `bdd_prepare_rename_then_rename_from_call_site` after `wait_for_symbol` and before the `prepareRename` request. This mirrors the pattern used by other cross-file tests (e.g., `bdd_incremental_changes_refresh_cross_file_navigation`).

## How to review

One-line change in `crates/perl-lsp/tests/lsp_bdd_workflows.rs` at line 713.

## Evidence

```
running 10 tests
test bdd_editor_intelligence_for_test_workflow ... ok
test bdd_definition_and_references_across_files ... ok
test bdd_formatting_workflow_returns_structured_edits ... ok
test bdd_incremental_changes_refresh_cross_file_navigation ... ok
test bdd_prepare_rename_then_rename_from_call_site ... ok
test bdd_pull_diagnostics_recovers_after_syntax_fix ... ok
test bdd_pull_diagnostics_supports_unchanged_report_cycle ... ok
test bdd_refactoring_workflow_surfaces_symbols_and_actions ... ok
test bdd_rename_updates_workspace_edits ... ok
test bdd_workspace_symbols_expose_module_api ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.80s
```

## Risk & rollback

**Blast radius**: Test-only, zero production impact.  
**Failure mode**: If `barrier()` itself times out, the test would fail deterministically rather than flakily—a strict improvement.  
**Rollback**: Revert the single line.

## Follow-ups

None.