### PR TITLE
Split feature-profile CLI parsing into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ dependencies = [
  "perl-lsp-feature-grid",
  "perl-lsp-feature-policy",
  "perl-lsp-feature-profile",
- "perl-tdd-support",
+ "perl-lsp-feature-profile-cli",
 ]
 
 [[package]]
@@ -1914,6 +1914,15 @@ name = "perl-lsp-feature-profile"
 version = "0.10.0"
 dependencies = [
  "perl-lsp-feature-contracts",
+]
+
+[[package]]
+name = "perl-lsp-feature-profile-cli"
+version = "0.10.0"
+dependencies = [
+ "perl-lsp-feature-policy",
+ "perl-lsp-feature-profile",
+ "perl-tdd-support",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/perl-lsp-feature-ids",
     "crates/perl-lsp-capability-map",
     "crates/perl-lsp-feature-profile",
+    "crates/perl-lsp-feature-profile-cli",
     "crates/perl-lsp-feature-governance",
     "crates/perl-lsp-launcher",
     "crates/perl-lsp-diagnostic-catalog",
@@ -209,6 +210,7 @@ allow = [
     "perl-lsp-feature-contracts",
     "perl-lsp-feature-flags",
     "perl-lsp-feature-profile",
+    "perl-lsp-feature-profile-cli",
     "perl-lsp-feature-policy",
     "perl-lsp-feature-grid",
     "perl-lsp-feature-governance",
@@ -330,6 +332,7 @@ perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
 perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.10.0" }
 perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.10.0" }
 perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.10.0" }
+perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.10.0" }
 perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.10.0" }
 perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.10.0" }
 perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.10.0" }

--- a/crates/perl-lsp-feature-governance/src/lib.rs
+++ b/crates/perl-lsp-feature-governance/src/lib.rs
@@ -1,10 +1,8 @@
 //! Feature governance façade for Perl LSP.
 //!
-//! This crate consolidates profile parsing, profile policy, and BDD-grid reporting
-//! APIs into a single stability boundary so CLI, runtime startup, and external
-//! tooling share one canonical implementation.
-
-use std::fmt;
+//! This crate consolidates profile policy and BDD-grid reporting APIs into a
+//! single stability boundary so runtime startup and external tooling share one
+//! canonical implementation.
 
 pub use perl_lsp_feature_contracts::{
     BddFeatureRow, Feature, FeatureProfileSpec, LSP_VERSION, VERSION, advertised_features,
@@ -24,95 +22,11 @@ pub use perl_lsp_feature_profile::{
     FeatureProfileKind, from_str_name as parse_profile_name, parse_profile_token,
     supported_cli_profiles,
 };
-
-/// Parse a `--feature-profile` argument into a runtime policy.
-///
-/// Returns a structured error when the raw token is unknown. The error includes
-/// the current supported token set for CLI/user-facing diagnostics.
-pub fn parse_feature_profile_arg(
-    raw_profile: &str,
-) -> Result<FeatureProfile, UnsupportedFeatureProfileError> {
-    match parse_profile_token(raw_profile) {
-        Some(kind) => Ok(FeatureProfile::from_kind(kind)),
-        None => Err(UnsupportedFeatureProfileError { raw_profile: raw_profile.to_string() }),
-    }
-}
-
-/// Parse a profile argument and fall back to `FeatureProfile::current()`.
-pub fn parse_feature_profile_arg_or_current(raw_profile: &str) -> FeatureProfile {
-    parse_feature_profile_arg(raw_profile).unwrap_or_else(|_| FeatureProfile::current())
-}
-
-/// Canonical profile label for logs and diagnostics.
-pub const fn feature_profile_label(profile: FeatureProfile) -> &'static str {
-    profile.as_str()
-}
-
-/// Supported CLI tokens accepted by the profile parser.
-pub const fn feature_profile_supported_tokens() -> &'static [&'static str] {
-    FeatureProfile::supported_cli_profiles()
-}
-
+pub use perl_lsp_feature_profile_cli::{
+    UnsupportedFeatureProfileError, feature_profile_label, feature_profile_supported_tokens,
+    parse_feature_profile_arg, parse_feature_profile_arg_or_current,
+};
 /// Return the canonical profile metadata contract rows used by BDD reporting.
 pub const fn feature_profile_metadata() -> &'static [FeatureProfileSpec] {
     feature_profile_specs()
-}
-
-/// Structured parse error for invalid profile tokens.
-#[derive(Debug)]
-pub struct UnsupportedFeatureProfileError {
-    /// Raw token that could not be resolved.
-    pub raw_profile: String,
-}
-
-impl UnsupportedFeatureProfileError {
-    /// Human-friendly error message with support list.
-    pub fn message(&self) -> String {
-        let supported = feature_profile_supported_tokens().join(", ");
-        format!("Invalid feature profile: {}. Supported: {}", self.raw_profile, supported)
-    }
-}
-
-impl fmt::Display for UnsupportedFeatureProfileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message())
-    }
-}
-
-impl std::error::Error for UnsupportedFeatureProfileError {}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        FeatureProfile, feature_profile_supported_tokens, parse_feature_profile_arg,
-        parse_feature_profile_arg_or_current,
-    };
-    use perl_tdd_support::must;
-
-    #[test]
-    fn parse_feature_profile_accepts_known_aliases() {
-        let profile = must(parse_feature_profile_arg("ga_lock"));
-        assert_eq!(profile.as_str(), "ga-lock");
-
-        let profile = must(parse_feature_profile_arg("Prod"));
-        assert_eq!(profile.as_str(), "production");
-
-        let profile = must(parse_feature_profile_arg("  ALL  "));
-        assert_eq!(profile.as_str(), "all");
-    }
-
-    #[test]
-    fn parse_unknown_profile_falls_back_to_current() {
-        let profile = parse_feature_profile_arg_or_current("unknown-profile");
-        assert_eq!(profile, FeatureProfile::current());
-    }
-
-    #[test]
-    fn supported_tokens_contain_expected() {
-        let supported = feature_profile_supported_tokens();
-        assert!(supported.contains(&"auto"));
-        assert!(supported.contains(&"ga"));
-        assert!(supported.contains(&"prod"));
-        assert!(supported.contains(&"all"));
-    }
 }

--- a/crates/perl-lsp-feature-profile-cli/Cargo.toml
+++ b/crates/perl-lsp-feature-profile-cli/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "perl-lsp-feature-profile-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "CLI profile token parsing for Perl LSP feature profiles."
+documentation = "https://docs.rs/perl-lsp-feature-profile-cli"
+readme = "README.md"
+keywords = ["perl", "lsp", "features", "profile", "cli"]
+categories = ["development-tools", "command-line-interface"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+perl-lsp-feature-policy = { workspace = true }
+perl-lsp-feature-profile = { workspace = true }
+
+[features]
+lsp-ga-lock = [
+    "perl-lsp-feature-policy/lsp-ga-lock",
+    "perl-lsp-feature-profile/lsp-ga-lock",
+]
+
+[dev-dependencies]
+perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-feature-profile-cli/README.md
+++ b/crates/perl-lsp-feature-profile-cli/README.md
@@ -1,0 +1,9 @@
+# perl-lsp-feature-profile-cli
+
+CLI argument parsing helpers for Perl LSP feature profile selection.
+
+This microcrate is intentionally small and focused:
+
+- Parse user-provided `--feature-profile` tokens.
+- Provide canonical profile labels and supported token lists.
+- Emit structured errors for unsupported profile names.

--- a/crates/perl-lsp-feature-profile-cli/src/lib.rs
+++ b/crates/perl-lsp-feature-profile-cli/src/lib.rs
@@ -1,0 +1,96 @@
+//! CLI profile-token parsing for Perl LSP feature governance.
+//!
+//! This microcrate owns one responsibility: parse user-facing profile tokens
+//! and expose diagnostics helpers for invalid values.
+
+use std::fmt;
+
+pub use perl_lsp_feature_policy::FeatureProfile;
+use perl_lsp_feature_profile::parse_profile_token;
+
+/// Parse a `--feature-profile` argument into a runtime policy.
+///
+/// Returns a structured error when the raw token is unknown. The error includes
+/// the current supported token set for CLI/user-facing diagnostics.
+pub fn parse_feature_profile_arg(
+    raw_profile: &str,
+) -> Result<FeatureProfile, UnsupportedFeatureProfileError> {
+    match parse_profile_token(raw_profile) {
+        Some(kind) => Ok(FeatureProfile::from_kind(kind)),
+        None => Err(UnsupportedFeatureProfileError { raw_profile: raw_profile.to_string() }),
+    }
+}
+
+/// Parse a profile argument and fall back to `FeatureProfile::current()`.
+pub fn parse_feature_profile_arg_or_current(raw_profile: &str) -> FeatureProfile {
+    parse_feature_profile_arg(raw_profile).unwrap_or_else(|_| FeatureProfile::current())
+}
+
+/// Canonical profile label for logs and diagnostics.
+pub const fn feature_profile_label(profile: FeatureProfile) -> &'static str {
+    profile.as_str()
+}
+
+/// Supported CLI tokens accepted by the profile parser.
+pub const fn feature_profile_supported_tokens() -> &'static [&'static str] {
+    FeatureProfile::supported_cli_profiles()
+}
+
+/// Structured parse error for invalid profile tokens.
+#[derive(Debug)]
+pub struct UnsupportedFeatureProfileError {
+    /// Raw token that could not be resolved.
+    pub raw_profile: String,
+}
+
+impl UnsupportedFeatureProfileError {
+    /// Human-friendly error message with support list.
+    pub fn message(&self) -> String {
+        let supported = feature_profile_supported_tokens().join(", ");
+        format!("Invalid feature profile: {}. Supported: {}", self.raw_profile, supported)
+    }
+}
+
+impl fmt::Display for UnsupportedFeatureProfileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message())
+    }
+}
+
+impl std::error::Error for UnsupportedFeatureProfileError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FeatureProfile, feature_profile_supported_tokens, parse_feature_profile_arg,
+        parse_feature_profile_arg_or_current,
+    };
+    use perl_tdd_support::must;
+
+    #[test]
+    fn parse_feature_profile_accepts_known_aliases() {
+        let profile = must(parse_feature_profile_arg("ga_lock"));
+        assert_eq!(profile.as_str(), "ga-lock");
+
+        let profile = must(parse_feature_profile_arg("Prod"));
+        assert_eq!(profile.as_str(), "production");
+
+        let profile = must(parse_feature_profile_arg("  ALL  "));
+        assert_eq!(profile.as_str(), "all");
+    }
+
+    #[test]
+    fn parse_unknown_profile_falls_back_to_current() {
+        let profile = parse_feature_profile_arg_or_current("unknown-profile");
+        assert_eq!(profile, FeatureProfile::current());
+    }
+
+    #[test]
+    fn supported_tokens_contain_expected() {
+        let supported = feature_profile_supported_tokens();
+        assert!(supported.contains(&"auto"));
+        assert!(supported.contains(&"ga"));
+        assert!(supported.contains(&"prod"));
+        assert!(supported.contains(&"all"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Extract the CLI-facing profile-token parsing logic from the governance façade to follow SRP and make the parsing helpers independently reusable by CLI/runtime entrypoints.
- Preserve the governance crate as the stability boundary for profile policy and BDD reporting while reducing surface area and coupling.

### Description
- Added a new microcrate `perl-lsp-feature-profile-cli` containing `parse_feature_profile_arg`, `parse_feature_profile_arg_or_current`, `feature_profile_label`, `feature_profile_supported_tokens`, and the `UnsupportedFeatureProfileError` type with tests and README. 
- Removed the CLI parsing implementation from `perl-lsp-feature-governance` and re-exported the CLI symbols from the new microcrate to keep downstream API compatibility. 
- Wired the new crate into the workspace by adding it to `members`, the workspace dependency catalog, and the publish allowlist, and forwarded the `lsp-ga-lock` feature into the governance features. 
- Added `Cargo.toml` metadata and small docs for the new microcrate and updated formatting (`cargo fmt`).

### Testing
- Ran `cargo fmt --all` and it completed successfully. 
- Ran `cargo test -p perl-lsp-feature-profile-cli -p perl-lsp-feature-governance` and all unit tests passed for the new crate and governance re-exports. 
- Ran `cargo check -p perl-lsp` to verify workspace integration and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b810f688333a9292d386889418f)