### PR TITLE
fix(parser): handle coderef invocation via ->()

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/coderef_invocation_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/coderef_invocation_tests.rs
@@ -1,0 +1,91 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::Parser;
+    use perl_tdd_support::must;
+
+    #[test]
+    fn test_coderef_invocation_no_args() {
+        let code = "$code->();";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("method_call"),
+            "Coderef invocation $code->() should parse as method_call: {sexp}",
+        );
+    }
+
+    #[test]
+    fn test_coderef_invocation_with_args() {
+        let code = r#"$code->("arg1", "arg2");"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("method_call"),
+            "Coderef invocation $code->(args) should parse as method_call: {sexp}",
+        );
+    }
+
+    #[test]
+    fn test_coderef_invocation_from_hash_value() {
+        let code = "$hash{callback}->();";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("method_call"),
+            "Coderef from hash $hash{{callback}}->() should parse as method_call: {sexp}",
+        );
+    }
+
+    #[test]
+    fn test_coderef_invocation_from_array_element() {
+        let code = "$array[0]->();";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("method_call"),
+            "Coderef from array $array[0]->() should parse as method_call: {sexp}",
+        );
+    }
+
+    #[test]
+    fn test_coderef_invocation_chained_after_method() {
+        let code = "$obj->method()->();";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        // Should contain two method_call nodes: one for ->method() and one for ->()
+        let count = sexp.matches("method_call").count();
+        assert!(
+            count >= 2,
+            "Chained $obj->method()->() should produce at least 2 method_call nodes, got {count}: {sexp}",
+        );
+    }
+
+    #[test]
+    fn test_coderef_invocation_with_sub_assignment() {
+        let code = r#"
+my $code = sub { print "hello" };
+$code->();
+"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("method_call"), "Coderef with sub assignment should parse: {sexp}",);
+    }
+
+    #[test]
+    fn test_coderef_invocation_no_errors() {
+        let code = "$code->();";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR") && !sexp.contains("Missing"),
+            "Coderef invocation should produce no error nodes: {sexp}",
+        );
+    }
+}

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -173,6 +173,25 @@ impl<'a> Parser<'a> {
                             );
                         }
 
+                        Some(TokenKind::LeftParen) => {
+                            // Coderef invocation: $code->() or $code->("arg")
+                            // No method name — the arrow target is a parenthesized
+                            // argument list, invoking the LHS as a code reference.
+                            let args = self.parse_args()?;
+
+                            let start = expr.location.start;
+                            let end = self.previous_position();
+
+                            expr = Node::new(
+                                NodeKind::MethodCall {
+                                    object: Box::new(expr),
+                                    method: String::new(),
+                                    args,
+                                },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         _ => {
                             // Just the arrow by itself - could be an error or incomplete
                             // For now, we'll leave expr unchanged

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -414,6 +414,8 @@ mod error_recovery_tests;
 #[cfg(test)]
 mod builtin_expansion_tests;
 #[cfg(test)]
+mod coderef_invocation_tests;
+#[cfg(test)]
 mod format_comprehensive_tests;
 #[cfg(test)]
 mod format_tests;


### PR DESCRIPTION
## Summary

- Adds handling for coderef invocation syntax (`$code->()`) in the recursive descent parser's postfix expression handler
- Previously, the parser handled `$obj->method()` but did not recognize `->()` (arrow followed directly by parentheses without a method name), causing parse failures for common Perl patterns like `$code->()`, `$hash{cb}->()`, and `$obj->method()->()`
- Represented as `MethodCall` with an empty method name to reuse existing AST infrastructure without touching 40+ downstream match sites

## Test plan

- [x] `$code->()` parses without errors
- [x] `$code->("arg1", "arg2")` parses with arguments
- [x] `$hash{callback}->()` parses coderef from hash value
- [x] `$array[0]->()` parses coderef from array element
- [x] `$obj->method()->()` chained invocation produces two method_call nodes
- [x] `my $code = sub { ... }; $code->()` full coderef assignment and invocation
- [x] No ERROR or Missing nodes in AST output
- [x] All 152 existing `perl-parser-core` tests pass (no regressions)
- [x] All 12 `perl-parser` lib tests pass
- [x] `cargo clippy -p perl-parser-core -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean