### PR TITLE
docs: add SECURITY.md and document release secrets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -563,6 +563,20 @@ scripts/release-turnkey-pr.sh <0.x.y>
 # --skip-crates, --skip-extension, --skip-docker, --prerelease
 ```
 
+#### Required GitHub Secrets
+
+The full release pipeline requires the following repository secrets. Configure them under **Settings > Secrets and variables > Actions** in the GitHub repository.
+
+| Secret | Purpose | Where to create |
+|--------|---------|-----------------|
+| `CARGO_REGISTRY_TOKEN` | Publish crates to crates.io | [crates.io Account Settings > API Tokens](https://crates.io/settings/tokens) -- create a token scoped to the `perl-lsp` and related crates |
+| `VSCE_PAT` | Publish the VS Code extension to the Visual Studio Marketplace | [Azure DevOps > User Settings > Personal Access Tokens](https://dev.azure.com/) -- scope to **Marketplace (Manage)** |
+| `OVSX_PAT` | Publish the VS Code extension to the Open VSX Registry | [Open VSX > User Settings > Access Tokens](https://open-vsx.org/user-settings/tokens) |
+| `DOCKER_USERNAME` | Push container images to Docker Hub (optional -- GHCR works without secrets) | [Docker Hub Account Settings](https://hub.docker.com/settings/general) |
+| `DOCKER_PASSWORD` | Docker Hub authentication (optional -- GHCR works without secrets) | Same Docker Hub account; use an access token rather than your password |
+
+> **Note:** `DOCKER_USERNAME` and `DOCKER_PASSWORD` are only needed if you publish to Docker Hub. GitHub Container Registry (GHCR) uses the built-in `GITHUB_TOKEN` and requires no additional secrets.
+
 #### 4. Post-Release Tasks
 
 - [ ] Update website/documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,248 +2,59 @@
 
 ## Supported Versions
 
-We actively support security updates for the following versions:
-
-| Version | Supported          | Status |
-| ------- | ------------------ | -------- |
-| 0.10.x  | :white_check_mark: | **Current Release** |
-| 0.9.x   | :white_check_mark: | Legacy Support |
-| 0.8.x   | :white_check_mark: | Legacy Support |
-| < 0.8   | :x:                | End of Life |
-
-**v0.10.x Security Guarantee**: v0.10.x receives priority security support with rapid response times and comprehensive security validation.
+| Version | Supported |
+| ------- | --------- |
+| 0.10.x  | Yes -- current release line |
+| < 0.10  | No |
 
 ## Reporting a Vulnerability
 
-**DO NOT** open public issues for security vulnerabilities.
+**Please do not open public issues for security vulnerabilities.**
 
-### How to Report
+We prefer reports through [GitHub Security Advisories](https://github.com/EffortlessMetrics/perl-lsp/security/advisories/new). If that is not possible, email the maintainers listed in the root `Cargo.toml`.
 
-1. **Email**: Send security reports to the maintainers listed in `Cargo.toml`
-2. **Subject Line**: Use "SECURITY:" prefix (e.g., "SECURITY: Buffer overflow in parser")
-3. **Include**:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if available)
-   - Your preferred method of contact
+### What to include
 
-### What to Expect
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Suggested fix, if you have one
 
-| Timeline | Action |
-|----------|--------|
-| **24 hours** | Initial acknowledgment of your report |
-| **72 hours** | Initial assessment and severity classification |
-| **7 days** | Preliminary fix or mitigation strategy (for CRITICAL/HIGH) |
-| **30 days** | Coordinated disclosure and patch release (standard timeline) |
-| **90 days** | Maximum disclosure timeline (per industry standard) |
+### Response timeline
 
-### Disclosure Policy
+| Milestone | Target |
+|-----------|--------|
+| Acknowledge report | 48 hours |
+| Severity assessment | 72 hours |
+| Fix for critical/high | 30 days |
+| Coordinated disclosure | After fix is released |
 
-We follow **coordinated disclosure**:
+We follow coordinated disclosure. You will be notified before any public advisory, and we will credit you unless you prefer to remain anonymous.
 
-1. **Report received** → We acknowledge within 24 hours
-2. **Assessment** → We classify severity (CRITICAL/HIGH/MEDIUM/LOW)
-3. **Fix development** → We develop and test a fix
-4. **Private notification** → We notify you before public disclosure
-5. **Public disclosure** → We publish advisory and release patch
-6. **Credit** → We credit you in the security advisory (unless you prefer anonymity)
+## Scope
 
-### Severity Classification
+The following are considered security issues for this project:
 
-| Severity | Response Time | Public Disclosure |
-|----------|---------------|-------------------|
-| **CRITICAL** | 48 hours | 7-14 days after fix |
-| **HIGH** | 1 week | 14-30 days after fix |
-| **MEDIUM** | 2 weeks | 30-60 days after fix |
-| **LOW** | 1 month | Next release cycle |
+- **Path traversal** in file operations (e.g., workspace file access escaping configured roots)
+- **Arbitrary code execution** triggered by LSP protocol messages or parsed input
+- **LSP protocol injection** (malformed messages causing unintended server behavior)
+- **Denial of service** through crafted input that causes unbounded resource consumption
+- **Dependency vulnerabilities** in crates shipped as part of perl-lsp
 
-## Security Scanning
+### Out of scope
 
-This project uses comprehensive automated security scanning:
+- Bugs in the Perl source code being analyzed (perl-lsp is a read-only tool; it does not execute Perl)
+- Editor or client-side issues (report those to the editor/extension maintainer)
+- Vulnerabilities that require local shell access beyond what the LSP client already provides
 
-- **Cargo Audit**: Daily scans against RustSec Advisory Database
-- **Cargo Deny**: License and dependency policy enforcement
-- **Trivy**: Comprehensive vulnerability scanning (dependencies, containers, secrets)
-- **GitHub Security Tab**: Centralized SARIF report tracking
-- **Mutation Testing**: Security-focused mutation hardening with 87% quality score
-- **Fuzz Testing**: Property-based testing with crash detection and AST invariant validation
+## Security Practices
 
-### v0.10.x Security Features
-
-- **Comprehensive Security**: Path traversal prevention, input validation, secure defaults
-- **UTF-16 Boundary Protection**: Fixes for symmetric position conversion vulnerabilities
-- **Process Isolation**: Safe execution environment for untrusted Perl code
-- **Memory Safety**: Full Rust memory safety guarantees with minimal unsafe code
-- **Supply Chain Security**: Audited dependencies with pinned versions
-
-See `docs/how-to/SECURITY_DEVELOPMENT_GUIDE.md` for detailed security procedures.
-
-## Security Best Practices
-
-### For Contributors
-
-When contributing code:
-
-1. **No `unwrap()`/`expect()`** - Use proper error handling with `Result<T, E>`
-2. **No hardcoded secrets** - Use environment variables or secure vaults
-3. **Validate all inputs** - Especially from LSP clients or file system
-4. **Use safe defaults** - Fail closed, not open
-5. **Minimize `unsafe`** - Document all unsafe blocks with safety justification
-6. **Check dependencies** - Run `cargo audit` before submitting PR
-
-### For Users
-
-When using perl-lsp:
-
-1. **Keep updated** - Always use the latest stable version
-2. **Monitor advisories** - Subscribe to security notifications
-3. **Report issues** - Follow the reporting guidelines above
-4. **Isolate untrusted input** - Use appropriate sandboxing for untrusted Perl code
-5. **Review dependencies** - Check `Cargo.lock` for your deployment
-
-## Known Security Considerations
-
-### v0.10.x Security
-
-**Parser Security**:
-- **Input validation**: The parser handles arbitrary Perl code with bounded recursion to prevent stack overflow
-- **Memory safety**: All parser code uses Rust's memory safety guarantees with comprehensive fuzz testing
-- **DoS protection**: Large files and deep nesting handled with configurable limits and timeout protection
-- **AST Security**: Comprehensive invariant validation with mutation hardening (87% quality score)
-
-**LSP Server Security**:
-- **IPC security**: LSP communication over stdio/pipes only (no network exposure by default)
-- **File system access**: Limited to workspace roots configured by client with comprehensive validation
-- **Path traversal prevention**: All file paths validated and canonicalized with UTF-16 boundary protection
-- **Resource limits**: Memory and CPU usage bounded with <1MB overhead and adaptive timeout scaling
-
-**DAP Debugging Security**:
-- **Process isolation**: Debug adapter runs in isolated environment with controlled process spawning
-- **Cross-platform security**: Windows, macOS, Linux, WSL with automatic path normalization
-- **Secure defaults**: Safe configuration with security-focused defaults
-- **Performance security**: <50ms operations with resource monitoring
-
-**Dependency Security**:
-- **Supply chain**: Regular audits with `cargo-audit`, `cargo-deny`, and comprehensive vulnerability scanning
-- **Minimal dependencies**: Reduced attack surface with carefully vetted dependencies
-- **Pinned versions**: `Cargo.lock` committed for reproducible builds with automated dependency updates
-- **License compliance**: All dependencies use approved open-source licenses with automated compliance checking
-
-## Security Updates
-
-### v0.10.x Security Update Process
-
-**Notification Channels**:
-1. **GitHub Security Advisories**: https://github.com/EffortlessMetrics/perl-lsp/security/advisories
-2. **GitHub Releases**: Tagged with `[SECURITY]` prefix
-3. **CHANGELOG.md**: With `[SECURITY]` section and CVE references
-4. **RustSec Database**: Critical vulnerabilities reported to RustSec
-
-**Update Procedure**:
-
-When a security update is released:
-
-```bash
-# Update perl-lsp (production systems)
-cargo install perl-lsp --force
-
-# Or update in your project
-cargo update -p perl-lsp
-cargo build --release
-
-# Verify version and security status
-perl-lsp --version
-perl-lsp --security-status
-```
-
-**Emergency Security Updates**:
-
-For critical vulnerabilities (CVSS 9.0+):
-- **Hotfix Release**: Within 48 hours of disclosure
-- **Security Advisory**: Detailed impact analysis and mitigation
-
-## Security Tooling
-
-### Required Tools
-
-```bash
-# Install security scanning tools
-cargo install cargo-audit --locked
-cargo install cargo-deny --locked
-
-# Install Trivy (platform-specific)
-# See: https://aquasecurity.github.io/trivy/latest/getting-started/installation/
-```
-
-### Local Security Checks
-
-```bash
-# Run comprehensive security scan
-just security-scan
-
-# Quick pre-commit check
-just security-quick
-
-# Generate security report
-just security-report
-```
-
-## Vulnerability Database
-
-We track vulnerabilities in:
-
-- **RustSec Advisory Database**: https://rustsec.org/
-- **GitHub Security Advisories**: Project-specific advisories
-- **National Vulnerability Database (NVD)**: CVE tracking
-
-## Bug Bounty Program
-
-We currently **do not** have a formal bug bounty program. However:
-
-- **v0.10.x Security Focus**: Increased attention to security vulnerabilities
-- **Responsible Disclosure**: We appreciate and reward responsible disclosure
-- **Security Credits**: We provide credit in security advisories and annual security report
-- **Contributor Recognition**: Security researchers recognized in our contributors page and release notes
-
-**Security Researcher Recognition**:
-- Security advisories credit
-- Annual security report acknowledgment
-- Contributor page recognition
-- Early access to security features
-- Direct maintainer communication for security issues
-
-## Contact
-
-- **Security email**: See maintainers in `Cargo.toml`
-- **General inquiries**: Open a non-security issue on GitHub
-- **Security Discord**: Private channel for security researchers (request access via security email)
-
-## v0.10.x Security Commitments
-
-We target the following for v0.10.x:
-
-- **48-hour response** for critical security vulnerabilities
-- **Comprehensive security testing** for all releases
-- **Transparent disclosure** with coordinated vulnerability disclosure
-
-### Security Roadmap
-
-- **Q2 2026**: Enhanced fuzz testing infrastructure
-- **Q3 2026**: Security hardening
-- **Q4 2026**: Formal bug bounty program establishment
-
-## Acknowledgments
-
-We thank the following security researchers and contributors:
-
-- **Internal Security Team**: Comprehensive security hardening and validation
-- **Community Contributors**: Security-focused bug reports and improvements
-- **Rust Security Team**: RustSec advisory database and security tools
-
-*(This section will be updated as researchers report vulnerabilities)*
+- All production code is written in safe Rust. Fatal constructs (`unwrap`, `panic!`, `process::abort`) are banned outside of tests.
+- Dependencies are audited with `cargo-audit` and `cargo-deny`; see `deny.toml` for policy.
+- Fuzz testing covers the parser and lexer.
+- LSP communication uses stdio by default (no network listener).
+- File system access is limited to workspace roots configured by the client.
 
 ---
 
-**Last Updated**: 2026-02-20 (v0.10.0 Release)
-**Next Review**: 2026-05-20 (quarterly review)
+*Last updated: 2026-03-11*


### PR DESCRIPTION
## Summary

- **Rewrote `SECURITY.md`** to be concise and professional, modeled after well-known Rust projects (tokio, rustls). The previous version was over 250 lines of verbose boilerplate. The new version is focused and actionable:
  - Supported versions (0.10.x only)
  - Preferred reporting channel (GitHub Security Advisories)
  - Response timeline (48h acknowledge, 30d fix for critical/high)
  - Clear scope definition for a language server (path traversal, code execution, protocol injection, dependency vulns)
  - Explicit out-of-scope section (analyzed Perl code, editor-side issues)
  - Brief security practices summary

- **Added Required GitHub Secrets section to `CONTRIBUTING.md`** in the Release Process area, documenting the 5 secrets needed for the full release pipeline:
  - `CARGO_REGISTRY_TOKEN` (crates.io)
  - `VSCE_PAT` (VS Code Marketplace)
  - `OVSX_PAT` (Open VSX Registry)
  - `DOCKER_USERNAME` / `DOCKER_PASSWORD` (Docker Hub, optional)
  - Each entry includes a link to where the token is created

Both changes improve release readiness by ensuring security policy is clear for external contributors and maintainers know exactly which secrets to configure.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all` produces no changes
- Documentation-only changes; no code modified