### PR TITLE
vscode-extension: make vsce packaging resilient in pnpm envs

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -453,8 +453,8 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "bundle-lsp": "node ./scripts/bundle-lsp.js",
-    "package": "npx @vscode/vsce package",
-    "publish": "npx @vscode/vsce publish",
+    "package": "npx @vscode/vsce package --no-dependencies",
+    "publish": "npx @vscode/vsce publish --no-dependencies",
     "verify:marketplace": "npm run compile && npm run bundle-lsp && npm run package"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- `vsce` ran `npm list --production` during packaging which fails in pnpm-style dependency layouts (causing `ELSPROBLEMS`) and prevented `.vsix` generation required for Marketplace validation.

### Description
- Update `vscode-extension/package.json` so both `package` and `publish` use `npx @vscode/vsce ... --no-dependencies`, avoiding `vsce`'s dependency checks and allowing VSIX creation in mixed npm/pnpm environments.

### Testing
- Ran `bash scripts/prep-crates-io-launch.sh --core` which completed successfully, `cd vscode-extension && npm run package` which produced `perl-lsp-0.10.0.vsix` successfully, and `cargo check -p perl-parser -q` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e01b2bbc83339730998a669fb504)