### PR TITLE
refactor: split shared SLO latency math into perl-slo-metrics microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-slo-metrics"
+version = "0.10.0"
+
+[[package]]
 name = "perl-source-file"
 version = "0.10.0"
 
@@ -2498,6 +2502,7 @@ name = "perl-workspace-index-slo"
 version = "0.10.0"
 dependencies = [
  "parking_lot",
+ "perl-slo-metrics",
  "proptest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/perl-semantic-analyzer",
     "crates/perl-workspace-index",
     "crates/perl-workspace-index-slo",
+    "crates/perl-slo-metrics",
     "crates/perl-refactoring",
     "crates/perl-incremental-parsing",
     "crates/perl-tdd-support",
@@ -129,6 +130,7 @@ allow = [
 "perl-symbol-cursor",
 "perl-symbol-table",
     "perl-uri",
+    "perl-slo-metrics",
     "perl-workspace-index-slo",
 
     # Tier 3 — Analysis and indexing
@@ -231,6 +233,7 @@ perl-heredoc = { path = "crates/perl-heredoc", version = "0.10.0" }
 perl-error = { path = "crates/perl-error", version = "0.10.0" }
 perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.10.0" }
 perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.10.0" }
+perl-slo-metrics = { path = "crates/perl-slo-metrics", version = "0.10.0" }
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
 perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }

--- a/crates/perl-slo-metrics/Cargo.toml
+++ b/crates/perl-slo-metrics/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-slo-metrics"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Shared latency percentile and summary metrics primitives"
+readme = "README.md"
+documentation = "https://docs.rs/perl-slo-metrics"
+keywords = ["perl", "slo", "metrics", "latency", "percentile"]
+categories = ["algorithms", "development-tools"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/perl-slo-metrics/README.md
+++ b/crates/perl-slo-metrics/README.md
@@ -1,0 +1,9 @@
+# perl-slo-metrics
+
+Shared latency metric helpers for SLO-style tracking.
+
+Provides:
+
+- nearest-rank percentile calculation
+- aggregate latency summary from millisecond samples
+

--- a/crates/perl-slo-metrics/src/lib.rs
+++ b/crates/perl-slo-metrics/src/lib.rs
@@ -1,0 +1,75 @@
+//! Shared latency metric helpers for SLO-oriented crates.
+
+/// Aggregated latency metrics derived from a sample set in milliseconds.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LatencySummary {
+    /// P50 latency (median).
+    pub p50_ms: u64,
+    /// P95 latency.
+    pub p95_ms: u64,
+    /// P99 latency.
+    pub p99_ms: u64,
+    /// Average latency.
+    pub avg_ms: f64,
+}
+
+impl LatencySummary {
+    /// Build a latency summary from sorted millisecond values.
+    pub fn from_sorted_ms(sorted_values: &[u64]) -> Self {
+        if sorted_values.is_empty() {
+            return Self::default();
+        }
+
+        let p50_ms = percentile_nearest_rank(sorted_values, 50);
+        let p95_ms = percentile_nearest_rank(sorted_values, 95);
+        let p99_ms = percentile_nearest_rank(sorted_values, 99);
+        let avg_ms = sorted_values.iter().map(|&duration| duration as f64).sum::<f64>()
+            / sorted_values.len() as f64;
+
+        Self { p50_ms, p95_ms, p99_ms, avg_ms }
+    }
+}
+
+impl Default for LatencySummary {
+    fn default() -> Self {
+        Self { p50_ms: 0, p95_ms: 0, p99_ms: 0, avg_ms: 0.0 }
+    }
+}
+
+/// Calculate a percentile from sorted values using the nearest-rank method.
+#[must_use]
+pub fn percentile_nearest_rank(sorted_values: &[u64], percentile: u64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+
+    let rank = ((percentile as f64 / 100.0) * sorted_values.len() as f64).ceil() as usize;
+    sorted_values[rank.min(sorted_values.len()).saturating_sub(1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_returns_zero_for_empty_input() {
+        assert_eq!(percentile_nearest_rank(&[], 95), 0);
+    }
+
+    #[test]
+    fn percentile_calculates_nearest_rank() {
+        let sorted_values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        assert_eq!(percentile_nearest_rank(&sorted_values, 50), 5);
+        assert_eq!(percentile_nearest_rank(&sorted_values, 95), 10);
+    }
+
+    #[test]
+    fn summary_calculates_expected_percentiles_and_average() {
+        let sorted_values = [1, 2, 3, 4, 5];
+        let summary = LatencySummary::from_sorted_ms(&sorted_values);
+        assert_eq!(summary.p50_ms, 3);
+        assert_eq!(summary.p95_ms, 5);
+        assert_eq!(summary.p99_ms, 5);
+        assert_eq!(summary.avg_ms, 3.0);
+    }
+}

--- a/crates/perl-workspace-index-slo/Cargo.toml
+++ b/crates/perl-workspace-index-slo/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 parking_lot = "0.12.5"
+perl-slo-metrics.workspace = true
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/crates/perl-workspace-index-slo/src/lib.rs
+++ b/crates/perl-workspace-index-slo/src/lib.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use parking_lot::Mutex;
+use perl_slo_metrics::LatencySummary;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -258,39 +259,23 @@ impl OperationSloTracker {
             self.samples.iter().map(|s| s.duration.as_millis() as u64).collect();
         durations_ms.sort_unstable();
 
-        let p50_ms = percentile(&durations_ms, 50);
-        let p95_ms = percentile(&durations_ms, 95);
-        let p99_ms = percentile(&durations_ms, 99);
-
-        let avg_ms =
-            durations_ms.iter().map(|&d| d as f64).sum::<f64>() / durations_ms.len() as f64;
+        let summary = LatencySummary::from_sorted_ms(&durations_ms);
 
         // Check if SLO is met
-        let slo_met = p95_ms <= self.slo_target_ms && error_rate <= self.max_error_rate;
+        let slo_met = summary.p95_ms <= self.slo_target_ms && error_rate <= self.max_error_rate;
 
         SloStatistics {
             total_count,
             success_count,
             failure_count,
             error_rate,
-            p50_ms,
-            p95_ms,
-            p99_ms,
-            avg_ms,
+            p50_ms: summary.p50_ms,
+            p95_ms: summary.p95_ms,
+            p99_ms: summary.p99_ms,
+            avg_ms: summary.avg_ms,
             slo_met,
         }
     }
-}
-
-/// Calculate a percentile from a sorted slice of values.
-fn percentile(sorted_values: &[u64], pct: u64) -> u64 {
-    if sorted_values.is_empty() {
-        return 0;
-    }
-
-    // Nearest-rank method: ceil(pct/100 * n) gives 1-based rank
-    let rank = ((pct as f64 / 100.0) * sorted_values.len() as f64).ceil() as usize;
-    sorted_values[rank.min(sorted_values.len()).saturating_sub(1)]
 }
 
 /// SLO tracker for workspace index operations.
@@ -600,9 +585,10 @@ mod tests {
     }
 
     #[test]
-    fn test_percentile() {
+    fn test_latency_summary() {
         let values = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        assert_eq!(percentile(&values, 50), 5); // Median
-        assert_eq!(percentile(&values, 95), 10); // P95
+        let summary = LatencySummary::from_sorted_ms(&values);
+        assert_eq!(summary.p50_ms, 5);
+        assert_eq!(summary.p95_ms, 10);
     }
 }


### PR DESCRIPTION
### Motivation
- Isolate nearest-rank percentile and latency aggregation logic from the workspace SLO tracker so the metric math is single-responsibility and reusable across crates.
- Reduce cognitive coupling in `perl-workspace-index-slo` by moving pure metric computations into a focused microcrate.

### Description
- Added a new crate `crates/perl-slo-metrics` that provides `LatencySummary` and `percentile_nearest_rank` for producing P50/P95/P99 and average summaries from sorted millisecond samples.
- Removed percentile/summary math from `crates/perl-workspace-index-slo/src/lib.rs` and replaced it with `use perl_slo_metrics::LatencySummary;` and usage of `LatencySummary::from_sorted_ms(...)` to populate `SloStatistics`.
- Wired the workspace: added `crates/perl-slo-metrics` to the workspace members and `[workspace.dependencies]`, and added a workspace dependency entry in `crates/perl-workspace-index-slo/Cargo.toml`.
- Updated and adjusted unit/integration tests to validate the extracted behavior in `perl-slo-metrics` and the integration in `perl-workspace-index-slo`.

### Testing
- Ran formatting: `cargo fmt --all` (succeeded).
- Ran tests for the affected crates: `cargo test -p perl-slo-metrics -p perl-workspace-index-slo` and all tests passed for both crates (unit, bdd, fuzz, and property tests).
- Ran lints: `cargo clippy -p perl-slo-metrics -p perl-workspace-index-slo --all-targets -- -D warnings` and the clippy pass completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b873b448333837ed319aa2bcff4)