### PR TITLE
Fix parser test helper regressions and rename rustdoc link blocker

### DIFF
--- a/crates/perl-lsp-rename/src/rename/mod.rs
+++ b/crates/perl-lsp-rename/src/rename/mod.rs
@@ -61,7 +61,7 @@
 //! # See also
 //!
 //! - [`RenameProvider`] for executing rename operations
-//! - [`crate::ide::lsp_compat::references`] for related navigation workflows
+//! - Reference/navigation providers in `perl-lsp-navigation` for related workflows
 //!
 //! # Usage Examples
 //!

--- a/crates/perl-parser/tests/incremental_performance_tests.rs
+++ b/crates/perl-parser/tests/incremental_performance_tests.rs
@@ -7,6 +7,7 @@
 mod incremental_performance_tests {
     use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
     use perl_parser::{edit::Edit, position::Position};
+    use perl_tdd_support::{must, must_some};
     use std::time::{Duration, Instant};
 
     /// Performance test utilities for incremental parsing
@@ -287,10 +288,7 @@ if ($condition) {
             TestSourceGenerator::simple_variable(),
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,
@@ -344,7 +342,6 @@ if ($condition) {
             &source,
             |source| {
                 let new_source = source.replace("10", "100");
-                use perl_tdd_support::must_some;
                 let pos = must_some(source.find("10"));
                 let edit = Edit::new(
                     pos,
@@ -384,10 +381,7 @@ if ($condition) {
             &source,
             |source| {
                 let new_source = source.replace("42", "9999");
-                let pos = match source.find("42") {
-                    Some(p) => p,
-                    None => must(Err::<(), _>(format!("Test data should contain '42'"))),
-                };
+                let pos = must_some(source.find("42"));
                 let edit = Edit::new(
                     pos,
                     pos + 2,

--- a/crates/perl-parser/tests/mutation_hardening_tests.rs
+++ b/crates/perl-parser/tests/mutation_hardening_tests.rs
@@ -1071,6 +1071,7 @@ mod ast_node_validation_tests {
 #[cfg(all(test, feature = "incremental"))]
 mod integration_mutation_tests {
     use super::*;
+    use perl_tdd_support::must;
 
     /// Test complex scenarios that exercise multiple mutation points
     #[test]
@@ -1129,10 +1130,7 @@ mod integration_mutation_tests {
         // This test documents a real bug in incremental_document.rs:356
         // where nodes_reused can be larger than count_nodes(), causing underflow
         let source = "package Test; sub test_function { }";
-        let mut doc = match IncrementalDocument::new(source.to_string()) {
-            Ok(d) => d,
-            Err(e) => must(Err::<(), _>(format!("Should create document: {:?}", e))),
-        };
+        let mut doc = must(IncrementalDocument::new(source.to_string()));
 
         // This edit triggers the underflow bug - it's a legitimate bug to fix
         let edit = IncrementalEdit::with_positions(

--- a/crates/perl-parser/tests/support/incremental_test_utils.rs
+++ b/crates/perl-parser/tests/support/incremental_test_utils.rs
@@ -5,6 +5,7 @@
 
 use perl_parser::incremental_v2::{IncrementalMetrics, IncrementalParserV2};
 use perl_parser::{edit::Edit, position::Position};
+use perl_tdd_support::{must, must_some};
 use std::time::{Duration, Instant};
 
 /// Comprehensive performance measurement utilities for incremental parsing
@@ -17,7 +18,6 @@ impl IncrementalTestUtils {
     /// Create a performance edit that changes a value in the source
     #[allow(dead_code)]
     pub fn create_value_edit(source: &str, old_value: &str, new_value: &str) -> (String, Edit) {
-        use perl_tdd_support::must_some;
         let pos = must_some(source.find(old_value));
         let end_pos = pos + old_value.len();
         let new_end = pos + new_value.len();


### PR DESCRIPTION
### Motivation

- Release-gate checks were failing because parser test helpers (`must`, `must_some`) were not imported into several incremental-test modules, causing compile errors in test targets and blocking packaging/documentation steps. 
- Strict rustdoc validation failed in `perl-lsp-rename` due to an invalid intra-doc link to a non-existent path, which prevents `cargo doc` under `-D rustdoc::broken-intra-doc-links`.
- The workspace quick-check still exposes an unrelated existing failure in the logos-based token lexer (`perl-ts-logos-lexer`) that must be addressed separately.

### Description

- Added `use perl_tdd_support::{must, must_some};` where needed in incremental test support files to bring test helpers into scope and removed the local `use` shadowing. (`crates/perl-parser/tests/support/incremental_test_utils.rs`)
- Replaced `match ... { Some(p) => p, None => must(Err(...)) }` fallback patterns with type-preserving helper calls `must_some(...)` or `must(...)` to keep expression types consistent and avoid mismatched-arm errors in closures used by tests. (`crates/perl-parser/tests/incremental_performance_tests.rs` and `crates/perl-parser/tests/mutation_hardening_tests.rs`)
- Simplified document construction in an incremental mutation test to `must(IncrementalDocument::new(...))` to remove an incompatible `match` fallback branch. (`crates/perl-parser/tests/mutation_hardening_tests.rs`)
- Removed a broken intra-doc reference and replaced it with a stable textual pointer to the navigation providers in `perl-lsp-navigation` to satisfy rustdoc strict checking. (`crates/perl-lsp-rename/src/rename/mod.rs`)

### Testing

- Ran `cargo test -p perl-parser --test incremental_statistical_validation_test --no-run` and the parser test binary built successfully (compile-only verification passed). — succeeded.
- Ran `cargo doc -p perl-lsp-rename --no-deps` to validate the rustdoc fix and documentation now builds without the previous broken-intra-doc-links error. — succeeded.
- Built and verified VS Code extension packaging steps: `cd vscode-extension && npm ci` and `npm run verify:marketplace` (bundled `perl-lsp` and produced VSIX). — succeeded.
- Ran the workspace packaging dry-run via `cargo run -p perl-ci-hygiene -- cargo-package-workspace-dry-run perl-parser perl-dap perl-lsp` to validate crate packaging paths and workspace publish readiness. — succeeded.
- Ran the CI mirror `quick-check` (`cargo run -p perl-ci-hygiene -- quick-check`) after the fixes; clippy/docs/tests progressed but the run still fails due to existing errors in `crates/perl-ts-logos-lexer` (logos greedy-regex diagnostics and chumsky parser lifetime/type mismatches). This failure is pre-existing and outside the scope of the current change. — failed (unrelated crate `perl-ts-logos-lexer`).

If you want, I can continue by tackling the `perl-ts-logos-lexer` issues (adjusting greedy regex annotations and fixing the logos/chumsky lifetime/type plumbing) in a follow-up change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e01b2bbc83339730998a669fb504)