### PR TITLE
docs: polish API documentation for published crates

### DIFF
--- a/crates/perl-corpus/README.md
+++ b/crates/perl-corpus/README.md
@@ -4,7 +4,7 @@
 
 Test corpus management, property-based generators, and edge case fixtures for Perl parsers.
 
-Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+Part of the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) workspace.
 
 ## Overview
 
@@ -25,7 +25,7 @@ Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp)
 use perl_corpus::{parse_dir, find_by_tag, EdgeCaseGenerator, generate_perl_code_with_seed};
 
 // Load and query corpus sections
-let sections = parse_dir(std::path::Path::new("test_corpus")).unwrap();
+let sections = parse_dir(std::path::Path::new("test_corpus"))?;
 let regex_tests = find_by_tag(&sections, "regex");
 
 // Generate deterministic Perl code

--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -4,7 +4,7 @@
 
 Debug Adapter Protocol (DAP) server for Perl, enabling debugging in VS Code, Neovim, Emacs, and other DAP-compatible editors.
 
-Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+Part of the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) workspace.
 
 ## Features
 
@@ -19,7 +19,7 @@ Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp)
 ## Usage
 
 ```bash
-cargo install --path crates/perl-dap
+cargo install perl-dap
 perl-dap --stdio            # Native adapter on stdio (default)
 perl-dap --socket --port 13603  # Native adapter on TCP
 perl-dap --bridge           # Bridge mode (requires Perl::LanguageServer)

--- a/crates/perl-lexer/README.md
+++ b/crates/perl-lexer/README.md
@@ -3,7 +3,7 @@
 [![Documentation](https://docs.rs/perl-lexer/badge.svg)](https://docs.rs/perl-lexer)
 
 Context-aware Perl lexer with mode-based tokenization for the
-[tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+[perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) workspace.
 
 ## Overview
 

--- a/crates/perl-lsp/README.md
+++ b/crates/perl-lsp/README.md
@@ -24,7 +24,7 @@ perl-lsp --version        # version info
 
 The `perl_lsp` library re-exports `LspServer`, `JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`, and a convenience `run_stdio()` entry point for embedding.
 
-## Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace
+## Part of the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) workspace
 
 Tier 6 executable crate. Delegates parsing to `perl-parser` and dispatches LSP features through dedicated provider crates (`perl-lsp-completion`, `perl-lsp-navigation`, `perl-lsp-diagnostics`, etc.).
 

--- a/crates/perl-parser/README.md
+++ b/crates/perl-parser/README.md
@@ -12,7 +12,7 @@ indexing, refactoring, and LSP provider re-exports.
 use perl_parser::Parser;
 
 let mut parser = Parser::new("my $x = 42;");
-let ast = parser.parse().unwrap();
+let ast = parser.parse()?;
 println!("{}", ast.to_sexp());
 ```
 
@@ -31,6 +31,8 @@ in S-expression, JSON, or debug format.
 | `refactor` | `perl-refactoring` | Import optimizer, modernization, refactoring engine |
 | `tdd` | `perl-tdd-support` | Test generation and TDD workflow |
 | `completion`, `diagnostics`, `rename`, ... | `perl-lsp-*` | LSP feature providers |
+
+Part of the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) workspace.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replace stale "tree-sitter-perl-rs" workspace name with "perl-lsp" in link text across `perl-lsp`, `perl-lexer`, `perl-dap`, and `perl-corpus` README files
- Replace `unwrap()` with `?` in code examples (`perl-parser`, `perl-corpus`) to align with project coding standards
- Use `cargo install perl-dap` instead of local path install in `perl-dap` README for crates.io users
- Add repo link to `perl-parser` README

## Test plan

- [x] `cargo doc` builds without warnings for all 5 crates (verified before changes)
- [x] All lib.rs files already have crate-level `//!` doc comments
- [x] All 5 crates have complete Cargo.toml metadata (description, repository, license, keywords, categories, documentation)
- [ ] Visually inspect README rendering on GitHub after merge