### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-position-tracking",
  "perl-token",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "perl-builtins"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-builtins-phf",
  "perl-tdd-support",
@@ -1526,14 +1526,14 @@ dependencies = [
 
 [[package]]
 name = "perl-builtins-phf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "phf",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1546,11 +1546,11 @@ dependencies = [
 
 [[package]]
 name = "perl-content-length-framing"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-corpus"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-breakpoint"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser",
  "perl-tdd-support",
@@ -1613,11 +1613,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-command-args"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-dap-eval"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-platform"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "perl-dap-shell",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-security"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -1647,11 +1647,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-shell"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-dap-stack"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1663,14 +1663,14 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-value"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perl-dap-variables"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "once_cell",
  "perl-dap-value",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-workspace-index",
  "serde",
@@ -1692,14 +1692,14 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics-codes"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perl-edit"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "perl-error"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-ast",
  "perl-lexer",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "perl-feature-catalog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
  "serde",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "perl-heredoc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -1754,11 +1754,11 @@ dependencies = [
 
 [[package]]
 name = "perl-keywords"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lexer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "memchr",
@@ -1772,14 +1772,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1843,14 +1843,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ast-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-cancellation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-capability-map"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-ids",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-actions"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-ast-utils",
  "perl-lsp-diagnostics",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-keywords",
@@ -1896,28 +1896,28 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion-item"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-critic-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp-diagnostic-catalog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-diagnostics-codes",
  "serde_json",
@@ -1925,11 +1925,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-diagnostic-types"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lsp-diagnostics"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-diagnostic-types",
  "perl-parser-core",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-links"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-import",
  "perl-module-path",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-contracts"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-flags"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-ids",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-governance"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-grid",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-grid"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-policy",
@@ -1995,11 +1995,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-ids"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lsp-feature-policy"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
@@ -2008,14 +2008,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-profile"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-contracts",
 ]
 
 [[package]]
 name = "perl-lsp-feature-profile-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-feature-policy",
  "perl-lsp-feature-profile",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-folding"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-formatting-types",
  "perl-lsp-tooling",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2050,11 +2050,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-import-management"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lsp-inlay-hints"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-core",
  "perl-position-tracking",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-input-validation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-launcher"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "perl-lsp-feature-governance",
@@ -2085,14 +2085,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-limits"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-navigation"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-document-links",
@@ -2111,14 +2111,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-on-type-formatting"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-performance"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "moka",
  "perl-parser-core",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-protocol"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-contracts",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-providers"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "nix",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rename"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-keywords",
  "perl-parser-core",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-semantic-tokens"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2185,15 +2185,15 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-symbol-query"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lsp-text-utils"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-lsp-tooling"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-transport"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-content-length-framing",
  "perl-lsp-protocol",
@@ -2219,14 +2219,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-uri"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-workspace-symbols"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-lsp-symbol-query",
  "perl-module-path",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-boundary"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-path",
  "perl-module-token",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import-match"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-boundary",
  "perl-module-import",
@@ -2270,21 +2270,21 @@ dependencies = [
 
 [[package]]
 name = "perl-module-name"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-path"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-name",
 ]
 
 [[package]]
 name = "perl-module-reference"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-rename"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-import-match",
  "perl-module-path",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-resolution-path",
  "perl-module-resolution-uri",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-path"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-uri"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-boundary",
  "perl-module-name",
@@ -2350,14 +2350,14 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-token-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-reference",
  "perl-module-token-core",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-ast",
  "perl-builtins",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lazy_static",
  "once_cell",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-normalize"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-security"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-path-normalize",
  "tempfile",
@@ -2464,14 +2464,14 @@ dependencies = [
 
 [[package]]
 name = "perl-percentile"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-ast",
  "perl-tdd-support",
@@ -2490,21 +2490,21 @@ dependencies = [
 
 [[package]]
 name = "perl-qualified-name"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-quote"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-refactoring"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-path",
  "perl-parser-core",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
  "thiserror",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-core",
  "perl-symbol-types",
@@ -2541,30 +2541,30 @@ dependencies = [
 
 [[package]]
 name = "perl-source-editing"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-source-file"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-symbol-cursor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-index"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-symbol-table"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-position-tracking",
  "perl-symbol-types",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "perl-symbol-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "perl-text-line"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-module-token-parser",
  "perl-tdd-support",
@@ -2602,11 +2602,11 @@ dependencies = [
 
 [[package]]
 name = "perl-token"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-tokenizer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-ast",
  "perl-error",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-advanced-parsers"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-analysis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "encoding_rs",
  "perl-tdd-support",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-logos-lexer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chumsky",
  "logos",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-partial-ast"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-tdd-support",
  "perl-uri-classify",
@@ -2686,14 +2686,14 @@ dependencies = [
 
 [[package]]
 name = "perl-uri-classify"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "url",
 ]
 
 [[package]]
 name = "perl-workspace-discovery"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-source-file",
  "perl-workspace-ignore",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-folder"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "perl-uri",
  "proptest",
@@ -2715,11 +2715,11 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-ignore"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "perl-workspace-index"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-slo"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "parking_lot",
  "perl-percentile",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-state-machine"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "parking_lot",
 ]
@@ -3906,7 +3906,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4556,7 +4556,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -279,127 +279,127 @@ homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.10.0" }
-perl-quote = { path = "crates/perl-quote", version = "0.10.0" }
-perl-edit = { path = "crates/perl-edit", version = "0.10.0" }
-perl-builtins = { path = "crates/perl-builtins", version = "0.10.0" }
-perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.10.0" }
-perl-regex = { path = "crates/perl-regex", version = "0.10.0" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.10.0" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.10.0" }
-perl-ast = { path = "crates/perl-ast", version = "0.10.0" }
-perl-heredoc = { path = "crates/perl-heredoc", version = "0.10.0" }
-perl-error = { path = "crates/perl-error", version = "0.10.0" }
-perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.10.0" }
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.10.0" }
-perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.10.0" }
-perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.10.0" }
-perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.10.0" }
-perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.10.0" }
-perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.10.0" }
-perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.10.0" }
-perl-module-token = { path = "crates/perl-module-token", version = "0.10.0" }
-perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.10.0" }
-perl-module-name = { path = "crates/perl-module-name", version = "0.10.0" }
-perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.10.0" }
-perl-module-reference = { path = "crates/perl-module-reference", version = "0.10.0" }
-perl-module-import = { path = "crates/perl-module-import", version = "0.10.0" }
-perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.10.0" }
-perl-module-path = { path = "crates/perl-module-path", version = "0.10.0" }
-perl-module-rename = { path = "crates/perl-module-rename", version = "0.10.0" }
-perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.10.0" }
-perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.10.0" }
-perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.10.0" }
-perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.10.0" }
-perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.10.0" }
-perl-keywords = { path = "crates/perl-keywords", version = "0.10.0" }
-perl-source-file = { path = "crates/perl-source-file", version = "0.10.0" }
-perl-text-line = { path = "crates/perl-text-line", version = "0.10.0" }
-perl-source-editing = { path = "crates/perl-source-editing", version = "0.10.0" }
-perl-line-index = { path = "crates/perl-line-index", version = "0.10.0" }
-perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.10.0" }
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.10.0" }
-perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.10.0" }
-perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.10.0" }
-perl-lsp-ast-utils = { path = "crates/perl-lsp-ast-utils", version = "0.10.0" }
-perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.10.0" }
-perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.10.0" }
-perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.10.0" }
-perl-uri = { path = "crates/perl-uri", version = "0.10.0" }
-perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.10.0" }
-perl-percentile = { path = "crates/perl-percentile", version = "0.10.0" }
-perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.10.0" }
-perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.10.0" }
-perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.10.0" }
-perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.10.0" }
-perl-path-security = { path = "crates/perl-path-security", version = "0.10.0" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.10.0" }
-perl-dap = { path = "crates/perl-dap", version = "0.10.0" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.10.0" }
-perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.10.0" }
-perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.10.0" }
-perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.10.0" }
-perl-dap-value = { path = "crates/perl-dap-value", version = "0.10.0" }
-perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.10.0" }
-perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.10.0" }
-perl-dap-security = { path = "crates/perl-dap-security", version = "0.10.0" }
-perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.10.0" }
-perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.10.0" }
-perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.10.0" }
-perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.10.0" }
-perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.10.0" }
-perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.10.0" }
+perl-token = { path = "crates/perl-token", version = "0.11.0" }
+perl-quote = { path = "crates/perl-quote", version = "0.11.0" }
+perl-edit = { path = "crates/perl-edit", version = "0.11.0" }
+perl-builtins = { path = "crates/perl-builtins", version = "0.11.0" }
+perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.11.0" }
+perl-regex = { path = "crates/perl-regex", version = "0.11.0" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.11.0" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.11.0" }
+perl-ast = { path = "crates/perl-ast", version = "0.11.0" }
+perl-heredoc = { path = "crates/perl-heredoc", version = "0.11.0" }
+perl-error = { path = "crates/perl-error", version = "0.11.0" }
+perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.11.0" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.11.0" }
+perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.11.0" }
+perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.11.0" }
+perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.11.0" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.11.0" }
+perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.11.0" }
+perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.11.0" }
+perl-module-token = { path = "crates/perl-module-token", version = "0.11.0" }
+perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.11.0" }
+perl-module-name = { path = "crates/perl-module-name", version = "0.11.0" }
+perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.11.0" }
+perl-module-reference = { path = "crates/perl-module-reference", version = "0.11.0" }
+perl-module-import = { path = "crates/perl-module-import", version = "0.11.0" }
+perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.11.0" }
+perl-module-path = { path = "crates/perl-module-path", version = "0.11.0" }
+perl-module-rename = { path = "crates/perl-module-rename", version = "0.11.0" }
+perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.11.0" }
+perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.11.0" }
+perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.11.0" }
+perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.11.0" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.11.0" }
+perl-keywords = { path = "crates/perl-keywords", version = "0.11.0" }
+perl-source-file = { path = "crates/perl-source-file", version = "0.11.0" }
+perl-text-line = { path = "crates/perl-text-line", version = "0.11.0" }
+perl-source-editing = { path = "crates/perl-source-editing", version = "0.11.0" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.11.0" }
+perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.11.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.11.0" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.11.0" }
+perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.11.0" }
+perl-lsp-ast-utils = { path = "crates/perl-lsp-ast-utils", version = "0.11.0" }
+perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.11.0" }
+perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.11.0" }
+perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.11.0" }
+perl-uri = { path = "crates/perl-uri", version = "0.11.0" }
+perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.11.0" }
+perl-percentile = { path = "crates/perl-percentile", version = "0.11.0" }
+perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.11.0" }
+perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.11.0" }
+perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.11.0" }
+perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.11.0" }
+perl-path-security = { path = "crates/perl-path-security", version = "0.11.0" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.11.0" }
+perl-dap = { path = "crates/perl-dap", version = "0.11.0" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.11.0" }
+perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.11.0" }
+perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.11.0" }
+perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.11.0" }
+perl-dap-value = { path = "crates/perl-dap-value", version = "0.11.0" }
+perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.11.0" }
+perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.11.0" }
+perl-dap-security = { path = "crates/perl-dap-security", version = "0.11.0" }
+perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.11.0" }
+perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.11.0" }
+perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.11.0" }
+perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.11.0" }
+perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.11.0" }
+perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.11.0" }
 
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.10.0" }
-perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.10.0" }
-perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.10.0" }
-perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.10.0" }
-perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.10.0" }
-perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.10.0" }
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.10.0" }
-perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.10.0" }
-perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.10.0" }
-perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.10.0" }
-perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.10.0" }
-perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.10.0" }
-perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.10.0" }
-perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.10.0" }
-perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.10.0" }
-perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.10.0" }
-perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.10.0" }
-perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.10.0" }
-perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.10.0" }
-perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.10.0" }
-perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.10.0" }
-perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.10.0" }
-perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.10.0" }
-perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.10.0" }
-perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.10.0" }
-perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.10.0" }
-perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.10.0" }
-perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.10.0" }
-perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.10.0" }
-perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.10.0" }
-perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.10.0" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.11.0" }
+perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.11.0" }
+perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.11.0" }
+perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.11.0" }
+perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.11.0" }
+perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.11.0" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.11.0" }
+perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.11.0" }
+perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.11.0" }
+perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.11.0" }
+perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.11.0" }
+perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.11.0" }
+perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.11.0" }
+perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.11.0" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.11.0" }
+perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.11.0" }
+perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.11.0" }
+perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.11.0" }
+perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.11.0" }
+perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.11.0" }
+perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.11.0" }
+perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.11.0" }
+perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.11.0" }
+perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.11.0" }
+perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.11.0" }
+perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.11.0" }
+perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.11.0" }
+perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.11.0" }
+perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.11.0" }
+perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.11.0" }
+perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.11.0" }
 
 # Tier 3: Two-level dependencies
-perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.10.0" }
-perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.10.0" }
-perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.10.0" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.10.0" }
-perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.10.0" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.10.0" }
+perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.11.0" }
+perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.11.0" }
+perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.11.0" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.11.0" }
+perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.11.0" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.11.0" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.10.0" }
-perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.10.0", default-features = false }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.11.0" }
+perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.11.0", default-features = false }
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.10.0" }
+perl-parser = { path = "crates/perl-parser", version = "0.11.0" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.10.0" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.11.0" }
 
 # External dependencies
 tree-sitter-perl = { path = "crates/tree-sitter-perl-rs", features = ["pure-rust"] }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.10.x  | Yes -- current release line |
+| 0.11.x  | Yes -- current release line |
+| 0.10.x  | Security fixes only |
 | < 0.10  | No |
 
 ## Reporting a Vulnerability

--- a/crates/perl-ast/Cargo.toml
+++ b/crates/perl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ast"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins-phf/Cargo.toml
+++ b/crates/perl-builtins-phf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins-phf"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins/Cargo.toml
+++ b/crates/perl-builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ keywords = ["perl", "builtins", "parser", "lsp", "signatures"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.10.0" }
+perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.11.0" }
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-corpus"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-breakpoint/Cargo.toml
+++ b/crates/perl-dap-breakpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-breakpoint"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ categories = ["development-tools::debugging", "development-tools"]
 
 [dependencies]
 # Perl parser for AST-based validation
-perl-parser = { path = "../perl-parser", version = "0.10.0" }
+perl-parser = { path = "../perl-parser", version = "0.11.0" }
 
 # Rope for position mapping
 ropey = "1.6.1"

--- a/crates/perl-dap-eval/Cargo.toml
+++ b/crates/perl-dap-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-eval"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-platform/Cargo.toml
+++ b/crates/perl-dap-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-platform"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-security/Cargo.toml
+++ b/crates/perl-dap-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-security"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-shell/Cargo.toml
+++ b/crates/perl-dap-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-shell"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-stack"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-variables/Cargo.toml
+++ b/crates/perl-dap-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-variables"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dead-code"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-diagnostics-codes/Cargo.toml
+++ b/crates/perl-diagnostics-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-diagnostics-codes"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-edit/Cargo.toml
+++ b/crates/perl-edit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-edit"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-error/Cargo.toml
+++ b/crates/perl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-error"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-feature-catalog/Cargo.toml
+++ b/crates/perl-feature-catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-feature-catalog"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-heredoc/Cargo.toml
+++ b/crates/perl-heredoc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-heredoc"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-incremental-parsing"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lexer"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-capability-map"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-contracts"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-grid/Cargo.toml
+++ b/crates/perl-lsp-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-grid"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-policy"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-profile/Cargo.toml
+++ b/crates/perl-lsp-feature-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-profile"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-folding/Cargo.toml
+++ b/crates/perl-lsp-folding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-folding"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-protocol/Cargo.toml
+++ b/crates/perl-lsp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-protocol"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-providers"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-core"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-pest"
-version = "0.10.0"
+version = "0.11.0"
 publish = false
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-pragma"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-quote/Cargo.toml
+++ b/crates/perl-quote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-quote"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-refactoring/Cargo.toml
+++ b/crates/perl-refactoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-refactoring"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-regex/Cargo.toml
+++ b/crates/perl-regex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-regex"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-semantic-analyzer"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-symbol-table/Cargo.toml
+++ b/crates/perl-symbol-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-symbol-table"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-symbol-types/Cargo.toml
+++ b/crates/perl-symbol-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-symbol-types"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tdd-support"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-token"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tokenizer/Cargo.toml
+++ b/crates/perl-tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tokenizer"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-ts-advanced-parsers/Cargo.toml
+++ b/crates/perl-ts-advanced-parsers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-advanced-parsers"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Composed parser experiments for Perl"

--- a/crates/perl-ts-heredoc-analysis/Cargo.toml
+++ b/crates/perl-ts-heredoc-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-analysis"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Standalone heredoc analysis tools for Perl parsing"

--- a/crates/perl-ts-heredoc-parser/Cargo.toml
+++ b/crates/perl-ts-heredoc-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-parser"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Heredoc parsing pipeline for Perl"

--- a/crates/perl-ts-logos-lexer/Cargo.toml
+++ b/crates/perl-ts-logos-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-logos-lexer"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Logos-based token parser for Perl"

--- a/crates/perl-ts-partial-ast/Cargo.toml
+++ b/crates/perl-ts-partial-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-partial-ast"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Partial parse and anti-pattern AST for Perl"

--- a/crates/perl-uri/Cargo.toml
+++ b/crates/perl-uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-uri"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-workspace-index"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-perl-c"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Tree-sitter Perl grammar with C scanner (legacy implementation)"

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Canonical**: This is the authoritative roadmap. See `CURRENT_STATUS.md` for computed metrics.
 > **Stale roadmaps**: Archived at `docs/archive/roadmaps/`; retrieve from git history if needed.
 
-> **Status (2026-03-11)**: **Initial Public Alpha (v0.10.0)**. Release preparation (crates.io, VS Code marketplace) and documentation alignment underway.
+> **Status (2026-03-11)**: **Public Alpha (v0.11.0)**. Release preparation (crates.io, VS Code marketplace) and documentation alignment underway.
 >
 > **Canonical receipt**: `nix develop -c just ci-gate` must be green before merging.
 > **CI** is intentionally optional/opt-in; the repo is local-first by design.
@@ -12,11 +12,11 @@
 
 ## Alpha Disclaimer
 
-Perl LSP is currently in **Initial Public Alpha**. Version 0.10.0 represents a substantially complete feature set, but APIs and protocols are still evolving. We value early adopter feedback to refine the project toward the v0.15.0 Stability Contract milestone.
+Perl LSP is currently in **Public Alpha**. Version 0.11.0 represents a substantially complete feature set, but APIs and protocols are still evolving. We value early adopter feedback to refine the project toward the v0.15.0 Stability Contract milestone.
 
 ---
 
-## Current State (v0.10.0)
+## Current State (v0.11.0)
 
 | Component | Release Stance | Evidence | Notes |
 |-----------|----------------|----------|-------|
@@ -58,12 +58,12 @@ For current metrics (LSP coverage %, corpus counts, test pass rates), see [CURRE
 
 | Crate | Version | Status | Purpose |
 |-------|---------|--------|----------|
-| **perl-parser** | v0.10.0 | Public Alpha | Main parser library |
-| **perl-lsp** | v0.10.0 | Public Alpha | LSP server |
-| **perl-lexer** | v0.10.0 | Public Alpha | Context-aware tokenizer |
-| **perl-corpus** | v0.10.0 | Public Alpha | Test corpus |
-| **perl-dap** | v0.2.0 | Preview (Native + Bridge) | Debug Adapter Protocol |
-| **perl-parser-pest** | v0.10.0 | Legacy | Pest-based parser (maintained) |
+| **perl-parser** | v0.11.0 | Public Alpha | Main parser library |
+| **perl-lsp** | v0.11.0 | Public Alpha | LSP server |
+| **perl-lexer** | v0.11.0 | Public Alpha | Context-aware tokenizer |
+| **perl-corpus** | v0.11.0 | Public Alpha | Test corpus |
+| **perl-dap** | v0.11.0 | Preview (Native + Bridge) | Debug Adapter Protocol |
+| **perl-parser-pest** | v0.11.0 | Legacy | Pest-based parser (maintained) |
 
 ---
 

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.11.0"
 lsp_version = "3.18"
 compliance_percent = 99  # 96/97 features advertised, all GA
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp",
   "displayName": "Perl Language Server",
   "description": "Comprehensive Perl language support powered by perl-lsp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "effortlesssteven",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
## Summary

- Bump all 116 workspace crates from 0.10.0 to 0.11.0
- Update `features.toml` version
- Update VS Code extension version in `package.json`
- Update ROADMAP.md version references and component table
- Update SECURITY.md supported versions

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo generate-lockfile` succeeds
- [ ] CI gate passes