### PR TITLE
Fix end-of-document position when content ends with newline

### DIFF
--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -1554,6 +1554,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn end_position_handles_trailing_final_newline() {
+        let server = LspServer::new();
+        let content = "package Foo;\n";
+        let pos = server.get_document_end_position(content);
+        assert_eq!(pos, json!({"line": 1, "character": 0}));
+    }
+
+    #[test]
     fn end_position_handles_missing_final_newline() {
         let server = LspServer::new();
         let content = "package Foo;";

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -539,7 +539,7 @@ impl LspServer {
 
     /// Get the end position of a document
     pub(crate) fn get_document_end_position(&self, content: &str) -> Value {
-        let lines: Vec<&str> = content.lines().collect();
+        let lines: Vec<&str> = content.split('\n').collect();
         let last_line = lines.len().saturating_sub(1);
         let last_char = lines.last().map(|l| l.len()).unwrap_or(0);
 

--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 1444 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 1445 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -83,7 +83,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 1444 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 1445 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
### Motivation
- `str::lines()` drops a trailing final newline which made the computed LSP end position point to the previous line instead of the insertion point on the following empty line, causing incorrect ranges for append-style edits.

### Description
- Change `get_document_end_position` in `crates/perl-lsp/src/runtime/text_sync.rs` to split on `\n` (`content.split('\n')`) so a trailing newline produces an extra final empty line and the correct end position.
- Add a regression test `end_position_handles_trailing_final_newline` in `crates/perl-lsp/src/runtime/mod.rs` that verifies `"package Foo:\n"` yields `{"line": 1, "character": 0}`.

### Testing
- Ran `cargo fmt --all` successfully to format changes.
- Ran tests: `cargo test -p perl-lsp --lib end_position_handles_` and the targeted tests (`end_position_handles_trailing_final_newline` and `end_position_handles_missing_final_newline`) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bbf86188333a6f78b35a5793f2a)