### PR TITLE
Split workspace index limit types into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,11 +2487,16 @@ dependencies = [
  "perl-symbol-types",
  "perl-tdd-support",
  "perl-uri",
+ "perl-workspace-index-limits",
  "perl-workspace-index-slo",
  "serde",
  "tempfile",
  "url",
 ]
+
+[[package]]
+name = "perl-workspace-index-limits"
+version = "0.10.0"
 
 [[package]]
 name = "perl-workspace-index-slo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/perl-parser-pest",
     "crates/perl-semantic-analyzer",
     "crates/perl-workspace-index",
+    "crates/perl-workspace-index-limits",
     "crates/perl-workspace-index-slo",
     "crates/perl-refactoring",
     "crates/perl-incremental-parsing",
@@ -130,6 +131,7 @@ allow = [
 "perl-symbol-table",
     "perl-uri",
     "perl-workspace-index-slo",
+    "perl-workspace-index-limits",
 
     # Tier 3 — Analysis and indexing
     "perl-workspace-index",
@@ -298,6 +300,7 @@ perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.
 
 # Tier 3: Two-level dependencies
 perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.10.0" }
+perl-workspace-index-limits = { path = "crates/perl-workspace-index-limits", version = "0.10.0" }
 perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.10.0" }
 perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.10.0" }
 perl-refactoring = { path = "crates/perl-refactoring", version = "0.10.0" }

--- a/crates/perl-workspace-index-limits/Cargo.toml
+++ b/crates/perl-workspace-index-limits/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "perl-workspace-index-limits"
+version = "0.10.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Resource and performance limits for perl-workspace-index"
+readme = "README.md"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-workspace-index-limits"
+keywords = ["perl", "workspace", "index", "limits"]
+categories = ["development-tools"]
+include = [
+  "src/**",
+  "Cargo.toml",
+  "LICENSE*",
+  "README.md"
+]
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-index-limits/README.md
+++ b/crates/perl-workspace-index-limits/README.md
@@ -1,0 +1,3 @@
+# perl-workspace-index-limits
+
+Shared resource and performance limit types for `perl-workspace-index`.

--- a/crates/perl-workspace-index-limits/src/lib.rs
+++ b/crates/perl-workspace-index-limits/src/lib.rs
@@ -1,0 +1,99 @@
+//! Resource and performance limits for workspace indexing.
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Type of resource limit that was exceeded.
+///
+/// Identifies which bounded resource triggered index degradation,
+/// enabling targeted eviction strategies and capacity planning.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResourceKind {
+    /// Maximum number of files in index exceeded
+    MaxFiles,
+
+    /// Maximum total symbols exceeded
+    MaxSymbols,
+
+    /// Maximum AST cache bytes exceeded
+    MaxCacheBytes,
+}
+
+/// Configurable resource limits for workspace index.
+#[derive(Clone, Debug)]
+pub struct IndexResourceLimits {
+    /// Maximum files to index (default: 10,000)
+    pub max_files: usize,
+
+    /// Maximum symbols per file (default: 5,000)
+    pub max_symbols_per_file: usize,
+
+    /// Maximum total symbols (default: 500,000)
+    pub max_total_symbols: usize,
+
+    /// Maximum AST cache size in bytes (default: 256MB)
+    pub max_ast_cache_bytes: usize,
+
+    /// Maximum AST cache items (default: 100)
+    pub max_ast_cache_items: usize,
+
+    /// Maximum workspace scan duration in milliseconds (default: 30,000ms = 30s)
+    pub max_scan_duration_ms: u64,
+}
+
+impl Default for IndexResourceLimits {
+    fn default() -> Self {
+        Self {
+            max_files: 10_000,
+            max_symbols_per_file: 5_000,
+            max_total_symbols: 500_000,
+            max_ast_cache_bytes: 256 * 1024 * 1024,
+            max_ast_cache_items: 100,
+            max_scan_duration_ms: 30_000,
+        }
+    }
+}
+
+/// Performance caps for workspace indexing operations.
+#[derive(Clone, Debug)]
+pub struct IndexPerformanceCaps {
+    /// Initial workspace scan budget in milliseconds (default: 100ms)
+    pub initial_scan_budget_ms: u64,
+    /// Incremental update budget in milliseconds (default: 10ms)
+    pub incremental_budget_ms: u64,
+}
+
+impl Default for IndexPerformanceCaps {
+    fn default() -> Self {
+        Self { initial_scan_budget_ms: 100, incremental_budget_ms: 10 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IndexPerformanceCaps, IndexResourceLimits, ResourceKind};
+
+    #[test]
+    fn default_resource_limits_are_stable() {
+        let limits = IndexResourceLimits::default();
+        assert_eq!(limits.max_files, 10_000);
+        assert_eq!(limits.max_symbols_per_file, 5_000);
+        assert_eq!(limits.max_total_symbols, 500_000);
+        assert_eq!(limits.max_ast_cache_bytes, 256 * 1024 * 1024);
+        assert_eq!(limits.max_ast_cache_items, 100);
+        assert_eq!(limits.max_scan_duration_ms, 30_000);
+    }
+
+    #[test]
+    fn default_performance_caps_are_stable() {
+        let caps = IndexPerformanceCaps::default();
+        assert_eq!(caps.initial_scan_budget_ms, 100);
+        assert_eq!(caps.incremental_budget_ms, 10);
+    }
+
+    #[test]
+    fn resource_kind_variants_are_comparable() {
+        assert_eq!(ResourceKind::MaxFiles, ResourceKind::MaxFiles);
+        assert_ne!(ResourceKind::MaxSymbols, ResourceKind::MaxCacheBytes);
+    }
+}

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -27,6 +27,7 @@ perl-parser-core = { workspace = true }
 perl-position-tracking = { workspace = true, features = ["lsp-compat"] }
 perl-symbol-types = { workspace = true }
 perl-uri = { workspace = true }
+perl-workspace-index-limits = { workspace = true }
 perl-workspace-index-slo = { workspace = true }
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -13,6 +13,7 @@ pub use cache::{
     AstCacheConfig, BoundedLruCache, CacheConfig, CombinedWorkspaceCacheConfig, EstimateSize,
     SymbolCacheConfig, WorkspaceCacheConfig,
 };
+pub use perl_workspace_index_limits::{IndexPerformanceCaps, IndexResourceLimits, ResourceKind};
 pub use production_coordinator::{
     CoordinatorStatistics, ProductionCoordinatorConfig, ProductionIndexCoordinator,
     WorkspaceCacheManager,
@@ -20,6 +21,6 @@ pub use production_coordinator::{
 pub use slo::{OperationResult, OperationType, SloConfig, SloStatistics, SloTracker};
 pub use state_machine::{
     BuildPhase, DegradationReason, IndexState, IndexStateKind, IndexStateMachine,
-    InvalidationReason, ResourceKind, TransitionResult,
+    InvalidationReason, TransitionResult,
 };
-pub use workspace_index::{IndexResourceLimits, Location, WorkspaceIndex};
+pub use workspace_index::{Location, WorkspaceIndex};

--- a/crates/perl-workspace-index/src/workspace/state_machine.rs
+++ b/crates/perl-workspace-index/src/workspace/state_machine.rs
@@ -46,6 +46,7 @@
 //! ```
 
 use parking_lot::RwLock;
+use perl_workspace_index_limits::ResourceKind;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -250,17 +251,6 @@ pub enum DegradationReason {
         /// Which resource limit was exceeded
         kind: ResourceKind,
     },
-}
-
-/// Type of resource limit that was exceeded.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ResourceKind {
-    /// Maximum number of files in index exceeded
-    MaxFiles,
-    /// Maximum total symbols exceeded
-    MaxSymbols,
-    /// Maximum AST cache bytes exceeded
-    MaxCacheBytes,
 }
 
 /// State transition for index lifecycle instrumentation.

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -75,6 +75,9 @@ use std::sync::Arc;
 use std::time::Instant;
 use url::Url;
 
+/// Resource and performance limit types for index coordination.
+pub use perl_workspace_index_limits::{IndexPerformanceCaps, IndexResourceLimits, ResourceKind};
+
 // Re-export URI utilities for backward compatibility
 #[cfg(not(target_arch = "wasm32"))]
 /// URI ↔ filesystem helpers used during Index/Analyze workflows.
@@ -307,103 +310,6 @@ pub enum DegradationReason {
         /// Which resource limit was exceeded
         kind: ResourceKind,
     },
-}
-
-#[derive(Clone, Debug, PartialEq)]
-/// Type of resource limit that was exceeded
-///
-/// Identifies which bounded resource triggered index degradation,
-/// enabling targeted eviction strategies and capacity planning.
-pub enum ResourceKind {
-    /// Maximum number of files in index exceeded
-    MaxFiles,
-
-    /// Maximum total symbols exceeded
-    MaxSymbols,
-
-    /// Maximum AST cache bytes exceeded
-    MaxCacheBytes,
-}
-
-#[derive(Clone, Debug)]
-/// Configurable resource limits for workspace index
-///
-/// Defines hard caps on various index resources to prevent unbounded
-/// memory growth in large Perl workspaces. These limits trigger
-/// graceful degradation with LRU eviction when exceeded.
-///
-/// # Performance Characteristics
-///
-/// - Default limits support ~10K files with ~500K total symbols
-/// - AST cache defaults to 256MB with 100 items (LRU eviction)
-/// - Eviction is deterministic for reproducible behavior
-/// - Limits are configurable per workspace via LSP initialization
-///
-/// # Usage
-///
-/// ```rust,ignore
-/// use perl_parser::workspace_index::IndexResourceLimits;
-///
-/// // Use default limits
-/// let limits = IndexResourceLimits::default();
-/// assert_eq!(limits.max_files, 10_000);
-///
-/// // Custom limits for large workspace
-/// let custom = IndexResourceLimits {
-///     max_files: 50_000,
-///     max_total_symbols: 2_000_000,
-///     ..Default::default()
-/// };
-/// ```
-pub struct IndexResourceLimits {
-    /// Maximum files to index (default: 10,000)
-    pub max_files: usize,
-
-    /// Maximum symbols per file (default: 5,000)
-    pub max_symbols_per_file: usize,
-
-    /// Maximum total symbols (default: 500,000)
-    pub max_total_symbols: usize,
-
-    /// Maximum AST cache size in bytes (default: 256MB)
-    pub max_ast_cache_bytes: usize,
-
-    /// Maximum AST cache items (default: 100)
-    pub max_ast_cache_items: usize,
-
-    /// Maximum workspace scan duration in milliseconds (default: 30,000ms = 30s)
-    pub max_scan_duration_ms: u64,
-}
-
-impl Default for IndexResourceLimits {
-    fn default() -> Self {
-        Self {
-            max_files: 10_000,
-            max_symbols_per_file: 5_000,
-            max_total_symbols: 500_000,
-            max_ast_cache_bytes: 256 * 1024 * 1024, // 256MB
-            max_ast_cache_items: 100,
-            max_scan_duration_ms: 30_000, // 30 seconds
-        }
-    }
-}
-
-/// Performance caps for workspace indexing operations
-///
-/// These caps are soft budgets that enable early-exit heuristics to keep
-/// indexing responsive on constrained machines.
-#[derive(Clone, Debug)]
-pub struct IndexPerformanceCaps {
-    /// Initial workspace scan budget in milliseconds (default: 100ms)
-    pub initial_scan_budget_ms: u64,
-    /// Incremental update budget in milliseconds (default: 10ms)
-    pub incremental_budget_ms: u64,
-}
-
-impl Default for IndexPerformanceCaps {
-    fn default() -> Self {
-        Self { initial_scan_budget_ms: 100, incremental_budget_ms: 10 }
-    }
 }
 
 /// Metrics for index lifecycle management and degradation detection


### PR DESCRIPTION
### Motivation

- Separate the index limit/policy types (resource kinds, resource limits, performance caps) from the large `perl-workspace-index` implementation so they follow single-responsibility and can be reused/tested independently.
- Reduce coupling and duplicate definitions across modules by providing a single canonical source for limit types.
- Preserve API ergonomics for consumers by re-exporting the new crate from `perl-workspace-index` so existing imports remain stable.

### Description

- Added a new crate `crates/perl-workspace-index-limits` that defines `ResourceKind`, `IndexResourceLimits`, and `IndexPerformanceCaps` along with unit tests and crate metadata.
- Wired the new crate into the workspace: added it to `members`, the publish allowlist, and workspace dependencies in `Cargo.toml`.
- Updated `crates/perl-workspace-index` to depend on and re-export the new limits crate so downstream code continues to see the same public types from `perl_workspace_index`.
- Removed the duplicated limit/type definitions from `workspace_index.rs` and `state_machine.rs` and adjusted imports so `state_machine` and `workspace_index` use `perl_workspace_index_limits::ResourceKind` (and other types) instead of local definitions.
- Ran formatting (`cargo fmt`) and fixed small import/format drift to keep the crate consistent.

### Testing

- Ran `cargo test -p perl-workspace-index-limits` and unit tests in the new crate passed (`3 passed`).
- Ran `cargo test -p perl-workspace-index --lib` and the workspace index test-suite passed (`77 passed`).
- Ran `cargo check -p perl-lsp` to ensure the broader workspace compiles against the change and it completed successfully.
- Ran `cargo fmt --all` to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80b79fe588333ad2b87fd9d347880)