### PR TITLE
refactor: split workspace-folder parsing helpers into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,7 @@ dependencies = [
  "perl-symbol-cursor",
  "perl-tdd-support",
  "perl-workspace-discovery",
+ "perl-workspace-folder",
  "predicates",
  "pretty_assertions",
  "proptest",
@@ -2574,6 +2575,7 @@ version = "0.10.0"
 dependencies = [
  "perl-uri",
  "proptest",
+ "serde_json",
  "tempfile",
  "url",
 ]

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -51,6 +51,7 @@ perl-module-resolution = { workspace = true }
 perl-source-file = { workspace = true }
 perl-content-length-framing = { workspace = true }
 perl-workspace-discovery = { workspace = true }
+perl-workspace-folder = { workspace = true }
 perl-keywords = { workspace = true }
 lsp-types = "0.97.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -3,6 +3,7 @@
 //! Handles client capability parsing and server capabilities construction.
 
 use super::super::*;
+use perl_workspace_folder::{extract_workspace_folder_uris, root_path_to_file_uri};
 use serde_json::{Value, json};
 
 impl LspServer {
@@ -151,11 +152,9 @@ impl LspServer {
                 params.get("workspaceFolders").and_then(|f| f.as_array())
             {
                 let mut folders = self.workspace_folders.lock();
-                for folder in workspace_folders {
-                    if let Some(uri) = folder["uri"].as_str() {
-                        eprintln!("Initialized with workspace folder: {}", uri);
-                        folders.push(uri.to_string());
-                    }
+                for uri in extract_workspace_folder_uris(workspace_folders) {
+                    eprintln!("Initialized with workspace folder: {}", uri);
+                    folders.push(uri);
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
@@ -167,17 +166,7 @@ impl LspServer {
             } else if let Some(root_path) = params.get("rootPath").and_then(|p| p.as_str()) {
                 // Legacy fallback: rootPath is deprecated since LSP 3.0 but still sent by some clients
                 eprintln!("Initialized with legacy rootPath: {}", root_path);
-                // Convert rootPath to URI format using proper URL encoding
-                let path = std::path::Path::new(root_path);
-                let root_uri =
-                    url::Url::from_file_path(path).map(|u| u.to_string()).unwrap_or_else(|_| {
-                        // Fallback for edge cases (e.g., relative paths, UNC paths)
-                        if root_path.starts_with('/') {
-                            format!("file://{}", root_path)
-                        } else {
-                            format!("file:///{}", root_path.replace('\\', "/"))
-                        }
-                    });
+                let root_uri = root_path_to_file_uri(root_path);
                 let mut folders = self.workspace_folders.lock();
                 folders.push(root_uri.clone());
                 self.set_root_uri(&root_uri);

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -20,6 +20,7 @@ use perl_module_rename::plan_module_rename_edits;
 use perl_parser::workspace_index::{DegradationReason, EarlyExitReason, ResourceKind};
 #[cfg(feature = "workspace")]
 use perl_source_file::{is_perl_source_path, is_perl_source_uri};
+use perl_workspace_folder::extract_workspace_folder_change;
 #[cfg(feature = "workspace")]
 use std::io::Write;
 #[cfg(feature = "workspace")]
@@ -920,37 +921,33 @@ impl LspServer {
     ) -> Result<(), JsonRpcError> {
         if let Some(params) = params {
             if let Some(event) = params.get("event") {
-                // Handle added folders
-                if let Some(added) = event["added"].as_array() {
+                let change = extract_workspace_folder_change(event);
+
+                if !change.added.is_empty() {
                     let mut workspace_folders = self.workspace_folders.lock();
-                    for folder in added {
-                        if let Some(uri) = folder["uri"].as_str() {
-                            eprintln!("Added workspace folder: {}", uri);
-                            workspace_folders.push(uri.to_string());
-                        }
+                    for uri in &change.added {
+                        eprintln!("Added workspace folder: {}", uri);
+                        workspace_folders.push(uri.to_string());
                     }
                 }
 
-                // Handle removed folders
-                if let Some(removed) = event["removed"].as_array() {
+                if !change.removed.is_empty() {
                     let mut workspace_folders = self.workspace_folders.lock();
-                    for folder in removed {
-                        if let Some(uri) = folder["uri"].as_str() {
-                            eprintln!("Removed workspace folder: {}", uri);
-                            workspace_folders.retain(|f| f.as_str() != uri);
+                    for uri in &change.removed {
+                        eprintln!("Removed workspace folder: {}", uri);
+                        workspace_folders.retain(|f| f.as_str() != uri);
 
-                            // Also remove documents from the removed workspace
-                            let mut documents = self.documents.lock();
-                            let docs_to_remove: Vec<String> = documents
-                                .keys()
-                                .filter(|doc_uri| doc_uri.starts_with(uri))
-                                .cloned()
-                                .collect();
+                        // Also remove documents from the removed workspace
+                        let mut documents = self.documents.lock();
+                        let docs_to_remove: Vec<String> = documents
+                            .keys()
+                            .filter(|doc_uri| doc_uri.starts_with(uri))
+                            .cloned()
+                            .collect();
 
-                            for doc_uri in docs_to_remove {
-                                eprintln!("Removing document from removed workspace: {}", doc_uri);
-                                documents.remove(&doc_uri);
-                            }
+                        for doc_uri in docs_to_remove {
+                            eprintln!("Removing document from removed workspace: {}", doc_uri);
+                            documents.remove(&doc_uri);
                         }
                     }
                 }

--- a/crates/perl-workspace-folder/Cargo.toml
+++ b/crates/perl-workspace-folder/Cargo.toml
@@ -16,11 +16,12 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-uri = { workspace = true }
+serde_json = "1.0.149"
+url = "2.5.8"
 
 [dev-dependencies]
 proptest = "1.9.0"
 tempfile = "3.24.0"
-url = "2.5.8"
 
 [lints]
 workspace = true

--- a/crates/perl-workspace-folder/src/lib.rs
+++ b/crates/perl-workspace-folder/src/lib.rs
@@ -13,6 +13,16 @@ use std::path::PathBuf;
 
 #[cfg(not(target_arch = "wasm32"))]
 use perl_uri::uri_to_fs_path;
+use serde_json::Value;
+
+/// URI lists extracted from an LSP workspace folder change event.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkspaceFolderChange {
+    /// Added workspace folder URIs.
+    pub added: Vec<String>,
+    /// Removed workspace folder URIs.
+    pub removed: Vec<String>,
+}
 
 /// Parse a workspace folder declaration into a filesystem path.
 ///
@@ -34,9 +44,62 @@ pub fn workspace_folder_to_path(workspace_folder: &str) -> PathBuf {
     PathBuf::from(workspace_folder)
 }
 
+/// Extract workspace folder URIs from an LSP `workspaceFolders` array.
+///
+/// Invalid entries are ignored.
+#[must_use]
+pub fn extract_workspace_folder_uris(workspace_folders: &[Value]) -> Vec<String> {
+    workspace_folders
+        .iter()
+        .filter_map(|folder| {
+            folder.get("uri").and_then(Value::as_str).map(std::string::ToString::to_string)
+        })
+        .collect()
+}
+
+/// Extract URI changes from an LSP `workspace/didChangeWorkspaceFolders` event payload.
+///
+/// Missing/invalid sections are treated as empty.
+#[must_use]
+pub fn extract_workspace_folder_change(event: &Value) -> WorkspaceFolderChange {
+    let added = event
+        .get("added")
+        .and_then(Value::as_array)
+        .map_or_else(Vec::new, |entries| extract_workspace_folder_uris(entries));
+
+    let removed = event
+        .get("removed")
+        .and_then(Value::as_array)
+        .map_or_else(Vec::new, |entries| extract_workspace_folder_uris(entries));
+
+    WorkspaceFolderChange { added, removed }
+}
+
+/// Convert a legacy LSP `rootPath` string to a `file://` URI.
+///
+/// This keeps behavior deterministic across absolute POSIX and Windows-style paths.
+#[must_use]
+pub fn root_path_to_file_uri(root_path: &str) -> String {
+    let path = std::path::Path::new(root_path);
+    url::Url::from_file_path(path).map_or_else(
+        |_| {
+            if root_path.starts_with('/') {
+                format!("file://{}", root_path)
+            } else {
+                format!("file:///{}", root_path.replace('\\', "/"))
+            }
+        },
+        |uri| uri.to_string(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::workspace_folder_to_path;
+    use super::{
+        extract_workspace_folder_change, extract_workspace_folder_uris, root_path_to_file_uri,
+        workspace_folder_to_path,
+    };
+    use serde_json::json;
     use std::path::PathBuf;
 
     #[test]
@@ -50,5 +113,33 @@ mod tests {
         let parsed = workspace_folder_to_path("file:///tmp/project");
         assert!(parsed.to_string_lossy().contains("tmp"));
         assert!(parsed.to_string_lossy().contains("project"));
+    }
+
+    #[test]
+    fn extracts_workspace_uris() {
+        let entries = vec![
+            json!({"uri": "file:///one"}),
+            json!({"uri": "file:///two"}),
+            json!({"name": "invalid"}),
+        ];
+        let uris = extract_workspace_folder_uris(&entries);
+        assert_eq!(uris, vec!["file:///one", "file:///two"]);
+    }
+
+    #[test]
+    fn extracts_workspace_change_entries() {
+        let change = extract_workspace_folder_change(&json!({
+            "added": [{"uri": "file:///add"}],
+            "removed": [{"uri": "file:///remove"}],
+        }));
+
+        assert_eq!(change.added, vec!["file:///add"]);
+        assert_eq!(change.removed, vec!["file:///remove"]);
+    }
+
+    #[test]
+    fn converts_legacy_root_path_to_file_uri() {
+        let uri = root_path_to_file_uri("/legacy/workspace");
+        assert_eq!(uri, "file:///legacy/workspace");
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce protocol-shape and URI parsing logic in the `perl-lsp` runtime by moving workspace-folder handling to a single-responsibility microcrate. 
- Make workspace folder / `rootPath` parsing reusable across crates and easier to unit test. 

### Description
- Added helpers to the `perl-workspace-folder` crate: `WorkspaceFolderChange`, `extract_workspace_folder_uris`, `extract_workspace_folder_change`, and `root_path_to_file_uri` in `crates/perl-workspace-folder/src/lib.rs`. 
- Added unit tests for the new helpers and included `serde_json` and `url` as crate dependencies in `crates/perl-workspace-folder/Cargo.toml`. 
- Wired `perl-lsp` to consume the new helpers by updating `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs` to use `extract_workspace_folder_uris` and `root_path_to_file_uri`, and `crates/perl-lsp/src/runtime/workspace.rs` to use `extract_workspace_folder_change`. 
- Updated `crates/perl-lsp/Cargo.toml` to add `perl-workspace-folder` as a workspace dependency and formatted the workspace with `cargo fmt --all`.

### Testing
- Ran `cargo fmt --all` (formatting applied). 
- Ran `cargo test -p perl-workspace-folder` and all tests passed. 
- Ran `cargo test -p perl-lsp --test workspace_resolution_tests` and `cargo test -p perl-lsp --test lsp_workspace_tests` and all listed tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b8481f883339a7c617a9a3f2405)