### PR TITLE
Add `just doctor` developer environment check and onboarding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ cargo test --workspace
 # Lint + format
 cargo clippy --workspace --lib && cargo fmt --all
 
+# Check local tooling (dev environment doctor)
+just doctor
+
 # Full local gate (requires Nix)
 nix develop -c just ci-gate
 ```

--- a/justfile
+++ b/justfile
@@ -266,6 +266,13 @@ ci-local:
         exit 1; \
     fi
 
+# Developer environment diagnostics (onboarding/troubleshooting helper)
+doctor:
+    @echo "=============================================="
+    @echo "  perl-lsp developer environment doctor"
+    @echo "=============================================="
+    @bash scripts/devex-doctor.sh
+
 # Tool availability check (basic tools for PR-fast)
 [private]
 _check-tools-basic:

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pass() { printf '✅ %s\n' "$1"; }
+warn() { printf '⚠️  %s\n' "$1"; }
+fail() { printf '❌ %s\n' "$1"; }
+
+check_cmd() {
+  local cmd="$1"
+  local label="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "$label: found ($(command -v "$cmd"))"
+    return 0
+  fi
+  warn "$label: not found"
+  return 1
+}
+
+show_version() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    local out
+    out=$("$@" 2>/dev/null | head -n1)
+    pass "$label version: $out"
+  else
+    warn "$label version check failed"
+  fi
+}
+
+MISSING_REQUIRED=0
+
+echo "Repository: $(pwd)"
+
+echo
+printf '== Required ==\n'
+if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
+if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
+
+show_version "rustc" rustc --version
+show_version "cargo" cargo --version
+
+echo
+printf '== Recommended ==\n'
+check_cmd just "just" || true
+check_cmd nix "nix" || true
+check_cmd cargo-audit "cargo-audit" || true
+
+if [ -f rust-toolchain.toml ]; then
+  TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
+  if [ -n "${TOOLCHAIN:-}" ]; then
+    pass "Pinned toolchain: $TOOLCHAIN"
+  else
+    warn "Could not parse rust-toolchain.toml"
+  fi
+else
+  warn "rust-toolchain.toml not found"
+fi
+
+echo
+printf '== Suggested next commands ==\n'
+echo "  just pr-fast"
+echo "  just ci-gate"
+echo "  nix develop -c just ci-gate"
+
+if [ "$MISSING_REQUIRED" -ne 0 ]; then
+  echo
+  fail "Missing required tools. Install Rust via https://rustup.rs"
+  exit 1
+fi
+
+echo
+pass "Doctor completed: required tooling is available"


### PR DESCRIPTION
### Motivation
- Provide a one-step onboarding/troubleshooting helper so contributors can quickly validate local dev tooling and avoid common setup friction. 
- Surface required vs recommended tools and suggest the canonical local gate commands to reduce context switching for new contributors.

### Description
- Added a new `doctor` recipe to the `justfile` that runs a lightweight developer diagnostics script (`just doctor`).
- Added `scripts/devex-doctor.sh`, a small POSIX-friendly script that verifies required tools (`cargo`, `rustfmt`), reports recommended tools (`just`, `nix`, `cargo-audit`), prints `rustc`/`cargo` versions, parses `rust-toolchain.toml` for a pinned toolchain, and prints suggested next commands (`just pr-fast`, `just ci-gate`, `nix develop -c just ci-gate`).
- Updated `README.md` development section to call out the new `just doctor` check in the standard development quick-start snippet.

### Testing
- Ran `bash -n scripts/devex-doctor.sh` to validate shell syntax and it succeeded.
- Executed `./scripts/devex-doctor.sh` which completed successfully and reported the environment status (it flagged missing recommended tools `just`, `nix`, and `cargo-audit` in the test environment). 
- Ran `git diff --check` to ensure no whitespace or diff errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c8192de08333a78a82348e0b87cd)