### PR TITLE
fix(ci): gate VS Code/Open VSX publish steps on secrets directly

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -70,7 +70,7 @@ jobs:
           echo "VSIX_FILE=$(ls *.vsix)" >> $GITHUB_ENV
 
       - name: Publish to VSCode Marketplace
-        if: env.VSCE_PAT != ''
+        if: ${{ secrets.VSCE_PAT != '' }}
         working-directory: vscode-extension
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -78,7 +78,7 @@ jobs:
           vsce publish --pat $VSCE_PAT --packagePath ${{ env.VSIX_FILE }}
 
       - name: Publish to Open VSX
-        if: env.OVSX_PAT != ''
+        if: ${{ secrets.OVSX_PAT != '' }}
         working-directory: vscode-extension
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
### Motivation
- Ensure the GitHub publish job actually runs the Marketplace/Open VSX publish steps when the relevant repository secrets are configured, because the previous conditions used step-local env vars that evaluated false at workflow-evaluation time.

### Description
- Update `.github/workflows/publish-extension.yml` to gate publishing using `if: ${{ secrets.VSCE_PAT != '' }}` and `if: ${{ secrets.OVSX_PAT != '' }}` instead of `if: env.VSCE_PAT != ''` and `if: env.OVSX_PAT != ''` so the workflow checks secrets at evaluation time.

### Testing
- `npm run verify:marketplace` initially failed due to a corrupted/inconsistent local `node_modules` state during `vsce` dependency validation; `npm ci` was run to reinstall dependencies successfully, and `npm run package` succeeded and produced `perl-lsp-0.10.0.vsix`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c7ba7c2883338c7e41f0bc5ae7f9)