### PR TITLE
refactor(lsp): extract document links into dedicated SRP microcrate

### DIFF
--- a/crates/perl-lsp-code-actions/Cargo.toml
+++ b/crates/perl-lsp-code-actions/Cargo.toml
@@ -23,7 +23,6 @@ perl-lsp-text-utils = { workspace = true }
 perl-lsp-rename = { workspace = true }
 perl-lsp-import-management = { workspace = true }
 perl-lsp-diagnostics = { workspace = true }
-perl-lsp-import-management = { workspace = true }
 perl-source-editing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
### Motivation
- Separate the single responsibility of document-link extraction out of the larger `perl-lsp-navigation` crate so the functionality is reusable and easier to maintain. 
- Reduce coupling in navigation providers by isolating `compute_links` and related helpers into a focused microcrate.

### Description
- Added a new SRP crate `crates/perl-lsp-document-links` containing the extracted implementation and tests from `document_links` (`crates/perl-lsp-document-links/src/lib.rs`, `crates/perl-lsp-document-links/Cargo.toml`, `crates/perl-lsp-document-links/README.md`).
- Removed the local `document_links` module from `crates/perl-lsp-navigation` and updated `crates/perl-lsp-navigation/src/lib.rs` to re-export `compute_links` from `perl_lsp_document_links` and updated its `Cargo.toml` to depend on the new crate.
- Wired the new crate into workspace membership and workspace dependencies by updating the top-level `Cargo.toml` (members, publish allowlist, and dependency entries) and regenerated the SRP inventory (`docs/SRP_MICROCRATES.md`).
- Kept existing unit tests (moved with the implementation) so the public API behavior of `compute_links` is preserved.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran unit tests for the new crate with `cargo test -p perl-lsp-document-links` and all tests passed (3 passed, 0 failed).
- Ran `cargo test -p perl-lsp-navigation` and the navigation test suite passed (all unit/extended tests shown passed).
- Performed `cargo check -p perl-lsp` and executed `cargo run -p xtask -- srp-microcrates` to update the SRP report, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97d00946c8333b7a3f352e77eaf74)