### PR TITLE
Extract panic-free LSP URI parsing into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,6 +1753,7 @@ dependencies = [
  "perl-lsp-semantic-tokens",
  "perl-lsp-tooling",
  "perl-lsp-transport",
+ "perl-lsp-uri",
  "perl-module-path",
  "perl-module-reference",
  "perl-module-rename",
@@ -2035,6 +2036,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-uri"
+version = "0.10.0"
+dependencies = [
+ "lsp-types",
+]
+
+[[package]]
 name = "perl-module-boundary"
 version = "0.10.0"
 dependencies = [
@@ -2254,6 +2262,7 @@ name = "perl-position-tracking"
 version = "0.10.0"
 dependencies = [
  "lsp-types",
+ "perl-lsp-uri",
  "perl-tdd-support",
  "ropey",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
     "crates/perl-lsp-limits",
+    "crates/perl-lsp-uri",
     "crates/perl-lsp-feature-policy",
     "crates/perl-diagnostics-codes",
     "crates/perl-position-tracking",
@@ -185,6 +186,7 @@ allow = [
     "perl-lsp-feature-governance",
     "perl-lsp-launcher",
     "perl-lsp-limits",
+    "perl-lsp-uri",
     "perl-lsp-protocol",
     "perl-lsp-transport",
 
@@ -255,6 +257,7 @@ perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
 perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
 perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.10.0" }
 perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }

--- a/crates/perl-lsp-uri/Cargo.toml
+++ b/crates/perl-lsp-uri/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "perl-lsp-uri"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Panic-free LSP Uri parsing with stable fallback behavior"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-uri"
+readme = "README.md"
+keywords = ["perl", "lsp", "uri", "language-server", "jsonrpc"]
+categories = ["development-tools", "text-editors"]
+include = [
+  "src/**",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE*"
+]
+
+[lib]
+name = "perl_lsp_uri"
+path = "src/lib.rs"
+
+[dependencies]
+lsp-types = "0.97.0"
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-uri/README.md
+++ b/crates/perl-lsp-uri/README.md
@@ -1,0 +1,10 @@
+# perl-lsp-uri
+
+Small SRP utility crate for panic-free `lsp_types::Uri` parsing.
+
+## What it provides
+
+- `parse_uri`: parse a string into `lsp_types::Uri` and fall back to a valid sentinel URI.
+- `fallback_uri`: produce the stable fallback URI used by the parser.
+
+This crate is intended for internal workspace use by LSP/DAP-facing crates that need robust URI parsing without panics.

--- a/crates/perl-lsp-uri/src/lib.rs
+++ b/crates/perl-lsp-uri/src/lib.rs
@@ -1,0 +1,57 @@
+//! Panic-free `lsp_types::Uri` parsing helpers.
+
+use lsp_types::Uri;
+
+/// Build a fallback URI for parse failures.
+///
+/// This function intentionally guarantees returning a valid URI without panicking,
+/// even if parser behavior changes in upstream dependencies.
+pub fn fallback_uri() -> Uri {
+    for candidate in ["file:///unknown", "file:///", "about:blank", "urn:perl-lsp:unknown"] {
+        if let Ok(uri) = candidate.parse::<Uri>() {
+            return uri;
+        }
+    }
+
+    let mut suffix = 0usize;
+    loop {
+        let candidate = format!("http://localhost/{suffix}");
+        if let Ok(uri) = candidate.parse::<Uri>() {
+            return uri;
+        }
+        suffix = suffix.saturating_add(1);
+    }
+}
+
+/// Parse a URI string into an `lsp_types::Uri`.
+///
+/// Returns [`fallback_uri`] when parsing fails.
+pub fn parse_uri(input: &str) -> Uri {
+    match input.parse::<Uri>() {
+        Ok(uri) => uri,
+        Err(_) => fallback_uri(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fallback_uri, parse_uri};
+
+    #[test]
+    fn parse_uri_returns_parsed_value_when_valid() {
+        let uri = parse_uri("file:///tmp/test.pl");
+        assert_eq!(uri.as_str(), "file:///tmp/test.pl");
+    }
+
+    #[test]
+    fn parse_uri_returns_fallback_when_invalid() {
+        let parsed = parse_uri("not a uri");
+        assert_eq!(parsed.as_str(), fallback_uri().as_str());
+    }
+
+    #[test]
+    fn fallback_uri_is_valid_and_stable() {
+        let uri = fallback_uri();
+        assert_eq!(uri.as_str(), "file:///unknown");
+    }
+}

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -31,6 +31,7 @@ perl-lsp-limits = { workspace = true }
 perl-lsp-feature-governance = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-lsp-protocol = { workspace = true }
+perl-lsp-uri = { workspace = true }
 perl-lsp-transport = { workspace = true }
 perl-lsp-code-actions = { workspace = true }
 perl-lsp-completion = { workspace = true }

--- a/crates/perl-lsp/src/util/uri.rs
+++ b/crates/perl-lsp/src/util/uri.rs
@@ -1,30 +1,3 @@
 //! URI utilities for LSP
 
-use lsp_types::Uri;
-
-fn fallback_uri() -> Uri {
-    for candidate in ["file:///unknown", "file:///", "about:blank", "urn:perl-lsp:unknown"] {
-        if let Ok(uri) = candidate.parse::<Uri>() {
-            return uri;
-        }
-    }
-
-    // Last-resort fallback that avoids panicking if URI parser behavior changes unexpectedly.
-    let mut suffix = 0usize;
-    loop {
-        let candidate = format!("http://localhost/{suffix}");
-        if let Ok(uri) = candidate.parse::<Uri>() {
-            return uri;
-        }
-        suffix = suffix.saturating_add(1);
-    }
-}
-
-/// Helper function to parse a URI string into an lsp_types::Uri.
-/// Falls back to a valid URI if parsing fails.
-pub fn parse_uri(s: &str) -> Uri {
-    match s.parse::<Uri>() {
-        Ok(uri) => uri,
-        Err(_) => fallback_uri(),
-    }
-}
+pub use perl_lsp_uri::parse_uri;

--- a/crates/perl-position-tracking/Cargo.toml
+++ b/crates/perl-position-tracking/Cargo.toml
@@ -26,10 +26,14 @@ serde = { version = "1.0.228", features = ["derive"] }
 
 [features]
 default = []
-lsp-compat = ["lsp-types"]
+lsp-compat = ["lsp-types", "dep:perl-lsp-uri"]
 
 [dependencies.lsp-types]
 version = "0.97.0"
+optional = true
+
+[dependencies.perl-lsp-uri]
+workspace = true
 optional = true
 
 [dev-dependencies]

--- a/crates/perl-position-tracking/src/wire.rs
+++ b/crates/perl-position-tracking/src/wire.rs
@@ -78,31 +78,9 @@ impl From<lsp_types::Range> for WireRange {
     }
 }
 #[cfg(feature = "lsp-compat")]
-fn fallback_lsp_uri() -> lsp_types::Uri {
-    for candidate in ["file:///unknown", "file:///", "about:blank", "urn:perl-lsp:unknown"] {
-        if let Ok(uri) = candidate.parse::<lsp_types::Uri>() {
-            return uri;
-        }
-    }
-
-    // Last-resort fallback that avoids panicking if URI parser behavior changes unexpectedly.
-    let mut suffix = 0usize;
-    loop {
-        let candidate = format!("http://localhost/{suffix}");
-        if let Ok(uri) = candidate.parse::<lsp_types::Uri>() {
-            return uri;
-        }
-        suffix = suffix.saturating_add(1);
-    }
-}
-
-#[cfg(feature = "lsp-compat")]
 impl From<WireLocation> for lsp_types::Location {
     fn from(l: WireLocation) -> Self {
-        let uri = match l.uri.parse::<lsp_types::Uri>() {
-            Ok(u) => u,
-            Err(_) => fallback_lsp_uri(),
-        };
+        let uri = perl_lsp_uri::parse_uri(&l.uri);
         Self { uri, range: l.range.into() }
     }
 }


### PR DESCRIPTION
### Motivation

- Remove duplicated panic-free `lsp_types::Uri` parsing and fallback logic scattered across LSP-facing crates. 
- Provide a single, well-scoped SRP microcrate that guarantees stable fallback behavior for URI parsing used by LSP/DAP layers. 
- Reduce responsibilities in `perl-lsp` and `perl-position-tracking` and centralize URI behavior for consistency.

### Description

- Added a new microcrate `crates/perl-lsp-uri` that exposes `parse_uri` and `fallback_uri` with unit tests and a small, explicit API.
- Replaced the inline URI parsing implementation in `crates/perl-lsp/src/util/uri.rs` with a re-export: `pub use perl_lsp_uri::parse_uri;`.
- Updated `crates/perl-position-tracking` to depend on `perl-lsp-uri` (added optional dependency and feature wiring) and removed the duplicated fallback implementation, replacing uses with `perl_lsp_uri::parse_uri`.
- Wired the new crate into the workspace: added it to `Cargo.toml` members, the publish allowlist, and workspace dependency table, and updated crate-level `Cargo.toml` entries where needed.

### Testing

- Ran formatting: `cargo fmt --all`, which completed successfully.
- Unit tests for the new crate: `cargo test -p perl-lsp-uri`, all tests passed (3/3).
- Ran `cargo test -p perl-position-tracking --features lsp-compat` (including `wire_location_new`); tests passed (all targeted tests succeeded).
- Verified top-level build/integration sanity with `cargo check -p perl-lsp`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b873b448333837ed319aa2bcff4)