### PR TITLE
Extract PHF builtin signature tables into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,14 @@ dependencies = [
 name = "perl-builtins"
 version = "0.10.0"
 dependencies = [
+ "perl-builtins-phf",
  "perl-tdd-support",
+]
+
+[[package]]
+name = "perl-builtins-phf"
+version = "0.10.0"
+dependencies = [
  "phf",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/perl-pragma",
     "crates/perl-edit",
     "crates/perl-builtins",
+    "crates/perl-builtins-phf",
     "crates/perl-regex",
     "crates/perl-heredoc",
     "crates/perl-error",
@@ -109,6 +110,7 @@ allow = [
     "perl-position-tracking",
     "perl-token",
     "perl-builtins",
+    "perl-builtins-phf",
     "perl-content-length-framing",
     "perl-subprocess-runtime",
     "perl-keywords",
@@ -229,6 +231,7 @@ perl-token = { path = "crates/perl-token", version = "0.10.0" }
 perl-quote = { path = "crates/perl-quote", version = "0.10.0" }
 perl-edit = { path = "crates/perl-edit", version = "0.10.0" }
 perl-builtins = { path = "crates/perl-builtins", version = "0.10.0" }
+perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.10.0" }
 perl-regex = { path = "crates/perl-regex", version = "0.10.0" }
 perl-pragma = { path = "crates/perl-pragma", version = "0.10.0" }
 perl-lexer = { path = "crates/perl-lexer", version = "0.10.0" }

--- a/crates/perl-builtins-phf/Cargo.toml
+++ b/crates/perl-builtins-phf/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-builtins-phf"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "PHF-backed Perl builtin signature tables for O(1) lookup"
+readme = "README.md"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-builtins-phf"
+keywords = ["perl", "builtins", "phf", "lsp", "signatures"]
+categories = ["development-tools", "text-processing"]
+
+[dependencies]
+phf = { version = "0.13.1", features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/perl-builtins-phf/README.md
+++ b/crates/perl-builtins-phf/README.md
@@ -1,0 +1,15 @@
+# perl-builtins-phf
+
+Compile-time PHF maps for Perl builtin function signatures.
+
+This crate is intentionally narrow: it provides static lookup tables and helper
+functions for identifying builtins and retrieving parameter names/signatures in
+O(1) time with zero runtime allocation.
+
+## API
+
+- `BUILTIN_SIGS`
+- `BUILTIN_FULL_SIGS`
+- `get_param_names(name)`
+- `is_builtin(name)`
+- `builtin_count()`

--- a/crates/perl-builtins-phf/src/lib.rs
+++ b/crates/perl-builtins-phf/src/lib.rs
@@ -306,3 +306,20 @@ pub fn is_builtin(function_name: &str) -> bool {
 pub fn builtin_count() -> usize {
     BUILTIN_SIGS.len()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{builtin_count, get_param_names, is_builtin};
+
+    #[test]
+    fn exposes_common_builtins() {
+        assert!(is_builtin("print"));
+        assert!(!is_builtin("not_a_builtin"));
+    }
+
+    #[test]
+    fn returns_open_param_names() {
+        assert_eq!(get_param_names("open"), ["FILEHANDLE", "MODE", "FILENAME"]);
+        assert!(builtin_count() > 150);
+    }
+}

--- a/crates/perl-builtins/Cargo.toml
+++ b/crates/perl-builtins/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "builtins", "parser", "lsp", "signatures"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-phf = { version = "0.13.1", features = ["macros"] }
+perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.10.0" }
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-builtins/README.md
+++ b/crates/perl-builtins/README.md
@@ -9,7 +9,7 @@ Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp)
 Provides two complementary lookup mechanisms for 200+ Perl built-in functions (including file test operators):
 
 - **`builtin_signatures`** -- `HashMap`-based store with `OnceLock` lazy init. Each entry carries multiple signature variants and a documentation string (`BuiltinSignature`). Used for signature help and hover.
-- **`builtin_signatures_phf`** -- Compile-time `phf::Map` tables (`BUILTIN_SIGS`, `BUILTIN_FULL_SIGS`) for O(1) lookups with zero runtime allocation. Exposes `get_param_names`, `is_builtin`, and `builtin_count` helpers. Used for inlay hints and completion.
+- **`builtin_signatures_phf`** -- Re-export of the `perl-builtins-phf` microcrate, which provides compile-time `phf::Map` tables (`BUILTIN_SIGS`, `BUILTIN_FULL_SIGS`) for O(1) lookups with zero runtime allocation. Exposes `get_param_names`, `is_builtin`, and `builtin_count` helpers. Used for inlay hints and completion.
 
 ## Categories covered
 

--- a/crates/perl-builtins/src/lib.rs
+++ b/crates/perl-builtins/src/lib.rs
@@ -6,4 +6,4 @@
 //! providers to surface accurate information without an external Perl runtime.
 
 pub mod builtin_signatures;
-pub mod builtin_signatures_phf;
+pub use perl_builtins_phf as builtin_signatures_phf;


### PR DESCRIPTION
### Motivation
- Reduce responsibility of `perl-builtins` by separating the compile-time PHF tables into a single-responsibility microcrate for reuse and clearer dependency boundaries.
- Improve build topology so other crates can depend on a tiny, O(1) lookup crate instead of the larger `perl-builtins` implementation.

### Description
- Added a new crate `crates/perl-builtins-phf` containing the PHF-backed tables and helpers (`BUILTIN_SIGS`, `BUILTIN_FULL_SIGS`, `get_param_names`, `is_builtin`, `builtin_count`).
- Moved the former `builtin_signatures_phf.rs` implementation into `crates/perl-builtins-phf/src/lib.rs` and added focused unit tests for common lookup behavior.
- Updated workspace wiring by adding `crates/perl-builtins-phf` to the workspace `members`, adding `perl-builtins-phf` to workspace dependencies, and changing `crates/perl-builtins` to depend on `perl-builtins-phf`.
- Preserved backward compatibility by re-exporting the new crate from `perl-builtins` as `perl_builtins::builtin_signatures_phf`, and updated `README.md`/crate metadata accordingly.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-builtins-phf` and `cargo test -p perl-builtins`, both completed successfully (unit and integration tests passed).
- Ran `cargo test -p perl-parser-core --lib` which passed its test suite.
- Ran `cargo clippy -p perl-builtins -p perl-builtins-phf --lib -- -D warnings` which completed OK for library targets; a broader `--all-targets` clippy run fails due to pre-existing test-only clippy violations in `perl-builtins` tests unrelated to this extraction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92106be508333995c9d385aa76ae0)