### PR TITLE
fix(tree-sitter-perl): add go.sum and update Go toolchain to 1.23

### DIFF
--- a/tree-sitter-perl/go.mod
+++ b/tree-sitter-perl/go.mod
@@ -1,5 +1,5 @@
 module github.com/tree-sitter/tree-sitter-perl
 
-go 1.22
+go 1.23
 
 require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/tree-sitter-perl/go.sum
+++ b/tree-sitter-perl/go.sum
@@ -1,0 +1,1 @@
+github.com/tree-sitter/go-tree-sitter v0.23.1/go.mod h1:EvIVhMvvPNvhu9x+ddSPxSnUEU5AnsSwi1LMqXIVE3A=


### PR DESCRIPTION
### Motivation
- Ensure Go module resolution is reproducible and compatible with readonly/module-locked CI and packaging flows by locking checksums and matching the toolchain directive.

### Description
- Added `tree-sitter-perl/go.sum` containing dependency checksum metadata for `github.com/tree-sitter/go-tree-sitter v0.23.1`.
- Updated `tree-sitter-perl/go.mod` toolchain directive from `go 1.22` to `go 1.23` to reflect the module state produced by current Go tooling.

### Testing
- Ran `cargo check -p perl-parser -p perl-lsp` and it completed successfully.
- Ran `cargo clippy -p perl-lsp -- -D warnings` (completed during validation run).
- Ran `cd vscode-extension && npm ci` and `cd vscode-extension && npm run verify:marketplace`, which successfully built and packaged the extension (`.vsix`).
- Ran `cd tree-sitter-perl && GOFLAGS=-mod=readonly go test ./...` and it succeeded, validating readonly-module behavior with the new `go.sum`.
- Attempted `cargo package -p perl-lsp --allow-dirty --no-verify` which failed due to workspace publish ordering (missing crates on crates.io), indicating a publish-order issue rather than a regression in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e01b2bbc83339730998a669fb504)