### PR TITLE
fix(parser): accept fat arrow as argument separator in function calls

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -116,10 +116,16 @@ impl<'a> Parser<'a> {
             if let Ok(next) = self.tokens.peek_second() {
                 let next_text = &next.text;
                 if next_text.starts_with('$') || next_text.starts_with('@') || next_text.starts_with('%') {
+                    // Bare sigil followed by { or [ is a dereference expression
+                    // like @{$ref}, %{$hash}, not an indirect object
+                    if next_text.len() <= 1 {
+                        return false;
+                    }
                     // Check if another typical arg or terminator follows to confirm it's not a regular call
                     if let Ok(third) = self.tokens.peek_third() {
-                        // Comma means regular call: func $arg, ...
-                        if third.kind == TokenKind::Comma {
+                        // Comma or fat arrow means regular call: func $arg, ...
+                        // e.g. push @array, $val  or  push @array => $val
+                        if matches!(third.kind, TokenKind::Comma | TokenKind::FatArrow) {
                             return false;
                         }
                         return true;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -449,9 +449,10 @@ impl<'a> Parser<'a> {
                                     // Parse the first argument
                                     args.push(self.parse_ternary()?);
 
-                                    // Parse remaining arguments separated by commas
-                                    while self.peek_kind() == Some(TokenKind::Comma) {
-                                        self.consume_token()?; // consume comma
+                                    // Parse remaining arguments separated by commas or fat arrows
+                                    // Perl allows `push @array => $value` as well as commas
+                                    while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                        self.consume_token()?;
                                         if self.is_at_statement_end() {
                                             break;
                                         }

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -381,9 +381,10 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_assignment()?);
                                 }
                             } else {
-                                // For other functions, require commas between arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // For other functions, require commas (or fat arrows) between arguments
+                                // Perl allows `push @array => $value` as well as `push @array, $value`
+                                while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    self.consume_token()?; // consume comma or fat arrow
 
                                     // Check if we hit a statement modifier
                                     match self.peek_kind() {

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3028,4 +3028,69 @@ mod line_index_extended_tests {
         assert_eq!(line, 2);
         Ok(())
     }
+
+    // ---- Wave 2B: Fat arrow as general separator ----
+
+    #[test]
+    fn wave2b_push_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @array => $value;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "push @array => $value should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("call push"), "should be a function call");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_bless_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("bless \\%opts => $class;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "bless \\%opts => $class should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_push_fat_arrow_nested() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @attrs => (key => $val);");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "push @attrs => (key => $val) should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_push_comma_regression() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @array, $value;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "push @array, $value should still work, got: {sexp}");
+        assert!(sexp.contains("call push"), "should be a function call");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_indirect_call_regression() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("print $fh \"data\";");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "print $fh \"data\" should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_hash_fat_arrow_regression() -> Result<(), Box<dyn std::error::Error>> {
+        // Hash construction should still work
+        let mut parser = Parser::new("my %h = (key => 'value');");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "hash construction should still work, got: {sexp}");
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Accept `=>` alongside `,` as separator in bareword function call argument lists
- Fix indirect object detection for bare sigil dereferences (`@{$ref}`)
- Changes in `calls.rs`, `statements.rs`, and `postfix.rs`

## Wave 2B — Fat arrow as general separator

**Bucket target**: `unexpected_fat_arrow_expr`

**Layer 1** — Minimal reproducer tests (6 tests):
- `push @array => $value`, `bless \%opts => $class`
- `push @attrs => (key => $val)` (nested fat arrows)
- Regressions: comma separator, indirect calls, hash construction

**Layer 2** — Real-world patterns from Moose, Moo, and CPAN idioms

## Test plan

- [x] All 6 wave2b tests pass
- [x] Full `perl-parser-core` test suite passes (no regressions)
- [x] `cargo clippy -p perl-parser-core` clean
- [ ] `just common-corpus-check` passes
- [ ] Corpus sweep shows bucket drop