### PR TITLE
feat(test): add deterministic crypto fixture infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +177,18 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -212,6 +236,20 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.2.17",
+]
 
 [[package]]
 name = "block-buffer"
@@ -473,6 +511,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +647,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -841,6 +917,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -896,6 +983,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1192,6 +1285,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1214,6 +1310,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1418,12 +1520,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1507,6 +1646,15 @@ name = "peak_alloc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc90935a8dd139fdf341762773687a1e361d3f54b396a55d9dd1f7001e484bb"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2556,6 +2704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+ "uselesskey",
 ]
 
 [[package]]
@@ -2813,6 +2962,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,7 +3150,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
  "rusty-fork",
@@ -3027,11 +3197,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -3048,12 +3228,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3169,6 +3368,26 @@ checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3481,6 +3700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +3759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3565,6 +3804,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4034,6 +4279,150 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "uselesskey"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b699dcd2fe0ab8ee5b415da7b8eb9fb27f9f31d89c6349ea4ac26ce82b5e8f"
+dependencies = [
+ "uselesskey-core",
+ "uselesskey-rsa",
+]
+
+[[package]]
+name = "uselesskey-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61a36f8ac29336006b4ca03f78f12e34e43964a0bd9d1ff334b42675cd74aed"
+dependencies = [
+ "rand_chacha 0.3.1",
+ "thiserror",
+ "uselesskey-core-cache",
+ "uselesskey-core-factory",
+ "uselesskey-core-id",
+ "uselesskey-core-negative",
+ "uselesskey-core-sink",
+]
+
+[[package]]
+name = "uselesskey-core-cache"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe24e6fffaa91e0467d19e49749810942341a973870a16409128c28c8772540"
+dependencies = [
+ "dashmap",
+ "spin",
+ "uselesskey-core-id",
+]
+
+[[package]]
+name = "uselesskey-core-factory"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4773ce6e936d7a8030cc7a5dce244a6716feaac6c285abacf9624772e239eca9"
+dependencies = [
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "uselesskey-core-cache",
+ "uselesskey-core-id",
+]
+
+[[package]]
+name = "uselesskey-core-hash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a033348427ea4ef1bccdffd0e82d37d838a39d0bfc21d17796ed2f8bee55d9d"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
+name = "uselesskey-core-id"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87a3fdc12173dab526dff81813cfabe2b0c5b565660306dc4485592a55b4aae"
+dependencies = [
+ "uselesskey-core-hash",
+ "uselesskey-core-seed",
+]
+
+[[package]]
+name = "uselesskey-core-keypair-material"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3c5a6edacd46be157a4ab027b037bc2d4548dde732acd7991fac59c5c74aaa"
+dependencies = [
+ "uselesskey-core",
+ "uselesskey-core-kid",
+]
+
+[[package]]
+name = "uselesskey-core-kid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a024c1f2966436baa4e302fa5bc878312f4526d9a1a624575b421776245fb7c"
+dependencies = [
+ "base64",
+ "blake3",
+]
+
+[[package]]
+name = "uselesskey-core-negative"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8db160b7424fa04d1bbe69d9b8cde990a0c6b1a744122c7d9046318ce9e0784"
+dependencies = [
+ "uselesskey-core-negative-der",
+ "uselesskey-core-negative-pem",
+]
+
+[[package]]
+name = "uselesskey-core-negative-der"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5be41e3fcadac186f9ad88852eb3b2a9b4905b3c6dfbeb2252b6cc44ba0c730"
+dependencies = [
+ "uselesskey-core-hash",
+]
+
+[[package]]
+name = "uselesskey-core-negative-pem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804b7f55793d170397c73a98a883a4fde193d2f86ab49a6769c9aa33c0465567"
+dependencies = [
+ "uselesskey-core-hash",
+]
+
+[[package]]
+name = "uselesskey-core-seed"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0664d542017cd3c2a0444547a46ed533c93de60e8baddc9e3c60b53cb4f726fc"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
+name = "uselesskey-core-sink"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650162c195beeb6e746822fb0760e62e9d71df66b129192d315d63f08f9d82c1"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
+name = "uselesskey-rsa"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17fa5011811f2ce3ab875b68a0d8cb208010ff9377123c1d185ee0ab74ba9f8b"
+dependencies = [
+ "rsa",
+ "uselesskey-core",
+ "uselesskey-core-keypair-material",
 ]
 
 [[package]]
@@ -4679,6 +5068,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -113,7 +113,7 @@ pretty_assertions = "1.4.1"
 serial_test = "3.4.0"
 tempfile = "3.24.0"
 proptest = "1.9.0"
-perl-tdd-support = { workspace = true }
+perl-tdd-support = { workspace = true, features = ["crypto-fixtures"] }
 which = "8.0.0"
 parking_lot = "0.12.5"
 criterion = "0.8.1"

--- a/crates/perl-lsp/tests/crypto_fixture_integration_tests.rs
+++ b/crates/perl-lsp/tests/crypto_fixture_integration_tests.rs
@@ -1,0 +1,48 @@
+mod support;
+
+use perl_tdd_support::crypto::{CorruptPem, RsaKeyFixture, scoped_seed};
+use support::TempWorkspace;
+
+#[test]
+fn writes_deterministic_rsa_fixtures_into_temp_workspace() -> Result<(), Box<dyn std::error::Error>>
+{
+    let seed = scoped_seed(module_path!(), "writes_deterministic_rsa_fixtures_into_temp_workspace");
+
+    let first = RsaKeyFixture::rs256(&seed, "perl-lsp-test-signer")?;
+    let second = RsaKeyFixture::rs256(&seed, "perl-lsp-test-signer")?;
+
+    assert_eq!(first, second, "same seed + label should generate identical runtime fixtures");
+
+    let workspace = TempWorkspace::new().map_err(std::io::Error::other)?;
+    let fixture_dir = workspace.dir.path().join("test-fixtures/crypto");
+    let paths = first.write_into(&fixture_dir, "signing")?;
+
+    assert!(paths.private_key_pem.starts_with(workspace.dir.path()));
+    assert!(paths.public_key_pem.starts_with(workspace.dir.path()));
+
+    let private_key = std::fs::read_to_string(&paths.private_key_pem)?;
+    let public_key = std::fs::read_to_string(&paths.public_key_pem)?;
+
+    assert!(
+        private_key.contains("-----BEGIN PRIVATE KEY-----"),
+        "private key fixture should be written as PKCS#8 PEM"
+    );
+    assert!(
+        public_key.contains("-----BEGIN PUBLIC KEY-----"),
+        "public key fixture should be written as SPKI PEM"
+    );
+
+    let bad_private_key = first.corrupt_private_key_pem(CorruptPem::BadHeader);
+    assert_ne!(
+        bad_private_key,
+        first.private_key_pkcs8_pem(),
+        "negative fixture should differ from the valid PEM"
+    );
+    assert!(
+        bad_private_key.contains("CORRUPTED")
+            || !bad_private_key.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "negative fixture should visibly break the PEM header"
+    );
+
+    Ok(())
+}

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -29,11 +29,12 @@ serde_json = "1.0.149"
 anyhow = "1.0.102"
 lsp-types = { version = "0.97.0", optional = true }
 url = { version = "2.5.8", optional = true }
+uselesskey = { version = "0.2.0", default-features = false, features = ["rsa"], optional = true }
 
 [features]
 default = []
 lsp-compat = ["lsp-types", "url"]
+crypto-fixtures = ["dep:uselesskey"]
 
 [lints]
 workspace = true
-

--- a/crates/perl-tdd-support/src/crypto.rs
+++ b/crates/perl-tdd-support/src/crypto.rs
@@ -1,0 +1,109 @@
+//! Deterministic cryptographic fixtures for test code.
+//!
+//! This module keeps secrets-shaped fixtures out of version control by
+//! generating them at runtime from stable seeds.
+
+use anyhow::{Context, Result, anyhow, ensure};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec, Seed};
+
+pub use uselesskey::negative::{CorruptPem, corrupt_pem};
+
+/// Create a stable seed string scoped to a module and test case.
+pub fn scoped_seed(scope: &str, case: &str) -> String {
+    let scope = scope.trim();
+    let case = case.trim();
+
+    match (scope.is_empty(), case.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => scope.to_string(),
+        (true, false) => case.to_string(),
+        (false, false) => format!("{scope}::{case}"),
+    }
+}
+
+/// Build a deterministic `uselesskey` factory from a seed string.
+pub fn deterministic_factory(seed_input: &str) -> Result<Factory> {
+    let seed = Seed::from_env_value(seed_input)
+        .map_err(|err| anyhow!("failed to derive uselesskey seed: {err}"))?;
+    Ok(Factory::deterministic(seed))
+}
+
+/// In-memory RSA fixture material suitable for signing and parser/path tests.
+#[derive(Clone, Eq, PartialEq)]
+pub struct RsaKeyFixture {
+    private_key_pkcs8_pem: String,
+    public_key_spki_pem: String,
+}
+
+impl RsaKeyFixture {
+    /// Generate a deterministic RSA-2048 / RS256 fixture.
+    pub fn rs256(seed_input: &str, label: &str) -> Result<Self> {
+        let factory = deterministic_factory(seed_input)?;
+        let keypair = factory.rsa(label, RsaSpec::rs256());
+
+        Ok(Self {
+            private_key_pkcs8_pem: keypair.private_key_pkcs8_pem().to_string(),
+            public_key_spki_pem: keypair.public_key_spki_pem().to_string(),
+        })
+    }
+
+    /// Return the PKCS#8 private key PEM.
+    pub fn private_key_pkcs8_pem(&self) -> &str {
+        &self.private_key_pkcs8_pem
+    }
+
+    /// Return the SPKI public key PEM.
+    pub fn public_key_spki_pem(&self) -> &str {
+        &self.public_key_spki_pem
+    }
+
+    /// Produce a deterministically corrupted private-key PEM for sad-path tests.
+    pub fn corrupt_private_key_pem(&self, variant: CorruptPem) -> String {
+        corrupt_pem(self.private_key_pkcs8_pem(), variant)
+    }
+
+    /// Write both PEM files into an existing directory with a predictable stem.
+    pub fn write_into<P: AsRef<Path>>(&self, dir: P, stem: &str) -> Result<RsaKeyFixturePaths> {
+        ensure!(!stem.trim().is_empty(), "fixture file stem must not be empty");
+
+        let dir = dir.as_ref();
+        fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create fixture directory {}", dir.display()))?;
+
+        let paths = RsaKeyFixturePaths {
+            private_key_pem: dir.join(format!("{stem}.private-key.pem")),
+            public_key_pem: dir.join(format!("{stem}.public-key.pem")),
+        };
+
+        write_pem_file(&paths.private_key_pem, self.private_key_pkcs8_pem(), "private key")?;
+        write_pem_file(&paths.public_key_pem, self.public_key_spki_pem(), "public key")?;
+
+        Ok(paths)
+    }
+}
+
+impl fmt::Debug for RsaKeyFixture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RsaKeyFixture")
+            .field("private_key_pkcs8_pem", &"<redacted>")
+            .field("public_key_spki_pem", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Concrete paths written by [`RsaKeyFixture::write_into`].
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RsaKeyFixturePaths {
+    /// Filesystem path to the private key PEM.
+    pub private_key_pem: PathBuf,
+    /// Filesystem path to the public key PEM.
+    pub public_key_pem: PathBuf,
+}
+
+fn write_pem_file(path: &Path, contents: &str, description: &str) -> Result<()> {
+    fs::write(path, contents)
+        .with_context(|| format!("failed to write {description} fixture to {}", path.display()))
+}

--- a/crates/perl-tdd-support/src/lib.rs
+++ b/crates/perl-tdd-support/src/lib.rs
@@ -83,3 +83,7 @@ pub use must::{must, must_err, must_some};
 
 /// CI Guardrail Ignored Test Monitoring and Governance.
 pub mod governance;
+
+/// Deterministic cryptographic fixtures for tests.
+#[cfg(feature = "crypto-fixtures")]
+pub mod crypto;


### PR DESCRIPTION
## Summary

- Add `crypto-fixtures` feature gate to `perl-tdd-support` with `uselesskey` dependency for deterministic RSA-2048/RS256 key generation
- Provide `RsaKeyFixture` API: `rs256()` generates from seed+label, `write_into()` persists PEM files, `corrupt_private_key_pem()` produces negative-test material
- Add integration test in `perl-lsp` verifying determinism, file I/O, and PEM format correctness

## Design

- **Feature-gated**: `crypto-fixtures` is off by default — no impact on existing builds
- **Deterministic**: Same seed + label always produces identical key material (via `uselesskey::Seed::from_env_value`)
- **No secrets in VCS**: Keys are generated at runtime from stable seeds, not checked in
- **Negative testing**: `CorruptPem` variants (re-exported from `uselesskey`) enable sad-path coverage
- **Debug safety**: `RsaKeyFixture` redacts key material in `Debug` output

## Files changed

| File | Change |
|------|--------|
| `crates/perl-tdd-support/Cargo.toml` | Add optional `uselesskey` dep, `crypto-fixtures` feature |
| `crates/perl-tdd-support/src/lib.rs` | `pub mod crypto` gated by feature |
| `crates/perl-tdd-support/src/crypto.rs` | ~110 lines: `scoped_seed`, `deterministic_factory`, `RsaKeyFixture`, `RsaKeyFixturePaths` |
| `crates/perl-lsp/Cargo.toml` | Enable `crypto-fixtures` in dev-dep |
| `crates/perl-lsp/tests/crypto_fixture_integration_tests.rs` | Integration test (~49 lines) |
| `Cargo.lock` | New crypto dependency tree |

## Test plan

- [x] `cargo test -p perl-tdd-support --lib --features crypto-fixtures` — 15 tests pass
- [x] `cargo test -p perl-lsp --test crypto_fixture_integration_tests` — integration test passes
- [x] `cargo clippy -p perl-tdd-support -p perl-lsp` — no warnings