### PR TITLE
tree-sitter-perl: enforce octal-only braced \o escapes

### DIFF
--- a/crates/tree-sitter-perl-rs/src/scanner.c
+++ b/crates/tree-sitter-perl-rs/src/scanner.c
@@ -304,6 +304,20 @@ static void skip_braced(TSLexer *lexer) {
   ADVANCE_C;
 }
 
+static void skip_braced_chars(TSLexer *lexer, const char *allow) {
+  int32_t c = lexer->lookahead;
+
+  if (c != '{') return;
+
+  ADVANCE_C;
+  while (c && c != '}') {
+    if (!tsp_strchr(allow, c)) break;
+    ADVANCE_C;
+  }
+
+  if (c == '}') ADVANCE_C;
+}
+
 static bool isidfirst(int32_t c) { return c == '_' || is_tsp_id_start(c); }
 
 static bool isidcont(int32_t c) { return c == '_' || is_tsp_id_continue(c); }
@@ -782,8 +796,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           break;
 
         case 'o':
-          /* TODO: contents should just be octal */
-          skip_braced(lexer);
+          skip_braced_chars(lexer, "01234567_");
           break;
 
         case '0':


### PR DESCRIPTION
### Motivation
- Close the `TODO` in the C scanner that previously allowed any braced payload for `\o{...}` escapes and instead enforce that braced `\o` contents are valid octal sequences.

### Description
- Added a new helper `skip_braced_chars(TSLexer *lexer, const char *allow)` that consumes braced content only while characters belong to an allowed set and only consumes the closing brace when present.
- Updated the `case 'o'` escape branch to use `skip_braced_chars(lexer, "01234567_")` so `\o{...}` only accepts octal digits and underscore separators.
- The change is contained in `crates/tree-sitter-perl-rs/src/scanner.c` and replaces the prior permissive `skip_braced(lexer)` behavior for `\o{}`.

### Testing
- Ran `cargo check -p tree-sitter-perl --features c-parser,c-scanner` and it completed successfully.
- Ran `cargo test -p tree-sitter-perl --test integration_test test_basic_parsing` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bb7a458833388c3e860dc8bd8e8)