### PR TITLE
Add multi-hit DAP hit-condition E2E receipt test and mark TODO done

### DIFF
--- a/crates/perl-dap/tests/dap_preview_e2e_receipts.rs
+++ b/crates/perl-dap/tests/dap_preview_e2e_receipts.rs
@@ -77,6 +77,60 @@ $x++;
 }
 
 #[test]
+fn preview_hit_condition_multi_hit_receipt() -> TestResult {
+    let workspace = tempdir()?;
+    let script = workspace.path().join("hit_condition_multi_receipt.pl");
+    write(
+        &script,
+        r#"use strict;
+use warnings;
+my $x = 0;
+$x++;
+$x++;
+$x++;
+"#,
+    )?;
+    let script_path = script.to_string_lossy().to_string();
+
+    let store = BreakpointStore::new();
+    let response = store.set_breakpoints(&SetBreakpointsArguments {
+        source: Source {
+            path: Some(script_path.clone()),
+            name: Some("hit_condition_multi_receipt.pl".to_string()),
+        },
+        breakpoints: Some(vec![SourceBreakpoint {
+            line: 4,
+            column: None,
+            condition: None,
+            hit_condition: Some("%3".to_string()),
+            log_message: None,
+        }]),
+        source_modified: None,
+    });
+
+    assert_eq!(response.len(), 1);
+    assert!(response[0].verified, "multi-hit breakpoint should verify on executable line");
+
+    let first = store.register_breakpoint_hit(&script_path, 4);
+    assert!(first.matched, "first hit should match breakpoint");
+    assert!(!first.should_stop, "first hit should not stop for hitCondition `%3`");
+
+    let second = store.register_breakpoint_hit(&script_path, 4);
+    assert!(second.matched, "second hit should match breakpoint");
+    assert!(!second.should_stop, "second hit should not stop for hitCondition `%3`");
+
+    let third = store.register_breakpoint_hit(&script_path, 4);
+    assert!(third.matched, "third hit should match breakpoint");
+    assert!(third.should_stop, "third hit should stop for hitCondition `%3`");
+
+    let fourth = store.register_breakpoint_hit(&script_path, 4);
+    assert!(fourth.matched, "fourth hit should still match breakpoint");
+    assert!(!fourth.should_stop, "fourth hit should not stop for hitCondition `%3`");
+
+    Ok(())
+}
+
+#[test]
 fn preview_log_message_receipt() -> TestResult {
     let workspace = tempdir()?;
     let script = workspace.path().join("log_message_receipt.pl");

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,7 +57,7 @@
 
 - **`dap.breakpoints.hit_condition`** (preview, not advertised)
   - [x] Validate hit-count parsing and runtime counter behavior
-  - [ ] Add dedicated E2E fixture coverage for multi-hit workflows
+  - [x] Add dedicated E2E fixture coverage for multi-hit workflows
 
 - **`dap.breakpoints.logpoints`** (preview, not advertised)
   - [x] Implement logMessage parsing and output emission path


### PR DESCRIPTION
### Motivation

- Provide deterministic E2E coverage for multi-hit `hit_condition` behavior in the DAP preview feature set to close an outstanding TODO and ensure runtime counter semantics are validated.

### Description

- Added a new deterministic preview receipt test `preview_hit_condition_multi_hit_receipt` in `crates/perl-dap/tests/dap_preview_e2e_receipts.rs` that creates a temporary script, registers a breakpoint with `hit_condition: "%3"`, and asserts matching/stop behavior across four successive hits.
- Updated `docs/TODO.md` to mark the `dap.breakpoints.hit_condition` multi-hit E2E fixture task as completed.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.
- Executed the targeted test suite with `cargo test -p perl-dap --test dap_preview_e2e_receipts` and all tests passed (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bb7a458833388c3e860dc8bd8e8)