### PR TITLE
Split document link extraction into perl-lsp-document-links microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-document-links"
+version = "0.10.0"
+dependencies = [
+ "perl-module-import",
+ "perl-module-path",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "perl-lsp-feature-contracts"
 version = "0.10.0"
 dependencies = [
@@ -1945,7 +1955,7 @@ name = "perl-lsp-navigation"
 version = "0.10.0"
 dependencies = [
  "lsp-types",
- "perl-module-import",
+ "perl-lsp-document-links",
  "perl-module-path",
  "perl-parser-core",
  "perl-position-tracking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/perl-lsp-feature-governance",
     "crates/perl-lsp-launcher",
     "crates/perl-lsp-navigation",
+    "crates/perl-lsp-document-links",
     "crates/perl-lsp-completion",
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
@@ -150,6 +151,7 @@ allow = [
 
     # Tier 4 — LSP providers
     "perl-lsp-navigation",
+    "perl-lsp-document-links",
     "perl-lsp-tooling",
     "perl-lsp-formatting-types",
     "perl-lsp-formatting",
@@ -255,6 +257,7 @@ perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
 perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.10.0" }
 perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }

--- a/crates/perl-lsp-document-links/Cargo.toml
+++ b/crates/perl-lsp-document-links/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "perl-lsp-document-links"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "LSP document link extraction for Perl use/require statements"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-document-links"
+keywords = ["perl", "lsp", "document-links", "navigation"]
+categories = ["development-tools", "text-editors"]
+
+[dependencies]
+perl-module-import = { workspace = true }
+perl-module-path = { workspace = true }
+serde_json = { workspace = true }
+url = "2.5.8"
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-document-links/README.md
+++ b/crates/perl-lsp-document-links/README.md
@@ -1,0 +1,7 @@
+# perl-lsp-document-links
+
+Focused SRP microcrate for extracting Perl `use`/`require` document links for LSP responses.
+
+## API
+
+- `compute_links(uri, text, roots)` - scans source text and returns deferred-resolve link payloads.

--- a/crates/perl-lsp-document-links/src/lib.rs
+++ b/crates/perl-lsp-document-links/src/lib.rs
@@ -1,7 +1,12 @@
 //! Document links provider for LSP protocol compatibility.
 //!
-//! This module provides document link detection for Perl source files,
+//! This crate provides document link detection for Perl source files,
 //! identifying `use`, `require` module statements, and file includes.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
 
 use perl_module_import::{ModuleImportKind, parse_module_import_head};
 use perl_module_path::module_name_to_path;
@@ -97,7 +102,7 @@ pub fn compute_links(uri: &str, text: &str, _roots: &[Url]) -> Vec<Value> {
     out
 }
 
-/// Create a document link with deferred target resolution
+/// Create a document link with deferred target resolution.
 ///
 /// Returns a link structure with a `data` field that will be used
 /// by `documentLink/resolve` to compute the actual target URI.

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.149"
 url = "2.5.8"
 perl-position-tracking = { workspace = true }
 perl-module-path = { workspace = true }
-perl-module-import = { workspace = true }
+perl-lsp-document-links = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-lsp-navigation/src/lib.rs
+++ b/crates/perl-lsp-navigation/src/lib.rs
@@ -27,18 +27,17 @@
 #![warn(clippy::all)]
 
 // Declare modules
-mod document_links;
 mod references;
 mod type_definition;
 mod type_hierarchy;
 mod workspace_symbols;
 
 // Re-export key types and functions
-pub use self::document_links::compute_links;
 pub use self::references::find_references_single_file;
 pub use self::type_definition::TypeDefinitionProvider;
 pub use self::type_hierarchy::{TypeHierarchyItem, TypeHierarchyProvider, TypeHierarchySymbolKind};
 pub use self::workspace_symbols::{WorkspaceSymbol, WorkspaceSymbolsProvider};
+pub use perl_lsp_document_links::compute_links;
 
 // Re-export Location type for convenience
 pub use lsp_types::Location;


### PR DESCRIPTION
### Motivation

- Isolate the single-responsibility concern of extracting `use`/`require` document links from broader navigation logic to improve modularity and make the code easier to reuse and maintain.
- Preserve the public API available to callers while decoupling implementation so navigation, module resolution, and document-link resolution can evolve independently.

### Description

- Carved out `compute_links` and its helpers/tests into a new SRP crate at `crates/perl-lsp-document-links/` with its own `Cargo.toml`, `README.md`, and `src/lib.rs` containing the previously inlined `document_links` implementation.
- Updated `crates/perl-lsp-navigation` to remove the local `document_links.rs` file, add a workspace dependency on `perl-lsp-document-links`, and re-export the function via `pub use perl_lsp_document_links::compute_links;` so callers continue to work unchanged.
- Wired the new crate into the workspace by adding it to the workspace `members`, the publish `allow` list, and `workspace.dependencies` in the root `Cargo.toml` so it builds and publishes with the workspace.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp-document-links` and all unit tests passed (`3 passed; 0 failed`).
- Ran `cargo test -p perl-lsp-navigation` (unit + comprehensive tests) and all tests passed (`75 passed; 0 failed`).
- Ran `cargo test -p perl-lsp --lib` and the library test-suite passed (`134 passed; 0 failed`).
- Ran `cargo clippy -p perl-lsp-document-links --all-targets -- -D warnings` and the crate passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b87b10883338ee9f0d54c0742c7)