### PR TITLE
Extract symbol query matching into `perl-symbol-query` crate and use it in navigation provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,6 +1950,7 @@ dependencies = [
  "perl-parser-core",
  "perl-position-tracking",
  "perl-semantic-analyzer",
+ "perl-symbol-query",
  "perl-tdd-support",
  "serde",
  "serde_json",
@@ -2333,6 +2334,10 @@ version = "0.10.0"
 dependencies = [
  "perl-tdd-support",
 ]
+
+[[package]]
+name = "perl-symbol-query"
+version = "0.10.0"
 
 [[package]]
 name = "perl-symbol-table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "crates/perl-symbol-types",
     "crates/perl-symbol-cursor",
     "crates/perl-symbol-table",
+    "crates/perl-symbol-query",
     "crates/perl-module-boundary",
     "crates/perl-module-token-core",
     "crates/perl-module-token",
@@ -234,6 +235,7 @@ perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
 perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
+perl-symbol-query = { path = "crates/perl-symbol-query", version = "0.10.0" }
 perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
 perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }
 perl-module-token = { path = "crates/perl-module-token", version = "0.10.0" }

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.8"
 perl-position-tracking = { workspace = true }
 perl-module-path = { workspace = true }
 perl-module-import = { workspace = true }
+perl-symbol-query = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-lsp-navigation/src/workspace_symbols.rs
+++ b/crates/perl-lsp-navigation/src/workspace_symbols.rs
@@ -68,6 +68,7 @@ use perl_module_path::normalize_package_separator;
 use perl_parser_core::{SourceLocation, ast::Node};
 use perl_position_tracking::{WireLocation, WireRange};
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind};
+use perl_symbol_query::{compare_names_by_query, matches_query_lowercase};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -235,7 +236,7 @@ impl WorkspaceSymbolsProvider {
             for symbol in symbols {
                 // Check if this symbol is in our candidate set
                 if candidate_set.contains(&symbol.name.to_lowercase())
-                    && self.matches_query(&symbol.name, &query_lower)
+                    && matches_query_lowercase(&symbol.name, &query_lower)
                 {
                     results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
                 }
@@ -243,25 +244,7 @@ impl WorkspaceSymbolsProvider {
         }
 
         // Sort by relevance
-        results.sort_by(|a, b| {
-            let a_exact = a.name.to_lowercase() == query_lower;
-            let b_exact = b.name.to_lowercase() == query_lower;
-
-            match (a_exact, b_exact) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => {
-                    let a_starts = a.name.to_lowercase().starts_with(&query_lower);
-                    let b_starts = b.name.to_lowercase().starts_with(&query_lower);
-
-                    match (a_starts, b_starts) {
-                        (true, false) => std::cmp::Ordering::Less,
-                        (false, true) => std::cmp::Ordering::Greater,
-                        _ => a.name.cmp(&b.name),
-                    }
-                }
-            }
-        });
+        results.sort_by(|a, b| compare_names_by_query(&a.name, &b.name, &query_lower));
 
         results
     }
@@ -293,74 +276,16 @@ impl WorkspaceSymbolsProvider {
             };
 
             for symbol in symbols {
-                if self.matches_query(&symbol.name, &query_lower) {
+                if matches_query_lowercase(&symbol.name, &query_lower) {
                     results.push(self.symbol_to_workspace_symbol(uri, symbol, source));
                 }
             }
         }
 
         // Sort by relevance
-        results.sort_by(|a, b| {
-            let a_exact = a.name.to_lowercase() == query_lower;
-            let b_exact = b.name.to_lowercase() == query_lower;
-            let a_prefix = a.name.to_lowercase().starts_with(&query_lower);
-            let b_prefix = b.name.to_lowercase().starts_with(&query_lower);
-
-            match (a_exact, b_exact) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => match (a_prefix, b_prefix) {
-                    (true, false) => std::cmp::Ordering::Less,
-                    (false, true) => std::cmp::Ordering::Greater,
-                    _ => a.name.cmp(&b.name),
-                },
-            }
-        });
+        results.sort_by(|a, b| compare_names_by_query(&a.name, &b.name, &query_lower));
 
         results
-    }
-
-    /// Checks if a symbol name matches the query using multiple strategies.
-    ///
-    /// Returns true if query is empty, or if name matches via exact, prefix,
-    /// contains, or fuzzy (subsequence) matching.
-    fn matches_query(&self, name: &str, query: &str) -> bool {
-        if query.is_empty() {
-            return true;
-        }
-
-        let name_lower = name.to_lowercase();
-
-        // Exact match
-        if name_lower == query {
-            return true;
-        }
-
-        // Prefix match
-        if name_lower.starts_with(query) {
-            return true;
-        }
-
-        // Contains match
-        if name_lower.contains(query) {
-            return true;
-        }
-
-        // Simple fuzzy match
-        let mut query_chars = query.chars();
-        let mut current_char = query_chars.next();
-
-        for ch in name_lower.chars() {
-            if let Some(qch) = current_char {
-                if ch == qch {
-                    current_char = query_chars.next();
-                }
-            } else {
-                return true;
-            }
-        }
-
-        current_char.is_none()
     }
 
     /// Converts an internal `SymbolInfo` to an LSP `WorkspaceSymbol`.

--- a/crates/perl-lsp-navigation/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-navigation/tests/comprehensive_unit_tests.rs
@@ -249,8 +249,10 @@ fn refs_variable_with_different_sigils_not_confused() {
 
 #[test]
 fn type_definition_provider_default_trait() {
-    let provider = TypeDefinitionProvider::default();
-    // Just ensure Default impl works without panic
+    fn assert_default_impl<T: Default>() {}
+
+    assert_default_impl::<TypeDefinitionProvider>();
+    let provider = TypeDefinitionProvider;
     let _ = provider;
 }
 
@@ -266,7 +268,10 @@ fn type_definition_provider_new() {
 
 #[test]
 fn type_hierarchy_provider_default_trait() {
-    let provider = TypeHierarchyProvider::default();
+    fn assert_default_impl<T: Default>() {}
+
+    assert_default_impl::<TypeHierarchyProvider>();
+    let provider = TypeHierarchyProvider;
     let _ = provider;
 }
 

--- a/crates/perl-symbol-query/Cargo.toml
+++ b/crates/perl-symbol-query/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "perl-symbol-query"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Symbol query matching and relevance ordering"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-symbol-query/src/lib.rs
+++ b/crates/perl-symbol-query/src/lib.rs
@@ -1,0 +1,108 @@
+//! Symbol query matching and relevance ordering.
+//!
+//! This crate has a single responsibility: evaluate whether symbol names match
+//! a user query and rank those matches for stable workspace symbol results.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::cmp::Ordering;
+
+/// Returns true when a symbol name matches a lowercased query.
+///
+/// Matching strategy order:
+/// 1. Empty query (always match)
+/// 2. Exact match (case-insensitive)
+/// 3. Prefix match
+/// 4. Contains match
+/// 5. Fuzzy subsequence match
+#[must_use]
+pub fn matches_query_lowercase(name: &str, query_lower: &str) -> bool {
+    if query_lower.is_empty() {
+        return true;
+    }
+
+    let name_lower = name.to_lowercase();
+
+    if name_lower == query_lower {
+        return true;
+    }
+
+    if name_lower.starts_with(query_lower) {
+        return true;
+    }
+
+    if name_lower.contains(query_lower) {
+        return true;
+    }
+
+    let mut query_chars = query_lower.chars();
+    let mut current_char = query_chars.next();
+
+    for ch in name_lower.chars() {
+        if let Some(qch) = current_char {
+            if ch == qch {
+                current_char = query_chars.next();
+            }
+        } else {
+            return true;
+        }
+    }
+
+    current_char.is_none()
+}
+
+/// Compares two symbol names by query relevance.
+///
+/// Relevance order:
+/// 1. Exact matches first
+/// 2. Prefix matches second
+/// 3. Alphabetical order as stable tie-breaker
+#[must_use]
+pub fn compare_names_by_query(a: &str, b: &str, query_lower: &str) -> Ordering {
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+
+    let a_exact = a_lower == query_lower;
+    let b_exact = b_lower == query_lower;
+
+    match (a_exact, b_exact) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => {
+            let a_prefix = a_lower.starts_with(query_lower);
+            let b_prefix = b_lower.starts_with(query_lower);
+
+            match (a_prefix, b_prefix) {
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                _ => a.cmp(b),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compare_names_by_query, matches_query_lowercase};
+    use std::cmp::Ordering;
+
+    #[test]
+    fn match_strategies_work_in_order() {
+        assert!(matches_query_lowercase("foobar", ""));
+        assert!(matches_query_lowercase("Foo", "foo"));
+        assert!(matches_query_lowercase("Foobar", "foo"));
+        assert!(matches_query_lowercase("Foobar", "oba"));
+        assert!(matches_query_lowercase("foobar", "fbr"));
+        assert!(!matches_query_lowercase("foobar", "fzr"));
+    }
+
+    #[test]
+    fn relevance_sort_prefers_exact_then_prefix() {
+        assert_eq!(compare_names_by_query("foo", "foobar", "foo"), Ordering::Less);
+        assert_eq!(compare_names_by_query("foobar", "barfoo", "foo"), Ordering::Less);
+        assert_eq!(compare_names_by_query("alpha", "beta", "zzz"), Ordering::Less);
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize symbol matching and relevance ordering logic so multiple crates can reuse a single implementation.
- Reduce duplication in `perl-lsp-navigation` by delegating match/sort behavior to a dedicated crate.
- Make workspace symbol ranking easier to test and evolve independently.

### Description

- Added a new crate `crates/perl-symbol-query` that implements `matches_query_lowercase` and `compare_names_by_query` for matching and relevance ordering.
- Wired the new crate into the workspace by updating `Cargo.toml` and `Cargo.lock` and adding `perl-symbol-query` to workspace dependencies and members.
- Replaced local matching/sorting logic in `crates/perl-lsp-navigation/src/workspace_symbols.rs` with calls to `matches_query_lowercase` and `compare_names_by_query`, and removed the old `matches_query` implementation.
- Adjusted unit tests in `crates/perl-lsp-navigation/tests/comprehensive_unit_tests.rs` to use a small `assert_default_impl` helper and minor test initialization changes.

### Testing

- Ran `cargo test -p perl-symbol-query` which executed the new crate's unit tests and they passed. 
- Ran `cargo test -p perl-lsp-navigation` which executed the navigation crate tests (including modified tests) and they passed. 
- Ran `cargo test --workspace` to validate workspace integration and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b837c088333a6acc1615614f12e)