### PR TITLE
tree-sitter scanner: validate braced \o escape contents as octal

### DIFF
--- a/crates/tree-sitter-perl-rs/src/scanner.c
+++ b/crates/tree-sitter-perl-rs/src/scanner.c
@@ -304,6 +304,23 @@ static void skip_braced(TSLexer *lexer) {
   ADVANCE_C;
 }
 
+static void skip_braced_octdigits(TSLexer *lexer) {
+  int32_t c = lexer->lookahead;
+
+  if (c != '{') return;
+
+  ADVANCE_C;
+  while (c && c != '}') {
+    if (c >= '0' && c <= '7') {
+      ADVANCE_C;
+    } else {
+      return;
+    }
+  }
+
+  if (c == '}') ADVANCE_C;
+}
+
 static bool isidfirst(int32_t c) { return c == '_' || is_tsp_id_start(c); }
 
 static bool isidcont(int32_t c) { return c == '_' || is_tsp_id_continue(c); }
@@ -782,8 +799,7 @@ bool tree_sitter_perl_external_scanner_scan(void *payload, TSLexer *lexer,
           break;
 
         case 'o':
-          /* TODO: contents should just be octal */
-          skip_braced(lexer);
+          skip_braced_octdigits(lexer);
           break;
 
         case '0':


### PR DESCRIPTION
### Motivation
- Resolve a scanner `TODO` by enforcing correct Perl semantics for `\o{...}` escapes, which must contain only octal digits (`0-7`), instead of permissively consuming arbitrary braced content.

### Description
- Added `skip_braced_octdigits` in `crates/tree-sitter-perl-rs/src/scanner.c` to consume braced content only when every character is an octal digit (`'0'..'7'`).
- Replaced the `case 'o'` branch in the escape-sequence handling to call `skip_braced_octdigits` instead of the generic `skip_braced` helper.
- The new helper stops early on invalid content and only advances past the closing `}` when the braced payload is strictly octal.

### Testing
- Ran `cargo check -p tree-sitter-perl --features c-parser,c-scanner --lib` which completed successfully.
- Ran `cargo test -p tree-sitter-perl --features c-parser,c-scanner --no-run` which reported unrelated pre-existing test compilation errors in `crates/tree-sitter-perl-rs/src/tests.rs` (missing `must`/`must_some` imports), so the full test suite could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bb7a458833388c3e860dc8bd8e8)