### PR TITLE
refactor: split Perl::Critic parsing/models into perl-lsp-critic microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-critic"
+version = "0.10.0"
+dependencies = [
+ "lsp-types",
+ "perl-parser-core",
+ "serde",
+]
+
+[[package]]
 name = "perl-lsp-diagnostic-types"
 version = "0.10.0"
 
@@ -2019,6 +2028,7 @@ dependencies = [
  "criterion",
  "lsp-types",
  "moka",
+ "perl-lsp-critic",
  "perl-parser-core",
  "perl-subprocess-runtime",
  "perl-tdd-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/perl-lsp-protocol",
     "crates/perl-lsp-transport",
     "crates/perl-lsp-tooling",
+    "crates/perl-lsp-critic",
     "crates/perl-subprocess-runtime",
     "crates/perl-lsp-formatting-types",
     "crates/perl-lsp-formatting",
@@ -151,6 +152,7 @@ allow = [
     # Tier 4 — LSP providers
     "perl-lsp-navigation",
     "perl-lsp-tooling",
+    "perl-lsp-critic",
     "perl-lsp-formatting-types",
     "perl-lsp-formatting",
     "perl-lsp-semantic-tokens",
@@ -275,6 +277,7 @@ perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "
 perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
+perl-lsp-critic = { path = "crates/perl-lsp-critic", version = "0.10.0" }
 perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.10.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
 perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }

--- a/crates/perl-lsp-critic/Cargo.toml
+++ b/crates/perl-lsp-critic/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "perl-lsp-critic"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Shared Perl::Critic domain models and output parsing for perl-lsp crates"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+
+[features]
+default = ["lsp-compat"]
+lsp-compat = ["dep:lsp-types"]
+
+[dependencies]
+perl-parser-core = { workspace = true }
+serde = { version = "1.0.228", features = ["derive"] }
+lsp-types = { version = "0.97.0", optional = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-critic/src/lib.rs
+++ b/crates/perl-lsp-critic/src/lib.rs
@@ -1,0 +1,200 @@
+//! Shared Perl::Critic domain models and parsers.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+use perl_parser_core::position::{Position, Range};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "lsp-compat")]
+use lsp_types::DiagnosticSeverity;
+
+/// Severity levels for Perl::Critic violations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Severity {
+    /// Cosmetic issues (severity 5)
+    Gentle = 5,
+    /// Minor issues (severity 4)
+    Stern = 4,
+    /// Important issues (severity 3)
+    Harsh = 3,
+    /// Serious issues (severity 2)
+    Cruel = 2,
+    /// Critical issues (severity 1)
+    Brutal = 1,
+}
+
+impl Severity {
+    /// Converts a numeric severity (1-5) to a `Severity` variant.
+    pub fn from_number(n: u8) -> Self {
+        match n {
+            1 => Self::Brutal,
+            2 => Self::Cruel,
+            3 => Self::Harsh,
+            4 => Self::Stern,
+            5 => Self::Gentle,
+            _ => Self::Harsh,
+        }
+    }
+
+    /// Converts this severity to an LSP diagnostic severity.
+    #[cfg(feature = "lsp-compat")]
+    pub fn to_diagnostic_severity(&self) -> DiagnosticSeverity {
+        match self {
+            Self::Brutal | Self::Cruel => DiagnosticSeverity::ERROR,
+            Self::Harsh => DiagnosticSeverity::WARNING,
+            Self::Stern | Self::Gentle => DiagnosticSeverity::INFORMATION,
+        }
+    }
+
+    /// Converts this severity to a numeric severity level.
+    #[cfg(not(feature = "lsp-compat"))]
+    pub fn to_severity_level(&self) -> u8 {
+        *self as u8
+    }
+}
+
+/// A Perl::Critic violation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Violation {
+    /// The policy name that was violated.
+    pub policy: String,
+    /// A brief description of the violation.
+    pub description: String,
+    /// A detailed explanation of why this policy exists.
+    pub explanation: String,
+    /// The severity level of this violation.
+    pub severity: Severity,
+    /// The source location where the violation occurred.
+    pub range: Range,
+    /// The file path where the violation was found.
+    pub file: String,
+}
+
+/// Configuration for Perl::Critic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CriticConfig {
+    /// Minimum severity level to report (1-5).
+    pub severity: u8,
+    /// Path to perlcriticrc file.
+    pub profile: Option<String>,
+    /// Policies to explicitly include in analysis.
+    pub include: Vec<String>,
+    /// Policies to explicitly exclude from analysis.
+    pub exclude: Vec<String>,
+    /// Theme to use.
+    pub theme: Option<String>,
+    /// Enable verbose output.
+    pub verbose: bool,
+    /// Color output.
+    pub color: bool,
+}
+
+impl Default for CriticConfig {
+    fn default() -> Self {
+        Self {
+            severity: 3,
+            profile: None,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            theme: None,
+            verbose: false,
+            color: false,
+        }
+    }
+}
+
+/// Builds perlcritic CLI arguments including a parse-stable verbose format.
+pub fn build_perlcritic_args(config: &CriticConfig, file_path: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    args.push(format!("--severity={}", config.severity));
+
+    if let Some(profile) = &config.profile {
+        args.push(format!("--profile={profile}"));
+    }
+    if let Some(theme) = &config.theme {
+        args.push(format!("--theme={theme}"));
+    }
+
+    for policy in &config.include {
+        args.push(format!("--include={policy}"));
+    }
+    for policy in &config.exclude {
+        args.push(format!("--exclude={policy}"));
+    }
+
+    // Tab separator prevents ambiguous parsing when policy/message contain ':'.
+    args.push("--verbose=%f:%l:%c:%s:%p\t%m\\n".to_string());
+    // Prevent argument injection from filenames beginning with '-'.
+    args.push("--".to_string());
+    args.push(file_path.to_string());
+    args
+}
+
+/// Parse perlcritic output into violations.
+pub fn parse_perlcritic_output(output: &[u8], file_path: &str) -> Vec<Violation> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| parse_violation_line(line, file_path))
+        .collect()
+}
+
+/// Returns a generic policy explanation text.
+pub fn policy_explanation(policy: &str) -> String {
+    format!("See perldoc Perl::Critic::Policy::{policy}")
+}
+
+fn parse_violation_line(line: &str, file_path: &str) -> Option<Violation> {
+    if line.trim().is_empty() {
+        return None;
+    }
+
+    let (left, message) = line.split_once('\t')?;
+    let parts: Vec<&str> = left.splitn(5, ':').collect();
+    if parts.len() != 5 {
+        return None;
+    }
+
+    let line_num = parts[1].parse::<u32>().unwrap_or(1);
+    let column = parts[2].parse::<u32>().unwrap_or(1);
+    let severity = parts[3].parse::<u8>().unwrap_or(3);
+    let policy = parts[4].to_string();
+
+    Some(Violation {
+        policy: policy.clone(),
+        description: message.to_string(),
+        explanation: policy_explanation(&policy),
+        severity: Severity::from_number(severity),
+        range: Range {
+            start: Position { byte: 0, line: line_num - 1, column: column - 1 },
+            end: Position { byte: 0, line: line_num - 1, column },
+        },
+        file: file_path.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_policy_with_namespace_and_colon_message() {
+        let line = b"test.pl:5:1:3:TestingAndDebugging::RequireUseStrict\tMissing: use strict\n";
+        let violations = parse_perlcritic_output(line, "test.pl");
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "TestingAndDebugging::RequireUseStrict");
+        assert_eq!(violations[0].description, "Missing: use strict");
+    }
+
+    #[test]
+    fn args_include_safe_separator_and_verbose_format() {
+        let args = build_perlcritic_args(&CriticConfig::default(), "test.pl");
+        assert!(args.iter().any(|a| a == "--verbose=%f:%l:%c:%s:%p\t%m\\n"));
+        let sep_pos = args.iter().position(|a| a == "--").unwrap_or(usize::MAX);
+        let file_pos = args.iter().position(|a| a == "test.pl").unwrap_or(0);
+        assert!(sep_pos < file_pos);
+    }
+}

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -22,6 +22,7 @@ lsp-compat = ["dep:lsp-types"]
 
 [dependencies]
 perl-subprocess-runtime = { workspace = true }
+perl-lsp-critic = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser-core = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }

--- a/crates/perl-lsp-tooling/src/perl_critic.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic.rs
@@ -3,11 +3,14 @@
 //! This module provides integration with Perl::Critic for static code analysis
 //! and policy enforcement in Perl code.
 
+pub use perl_lsp_critic::{CriticConfig, Severity, Violation};
+use perl_lsp_critic::{build_perlcritic_args, parse_perlcritic_output};
 use perl_parser_core::{
     Node,
     position::{Position, Range},
 };
 use perl_subprocess_runtime::SubprocessRuntime;
+#[cfg(not(feature = "lsp-compat"))]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -15,103 +18,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "lsp-compat")]
 use lsp_types;
-
-/// Severity levels for Perl::Critic violations
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Severity {
-    /// Cosmetic issues (severity 5)
-    Gentle = 5,
-    /// Minor issues (severity 4)
-    Stern = 4,
-    /// Important issues (severity 3)
-    Harsh = 3,
-    /// Serious issues (severity 2)
-    Cruel = 2,
-    /// Critical issues (severity 1)
-    Brutal = 1,
-}
-
-impl Severity {
-    /// Converts a numeric severity (1-5) to a `Severity` variant.
-    ///
-    /// Values outside 1-5 default to `Harsh`.
-    pub fn from_number(n: u8) -> Self {
-        match n {
-            1 => Self::Brutal,
-            2 => Self::Cruel,
-            3 => Self::Harsh,
-            4 => Self::Stern,
-            5 => Self::Gentle,
-            _ => Self::Harsh,
-        }
-    }
-
-    /// Converts this severity to a `DiagnosticSeverity` for LSP reporting.
-    #[cfg(feature = "lsp-compat")]
-    pub fn to_diagnostic_severity(&self) -> lsp_types::DiagnosticSeverity {
-        match self {
-            Self::Brutal | Self::Cruel => lsp_types::DiagnosticSeverity::ERROR,
-            Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
-            Self::Stern | Self::Gentle => lsp_types::DiagnosticSeverity::INFORMATION,
-        }
-    }
-
-    /// Converts this severity to a numeric severity level (for non-LSP contexts).
-    #[cfg(not(feature = "lsp-compat"))]
-    pub fn to_severity_level(&self) -> u8 {
-        *self as u8
-    }
-}
-
-/// A Perl::Critic violation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Violation {
-    /// The policy name that was violated (e.g., "TestingAndDebugging::RequireUseStrict")
-    pub policy: String,
-    /// A brief description of the violation
-    pub description: String,
-    /// A detailed explanation of why this policy exists
-    pub explanation: String,
-    /// The severity level of this violation
-    pub severity: Severity,
-    /// The source location where the violation occurred
-    pub range: Range,
-    /// The file path where the violation was found
-    pub file: String,
-}
-
-/// Configuration for Perl::Critic
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CriticConfig {
-    /// Minimum severity level to report (1-5)
-    pub severity: u8,
-    /// Path to perlcriticrc file
-    pub profile: Option<String>,
-    /// Policies to explicitly include in analysis
-    pub include: Vec<String>,
-    /// Policies to explicitly exclude from analysis
-    pub exclude: Vec<String>,
-    /// Theme to use
-    pub theme: Option<String>,
-    /// Enable verbose output
-    pub verbose: bool,
-    /// Color output
-    pub color: bool,
-}
-
-impl Default for CriticConfig {
-    fn default() -> Self {
-        Self {
-            severity: 3, // Harsh and above
-            profile: None,
-            include: Vec::new(),
-            exclude: Vec::new(),
-            theme: None,
-            verbose: false,
-            color: false,
-        }
-    }
-}
 
 /// Perl::Critic analyzer
 pub struct CriticAnalyzer {
@@ -146,40 +52,7 @@ impl CriticAnalyzer {
         }
 
         // Build argument list
-        let mut args: Vec<String> = Vec::new();
-
-        // Add severity
-        args.push(format!("--severity={}", self.config.severity));
-
-        // Add profile if specified
-        if let Some(ref profile) = self.config.profile {
-            args.push(format!("--profile={}", profile));
-        }
-
-        // Add theme if specified
-        if let Some(ref theme) = self.config.theme {
-            args.push(format!("--theme={}", theme));
-        }
-
-        // Add includes
-        for policy in &self.config.include {
-            args.push(format!("--include={}", policy));
-        }
-
-        // Add excludes
-        for policy in &self.config.exclude {
-            args.push(format!("--exclude={}", policy));
-        }
-
-        // Use verbose format for parsing
-        args.push("--verbose=%f:%l:%c:%s:%p:%m\\n".to_string());
-
-        // SECURITY: Add `--` to prevent argument injection via filenames starting with `-`
-        // (e.g., a file named `-rf` would otherwise be interpreted as a flag)
-        args.push("--".to_string());
-
-        // Add file path
-        args.push(path_str.clone());
+        let args = build_perlcritic_args(&self.config, &path_str);
 
         // Convert to &str slice for the runtime
         let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -189,59 +62,13 @@ impl CriticAnalyzer {
             self.runtime.run_command("perlcritic", &args_refs, None).map_err(|e| e.message)?;
 
         // Parse output
-        let violations = self.parse_output(&output.stdout, &path_str)?;
+        let violations = parse_perlcritic_output(&output.stdout, &path_str);
 
         // Cache results
         self.cache.insert(path_str, violations.clone());
 
         Ok(violations)
     }
-
-    /// Parse perlcritic output
-    fn parse_output(&self, output: &[u8], file_path: &str) -> Result<Vec<Violation>, String> {
-        let output_str = String::from_utf8_lossy(output);
-        let mut violations = Vec::new();
-
-        for line in output_str.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            // Parse format: file:line:column:severity:policy:message
-            let parts: Vec<&str> = line.splitn(6, ':').collect();
-            if parts.len() != 6 {
-                continue;
-            }
-
-            let line_num: u32 = parts[1].parse().unwrap_or(1);
-            let column: u32 = parts[2].parse().unwrap_or(1);
-            let severity: u8 = parts[3].parse().unwrap_or(3);
-            let policy = parts[4].to_string();
-            let message = parts[5].to_string();
-
-            violations.push(Violation {
-                policy: policy.clone(),
-                description: message,
-                explanation: self.get_policy_explanation(&policy),
-                severity: Severity::from_number(severity),
-                range: Range {
-                    start: Position { byte: 0, line: line_num - 1, column: column - 1 },
-                    end: Position { byte: 0, line: line_num - 1, column },
-                },
-                file: file_path.to_string(),
-            });
-        }
-
-        Ok(violations)
-    }
-
-    /// Get explanation for a policy
-    fn get_policy_explanation(&self, policy: &str) -> String {
-        // In a real implementation, this would look up detailed explanations
-        // For now, return a generic message
-        format!("See perldoc Perl::Critic::Policy::{}", policy)
-    }
-
     /// Clear cache for a file
     pub fn invalidate_cache(&mut self, file_path: &str) {
         self.cache.remove(file_path);
@@ -530,10 +357,8 @@ mod tests {
         use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
-        // Mock perlcritic output format: file:line:column:severity:policy:message
-        // Note: The current parser uses splitn(6, ':') which doesn't handle policy names
-        // with '::' well - using a simple policy name for this test
-        let mock_output = b"test.pl:5:1:3:RequireStrict:Code does not use strict\n";
+        let mock_output =
+            b"test.pl:5:1:3:TestingAndDebugging::RequireUseStrict\tCode does not use strict\n";
         runtime.add_response(MockResponse::success(mock_output.to_vec()));
 
         let config = CriticConfig::default();
@@ -542,7 +367,7 @@ mod tests {
         let result = analyzer.analyze_file(Path::new("test.pl"));
         let violations = must(result);
         assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].policy, "RequireStrict");
+        assert_eq!(violations[0].policy, "TestingAndDebugging::RequireUseStrict");
         assert_eq!(violations[0].range.start.line, 4); // 0-indexed
 
         let invocations = runtime.invocations();


### PR DESCRIPTION
### Motivation
- Separate Perl::Critic domain concerns (data models and parsing) from runtime/subprocess orchestration to follow SRP and make parsing/formatting logic reusable and testable.
- Improve robustness of perlcritic output parsing so policy names containing `::` and messages containing `:` are handled unambiguously.

### Description
- Added a new microcrate `crates/perl-lsp-critic` that owns shared types and helpers: `CriticConfig`, `Severity`, `Violation`, `build_perlcritic_args`, and `parse_perlcritic_output`.
- Refactored `crates/perl-lsp-tooling/src/perl_critic.rs` to re-export `CriticConfig`, `Severity`, and `Violation` and to delegate CLI arg construction and output parsing to the new microcrate via `build_perlcritic_args` and `parse_perlcritic_output`.
- Changed the verbose `perlcritic` format to use a tab separator between the policy and message (`%p\t%m\n`) to avoid ambiguous parsing; updated parsing logic to split on the tab and then split the prefix for `file:line:column:severity:policy`.
- Wired the new crate into the workspace: added `crates/perl-lsp-critic` to workspace members, workspace dependencies and the publish allowlist, and added the crate as a dependency of `perl-lsp-tooling`.

### Testing
- Ran formatting: `cargo fmt --all` and the workspace is formatted successfully.
- Unit tests: `cargo test -p perl-lsp-critic` passed (all tests ok) and `cargo test -p perl-lsp-tooling` passed (19 tests; 19 passed).
- Ran a targeted tooling test: `cargo test -p perl-lsp-tooling --lib perl_critic::tests::test_analyzer_with_mock_runtime` which passed.
- Linting: `cargo clippy -p perl-lsp-critic -p perl-lsp-tooling --all-targets -- -D warnings` completed without warnings (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b7f8be08333b9852558aa09f25e)