### PR TITLE
fix: remove direct framing dependency from perl-lsp crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,6 @@ dependencies = [
  "md5",
  "once_cell",
  "parking_lot",
- "perl-content-length-framing",
  "perl-dap",
  "perl-keywords",
  "perl-lsp-cancellation",

--- a/crates/perl-lsp-transport/src/framing.rs
+++ b/crates/perl-lsp-transport/src/framing.rs
@@ -1,6 +1,7 @@
 //! Message framing for the LSP base protocol.
 
-use perl_content_length_framing::{ContentLengthFramer, frame};
+use perl_content_length_framing::ContentLengthFramer;
+pub use perl_content_length_framing::frame;
 use perl_lsp_protocol::{JsonRpcRequest, JsonRpcResponse};
 use std::io::{self, BufRead, Read, Write};
 

--- a/crates/perl-lsp-transport/src/lib.rs
+++ b/crates/perl-lsp-transport/src/lib.rs
@@ -43,5 +43,6 @@
 mod framing;
 
 pub use framing::{
-    ContentLengthMessageReader, log_response, read_message, write_message, write_notification,
+    ContentLengthMessageReader, frame, log_response, read_message, write_message,
+    write_notification,
 };

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -51,7 +51,6 @@ perl-module-reference = { workspace = true }
 perl-module-rename = { workspace = true }
 perl-module-resolution = { workspace = true }
 perl-source-file = { workspace = true }
-perl-content-length-framing = { workspace = true }
 perl-workspace-discovery = { workspace = true }
 perl-workspace-folder = { workspace = true }
 perl-workspace-ignore = { workspace = true }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -37,7 +37,6 @@ use perl_parser::{
 
 use crate::call_hierarchy_provider::CallHierarchyProvider;
 use crate::cancellation::{GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken};
-use perl_content_length_framing::frame;
 use perl_lsp_feature_governance::FeatureProfile;
 
 // Import LSP providers from features (these moved from perl-parser to perl-lsp)
@@ -71,7 +70,7 @@ use crate::{
         ClientCapabilities, DocumentState, ServerConfig, WorkspaceConfig,
         normalize_package_separator,
     },
-    transport::{ContentLengthMessageReader, log_response, write_message},
+    transport::{ContentLengthMessageReader, frame, log_response, write_message},
     // Import text processing helpers
     util::{
         byte_to_line_col, byte_to_utf16_col, extract_module_reference, get_text_around_offset,


### PR DESCRIPTION
### Motivation
- Packaging `crates/perl-lsp` for crates.io failed because it referenced an internal crate (`perl-content-length-framing`) directly, which prevented `cargo package` from preparing the package against the crates.io index.
- The goal was to remove that direct publish-chain coupling while preserving existing framing behaviour and keeping the VS Code extension packaging flow working.

### Description
- Removed the direct `perl-content-length-framing` dependency from `crates/perl-lsp/Cargo.toml` and stopped importing it directly from `perl-lsp` runtime.
- Re-exported `frame` from `crates/perl-lsp-transport` by changing `crates/perl-lsp-transport/src/framing.rs` to `pub use perl_content_length_framing::frame;` and adjusted `crates/perl-lsp-transport/src/lib.rs` to include `frame` in the public export surface.
- Updated `crates/perl-lsp/src/runtime/mod.rs` to use the transport re-export (`crate::transport::frame`) instead of importing `perl_content_length_framing` directly.
- Ran code formatting (`cargo fmt --all`) and ensured the transport compatibility layer preserved previous behaviour (no behavior changes to framing API usage).

### Testing
- Ran `cargo fmt --all` (succeeded).
- Ran `cargo check -p perl-lsp --quiet` to validate the crate builds with the new indirection (succeeded).
- In the extension workspace ran `npm ci` and `npm run verify:marketplace` to validate VS Code marketplace packaging and bundling (extension VSIX was produced successfully).
- Attempted `cargo package -p perl-lsp --allow-dirty --no-verify` to validate crates.io packaging; this still fails due to a separate unresolved dependency (`perl-dap`) on the crates.io index, so full crates.io publish readiness requires addressing `perl-dap` publish-order or dependency strategy (failure persists).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e01332a88333b0950b92274cc731)