### PR TITLE
Split feature profile CLI parsing into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-feature-cli"
+version = "0.10.0"
+dependencies = [
+ "perl-lsp-feature-policy",
+ "perl-lsp-feature-profile",
+ "perl-tdd-support",
+]
+
+[[package]]
 name = "perl-lsp-feature-contracts"
 version = "0.10.0"
 dependencies = [
@@ -1859,6 +1868,7 @@ dependencies = [
 name = "perl-lsp-feature-governance"
 version = "0.10.0"
 dependencies = [
+ "perl-lsp-feature-cli",
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-grid",
  "perl-lsp-feature-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/perl-lsp-semantic-tokens",
     "crates/perl-lsp-inlay-hints",
     "crates/perl-lsp-feature-contracts",
+    "crates/perl-lsp-feature-cli",
     "crates/perl-lsp-feature-flags",
     "crates/perl-lsp-feature-grid",
     "crates/perl-lsp-feature-ids",
@@ -178,6 +179,7 @@ allow = [
     "perl-lsp-feature-ids",
     "perl-lsp-capability-map",
     "perl-lsp-feature-contracts",
+    "perl-lsp-feature-cli",
     "perl-lsp-feature-flags",
     "perl-lsp-feature-profile",
     "perl-lsp-feature-policy",
@@ -283,6 +285,7 @@ perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0
 perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.10.0" }
 perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.10.0" }
 perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.10.0" }
+perl-lsp-feature-cli = { path = "crates/perl-lsp-feature-cli", version = "0.10.0" }
 perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.10.0" }
 perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
 perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.10.0" }

--- a/crates/perl-lsp-feature-cli/Cargo.toml
+++ b/crates/perl-lsp-feature-cli/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "perl-lsp-feature-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "CLI-oriented feature profile parsing helpers for Perl LSP."
+documentation = "https://docs.rs/perl-lsp-feature-cli"
+readme = "README.md"
+keywords = ["perl", "lsp", "features", "profile", "cli"]
+categories = ["development-tools", "command-line-interface"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+perl-lsp-feature-policy = { workspace = true }
+perl-lsp-feature-profile = { workspace = true }
+
+[features]
+lsp-ga-lock = [
+    "perl-lsp-feature-policy/lsp-ga-lock",
+    "perl-lsp-feature-profile/lsp-ga-lock",
+]
+
+[dev-dependencies]
+perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-feature-cli/README.md
+++ b/crates/perl-lsp-feature-cli/README.md
@@ -1,0 +1,3 @@
+# perl-lsp-feature-cli
+
+CLI-facing helpers for parsing and validating Perl LSP feature profile arguments.

--- a/crates/perl-lsp-feature-cli/src/lib.rs
+++ b/crates/perl-lsp-feature-cli/src/lib.rs
@@ -1,0 +1,98 @@
+//! CLI-facing feature profile parsing and validation helpers.
+//!
+//! This crate centralizes argument parsing semantics so launcher/runtime code can
+//! share one stable behavior surface for supported profile tokens.
+
+#![deny(unsafe_code)]
+
+use std::fmt;
+
+pub use perl_lsp_feature_policy::FeatureProfile;
+use perl_lsp_feature_profile::parse_profile_token;
+
+/// Parse a `--feature-profile` argument into a runtime policy.
+///
+/// Returns a structured error when the raw token is unknown. The error includes
+/// the current supported token set for CLI/user-facing diagnostics.
+pub fn parse_feature_profile_arg(
+    raw_profile: &str,
+) -> Result<FeatureProfile, UnsupportedFeatureProfileError> {
+    match parse_profile_token(raw_profile) {
+        Some(kind) => Ok(FeatureProfile::from_kind(kind)),
+        None => Err(UnsupportedFeatureProfileError { raw_profile: raw_profile.to_string() }),
+    }
+}
+
+/// Parse a profile argument and fall back to `FeatureProfile::current()`.
+pub fn parse_feature_profile_arg_or_current(raw_profile: &str) -> FeatureProfile {
+    parse_feature_profile_arg(raw_profile).unwrap_or_else(|_| FeatureProfile::current())
+}
+
+/// Canonical profile label for logs and diagnostics.
+pub const fn feature_profile_label(profile: FeatureProfile) -> &'static str {
+    profile.as_str()
+}
+
+/// Supported CLI tokens accepted by the profile parser.
+pub const fn feature_profile_supported_tokens() -> &'static [&'static str] {
+    FeatureProfile::supported_cli_profiles()
+}
+
+/// Structured parse error for invalid profile tokens.
+#[derive(Debug)]
+pub struct UnsupportedFeatureProfileError {
+    /// Raw token that could not be resolved.
+    pub raw_profile: String,
+}
+
+impl UnsupportedFeatureProfileError {
+    /// Human-friendly error message with support list.
+    pub fn message(&self) -> String {
+        let supported = feature_profile_supported_tokens().join(", ");
+        format!("Invalid feature profile: {}. Supported: {}", self.raw_profile, supported)
+    }
+}
+
+impl fmt::Display for UnsupportedFeatureProfileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message())
+    }
+}
+
+impl std::error::Error for UnsupportedFeatureProfileError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FeatureProfile, feature_profile_supported_tokens, parse_feature_profile_arg,
+        parse_feature_profile_arg_or_current,
+    };
+    use perl_tdd_support::must;
+
+    #[test]
+    fn parse_feature_profile_accepts_known_aliases() {
+        let profile = must(parse_feature_profile_arg("ga_lock"));
+        assert_eq!(profile.as_str(), "ga-lock");
+
+        let profile = must(parse_feature_profile_arg("Prod"));
+        assert_eq!(profile.as_str(), "production");
+
+        let profile = must(parse_feature_profile_arg("  ALL  "));
+        assert_eq!(profile.as_str(), "all");
+    }
+
+    #[test]
+    fn parse_unknown_profile_falls_back_to_current() {
+        let profile = parse_feature_profile_arg_or_current("unknown-profile");
+        assert_eq!(profile, FeatureProfile::current());
+    }
+
+    #[test]
+    fn supported_tokens_contain_expected() {
+        let supported = feature_profile_supported_tokens();
+        assert!(supported.contains(&"auto"));
+        assert!(supported.contains(&"ga"));
+        assert!(supported.contains(&"prod"));
+        assert!(supported.contains(&"all"));
+    }
+}

--- a/crates/perl-lsp-feature-governance/Cargo.toml
+++ b/crates/perl-lsp-feature-governance/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
+perl-lsp-feature-cli = { workspace = true }
 perl-lsp-feature-contracts = { workspace = true }
 perl-lsp-feature-grid = { workspace = true }
 perl-lsp-feature-policy = { workspace = true }
@@ -23,6 +24,7 @@ perl-lsp-feature-profile = { workspace = true }
 [features]
 lsp-ga-lock = [
     "perl-lsp-feature-contracts/lsp-ga-lock",
+    "perl-lsp-feature-cli/lsp-ga-lock",
     "perl-lsp-feature-grid/lsp-ga-lock",
     "perl-lsp-feature-policy/lsp-ga-lock",
     "perl-lsp-feature-profile/lsp-ga-lock",

--- a/crates/perl-lsp-feature-governance/src/lib.rs
+++ b/crates/perl-lsp-feature-governance/src/lib.rs
@@ -4,8 +4,11 @@
 //! APIs into a single stability boundary so CLI, runtime startup, and external
 //! tooling share one canonical implementation.
 
-use std::fmt;
-
+pub use perl_lsp_feature_cli::{
+    FeatureProfile, UnsupportedFeatureProfileError, feature_profile_label,
+    feature_profile_supported_tokens, parse_feature_profile_arg,
+    parse_feature_profile_arg_or_current,
+};
 pub use perl_lsp_feature_contracts::{
     BddFeatureRow, Feature, FeatureProfileSpec, LSP_VERSION, VERSION, advertised_features,
     advertised_trackable_feature_count_for_grid, all_features, bdd_feature_rows,
@@ -17,102 +20,14 @@ pub use perl_lsp_feature_grid::{
     to_json_for_all_profiles, to_json_for_profile, to_json_for_profiles,
 };
 pub use perl_lsp_feature_policy::{
-    FeatureProfile, catalog_advertised_feature_ids, feature_ids_from_flags, flags_for_profile,
-    flags_for_runtime,
+    catalog_advertised_feature_ids, feature_ids_from_flags, flags_for_profile, flags_for_runtime,
 };
 pub use perl_lsp_feature_profile::{
     FeatureProfileKind, from_str_name as parse_profile_name, parse_profile_token,
     supported_cli_profiles,
 };
 
-/// Parse a `--feature-profile` argument into a runtime policy.
-///
-/// Returns a structured error when the raw token is unknown. The error includes
-/// the current supported token set for CLI/user-facing diagnostics.
-pub fn parse_feature_profile_arg(
-    raw_profile: &str,
-) -> Result<FeatureProfile, UnsupportedFeatureProfileError> {
-    match parse_profile_token(raw_profile) {
-        Some(kind) => Ok(FeatureProfile::from_kind(kind)),
-        None => Err(UnsupportedFeatureProfileError { raw_profile: raw_profile.to_string() }),
-    }
-}
-
-/// Parse a profile argument and fall back to `FeatureProfile::current()`.
-pub fn parse_feature_profile_arg_or_current(raw_profile: &str) -> FeatureProfile {
-    parse_feature_profile_arg(raw_profile).unwrap_or_else(|_| FeatureProfile::current())
-}
-
-/// Canonical profile label for logs and diagnostics.
-pub const fn feature_profile_label(profile: FeatureProfile) -> &'static str {
-    profile.as_str()
-}
-
-/// Supported CLI tokens accepted by the profile parser.
-pub const fn feature_profile_supported_tokens() -> &'static [&'static str] {
-    FeatureProfile::supported_cli_profiles()
-}
-
 /// Return the canonical profile metadata contract rows used by BDD reporting.
 pub const fn feature_profile_metadata() -> &'static [FeatureProfileSpec] {
     feature_profile_specs()
-}
-
-/// Structured parse error for invalid profile tokens.
-#[derive(Debug)]
-pub struct UnsupportedFeatureProfileError {
-    /// Raw token that could not be resolved.
-    pub raw_profile: String,
-}
-
-impl UnsupportedFeatureProfileError {
-    /// Human-friendly error message with support list.
-    pub fn message(&self) -> String {
-        let supported = feature_profile_supported_tokens().join(", ");
-        format!("Invalid feature profile: {}. Supported: {}", self.raw_profile, supported)
-    }
-}
-
-impl fmt::Display for UnsupportedFeatureProfileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message())
-    }
-}
-
-impl std::error::Error for UnsupportedFeatureProfileError {}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        FeatureProfile, feature_profile_supported_tokens, parse_feature_profile_arg,
-        parse_feature_profile_arg_or_current,
-    };
-    use perl_tdd_support::must;
-
-    #[test]
-    fn parse_feature_profile_accepts_known_aliases() {
-        let profile = must(parse_feature_profile_arg("ga_lock"));
-        assert_eq!(profile.as_str(), "ga-lock");
-
-        let profile = must(parse_feature_profile_arg("Prod"));
-        assert_eq!(profile.as_str(), "production");
-
-        let profile = must(parse_feature_profile_arg("  ALL  "));
-        assert_eq!(profile.as_str(), "all");
-    }
-
-    #[test]
-    fn parse_unknown_profile_falls_back_to_current() {
-        let profile = parse_feature_profile_arg_or_current("unknown-profile");
-        assert_eq!(profile, FeatureProfile::current());
-    }
-
-    #[test]
-    fn supported_tokens_contain_expected() {
-        let supported = feature_profile_supported_tokens();
-        assert!(supported.contains(&"auto"));
-        assert!(supported.contains(&"ga"));
-        assert!(supported.contains(&"prod"));
-        assert!(supported.contains(&"all"));
-    }
 }


### PR DESCRIPTION
### Motivation
- Reduce coupling by extracting CLI-facing feature profile parsing and validation into a single-responsibility microcrate so governance code can focus on aggregation/reporting.
- Preserve downstream compatibility by keeping governance as a façade while moving user-facing parse semantics into a focused crate.

### Description
- Add a new crate `crates/perl-lsp-feature-cli` containing CLI helpers: `parse_feature_profile_arg`, `parse_feature_profile_arg_or_current`, `feature_profile_label`, `feature_profile_supported_tokens`, and `UnsupportedFeatureProfileError` with unit tests in `src/lib.rs` and crate metadata in `Cargo.toml` and `README.md`.
- Remove the CLI parsing implementation from `crates/perl-lsp-feature-governance/src/lib.rs` and re-export the new crate's APIs from `perl-lsp-feature-governance` so existing call sites remain unchanged.
- Wire the workspace: add `crates/perl-lsp-feature-cli` to the workspace `members`, the publish allowlist, and the workspace dependency table in the top-level `Cargo.toml`, and update `crates/perl-lsp-feature-governance/Cargo.toml` to depend on the new crate and pass its `lsp-ga-lock` feature through.
- Add the new crate entry to `Cargo.lock` and run formatting updates.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-lsp-feature-cli -p perl-lsp-feature-governance -p perl-lsp-launcher` and all targeted unit tests passed (3 tests in `perl-lsp-feature-cli` passed; `perl-lsp-feature-governance` tests ran with no tests; 7 tests in `perl-lsp-launcher` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b807e008333ad7d5034fbcab501)