### PR TITLE
Split SymbolIndex into dedicated perl-symbol-index SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "moka",
  "perl-parser-core",
  "perl-subprocess-runtime",
+ "perl-symbol-index",
  "perl-tdd-support",
  "serde",
 ]
@@ -2333,6 +2334,10 @@ version = "0.10.0"
 dependencies = [
  "perl-tdd-support",
 ]
+
+[[package]]
+name = "perl-symbol-index"
+version = "0.10.0"
 
 [[package]]
 name = "perl-symbol-table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "crates/perl-position-tracking",
     "crates/perl-symbol-types",
     "crates/perl-symbol-cursor",
+    "crates/perl-symbol-index",
     "crates/perl-symbol-table",
     "crates/perl-module-boundary",
     "crates/perl-module-token-core",
@@ -127,6 +128,7 @@ allow = [
     "perl-incremental-parsing",
     "perl-symbol-types",
 "perl-symbol-cursor",
+"perl-symbol-index",
 "perl-symbol-table",
     "perl-uri",
     "perl-workspace-index-slo",
@@ -233,6 +235,7 @@ perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.10.0" }
 perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.10.0" }
 perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
 perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.10.0" }
 perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
 perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
 perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -24,6 +24,7 @@ lsp-compat = ["dep:lsp-types"]
 perl-subprocess-runtime = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
+perl-symbol-index = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
 lsp-types = { version = "0.97.0", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp-tooling/src/lib.rs
+++ b/crates/perl-lsp-tooling/src/lib.rs
@@ -33,6 +33,7 @@ pub mod perl_critic;
 pub mod perltidy;
 
 pub use perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
+pub use perl_symbol_index::SymbolIndex;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use perl_subprocess_runtime::OsSubprocessRuntime;

--- a/crates/perl-lsp-tooling/src/performance.rs
+++ b/crates/perl-lsp-tooling/src/performance.rs
@@ -7,7 +7,6 @@
 
 use moka::sync::Cache;
 use perl_parser_core::Node;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -45,13 +44,10 @@ impl AstCache {
         let content_hash = Self::hash_content(content);
 
         if let Some(cached) = self.cache.get(uri) {
-            // Check if content hash matches (skip if content changed)
             if cached.content_hash == content_hash {
                 return Some(Arc::clone(&cached.ast));
-            } else {
-                // Remove stale entry
-                self.cache.remove(uri);
             }
+            self.cache.remove(uri);
         }
         None
     }
@@ -113,10 +109,7 @@ impl IncrementalParser {
     ///
     /// Returns true if the node overlaps with any changed region.
     pub fn needs_reparse(&self, node_start: usize, node_end: usize) -> bool {
-        self.changed_regions.iter().any(|(start, end)| {
-            // Check if node overlaps with any changed region
-            node_start < *end && node_end > *start
-        })
+        self.changed_regions.iter().any(|(start, end)| node_start < *end && node_end > *start)
     }
 
     /// Clear all changed regions.
@@ -138,10 +131,8 @@ impl IncrementalParser {
 
         for &(start, end) in &self.changed_regions[1..] {
             if start <= current.1 {
-                // Overlapping or adjacent regions
                 current.1 = current.1.max(end);
             } else {
-                // Non-overlapping region
                 merged.push(current);
                 current = (start, end);
             }
@@ -154,6 +145,7 @@ impl IncrementalParser {
 
 /// Parallel processing utilities for large workspaces
 pub mod parallel {
+    use super::*;
     use std::sync::mpsc;
     use std::thread;
 
@@ -184,7 +176,7 @@ pub mod parallel {
                 loop {
                     let file = {
                         let Ok(mut queue) = work_queue.lock() else {
-                            break; // Exit if lock is poisoned
+                            break;
                         };
                         queue.pop()
                     };
@@ -193,7 +185,7 @@ pub mod parallel {
                         Some(f) => {
                             let result = processor(f);
                             if tx.send(result).is_err() {
-                                break; // Exit if receiver is dropped
+                                break;
                             }
                         }
                         None => break,
@@ -207,155 +199,10 @@ pub mod parallel {
         drop(tx);
 
         for handle in handles {
-            let _ = handle.join(); // Ignore join errors - worker threads handle errors internally
+            let _ = handle.join();
         }
 
         rx.into_iter().collect()
-    }
-
-    use super::*;
-}
-
-/// Symbol index for fast lookups.
-///
-/// Supports both prefix and fuzzy matching using a trie and inverted index.
-pub struct SymbolIndex {
-    /// Trie structure for prefix matching
-    trie: SymbolTrie,
-    /// Inverted index for fuzzy matching
-    inverted_index: HashMap<String, Vec<String>>,
-}
-
-/// Trie data structure for efficient prefix matching
-struct SymbolTrie {
-    /// Child nodes indexed by character
-    children: HashMap<char, Box<SymbolTrie>>,
-    /// Symbols stored at this node
-    symbols: Vec<String>,
-}
-
-impl Default for SymbolIndex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SymbolIndex {
-    /// Create a new empty symbol index
-    pub fn new() -> Self {
-        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
-    }
-
-    /// Add a symbol to the index.
-    ///
-    /// Indexes the symbol for both prefix and fuzzy matching.
-    pub fn add_symbol(&mut self, symbol: String) {
-        // Add to trie for prefix matching
-        self.trie.insert(&symbol);
-
-        // Add to inverted index for fuzzy matching
-        let tokens = Self::tokenize(&symbol);
-        for token in tokens {
-            self.inverted_index.entry(token).or_default().push(symbol.clone());
-        }
-    }
-
-    /// Search symbols with prefix.
-    ///
-    /// Returns all symbols starting with the given prefix.
-    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        self.trie.search_prefix(prefix)
-    }
-
-    /// Fuzzy search symbols.
-    ///
-    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
-    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
-        let tokens = Self::tokenize(query);
-        let mut results = HashMap::new();
-
-        for token in tokens {
-            if let Some(symbols) = self.inverted_index.get(&token) {
-                for symbol in symbols {
-                    *results.entry(symbol.clone()).or_insert(0) += 1;
-                }
-            }
-        }
-
-        // Sort by relevance (number of matching tokens)
-        let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
-
-        sorted.into_iter().map(|(symbol, _)| symbol).collect()
-    }
-
-    fn tokenize(s: &str) -> Vec<String> {
-        // Split on word boundaries and case changes
-        let mut tokens = Vec::new();
-        let mut current = String::new();
-        let mut prev_upper = false;
-
-        for ch in s.chars() {
-            if ch.is_uppercase() && !prev_upper && !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-            }
-
-            if ch.is_alphanumeric() {
-                current.push(ch);
-                prev_upper = ch.is_uppercase();
-            } else if !current.is_empty() {
-                tokens.push(current.to_lowercase());
-                current = String::new();
-                prev_upper = false;
-            }
-        }
-
-        if !current.is_empty() {
-            tokens.push(current.to_lowercase());
-        }
-
-        tokens
-    }
-}
-
-impl SymbolTrie {
-    fn new() -> Self {
-        Self { children: HashMap::new(), symbols: Vec::new() }
-    }
-
-    fn insert(&mut self, symbol: &str) {
-        let mut node = self;
-
-        for ch in symbol.chars() {
-            node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
-        }
-
-        node.symbols.push(symbol.to_string());
-    }
-
-    fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        let mut node = self;
-
-        for ch in prefix.chars() {
-            match node.children.get(&ch) {
-                Some(child) => node = child,
-                None => return Vec::new(),
-            }
-        }
-
-        // Collect all symbols from this node and descendants
-        let mut results = Vec::new();
-        Self::collect_all(node, &mut results);
-        results
-    }
-
-    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
-        results.extend(node.symbols.clone());
-
-        for child in node.children.values() {
-            Self::collect_all(child, results);
-        }
     }
 }
 
@@ -378,20 +225,15 @@ mod tests {
         cache.put("file1.pl".to_string(), "content1", ast1.clone());
         cache.put("file2.pl".to_string(), "content2", ast2.clone());
 
-        // Should retrieve cached AST
         assert!(cache.get("file1.pl", "content1").is_some());
-
-        // Different content should miss cache
         assert!(cache.get("file1.pl", "different").is_none());
 
-        // Adding third item should evict oldest
         let ast3 = Arc::new(Node::new(
             perl_parser_core::NodeKind::Program { statements: vec![] },
             perl_parser_core::SourceLocation { start: 0, end: 0 },
         ));
         cache.put("file3.pl".to_string(), "content3", ast3);
 
-        // file1 should be evicted (oldest)
         assert!(cache.get("file1.pl", "content1").is_none());
         assert!(cache.get("file2.pl", "content2").is_some());
         assert!(cache.get("file3.pl", "content3").is_some());
@@ -404,37 +246,15 @@ mod tests {
         parser.mark_changed(10, 20);
         parser.mark_changed(30, 40);
 
-        // Node overlapping with changed region
         assert!(parser.needs_reparse(15, 25));
         assert!(parser.needs_reparse(35, 45));
 
-        // Node not overlapping
         assert!(!parser.needs_reparse(0, 5));
         assert!(!parser.needs_reparse(50, 60));
 
-        // Test merging overlapping regions
         parser.mark_changed(18, 35);
         assert_eq!(parser.changed_regions.len(), 1);
         assert_eq!(parser.changed_regions[0], (10, 40));
-    }
-
-    #[test]
-    fn test_symbol_index() {
-        let mut index = SymbolIndex::new();
-
-        index.add_symbol("calculate_total".to_string());
-        index.add_symbol("calculate_average".to_string());
-        index.add_symbol("get_user_name".to_string());
-
-        // Prefix search
-        let results = index.search_prefix("calc");
-        assert_eq!(results.len(), 2);
-        assert!(results.contains(&"calculate_total".to_string()));
-        assert!(results.contains(&"calculate_average".to_string()));
-
-        // Fuzzy search
-        let results = index.search_fuzzy("user name");
-        assert!(results.contains(&"get_user_name".to_string()));
     }
 
     #[test]
@@ -444,7 +264,6 @@ mod tests {
         let cache = Arc::new(AstCache::new(100, 60));
         let mut handles = vec![];
 
-        // Spawn multiple threads that access the cache concurrently
         for i in 0..10 {
             let cache_clone = Arc::clone(&cache);
             let handle = thread::spawn(move || {
@@ -453,18 +272,13 @@ mod tests {
                     perl_parser_core::SourceLocation { start: 0, end: 0 },
                 ));
 
-                // Perform multiple operations
                 for j in 0..50 {
                     let key = format!("file_{}_{}.pl", i, j);
                     let content = format!("content_{}", j);
 
-                    // Put
                     cache_clone.put(key.clone(), &content, ast.clone());
-
-                    // Get
                     let _ = cache_clone.get(&key, &content);
 
-                    // Cleanup (occasionally)
                     if j % 10 == 0 {
                         cache_clone.cleanup();
                     }
@@ -473,13 +287,11 @@ mod tests {
             handles.push(handle);
         }
 
-        // Wait for all threads to complete
         for handle in handles {
             let res = handle.join();
             assert!(res.is_ok(), "Thread should not panic");
         }
 
-        // Cache should still be functional
         let ast = Arc::new(Node::new(
             perl_parser_core::NodeKind::Program { statements: vec![] },
             perl_parser_core::SourceLocation { start: 0, end: 0 },
@@ -493,7 +305,6 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        // Create cache with 1 second TTL
         let cache = AstCache::new(10, 1);
         let ast = Arc::new(Node::new(
             perl_parser_core::NodeKind::Program { statements: vec![] },
@@ -501,14 +312,9 @@ mod tests {
         ));
 
         cache.put("test.pl".to_string(), "content", ast.clone());
-
-        // Should be cached immediately
         assert!(cache.get("test.pl", "content").is_some());
 
-        // Wait for TTL to expire
         thread::sleep(Duration::from_millis(1100));
-
-        // Should be expired now
         assert!(cache.get("test.pl", "content").is_none());
     }
 
@@ -524,14 +330,11 @@ mod tests {
             perl_parser_core::SourceLocation { start: 1, end: 1 },
         ));
 
-        // Cache with original content
         cache.put("test.pl".to_string(), "original content", ast1.clone());
         assert!(cache.get("test.pl", "original content").is_some());
 
-        // Different content should invalidate cache
         assert!(cache.get("test.pl", "modified content").is_none());
 
-        // Update with new content and AST
         cache.put("test.pl".to_string(), "modified content", ast2.clone());
         assert!(cache.get("test.pl", "modified content").is_some());
         assert!(cache.get("test.pl", "original content").is_none());
@@ -547,10 +350,9 @@ mod tests {
         let processed_clone = Arc::clone(&processed);
         let results = parallel::process_files_parallel(files, 2, move |_file| {
             processed_clone.fetch_add(1, Ordering::SeqCst);
-            42 // Return a value
+            42
         });
 
-        // All files should be processed
         assert_eq!(results.len(), 3);
         assert_eq!(processed.load(Ordering::SeqCst), 3);
         assert!(results.iter().all(|&x| x == 42));

--- a/crates/perl-parser/src/tooling.rs
+++ b/crates/perl-parser/src/tooling.rs
@@ -2,7 +2,8 @@
 
 /// Performance utilities for LSP feature optimization.
 pub mod performance {
-    pub use perl_lsp_tooling::performance::{AstCache, IncrementalParser, SymbolIndex, parallel};
+    pub use perl_lsp_tooling::SymbolIndex;
+    pub use perl_lsp_tooling::performance::{AstCache, IncrementalParser, parallel};
 }
 
 /// Perl critic integration for linting.

--- a/crates/perl-symbol-index/Cargo.toml
+++ b/crates/perl-symbol-index/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perl-symbol-index"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Symbol indexing helpers for prefix and fuzzy matching in Perl tooling"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-symbol-index"
+keywords = ["perl", "lsp", "symbol", "index"]
+categories = ["text-editors", "development-tools"]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-symbol-index/README.md
+++ b/crates/perl-symbol-index/README.md
@@ -1,0 +1,3 @@
+# perl-symbol-index
+
+Single-responsibility symbol indexing microcrate for prefix and fuzzy symbol matching.

--- a/crates/perl-symbol-index/src/lib.rs
+++ b/crates/perl-symbol-index/src/lib.rs
@@ -1,0 +1,168 @@
+//! Symbol indexing helpers for prefix and fuzzy matching.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::collections::HashMap;
+
+/// Symbol index for fast lookups.
+///
+/// Supports both prefix and fuzzy matching using a trie and inverted index.
+pub struct SymbolIndex {
+    /// Trie structure for prefix matching
+    trie: SymbolTrie,
+    /// Inverted index for fuzzy matching
+    inverted_index: HashMap<String, Vec<String>>,
+}
+
+/// Trie data structure for efficient prefix matching
+struct SymbolTrie {
+    /// Child nodes indexed by character
+    children: HashMap<char, Box<SymbolTrie>>,
+    /// Symbols stored at this node
+    symbols: Vec<String>,
+}
+
+impl Default for SymbolIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SymbolIndex {
+    /// Create a new empty symbol index
+    pub fn new() -> Self {
+        Self { trie: SymbolTrie::new(), inverted_index: HashMap::new() }
+    }
+
+    /// Add a symbol to the index.
+    ///
+    /// Indexes the symbol for both prefix and fuzzy matching.
+    pub fn add_symbol(&mut self, symbol: String) {
+        self.trie.insert(&symbol);
+
+        let tokens = Self::tokenize(&symbol);
+        for token in tokens {
+            self.inverted_index.entry(token).or_default().push(symbol.clone());
+        }
+    }
+
+    /// Search symbols with prefix.
+    ///
+    /// Returns all symbols starting with the given prefix.
+    pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        self.trie.search_prefix(prefix)
+    }
+
+    /// Fuzzy search symbols.
+    ///
+    /// Returns symbols matching any of the tokenized query words, sorted by relevance.
+    pub fn search_fuzzy(&self, query: &str) -> Vec<String> {
+        let tokens = Self::tokenize(query);
+        let mut results = HashMap::new();
+
+        for token in tokens {
+            if let Some(symbols) = self.inverted_index.get(&token) {
+                for symbol in symbols {
+                    *results.entry(symbol.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let mut sorted: Vec<_> = results.into_iter().collect();
+        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+        sorted.into_iter().map(|(symbol, _)| symbol).collect()
+    }
+
+    fn tokenize(s: &str) -> Vec<String> {
+        let mut tokens = Vec::new();
+        let mut current = String::new();
+        let mut prev_upper = false;
+
+        for ch in s.chars() {
+            if ch.is_uppercase() && !prev_upper && !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+            }
+
+            if ch.is_alphanumeric() {
+                current.push(ch);
+                prev_upper = ch.is_uppercase();
+            } else if !current.is_empty() {
+                tokens.push(current.to_lowercase());
+                current = String::new();
+                prev_upper = false;
+            }
+        }
+
+        if !current.is_empty() {
+            tokens.push(current.to_lowercase());
+        }
+
+        tokens
+    }
+}
+
+impl SymbolTrie {
+    fn new() -> Self {
+        Self { children: HashMap::new(), symbols: Vec::new() }
+    }
+
+    fn insert(&mut self, symbol: &str) {
+        let mut node = self;
+
+        for ch in symbol.chars() {
+            node = node.children.entry(ch).or_insert_with(|| Box::new(SymbolTrie::new()));
+        }
+
+        node.symbols.push(symbol.to_string());
+    }
+
+    fn search_prefix(&self, prefix: &str) -> Vec<String> {
+        let mut node = self;
+
+        for ch in prefix.chars() {
+            match node.children.get(&ch) {
+                Some(child) => node = child,
+                None => return Vec::new(),
+            }
+        }
+
+        let mut results = Vec::new();
+        Self::collect_all(node, &mut results);
+        results
+    }
+
+    fn collect_all(node: &SymbolTrie, results: &mut Vec<String>) {
+        results.extend(node.symbols.clone());
+
+        for child in node.children.values() {
+            Self::collect_all(child, results);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_symbol_index() {
+        let mut index = SymbolIndex::new();
+
+        index.add_symbol("calculate_total".to_string());
+        index.add_symbol("calculate_average".to_string());
+        index.add_symbol("get_user_name".to_string());
+
+        let results = index.search_prefix("calc");
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&"calculate_total".to_string()));
+        assert!(results.contains(&"calculate_average".to_string()));
+
+        let results = index.search_fuzzy("user name");
+        assert!(results.contains(&"get_user_name".to_string()));
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve single-responsibility separation by extracting symbol indexing (prefix + fuzzy search) out of the large `perl-lsp-tooling::performance` module into a focused microcrate to make the indexing code easier to maintain and reuse.
- Reduce surface area of the `performance` module so it concentrates on `AstCache`, incremental parsing and parallel file processing only.

### Description

- Added a new workspace microcrate `crates/perl-symbol-index` implementing `SymbolIndex` and its trie internals in `src/lib.rs` with focused unit tests and a `README.md` and `Cargo.toml` for the crate.
- Removed the `SymbolIndex` implementation from `crates/perl-lsp-tooling/src/performance.rs` and kept the `performance` module focused on `AstCache`, `IncrementalParser`, and `parallel::process_files_parallel`.
- Wired the new crate into the workspace by adding `crates/perl-symbol-index` to `Cargo.toml` members, `workspace.dependencies`, and the publish allowlist, and added `perl-symbol-index` as a dependency of `perl-lsp-tooling`.
- Re-exported the type via `perl-lsp-tooling` (`pub use perl_symbol_index::SymbolIndex;`) so downstream code continues to access the stable API, and updated `crates/perl-parser/src/tooling.rs` to re-export accordingly.

### Testing

- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-symbol-index -p perl-lsp-tooling -p perl-parser --lib` and all targeted unit tests passed (tests for the three crates succeeded).
- Ran `cargo clippy -p perl-symbol-index -p perl-lsp-tooling --all-targets -- -D warnings` and the checked crates passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b8261148333ab82b139c31fe474)