### PR TITLE
Print CLI help to stdout and add smoke test

### DIFF
--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
             process::exit(0);
         }
         LaunchAction::Help => {
-            eprintln!("{}", help_text());
+            println!("{}", help_text());
             process::exit(0);
         }
     }

--- a/crates/perl-lsp/tests/cli_smoke.rs
+++ b/crates/perl-lsp/tests/cli_smoke.rs
@@ -15,3 +15,9 @@ fn version_shows_git_tag() {
         .stdout(predicates::str::contains("perl-lsp"))
         .stdout(predicates::str::contains("Git tag:"));
 }
+
+#[test]
+fn help_prints_to_stdout() {
+    let mut cmd = cargo_bin_cmd!("perl-lsp");
+    cmd.arg("--help").assert().success().stdout(predicates::str::contains("Usage: perl-lsp"));
+}


### PR DESCRIPTION
### Motivation
- Ensure `perl-lsp --help` prints to stdout (informational output) to match common CLI expectations and make help text easier to pipe and capture.

### Description
- Use `println!` instead of `eprintln!` for `LaunchAction::Help` in `crates/perl-lsp/src/main.rs` and add a smoke test `help_prints_to_stdout` in `crates/perl-lsp/tests/cli_smoke.rs` that asserts `--help` succeeds and contains the usage text.

### Testing
- Ran `cargo test -p perl-lsp --test cli_smoke` which passed, ran `cargo clippy -p perl-lsp --tests -q` which passed, and ensured formatting with `cargo fmt --all`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c7facd748333aef29253fd150db1)