### PR TITLE
Extract workspace parallel worker pool into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "perl-parser-core",
  "perl-subprocess-runtime",
  "perl-tdd-support",
+ "perl-workspace-parallel",
  "serde",
 ]
 
@@ -2500,6 +2501,10 @@ dependencies = [
  "parking_lot",
  "proptest",
 ]
+
+[[package]]
+name = "perl-workspace-parallel"
+version = "0.10.0"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "crates/perl-uri",
     "crates/perl-path-security",
     "crates/perl-workspace-discovery",
+    "crates/perl-workspace-parallel",
     "crates/perl-corpus",
     "crates/perl-lsp",
     "crates/perl-dap",
@@ -130,6 +131,7 @@ allow = [
 "perl-symbol-table",
     "perl-uri",
     "perl-workspace-index-slo",
+    "perl-workspace-parallel",
 
     # Tier 3 — Analysis and indexing
     "perl-workspace-index",
@@ -258,6 +260,7 @@ perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
 perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }
+perl-workspace-parallel = { path = "crates/perl-workspace-parallel", version = "0.10.0" }
 perl-corpus = { path = "crates/perl-corpus", version = "0.10.0" }
 perl-dap = { path = "crates/perl-dap", version = "0.10.0" }
 perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -24,6 +24,7 @@ lsp-compat = ["dep:lsp-types"]
 perl-subprocess-runtime = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
+perl-workspace-parallel = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
 lsp-types = { version = "0.97.0", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp-tooling/src/performance.rs
+++ b/crates/perl-lsp-tooling/src/performance.rs
@@ -8,8 +8,13 @@
 use moka::sync::Cache;
 use perl_parser_core::Node;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
+
+/// Parallel processing utilities for large workspaces.
+pub mod parallel {
+    pub use perl_workspace_parallel::process_files_parallel;
+}
 
 /// Cache for parsed ASTs with TTL.
 ///
@@ -150,70 +155,6 @@ impl IncrementalParser {
 
         self.changed_regions = merged;
     }
-}
-
-/// Parallel processing utilities for large workspaces
-pub mod parallel {
-    use std::sync::mpsc;
-    use std::thread;
-
-    /// Process files in parallel with a worker pool.
-    ///
-    /// Distributes file processing across multiple threads for faster indexing.
-    pub fn process_files_parallel<T, F>(
-        files: Vec<String>,
-        num_workers: usize,
-        processor: F,
-    ) -> Vec<T>
-    where
-        T: Send + 'static,
-        F: Fn(String) -> T + Send + Sync + 'static,
-    {
-        let (tx, rx) = mpsc::channel();
-        let work_queue = Arc::new(Mutex::new(files));
-        let processor = Arc::new(processor);
-
-        let mut handles = vec![];
-
-        for _ in 0..num_workers {
-            let tx = tx.clone();
-            let work_queue = Arc::clone(&work_queue);
-            let processor = Arc::clone(&processor);
-
-            let handle = thread::spawn(move || {
-                loop {
-                    let file = {
-                        let Ok(mut queue) = work_queue.lock() else {
-                            break; // Exit if lock is poisoned
-                        };
-                        queue.pop()
-                    };
-
-                    match file {
-                        Some(f) => {
-                            let result = processor(f);
-                            if tx.send(result).is_err() {
-                                break; // Exit if receiver is dropped
-                            }
-                        }
-                        None => break,
-                    }
-                }
-            });
-
-            handles.push(handle);
-        }
-
-        drop(tx);
-
-        for handle in handles {
-            let _ = handle.join(); // Ignore join errors - worker threads handle errors internally
-        }
-
-        rx.into_iter().collect()
-    }
-
-    use super::*;
 }
 
 /// Symbol index for fast lookups.

--- a/crates/perl-workspace-parallel/Cargo.toml
+++ b/crates/perl-workspace-parallel/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "perl-workspace-parallel"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Threaded worker-pool helpers for workspace file processing"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-workspace-parallel"
+keywords = ["perl", "workspace", "parallel", "threading"]
+categories = ["concurrency", "development-tools"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-parallel/src/lib.rs
+++ b/crates/perl-workspace-parallel/src/lib.rs
@@ -1,0 +1,96 @@
+//! Parallel file-processing helpers for workspace operations.
+//!
+//! This crate has one narrow responsibility: run independent file tasks across
+//! a fixed-size thread pool and collect results.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+
+/// Process files in parallel with a worker pool.
+///
+/// Each worker repeatedly pops one file from the shared queue, runs
+/// `processor`, and sends the result through a channel. The function returns
+/// all results that were successfully produced.
+#[must_use]
+pub fn process_files_parallel<T, F>(files: Vec<String>, num_workers: usize, processor: F) -> Vec<T>
+where
+    T: Send + 'static,
+    F: Fn(String) -> T + Send + Sync + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    let work_queue = Arc::new(Mutex::new(files));
+    let processor = Arc::new(processor);
+
+    let mut handles = Vec::new();
+
+    for _ in 0..num_workers {
+        let tx = tx.clone();
+        let work_queue = Arc::clone(&work_queue);
+        let processor = Arc::clone(&processor);
+
+        let handle = thread::spawn(move || {
+            loop {
+                let file = {
+                    let Ok(mut queue) = work_queue.lock() else {
+                        break;
+                    };
+                    queue.pop()
+                };
+
+                match file {
+                    Some(f) => {
+                        let result = processor(f);
+                        if tx.send(result).is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    drop(tx);
+
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    rx.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::process_files_parallel;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn processes_all_files() {
+        let files = vec!["one.pl".to_string(), "two.pl".to_string(), "three.pl".to_string()];
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let counter_clone = Arc::clone(&counter);
+        let results = process_files_parallel(files, 2, move |_file| {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            7
+        });
+
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|value| *value == 7));
+    }
+
+    #[test]
+    fn returns_empty_when_no_files() {
+        let results = process_files_parallel(Vec::new(), 4, |_file| 1usize);
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Isolate a single-responsibility, generic worker-pool helper from the larger `perl-lsp-tooling::performance` implementation so it can evolve and be reused independently by other workspace/indexing crates.
- Reduce coupling and keep `perl-lsp-tooling` focused on tooling-specific concerns while exposing the same API surface for callers.

### Description
- Added a new microcrate `crates/perl-workspace-parallel` that implements `process_files_parallel` as the canonical worker-pool helper and includes focused unit tests and crate metadata (`crates/perl-workspace-parallel/Cargo.toml`, `crates/perl-workspace-parallel/src/lib.rs`).
- Removed the inline `parallel` implementation from `crates/perl-lsp-tooling/src/performance.rs` and re-exported the helper via `pub mod parallel { pub use perl_workspace_parallel::process_files_parallel; }` to preserve existing call sites (`perl_lsp_tooling::performance::parallel::process_files_parallel`).
- Wired the new crate into the workspace by adding it to `members`, the workspace `dependencies` map, and the `workspace.metadata.publish.allow` list in `Cargo.toml` and accepted the lockfile update in `Cargo.lock`.
- Kept behavior unchanged; this is a mechanical extraction with API compatibility preserved and focused tests moved/added to the new crate.

### Testing
- Ran formatting: `cargo fmt --all` (succeeded).
- Ran unit tests: `cargo test -p perl-workspace-parallel -p perl-lsp-tooling` (all tests passed for both crates).
- Ran linting: `cargo clippy -p perl-workspace-parallel -p perl-lsp-tooling --all-targets -- -D warnings` (no warnings, succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b837c088333a6acc1615614f12e)