### PR TITLE
refactor: reuse perl-qualified-name helpers in navigation symbol parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,7 @@ dependencies = [
  "perl-module-path",
  "perl-parser-core",
  "perl-position-tracking",
+ "perl-qualified-name",
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "serde",

--- a/crates/perl-lsp-navigation/src/references.rs
+++ b/crates/perl-lsp-navigation/src/references.rs
@@ -35,6 +35,7 @@
 //! ```
 
 use perl_parser_core::ast::{Node, NodeKind};
+use perl_qualified_name::split_qualified_name;
 
 /// Return (start_offset, end_offset) for same-file references
 pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usize, usize)>> {
@@ -47,19 +48,15 @@ pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usi
             ("var", "main".to_string(), name.clone(), sigil_char)
         }
         NodeKind::FunctionCall { name, .. } => {
-            let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                (name[..idx].to_string(), name[idx + 2..].to_string())
-            } else {
-                ("main".to_string(), name.clone())
-            };
+            let (pkg, bare) = split_qualified_name(name);
+            let pkg = pkg.unwrap_or("main").to_string();
+            let bare = bare.to_string();
             ("sub", pkg, bare, None)
         }
         NodeKind::Subroutine { name: Some(name), .. } => {
-            let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                (name[..idx].to_string(), name[idx + 2..].to_string())
-            } else {
-                ("main".to_string(), name.clone())
-            };
+            let (pkg, bare) = split_qualified_name(name);
+            let pkg = pkg.unwrap_or("main").to_string();
+            let bare = bare.to_string();
             ("sub", pkg, bare, None)
         }
         _ => return None,
@@ -84,11 +81,8 @@ pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usi
                 }
             }
             NodeKind::FunctionCall { name, .. } if want_kind == "sub" => {
-                let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                    (&name[..idx], &name[idx + 2..])
-                } else {
-                    ("main", name.as_str())
-                };
+                let (pkg, bare) = split_qualified_name(name);
+                let pkg = pkg.unwrap_or("main");
                 if bare == want_name && pkg == want_pkg {
                     out.push((location.start, location.end));
                 }

--- a/crates/perl-lsp-navigation/src/workspace_symbols.rs
+++ b/crates/perl-lsp-navigation/src/workspace_symbols.rs
@@ -68,28 +68,10 @@ use perl_lsp_symbol_query::{compare_names_by_query, matches_query};
 use perl_module_path::normalize_package_separator;
 use perl_parser_core::{SourceLocation, ast::Node};
 use perl_position_tracking::{WireLocation, WireRange};
+use perl_qualified_name::container_name;
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-/// Extract container name from qualified symbol name.
-///
-/// Extracts the package/class portion from a fully qualified symbol name,
-/// following Perl's package qualification rules.
-///
-/// Examples:
-/// - `"Foo::Bar::baz"` → `Some("Foo::Bar")`
-/// - `"MyClass::new"` → `Some("MyClass")`
-/// - `"toplevel"` → `None`
-///
-/// # Performance
-/// - Time complexity: O(n) string scan
-/// - Memory: Allocates only when container exists
-fn extract_container_name(qualified_name: &str) -> Option<String> {
-    // "Foo::Bar::baz" → container = "Foo::Bar"
-    // Top-level symbols have no container
-    qualified_name.rfind("::").map(|idx| qualified_name[..idx].to_string())
-}
 
 /// LSP WorkspaceSymbol representing a symbol found in the workspace.
 ///
@@ -158,7 +140,7 @@ impl WorkspaceSymbolsProvider {
         // Extract symbols from the symbol table
         for (name, symbol_list) in &table.symbols {
             for symbol in symbol_list {
-                let container = extract_container_name(&symbol.qualified_name);
+                let container = container_name(&symbol.qualified_name).map(str::to_string);
 
                 symbols.push(SymbolInfo {
                     name: name.clone(),
@@ -431,22 +413,28 @@ sub baz {
     #[test]
     fn test_extract_container_name() {
         // Nested package qualification
-        assert_eq!(extract_container_name("Foo::Bar::baz"), Some("Foo::Bar".to_string()));
+        assert_eq!(
+            container_name("Foo::Bar::baz").map(str::to_string),
+            Some("Foo::Bar".to_string())
+        );
 
         // Simple package qualification
-        assert_eq!(extract_container_name("MyClass::new"), Some("MyClass".to_string()));
+        assert_eq!(container_name("MyClass::new").map(str::to_string), Some("MyClass".to_string()));
 
         // Top-level symbol (no container)
-        assert_eq!(extract_container_name("toplevel"), None);
+        assert_eq!(container_name("toplevel").map(str::to_string), None);
 
         // Empty string
-        assert_eq!(extract_container_name(""), None);
+        assert_eq!(container_name("").map(str::to_string), None);
 
         // Package name only (no method)
-        assert_eq!(extract_container_name("Package::"), Some("Package".to_string()));
+        assert_eq!(container_name("Package::").map(str::to_string), Some("Package".to_string()));
 
         // Deep nesting
-        assert_eq!(extract_container_name("A::B::C::D::method"), Some("A::B::C::D".to_string()));
+        assert_eq!(
+            container_name("A::B::C::D::method").map(str::to_string),
+            Some("A::B::C::D".to_string())
+        );
     }
 
     #[test]

--- a/crates/perl-qualified-name/src/lib.rs
+++ b/crates/perl-qualified-name/src/lib.rs
@@ -61,6 +61,15 @@ pub fn split_qualified_name(name: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// Extract the parent container/package from a qualified Perl symbol.
+///
+/// `Foo::Bar::baz` => `Some("Foo::Bar")`
+/// `process` => `None`
+#[must_use]
+pub fn container_name(name: &str) -> Option<&str> {
+    split_qualified_name(name).0
+}
+
 /// Validate a full Perl qualified name with package separators.
 ///
 /// - Rejects empty input.
@@ -102,12 +111,24 @@ pub fn is_valid_identifier_part(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_valid_identifier_part, split_qualified_name, validate_perl_qualified_name};
+    use super::{
+        container_name, is_valid_identifier_part, split_qualified_name,
+        validate_perl_qualified_name,
+    };
 
     #[test]
     fn splits_qualified_and_unqualified_names() {
         assert_eq!(split_qualified_name("Foo::Bar"), (Some("Foo"), "Bar"));
         assert_eq!(split_qualified_name("process"), (None, "process"));
+    }
+
+    #[test]
+    fn extracts_container_name() {
+        assert_eq!(container_name("Foo::Bar::baz"), Some("Foo::Bar"));
+        assert_eq!(container_name("MyClass::new"), Some("MyClass"));
+        assert_eq!(container_name("toplevel"), None);
+        assert_eq!(container_name(""), None);
+        assert_eq!(container_name("Package::"), Some("Package"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Remove duplicated `::` qualified-name parsing logic spread across navigation code and centralize it in the existing SRP microcrate that already owns qualified-name behavior.
- Keep package/container extraction behavior consistent across workspace symbol indexing and reference finding by reusing a single, tested helper.

### Description

- Added `container_name()` to `crates/perl-qualified-name/src/lib.rs` to expose parent container/package extraction for qualified Perl symbols and added unit tests for it.
- Updated `crates/perl-lsp-navigation/src/workspace_symbols.rs` to consume `perl_qualified_name::container_name` instead of an internal `extract_container_name` implementation and adapted tests to call the new helper.
- Updated `crates/perl-lsp-navigation/src/references.rs` to use `perl_qualified_name::split_qualified_name` for subroutine/function name splitting instead of inline `rfind("::")` logic.
- Wired `perl-lsp-navigation` to depend on `perl-qualified-name` by updating `crates/perl-lsp-navigation/Cargo.toml` and refreshed `Cargo.lock` to include the new dependency.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran unit tests with `cargo test -p perl-qualified-name -p perl-lsp-navigation` and all tests for both crates passed (see `perl-qualified-name` and `perl-lsp-navigation` test suites).
- Ran `cargo clippy -p perl-qualified-name -p perl-lsp-navigation --all-targets -- -D warnings`; Clippy surfaced pre-existing test-only warnings about default-constructed unit structs in test files which are unrelated to this refactor and are not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b807e008333ad7d5034fbcab501)