### PR TITLE
refactor(code-actions): use perl-lsp-import-management for import actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,6 +1868,7 @@ version = "0.10.0"
 dependencies = [
  "perl-lsp-ast-utils",
  "perl-lsp-diagnostics",
+ "perl-lsp-import-management",
  "perl-lsp-rename",
  "perl-lsp-text-utils",
  "perl-parser-core",

--- a/crates/perl-lsp-code-actions/Cargo.toml
+++ b/crates/perl-lsp-code-actions/Cargo.toml
@@ -22,6 +22,7 @@ perl-lsp-ast-utils = { workspace = true }
 perl-lsp-text-utils = { workspace = true }
 perl-lsp-rename = { workspace = true }
 perl-lsp-diagnostics = { workspace = true }
+perl-lsp-import-management = { workspace = true }
 perl-source-editing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/perl-lsp-code-actions/src/enhanced/import_management.rs
+++ b/crates/perl-lsp-code-actions/src/enhanced/import_management.rs
@@ -1,6 +1,9 @@
 //! Import management code actions
 
 use crate::types::{CodeAction, CodeActionEdit, CodeActionKind};
+use perl_lsp_import_management::{
+    collect_imports, find_imports_range, guess_module_for_function, sort_imports,
+};
 use perl_lsp_rename::TextEdit;
 use perl_parser_core::ast::{Node, SourceLocation};
 
@@ -77,83 +80,4 @@ pub fn find_undefined_functions(_ast: &Node) -> Vec<String> {
     // This would require full semantic analysis
     // For now, return empty
     Vec::new()
-}
-
-/// Guess module for a function
-pub fn guess_module_for_function(func: &str) -> Option<String> {
-    match func {
-        "dumper" => Some("Data::Dumper"),
-        "encode" | "decode" => Some("Encode"),
-        "basename" | "dirname" => Some("File::Basename"),
-        "mkpath" | "rmtree" => Some("File::Path"),
-        "slurp" => Some("File::Slurp"),
-        "decode_json" | "encode_json" => Some("JSON"),
-        _ => None,
-    }
-    .map(|s| s.to_string())
-}
-
-/// Collect all import statements
-pub fn collect_imports(lines: &[String]) -> Vec<String> {
-    let mut imports = Vec::new();
-
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed.starts_with("use ") || trimmed.starts_with("require ") {
-            imports.push(line.to_owned());
-        }
-    }
-
-    imports
-}
-
-/// Sort imports by category
-pub fn sort_imports(imports: Vec<String>) -> Vec<String> {
-    let mut pragmas = Vec::new();
-    let mut core = Vec::new();
-    let mut cpan = Vec::new();
-    let mut local = Vec::new();
-
-    for import in imports {
-        if import.contains("strict")
-            || import.contains("warnings")
-            || import.contains("utf8")
-            || import.contains("feature")
-        {
-            pragmas.push(import);
-        } else if import.contains("::") {
-            cpan.push(import);
-        } else if import.starts_with("use lib") || import.contains("./") {
-            local.push(import);
-        } else {
-            core.push(import);
-        }
-    }
-
-    pragmas.sort();
-    core.sort();
-    cpan.sort();
-    local.sort();
-
-    let mut result = Vec::new();
-    result.extend(pragmas);
-    result.extend(core);
-    result.extend(cpan);
-    result.extend(local);
-
-    result
-}
-
-/// Find the range of import statements
-pub fn find_imports_range(source: &str, lines: &[String]) -> Option<(usize, usize)> {
-    let imports = collect_imports(lines);
-    if imports.is_empty() {
-        return None;
-    }
-
-    let first = source.find(&imports[0])?;
-    let last = source.find(&imports[imports.len() - 1])?;
-    let last_end = last + imports[imports.len() - 1].len();
-
-    Some((first, last_end))
 }


### PR DESCRIPTION
### Motivation

- Reduce duplication by delegating import-management helpers to the existing SRP microcrate `perl-lsp-import-management` and improve single-responsibility alignment.

### Description

- Replaced local helper implementations in `crates/perl-lsp-code-actions/src/enhanced/import_management.rs` with imports from `perl_lsp_import_management` and removed the in-file implementations of `guess_module_for_function`, `collect_imports`, `sort_imports`, and `find_imports_range`.
- Added `perl-lsp-import-management` as a dependency in `crates/perl-lsp-code-actions/Cargo.toml` to wire the microcrate into the code-actions provider.
- Updated lockfile (dependency graph) to reflect the new crate usage and ran formatting updates with `cargo fmt --all`.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp-import-management -p perl-lsp-code-actions` and all tests in both crates passed (import-management unit tests and the full code-actions test suite).
- Ran `cargo clippy -p perl-lsp-code-actions -p perl-lsp-import-management --all-targets -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b595871c8333a8e572a261522cc3)