### PR TITLE
fix: complete crates.io metadata and mark legacy parser unpublished

### DIFF
--- a/crates/perl-lsp-config/Cargo.toml
+++ b/crates/perl-lsp-config/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Configuration models for perl-lsp server and workspace behavior"
+readme = "README.md"
+documentation = "https://docs.rs/perl-lsp-config"
+keywords = ["perl", "lsp", "config", "language-server", "settings"]
+categories = ["development-tools", "text-editors"]
 
 [dependencies]
 serde_json = "1.0.149"

--- a/crates/perl-lsp-critic-parser/Cargo.toml
+++ b/crates/perl-lsp-critic-parser/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 description = "SRP microcrate for parsing Perl::Critic output lines"
 readme = "README.md"
+documentation = "https://docs.rs/perl-lsp-critic-parser"
+keywords = ["perl", "lsp", "perlcritic", "diagnostics", "parsing"]
+categories = ["development-tools", "text-editors", "parsing"]
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-diagnostic-catalog/Cargo.toml
+++ b/crates/perl-lsp-diagnostic-catalog/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Stable LSP diagnostic metadata catalog for Perl"
+readme = "README.md"
+documentation = "https://docs.rs/perl-lsp-diagnostic-catalog"
+keywords = ["perl", "lsp", "diagnostics", "language-server", "lint"]
+categories = ["development-tools", "text-editors"]
 
 [dependencies]
 perl-diagnostics-codes = { workspace = true }

--- a/crates/perl-lsp-limits/Cargo.toml
+++ b/crates/perl-lsp-limits/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 description = "SRP microcrate for bounded LSP limits and deadline policy"
 readme = "README.md"
+documentation = "https://docs.rs/perl-lsp-limits"
+keywords = ["perl", "lsp", "limits", "timeout", "resource-management"]
+categories = ["development-tools", "text-editors"]
 
 [dependencies]
 serde_json = "1.0.149"


### PR DESCRIPTION
## Summary

- **perl-lsp-config**: added `readme`, `documentation`, `keywords`, `categories`
- **perl-lsp-diagnostic-catalog**: added `readme`, `documentation`, `keywords`, `categories`
- **perl-lsp-critic-parser**: added `documentation`, `keywords`, `categories` (already had `readme`)
- **perl-lsp-limits**: added `documentation`, `keywords`, `categories` (already had `readme`)
- **perl-parser-pest**: already had `publish = false` -- no change needed

These fields are required for professional crates.io listings and were the only crates missing them.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all` clean
- [ ] Verify metadata renders correctly on crates.io after next publish