### PR TITLE
Extract document link logic into dedicated microcrate (perl-lsp-document-links)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-document-links"
+version = "0.10.0"
+dependencies = [
+ "perl-module-import",
+ "perl-module-path",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "perl-lsp-feature-contracts"
 version = "0.10.0"
 dependencies = [
@@ -1945,7 +1955,7 @@ name = "perl-lsp-navigation"
 version = "0.10.0"
 dependencies = [
  "lsp-types",
- "perl-module-import",
+ "perl-lsp-document-links",
  "perl-module-path",
  "perl-parser-core",
  "perl-position-tracking",
@@ -1953,7 +1963,6 @@ dependencies = [
  "perl-tdd-support",
  "serde",
  "serde_json",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/perl-lsp-feature-governance",
     "crates/perl-lsp-launcher",
     "crates/perl-lsp-navigation",
+    "crates/perl-lsp-document-links",
     "crates/perl-lsp-completion",
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
@@ -150,6 +151,7 @@ allow = [
 
     # Tier 4 — LSP providers
     "perl-lsp-navigation",
+    "perl-lsp-document-links",
     "perl-lsp-tooling",
     "perl-lsp-formatting-types",
     "perl-lsp-formatting",
@@ -291,6 +293,7 @@ perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "
 perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.10.0" }
 perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.10.0" }
 perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.10.0" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.10.0" }
 perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.10.0" }
 perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.10.0" }
 perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.10.0" }

--- a/crates/perl-lsp-document-links/Cargo.toml
+++ b/crates/perl-lsp-document-links/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "perl-lsp-document-links"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Document link extraction for Perl LSP providers"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-document-links"
+keywords = ["perl", "lsp", "document-links", "navigation"]
+categories = ["development-tools", "text-editors"]
+
+[lib]
+doctest = false
+
+[dependencies]
+perl-module-import = { workspace = true }
+perl-module-path = { workspace = true }
+serde_json = "1.0.149"
+url = "2.5.8"
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-document-links/README.md
+++ b/crates/perl-lsp-document-links/README.md
@@ -1,0 +1,7 @@
+# perl-lsp-document-links
+
+Focused document link extraction utilities for Perl source files used by LSP implementations.
+
+## API
+
+- `compute_links(uri, text, roots)` scans `use`/`require` statements and emits deferred link metadata for `documentLink/resolve`.

--- a/crates/perl-lsp-document-links/src/lib.rs
+++ b/crates/perl-lsp-document-links/src/lib.rs
@@ -1,7 +1,12 @@
-//! Document links provider for LSP protocol compatibility.
+//! Document links provider utilities for Perl LSP support.
 //!
-//! This module provides document link detection for Perl source files,
+//! This crate provides document link detection for Perl source files,
 //! identifying `use`, `require` module statements, and file includes.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
 
 use perl_module_import::{ModuleImportKind, parse_module_import_head};
 use perl_module_path::module_name_to_path;

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -22,10 +22,9 @@ perl-semantic-analyzer = { workspace = true }
 lsp-types = { version = "0.97.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-url = "2.5.8"
 perl-position-tracking = { workspace = true }
 perl-module-path = { workspace = true }
-perl-module-import = { workspace = true }
+perl-lsp-document-links = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-lsp-navigation/src/lib.rs
+++ b/crates/perl-lsp-navigation/src/lib.rs
@@ -27,18 +27,17 @@
 #![warn(clippy::all)]
 
 // Declare modules
-mod document_links;
 mod references;
 mod type_definition;
 mod type_hierarchy;
 mod workspace_symbols;
 
 // Re-export key types and functions
-pub use self::document_links::compute_links;
 pub use self::references::find_references_single_file;
 pub use self::type_definition::TypeDefinitionProvider;
 pub use self::type_hierarchy::{TypeHierarchyItem, TypeHierarchyProvider, TypeHierarchySymbolKind};
 pub use self::workspace_symbols::{WorkspaceSymbol, WorkspaceSymbolsProvider};
+pub use perl_lsp_document_links::compute_links;
 
 // Re-export Location type for convenience
 pub use lsp_types::Location;


### PR DESCRIPTION
### Motivation

- Reduce coupling by isolating document-link extraction from the broader navigation provider crate so the logic follows SRP and is easier to iterate on. 
- Provide a small reusable microcrate that other teams can depend on for `use`/`require`-based document link extraction without pulling in full navigation features. 
- Preserve the existing public API surface for consumers by keeping a re-export in the navigation crate.

### Description

- Added a new crate `crates/perl-lsp-document-links` which implements `compute_links(uri, text, roots)` and includes the existing document-link unit tests. 
- Moved the implementation from `crates/perl-lsp-navigation/src/document_links.rs` into `crates/perl-lsp-document-links/src/lib.rs` (rename + relocate). 
- Updated `crates/perl-lsp-navigation` to depend on `perl-lsp-document-links` and re-export `compute_links` to preserve backward compatibility. 
- Wired workspace metadata: added the new crate as a workspace member, added it to the workspace dependency table and publish allowlist entries in `Cargo.toml` and updated crate `Cargo.toml` files accordingly.

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perl-lsp-document-links` and all unit tests passed (`3` passed). 
- Ran `cargo test -p perl-lsp-navigation` and the navigation crate tests passed (unit and comprehensive tests; all passed). 
- Ran `cargo test -p perl-lsp --lib` and the library test suite passed (`134` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b8af7a883339ffe60ff170de8ba)