### PR TITLE
Extract workspace symbol query logic into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ name = "perl-lsp-navigation"
 version = "0.10.0"
 dependencies = [
  "lsp-types",
+ "perl-lsp-symbol-query",
  "perl-module-import",
  "perl-module-path",
  "perl-parser-core",
@@ -2051,6 +2052,10 @@ dependencies = [
  "perl-tdd-support",
  "rustc-hash",
 ]
+
+[[package]]
+name = "perl-lsp-symbol-query"
+version = "0.10.0"
 
 [[package]]
 name = "perl-lsp-tooling"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/perl-lsp-transport",
     "crates/perl-lsp-on-type-formatting",
     "crates/perl-lsp-tooling",
+    "crates/perl-lsp-symbol-query",
     "crates/perl-subprocess-runtime",
     "crates/perl-lsp-formatting-types",
     "crates/perl-lsp-formatting",
@@ -118,6 +119,7 @@ allow = [
     "perl-content-length-framing",
     "perl-percentile",
     "perl-subprocess-runtime",
+    "perl-lsp-symbol-query",
     "perl-keywords",
     "perl-regex",
     "perl-quote",
@@ -272,7 +274,7 @@ perl-content-length-framing = { path = "crates/perl-content-length-framing", ver
 perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
 perl-lsp-ast-utils = { path = "crates/perl-lsp-ast-utils", version = "0.10.0" }
-perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
+perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-percentile = { path = "crates/perl-percentile", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.8"
 perl-position-tracking = { workspace = true }
 perl-module-path = { workspace = true }
 perl-module-import = { workspace = true }
+perl-lsp-symbol-query = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-lsp-navigation/src/workspace_symbols.rs
+++ b/crates/perl-lsp-navigation/src/workspace_symbols.rs
@@ -64,6 +64,7 @@
 //! # }
 //! ```
 
+use perl_lsp_symbol_query::{compare_names_by_query, matches_query};
 use perl_module_path::normalize_package_separator;
 use perl_parser_core::{SourceLocation, ast::Node};
 use perl_position_tracking::{WireLocation, WireRange};
@@ -218,7 +219,6 @@ impl WorkspaceSymbolsProvider {
         source_map: &HashMap<String, String>,
         candidates: &[String],
     ) -> Vec<WorkspaceSymbol> {
-        let query_lower = query.to_lowercase();
         let mut results = Vec::new();
 
         // Create a set of candidate names for fast lookup
@@ -235,7 +235,7 @@ impl WorkspaceSymbolsProvider {
             for symbol in symbols {
                 // Check if this symbol is in our candidate set
                 if candidate_set.contains(&symbol.name.to_lowercase())
-                    && self.matches_query(&symbol.name, &query_lower)
+                    && matches_query(&symbol.name, query)
                 {
                     results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
                 }
@@ -243,25 +243,7 @@ impl WorkspaceSymbolsProvider {
         }
 
         // Sort by relevance
-        results.sort_by(|a, b| {
-            let a_exact = a.name.to_lowercase() == query_lower;
-            let b_exact = b.name.to_lowercase() == query_lower;
-
-            match (a_exact, b_exact) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => {
-                    let a_starts = a.name.to_lowercase().starts_with(&query_lower);
-                    let b_starts = b.name.to_lowercase().starts_with(&query_lower);
-
-                    match (a_starts, b_starts) {
-                        (true, false) => std::cmp::Ordering::Less,
-                        (false, true) => std::cmp::Ordering::Greater,
-                        _ => a.name.cmp(&b.name),
-                    }
-                }
-            }
-        });
+        results.sort_by(|a, b| compare_names_by_query(&a.name, &b.name, query));
 
         results
     }
@@ -282,7 +264,6 @@ impl WorkspaceSymbolsProvider {
         query: &str,
         source_map: &HashMap<String, String>,
     ) -> Vec<WorkspaceSymbol> {
-        let query_lower = query.to_lowercase();
         let mut results = Vec::new();
 
         for (uri, symbols) in &self.documents {
@@ -293,74 +274,16 @@ impl WorkspaceSymbolsProvider {
             };
 
             for symbol in symbols {
-                if self.matches_query(&symbol.name, &query_lower) {
+                if matches_query(&symbol.name, query) {
                     results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
                 }
             }
         }
 
         // Sort by relevance
-        results.sort_by(|a, b| {
-            let a_exact = a.name.to_lowercase() == query_lower;
-            let b_exact = b.name.to_lowercase() == query_lower;
-            let a_prefix = a.name.to_lowercase().starts_with(&query_lower);
-            let b_prefix = b.name.to_lowercase().starts_with(&query_lower);
-
-            match (a_exact, b_exact) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => match (a_prefix, b_prefix) {
-                    (true, false) => std::cmp::Ordering::Less,
-                    (false, true) => std::cmp::Ordering::Greater,
-                    _ => a.name.cmp(&b.name),
-                },
-            }
-        });
+        results.sort_by(|a, b| compare_names_by_query(&a.name, &b.name, query));
 
         results
-    }
-
-    /// Checks if a symbol name matches the query using multiple strategies.
-    ///
-    /// Returns true if query is empty, or if name matches via exact, prefix,
-    /// contains, or fuzzy (subsequence) matching.
-    fn matches_query(&self, name: &str, query: &str) -> bool {
-        if query.is_empty() {
-            return true;
-        }
-
-        let name_lower = name.to_lowercase();
-
-        // Exact match
-        if name_lower == query {
-            return true;
-        }
-
-        // Prefix match
-        if name_lower.starts_with(query) {
-            return true;
-        }
-
-        // Contains match
-        if name_lower.contains(query) {
-            return true;
-        }
-
-        // Simple fuzzy match
-        let mut query_chars = query.chars();
-        let mut current_char = query_chars.next();
-
-        for ch in name_lower.chars() {
-            if let Some(qch) = current_char {
-                if ch == qch {
-                    current_char = query_chars.next();
-                }
-            } else {
-                return true;
-            }
-        }
-
-        current_char.is_none()
     }
 
     /// Converts an internal `SymbolInfo` to an LSP `WorkspaceSymbol`.

--- a/crates/perl-lsp-symbol-query/Cargo.toml
+++ b/crates/perl-lsp-symbol-query/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-lsp-symbol-query"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Workspace symbol query matching and ranking helpers"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-symbol-query"
+keywords = ["perl", "lsp", "symbol", "query", "search"]
+categories = ["development-tools", "text-editors"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-symbol-query/README.md
+++ b/crates/perl-lsp-symbol-query/README.md
@@ -1,0 +1,4 @@
+# perl-lsp-symbol-query
+
+Small SRP microcrate for matching and ranking workspace symbol names against
+LSP `workspace/symbol` queries.

--- a/crates/perl-lsp-symbol-query/src/lib.rs
+++ b/crates/perl-lsp-symbol-query/src/lib.rs
@@ -1,0 +1,115 @@
+//! Query matching and ranking helpers for workspace symbol search.
+//!
+//! This crate has a single responsibility: provide reusable matching and
+//! ranking primitives used by LSP symbol-search providers.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::cmp::Ordering;
+
+/// Returns `true` when a symbol name matches the provided query.
+///
+/// Matching strategy order:
+/// 1. Empty query (matches everything)
+/// 2. Exact case-insensitive match
+/// 3. Prefix case-insensitive match
+/// 4. Contains case-insensitive match
+/// 5. Subsequence/fuzzy case-insensitive match
+#[must_use]
+pub fn matches_query(name: &str, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+
+    let name_lower = name.to_lowercase();
+    let query_lower = query.to_lowercase();
+
+    if name_lower == query_lower {
+        return true;
+    }
+
+    if name_lower.starts_with(&query_lower) {
+        return true;
+    }
+
+    if name_lower.contains(&query_lower) {
+        return true;
+    }
+
+    is_subsequence(&name_lower, &query_lower)
+}
+
+/// Compares two symbol names by query relevance.
+///
+/// Ordering:
+/// 1. Exact match first
+/// 2. Prefix match second
+/// 3. Lexicographic name order
+#[must_use]
+pub fn compare_names_by_query(a: &str, b: &str, query: &str) -> Ordering {
+    let query_lower = query.to_lowercase();
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+
+    let a_exact = a_lower == query_lower;
+    let b_exact = b_lower == query_lower;
+    let a_prefix = a_lower.starts_with(&query_lower);
+    let b_prefix = b_lower.starts_with(&query_lower);
+
+    match (a_exact, b_exact) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => match (a_prefix, b_prefix) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => a.cmp(b),
+        },
+    }
+}
+
+fn is_subsequence(haystack: &str, needle: &str) -> bool {
+    let mut needle_chars = needle.chars();
+    let mut current = needle_chars.next();
+
+    for ch in haystack.chars() {
+        if let Some(target) = current {
+            if ch == target {
+                current = needle_chars.next();
+            }
+        } else {
+            return true;
+        }
+    }
+
+    current.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compare_names_by_query, matches_query};
+
+    #[test]
+    fn query_matching_covers_exact_prefix_contains_and_fuzzy() {
+        assert!(matches_query("foo", "foo"));
+        assert!(matches_query("foobar", "foo"));
+        assert!(matches_query("foobar", "bar"));
+        assert!(matches_query("foobar", "fb"));
+        assert!(!matches_query("alpha", "zq"));
+    }
+
+    #[test]
+    fn empty_query_matches_anything() {
+        assert!(matches_query("anything", ""));
+    }
+
+    #[test]
+    fn relevance_prefers_exact_then_prefix_then_name_order() {
+        let mut names = ["foxtrot", "foo", "foobar", "alpha"];
+        names.sort_by(|a, b| compare_names_by_query(a, b, "foo"));
+
+        assert_eq!(names, ["foo", "foobar", "alpha", "foxtrot"]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce responsibility of the navigation provider by extracting query matching and ranking into a small SRP microcrate so symbol query semantics become reusable and easier to test. 

### Description

- Add new microcrate `perl-lsp-symbol-query` with `src/lib.rs` implementing `matches_query` and `compare_names_by_query` and focused unit tests.  
- Replace duplicated matching/sorting code in `crates/perl-lsp-navigation/src/workspace_symbols.rs` to call `perl_lsp_symbol_query::{matches_query, compare_names_by_query}` and remove the inlined implementations.  
- Wire the new crate into the workspace and dependency graph by updating `Cargo.toml`, `crates/perl-lsp-navigation/Cargo.toml`, and the lockfile, and add `README.md` for the new microcrate.  

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.  
- Ran unit tests with `cargo test -p perl-lsp-symbol-query -p perl-lsp-navigation` and all tests passed for both crates.  
- Ran lints with `cargo clippy -p perl-lsp-symbol-query -p perl-lsp-navigation --lib -- -D warnings` which passed, and noted that `cargo clippy --all-targets -p perl-lsp-navigation -p perl-lsp-symbol-query -D warnings` fails due to existing upstream clippy warnings in unrelated test code (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b85be708333abccf5859d4b5e55)