### PR TITLE
Relax formatting capability assertions in LSP batteries test

### DIFF
--- a/crates/perl-lsp/tests/lsp_batteries_included_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_included_test.rs
@@ -31,12 +31,22 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
         result.get("capabilities").ok_or("Expected capabilities in initialize result")?;
 
     // Verify formatting is advertised
-    let formatting_provider = capabilities.get("documentFormattingProvider");
-    // Formatting is conditional on perltidy availability, so we do not strictly assert its presence here
+    if let Some(formatting_provider) = capabilities.get("documentFormattingProvider") {
+        // Formatting is conditional on perltidy availability; when present it should be a valid
+        // capability payload.
+        assert!(
+            formatting_provider.is_boolean() || formatting_provider.is_object(),
+            "documentFormattingProvider should be bool or object when advertised"
+        );
+    }
 
-    // Verify range formatting is advertised
-    let range_formatting_provider = capabilities.get("documentRangeFormattingProvider");
-    assert!(range_formatting_provider.is_some(),);
+    // Range formatting follows the same tool-availability gating as full-document formatting.
+    if let Some(range_formatting_provider) = capabilities.get("documentRangeFormattingProvider") {
+        assert!(
+            range_formatting_provider.is_boolean() || range_formatting_provider.is_object(),
+            "documentRangeFormattingProvider should be bool or object when advertised"
+        );
+    }
 
     Ok(())
 }
@@ -271,7 +281,6 @@ fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>>
         "completionProvider",
         "definitionProvider",
         "referencesProvider",
-        "documentFormattingProvider",
         "documentSymbolProvider",
         "codeActionProvider",
         "executeCommandProvider",


### PR DESCRIPTION
### Motivation
- The batteries-included capability tests assumed formatting capabilities are always advertised, which breaks in environments where external tools (e.g., `perltidy`) are unavailable. 
- Tests should reflect the server's documented graceful-degradation behavior instead of requiring environment-dependent features.

### Description
- Replace the unconditional check for `documentFormattingProvider` with a conditional `if let Some(...)` that validates the advertised value is a boolean or an object when present.
- Apply the same conditional validation for `documentRangeFormattingProvider` so range-formatting is checked only when advertised.
- Remove `documentFormattingProvider` from the unconditional `expected_capabilities` list so core capabilities checks remain tool-independent.
- Addressed a Clippy unused-variable failure by eliminating the unused binding and asserting on the provider only when present.

### Testing
- Ran `cargo test -p perl-lsp --test lsp_batteries_included_test` and all tests in that binary passed (7 passed; 0 failed). 
- Ran `cargo test -p perl-lsp --lib` earlier during validation and the library tests passed (134 passed; 0 failed). 
- Ran `cargo clippy -p perl-lsp --all-targets -- -D warnings` and `cargo fmt --all`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bbf86188333a6f78b35a5793f2a)