### PR TITLE
Make formatting capability assertions in batteries-included tests tolerant of missing perltidy

### DIFF
--- a/crates/perl-lsp/tests/lsp_batteries_included_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_included_test.rs
@@ -32,11 +32,17 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
 
     // Verify formatting is advertised
     let formatting_provider = capabilities.get("documentFormattingProvider");
-    // Formatting is conditional on perltidy availability, so we do not strictly assert its presence here
+    // Formatting is conditional on perltidy availability, so we do not strictly assert its presence here.
+    // When present, ensure the capability value has a valid LSP shape.
+    if let Some(provider) = formatting_provider {
+        assert!(provider.is_boolean() || provider.is_object());
+    }
 
-    // Verify range formatting is advertised
+    // Range formatting follows the same perltidy availability gate.
     let range_formatting_provider = capabilities.get("documentRangeFormattingProvider");
-    assert!(range_formatting_provider.is_some(),);
+    if let Some(provider) = range_formatting_provider {
+        assert!(provider.is_boolean() || provider.is_object());
+    }
 
     Ok(())
 }
@@ -271,7 +277,6 @@ fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>>
         "completionProvider",
         "definitionProvider",
         "referencesProvider",
-        "documentFormattingProvider",
         "documentSymbolProvider",
         "codeActionProvider",
         "executeCommandProvider",
@@ -279,6 +284,14 @@ fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>>
 
     for capability in &expected_capabilities {
         assert!(capabilities.get(capability).is_some(), "Missing capability: {}", capability);
+    }
+
+    // Formatting-related capabilities are conditional on perltidy availability.
+    if let Some(provider) = capabilities.get("documentFormattingProvider") {
+        assert!(provider.is_boolean() || provider.is_object());
+    }
+    if let Some(provider) = capabilities.get("documentRangeFormattingProvider") {
+        assert!(provider.is_boolean() || provider.is_object());
     }
 
     Ok(())


### PR DESCRIPTION
### Motivation

- Tests assumed `documentFormattingProvider` / `documentRangeFormattingProvider` are always present, which fails in environments where `perltidy` is not available. This produced flaky failures unrelated to server regressions. 

### Description

- Adjusted `crates/perl-lsp/tests/lsp_batteries_included_test.rs` to treat formatting-related capabilities as optional and validate their JSON shape when present (`bool` or object) instead of requiring unconditional presence. 
- Removed `documentFormattingProvider` from the always-required capability list and added conditional shape checks for both `documentFormattingProvider` and `documentRangeFormattingProvider` in the server capabilities test. 

### Testing

- Ran the failing test to reproduce the issue with `cargo test -p perl-lsp --test lsp_batteries_included_test` which initially failed due to brittle assertions. 
- Re-ran the targeted test after the change with `cargo test -p perl-lsp --test lsp_batteries_included_test` and all tests in that file passed. 
- Ran lints with `cargo clippy -p perl-lsp --all-targets -- -D warnings` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bbf86188333a6f78b35a5793f2a)