### PR TITLE
fix: resolve rustdoc warnings for clean docs.rs publishing

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -56,7 +56,7 @@ pub struct LspArgs {
     #[arg(long)]
     pub log: bool,
 
-    /// Quick health check (prints 'ok <version>')
+    /// Quick health check (prints 'ok `<version>`')
     #[arg(long)]
     pub health: bool,
 

--- a/crates/perl-lsp-rename/src/rename/mod.rs
+++ b/crates/perl-lsp-rename/src/rename/mod.rs
@@ -61,7 +61,7 @@
 //! # See also
 //!
 //! - [`RenameProvider`] for executing rename operations
-//! - [`crate::ide::lsp_compat::references`] for related navigation workflows
+//! - `crate::ide::lsp_compat::references` for related navigation workflows
 //!
 //! # Usage Examples
 //!


### PR DESCRIPTION
## Summary

- **perl-lsp-launcher**: Wrap `<version>` in backticks in a doc comment to prevent rustdoc from interpreting it as an unclosed HTML tag
- **perl-lsp-rename**: Convert unresolvable `[crate::ide::lsp_compat::references]` rustdoc link to inline code, since the path belongs to a different crate (`perl-lsp-providers`) and cannot be resolved from `perl-lsp-rename`

## Test plan

- [x] `cargo doc --workspace --no-deps` produces zero warnings
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --lib` passes