### PR TITLE
test(lsp-ast-utils): add comprehensive unit tests

### DIFF
--- a/crates/perl-lsp-ast-utils/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-ast-utils/tests/comprehensive_unit_tests.rs
@@ -420,11 +420,7 @@ fn find_node_at_range_binary_expression() {
     let right = create_test_node(NodeKind::Number { value: "2".to_string() }, 3, 4);
 
     let binary = create_test_node(
-        NodeKind::Binary {
-            op: "+".to_string(),
-            left: Box::new(left),
-            right: Box::new(right),
-        },
+        NodeKind::Binary { op: "+".to_string(), left: Box::new(left), right: Box::new(right) },
         0,
         4,
     );
@@ -439,11 +435,7 @@ fn find_node_at_range_binary_left_child() {
     let right = create_test_node(NodeKind::Number { value: "2".to_string() }, 3, 4);
 
     let binary = create_test_node(
-        NodeKind::Binary {
-            op: "+".to_string(),
-            left: Box::new(left),
-            right: Box::new(right),
-        },
+        NodeKind::Binary { op: "+".to_string(), left: Box::new(left), right: Box::new(right) },
         0,
         4,
     );
@@ -535,22 +527,14 @@ fn find_node_at_range_deeply_nested() {
         NodeKind::Binary {
             op: "+".to_string(),
             left: Box::new(num),
-            right: Box::new(create_test_node(
-                NodeKind::Number { value: "2".to_string() },
-                12,
-                13,
-            )),
+            right: Box::new(create_test_node(NodeKind::Number { value: "2".to_string() }, 12, 13)),
         },
         10,
         13,
     );
     let right = create_test_node(NodeKind::Number { value: "3".to_string() }, 14, 15);
     let top_binary = create_test_node(
-        NodeKind::Binary {
-            op: "*".to_string(),
-            left: Box::new(left),
-            right: Box::new(right),
-        },
+        NodeKind::Binary { op: "*".to_string(), left: Box::new(left), right: Box::new(right) },
         10,
         15,
     );


### PR DESCRIPTION
## Summary
Add 63 comprehensive unit tests for perl-lsp-ast-utils covering all public API functions.

## What changed
- New test file: `crates/perl-lsp-ast-utils/tests/comprehensive_unit_tests.rs`
- 63 tests covering: find_declaration_position, find_statement_start, find_function_insert_position, find_node_at_range, get_indent_at

## Evidence
- `cargo test -p perl-lsp-ast-utils` — 63 passed
- `cargo fmt --all` — clean

## Interface & compatibility
- No code changes, test-only PR
