### PR TITLE
test(module-name): add comprehensive unit tests

### DIFF
--- a/crates/perl-module-name/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-module-name/tests/comprehensive_unit_tests.rs
@@ -443,3 +443,458 @@ fn cow_owned_when_transformation_needed_legacy() -> Result<(), Box<dyn std::erro
     }
     Ok(())
 }
+
+// ──────────────────────────────────────────────────────────────
+// Idempotency: applying the same transform twice yields same result
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let inputs = ["Foo'Bar", "A::B::C", "strict", "", "X'Y::Z"];
+    for input in &inputs {
+        let once = normalize_package_separator(input).into_owned();
+        let twice = normalize_package_separator(&once).into_owned();
+        assert_eq!(once, twice, "normalize not idempotent for {input:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn legacy_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let inputs = ["Foo::Bar", "A'B'C", "strict", "", "X'Y::Z"];
+    for input in &inputs {
+        let once = legacy_package_separator(input).into_owned();
+        let twice = legacy_package_separator(&once).into_owned();
+        assert_eq!(once, twice, "legacy not idempotent for {input:?}");
+    }
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Stability: variant_pairs output is deterministic
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_deterministic_across_calls() -> Result<(), Box<dyn std::error::Error>> {
+    let a = module_variant_pairs("Foo::Bar", "Baz::Qux");
+    let b = module_variant_pairs("Foo::Bar", "Baz::Qux");
+    assert_eq!(a, b);
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_legacy_input_matches_canonical_input() -> Result<(), Box<dyn std::error::Error>> {
+    let from_canonical = module_variant_pairs("Foo::Bar", "Baz::Qux");
+    let from_legacy = module_variant_pairs("Foo'Bar", "Baz'Qux");
+    assert_eq!(from_canonical, from_legacy);
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Real-world CPAN module names
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_dbi_module() -> Result<(), Box<dyn std::error::Error>> {
+    let result = normalize_package_separator("DBI");
+    assert!(matches!(result, Cow::Borrowed(_)));
+    assert_eq!(result, "DBI");
+    Ok(())
+}
+
+#[test]
+fn normalize_dbd_mysql() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("DBD'mysql"), "DBD::mysql");
+    Ok(())
+}
+
+#[test]
+fn legacy_test_more() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator("Test::More"), "Test'More");
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_lwp_useragent() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("LWP::UserAgent", "HTTP::Tiny");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("LWP::UserAgent".to_string(), "HTTP::Tiny".to_string()));
+    assert_eq!(pairs[1], ("LWP'UserAgent".to_string(), "HTTP'Tiny".to_string()));
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_datetime_format() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("DateTime::Format::Strptime", "Time::Piece");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("DateTime::Format::Strptime".to_string(), "Time::Piece".to_string()));
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Boundary: very long module names
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_very_long_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    let segments: Vec<&str> = (0..20).map(|_| "Segment").collect();
+    let legacy = segments.join("'");
+    let canonical = segments.join("::");
+    assert_eq!(normalize_package_separator(&legacy), canonical);
+    Ok(())
+}
+
+#[test]
+fn legacy_very_long_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    let segments: Vec<&str> = (0..20).map(|_| "Segment").collect();
+    let canonical = segments.join("::");
+    let legacy = segments.join("'");
+    assert_eq!(legacy_package_separator(&canonical), legacy);
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_very_long_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    let segments: Vec<&str> = (0..10).map(|_| "A").collect();
+    let canonical = segments.join("::");
+    let pairs = module_variant_pairs(&canonical, &canonical);
+    assert_eq!(pairs.len(), 2);
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Separator-only strings
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_multiple_quotes_only() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("'''"), "::::::");
+    Ok(())
+}
+
+#[test]
+fn legacy_multiple_colons_only() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator("::::::"), "'''");
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_separator_only() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("::", "::");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("::".to_string(), "::".to_string()));
+    assert_eq!(pairs[1], ("'".to_string(), "'".to_string()));
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Asymmetric variant pairs: one has separator, other doesn't
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_old_qualified_new_bare() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("My::Module", "newname");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("My::Module".to_string(), "newname".to_string()));
+    assert_eq!(pairs[1], ("My'Module".to_string(), "newname".to_string()));
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_old_bare_new_bare() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("oldname", "newname");
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0], ("oldname".to_string(), "newname".to_string()));
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Normalize preserves non-separator characters exactly
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_preserves_underscores() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("My_Module'Sub_Pkg"), "My_Module::Sub_Pkg");
+    Ok(())
+}
+
+#[test]
+fn normalize_preserves_hyphens() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("My-Module'Sub"), "My-Module::Sub");
+    Ok(())
+}
+
+#[test]
+fn normalize_preserves_digits() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("Module123'V456"), "Module123::V456");
+    Ok(())
+}
+
+#[test]
+fn legacy_preserves_underscores() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator("My_Module::Sub_Pkg"), "My_Module'Sub_Pkg");
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Cow lifetime: borrowed result references original input
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn cow_borrowed_points_to_original_normalize() -> Result<(), Box<dyn std::error::Error>> {
+    let input = "Foo::Bar";
+    let result = normalize_package_separator(input);
+    if let Cow::Borrowed(s) = result {
+        assert!(std::ptr::eq(s.as_bytes(), input.as_bytes()));
+    }
+    Ok(())
+}
+
+#[test]
+fn cow_borrowed_points_to_original_legacy() -> Result<(), Box<dyn std::error::Error>> {
+    let input = "Foo'Bar";
+    let result = legacy_package_separator(input);
+    if let Cow::Borrowed(s) = result {
+        assert!(std::ptr::eq(s.as_bytes(), input.as_bytes()));
+    }
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Comparison: Cow<str> equality with &str
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn cow_result_compares_equal_to_str() -> Result<(), Box<dyn std::error::Error>> {
+    let borrowed = normalize_package_separator("Foo::Bar");
+    let owned = normalize_package_separator("Foo'Bar");
+    assert_eq!(borrowed, "Foo::Bar");
+    assert_eq!(owned, "Foo::Bar");
+    assert_eq!(borrowed, owned);
+    Ok(())
+}
+
+#[test]
+fn cow_result_can_be_used_as_str_ref() -> Result<(), Box<dyn std::error::Error>> {
+    let result = normalize_package_separator("A'B");
+    let s: &str = &result;
+    assert_eq!(s, "A::B");
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variant pairs: vector content guarantees
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_always_has_at_least_one() -> Result<(), Box<dyn std::error::Error>> {
+    let test_cases = [("", ""), ("strict", "warnings"), ("A::B", "C::D"), ("A'B", "C'D")];
+    for (old, new) in &test_cases {
+        let pairs = module_variant_pairs(old, new);
+        assert!(!pairs.is_empty(), "variant_pairs({old:?}, {new:?}) returned empty vec");
+    }
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_never_more_than_two() -> Result<(), Box<dyn std::error::Error>> {
+    let test_cases =
+        [("", ""), ("strict", "warnings"), ("A::B", "C::D"), ("A'B", "C'D"), ("A'B::C", "D'E::F")];
+    for (old, new) in &test_cases {
+        let pairs = module_variant_pairs(old, new);
+        assert!(pairs.len() <= 2, "variant_pairs({old:?}, {new:?}) returned {} pairs", pairs.len());
+    }
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_first_element_is_always_canonical() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("X'Y'Z", "A'B'C");
+    assert!(!pairs[0].0.contains('\''), "first pair old contains quote");
+    assert!(!pairs[0].1.contains('\''), "first pair new contains quote");
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_second_element_is_always_legacy() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("X::Y::Z", "A::B::C");
+    if pairs.len() == 2 {
+        assert!(!pairs[1].0.contains("::"), "second pair old contains ::");
+        assert!(!pairs[1].1.contains("::"), "second pair new contains ::");
+    }
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Mixed legacy+canonical in single input
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_mixed_legacy_and_canonical() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("A'B::C'D"), "A::B::C::D");
+    Ok(())
+}
+
+#[test]
+fn legacy_mixed_canonical_and_legacy() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator("A::B'C::D"), "A'B'C'D");
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_mixed_input_normalizes() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("A'B::C", "X'Y::Z");
+    assert_eq!(pairs[0].0, "A::B::C");
+    assert_eq!(pairs[0].1, "X::Y::Z");
+    if pairs.len() == 2 {
+        assert_eq!(pairs[1].0, "A'B'C");
+        assert_eq!(pairs[1].1, "X'Y'Z");
+    }
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Single-segment (no separator) module names
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_common_pragmas() -> Result<(), Box<dyn std::error::Error>> {
+    for pragma in &["strict", "warnings", "utf8", "feature", "constant"] {
+        let result = normalize_package_separator(pragma);
+        assert_eq!(result.as_ref(), *pragma);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+    Ok(())
+}
+
+#[test]
+fn legacy_common_pragmas() -> Result<(), Box<dyn std::error::Error>> {
+    for pragma in &["strict", "warnings", "utf8", "feature", "constant"] {
+        let result = legacy_package_separator(pragma);
+        assert_eq!(result.as_ref(), *pragma);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Adjacent separators
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_adjacent_mixed_separators() -> Result<(), Box<dyn std::error::Error>> {
+    // 3 quotes become 3 × "::" = 6 colons, plus the existing "::" = 8 colons
+    // Actually: "'" → "::", then "::" stays, then "'" → "::"
+    // So "'::'" = "::" + "::" + "::" = "::::::"
+    assert_eq!(normalize_package_separator("'::'"), "::::::");
+    Ok(())
+}
+
+#[test]
+fn legacy_adjacent_colons_triple() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator(":::"), "':");
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Cow into_owned
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_into_owned_produces_string() -> Result<(), Box<dyn std::error::Error>> {
+    let owned: String = normalize_package_separator("A'B").into_owned();
+    assert_eq!(owned, "A::B");
+    Ok(())
+}
+
+#[test]
+fn legacy_into_owned_produces_string() -> Result<(), Box<dyn std::error::Error>> {
+    let owned: String = legacy_package_separator("A::B").into_owned();
+    assert_eq!(owned, "A'B");
+    Ok(())
+}
+
+#[test]
+fn normalize_borrowed_into_owned_clones() -> Result<(), Box<dyn std::error::Error>> {
+    let owned: String = normalize_package_separator("A::B").into_owned();
+    assert_eq!(owned, "A::B");
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variant pairs: old == new (identity rename)
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_identity_bare() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("strict", "strict");
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(pairs[0].0, pairs[0].1);
+    Ok(())
+}
+
+#[test]
+fn variant_pairs_identity_qualified() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("A::B::C", "A::B::C");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0].0, pairs[0].1);
+    assert_eq!(pairs[1].0, pairs[1].1);
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variant pairs: depth mismatch
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_different_depth() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("A::B", "X::Y::Z::W");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("A::B".to_string(), "X::Y::Z::W".to_string()));
+    assert_eq!(pairs[1], ("A'B".to_string(), "X'Y'Z'W".to_string()));
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Unicode: multi-byte characters near separators
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_cjk_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("模块'名称"), "模块::名称");
+    Ok(())
+}
+
+#[test]
+fn legacy_cjk_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(legacy_package_separator("模块::名称"), "模块'名称");
+    Ok(())
+}
+
+#[test]
+fn roundtrip_cjk_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    let input = "模块'名称'子包";
+    let canonical = normalize_package_separator(input);
+    let back = legacy_package_separator(&canonical);
+    assert_eq!(back, input);
+    Ok(())
+}
+
+#[test]
+fn normalize_emoji_module_name() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(normalize_package_separator("🦀'Module"), "🦀::Module");
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variant pairs with Unicode
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn variant_pairs_unicode() -> Result<(), Box<dyn std::error::Error>> {
+    let pairs = module_variant_pairs("Ünïcödë::Mödülé", "Néw::Nàmé");
+    assert_eq!(pairs.len(), 2);
+    assert_eq!(pairs[0], ("Ünïcödë::Mödülé".to_string(), "Néw::Nàmé".to_string()));
+    assert_eq!(pairs[1], ("Ünïcödë'Mödülé".to_string(), "Néw'Nàmé".to_string()));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds 47 new unit tests to `perl-module-name` comprehensive test file (99 total in file, 117 total in crate).

### Coverage areas added

- **Idempotency**: normalize/legacy transforms applied twice yield same result
- **Determinism**: variant pairs output is stable across calls
- **Real-world CPAN modules**: DBI, DBD::mysql, Test::More, LWP::UserAgent, DateTime::Format::Strptime
- **Boundary conditions**: very long module names (20 segments), separator-only strings
- **Asymmetric pairs**: qualified↔bare name combinations
- **Character preservation**: underscores, hyphens, digits survive transforms
- **Cow semantics**: lifetime guarantees, pointer identity, into_owned, equality
- **Vector guarantees**: variant pairs always returns 1–2 elements, canonical first, legacy second
- **Mixed separators**: inputs containing both `'` and `::`
- **Common pragmas**: bare single-segment names (strict, warnings, utf8, etc.)
- **Adjacent separators**: edge cases with consecutive/overlapping separators
- **Identity renames**: same name → same name (bare and qualified)
- **Depth mismatches**: different nesting levels between old and new names
- **Unicode**: CJK characters, emoji, accented characters, roundtrip with CJK

## Evidence

```
cargo test -p perl-module-name — 99 tests pass (comprehensive_unit_tests.rs), 117 total
cargo fmt --all — clean
```