### PR TITLE
tree-sitter-perl: validate octal braced escapes

### DIFF
--- a/crates/tree-sitter-perl-rs/src/scanner.c
+++ b/crates/tree-sitter-perl-rs/src/scanner.c
@@ -304,6 +304,20 @@ static void skip_braced(TSLexer *lexer) {
   ADVANCE_C;
 }
 
+static void skip_braced_chars(TSLexer *lexer, const char *allow) {
+  int32_t c = lexer->lookahead;
+
+  if (c != '{') return;
+
+  ADVANCE_C;
+  while (c && c != '}') {
+    if (!tsp_strchr(allow, c)) return;
+    ADVANCE_C;
+  }
+
+  if (c == '}') ADVANCE_C;
+}
+
 static bool isidfirst(int32_t c) { return c == '_' || is_tsp_id_start(c); }
 
 static bool isidcont(int32_t c) { return c == '_' || is_tsp_id_continue(c); }
@@ -782,8 +796,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           break;
 
         case 'o':
-          /* TODO: contents should just be octal */
-          skip_braced(lexer);
+          skip_braced_chars(lexer, "01234567");
           break;
 
         case '0':

--- a/crates/tree-sitter-perl-rs/src/tests.rs
+++ b/crates/tree-sitter-perl-rs/src/tests.rs
@@ -149,6 +149,25 @@ mod tests {
     }
 
     #[test]
+    fn test_octal_escape_sequence_validation() {
+        let valid = parse(r#"my $x = qq(\\o{127});"#);
+        assert!(valid.is_ok(), "Valid octal escape should parse");
+        let valid_tree = must(valid);
+        assert!(
+            !valid_tree.root_node().has_error(),
+            "Valid octal escape should not produce parse errors"
+        );
+
+        let invalid = parse(r#"my $x = qq(\\o{128});"#);
+        assert!(invalid.is_ok(), "Invalid octal escape should still produce a tree");
+        let invalid_tree = must(invalid);
+        assert!(
+            invalid_tree.root_node().has_error(),
+            "Invalid octal escape should produce parse errors"
+        );
+    }
+
+    #[test]
     fn test_parser_reuse() {
         let mut parser = Parser::new();
         must(parser.set_language(&language()));


### PR DESCRIPTION
### Motivation

- Fix a scanner `TODO` that allowed arbitrary braced content for `\o{...}` escapes so non-octal digits were treated as valid; the intent is to only accept octal digits `0-7` inside braced octal escapes.

### Description

- Added a helper `skip_braced_chars(TSLexer *lexer, const char *allow)` to consume only allowed characters inside `{...}` and used it for the `\o` escape path in `crates/tree-sitter-perl-rs/src/scanner.c`.
- Replaced the previous `skip_braced(lexer)` usage in the `case 'o'` branch with `skip_braced_chars(lexer, "01234567")` to restrict content to octal digits.
- Added a focused regression test `test_octal_escape_sequence_validation` to `crates/tree-sitter-perl-rs/src/tests.rs` that asserts `qq(\o{127})` parses without errors and `qq(\o{128})` produces a parse tree containing an error.

### Testing

- Ran `cargo fmt --all` successfully to format code.
- Ran `cargo check --manifest-path crates/tree-sitter-perl-rs/Cargo.toml --features c-parser` which completed successfully.
- Ran `cargo test --manifest-path crates/tree-sitter-perl-rs/Cargo.toml --features c-parser --lib` and it failed to complete because of pre-existing compilation issues (missing `must`/`must_some` imports and a type-inference error) in other test code in `src/tests.rs`; the new scanner logic and the introduced test are localized and `cargo check` shows the crate builds with the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bb7a458833388c3e860dc8bd8e8)