### PR TITLE
fix: resolve clippy warnings and missing dev-dependency for ci-gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "md5",
  "once_cell",
  "parking_lot",
+ "perl-content-length-framing",
  "perl-dap",
  "perl-keywords",
  "perl-lsp-cancellation",

--- a/crates/perl-incremental-parsing/tests/extended_unit_tests.rs
+++ b/crates/perl-incremental-parsing/tests/extended_unit_tests.rs
@@ -36,7 +36,7 @@ use perl_incremental_parsing::incremental::{
     Edit, IncrementalState, LineIndex, ParseCheckpoint, ScopeSnapshot, apply_edits,
 };
 use perl_incremental_parsing::position::Position;
-use perl_incremental_parsing::{Node, NodeKind, Parser, SourceLocation};
+use perl_incremental_parsing::{Node, NodeKind, Parser};
 
 use lsp_types::{Range as LspRange, TextDocumentContentChangeEvent};
 use ropey::Rope;
@@ -984,7 +984,7 @@ fn byte_to_lsp_pos_middle() {
 #[test]
 fn byte_to_lsp_pos_past_end_clamped() {
     let rope = Rope::from_str("Hi");
-    let (line, col) = byte_to_lsp_pos(&rope, 1000);
+    let (line, _col) = byte_to_lsp_pos(&rope, 1000);
     // Should clamp to end of document
     assert!(line <= 1);
 }

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -113,6 +113,7 @@ serial_test = "3.4.0"
 tempfile = "3.24.0"
 proptest = "1.9.0"
 perl-tdd-support = { workspace = true }
+perl-content-length-framing = { workspace = true }
 which = "8.0.2"
 parking_lot = "0.12.5"
 criterion = "0.8.1"

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -784,6 +784,7 @@ mod prototype_heuristic_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod code_dereference_tests {
     use super::*;
 

--- a/crates/perl-tokenizer/tests/extended_unit_tests.rs
+++ b/crates/perl-tokenizer/tests/extended_unit_tests.rs
@@ -21,11 +21,7 @@ use perl_tokenizer::util::{code_slice, find_data_marker_byte_lexed};
 fn collect_kinds(src: &str) -> Vec<TokenKind> {
     let mut s = TokenStream::new(src);
     let mut kinds = Vec::new();
-    loop {
-        let t = match s.next() {
-            Ok(t) => t,
-            Err(_) => break,
-        };
+    while let Ok(t) = s.next() {
         if t.kind == TokenKind::Eof {
             break;
         }
@@ -37,11 +33,7 @@ fn collect_kinds(src: &str) -> Vec<TokenKind> {
 fn collect_texts(src: &str) -> Vec<String> {
     let mut s = TokenStream::new(src);
     let mut texts = Vec::new();
-    loop {
-        let t = match s.next() {
-            Ok(t) => t,
-            Err(_) => break,
-        };
+    while let Ok(t) = s.next() {
         if t.kind == TokenKind::Eof {
             break;
         }
@@ -786,8 +778,6 @@ fn ext_format_with_trivia_includes_leading() -> Result<(), Box<dyn std::error::E
 
 #[test]
 fn ext_format_with_trivia_empty_trivia() -> Result<(), Box<dyn std::error::Error>> {
-    use perl_tokenizer::trivia::NodeWithTrivia;
-
     // Parse an empty source to get a program node with no trivia
     let parser = TriviaPreservingParser::new(String::new());
     let result = parser.parse();

--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -713,6 +713,7 @@ fn print_summary(report: &SweepReport) {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

- Allow `clippy::panic` in test module (`perl-parser-core/variables.rs`)
- Allow `clippy::expect_used` in test module (`xtask/parser_corpus_sweep.rs`)
- Fix unused imports and variables in test files
- Convert `loop`+`match` to `while let` in tokenizer test helpers
- Add `perl-content-length-framing` as dev-dependency (needed by test harness after #1253 removed it from prod deps)

## Test plan

- [x] `nix develop -c just ci-gate` passes locally