### PR TITLE
refactor: extract reusable file-completion path security helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "lsp-types",
  "perl-keywords",
  "perl-parser-core",
+ "perl-path-security",
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",

--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -21,6 +21,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-keywords = { workspace = true }
+perl-path-security = { workspace = true }
 lsp-types = { version = "0.97.0", optional = true }
 url = "2.5.8"
 walkdir = "2.5.0"

--- a/crates/perl-lsp-completion/src/completion/file_path.rs
+++ b/crates/perl-lsp-completion/src/completion/file_path.rs
@@ -40,7 +40,13 @@
 use super::context::CompletionContext;
 use super::items::{CompletionItem, CompletionItemKind};
 #[cfg(not(target_arch = "wasm32"))]
-use std::path::{Component, Path, PathBuf};
+use perl_path_security::{
+    build_completion_path as shared_build_completion_path, is_hidden_or_forbidden_entry_name,
+    is_safe_completion_filename, resolve_completion_base_directory, sanitize_completion_path_input,
+    split_completion_path_components,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
 
 /// Bundled callbacks for file path completion operations
 ///
@@ -323,146 +329,38 @@ pub(crate) fn add_file_completions_with_cancellation(
 /// Sanitize and validate a file path for security
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn sanitize_path(path: &str) -> Option<String> {
-    // Handle empty path (current directory completion)
-    if path.is_empty() {
-        return Some(String::new());
-    }
-
-    // Security checks
-    if path.contains('\0') {
-        return None; // Null bytes not allowed
-    }
-
-    // Check for path traversal attempts
-    let path_obj = Path::new(path);
-    for component in path_obj.components() {
-        match component {
-            Component::ParentDir => return None, // No .. allowed
-            Component::RootDir if path != "/" => return None, // Absolute paths generally not allowed
-            Component::Prefix(_) => return None,              // Windows drive letters not allowed
-            _ => {}
-        }
-    }
-
-    // Additional dangerous pattern checks
-    if path.contains("../") || path.contains("..\\") || path.starts_with('/') && path != "/" {
-        return None;
-    }
-
-    // Normalize path separators for cross-platform compatibility
-    Some(path.replace('\\', "/"))
+    sanitize_completion_path_input(path)
 }
 
 /// Split path into directory and filename components safely
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn split_path_components(path: &str) -> (String, String) {
-    match path.rsplit_once('/') {
-        Some((dir, file)) if !dir.is_empty() => (dir.to_string(), file.to_string()),
-        _ => (".".to_string(), path.to_string()),
-    }
+    split_completion_path_components(path)
 }
 
 /// Resolve and validate a directory path for safe traversal
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn resolve_safe_directory(dir_part: &str) -> Option<PathBuf> {
-    let path = Path::new(dir_part);
-
-    // Security: Only allow relative paths and current directory
-    if path.is_absolute() && dir_part != "/" {
-        return None;
-    }
-
-    // For current directory, just return it directly
-    if dir_part == "." {
-        return Some(Path::new(".").to_path_buf());
-    }
-
-    // Convert to canonical path to resolve any remaining issues
-    match path.canonicalize() {
-        Ok(canonical) => {
-            // For tests and scenarios where cwd has changed, be more permissive
-            Some(canonical)
-        }
-        Err(_) => {
-            // If canonicalization fails, try the original path if it exists and is safe
-            if path.exists() && path.is_dir() { Some(path.to_path_buf()) } else { None }
-        }
-    }
+    resolve_completion_base_directory(dir_part)
 }
 
 /// Check if a directory entry should be filtered out for security
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn is_hidden_or_forbidden(entry: &walkdir::DirEntry) -> bool {
     let file_name = entry.file_name().to_string_lossy();
-
-    // Skip hidden files (Unix convention)
-    if file_name.starts_with('.') && file_name.len() > 1 {
-        return true;
-    }
-
-    // Skip certain system directories and files
-    matches!(
-        file_name.as_ref(),
-        "node_modules"
-            | ".git"
-            | ".svn"
-            | ".hg"
-            | "target"
-            | "build"
-            | ".cargo"
-            | ".rustup"
-            | "System Volume Information"
-            | "$RECYCLE.BIN"
-            | "__pycache__"
-            | ".pytest_cache"
-            | ".mypy_cache"
-    )
+    is_hidden_or_forbidden_entry_name(file_name.as_ref())
 }
 
 /// Validate filename for safety
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn is_safe_filename(filename: &str) -> bool {
-    // Basic safety checks
-    if filename.is_empty() || filename.len() > 255 {
-        return false;
-    }
-
-    // Check for null bytes or other control characters
-    if filename.contains('\0') || filename.chars().any(|c| c.is_control()) {
-        return false;
-    }
-
-    // Check for Windows reserved names (even on Unix for cross-platform safety)
-    let name_upper = filename.to_uppercase();
-    let reserved = [
-        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
-        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
-    ];
-
-    for reserved_name in &reserved {
-        if name_upper == *reserved_name || name_upper.starts_with(&format!("{}.", reserved_name)) {
-            return false;
-        }
-    }
-
-    true
+    is_safe_completion_filename(filename)
 }
 
 /// Build the completion path string
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn build_completion_path(dir_part: &str, filename: &str, is_dir: bool) -> String {
-    let mut path = if dir_part == "." {
-        filename.to_string()
-    } else {
-        format!("{}/{}", dir_part.trim_end_matches('/'), filename)
-    };
-
-    // Add trailing slash for directories
-    if is_dir {
-        path.push('/');
-    }
-
-    path
+    shared_build_completion_path(dir_part, filename, is_dir)
 }
 
 /// Get metadata for file completion item

--- a/crates/perl-lsp-completion/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/comprehensive_unit_tests.rs
@@ -14,9 +14,7 @@
 //! - CompletionItemKind and CompletionItem fields
 //! - Sort/dedup ordering
 
-use perl_lsp_completion::{
-    CompletionContext, CompletionItem, CompletionItemKind, CompletionProvider,
-};
+use perl_lsp_completion::{CompletionItem, CompletionItemKind, CompletionProvider};
 use perl_parser_core::Parser;
 use perl_tdd_support::{must, must_some};
 use perl_workspace_index::workspace_index::WorkspaceIndex;

--- a/crates/perl-path-security/src/lib.rs
+++ b/crates/perl-path-security/src/lib.rs
@@ -105,9 +105,139 @@ pub fn validate_workspace_path(
     Ok(final_path)
 }
 
+/// Sanitize and normalize user-provided completion path input.
+///
+/// Returns `None` when path contains traversal, absolute path (except `/`),
+/// drive-prefix, null bytes, or suspicious traversal patterns.
+pub fn sanitize_completion_path_input(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return Some(String::new());
+    }
+
+    if path.contains('\0') {
+        return None;
+    }
+
+    let path_obj = Path::new(path);
+    for component in path_obj.components() {
+        match component {
+            Component::ParentDir => return None,
+            Component::RootDir if path != "/" => return None,
+            Component::Prefix(_) => return None,
+            _ => {}
+        }
+    }
+
+    if path.contains("../") || path.contains("..\\") || path.starts_with('/') && path != "/" {
+        return None;
+    }
+
+    Some(path.replace('\\', "/"))
+}
+
+/// Split sanitized completion path into `(directory_part, file_prefix)`.
+pub fn split_completion_path_components(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some((dir, file)) if !dir.is_empty() => (dir.to_string(), file.to_string()),
+        _ => (".".to_string(), path.to_string()),
+    }
+}
+
+/// Resolve a directory used for file completion traversal.
+pub fn resolve_completion_base_directory(dir_part: &str) -> Option<PathBuf> {
+    let path = Path::new(dir_part);
+
+    if path.is_absolute() && dir_part != "/" {
+        return None;
+    }
+
+    if dir_part == "." {
+        return Some(Path::new(".").to_path_buf());
+    }
+
+    match path.canonicalize() {
+        Ok(canonical) => Some(canonical),
+        Err(_) => {
+            if path.exists() && path.is_dir() {
+                Some(path.to_path_buf())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Check whether a filename should be skipped during file completion traversal.
+pub fn is_hidden_or_forbidden_entry_name(file_name: &str) -> bool {
+    if file_name.starts_with('.') && file_name.len() > 1 {
+        return true;
+    }
+
+    matches!(
+        file_name,
+        "node_modules"
+            | ".git"
+            | ".svn"
+            | ".hg"
+            | "target"
+            | "build"
+            | ".cargo"
+            | ".rustup"
+            | "System Volume Information"
+            | "$RECYCLE.BIN"
+            | "__pycache__"
+            | ".pytest_cache"
+            | ".mypy_cache"
+    )
+}
+
+/// Validate filename safety for completion entries.
+pub fn is_safe_completion_filename(filename: &str) -> bool {
+    if filename.is_empty() || filename.len() > 255 {
+        return false;
+    }
+
+    if filename.contains('\0') || filename.chars().any(|c| c.is_control()) {
+        return false;
+    }
+
+    let name_upper = filename.to_uppercase();
+    let reserved = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    for reserved_name in &reserved {
+        if name_upper == *reserved_name || name_upper.starts_with(&format!("{}.", reserved_name)) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Build completion path string and append trailing slash for directories.
+pub fn build_completion_path(dir_part: &str, filename: &str, is_dir: bool) -> String {
+    let mut path = if dir_part == "." {
+        filename.to_string()
+    } else {
+        format!("{}/{}", dir_part.trim_end_matches('/'), filename)
+    };
+
+    if is_dir {
+        path.push('/');
+    }
+
+    path
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{WorkspacePathError, validate_workspace_path};
+    use super::{
+        WorkspacePathError, build_completion_path, is_hidden_or_forbidden_entry_name,
+        is_safe_completion_filename, sanitize_completion_path_input,
+        split_completion_path_components, validate_workspace_path,
+    };
     use std::path::PathBuf;
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -189,5 +319,34 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn completion_path_sanitization_blocks_traversal() {
+        assert_eq!(sanitize_completion_path_input(""), Some(String::new()));
+        assert_eq!(sanitize_completion_path_input("lib/Foo.pm"), Some("lib/Foo.pm".to_string()));
+        assert!(sanitize_completion_path_input("../etc/passwd").is_none());
+    }
+
+    #[test]
+    fn completion_path_helpers_work() {
+        assert_eq!(
+            split_completion_path_components("lib/Foo"),
+            ("lib".to_string(), "Foo".to_string())
+        );
+        assert_eq!(split_completion_path_components("Foo"), (".".to_string(), "Foo".to_string()));
+        assert_eq!(build_completion_path(".", "Foo.pm", false), "Foo.pm".to_string());
+        assert_eq!(build_completion_path("lib", "Foo", true), "lib/Foo/".to_string());
+    }
+
+    #[test]
+    fn completion_filename_and_visibility_checks_work() {
+        assert!(is_hidden_or_forbidden_entry_name(".git"));
+        assert!(is_hidden_or_forbidden_entry_name("node_modules"));
+        assert!(!is_hidden_or_forbidden_entry_name("lib"));
+
+        assert!(is_safe_completion_filename("Foo.pm"));
+        assert!(!is_safe_completion_filename("CON"));
+        assert!(!is_safe_completion_filename("bad\0name"));
     }
 }


### PR DESCRIPTION
### Motivation

- Centralize single-responsibility path-safety and sanitization logic used by file-path completion so it can be reused and audited in one place. 
- Reduce duplicated security checks in the completion crate and make the behavior easier to maintain and test.

### Description

- Added focused helper APIs to `crates/perl-path-security/src/lib.rs`: `sanitize_completion_path_input`, `split_completion_path_components`, `resolve_completion_base_directory`, `is_hidden_or_forbidden_entry_name`, `is_safe_completion_filename`, and `build_completion_path` for file-completion usage. 
- Rewired `crates/perl-lsp-completion` to depend on `perl-path-security` and delegate its file-path helper functions to the shared APIs while keeping `walkdir::DirEntry`-specific adapters and file-metadata classification local to the completion crate. 
- Updated `crates/perl-lsp-completion/Cargo.toml` to add the workspace dependency on `perl-path-security`. 
- Added unit tests for the new helper APIs in `perl-path-security` and adjusted completion integration tests to remove an unused import so `clippy` passes.

### Testing

- Ran formatting with `cargo fmt --all` (succeeded). 
- Ran unit tests for the new microcrate with `cargo test -p perl-path-security` (9 tests passed). 
- Ran completion crate tests with `cargo test -p perl-lsp-completion` (8 unit tests + 81 comprehensive tests passed). 
- Ran lints with `cargo clippy -p perl-path-security -p perl-lsp-completion --all-targets -- -D warnings` (no warnings/errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b7d8b948333a5efa46c66e3ab73)