### PR TITLE
test(lsp-rename): add extended unit tests

### DIFF
--- a/crates/perl-lsp-rename/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-rename/tests/extended_unit_tests.rs
@@ -1,0 +1,879 @@
+//! Extended unit tests for perl-lsp-rename crate.
+//!
+//! This file contains 50+ comprehensive tests covering:
+//! - Complex rename scenarios (nested scopes, shadowing)
+//! - Edge cases (unicode, escape sequences, complex patterns)
+//! - Error handling and validation
+//! - Integration scenarios
+//! - Performance considerations
+//! - Comment/string handling
+//!
+//! All tests follow the Result-based error handling pattern and avoid
+//! unwrap()/expect() calls.
+
+use perl_lsp_rename::{RenameOptions, RenameProvider, RenameResult, TextEdit};
+use perl_parser_core::{Parser, SourceLocation};
+use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
+
+// ─── Test Utilities (Result-based) ──────────────────────────────────────
+
+fn parse_and_provider(code: &str) -> Result<RenameProvider, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    Ok(RenameProvider::new(&ast, code.to_string()))
+}
+
+fn find_position(code: &str, needle: &str) -> Result<usize, Box<dyn std::error::Error>> {
+    code.find(needle).ok_or("Position not found".into())
+}
+
+fn parse_symbol_table(code: &str) -> Result<SymbolTable, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    Ok(SymbolExtractor::new_with_source(code).extract(&ast))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+
+// ─── Test Group: Rename with nested scopes ──────────────────────────────
+
+#[test]
+fn test_rename_scalar_in_nested_block() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $outer = 1;
+{
+    my $outer = 2;
+    print $outer;
+}
+print $outer;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$outer")?;
+    let result = provider.rename(pos, "modified", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    assert!(!result.edits.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_rename_variable_in_for_loop() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+for my $i (1..10) {
+    print $i;
+    my $i = 999;
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$i")?;
+    let result = provider.rename(pos, "index", &RenameOptions::default());
+
+    // Should successfully handle loop variable
+    assert!(result.is_valid || result.error.is_some());
+    Ok(())
+}
+
+#[test]
+fn test_rename_variable_in_foreach_loop() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+foreach my $item (@list) {
+    print $item;
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "item")?;
+    let result = provider.rename(pos, "element", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Rename with shadowing ─────────────────────────────────
+
+#[test]
+fn test_rename_shadows_parent_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $name = "outer";
+{
+    my $name = "inner";
+    $name = "modified";
+}
+print $name;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "inner")?;
+    let result = provider.rename(pos, "changed", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_without_shadowing_parent() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $outer = 1;
+{
+    my $inner = 2;
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "inner")?;
+    let result = provider.rename(pos, "nested", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Complex symbol patterns ───────────────────────────────
+
+#[test]
+fn test_rename_underscore_prefixed_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $_private = 42;
+print $_private;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "_private")?;
+    let result = provider.rename(pos, "_secret", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_multiple_underscores() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $__internal__ = 1;
+print $__internal__;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "__internal__")?;
+    let result = provider.rename(pos, "__external__", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_numeric_suffix_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $var1 = 1;
+my $var2 = 2;
+print $var1;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "var1")?;
+    let result = provider.rename(pos, "variable1", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_camelcase_to_snake_case() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $myVariable = 1;
+print $myVariable;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "myVariable")?;
+    let result = provider.rename(pos, "my_variable", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Array and Hash renaming ───────────────────────────────
+
+#[test]
+fn test_rename_array_multiple_occurrences() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my @data = (1, 2, 3);
+push @data, 4;
+foreach my $x (@data) {
+    print $x;
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "data")?;
+    let result = provider.rename(pos, "values", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_hash_multiple_accesses() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my %config = (key => 'value');
+$config{key} = 'new';
+print $config{key};
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "config")?;
+    let result = provider.rename(pos, "settings", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_array_element_syntax() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my @list = (1, 2, 3);
+my $elem = $list[0];
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "list")?;
+    let result = provider.rename(pos, "items", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Function/Subroutine renaming ──────────────────────────
+
+#[test]
+fn test_rename_subroutine_with_no_calls() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+sub unused_func {
+    return 42;
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "unused_func")?;
+    let result = provider.rename(pos, "used_func", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_subroutine_multiple_calls() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+sub process {
+    return 1;
+}
+
+my $a = process();
+my $b = process();
+process();
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "process")?;
+    let result = provider.rename(pos, "execute", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    // Should have at least definition + calls
+    assert!(!result.edits.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_rename_recursive_subroutine() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+sub fibonacci {
+    my $n = shift;
+    return $n if $n < 2;
+    return fibonacci($n - 1) + fibonacci($n - 2);
+}
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "fibonacci")?;
+    let result = provider.rename(pos, "fib", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_subroutine_with_ampersand_call() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+sub my_func {
+    return 1;
+}
+
+&my_func();
+my_func();
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "my_func")?;
+    let result = provider.rename(pos, "other_func", &RenameOptions::default());
+
+    // Should handle both call styles
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Validation edge cases ──────────────────────────────────
+
+#[test]
+fn test_validate_single_underscore_only() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+    // Single underscore is actually allowed as a valid name (it's a throwaway variable in Perl)
+    // but it's blocked by can_rename_symbol
+    let result = perl_lsp_rename::rename::validate_name("_", SymbolKind::scalar(), &table);
+    // The implementation allows "_" as a valid name per validate_name
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_validate_consecutive_underscores() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+    let result = perl_lsp_rename::rename::validate_name("__var", SymbolKind::scalar(), &table);
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_validate_all_numeric_suffix() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+    let result = perl_lsp_rename::rename::validate_name("x999", SymbolKind::scalar(), &table);
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[test]
+fn test_validate_mixed_case_long_name() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+    let result = perl_lsp_rename::rename::validate_name(
+        "MyVeryLongVariableNameWithMixedCase",
+        SymbolKind::scalar(),
+        &table,
+    );
+    assert!(result.is_ok());
+    Ok(())
+}
+
+// ─── Test Group: Comment and string handling ────────────────────────────
+
+#[test]
+fn test_rename_with_inline_comment_no_rename() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $var = 1; # this is $var
+print $var;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "var")?;
+    let opts = RenameOptions {
+        rename_in_comments: false,
+        rename_in_strings: false,
+        validate_new_name: true,
+    };
+    let result = provider.rename(pos, "value", &opts);
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_with_inline_comment_rename() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $var = 1; # this is $var
+print $var;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "var")?;
+    let opts = RenameOptions {
+        rename_in_comments: true,
+        rename_in_strings: false,
+        validate_new_name: true,
+    };
+    let result = provider.rename(pos, "value", &opts);
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_in_string_double_quotes() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $x = 1; my $s = "value of $x"; print $x;"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "x")?;
+    let opts = RenameOptions {
+        rename_in_comments: false,
+        rename_in_strings: true,
+        validate_new_name: true,
+    };
+    let result = provider.rename(pos, "y", &opts);
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_multiline_comment() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $item = 1;
+# $item is used
+# in this context
+print $item;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "item")?;
+    let opts = RenameOptions {
+        rename_in_comments: true,
+        rename_in_strings: false,
+        validate_new_name: true,
+    };
+    let result = provider.rename(pos, "thing", &opts);
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Text edit operations ───────────────────────────────────
+
+#[test]
+fn test_apply_edits_at_boundaries() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "start middle end";
+    let edits = vec![
+        TextEdit { location: SourceLocation::new(0, 5), new_text: "BEGIN".to_string() },
+        TextEdit { location: SourceLocation::new(11, 14), new_text: "FINISH".to_string() },
+    ];
+
+    let result = perl_lsp_rename::rename::apply_rename_edits(code, &edits);
+    assert!(result.contains("BEGIN"));
+    assert!(result.contains("FINISH"));
+    Ok(())
+}
+
+#[test]
+fn test_apply_overlapping_edits_reversed() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "abcdef";
+    // Edits applied in reverse order should avoid boundary issues
+    let edits = vec![
+        TextEdit { location: SourceLocation::new(0, 2), new_text: "XX".to_string() },
+        TextEdit { location: SourceLocation::new(3, 5), new_text: "YY".to_string() },
+    ];
+
+    let result = perl_lsp_rename::rename::apply_rename_edits(code, &edits);
+    assert_eq!(result.len(), 6); // "XXcYYf"
+    Ok(())
+}
+
+#[test]
+fn test_apply_zero_length_insertion() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "test";
+    let edits =
+        vec![TextEdit { location: SourceLocation::new(0, 0), new_text: "prefix_".to_string() }];
+
+    let result = perl_lsp_rename::rename::apply_rename_edits(code, &edits);
+    assert!(result.contains("prefix_"));
+    Ok(())
+}
+
+#[test]
+fn test_apply_full_replacement() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "old_code";
+    let edits =
+        vec![TextEdit { location: SourceLocation::new(0, 8), new_text: "new_code".to_string() }];
+
+    let result = perl_lsp_rename::rename::apply_rename_edits(code, &edits);
+    assert_eq!(result, "new_code");
+    Ok(())
+}
+
+// ─── Test Group: String detection edge cases ────────────────────────────
+
+#[test]
+fn test_is_in_string_escaped_quote() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $s = "text with quote";"#;
+    // Position inside quoted string
+    let pos = find_position(code, "quote")?;
+    let result = perl_lsp_rename::rename::is_in_string(pos, code);
+    // Simple heuristic counts quotes; should detect it's in a string
+    assert!(result);
+    Ok(())
+}
+
+#[test]
+fn test_is_in_string_alternating_quotes() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $s = "a" . 'b' . "c";"#;
+    let pos = find_position(code, "'b'")?;
+    let result = perl_lsp_rename::rename::is_in_string(pos + 1, code);
+    assert!(result);
+    Ok(())
+}
+
+#[test]
+fn test_is_not_in_string_after_closing() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $s = "string"; $var = 5;"#;
+    let pos = find_position(code, "$var")?;
+    let result = perl_lsp_rename::rename::is_in_string(pos, code);
+    assert!(!result);
+    Ok(())
+}
+
+// ─── Test Group: Comment detection edge cases ──────────────────────────
+
+#[test]
+fn test_is_in_comment_hash_in_string() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $s = "normal"; print $s;"#;
+    // Position outside any comments/strings
+    let print_pos = find_position(code, "print")?;
+    let result = perl_lsp_rename::rename::is_in_comment(print_pos, code);
+    assert!(!result);
+    Ok(())
+}
+
+#[test]
+fn test_is_in_comment_multiple_hashes() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $x = 1; # comment # with # hashes";
+    let first_hash = find_position(code, "#")?;
+    let result = perl_lsp_rename::rename::is_in_comment(first_hash + 15, code);
+    assert!(result);
+    Ok(())
+}
+
+// ─── Test Group: RenameResult error scenarios ───────────────────────────
+
+#[test]
+fn test_rename_result_none_error() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $x = 1;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "x")?;
+    let result = provider.rename(pos, "y", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    assert!(result.error.is_none());
+    Ok(())
+}
+
+#[test]
+fn test_rename_result_with_multiple_edits() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $a = 1; $a = 2; print $a;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "a")?;
+    let result = provider.rename(pos, "b", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    assert!(result.edits.len() >= 2);
+    Ok(())
+}
+
+// ─── Test Group: Position boundary handling ────────────────────────────
+
+#[test]
+fn test_rename_at_exact_start() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $x = 0; $x = 1;";
+    let provider = parse_and_provider(code)?;
+    // Find exact start of variable definition
+    let pos = find_position(code, "my $x")?;
+    let result = provider.rename(pos + 4, "y", &RenameOptions::default()); // Skip "my $"
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_at_exact_end() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $count = 0; print $count;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "count")?;
+    let end_pos = pos + "count".len() - 1; // Last character of symbol
+    let result = provider.rename(end_pos, "total", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Large/complex code scenarios ───────────────────────────
+
+#[test]
+fn test_rename_many_occurrences() -> Result<(), Box<dyn std::error::Error>> {
+    let mut code = String::new();
+    code.push_str("my $counter = 0;\n");
+    for _ in 0..20 {
+        code.push_str("$counter++;\n");
+    }
+    code.push_str("print $counter;\n");
+
+    let provider = parse_and_provider(&code)?;
+    let pos = find_position(&code, "counter")?;
+    let result = provider.rename(pos, "cnt", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    assert!(result.edits.len() > 10); // Many occurrences
+    Ok(())
+}
+
+#[test]
+fn test_rename_interleaved_variables() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $a = 1;
+my $b = 2;
+my $a = 3;
+$a = $b;
+print $a;
+print $b;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$a")?;
+    let result = provider.rename(pos, "x", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_with_special_characters_in_context() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $val = 1;
+if ($val > 0) { $val--; }
+while ($val) { $val -= 1; }
+foreach ($val) { print; }
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "val")?;
+    let result = provider.rename(pos, "number", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Symbol table behavior ──────────────────────────────────
+
+#[test]
+fn test_find_symbol_in_complex_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+{
+    my $x = 1;
+    {
+        my $x = 2;
+        print $x;
+    }
+}
+"#;
+
+    let table = parse_symbol_table(code)?;
+    let pos = find_position(code, "print $x")?;
+    let result = perl_lsp_rename::rename::find_symbol_at_position(pos, &table, code);
+
+    // Should find the inner $x
+    assert!(result.is_some());
+    Ok(())
+}
+
+// ─── Test Group: Special Perl patterns ──────────────────────────────────
+
+#[test]
+fn test_rename_qw_list_content() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my @words = qw(one two three);
+my $one = 1;
+print $one;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$one")?;
+    let result = provider.rename(pos, "value", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_hash_key_reference() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my %data = (key => 'val');
+my $value = $data{key};
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$value")?;
+    let result = provider.rename(pos, "val", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+// ─── Test Group: Comprehensive validation combinations ───────────────────
+
+#[test]
+fn test_validate_name_all_valid_patterns() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+
+    let valid_names = vec![
+        "a",
+        "Z",
+        "_",
+        "var1",
+        "_var",
+        "__var__",
+        "CamelCase",
+        "snake_case",
+        "mix_Case_1",
+        "very_long_name_with_many_parts_here",
+    ];
+
+    for name in valid_names {
+        let result = perl_lsp_rename::rename::validate_name(name, SymbolKind::scalar(), &table);
+        assert!(result.is_ok(), "Expected '{}' to be valid", name);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_name_all_invalid_patterns() -> Result<(), Box<dyn std::error::Error>> {
+    let table = parse_symbol_table("")?;
+
+    let invalid_names = vec![
+        "", "1var", "var-name", "var.name", "var name", "var@name", "var$name", "var#name", "my",
+        "sub", "package", "for", "while", "if",
+    ];
+
+    for name in invalid_names {
+        let result = perl_lsp_rename::rename::validate_name(name, SymbolKind::scalar(), &table);
+        assert!(result.is_err(), "Expected '{}' to be invalid", name);
+    }
+
+    Ok(())
+}
+
+// ─── Test Group: Options combinations ───────────────────────────────────
+
+#[test]
+fn test_rename_all_options_disabled() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $var = 1; # comment $var
+print $var;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "var")?;
+    let opts = RenameOptions {
+        rename_in_comments: false,
+        rename_in_strings: false,
+        validate_new_name: false,
+    };
+    let result = provider.rename(pos, "x", &opts);
+
+    // Should succeed even with disabled options
+    assert!(result.is_valid || result.error.is_some());
+    Ok(())
+}
+
+#[test]
+fn test_rename_validation_forced() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $x = 1;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "x")?;
+
+    let opts = RenameOptions {
+        rename_in_comments: false,
+        rename_in_strings: false,
+        validate_new_name: true,
+    };
+
+    // Try invalid name with validation enabled
+    let result = provider.rename(pos, "123invalid", &opts);
+    assert!(!result.is_valid);
+    assert!(result.error.is_some());
+
+    Ok(())
+}
+
+// ─── Test Group: Edge cases with whitespace/formatting ───────────────────
+
+#[test]
+fn test_rename_with_excess_whitespace() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my  $var   =   1;
+print  $var  ;
+"#;
+
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "$var")?;
+    let result = provider.rename(pos, "value", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_with_no_whitespace() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my$x=1;print$x;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "x")?;
+    let result = provider.rename(pos, "y", &RenameOptions::default());
+
+    assert!(result.is_valid);
+    Ok(())
+}
+
+#[test]
+fn test_rename_preserves_whitespace_around_edits() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my   $long_variable_name   = 1;";
+    let provider = parse_and_provider(code)?;
+    let pos = find_position(code, "long_variable_name")?;
+    let result = provider.rename(pos, "short", &RenameOptions::default());
+
+    if result.is_valid && !result.edits.is_empty() {
+        let modified = perl_lsp_rename::rename::apply_rename_edits(code, &result.edits);
+        assert!(modified.contains("   ")); // Whitespace should be preserved
+    }
+
+    Ok(())
+}
+
+// ─── Test Group: Symbol kind correctness ────────────────────────────────
+
+#[test]
+fn test_can_rename_all_symbol_kinds() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds =
+        vec![SymbolKind::scalar(), SymbolKind::array(), SymbolKind::hash(), SymbolKind::Subroutine];
+
+    for kind in kinds {
+        let result = perl_lsp_rename::rename::can_rename_symbol("valid_name", kind);
+        assert!(result, "Expected valid_name to be renameable for kind {:?}", kind);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_adjust_sigil_all_kinds() -> Result<(), Box<dyn std::error::Error>> {
+    let loc = SourceLocation::new(10, 20);
+
+    let scalar_adjusted =
+        perl_lsp_rename::rename::adjust_location_for_sigil(loc, SymbolKind::scalar());
+    assert_eq!(scalar_adjusted.start, 11); // +1 for $
+
+    let array_adjusted =
+        perl_lsp_rename::rename::adjust_location_for_sigil(loc, SymbolKind::array());
+    assert_eq!(array_adjusted.start, 11); // +1 for @
+
+    let hash_adjusted = perl_lsp_rename::rename::adjust_location_for_sigil(loc, SymbolKind::hash());
+    assert_eq!(hash_adjusted.start, 11); // +1 for %
+
+    let sub_adjusted =
+        perl_lsp_rename::rename::adjust_location_for_sigil(loc, SymbolKind::Subroutine);
+    assert_eq!(sub_adjusted.start, 10); // No change for subroutine
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Add 52 extended unit tests. Test-only PR, no code changes.

## Evidence
- All tests pass locally
- `cargo fmt --all` — clean
