### PR TITLE
fix(parser): handle postfix modifiers after dereference expressions

### DIFF
--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3146,6 +3146,83 @@ mod line_index_extended_tests {
         assert!(!sexp.contains("ERROR"), "split with string should still work, got: {sexp}");
         Ok(())
     }
+
+    // ---- Wave 2D: Postfix modifiers after complex expressions ----
+
+    #[test]
+    fn wave2d_push_deref_with_if() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @{$hash{key}}, $val if $cond;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "push @{{$hash{{key}}}}, $val if $cond should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_push_deref_simple() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @{$arr}, 1;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "push @{{$arr}}, 1 should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_or_assign_for() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("$hash{$_} ||= '' for @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "$hash{{$_}} ||= '' for @list should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_simple_modifier_regression() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("print $msg unless $quiet;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "print $msg unless $quiet should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_do_thing_for_list() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("do_thing() for @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "do_thing() for @list should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_deref_hash_push() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("push @{$self->{items}}, $item;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "push @{{$self->{{items}}}}, $item should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2d_complex_lvalue_while() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("chomp($line) while ($line = <STDIN>);");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should parse cleanly, got: {sexp}");
+        Ok(())
+    }
 }
 
 // ---- Wave 2A: Package-qualified subscripts ----


### PR DESCRIPTION
## Summary

- Fix indirect object detection for bare sigil dereferences (`@{$ref}`, `%{$hash}`)
- Bare sigils (length <= 1) followed by `{` are now recognized as dereferences, not indirect objects
- Allows postfix modifiers (`if`, `for`, `unless`, `while`) after function calls with dereference args

## Wave 2D — Postfix modifiers after complex expressions

**Bucket target**: `expected_right_brace` / indirect object misdetection

**Layer 1** — Minimal reproducer tests (7 tests):
- `push @{$hash{key}}, $val if $cond`
- `push @{$arr}, 1`, `push @{$self->{items}}, $item`
- `$hash{$_} ||= '' for @list`
- Regressions: `print $msg unless $quiet`, `do_thing() for @list`
- `chomp($line) while ($line = <STDIN>)`

**Layer 2** — Real-world patterns from complex Perl modules

## Test plan

- [x] All 7 wave2d tests pass
- [x] Full `perl-parser-core` test suite passes (no regressions)
- [x] `cargo clippy -p perl-parser-core` clean
- [ ] `just common-corpus-check` passes
- [ ] Corpus sweep shows bucket drop