### PR TITLE
Split typed URI parsing into perl-lsp-uri microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,6 +1753,7 @@ dependencies = [
  "perl-lsp-semantic-tokens",
  "perl-lsp-tooling",
  "perl-lsp-transport",
+ "perl-lsp-uri",
  "perl-module-path",
  "perl-module-reference",
  "perl-module-rename",
@@ -1983,6 +1984,7 @@ dependencies = [
  "perl-lsp-rename",
  "perl-lsp-semantic-tokens",
  "perl-lsp-tooling",
+ "perl-lsp-uri",
  "perl-parser-core",
  "perl-semantic-analyzer",
  "perl-tdd-support",
@@ -2032,6 +2034,13 @@ dependencies = [
  "perl-content-length-framing",
  "perl-lsp-protocol",
  "serde_json",
+]
+
+[[package]]
+name = "perl-lsp-uri"
+version = "0.10.0"
+dependencies = [
+ "lsp-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-cancellation",
     "crates/perl-lsp-limits",
+    "crates/perl-lsp-uri",
     "crates/perl-lsp-feature-policy",
     "crates/perl-diagnostics-codes",
     "crates/perl-position-tracking",
@@ -185,6 +186,7 @@ allow = [
     "perl-lsp-feature-governance",
     "perl-lsp-launcher",
     "perl-lsp-limits",
+    "perl-lsp-uri",
     "perl-lsp-protocol",
     "perl-lsp-transport",
 
@@ -285,6 +287,7 @@ perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.10.0
 perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.10.0" }
 perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.10.0" }
 perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.10.0" }
 perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.10.0" }
 perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.10.0" }
 perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.10.0" }

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -35,6 +35,7 @@ perl-lsp-rename = { workspace = true }
 perl-lsp-navigation = { workspace = true }
 perl-lsp-completion = { workspace = true }
 perl-lsp-code-actions = { workspace = true }
+perl-lsp-uri = { workspace = true }
 rustc-hash = "2.1.1"
 serde_json = "1.0.149"
 lsp-types = { version = "0.97.0", optional = true }

--- a/crates/perl-lsp-providers/src/ide/lsp_compat/uri.rs
+++ b/crates/perl-lsp-providers/src/ide/lsp_compat/uri.rs
@@ -1,20 +1,6 @@
-//! LSP module (deprecated)
+//! LSP URI compatibility module.
 //!
-//! **DEPRECATED**: This module has moved to the `perl-lsp` crate.
-//!
-//! For backwards compatibility during the migration period, this module
-//! is kept as an empty stub. Migrate to `perl_lsp::utils::uri`.
-//!
-//! # Migration
-//!
-//! ```ignore
-//! // Old:
-//! use perl_parser::uri;
-//!
-//! // New:
-//! use perl_lsp::utils::uri;
-//! ```
+//! URI parsing helpers now live in the `perl-lsp-uri` microcrate.
+//! This module re-exports the public API for compatibility.
 
-// This module intentionally has no contents.
-// All functionality has moved to the perl-lsp crate.
-// Direct re-export is not possible due to circular dependency.
+pub use perl_lsp_uri::parse_uri;

--- a/crates/perl-lsp-uri/Cargo.toml
+++ b/crates/perl-lsp-uri/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "perl-lsp-uri"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Typed URI parsing helpers for perl-lsp"
+readme = "README.md"
+documentation = "https://docs.rs/perl-lsp-uri"
+keywords = ["perl", "lsp", "uri"]
+categories = ["development-tools", "text-editors"]
+include = [
+  "src/**",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE*"
+]
+
+[dependencies]
+lsp-types = "0.97.0"
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-uri/README.md
+++ b/crates/perl-lsp-uri/README.md
@@ -1,0 +1,6 @@
+# perl-lsp-uri
+
+Typed URI parsing helpers for the Perl LSP ecosystem.
+
+This microcrate centralizes parsing to `lsp_types::Uri` with a non-panicking
+fallback strategy.

--- a/crates/perl-lsp-uri/src/lib.rs
+++ b/crates/perl-lsp-uri/src/lib.rs
@@ -1,0 +1,49 @@
+//! Typed URI parsing helpers for LSP components.
+
+use lsp_types::Uri;
+
+fn fallback_uri() -> Uri {
+    for candidate in ["file:///unknown", "file:///", "about:blank", "urn:perl-lsp:unknown"] {
+        if let Ok(uri) = candidate.parse::<Uri>() {
+            return uri;
+        }
+    }
+
+    // Last-resort fallback that avoids panicking if URI parser behavior changes unexpectedly.
+    let mut suffix = 0usize;
+    loop {
+        let candidate = format!("http://localhost/{suffix}");
+        if let Ok(uri) = candidate.parse::<Uri>() {
+            return uri;
+        }
+        suffix = suffix.saturating_add(1);
+    }
+}
+
+/// Parse a URI string into [`lsp_types::Uri`].
+///
+/// Falls back to a guaranteed-valid URI if parsing fails.
+#[must_use]
+pub fn parse_uri(s: &str) -> Uri {
+    match s.parse::<Uri>() {
+        Ok(uri) => uri,
+        Err(_) => fallback_uri(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_uri;
+
+    #[test]
+    fn parse_uri_returns_original_for_valid_uri() {
+        let uri = parse_uri("file:///tmp/test.pl");
+        assert_eq!(uri.as_str(), "file:///tmp/test.pl");
+    }
+
+    #[test]
+    fn parse_uri_falls_back_for_invalid_uri() {
+        let uri = parse_uri("not a uri");
+        assert!(!uri.as_str().is_empty());
+    }
+}

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -28,6 +28,7 @@ perl-lsp-providers = { workspace = true, features = ["lsp-compat"] }
 perl-lsp-formatting = { workspace = true }
 perl-lsp-cancellation = { workspace = true }
 perl-lsp-limits = { workspace = true }
+perl-lsp-uri = { workspace = true }
 perl-lsp-feature-governance = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-lsp-protocol = { workspace = true }

--- a/crates/perl-lsp/src/util/uri.rs
+++ b/crates/perl-lsp/src/util/uri.rs
@@ -1,30 +1,5 @@
-//! URI utilities for LSP
+//! URI utilities for LSP.
+//!
+//! This module re-exports helpers from the `perl-lsp-uri` microcrate.
 
-use lsp_types::Uri;
-
-fn fallback_uri() -> Uri {
-    for candidate in ["file:///unknown", "file:///", "about:blank", "urn:perl-lsp:unknown"] {
-        if let Ok(uri) = candidate.parse::<Uri>() {
-            return uri;
-        }
-    }
-
-    // Last-resort fallback that avoids panicking if URI parser behavior changes unexpectedly.
-    let mut suffix = 0usize;
-    loop {
-        let candidate = format!("http://localhost/{suffix}");
-        if let Ok(uri) = candidate.parse::<Uri>() {
-            return uri;
-        }
-        suffix = suffix.saturating_add(1);
-    }
-}
-
-/// Helper function to parse a URI string into an lsp_types::Uri.
-/// Falls back to a valid URI if parsing fails.
-pub fn parse_uri(s: &str) -> Uri {
-    match s.parse::<Uri>() {
-        Ok(uri) => uri,
-        Err(_) => fallback_uri(),
-    }
-}
+pub use perl_lsp_uri::parse_uri;


### PR DESCRIPTION
### Motivation
- Extract a single-responsibility URI parsing helper out of the `perl-lsp` application crate so the logic can be reused and tested independently.
- Provide a stable, non-panicking `parse_uri` API for other workspace crates and compatibility layers to consume without introducing circular dependencies.

### Description
- Added a new microcrate `crates/perl-lsp-uri` that implements `parse_uri` with a robust fallback strategy and unit tests in `src/lib.rs`.
- Replaced the in-repo implementations with re-exports: `crates/perl-lsp/src/util/uri.rs` now `pub use perl_lsp_uri::parse_uri;` and `crates/perl-lsp-providers/src/ide/lsp_compat/uri.rs` now re-exports the same API for compatibility.
- Wired the new crate into the workspace by adding `crates/perl-lsp-uri` to `Cargo.toml` members, to the publish allowlist, and as a workspace dependency where needed (updated `Cargo.toml`, `crates/perl-lsp/Cargo.toml`, and `crates/perl-lsp-providers/Cargo.toml`).
- Added `perl-lsp-uri` to the generated `Cargo.lock` packages so dependency graphs remain consistent.

### Testing
- Ran formatter: `cargo fmt --all` and applied formatting successfully.
- Ran unit tests for the new crate: `cargo test -p perl-lsp-uri` and all tests passed (`2 passed`).
- Ran provider tests: `cargo test -p perl-lsp-providers --lib` and the test suite passed (`4 passed`).
- Verified workspace compilation for LSP: `cargo check -p perl-lsp` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b7f8be08333b9852558aa09f25e)