### PR TITLE
Refactor navigation qualified-name parsing into shared microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "perl-module-path",
  "perl-parser-core",
  "perl-position-tracking",
+ "perl-qualified-name",
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "serde",

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5.8"
 perl-position-tracking = { workspace = true }
 perl-module-path = { workspace = true }
 perl-module-import = { workspace = true }
+perl-qualified-name = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-lsp-navigation/src/references.rs
+++ b/crates/perl-lsp-navigation/src/references.rs
@@ -35,6 +35,7 @@
 //! ```
 
 use perl_parser_core::ast::{Node, NodeKind};
+use perl_qualified_name::split_with_default_package;
 
 /// Return (start_offset, end_offset) for same-file references
 pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usize, usize)>> {
@@ -47,20 +48,12 @@ pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usi
             ("var", "main".to_string(), name.clone(), sigil_char)
         }
         NodeKind::FunctionCall { name, .. } => {
-            let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                (name[..idx].to_string(), name[idx + 2..].to_string())
-            } else {
-                ("main".to_string(), name.clone())
-            };
-            ("sub", pkg, bare, None)
+            let (pkg, bare) = split_with_default_package(name, "main");
+            ("sub", pkg.to_string(), bare.to_string(), None)
         }
         NodeKind::Subroutine { name: Some(name), .. } => {
-            let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                (name[..idx].to_string(), name[idx + 2..].to_string())
-            } else {
-                ("main".to_string(), name.clone())
-            };
-            ("sub", pkg, bare, None)
+            let (pkg, bare) = split_with_default_package(name, "main");
+            ("sub", pkg.to_string(), bare.to_string(), None)
         }
         _ => return None,
     };
@@ -84,11 +77,7 @@ pub fn find_references_single_file(ast: &Node, offset: usize) -> Option<Vec<(usi
                 }
             }
             NodeKind::FunctionCall { name, .. } if want_kind == "sub" => {
-                let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                    (&name[..idx], &name[idx + 2..])
-                } else {
-                    ("main", name.as_str())
-                };
+                let (pkg, bare) = split_with_default_package(name, "main");
                 if bare == want_name && pkg == want_pkg {
                     out.push((location.start, location.end));
                 }

--- a/crates/perl-lsp-navigation/src/workspace_symbols.rs
+++ b/crates/perl-lsp-navigation/src/workspace_symbols.rs
@@ -67,28 +67,10 @@
 use perl_module_path::normalize_package_separator;
 use perl_parser_core::{SourceLocation, ast::Node};
 use perl_position_tracking::{WireLocation, WireRange};
+use perl_qualified_name::container_name;
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-/// Extract container name from qualified symbol name.
-///
-/// Extracts the package/class portion from a fully qualified symbol name,
-/// following Perl's package qualification rules.
-///
-/// Examples:
-/// - `"Foo::Bar::baz"` → `Some("Foo::Bar")`
-/// - `"MyClass::new"` → `Some("MyClass")`
-/// - `"toplevel"` → `None`
-///
-/// # Performance
-/// - Time complexity: O(n) string scan
-/// - Memory: Allocates only when container exists
-fn extract_container_name(qualified_name: &str) -> Option<String> {
-    // "Foo::Bar::baz" → container = "Foo::Bar"
-    // Top-level symbols have no container
-    qualified_name.rfind("::").map(|idx| qualified_name[..idx].to_string())
-}
 
 /// LSP WorkspaceSymbol representing a symbol found in the workspace.
 ///
@@ -157,7 +139,7 @@ impl WorkspaceSymbolsProvider {
         // Extract symbols from the symbol table
         for (name, symbol_list) in &table.symbols {
             for symbol in symbol_list {
-                let container = extract_container_name(&symbol.qualified_name);
+                let container = container_name(&symbol.qualified_name).map(str::to_string);
 
                 symbols.push(SymbolInfo {
                     name: name.clone(),
@@ -506,24 +488,24 @@ sub baz {
     }
 
     #[test]
-    fn test_extract_container_name() {
+    fn test_container_name_helper() {
         // Nested package qualification
-        assert_eq!(extract_container_name("Foo::Bar::baz"), Some("Foo::Bar".to_string()));
+        assert_eq!(container_name("Foo::Bar::baz"), Some("Foo::Bar"));
 
         // Simple package qualification
-        assert_eq!(extract_container_name("MyClass::new"), Some("MyClass".to_string()));
+        assert_eq!(container_name("MyClass::new"), Some("MyClass"));
 
         // Top-level symbol (no container)
-        assert_eq!(extract_container_name("toplevel"), None);
+        assert_eq!(container_name("toplevel"), None);
 
         // Empty string
-        assert_eq!(extract_container_name(""), None);
+        assert_eq!(container_name(""), None);
 
         // Package name only (no method)
-        assert_eq!(extract_container_name("Package::"), Some("Package".to_string()));
+        assert_eq!(container_name("Package::"), Some("Package"));
 
         // Deep nesting
-        assert_eq!(extract_container_name("A::B::C::D::method"), Some("A::B::C::D".to_string()));
+        assert_eq!(container_name("A::B::C::D::method"), Some("A::B::C::D"));
     }
 
     #[test]

--- a/crates/perl-qualified-name/src/lib.rs
+++ b/crates/perl-qualified-name/src/lib.rs
@@ -61,6 +61,28 @@ pub fn split_qualified_name(name: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// Return the container/package portion of a qualified Perl name.
+///
+/// `Foo::Bar::baz` => `Some("Foo::Bar")`
+/// `symbol` => `None`
+#[must_use]
+pub fn container_name(name: &str) -> Option<&str> {
+    split_qualified_name(name).0
+}
+
+/// Split a name into `(package, bare_name)` and apply a fallback package when unqualified.
+///
+/// `Foo::Bar` with default `main` => `(Foo, Bar)`
+/// `process` with default `main` => `(main, process)`
+#[must_use]
+pub fn split_with_default_package<'a>(
+    name: &'a str,
+    default_package: &'a str,
+) -> (&'a str, &'a str) {
+    let (package, bare) = split_qualified_name(name);
+    (package.unwrap_or(default_package), bare)
+}
+
 /// Validate a full Perl qualified name with package separators.
 ///
 /// - Rejects empty input.
@@ -102,12 +124,27 @@ pub fn is_valid_identifier_part(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_valid_identifier_part, split_qualified_name, validate_perl_qualified_name};
+    use super::{
+        container_name, is_valid_identifier_part, split_qualified_name, split_with_default_package,
+        validate_perl_qualified_name,
+    };
 
     #[test]
     fn splits_qualified_and_unqualified_names() {
         assert_eq!(split_qualified_name("Foo::Bar"), (Some("Foo"), "Bar"));
         assert_eq!(split_qualified_name("process"), (None, "process"));
+    }
+
+    #[test]
+    fn extracts_container_name_when_present() {
+        assert_eq!(container_name("Foo::Bar::baz"), Some("Foo::Bar"));
+        assert_eq!(container_name("top_level"), None);
+    }
+
+    #[test]
+    fn splits_with_default_package() {
+        assert_eq!(split_with_default_package("Foo::Bar", "main"), ("Foo", "Bar"));
+        assert_eq!(split_with_default_package("process", "main"), ("main", "process"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Remove duplicated qualified-name parsing logic from `perl-lsp-navigation` and centralize name helpers in a single SRP microcrate.
- Make package/container extraction and default-package behavior reusable across crates to reduce drift and bugs.

### Description
- Added `container_name` and `split_with_default_package` helpers to the `perl-qualified-name` crate (`crates/perl-qualified-name/src/lib.rs`) and added unit tests for both helpers.
- Updated `perl-lsp-navigation` to depend on `perl-qualified-name` by adding `perl-qualified-name = { workspace = true }` to `crates/perl-lsp-navigation/Cargo.toml`.
- Replaced local `rfind("::")`-based logic in `crates/perl-lsp-navigation/src/workspace_symbols.rs` with `perl_qualified_name::container_name` and removed the redundant local helper.
- Replaced local name-splitting in `crates/perl-lsp-navigation/src/references.rs` with `perl_qualified_name::split_with_default_package`.
- Adjusted related unit tests in `perl-lsp-navigation` to use the shared helpers and ensure types align.

### Testing
- Ran `cargo fmt --all` to normalize formatting, which completed successfully.
- Ran `cargo test -p perl-qualified-name` and all unit and integration tests passed (`6 passed` plus file tests reported in output).
- Ran `cargo test -p perl-lsp-navigation` and the navigation test suite passed (`78+` tests including unit and comprehensive tests passed as shown in output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b7d8b948333a5efa46c66e3ab73)