### PR TITLE
fix: make crates.io launch prep catch workspace publish blockers

### DIFF
--- a/scripts/prep-crates-io-launch.sh
+++ b/scripts/prep-crates-io-launch.sh
@@ -11,7 +11,7 @@ Usage: scripts/prep-crates-io-launch.sh [--core|--all]
 
 Runs crates.io launch readiness checks:
   1) cargo check --locked for selected crates
-  2) cargo package --list validation for selected crates
+  2) cargo package dry-run validation for selected crates
 
 Options:
   --core      Validate public launch crates (default)
@@ -63,7 +63,7 @@ PY
 fi
 
 echo "🚀 crates.io launch prep (${MODE})"
-echo "📦 Running cargo check + cargo package --list for ${#CRATES[@]} crate(s)"
+echo "📦 Running cargo check + cargo package dry-run for ${#CRATES[@]} crate(s)"
 
 for crate in "${CRATES[@]}"; do
   echo ""
@@ -71,7 +71,7 @@ for crate in "${CRATES[@]}"; do
   (
     cd "$ROOT_DIR"
     cargo check --locked -p "$crate"
-    cargo package --list -p "$crate" >/dev/null
+    CARGO_PACKAGE_NO_VERIFY=1 scripts/cargo-package-workspace-dry-run.sh "$crate" >/dev/null
   )
 done
 


### PR DESCRIPTION
### Motivation

- `cargo package --list` only validates file inclusion and can miss publish-time blockers caused by workspace-local dependencies and registry resolution differences. 
- The release prep script should surface these publishability issues earlier so crates.io publishing failures are caught during prep rather than during the release workflow.

### Description

- Updated `scripts/prep-crates-io-launch.sh` help text and logging to state it runs a `cargo package` dry-run instead of `--list`. 
- Replaced the `cargo package --list` invocation with `CARGO_PACKAGE_NO_VERIFY=1 scripts/cargo-package-workspace-dry-run.sh "$crate"` so packaging validation uses the workspace patch dry-run and detects workspace-only dependency publish blockers. 
- Kept the existing `cargo check --locked -p "$crate"` step and preserved the same crate selection logic for `--core` and `--all` modes.

### Testing

- `cargo test -p perl-parser --lib` ran and passed (12 tests: all ok). 
- `scripts/prep-crates-io-launch.sh --core` ran successfully and performed packaging dry-runs for the core crates (packaging output produced for each crate). 
- Targeted dry-run `CARGO_PACKAGE_NO_VERIFY=1 scripts/cargo-package-workspace-dry-run.sh perl-lsp` ran and produced a successful package dry-run, which previously failed with a registry-resolution blocker. 
- VS Code extension packaging via `npm ci` and `npm run verify:marketplace` completed successfully and produced `perl-lsp-0.10.0.vsix`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e01b2bbc83339730998a669fb504)