### PR TITLE
docs/devex: improve local CI fallback and hook install feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ You **must** run the local CI gate before pushing. The canonical command uses Ni
 # Canonical local gate (REQUIRED before push)
 nix develop -c just ci-gate
 
+# Fallback without `just`/Nix: run the Rust-native local mirror
+cargo run -p perl-ci-hygiene -- check-local
+
 # Install pre-push hook (runs gate automatically)
 bash scripts/install-githooks.sh
 ```

--- a/scripts/install-githooks.sh
+++ b/scripts/install-githooks.sh
@@ -5,7 +5,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
 
 if [ -x "$BIN" ]; then
+  echo "Using existing perl-ci-hygiene binary: $BIN"
   exec "$BIN" install-githooks
 fi
 
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- install-githooks
+echo "Building perl-ci-hygiene (first run may take a minute)..."
+exec cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- install-githooks


### PR DESCRIPTION
### Motivation

- Improve onboarding and local developer experience by providing a non-Nix/`just` fallback for the local CI gate and clearer feedback during githook installation.

### Description

- Add a documented fallback in `CONTRIBUTING.md`: `cargo run -p perl-ci-hygiene -- check-local` for contributors without `just`/Nix.
- Update `scripts/install-githooks.sh` to print when it is reusing an existing `perl-ci-hygiene` binary and to print a first-run build message before invoking `cargo run`, and remove `--quiet` so build progress is visible.

### Testing

- Ran `bash -n scripts/install-githooks.sh` to validate the script syntax and it succeeded.
- Ran `cargo run -p perl-ci-hygiene -- --help` to exercise the binary build/run path and it completed successfully (build emitted non-fatal compiler warnings but returned help output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c8192de08333a78a82348e0b87cd)