### PR TITLE
docs: align CLAUDE.md with current workspace state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ cargo test --workspace --lib
 
 ## Crate Structure
 
-The workspace is organized in dependency tiers. Key crates:
+The workspace contains **116 workspace members** across **121 crate directories** (see `Cargo.toml`), organized in dependency tiers. Key crates:
 
 | Crate | Path | Purpose |
 |-------|------|---------|
@@ -170,9 +170,10 @@ CI is optional/opt-in. The repo is local-first by design.
 ## Workspace Exclusions
 
 These directories are excluded from the default workspace (require special builds):
-- `tree-sitter-perl-c/` - Requires libclang
+- `crates/tree-sitter-perl-c/` - Requires libclang (bindgen)
+- `tree-sitter-perl/` - Legacy C parser
 - `fuzz/` - Specialized fuzz testing build
-- `archive/` - Legacy components
+- `archive/` - Archived legacy components
 
 ## Key Paths
 


### PR DESCRIPTION
## Summary

- Add workspace member count (**116 members** across **121 crate directories**) to the Crate Structure section, which previously mentioned the workspace without giving the actual count
- Fix `tree-sitter-perl-c/` path to `crates/tree-sitter-perl-c/` in Workspace Exclusions (the directory lives under `crates/`, not at the repo root)
- Add missing `tree-sitter-perl/` entry to Workspace Exclusions (excluded in `Cargo.toml` but was not listed)
- Update exclusion descriptions to match `Cargo.toml` comments ("Requires libclang (bindgen)", "Archived legacy components")

## Verification performed

- Confirmed 116 workspace members by counting entries in `Cargo.toml` members list
- Verified all Key Paths entries exist on disk (`docs/`, `features.toml`, `.ci/gate-policy.yaml`, `.ci/debt-ledger.yaml`, `deny.toml`, etc.)
- Verified all referenced scripts exist (`scripts/install-githooks.sh`, `scripts/ignored-test-count.sh`, `scripts/update-current-status.py`)
- Verified all referenced `just` recipes exist in `justfile` (`health`, `status-check`, `ci-gate`, `pr-fast`, `ci-full`, etc.)
- Verified all referenced documentation files exist under `docs/`
- Confirmed workspace lints in `Cargo.toml` align with the Coding Standards section
- No stale numeric counts found in CLAUDE.md (the file previously had no counts at all)

## Test plan

- [ ] Verify `nix develop -c just ci-gate` still passes (docs-only change, no functional impact)