### PR TITLE
Extract workspace skip rules into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ name = "perl-workspace-discovery"
 version = "0.10.0"
 dependencies = [
  "perl-source-file",
+ "perl-workspace-skip",
  "proptest",
  "tempfile",
  "walkdir",
@@ -2500,6 +2501,10 @@ dependencies = [
  "parking_lot",
  "proptest",
 ]
+
+[[package]]
+name = "perl-workspace-skip"
+version = "0.10.0"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "crates/perl-uri",
     "crates/perl-path-security",
     "crates/perl-workspace-discovery",
+    "crates/perl-workspace-skip",
     "crates/perl-corpus",
     "crates/perl-lsp",
     "crates/perl-dap",
@@ -200,6 +201,7 @@ allow = [
     "perl-module-resolution",
     "perl-source-file",
     "perl-workspace-discovery",
+    "perl-workspace-skip",
     "perl-diagnostics-codes",
 
     # Tier 7 — Top-level application
@@ -258,6 +260,7 @@ perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
 perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
 perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }
+perl-workspace-skip = { path = "crates/perl-workspace-skip", version = "0.10.0" }
 perl-corpus = { path = "crates/perl-corpus", version = "0.10.0" }
 perl-dap = { path = "crates/perl-dap", version = "0.10.0" }
 perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }

--- a/crates/perl-workspace-discovery/Cargo.toml
+++ b/crates/perl-workspace-discovery/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-source-file = { workspace = true }
+perl-workspace-skip = { workspace = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -8,7 +8,8 @@
 //! are skipped in both modes (`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`).
 
 use perl_source_file::is_perl_source_path;
-use std::path::{Component, Path, PathBuf};
+use perl_workspace_skip::{is_skipped_dir_name, path_contains_skipped_component};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use walkdir::{DirEntry, WalkDir};
 
@@ -145,20 +146,7 @@ fn should_skip_dir(entry: &DirEntry) -> bool {
     }
 
     let name = entry.file_name().to_string_lossy();
-    matches!(name.as_ref(), ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-}
-
-fn path_contains_skipped_component(path: &Path) -> bool {
-    for component in path.components() {
-        if let Component::Normal(name) = component
-            && let Some(value) = name.to_str()
-            && matches!(value, ".git" | ".hg" | ".svn" | "target" | "node_modules" | ".cache")
-        {
-            return true;
-        }
-    }
-
-    false
+    is_skipped_dir_name(name.as_ref())
 }
 
 fn log_discovery(result: &DiscoveryResult) {

--- a/crates/perl-workspace-skip/Cargo.toml
+++ b/crates/perl-workspace-skip/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "perl-workspace-skip"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for workspace directory skip rules"
+readme = "README.md"
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-skip/README.md
+++ b/crates/perl-workspace-skip/README.md
@@ -1,0 +1,6 @@
+# perl-workspace-skip
+
+Reusable skip-directory rules for workspace scans.
+
+This crate centralizes the canonical list of non-source directories:
+`.git`, `.hg`, `.svn`, `target`, `node_modules`, `.cache`.

--- a/crates/perl-workspace-skip/src/lib.rs
+++ b/crates/perl-workspace-skip/src/lib.rs
@@ -1,0 +1,63 @@
+//! Canonical workspace skip-directory rules.
+//!
+//! This microcrate provides one responsibility: identify directories and paths
+//! that should be skipped during repository/workspace traversal.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use std::path::{Component, Path};
+
+/// Canonical directory names to skip during workspace traversal.
+pub const SKIPPED_DIRECTORY_NAMES: &[&str] =
+    &[".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+
+/// Return whether a directory name should be skipped.
+#[must_use]
+pub fn is_skipped_dir_name(name: &str) -> bool {
+    SKIPPED_DIRECTORY_NAMES.contains(&name)
+}
+
+/// Return whether any component in `path` should be skipped.
+#[must_use]
+pub fn path_contains_skipped_component(path: &Path) -> bool {
+    path.components().any(|component| {
+        if let Component::Normal(name) = component
+            && let Some(value) = name.to_str()
+        {
+            return is_skipped_dir_name(value);
+        }
+
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SKIPPED_DIRECTORY_NAMES, is_skipped_dir_name, path_contains_skipped_component};
+    use std::path::Path;
+
+    #[test]
+    fn skipped_directory_names_are_stable() {
+        assert_eq!(
+            SKIPPED_DIRECTORY_NAMES,
+            &[".git", ".hg", ".svn", "target", "node_modules", ".cache"]
+        );
+    }
+
+    #[test]
+    fn identifies_skipped_directory_names() {
+        assert!(is_skipped_dir_name("target"));
+        assert!(is_skipped_dir_name("node_modules"));
+        assert!(!is_skipped_dir_name("src"));
+    }
+
+    #[test]
+    fn detects_skipped_components_in_paths() {
+        assert!(path_contains_skipped_component(Path::new("/repo/node_modules/pkg.pm")));
+        assert!(path_contains_skipped_component(Path::new("a/target/build/out.pm")));
+        assert!(!path_contains_skipped_component(Path::new("/repo/lib/My/Module.pm")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication and follow Single Responsibility Principle by moving workspace skip-directory and path-component filtering out of the discovery crate into a small reusable microcrate.
- Make skip rules available to other workspace/indexing components without coupling them to `perl-workspace-discovery` implementation details.
- Keep discovery focused on the discovery strategy (git vs WalkDir) while centralizing the canonical skip list for easier maintenance and testing.

### Description
- Added a new microcrate `perl-workspace-skip` containing `SKIPPED_DIRECTORY_NAMES`, `is_skipped_dir_name`, and `path_contains_skipped_component` along with unit tests in `crates/perl-workspace-skip/src/lib.rs`.
- Wired `perl-workspace-discovery` to depend on `perl-workspace-skip` and replaced the local inline skip logic with calls to `is_skipped_dir_name` and `path_contains_skipped_component` in `crates/perl-workspace-discovery/src/lib.rs`.
- Registered `perl-workspace-skip` in the workspace members, workspace dependency table, and publish allowlist in `Cargo.toml` and the workspace lock updated accordingly.
- Added crate metadata and a short `README.md` for the new microcrate to make it independently consumable.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Executed the unit test suites with `cargo test -p perl-workspace-skip -p perl-workspace-discovery` and all tests in both crates passed.
- Verified the new crate tests cover the canonical skip names and path-component detection and that discovery tests remain green after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b810f688333a9292d386889418f)