### PR TITLE
docs: add cross-article meta-analysis and reading guide

### DIFF
--- a/docs/project/META_ANALYSIS.md
+++ b/docs/project/META_ANALYSIS.md
@@ -1,0 +1,480 @@
+# Meta-Analysis: Connecting the Dots Across 11 Articles
+
+*A cross-cutting synthesis of the perl-lsp article series, identifying the
+through-line, the tensions, the corrections, and the gaps.*
+
+---
+
+## 1. The Big Picture: How Does This Happen?
+
+Eleven articles, read together, tell a single story with three acts.
+
+**Act I: The Parsing Problem (July 2022 -- July 2025).**
+A tree-sitter grammar for Perl runs into the same wall that every Perl
+parser hits: context sensitivity. The slash is division or regex. Heredocs
+stack across lines. Quote operators use arbitrary delimiters. Three years
+of steady human work (Veesh Goldman, Paul "LeoNerd" Evans, community
+contributors) produce a solid grammar that covers ~85% of Perl syntax but
+cannot go further without an increasingly baroque C external scanner.
+
+**Act II: The Parser Sprint and LSP Ignition (July -- October 2025).**
+Steven Zimmerman arrives in mid-July 2025 with a specific goal: build a
+full language server, not just a grammar. In a compressed five-week burst
+he moves through three parser generations (tree-sitter, Pest PEG, native
+recursive descent), stands up an LSP server, adds a VSCode extension, and
+reaches v0.8.5 with typed capabilities. The 4-day Pest parser is the pivot
+point: it proves that pure-Rust parsing is viable, reveals PEG's
+limitations (no error recovery, backtracking overhead, preprocessor hacks
+for slash disambiguation), and motivates the hand-written v3 parser that
+becomes the production engine.
+
+**Act III: The Agentic Scaling Era (January -- March 2026).**
+AI agents -- Codex, Claude Code, and Google Jules -- become the primary
+code production force. The codebase explodes from ~9 crates to 121,
+from hundreds of tests to 4,400+, from a handful of CI checks to a
+three-tier gate system with mutation testing, fuzzing, debt budgets, and
+supply chain security. The human role shifts from writing code to
+designing guardrails and selecting from competing agent outputs. Every
+rule in CLAUDE.md is a scar from a past agent mistake. The rejection
+rate is high, the velocity is higher, and the quality infrastructure
+that emerges is more sophisticated than most hand-built projects achieve.
+
+**The through-line** is a feedback loop between ambition and constraint.
+The parsing ambition (tackle the "unparseable" language) forced
+architectural discipline (mode-based lexer, FIFO heredoc queue,
+IDE-friendly error recovery). The scaling ambition (ship 97 LSP features)
+forced agent guardrails (no-unwrap policy, CI gates, computed metrics).
+The guardrails themselves forced architectural decomposition (microcrates
+with small blast radii, making it possible for agents to work in bounded
+scopes). Each constraint enabled the next wave of velocity.
+
+The project is not primarily a story about AI writing code. It is a story
+about a human designing a system of constraints that makes AI-generated
+code trustworthy enough to ship.
+
+---
+
+## 2. Contradictions and Tensions
+
+The articles surface several tensions that are more interesting than
+any single article acknowledges.
+
+### High Rejection Rate vs. Massive Productivity
+
+AGENTIC_DEVELOPMENT reports a 42% Codex rejection rate.
+AGENTIC_SWARM_ERA reports an 85% Jules rejection rate.
+Yet both articles also report extraordinary output: 121 crates, 97 LSP
+features, 4,400+ tests.
+
+**The resolution** (see Section 3 below for an important correction):
+the rejection rate is not a quality signal in the way these articles
+imply. The Codex workflow is deliberately "pick the best of N." Multiple
+agents solve the same problem in parallel worktrees; the maintainer
+selects the best solution and closes the rest. A 42% "rejection" rate in
+this model is more like a 58% selection rate from a portfolio of options.
+The wasted compute is the cost of parallelism, not the cost of failure.
+
+Jules is a different story. Its 85% rejection rate reflects genuinely
+ungrounded output: security fixes for nonexistent vulnerabilities,
+performance optimizations that do not compile. AGENTIC_SWARM_ERA
+correctly identifies this as a qualitatively different failure mode.
+
+### 121 Microcrates vs. Management Overhead
+
+WORKSPACE_ARCHITECTURE argues that microcrates enable incremental
+compilation, independent versioning, and API surface control.
+CODEBASE_CURIOSITIES observes that `perl-dap-command-args` is 47 lines
+of Rust with its own `Cargo.toml`, `README.md`, and `LICENSE`.
+
+**The tension is real.** Publishing 111 crates requires topological
+ordering, index propagation waits, and retry logic. 120 `Cargo.toml`
+files need maintenance. Newcomers must navigate a dependency graph to
+find where folding range computation lives. WORKSPACE_ARCHITECTURE
+acknowledges these costs but argues they are paid back in compilation
+parallelism and agent-friendly bounded scopes.
+
+The unstated question: is 121 the right number, or did the SRP extraction
+campaign -- driven largely by agents following a systematic pattern --
+overshoot? CODEBASE_CURIOSITIES notes that 70 extraction PRs were
+rejected, meaning agents submitted roughly 2 failed extractions for every
+success. The extraction campaign may have been driven more by the
+mechanical ease of asking agents to extract than by genuine architectural
+need.
+
+### Custom LSP Runtime vs. NIH Syndrome
+
+CUSTOM_LSP_RUNTIME makes a detailed case for building a bespoke JSON-RPC
+runtime instead of using tower-lsp. The arguments are reasonable: feature
+governance integration, synchronous simplicity, zero-copy transport,
+total control over error handling.
+
+**The counter-argument**, which the article acknowledges but
+underweights: the seven runtime crates represent thousands of lines of
+transport, framing, and dispatch code that tower-lsp would provide for
+free. The project must maintain its own Content-Length parser, its own
+error code catalog, its own capability builder. The synchronous model
+means a slow handler blocks all subsequent requests -- a limitation
+tower-lsp handles automatically.
+
+The decision is defensible for this project specifically because the
+feature governance system is a genuine differentiator. But it is not
+obvious that this justifies the full scope of the custom runtime. A
+hybrid approach (tower-lsp for transport/dispatch, custom governance
+layer on top) might have achieved the same outcome with less code.
+
+### AI Agents Writing Quality Infrastructure to Constrain AI Agents
+
+This is the most philosophically interesting tension in the series.
+QUALITY_INFRASTRUCTURE documents a sophisticated system of ratchets,
+debt budgets, mutation testing, and corpus validation. AGENTIC_SWARM_ERA
+reveals that much of this infrastructure was itself built by AI agents,
+in response to failures caused by AI agents.
+
+The feedback loop: agents introduce `unwrap()` calls, so the human adds
+a clippy denial. Agents inflate metrics in documentation, so the human
+builds computed status generation. Agents submit identical PRs, so the
+human designs worktree isolation. Each guardrail is a rule that an agent
+could have followed from the start -- but did not, because agents
+optimize for the immediate task, not for systemic quality.
+
+The deeper tension: the guardrails work *because* they are
+machine-readable and mechanically enforced. A human code review saying
+"do not use unwrap" is easily forgotten. A clippy denial saying
+`unwrap_used = "deny"` is impossible to ignore. The project discovered
+that the most effective way to manage AI agents is to encode constraints
+in the same language the agents already understand: build tools and
+linters.
+
+### The 4-Day Pest Parser: Waste or Learning?
+
+PARSER_EVOLUTION frames the Pest parser as a "prototyping tool" that
+"validated the approach of pure-Rust parsing." CODEBASE_CURIOSITIES
+frames it as a curiosity that was "already being superseded within 4
+days." CODEBASE_HISTORY calls it a phase that "demonstrated that a
+Rust-native approach was viable."
+
+**It was both.** The Pest parser was essential learning because:
+1. It proved pure-Rust Perl parsing was feasible (eliminating the C
+   dependency from tree-sitter).
+2. It exposed the specific limitations (no error recovery, preprocessor
+   hacks for slash disambiguation) that the v3 parser was designed to
+   solve.
+3. It provided a reference implementation that the v3 parser could be
+   validated against.
+4. It still exists as a v2 parity check in the merge gate.
+
+Four days of effort that produces a permanent benchmark baseline and
+informs every subsequent architectural decision is not wasted work. It
+is rapid prototyping working as intended.
+
+---
+
+## 3. Key Corrections Needed
+
+### Codex Rejection Rate Framing
+
+**Affected articles:** AGENTIC_DEVELOPMENT, AGENTIC_SWARM_ERA,
+CODEBASE_CURIOSITIES.
+
+All three articles frame the Codex rejection rate (42-55% of PRs closed
+without merge) as a significant problem. AGENTIC_DEVELOPMENT says "a 42%
+rejection rate is significant" and frames rejected PRs as "duplicate
+attempts at the same extraction task." AGENTIC_SWARM_ERA goes further,
+calling an 85% rejection rate "negative-productive."
+
+**The correction:** The high rate is primarily a feature of the
+deliberate workflow, not a quality problem. Codex PRs come in
+overlapping batches solving the same problem. The workflow is "pick
+the best of 3 and polish it." When PRs #1244, #1245, and #1246 all
+solve the same problem, the "rejection" of #1244 and #1246 is not
+failure -- it is selection. The parallel-solutions-then-pick pattern is
+described accurately in AGENTIC_SWARM_ERA's "What Worked" section, but
+the statistical framing elsewhere in the same article contradicts this
+by treating every closed PR as wasted effort.
+
+The Jules rejection rate (85%) is a genuinely different phenomenon and
+should be distinguished more clearly. Jules frequently submitted fixes
+for nonexistent problems. Codex submitted competing solutions to real
+problems.
+
+**Recommended fix:** Articles should separate "closed because a competing
+solution was selected" from "closed because the work was wrong" when
+reporting rejection rates.
+
+### tree-sitter-perl-better and the Rust Parser
+
+**Affected articles:** CODEBASE_HISTORY, AGENTIC_SWARM_ERA.
+
+CODEBASE_HISTORY describes the project as beginning life as
+`tree-sitter-perl-better` and implies a continuous evolution from the
+tree-sitter grammar to the Rust parser. AGENTIC_SWARM_ERA opens with
+"a tree-sitter fork" becoming the current codebase.
+
+**The correction:** tree-sitter-perl-better was a validation harness for
+the Rust project. There are no overlapping contributors between the
+tree-sitter grammar work and the Rust parser work. The Rust parser is
+entirely new work -- not a port, not a derivative, and not an evolution
+of the tree-sitter grammar. It was written from scratch using a
+different parsing strategy (recursive descent vs. GLR), a different
+language (Rust vs. JavaScript/C), and a different architecture
+(mode-based lexer vs. external scanner).
+
+The tree-sitter grammar and test corpus remain in the repository as
+benchmarking baselines and regression tests. They share a repository
+history but not a code lineage.
+
+**Recommended fix:** Articles should describe the tree-sitter grammar
+as a *precursor project that shares a repository* rather than as an
+*ancestor of the Rust parser*. The Rust parser should be described as
+entirely new work inspired by the same problem domain.
+
+---
+
+## 4. Patterns That Emerge Across Articles
+
+### CI as Agent Guardrails
+
+This is the dominant cross-cutting theme. Every article touches it:
+
+- **QUALITY_INFRASTRUCTURE** documents the three-tier gate system,
+  ratchets, and debt budgets.
+- **AGENTIC_DEVELOPMENT** calls CI "the reviewer that never gets tired."
+- **AGENTIC_SWARM_ERA** traces the evolution from "no process" to
+  five phases of increasing guardrail sophistication.
+- **CLEAN_CODE_SHOWCASE** shows the workspace-level clippy denials
+  that prevent agents from introducing fatal constructs.
+- **WORKSPACE_ARCHITECTURE** describes how the tiered dependency
+  structure enforces architectural boundaries mechanically.
+- **CUSTOM_LSP_RUNTIME** notes that "the project bans unwrap() and
+  expect() in production code. Every error path returns Result or Option.
+  tower-lsp's error handling model would conflict with this policy."
+
+The pattern: every quality problem caused by agents was solved not by
+better prompts or agent selection, but by mechanical enforcement. The
+project converged on a principle that could be stated as: **if a quality
+standard cannot be checked by a machine, it will not be maintained by
+agents.**
+
+### The Evolution from Chaos to Structure
+
+Multiple articles document the same arc from different angles:
+
+- **Commits**: From direct pushes to master, to PRs, to tiered CI
+  gates (AGENTIC_SWARM_ERA).
+- **PRs**: From monolithic 1,400-line changes to surgical 436-line
+  average (AGENTIC_SWARM_ERA).
+- **CLAUDE.md**: From a 50-line project guide to a 282-line
+  constitution (AGENTIC_SWARM_ERA, AGENTIC_DEVELOPMENT).
+- **Architecture**: From a monolithic server to 121 microcrates with
+  tiered dependencies (WORKSPACE_ARCHITECTURE, CODEBASE_HISTORY).
+- **Parser**: From tree-sitter (context-free) to Pest (PEG) to native
+  (context-sensitive) (PARSER_EVOLUTION, PARSING_PERL).
+
+This is not coincidental. The chaos created by agent-scale development
+forced structural solutions. The project developed more process
+infrastructure in 6 months of agentic development than most projects
+develop in years, because agent mistakes created immediate, visible
+pressure.
+
+### The Micro-Crate as Architecture Pattern
+
+Seven of eleven articles discuss the microcrate architecture:
+
+- **WORKSPACE_ARCHITECTURE** provides the deepest treatment: the
+  extraction pattern, the 7-tier dependency system, the SRP microcrate
+  heuristic (700 LOC, 3 files, 8 deps).
+- **CODEBASE_CURIOSITIES** provides the sharpest critique: 47-line
+  crates with their own `Cargo.toml`.
+- **CLEAN_CODE_SHOWCASE** shows how microcrates enforce API boundaries.
+- **CUSTOM_LSP_RUNTIME** shows how microcrates enable code sharing
+  (the `perl-content-length-framing` crate shared between LSP and DAP).
+- **LSP_IMPLEMENTATION_STORY** documents the feature governance
+  subsystem as 7 focused microcrates.
+
+The microcrate strategy emerges as simultaneously the project's most
+distinctive architectural feature and its most debatable one. The
+benefits (compilation parallelism, agent-friendly scopes, forced API
+clarity) are real and well-documented. The costs (management overhead,
+publish complexity, cognitive load for newcomers) are acknowledged but
+probably underweighted.
+
+### The "Comprehensive" Problem in AI-Generated Code
+
+CODEBASE_CURIOSITIES quantifies it: 277 commit messages and 107 PR
+titles contain "comprehensive." AGENTIC_SWARM_ERA calls it a
+"telltale sign of AI-generated commit messages." AGENTIC_DEVELOPMENT
+identifies the broader pattern: "agents produce verbose, sometimes
+redundant commit messages."
+
+The "comprehensive" problem is not just a style issue. It reflects a
+deeper tendency of AI agents to optimize for *apparent thoroughness*
+over *actual precision*. When every PR is "comprehensive," the word
+loses all information content. When every change is "enhanced," the
+commit log becomes a stream of noise.
+
+The project's partial solution -- conventional commit formatting
+(`type(scope): description`) -- constrains the worst excesses but does
+not eliminate the underlying tendency. The 21 single-character "c"
+commits from the human maintainer stand as a pointed contrast.
+
+---
+
+## 5. Recommended Reading Order
+
+For someone discovering this project and wanting to understand it
+deeply, the following order builds knowledge progressively:
+
+### Tier 1: Orientation (start here)
+
+1. **PARSING_PERL** -- Start with the problem. This article explains
+   *why* Perl is hard to parse, covering slash ambiguity, heredocs,
+   quote operators, and source filters. Without understanding the
+   problem, the rest of the architecture is unmotivated. The most
+   engaging article in the series.
+
+2. **CODEBASE_HISTORY** -- The chronological spine. Read this second
+   for the timeline, contributor analysis, and key technical decisions.
+   Sets up the "what happened" before the other articles explain "how"
+   and "why."
+
+### Tier 2: Technical Deep Dives (the how)
+
+3. **PARSER_EVOLUTION** -- How three parser generations solved the
+   problems described in PARSING_PERL. The mode-based lexer, FIFO
+   heredoc queue, and error recovery architecture.
+
+4. **LSP_IMPLEMENTATION_STORY** -- How the parser feeds into 97 LSP
+   features, covering feature governance, module resolution, the DAP
+   server, and Perl-specific challenges like hash key context.
+
+5. **CUSTOM_LSP_RUNTIME** -- Why the project built its own JSON-RPC
+   runtime instead of using tower-lsp. The most focused and
+   architecturally detailed article.
+
+### Tier 3: The Agentic Story (the why)
+
+6. **AGENTIC_DEVELOPMENT** -- The measured version: statistics,
+   patterns, and lessons from the agentic development model. Read
+   this first for the data-driven perspective.
+
+7. **AGENTIC_SWARM_ERA** -- The narrative version: day-by-day
+   reconstruction of how the swarm emerged, the competing-solutions
+   pattern, and the evolution from chaos to CI gates. The most vivid
+   article in the series.
+
+### Tier 4: Engineering Practices (the discipline)
+
+8. **QUALITY_INFRASTRUCTURE** -- The three-tier CI system, mutation
+   testing, fuzz testing, corpus validation, supply chain security,
+   and codified debt tracking.
+
+9. **WORKSPACE_ARCHITECTURE** -- The 121-crate workspace: tier system,
+   extraction pattern, build performance, publishing pipeline.
+
+10. **CLEAN_CODE_SHOWCASE** -- Ten patterns worth stealing: zero-panic
+    code, feature governance as types, formal state machines, SLOs for
+    dev tools, structured debt, budget-bounded error recovery.
+
+### Tier 5: Fun (dessert)
+
+11. **CODEBASE_CURIOSITIES** -- The 47-line crate. The 21 "c" commits.
+    The agent rejection wall. Bolt's PHF obsession. The 18-way status
+    menu standoff. Read last for entertainment and to appreciate the
+    full picture.
+
+---
+
+## 6. Gaps in Coverage
+
+### Topics Not Covered
+
+**The VSCode extension.** No article examines the VSCode extension in
+depth -- its architecture, its contribution to the user experience, or
+how it integrates with the LSP server. The extension appears in several
+articles but always as a footnote.
+
+**The DAP server in detail.** LSP_IMPLEMENTATION_STORY covers the DAP
+briefly, but no article provides a deep dive into the native debugger
+adapter, the bridge mode architecture, or the challenges of driving
+`perl -d` from Rust.
+
+**Real-world usage and performance.** Every article discusses the
+project's capabilities, but none presents evidence of real users editing
+real Perl codebases. What happens when perl-lsp meets a 50,000-line
+legacy codebase with source filters and indirect object syntax? What are
+the actual failure modes in practice?
+
+**The semantic analyzer.** CODEBASE_HISTORY mentions it. CLEAN_CODE_
+SHOWCASE refers to hash key context detection. But no article explains
+how the semantic analysis engine works: scope analysis, type inference,
+unused variable detection, the diagnostic pipeline.
+
+**The human experience.** All articles focus on the code and the
+process. None addresses what it is actually like to work as the solo
+human directing a swarm of AI agents. What does the daily workflow look
+like? How does the maintainer decide what to assign to which agent?
+What are the cognitive costs?
+
+**Perl community reception.** The project builds IDE tooling for a
+language with an established community and existing tools (PLS,
+Perl-LanguageServer). No article discusses how the Perl community has
+received this project, whether there are adoption barriers, or how
+perl-lsp positions itself relative to alternatives.
+
+**Economics.** QUALITY_INFRASTRUCTURE mentions CI cost per PR (~$0.05),
+but no article examines the total cost of the agentic development model:
+API costs for Codex and Claude, compute costs for the 1,200+ PRs, time
+cost of human review. Is this model economically sustainable for a
+solo developer?
+
+### Follow-Up Articles That Would Complete the Picture
+
+1. **"The Solo Architect: Human Workflow in an Agent-Driven Project"** --
+   The maintainer's perspective on directing AI agents, making
+   architectural decisions, and managing the cognitive load of reviewing
+   hundreds of agent-generated PRs.
+
+2. **"Debugging Perl from Rust: The DAP Deep Dive"** -- The technical
+   story of driving `perl -d` from a Rust process, the bridge vs. native
+   architecture, and the security challenges of remote debugging.
+
+3. **"perl-lsp vs. the CPAN Corpus: Real-World Parser Coverage"** --
+   Run the parser against the top 1,000 CPAN distributions and report
+   what breaks. A genuine coverage assessment beyond synthetic tests.
+
+4. **"The Economics of Agent-Driven Development"** -- Total cost
+   analysis: API spend, CI spend, human time, and the break-even point
+   where agent development becomes cheaper than solo human development.
+
+5. **"Scope Analysis Without Running Perl"** -- How the semantic
+   analyzer infers scope, detects unused variables, and handles the
+   cases where static analysis necessarily diverges from Perl's dynamic
+   semantics.
+
+---
+
+## Appendix: Article Cross-Reference Matrix
+
+| Theme | History | Parser | Agentic Dev | Swarm Era | LSP Story | Quality | Workspace | Custom RT | Clean Code | Curiosities | Parsing |
+|-------|:-------:|:------:|:-----------:|:---------:|:---------:|:-------:|:---------:|:---------:|:----------:|:-----------:|:-------:|
+| Parser generations | X | X | | X | X | | | | | X | X |
+| Slash ambiguity | | X | | | | | | | | | X |
+| Heredoc handling | | X | | | | | | | | | X |
+| Microcrate architecture | X | X | X | X | X | | X | X | X | X | |
+| CI gates / guardrails | X | X | X | X | | X | X | | X | | |
+| No-unwrap policy | X | | X | X | | X | | X | X | | |
+| Feature governance | X | | | | X | | X | X | X | | |
+| Agent rejection rates | | | X | X | | | | | | X | |
+| "Comprehensive" signal | | | X | X | | | | | | X | |
+| CLAUDE.md evolution | | | X | X | | | | | | | |
+| Debt tracking | | | X | | | X | X | | X | | |
+| Incremental parsing | | X | | | | | | | X | | X |
+| Supply chain security | X | | | | | X | | | | | |
+| Performance data | X | X | | | X | | X | X | X | | |
+| tree-sitter heritage | X | X | | X | | | X | | | X | X |
+
+---
+
+*This meta-analysis was written after reading all 11 articles in full.
+Cross-references are to the articles by their short names as used
+throughout this document.*


### PR DESCRIPTION
## Summary

- Reads and synthesizes all 11 research articles in `docs/project/` into a single meta-analysis
- Identifies the project's three-act narrative (parsing problem, parser sprint, agentic scaling)
- Surfaces contradictions and tensions across articles (rejection rates vs. productivity, microcrate overhead, custom runtime vs. NIH, agents constraining agents)
- Documents two key corrections: Codex rejection rate is a feature of the parallel-solutions workflow (not a quality problem), and the Rust parser is entirely new work (not derived from tree-sitter-perl-better)
- Identifies four recurring cross-article patterns: CI as agent guardrails, chaos-to-structure evolution, microcrate architecture, the "comprehensive" problem
- Provides a recommended 5-tier reading order for the 11 articles
- Catalogs gaps in coverage and suggests 5 follow-up articles
- Includes a theme-by-article cross-reference matrix

## Test plan
- [ ] Verify the document renders correctly in GitHub markdown preview
- [ ] Confirm all 11 article names are referenced accurately
- [ ] Review the corrections section for accuracy against author's stated intent