### PR TITLE
chore(publish): fix Tier 1 leaf crate publish readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,17 +107,21 @@ allow = [
     # Tier 1 — Leaf crates (no workspace deps)
     "perl-position-tracking",
     "perl-token",
-    "perl-ast",
     "perl-builtins",
     "perl-content-length-framing",
     "perl-subprocess-runtime",
     "perl-keywords",
-    "perl-lexer",
     "perl-regex",
-    "perl-error",
-    "perl-heredoc",
-    "perl-pragma",
     "perl-quote",
+
+    # Tier 1b — Depend only on Tier 1 crates
+    "perl-ast",
+    "perl-lexer",
+    "perl-heredoc",
+
+    # Tier 1c — Depend on Tier 1b crates
+    "perl-error",
+    "perl-pragma",
     "perl-tokenizer",
 
     # Tier 2 — Core infrastructure
@@ -126,8 +130,8 @@ allow = [
     "perl-edit",
     "perl-incremental-parsing",
     "perl-symbol-types",
-"perl-symbol-cursor",
-"perl-symbol-table",
+    "perl-symbol-cursor",
+    "perl-symbol-table",
     "perl-uri",
     "perl-workspace-index-slo",
 

--- a/crates/perl-content-length-framing/Cargo.toml
+++ b/crates/perl-content-length-framing/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perl-content-length-framing"
 keywords = ["perl", "lsp", "dap", "jsonrpc", "framing"]
 categories = ["development-tools", "network-programming"]
-include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 

--- a/crates/perl-keywords/Cargo.toml
+++ b/crates/perl-keywords/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perl-keywords"
 keywords = ["perl", "keywords", "lexer", "lsp", "dap"]
 categories = ["development-tools", "text-editors"]
-include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 

--- a/crates/perl-keywords/LICENSE-APACHE
+++ b/crates/perl-keywords/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/perl-keywords/LICENSE-MIT
+++ b/crates/perl-keywords/LICENSE-MIT
@@ -1,0 +1,7 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perl-lexer"
 keywords = ["perl", "lexer", "tokenizer", "parser", "syntax"]
 categories = ["parsing", "text-processing"]
-include = ["src/**", "README.md", "LICENSE*", "Cargo.toml"]
+include = ["src/**", "tests/**", "examples/**", "benches/**", "README.md", "LICENSE*", "Cargo.toml"]
 
 [dependencies]
 # Core dependencies

--- a/crates/perl-position-tracking/Cargo.toml
+++ b/crates/perl-position-tracking/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["perl", "position", "utf16", "lsp", "utf8"]
 categories = ["development-tools", "text-editors"]
 include = [
   "src/**",
+  "tests/**",
   "Cargo.toml",
   "README.md",
   "LICENSE*"

--- a/crates/perl-subprocess-runtime/Cargo.toml
+++ b/crates/perl-subprocess-runtime/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perl-subprocess-runtime"
 keywords = ["perl", "subprocess", "runtime", "testing"]
 categories = ["development-tools"]
-include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 

--- a/crates/perl-subprocess-runtime/LICENSE-APACHE
+++ b/crates/perl-subprocess-runtime/LICENSE-APACHE
@@ -1,0 +1,13 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/crates/perl-subprocess-runtime/LICENSE-MIT
+++ b/crates/perl-subprocess-runtime/LICENSE-MIT
@@ -1,0 +1,7 @@
+Copyright 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary

Ran `cargo publish --dry-run` for all Tier 1 (leaf) crates in the workspace
publish allowlist and fixed every issue found. All 8 true leaf crates now pass
the dry-run with zero warnings.

Issues discovered and fixed:
- **Missing LICENSE files**: `perl-subprocess-runtime` and `perl-keywords` were
  missing `LICENSE-MIT` and `LICENSE-APACHE` — copied from the repo root.
- **Tests excluded from package**: 5 crates had `include` patterns that omitted
  `tests/**`, causing cargo warnings. Added the missing globs.
- **Examples/benches excluded**: `perl-lexer` also excluded `examples/**` and
  `benches/**` from its published package.
- **Incorrect tier comments**: 6 crates listed under "Tier 1 — Leaf crates (no
  workspace deps)" actually depend on other workspace crates. Split into Tier 1,
  1b, and 1c to accurately reflect the dependency graph.
- **Indentation**: Fixed 2 mis-indented entries (`perl-symbol-cursor`,
  `perl-symbol-table`).

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

No production code was modified — only Cargo.toml metadata and missing files.

## What changed

| File | Change |
|------|--------|
| `Cargo.toml` | Reordered publish allowlist with correct tier comments; fixed indentation |
| `crates/perl-position-tracking/Cargo.toml` | Added `tests/**` to include |
| `crates/perl-content-length-framing/Cargo.toml` | Added `tests/**` to include |
| `crates/perl-subprocess-runtime/Cargo.toml` | Added `tests/**` to include |
| `crates/perl-keywords/Cargo.toml` | Added `tests/**` to include |
| `crates/perl-lexer/Cargo.toml` | Added `tests/**`, `examples/**`, `benches/**` to include |
| `crates/perl-keywords/LICENSE-*` | Added missing license files |
| `crates/perl-subprocess-runtime/LICENSE-*` | Added missing license files |

## How to review

Single commit, metadata-only. Verify the include patterns and license files.

## Evidence

```
All 8 true Tier 1 leaf crates pass `cargo publish --dry-run` with 0 warnings:
  perl-position-tracking  ✅  15 files, 82.5KiB
  perl-token              ✅  11 files, 40.7KiB
  perl-builtins           ✅  13 files, 104.7KiB
  perl-content-length-framing ✅  9 files, 40.3KiB
  perl-subprocess-runtime ✅  9 files, 32.4KiB
  perl-keywords           ✅  9 files, 37.0KiB
  perl-regex              ✅  11 files, 42.2KiB
  perl-quote              ✅  11 files, 56.3KiB

cargo check --workspace: Finished in 29.24s (clean)
```

## Risk & rollback

Zero risk — only Cargo.toml metadata and license file additions. No code changes.
Rollback: revert the single commit.

## Follow-ups

- Tier 1b/1c crates (perl-ast, perl-lexer, perl-heredoc, perl-error, perl-pragma,
  perl-tokenizer) can be dry-run tested after Tier 1 crates are actually published.
- Higher-tier crates (Tier 2+) blocked on unpublished workspace deps — expected.