### PR TITLE
refactor: move cursor token utilities into perl-symbol-cursor microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "perl-parser",
  "perl-position-tracking",
  "perl-source-file",
+ "perl-symbol-cursor",
  "perl-tdd-support",
  "perl-workspace-discovery",
  "predicates",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -41,6 +41,7 @@ perl-lsp-rename = { workspace = true }
 perl-lsp-semantic-tokens = { workspace = true }
 perl-lsp-launcher = { workspace = true }
 perl-position-tracking = { workspace = true, features = ["lsp-compat"] }
+perl-symbol-cursor = { workspace = true }
 perl-module-path = { workspace = true }
 perl-module-reference = { workspace = true }
 perl-module-rename = { workspace = true }

--- a/crates/perl-lsp/src/util/mod.rs
+++ b/crates/perl-lsp/src/util/mod.rs
@@ -10,6 +10,7 @@ use perl_module_reference::extract_module_reference as extract_module_reference_
 
 // Re-export engine utilities
 pub use perl_parser::util::{code_slice, find_data_marker_byte_lexed};
+pub use perl_symbol_cursor::{byte_offset_utf16, is_modchar, is_word_boundary, token_under_cursor};
 
 // =============================================================================
 // Panic-free character accessors (Issue #143)
@@ -67,20 +68,6 @@ pub fn byte_to_utf16_col(line_text: &str, byte_pos: usize) -> usize {
     units
 }
 
-/// Convert UTF-16 column position to byte offset
-pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
-    let mut units = 0;
-    for (i, ch) in line_text.char_indices() {
-        if units == col_utf16 {
-            return i;
-        }
-        // UTF-16 encoding: chars >= U+10000 use 2 units (surrogate pairs)
-        let add = if ch as u32 >= 0x10000 { 2 } else { 1 };
-        units += add;
-    }
-    line_text.len()
-}
-
 /// Convert byte offset to line and column
 pub fn byte_to_line_col(source: &str, offset: usize) -> (u32, u32) {
     let mut line = 0;
@@ -99,64 +86,6 @@ pub fn byte_to_line_col(source: &str, offset: usize) -> (u32, u32) {
     }
 
     (line, col)
-}
-
-/// Helper character check for Perl identifiers
-pub fn is_modchar(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b':' || b == b'_'
-}
-
-/// Extract token at cursor position (UTF-16 aware)
-pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
-    let l = text.lines().nth(line)?;
-    let byte_pos = byte_offset_utf16(l, col_utf16);
-    let bytes = l.as_bytes();
-
-    if byte_pos >= bytes.len() {
-        return None;
-    }
-
-    // Expand to a "word" containing :: and \w
-    // Also include sigils if we're on or after one
-    let mut s = byte_pos;
-    let mut e = byte_pos;
-
-    // Expand left - if we hit a sigil, include it
-    while s > 0 && is_modchar(bytes[s - 1]) {
-        s -= 1;
-    }
-    if s > 0
-        && (bytes[s - 1] == b'$'
-            || bytes[s - 1] == b'@'
-            || bytes[s - 1] == b'%'
-            || bytes[s - 1] == b'&'
-            || bytes[s - 1] == b'*')
-    {
-        s -= 1;
-    }
-
-    // Expand right
-    while e < bytes.len() && is_modchar(bytes[e]) {
-        e += 1;
-    }
-
-    Some(l[s..e].to_string())
-}
-
-/// Check if position is at word boundary (for accurate reference matching)
-pub fn is_word_boundary(text: &[u8], pos: usize, word_len: usize) -> bool {
-    // Check left boundary (before the sigil if present)
-    if pos > 0 && is_modchar(text[pos - 1]) {
-        return false;
-    }
-
-    // Check right boundary (after the identifier part)
-    let end_pos = pos + word_len;
-    if end_pos < text.len() && is_modchar(text[end_pos]) {
-        return false;
-    }
-
-    true
 }
 
 /// Find matching closing parenthesis

--- a/crates/perl-symbol-cursor/src/lib.rs
+++ b/crates/perl-symbol-cursor/src/lib.rs
@@ -86,3 +86,96 @@ pub fn get_symbol_range_at_position(position: usize, source: &str) -> Option<(us
 
     Some((start, end))
 }
+
+/// Return true when `byte` is a module/name character (`[A-Za-z0-9_:]`).
+#[inline]
+pub fn is_modchar(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b':' || byte == b'_'
+}
+
+/// Convert a UTF-16 column index to a byte offset for a single line.
+#[inline]
+pub fn byte_offset_utf16(line_text: &str, col_utf16: usize) -> usize {
+    let mut units = 0;
+    for (i, ch) in line_text.char_indices() {
+        if units == col_utf16 {
+            return i;
+        }
+        units += if ch as u32 >= 0x10000 { 2 } else { 1 };
+    }
+    line_text.len()
+}
+
+/// Extract the module/symbol token under the cursor (UTF-16 aware).
+pub fn token_under_cursor(text: &str, line: usize, col_utf16: usize) -> Option<String> {
+    let line_text = text.lines().nth(line)?;
+    let byte_pos = byte_offset_utf16(line_text, col_utf16);
+    let bytes = line_text.as_bytes();
+
+    if byte_pos >= bytes.len() {
+        return None;
+    }
+
+    let mut start = byte_pos;
+    let mut end = byte_pos;
+
+    while start > 0 && is_modchar(bytes[start - 1]) {
+        start -= 1;
+    }
+    if start > 0 && matches!(bytes[start - 1], b'$' | b'@' | b'%' | b'&' | b'*') {
+        start -= 1;
+    }
+
+    while end < bytes.len() && is_modchar(bytes[end]) {
+        end += 1;
+    }
+
+    Some(line_text[start..end].to_string())
+}
+
+/// Check if a match at `pos..pos+word_len` is bounded by non-word chars.
+pub fn is_word_boundary(text: &[u8], pos: usize, word_len: usize) -> bool {
+    if pos > 0 && is_modchar(text[pos - 1]) {
+        return false;
+    }
+
+    let end_pos = pos + word_len;
+    if end_pos < text.len() && is_modchar(text[end_pos]) {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{byte_offset_utf16, is_word_boundary, token_under_cursor};
+
+    #[test]
+    fn token_under_cursor_extracts_perl_module_token() {
+        let text = "use Demo::Worker;\n";
+        assert_eq!(token_under_cursor(text, 0, 8), Some("Demo::Worker".to_string()));
+    }
+
+    #[test]
+    fn token_under_cursor_supports_sigils() {
+        let text = "my $value = 1;\n";
+        assert_eq!(token_under_cursor(text, 0, 5), Some("$value".to_string()));
+    }
+
+    #[test]
+    fn utf16_col_to_byte_offset_handles_surrogate_pairs() {
+        let line = "A😀B";
+        assert_eq!(byte_offset_utf16(line, 0), 0);
+        assert_eq!(byte_offset_utf16(line, 1), 1);
+        assert_eq!(byte_offset_utf16(line, 3), 5);
+        assert_eq!(byte_offset_utf16(line, 4), 6);
+    }
+
+    #[test]
+    fn word_boundary_detects_embedded_word() {
+        let text = b"fooDemo::Workerbar";
+        assert!(!is_word_boundary(text, 3, "Demo::Worker".len()));
+        assert!(is_word_boundary(b" Demo::Worker ", 1, "Demo::Worker".len()));
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve single-responsibility cohesion by moving cursor/token-focused helpers out of the broad `perl-lsp::util` module into the `perl-symbol-cursor` microcrate. 
- Centralize UTF-16-aware cursor logic and sigil-aware token extraction where it logically belongs so it can be reused and tested independently.

### Description
- Extracted the following helpers from `crates/perl-lsp/src/util/mod.rs` into `crates/perl-symbol-cursor/src/lib.rs`: `is_modchar`, `byte_offset_utf16`, `token_under_cursor`, and `is_word_boundary`.
- Added unit tests to `perl-symbol-cursor` exercising UTF-16 byte-offset conversion (including surrogate pairs), sigil-aware token extraction, and word-boundary detection.
- Re-exported the moved helpers from `perl-lsp::util` to preserve existing call sites and the public API shape.
- Wired `perl-lsp` to depend on `perl-symbol-cursor` in `crates/perl-lsp/Cargo.toml` so the microcrate is a first-class dependency.

### Testing
- Ran `cargo fmt --all` to format the workspace and the change was applied successfully.
- Ran `cargo test -p perl-symbol-cursor` and all added and existing unit tests passed (`4` focused tests plus existing test-suite passed).
- Ran `cargo check -p perl-lsp --lib` to validate integration and dependency wiring, which completed successfully.
- Ran `cargo test -p perl-lsp --lib util::tests::extract_module_reference_detects_use_statement_token` and the targeted util test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b7d8b948333a5efa46c66e3ab73)