### PR TITLE
fix(parser): handle subscripts on package-qualified variables

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1077,8 +1077,76 @@ impl<'a> PerlLexer<'a> {
             return None;
         }
 
-        // Consume initial digits - unrolled for better performance
+        // Check for hex (0x), binary (0b), or octal (0o) prefixes
         let mut pos = self.position;
+        if Self::byte_at(bytes, pos) == b'0' && pos + 1 < bytes.len() {
+            let prefix_byte = bytes[pos + 1];
+            if prefix_byte == b'x' || prefix_byte == b'X' {
+                // Hexadecimal: 0x[0-9a-fA-F_]+
+                pos += 2; // consume '0x'
+                let digit_start = pos;
+                while pos < bytes.len() && (bytes[pos].is_ascii_hexdigit() || bytes[pos] == b'_') {
+                    pos += 1;
+                }
+                if pos > digit_start {
+                    self.position = pos;
+                    let text = &self.input[start..self.position];
+                    self.mode = LexerMode::ExpectOperator;
+                    return Some(Token {
+                        token_type: TokenType::Number(Arc::from(text)),
+                        text: Arc::from(text),
+                        start,
+                        end: self.position,
+                    });
+                }
+                // No hex digits after 0x - fall through to parse '0' as decimal
+            } else if prefix_byte == b'b' || prefix_byte == b'B' {
+                // Binary: 0b[01_]+
+                pos += 2; // consume '0b'
+                let digit_start = pos;
+                while pos < bytes.len()
+                    && (bytes[pos] == b'0' || bytes[pos] == b'1' || bytes[pos] == b'_')
+                {
+                    pos += 1;
+                }
+                if pos > digit_start {
+                    self.position = pos;
+                    let text = &self.input[start..self.position];
+                    self.mode = LexerMode::ExpectOperator;
+                    return Some(Token {
+                        token_type: TokenType::Number(Arc::from(text)),
+                        text: Arc::from(text),
+                        start,
+                        end: self.position,
+                    });
+                }
+                // No binary digits after 0b - fall through to parse '0' as decimal
+            } else if prefix_byte == b'o' || prefix_byte == b'O' {
+                // Octal (explicit): 0o[0-7_]+
+                pos += 2; // consume '0o'
+                let digit_start = pos;
+                while pos < bytes.len()
+                    && ((bytes[pos] >= b'0' && bytes[pos] <= b'7') || bytes[pos] == b'_')
+                {
+                    pos += 1;
+                }
+                if pos > digit_start {
+                    self.position = pos;
+                    let text = &self.input[start..self.position];
+                    self.mode = LexerMode::ExpectOperator;
+                    return Some(Token {
+                        token_type: TokenType::Number(Arc::from(text)),
+                        text: Arc::from(text),
+                        start,
+                        end: self.position,
+                    });
+                }
+                // No octal digits after 0o - fall through to parse '0' as decimal
+            }
+        }
+
+        // Consume initial digits - unrolled for better performance
+        pos = self.position;
         while pos < bytes.len() {
             let byte = Self::byte_at(bytes, pos);
             if byte.is_ascii_digit() || byte == b'_' {

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3029,3 +3029,76 @@ mod line_index_extended_tests {
         Ok(())
     }
 }
+
+// ---- Wave 2A: Package-qualified subscripts ----
+
+mod wave2a_qualified_subscripts {
+    use super::*;
+
+    #[test]
+    fn wave2a_scalar_qualified_array_subscript() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$Text::Unidecode::Char[255];");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("[]"), "should have array subscript");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_scalar_qualified_array_subscript_hex() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$Text::Unidecode::Char[0xff];");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("[]"), "should have array subscript");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_scalar_qualified_hash_subscript() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$Package::Hash{key};");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("{}"), "should have hash subscript");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_deep_qualified_array() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$A::B::C::D[42];");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_qualified_hash_string_key() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$Config::Config{'osname'};");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_qualified_in_expression() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("my $val = $Pkg::data{$key};");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2a_unqualified_regression() -> Result<(), Box<dyn std::error::Error>> {
+        // Make sure normal subscripts still work
+        let mut parser = Parser::new("$hash{key};");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Add hex (`0x`), binary (`0b`), and octal (`0o`) number literal support to the lexer
- Fixes parsing of `$Text::Unidecode::Char[0xff]` and similar package-qualified subscript expressions
- Root cause: `0xff` was tokenized as `0` + `xff`, breaking subscript parsing

## Wave 2A — Package-qualified subscripts

**Bucket target**: `expected_right_bracket` / `expected_identifier` after qualified variable

**Layer 1** — Minimal reproducer tests (7 tests):
- `$Text::Unidecode::Char[0xff]`, `$Package::Hash{key}`, `$A::B::C::D[42]`
- `$Config::Config{'osname'}`, `my $val = $Pkg::data{$key}`
- Hex literal: `$Char[0xff]`
- Regression guard: `$hash{key}` still works

**Layer 2** — Real-world fixture: Text::Unidecode pattern

## Test plan

- [x] All 7 wave2a tests pass
- [x] Full `perl-parser-core` test suite passes (no regressions)
- [x] `cargo clippy -p perl-parser-core -p perl-lexer` clean
- [ ] `just common-corpus-check` passes
- [ ] Corpus sweep shows bucket drop