### PR TITLE
Handle reversed formatting ranges safely

### DIFF
--- a/crates/perl-lsp-formatting/src/formatting.rs
+++ b/crates/perl-lsp-formatting/src/formatting.rs
@@ -80,6 +80,10 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
             return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
         }
 
+        if end_line < start_line {
+            return Ok(FormattedDocument { text: content.to_string(), edits: vec![] });
+        }
+
         let text_to_format = lines[start_line..=end_line].join("\n");
         let formatted = self.run_perltidy(&text_to_format, options)?;
 

--- a/crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs
@@ -364,6 +364,22 @@ fn test_format_range_single_line() -> Result<(), Box<dyn std::error::Error>> {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_format_range_reversed_lines_returns_no_edits() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "line1
+line2
+line3";
+    let runtime = MockSubprocessRuntime::new();
+    let provider = make_provider(runtime);
+
+    let range = FormatRange::new(FormatPosition::new(2, 0), FormatPosition::new(1, 0));
+    let doc = must(provider.format_range(source, &range, &default_options()));
+
+    assert!(doc.edits.is_empty());
+    assert_eq!(doc.text, source);
+    Ok(())
+}
+
+#[test]
 fn test_format_range_start_beyond_document() -> Result<(), Box<dyn std::error::Error>> {
     let source = "only one line";
     let runtime = MockSubprocessRuntime::new();


### PR DESCRIPTION
### Motivation
- Prevent a panic in the formatting path when a client supplies a reversed line range (`start.line > end.line`) which could lead to an invalid slice when building the subset of lines to format.

### Description
- Add an early return in `FormattingProvider::format_range` that checks `if end_line < start_line` and returns the original document with no edits to avoid invalid slicing in `lines[start..=end]` (file: `crates/perl-lsp-formatting/src/formatting.rs`).
- Add a regression test `test_format_range_reversed_lines_returns_no_edits` to verify reversed ranges return no edits and preserve the original text (file: `crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs`).
- Run `cargo fmt --all` to ensure formatting consistency.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perl-lsp-formatting` and all unit tests passed (`48 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bbf86188333a6f78b35a5793f2a)