### PR TITLE
refactor: extract symbol index into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "moka",
  "perl-parser-core",
  "perl-subprocess-runtime",
+ "perl-symbol-index",
  "perl-tdd-support",
  "serde",
 ]
@@ -2333,6 +2334,10 @@ version = "0.10.0"
 dependencies = [
  "perl-tdd-support",
 ]
+
+[[package]]
+name = "perl-symbol-index"
+version = "0.10.0"
 
 [[package]]
 name = "perl-symbol-table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "crates/perl-symbol-types",
     "crates/perl-symbol-cursor",
     "crates/perl-symbol-table",
+    "crates/perl-symbol-index",
     "crates/perl-module-boundary",
     "crates/perl-module-token-core",
     "crates/perl-module-token",
@@ -234,6 +235,7 @@ perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
 perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.10.0" }
 perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
 perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }
 perl-module-token = { path = "crates/perl-module-token", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -25,6 +25,7 @@ perl-subprocess-runtime = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
+perl-symbol-index = { workspace = true }
 lsp-types = { version = "0.97.0", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 

--- a/crates/perl-lsp-tooling/src/performance.rs
+++ b/crates/perl-lsp-tooling/src/performance.rs
@@ -7,7 +7,7 @@
 
 use moka::sync::Cache;
 use perl_parser_core::Node;
-use std::collections::HashMap;
+pub use perl_symbol_index::SymbolIndex;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -216,149 +216,6 @@ pub mod parallel {
     use super::*;
 }
 
-/// Symbol index for fast lookups.
-///
-/// Supports both prefix and fuzzy matching using a trie and inverted index.
-pub struct SymbolIndex {
-    /// Trie structure for prefix matching
-    trie: SymbolTrie,
-    /// Inverted index for fuzzy matching
-    inverted_index: HashMap<String, Vec<String>>,
-}
-
-/// Trie data structure for efficient prefix matching
-struct SymbolTrie {
-    /// Child nodes indexed by character
-    children: HashMap<char, Box<SymbolTrie>>,
-    /// Symbols stored at this node
-    symbols: Vec<String>,
-}
-
-impl Default for SymbolIndex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SymbolIndex {
-    /// Create a new empty symbol index
-    pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
-    }
-
-    /// Add a symbol to the index.
-    ///
-    /// Indexes the symbol for both prefix and fuzzy matching.
-    pub fn add_symbol(&mut self, symbol: String) {
-        // Add to trie for prefix matching
-        self.trie.insert(&symbol);
-
-        // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
-        for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
-        }
-    }
-
-    /// Search symbols with prefix.
-    ///
-    /// Returns all symbols starting with the given prefix.
-    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        self.trie.search_prefix(prefix)
-    }
-
-    /// Fuzzy search symbols.
-    ///
-    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
-    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
-        let tokens = Self::tokenize(query);
-        let mut results = HashMap::new();
-
-        for token in tokens {
-            if let Some(symbols) = self.inverted_index.get(&token) {
-                for symbol in symbols {
-                    *results.entry(symbol.clone()).or_insert(0) += 1;
-                }
-            }
-        }
-
-        // Sort by relevance (number of matching tokens)
-        let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
-
-        sorted.into_iter().map(|(symbol, _)| symbol).collect()
-    }
-
-    fn tokenize(s: &str) -> Vec<String> {
-        // Split on word boundaries and case changes
-        let mut tokens = Vec::new();
-        let mut current = String::new();
-        let mut prev_upper = false;
-
-        for ch in s.chars() {
-            if ch.is_uppercase() && !prev_upper && !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-            }
-
-            if ch.is_alphanumeric() {
-                current.push(ch);
-                prev_upper = ch.is_uppercase();
-            } else if !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-                prev_upper = false;
-            }
-        }
-
-        if !current.is_empty() {
-            tokens.push(current.to_lowercase());
-        }
-
-        tokens
-    }
-}
-
-impl SymbolTrie {
-    fn new() -> Self {
-        Self { children: HashMap::new(), symbols: Vec::new() }
-    }
-
-    fn insert(&mut self, symbol: &str) {
-        let mut node = self;
-
-        for ch in symbol.chars() {
-            node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
-        }
-
-        node.symbols.push(symbol.to_string());
-    }
-
-    fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        let mut node = self;
-
-        for ch in prefix.chars() {
-            match node.children.get(&ch) {
-                Some(child) => node = child,
-                None => return Vec::new(),
-            }
-        }
-
-        // Collect all symbols from this node and descendants
-        let mut results = Vec::new();
-        Self::collect_all(node, &mut results);
-        results
-    }
-
-    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
-        results.extend(node.symbols.clone());
-
-        for child in node.children.values() {
-            Self::collect_all(child, results);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,25 +273,6 @@ mod tests {
         parser.mark_changed(18, 35);
         assert_eq!(parser.changed_regions.len(), 1);
         assert_eq!(parser.changed_regions[0], (10, 40));
-    }
-
-    #[test]
-    fn test_symbol_index() {
-        let mut index = SymbolIndex::new();
-
-        index.add_symbol("calculate_total".to_string());
-        index.add_symbol("calculate_average".to_string());
-        index.add_symbol("get_user_name".to_string());
-
-        // Prefix search
-        let results = index.search_prefix("calc");
-        assert_eq!(results.len(), 2);
-        assert!(results.contains(&"calculate_total".to_string()));
-        assert!(results.contains(&"calculate_average".to_string()));
-
-        // Fuzzy search
-        let results = index.search_fuzzy("user name");
-        assert!(results.contains(&"get_user_name".to_string()));
     }
 
     #[test]

--- a/crates/perl-symbol-index/Cargo.toml
+++ b/crates/perl-symbol-index/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-symbol-index"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "SRP microcrate for prefix and fuzzy symbol indexing"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-symbol-index"
+keywords = ["perl", "lsp", "symbol", "index", "search"]
+categories = ["development-tools", "text-editors"]
+include = ["src/**", "Cargo.toml", "README.md"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-symbol-index/README.md
+++ b/crates/perl-symbol-index/README.md
@@ -1,0 +1,22 @@
+# perl-symbol-index
+
+Small single-responsibility crate for symbol indexing and lookup.
+
+## Features
+
+- Prefix search via trie-backed index
+- Fuzzy token-based symbol search
+- Zero runtime dependencies
+
+## Usage
+
+```rust
+use perl_symbol_index::SymbolIndex;
+
+let mut index = SymbolIndex::new();
+index.add_symbol("calculate_total".to_string());
+index.add_symbol("get_user_name".to_string());
+
+let prefix = index.search_prefix("calc");
+let fuzzy = index.search_fuzzy("user name");
+```

--- a/crates/perl-symbol-index/src/lib.rs
+++ b/crates/perl-symbol-index/src/lib.rs
@@ -1,0 +1,180 @@
+//! Prefix and fuzzy symbol indexing utilities.
+//!
+//! This crate owns one responsibility: indexing symbol names for fast lookup.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::collections::HashMap;
+
+/// Symbol index for fast lookups.
+///
+/// Supports both prefix and fuzzy matching using a trie and inverted index.
+pub struct SymbolIndex {
+    /// Trie structure for prefix matching.
+    trie: SymbolTrie,
+    /// Inverted index for fuzzy matching.
+    inverted_index: HashMap<String, Vec<String>>,
+}
+
+/// Trie data structure for efficient prefix matching.
+struct SymbolTrie {
+    /// Child nodes indexed by character.
+    children: HashMap<char, Box<SymbolTrie>>,
+    /// Symbols stored at this node.
+    symbols: Vec<String>,
+}
+
+impl Default for SymbolIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SymbolIndex {
+    /// Create a new empty symbol index.
+    pub fn new() -> Self {
+        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
+    }
+
+    /// Add a symbol to the index.
+    ///
+    /// Indexes the symbol for both prefix and fuzzy matching.
+    pub fn add_symbol(&mut self, symbol: String) {
+        self.trie.insert(&symbol);
+
+        let tokens = Self::tokenize(&symbol);
+        for token in tokens {
+            self.inverted_index.entry(token).or_default().push(symbol.clone());
+        }
+    }
+
+    /// Search symbols with prefix.
+    ///
+    /// Returns all symbols starting with the given prefix.
+    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        self.trie.search_prefix(prefix)
+    }
+
+    /// Fuzzy search symbols.
+    ///
+    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
+    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
+        let tokens = Self::tokenize(query);
+        let mut results = HashMap::new();
+
+        for token in tokens {
+            if let Some(symbols) = self.inverted_index.get(&token) {
+                for symbol in symbols {
+                    *results.entry(symbol.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let mut sorted: Vec<_> = results.into_iter().collect();
+        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+        sorted.into_iter().map(|(symbol, _)| symbol).collect()
+    }
+
+    fn tokenize(symbol: &str) -> Vec<String> {
+        let mut tokens = Vec::new();
+        let mut current = String::new();
+        let mut previous_was_uppercase = false;
+
+        for ch in symbol.chars() {
+            if ch.is_uppercase() && !previous_was_uppercase && !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+            }
+
+            if ch.is_alphanumeric() {
+                current.push(ch);
+                previous_was_uppercase = ch.is_uppercase();
+            } else if !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+                previous_was_uppercase = false;
+            }
+        }
+
+        if !current.is_empty() {
+            tokens.push(current.to_lowercase());
+        }
+
+        tokens
+    }
+}
+
+impl SymbolTrie {
+    fn new() -> Self {
+        Self { children: HashMap::new(), symbols: Vec::new() }
+    }
+
+    fn insert(&mut self, symbol: &str) {
+        let mut node = self;
+
+        for ch in symbol.chars() {
+            node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
+        }
+
+        node.symbols.push(symbol.to_string());
+    }
+
+    fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        let mut node = self;
+
+        for ch in prefix.chars() {
+            match node.children.get(&ch) {
+                Some(child) => node = child,
+                None => return Vec::new(),
+            }
+        }
+
+        let mut results = Vec::new();
+        Self::collect_all(node, &mut results);
+        results
+    }
+
+    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
+        results.extend(node.symbols.clone());
+
+        for child in node.children.values() {
+            Self::collect_all(child, results);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolIndex;
+
+    #[test]
+    fn supports_prefix_and_fuzzy_lookups() {
+        let mut index = SymbolIndex::new();
+
+        index.add_symbol("calculate_total".to_string());
+        index.add_symbol("calculate_average".to_string());
+        index.add_symbol("get_user_name".to_string());
+
+        let prefix_results = index.search_prefix("calc");
+        assert_eq!(prefix_results.len(), 2);
+        assert!(prefix_results.contains(&"calculate_total".to_string()));
+        assert!(prefix_results.contains(&"calculate_average".to_string()));
+
+        let fuzzy_results = index.search_fuzzy("user name");
+        assert!(fuzzy_results.contains(&"get_user_name".to_string()));
+    }
+
+    #[test]
+    fn tokenizes_delimiter_separated_names() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("render_http_response".to_string());
+
+        let results = index.search_fuzzy("http response");
+        assert_eq!(results, vec!["render_http_response".to_string()]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Symbol indexing (prefix + fuzzy lookup) is a single responsibility that was embedded in `perl-lsp-tooling::performance`, coupling it to unrelated caching and parsing utilities.
- Extracting the index to a focused SRP crate enables independent reuse, clearer ownership, and simpler testing and maintenance.

### Description
- Added a new microcrate `crates/perl-symbol-index` that implements `SymbolIndex`, the trie, tokenization, fuzzy/inverted-index logic, focused docs, and unit tests.
- Removed the inlined `SymbolIndex` implementation from `crates/perl-lsp-tooling/src/performance.rs` and replaced it with a re-export `pub use perl_symbol_index::SymbolIndex;` to preserve the public API.
- Wired the workspace and dependencies: added `crates/perl-symbol-index` to the workspace members and added a workspace dependency entry so existing crates continue to build against the new microcrate.
- Kept behavior and tests intact by moving/adjusting unit tests into the new crate and removing duplicated tests from the old location, and ran `cargo fmt` to normalize formatting.

### Testing
- Ran formatting: `cargo fmt --all` and applied formatting changes successfully.
- Ran unit tests for the new crate: `cargo test -p perl-symbol-index` — all tests passed.
- Ran tests for the modified crate: `cargo test -p perl-lsp-tooling` — all tests passed.
- Ran core LSP tests: `cargo test -p perl-lsp --lib` — selected library tests passed locally (workspace integration validated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b87b10883338ee9f0d54c0742c7)