### PR TITLE
test(tokenizer): add comprehensive unit tests for perl-tokenizer

### DIFF
--- a/crates/perl-tokenizer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-tokenizer/tests/comprehensive_unit_tests.rs
@@ -1050,3 +1050,939 @@ fn format_with_trivia_empty() -> Result<(), Box<dyn std::error::Error>> {
     assert!(formatted.contains("Program"), "should contain Program node repr");
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Additional TokenStream — shift / defined-or / smart-match operators
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_shift_operators() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x << 2; $y >> 3;");
+    // consume tokens and look for LeftShift / RightShift
+    let mut found_left_shift = false;
+    let mut found_right_shift = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::LeftShift {
+            found_left_shift = true;
+        }
+        if t.kind == TokenKind::RightShift {
+            found_right_shift = true;
+        }
+    }
+    assert!(found_left_shift, "should detect <<");
+    assert!(found_right_shift, "should detect >>");
+    Ok(())
+}
+
+#[test]
+fn token_stream_defined_or_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x // $y;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::DefinedOr {
+            found = true;
+        }
+    }
+    assert!(found, "should detect // as DefinedOr");
+    Ok(())
+}
+
+#[test]
+fn token_stream_smart_match_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x ~~ @arr;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::SmartMatch {
+            found = true;
+        }
+    }
+    assert!(found, "should detect ~~ as SmartMatch");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — compound assignment operators
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_shift_assign_operators() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x <<= 2; $y >>= 3;");
+    let mut found_lsa = false;
+    let mut found_rsa = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::LeftShiftAssign {
+            found_lsa = true;
+        }
+        if t.kind == TokenKind::RightShiftAssign {
+            found_rsa = true;
+        }
+    }
+    assert!(found_lsa, "should detect <<=");
+    assert!(found_rsa, "should detect >>=");
+    Ok(())
+}
+
+#[test]
+fn token_stream_logical_assign_operators() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x &&= 1; $y ||= 2; $z //= 3;");
+    let mut found_and = false;
+    let mut found_or = false;
+    let mut found_defor = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        match t.kind {
+            TokenKind::LogicalAndAssign => found_and = true,
+            TokenKind::LogicalOrAssign => found_or = true,
+            TokenKind::DefinedOrAssign => found_defor = true,
+            _ => {}
+        }
+    }
+    assert!(found_and, "should detect &&=");
+    assert!(found_or, "should detect ||=");
+    assert!(found_defor, "should detect //=");
+    Ok(())
+}
+
+#[test]
+fn token_stream_power_assign_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x **= 2;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::PowerAssign {
+            found = true;
+        }
+    }
+    assert!(found, "should detect **=");
+    Ok(())
+}
+
+#[test]
+fn token_stream_xor_assign_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x ^= 0xFF;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::XorAssign {
+            found = true;
+        }
+    }
+    assert!(found, "should detect ^=");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — sigils and special tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_hash_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my %hash;");
+    let t = must(s.next()); // my
+    assert_eq!(t.kind, TokenKind::My);
+    // The lexer may produce the hash variable as a single token or sigil + ident
+    // Just verify we don't crash and get meaningful tokens
+    let t2 = must(s.next());
+    assert_ne!(t2.kind, TokenKind::Eof, "should have tokens after 'my'");
+    Ok(())
+}
+
+#[test]
+fn token_stream_double_colon() -> Result<(), Box<dyn std::error::Error>> {
+    // The lexer may tokenize Foo::Bar as a single qualified identifier
+    // Verify it produces valid tokens without crashing
+    let mut s = TokenStream::new("Foo::Bar");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Identifier, "qualified name should be an identifier");
+    Ok(())
+}
+
+#[test]
+fn token_stream_power_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("2 ** 10;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Power {
+            found = true;
+        }
+    }
+    assert!(found, "should detect ** as Power");
+    Ok(())
+}
+
+#[test]
+fn token_stream_spaceship_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$a <=> $b;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Spaceship {
+            found = true;
+        }
+    }
+    assert!(found, "should detect <=> as Spaceship");
+    Ok(())
+}
+
+#[test]
+fn token_stream_string_compare() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$a cmp $b;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::StringCompare {
+            found = true;
+        }
+    }
+    assert!(found, "should detect cmp");
+    Ok(())
+}
+
+#[test]
+fn token_stream_word_xor() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$a xor $b;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::WordXor {
+            found = true;
+        }
+    }
+    assert!(found, "should detect xor keyword");
+    Ok(())
+}
+
+#[test]
+fn token_stream_ellipsis() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("...");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Ellipsis);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — special keyword coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_eval_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("eval { 1 };");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Eval);
+    Ok(())
+}
+
+#[test]
+fn token_stream_do_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("do 'file.pl';");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Do);
+    Ok(())
+}
+
+#[test]
+fn token_stream_given_when_default() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("given ($x) { when (1) { } default { } }");
+    let mut found_given = false;
+    let mut found_when = false;
+    let mut found_default = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        match t.kind {
+            TokenKind::Given => found_given = true,
+            TokenKind::When => found_when = true,
+            TokenKind::Default => found_default = true,
+            _ => {}
+        }
+    }
+    assert!(found_given, "should detect given");
+    assert!(found_when, "should detect when");
+    assert!(found_default, "should detect default");
+    Ok(())
+}
+
+#[test]
+fn token_stream_try_catch_finally() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("try { } catch ($e) { } finally { }");
+    let mut found_try = false;
+    let mut found_catch = false;
+    let mut found_finally = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        match t.kind {
+            TokenKind::Try => found_try = true,
+            TokenKind::Catch => found_catch = true,
+            TokenKind::Finally => found_finally = true,
+            _ => {}
+        }
+    }
+    assert!(found_try, "should detect try");
+    assert!(found_catch, "should detect catch");
+    assert!(found_finally, "should detect finally");
+    Ok(())
+}
+
+#[test]
+fn token_stream_class_method() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("class Foo { method bar { } }");
+    let mut found_class = false;
+    let mut found_method = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        match t.kind {
+            TokenKind::Class => found_class = true,
+            TokenKind::Method => found_method = true,
+            _ => {}
+        }
+    }
+    assert!(found_class, "should detect class");
+    assert!(found_method, "should detect method");
+    Ok(())
+}
+
+#[test]
+fn token_stream_undef_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("undef;");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Undef);
+    Ok(())
+}
+
+#[test]
+fn token_stream_no_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("no strict;");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::No);
+    Ok(())
+}
+
+#[test]
+fn token_stream_state_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("state $x = 0;");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::State);
+    Ok(())
+}
+
+#[test]
+fn token_stream_format_keyword() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("format STDOUT =");
+    let t = must(s.next());
+    assert_eq!(t.kind, TokenKind::Format);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — token text and position verification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_token_text_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $variable = 42;");
+    let my_tok = must(s.next());
+    assert_eq!(my_tok.text.as_ref(), "my");
+    Ok(())
+}
+
+#[test]
+fn token_stream_token_positions_are_monotonic() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x = 1 + 2;");
+    let mut prev_start = 0;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        assert!(t.start >= prev_start, "token starts should be non-decreasing");
+        assert!(t.end > t.start, "token end should be after start");
+        prev_start = t.start;
+    }
+    Ok(())
+}
+
+#[test]
+fn token_stream_multiple_peeks_same_result() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x;");
+    let k1 = must(s.peek()).kind;
+    let k2 = must(s.peek()).kind;
+    let k3 = must(s.peek()).kind;
+    assert_eq!(k1, k2);
+    assert_eq!(k2, k3);
+    Ok(())
+}
+
+#[test]
+fn token_stream_peek_does_not_advance() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("if (1) { }");
+    let peeked = must(s.peek()).kind;
+    let consumed = must(s.next()).kind;
+    assert_eq!(peeked, consumed, "peek and next should return the same token");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — heredoc / regex / substitution / transliteration tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_heredoc_start() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x = <<'END';\nhello\nEND\n");
+    let mut found_heredoc = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::HeredocStart || t.kind == TokenKind::HeredocBody {
+            found_heredoc = true;
+        }
+    }
+    assert!(found_heredoc, "should detect heredoc tokens");
+    Ok(())
+}
+
+#[test]
+fn token_stream_regex_match() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x =~ /pattern/;");
+    let mut found_regex = false;
+    let mut found_match = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Regex {
+            found_regex = true;
+        }
+        if t.kind == TokenKind::Match {
+            found_match = true;
+        }
+    }
+    assert!(found_match, "should detect =~ match operator");
+    assert!(found_regex, "should detect regex literal");
+    Ok(())
+}
+
+#[test]
+fn token_stream_not_match_operator() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x !~ /pattern/;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::NotMatch {
+            found = true;
+        }
+    }
+    assert!(found, "should detect !~ not-match operator");
+    Ok(())
+}
+
+#[test]
+fn token_stream_substitution() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x =~ s/foo/bar/g;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Substitution {
+            found = true;
+        }
+    }
+    assert!(found, "should detect s/// substitution");
+    Ok(())
+}
+
+#[test]
+fn token_stream_transliteration() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("$x =~ tr/a-z/A-Z/;");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Transliteration {
+            found = true;
+        }
+    }
+    assert!(found, "should detect tr/// transliteration");
+    Ok(())
+}
+
+#[test]
+fn token_stream_quote_words() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my @list = qw(foo bar baz);");
+    let mut found = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::QuoteWords {
+            found = true;
+        }
+    }
+    assert!(found, "should detect qw() quote words");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — enter_format_mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_enter_format_mode_no_crash() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("format =\ntest\n.\n");
+    s.enter_format_mode();
+    // Just verify it doesn't crash
+    let _ = s.next();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — Unicode identifiers and edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_unicode_string_content() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x = \"日本語\";");
+    let mut found_string = false;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::String {
+            found_string = true;
+        }
+    }
+    assert!(found_string, "should tokenize strings with Unicode content");
+    Ok(())
+}
+
+#[test]
+fn token_stream_consecutive_semicolons() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new(";;;");
+    let mut count = 0;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::Semicolon {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 3, "should detect three consecutive semicolons");
+    Ok(())
+}
+
+#[test]
+fn token_stream_deeply_nested_parens() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("((((1))))");
+    let mut left_count = 0;
+    let mut right_count = 0;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        match t.kind {
+            TokenKind::LeftParen => left_count += 1,
+            TokenKind::RightParen => right_count += 1,
+            _ => {}
+        }
+    }
+    assert_eq!(left_count, 4);
+    assert_eq!(right_count, 4);
+    Ok(())
+}
+
+#[test]
+fn token_stream_multiline_code() -> Result<(), Box<dyn std::error::Error>> {
+    let input = "my $x = 1;\nmy $y = 2;\nmy $z = 3;\n";
+    let mut s = TokenStream::new(input);
+    let mut my_count = 0;
+    loop {
+        let t = must(s.next());
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        if t.kind == TokenKind::My {
+            my_count += 1;
+        }
+    }
+    assert_eq!(my_count, 3, "should tokenize across multiple lines");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// PositionTracker — additional edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn position_tracker_crlf_newlines() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "line1\r\nline2\r\n";
+    let tracker = PositionTracker::new(source);
+    // Byte 0 = start of line 1
+    let pos = tracker.byte_to_position(0);
+    assert_eq!(pos.line, 1);
+    assert_eq!(pos.column, 1);
+    Ok(())
+}
+
+#[test]
+fn position_tracker_end_of_file_offset() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "abc\ndef";
+    let tracker = PositionTracker::new(source);
+    let pos = tracker.byte_to_position(source.len());
+    // Should not crash, position should be valid
+    assert!(pos.line >= 1);
+    Ok(())
+}
+
+#[test]
+fn position_tracker_single_char_lines() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "a\nb\nc\n";
+    let tracker = PositionTracker::new(source);
+    let pos_a = tracker.byte_to_position(0);
+    let pos_b = tracker.byte_to_position(2);
+    let pos_c = tracker.byte_to_position(4);
+    assert_eq!(pos_a.line, 1);
+    assert_eq!(pos_b.line, 2);
+    assert_eq!(pos_c.line, 3);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenWithPosition — byte_range and kind accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_with_position_byte_range_accessors() -> Result<(), Box<dyn std::error::Error>> {
+    use perl_lexer::{Token as LToken, TokenType as LTT};
+    use std::sync::Arc;
+
+    let source = "my $x";
+    let tracker = PositionTracker::new(source);
+    let token = LToken::new(LTT::Keyword(Arc::from("my")), Arc::from("my"), 0, 2);
+    let wrapped = tracker.wrap_token(token);
+
+    assert_eq!(wrapped.byte_range(), (0, 2));
+    assert_eq!(wrapped.text(), "my");
+    assert!(matches!(wrapped.kind(), LTT::Keyword(_)));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Trivia — additional coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trivia_whitespace_as_str() -> Result<(), Box<dyn std::error::Error>> {
+    let t = Trivia::Whitespace("  \t".to_string());
+    assert_eq!(t.as_str(), "  \t");
+    assert_eq!(t.kind_name(), "whitespace");
+    Ok(())
+}
+
+#[test]
+fn trivia_newline_as_str() -> Result<(), Box<dyn std::error::Error>> {
+    let t = Trivia::Newline;
+    assert_eq!(t.as_str(), "\n");
+    assert_eq!(t.kind_name(), "newline");
+    Ok(())
+}
+
+#[test]
+fn trivia_pod_comment_as_str() -> Result<(), Box<dyn std::error::Error>> {
+    let pod = "=head1 NAME\n\ntest\n\n=cut".to_string();
+    let t = Trivia::PodComment(pod.clone());
+    assert_eq!(t.as_str(), pod.as_str());
+    assert_eq!(t.kind_name(), "pod");
+    Ok(())
+}
+
+#[test]
+fn trivia_line_comment_preserves_content() -> Result<(), Box<dyn std::error::Error>> {
+    let t = Trivia::LineComment("# hello world".to_string());
+    assert_eq!(t.as_str(), "# hello world");
+    assert_eq!(t.kind_name(), "comment");
+    Ok(())
+}
+
+#[test]
+fn trivia_equality_different_variants() -> Result<(), Box<dyn std::error::Error>> {
+    let a = Trivia::Whitespace(" ".to_string());
+    let b = Trivia::LineComment("# x".to_string());
+    assert_ne!(a, b);
+    Ok(())
+}
+
+#[test]
+fn trivia_equality_same_whitespace_content() -> Result<(), Box<dyn std::error::Error>> {
+    let a = Trivia::Whitespace("  ".to_string());
+    let b = Trivia::Whitespace("  ".to_string());
+    assert_eq!(a, b);
+    let c = Trivia::Whitespace(" ".to_string());
+    assert_ne!(a, c);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TriviaLexer — additional coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trivia_lexer_consecutive_comments() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "# line 1\n# line 2\nmy $x;".to_string();
+    let mut lexer = TriviaLexer::new(source);
+    let (_, trivia) = must_some(lexer.next_token_with_trivia());
+    let comment_count =
+        trivia.iter().filter(|t| matches!(&t.trivia, Trivia::LineComment(_))).count();
+    assert!(comment_count >= 2, "should detect consecutive comments, got {}", comment_count);
+    Ok(())
+}
+
+#[test]
+fn trivia_lexer_whitespace_only_source() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "   \t\t   ".to_string();
+    let mut lexer = TriviaLexer::new(source);
+    // Should eventually return None (no meaningful tokens)
+    let result = lexer.next_token_with_trivia();
+    // Either None or EOF token with trivia
+    if let Some((tok, _trivia)) = result {
+        assert!(
+            matches!(tok.token_type, perl_lexer::TokenType::EOF),
+            "whitespace-only source should yield EOF or None"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn trivia_lexer_comment_only_source() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "# just a comment\n".to_string();
+    let mut lexer = TriviaLexer::new(source);
+    let result = lexer.next_token_with_trivia();
+    // Should either return None or EOF with the comment in trivia
+    if let Some((tok, trivia)) = result {
+        if !matches!(tok.token_type, perl_lexer::TokenType::EOF) {
+            // If not EOF, the trivia should have the comment
+            let has_comment = trivia.iter().any(|t| matches!(&t.trivia, Trivia::LineComment(_)));
+            assert!(has_comment, "comment should be in trivia");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn trivia_lexer_mixed_whitespace_and_comments() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "  \n  # comment\n  my $x;".to_string();
+    let mut lexer = TriviaLexer::new(source);
+    let (_, trivia) = must_some(lexer.next_token_with_trivia());
+    let has_ws = trivia.iter().any(|t| matches!(&t.trivia, Trivia::Whitespace(_)));
+    let has_comment = trivia.iter().any(|t| matches!(&t.trivia, Trivia::LineComment(_)));
+    assert!(has_ws, "should have whitespace trivia");
+    assert!(has_comment, "should have comment trivia");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TriviaParserContext — additional coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trivia_parser_context_advance_past_end() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = TriviaParserContext::new("my $x;".to_string());
+    // is_eof on non-empty source should be false initially
+    assert!(!ctx.is_eof());
+    Ok(())
+}
+
+#[test]
+fn trivia_parser_context_empty_source() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = TriviaParserContext::new(String::new());
+    assert!(ctx.is_eof(), "empty source should be immediately eof");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TriviaPreservingParser (trivia_parser module) — additional coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trivia_parser_variable_declaration_with_comment() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "# header\nmy $x = 1;\nour $y = 2;\n".to_string();
+    let ctx = TriviaParserContext::new(source);
+    // Non-empty source with tokens should not be eof
+    assert!(!ctx.is_eof(), "should have parsed some tokens");
+    Ok(())
+}
+
+#[test]
+fn trivia_preserving_parser_format_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "# comment\nmy $x;".to_string();
+    let parser = TriviaPreservingParser::new(source);
+    let result = parser.parse();
+    let formatted = perl_tokenizer::trivia_parser::format_with_trivia(&result);
+    // Should include the comment in output
+    assert!(!formatted.is_empty(), "formatted output should not be empty");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions — additional coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn data_marker_at_very_start() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "__DATA__\nsome data here";
+    assert_eq!(find_data_marker_byte_lexed(src), Some(0));
+    Ok(())
+}
+
+#[test]
+fn data_marker_end_at_very_start() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "__END__\nsome data here";
+    assert_eq!(find_data_marker_byte_lexed(src), Some(0));
+    Ok(())
+}
+
+#[test]
+fn code_slice_data_at_start() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "__DATA__\ndata";
+    assert_eq!(code_slice(src), "");
+    Ok(())
+}
+
+#[test]
+fn code_slice_multiline_code_then_data() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "my $x = 1;\nmy $y = 2;\n__DATA__\ndata here\n";
+    let slice = code_slice(src);
+    assert!(slice.contains("my $x"));
+    assert!(slice.contains("my $y"));
+    assert!(!slice.contains("data here"));
+    Ok(())
+}
+
+#[test]
+fn find_data_marker_empty_input() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(find_data_marker_byte_lexed(""), None);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — on_stmt_boundary comprehensive
+// ---------------------------------------------------------------------------
+
+#[test]
+fn on_stmt_boundary_after_peek_second() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x; our $y;");
+    // Fill peek slots
+    let _ = must(s.peek());
+    let _ = must(s.peek_second());
+    // Reset boundary clears cache and sets lexer to ExpectTerm mode
+    s.on_stmt_boundary();
+    // After reset, cached peeks are cleared so next peek re-reads from lexer
+    let t = must(s.peek());
+    // The lexer continues from its current position (not from the start),
+    // so we just verify the boundary reset doesn't crash and returns a valid token
+    assert_ne!(t.kind, TokenKind::Unknown, "should return a valid token after boundary reset");
+    Ok(())
+}
+
+#[test]
+fn on_stmt_boundary_after_peek_third() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("my $x = 42;");
+    let _ = must(s.peek());
+    let _ = must(s.peek_second());
+    let _ = must(s.peek_third());
+    s.on_stmt_boundary();
+    // Boundary clears peek cache; lexer continues from its current position
+    let t = must(s.peek());
+    assert_ne!(t.kind, TokenKind::Unknown, "should return a valid token after boundary reset");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TokenStream — Division vs Regex context awareness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn token_stream_division_after_number() -> Result<(), Box<dyn std::error::Error>> {
+    let mut s = TokenStream::new("42 / 7;");
+    let num = must(s.next());
+    assert_eq!(num.kind, TokenKind::Number);
+    let div = must(s.next());
+    assert_eq!(div.kind, TokenKind::Slash, "/ after number should be division");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TriviaToken — range accessor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn trivia_token_range_is_valid() -> Result<(), Box<dyn std::error::Error>> {
+    use perl_position_tracking::{Position, Range};
+    let start = Position::new(0, 1, 1);
+    let end = Position::new(5, 1, 6);
+    let tt = TriviaToken::new(Trivia::Whitespace("     ".to_string()), Range::new(start, end));
+    assert_eq!(tt.range.start.byte, 0);
+    assert_eq!(tt.range.end.byte, 5);
+    assert_eq!(tt.trivia.as_str(), "     ");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds 65 new unit tests to the `perl-tokenizer` crate's `comprehensive_unit_tests.rs`, bringing the total from 80 to 145 passing tests. This significantly improves test coverage across all public APIs of the crate.

No production code was changed. This is a test-only PR.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

New tests cover areas that were previously untested:

- **Operators**: shift (`<<`/`>>`), defined-or (`//`), smart match (`~~`), power (`**`), spaceship (`<=>`), string compare (`cmp`), xor, ellipsis (`...`)
- **Compound assignments**: `<<=`, `>>=`, `&&=`, `||=`, `//=`, `**=`, `^=`
- **Keywords**: `eval`, `do`, `given`/`when`/`default`, `try`/`catch`/`finally`, `class`/`method`, `undef`, `no`, `state`, `format`
- **Literal types**: heredoc, regex, substitution, transliteration, quote words (`qw`)
- **Token properties**: text preservation, monotonic position ordering, peek idempotency
- **PositionTracker**: CRLF newlines, EOF offset, single-char lines
- **TokenWithPosition**: `byte_range()`, `kind()`, `text()` accessors
- **Trivia types**: all variant `as_str`/`kind_name`, equality semantics
- **TriviaLexer**: consecutive comments, whitespace-only source, comment-only source, mixed trivia
- **TriviaParserContext**: `is_eof` on empty/non-empty sources
- **Utilities**: `find_data_marker_byte_lexed` on empty input and markers at file start, `code_slice` multi-line
- **Edge cases**: `enter_format_mode`, `on_stmt_boundary` after multi-level peek, division context, deeply nested parens, consecutive semicolons, Unicode strings, multi-line tokenization

## How to review

Single file change: `crates/perl-tokenizer/tests/comprehensive_unit_tests.rs`. New tests are appended after the existing 80 tests, organized by category with section headers.

## Evidence

```
running 145 tests
...
test result: ok. 145 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

All 170 total crate tests pass (145 comprehensive + 16 edge cases + 8 inline + 1 doctest).

## Risk & rollback

Zero risk — test-only change with no production code modifications. Rollback: revert the single commit.

## Follow-ups

None required.