### PR TITLE
Extract workspace skip-directory policy into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "perl-source-file",
  "perl-tdd-support",
  "perl-workspace-discovery",
+ "perl-workspace-ignore",
  "predicates",
  "pretty_assertions",
  "proptest",
@@ -2459,6 +2460,7 @@ name = "perl-workspace-discovery"
 version = "0.10.0"
 dependencies = [
  "perl-source-file",
+ "perl-workspace-ignore",
  "proptest",
  "tempfile",
  "walkdir",
@@ -2473,6 +2475,10 @@ dependencies = [
  "tempfile",
  "url",
 ]
+
+[[package]]
+name = "perl-workspace-ignore"
+version = "0.10.0"
 
 [[package]]
 name = "perl-workspace-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "crates/perl-text-line",
     "crates/perl-keywords",
     "crates/perl-source-file",
+    "crates/perl-workspace-ignore",
     "crates/perl-content-length-framing",
     "crates/perl-uri",
     "crates/perl-path-security",
@@ -199,6 +200,7 @@ allow = [
     "perl-module-resolution-uri",
     "perl-module-resolution",
     "perl-source-file",
+    "perl-workspace-ignore",
     "perl-workspace-discovery",
     "perl-diagnostics-codes",
 
@@ -251,6 +253,7 @@ perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", versi
 perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.10.0" }
 perl-keywords = { path = "crates/perl-keywords", version = "0.10.0" }
 perl-source-file = { path = "crates/perl-source-file", version = "0.10.0" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.10.0" }
 perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
 perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -48,6 +48,7 @@ perl-module-resolution = { workspace = true }
 perl-source-file = { workspace = true }
 perl-content-length-framing = { workspace = true }
 perl-workspace-discovery = { workspace = true }
+perl-workspace-ignore = { workspace = true }
 perl-keywords = { workspace = true }
 lsp-types = "0.97.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -21,6 +21,8 @@ use perl_parser::workspace_index::{DegradationReason, EarlyExitReason, ResourceK
 #[cfg(feature = "workspace")]
 use perl_source_file::{is_perl_source_path, is_perl_source_uri};
 #[cfg(feature = "workspace")]
+use perl_workspace_ignore::is_skipped_workspace_dir_name;
+#[cfg(feature = "workspace")]
 use std::io::Write;
 #[cfg(feature = "workspace")]
 use std::path::Path;
@@ -46,7 +48,7 @@ fn should_skip_dir(entry: &walkdir::DirEntry) -> bool {
         return false;
     }
     let name = entry.file_name().to_string_lossy();
-    matches!(name.as_ref(), ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
+    is_skipped_workspace_dir_name(name.as_ref())
 }
 
 #[cfg(feature = "workspace")]

--- a/crates/perl-workspace-discovery/Cargo.toml
+++ b/crates/perl-workspace-discovery/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-source-file = { workspace = true }
+perl-workspace-ignore = { workspace = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -8,7 +8,10 @@
 //! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`).
 
 use perl_source_file::is_perl_source_path;
-use std::path::{Component, Path, PathBuf};
+use perl_workspace_ignore::{
+    is_skipped_workspace_dir_name, path_contains_skipped_workspace_component,
+};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
 
@@ -87,7 +90,7 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
         }
 
         let relative_path = Path::new(entry);
-        if path_contains_skipped_component(relative_path) {
+        if path_contains_skipped_workspace_component(relative_path) {
             excluded_count += 1;
             continue;
         }
@@ -145,20 +148,7 @@ fn should_skip_dir(entry: &DirEntry) -> bool {
     }
 
     let name = entry.file_name().to_string_lossy();
-    matches!(name.as_ref(), ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-}
-
-fn path_contains_skipped_component(path: &Path) -> bool {
-    for component in path.components() {
-        if let Component::Normal(name) = component
-            && let Some(value) = name.to_str()
-            && matches!(value, ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-        {
-            return true;
-        }
-    }
-
-    false
+    is_skipped_workspace_dir_name(name.as_ref())
 }
 
 fn log_discovery(result: &DiscoveryResult) {
@@ -173,10 +163,8 @@ fn log_discovery(result: &DiscoveryResult) {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DiscoveryMethod, parse_git_ls_files_output, path_contains_skipped_component,
-        should_skip_dir, walk_discovery,
-    };
+    use super::{DiscoveryMethod, parse_git_ls_files_output, should_skip_dir, walk_discovery};
+    use perl_workspace_ignore::path_contains_skipped_workspace_component;
     use std::fs;
     use std::path::Path;
     use std::time::Instant;
@@ -207,9 +195,11 @@ mod tests {
 
     #[test]
     fn skipped_component_detection_is_consistent() {
-        assert!(path_contains_skipped_component(Path::new("/repo/node_modules/pkg.pm")));
-        assert!(path_contains_skipped_component(Path::new("/repo/target/build/generated.pm")));
-        assert!(!path_contains_skipped_component(Path::new("/repo/lib/My/Module.pm")));
+        assert!(path_contains_skipped_workspace_component(Path::new("/repo/node_modules/pkg.pm")));
+        assert!(path_contains_skipped_workspace_component(Path::new(
+            "/repo/target/build/generated.pm"
+        )));
+        assert!(!path_contains_skipped_workspace_component(Path::new("/repo/lib/My/Module.pm")));
     }
 
     #[test]
@@ -346,7 +336,7 @@ mod tests {
         assert_eq!(files[0], Path::new("/home/user/project/lib/Module.pm"));
     }
 
-    // --- Additional coverage: path_contains_skipped_component ---
+    // --- Additional coverage: path_contains_skipped_workspace_component ---
 
     #[test]
     fn skipped_component_detects_each_directory_individually() {
@@ -354,7 +344,7 @@ mod tests {
         for dir in skipped {
             let path_str = format!("lib/{dir}/nested.pm");
             assert!(
-                path_contains_skipped_component(Path::new(&path_str)),
+                path_contains_skipped_workspace_component(Path::new(&path_str)),
                 "expected {dir} to be skipped"
             );
         }
@@ -366,7 +356,7 @@ mod tests {
         for dir in safe {
             let path_str = format!("{dir}/Module.pm");
             assert!(
-                !path_contains_skipped_component(Path::new(&path_str)),
+                !path_contains_skipped_workspace_component(Path::new(&path_str)),
                 "expected {dir} to be allowed"
             );
         }
@@ -374,17 +364,19 @@ mod tests {
 
     #[test]
     fn skipped_component_empty_path_returns_false() {
-        assert!(!path_contains_skipped_component(Path::new("")));
+        assert!(!path_contains_skipped_workspace_component(Path::new("")));
     }
 
     #[test]
     fn skipped_component_single_filename_returns_false() {
-        assert!(!path_contains_skipped_component(Path::new("Module.pm")));
+        assert!(!path_contains_skipped_workspace_component(Path::new("Module.pm")));
     }
 
     #[test]
     fn skipped_component_deeply_nested() {
-        assert!(path_contains_skipped_component(Path::new("a/b/c/node_modules/d/e/f.pm")));
+        assert!(path_contains_skipped_workspace_component(Path::new(
+            "a/b/c/node_modules/d/e/f.pm"
+        )));
     }
 
     // --- Additional coverage: walk_discovery edge cases ---

--- a/crates/perl-workspace-ignore/Cargo.toml
+++ b/crates/perl-workspace-ignore/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-workspace-ignore"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-workspace-ignore"
+description = "Shared skip-directory policy for Perl workspace traversal"
+readme = "README.md"
+keywords = ["perl", "workspace", "discovery", "ignore", "lsp"]
+categories = ["development-tools", "filesystem"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-ignore/README.md
+++ b/crates/perl-workspace-ignore/README.md
@@ -1,0 +1,6 @@
+# perl-workspace-ignore
+
+Shared helpers for workspace traversal skip-directory policy.
+
+This crate centralizes the conventional non-source directory exclusions used
+across Perl workspace discovery and runtime operations.

--- a/crates/perl-workspace-ignore/src/lib.rs
+++ b/crates/perl-workspace-ignore/src/lib.rs
@@ -1,0 +1,66 @@
+//! Shared workspace skip-directory policy.
+//!
+//! Centralizes conventional non-source directories excluded from workspace
+//! traversal and discovery.
+
+use std::path::{Component, Path};
+
+/// Conventional directory names that should be skipped during workspace
+/// traversal.
+pub const SKIPPED_WORKSPACE_DIRS: [&str; 6] =
+    [".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+
+/// Returns `true` if `name` is a conventional skip directory.
+#[must_use]
+pub fn is_skipped_workspace_dir_name(name: &str) -> bool {
+    SKIPPED_WORKSPACE_DIRS.iter().any(|candidate| candidate == &name)
+}
+
+/// Returns `true` if `path` contains any conventional skip directory
+/// component.
+#[must_use]
+pub fn path_contains_skipped_workspace_component(path: &Path) -> bool {
+    path.components().any(|component| {
+        if let Component::Normal(name) = component
+            && let Some(value) = name.to_str()
+        {
+            return is_skipped_workspace_dir_name(value);
+        }
+
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SKIPPED_WORKSPACE_DIRS, is_skipped_workspace_dir_name,
+        path_contains_skipped_workspace_component,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn exposes_expected_skip_dirs() {
+        assert_eq!(
+            SKIPPED_WORKSPACE_DIRS,
+            [".git", ".hg", ".svn", "target", "node_modules", ".cache"]
+        );
+    }
+
+    #[test]
+    fn matches_skip_names_exactly() {
+        for name in SKIPPED_WORKSPACE_DIRS {
+            assert!(is_skipped_workspace_dir_name(name));
+        }
+        assert!(!is_skipped_workspace_dir_name("src"));
+        assert!(!is_skipped_workspace_dir_name("Target"));
+    }
+
+    #[test]
+    fn detects_skip_components_in_paths() {
+        assert!(path_contains_skipped_workspace_component(Path::new("a/.git/config")));
+        assert!(path_contains_skipped_workspace_component(Path::new("a/node_modules/pkg.pm")));
+        assert!(path_contains_skipped_workspace_component(Path::new("target/debug/build")));
+        assert!(!path_contains_skipped_workspace_component(Path::new("lib/My/Module.pm")));
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce duplicated skip-directory logic by extracting the workspace traversal ignore policy into a single SRP microcrate so discovery and runtime logic stay consistent.
- Make the canonical list of non-source directories reusable across crates and easier to maintain and test.

### Description

- Add a new microcrate `perl-workspace-ignore` that exposes `SKIPPED_WORKSPACE_DIRS`, `is_skipped_workspace_dir_name`, and `path_contains_skipped_workspace_component` to centralize skip-policy logic.
- Replace ad-hoc skip checks in `crates/perl-workspace-discovery` with calls to `perl_workspace_ignore::{is_skipped_workspace_dir_name, path_contains_skipped_workspace_component}` and remove the duplicated implementations.
- Wire `perl-workspace-ignore` into `crates/perl-lsp` (runtime helpers) and the root workspace `Cargo.toml` (members, workspace dependencies, and publish allowlist) so both discovery and runtime share the same policy.
- Update unit tests to use the new helpers and run `cargo fmt` to keep formatting consistent.

### Testing

- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test -p perl-workspace-ignore` and all unit tests passed.
- Ran `cargo test -p perl-workspace-discovery` and the test suite passed (all tests green).
- Ran `cargo check -p perl-lsp` to verify integration and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b87b10883338ee9f0d54c0742c7)