### PR TITLE
fix(parser): handle my/our/local/state in call args

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declaration_in_args_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/declaration_in_args_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for variable declarations (my/our/local/state) inside function call
+//! argument lists.
+
+use super::*;
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Helper: parse code and return the full AST.
+    fn parse_program(code: &str) -> Node {
+        let mut parser = Parser::new(code);
+        parser.parse().unwrap_or_else(|e| panic!("Parse failed for `{code}`: {e:?}"))
+    }
+
+    /// Helper: assert that the AST sexp contains no ERROR nodes.
+    fn assert_no_errors(code: &str) {
+        let ast = parse_program(code);
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "Parse of `{code}` produced ERROR nodes: {sexp}",);
+    }
+
+    /// Helper: parse code and return the first statement node.
+    fn first_stmt(code: &str) -> Node {
+        let ast = parse_program(code);
+        match ast.kind {
+            NodeKind::Program { mut statements } if !statements.is_empty() => {
+                statements.swap_remove(0)
+            }
+            _ => panic!("Expected Program with statements, got: {}", ast.to_sexp()),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Basic: `foo(my $x, $y)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn my_scalar_in_call_args() {
+        let code = "foo(my $x, $y);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        // Sexp format uses `my_declaration` for VariableDeclaration with declarator "my"
+        assert!(sexp.contains("my_declaration"), "Expected my_declaration in sexp, got: {sexp}",);
+    }
+
+    // ---------------------------------------------------------------
+    // With initializer: `sort(my @arr = @data)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn my_array_with_initializer_in_call_args() {
+        let code = "sort(my @arr = @data);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(sexp.contains("my_declaration"), "Expected my_declaration in sexp, got: {sexp}",);
+    }
+
+    // ---------------------------------------------------------------
+    // Multiple args with declaration: `push(my @arr, 1, 2, 3)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn my_array_with_trailing_args() {
+        let code = "push(my @arr, 1, 2, 3);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(sexp.contains("my_declaration"), "Expected my_declaration in sexp, got: {sexp}",);
+        // Verify that 1, 2, 3 are separate args, not consumed into the declaration
+        assert!(
+            sexp.contains("1") && sexp.contains("2") && sexp.contains("3"),
+            "Expected numeric args 1, 2, 3 in sexp, got: {sexp}",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // our keyword: `print(our $fh, "hello")`
+    // ---------------------------------------------------------------
+    #[test]
+    fn our_scalar_in_call_args() {
+        let code = "print(our $fh, \"hello\");";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(sexp.contains("our_declaration"), "Expected our_declaration in sexp, got: {sexp}",);
+    }
+
+    // ---------------------------------------------------------------
+    // state keyword: `foo(state $count = 0)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn state_scalar_with_initializer() {
+        let code = "foo(state $count = 0);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(
+            sexp.contains("state_declaration"),
+            "Expected state_declaration in sexp, got: {sexp}",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // local keyword: `foo(local $var)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn local_scalar_in_call_args() {
+        let code = "foo(local $var);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(
+            sexp.contains("local_declaration"),
+            "Expected local_declaration in sexp, got: {sexp}",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Declaration with initializer and trailing args:
+    // `foo(my $x = 1, $y)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn my_scalar_initializer_then_more_args() {
+        let code = "foo(my $x = 1, $y);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        assert!(sexp.contains("my_declaration"), "Expected my_declaration in sexp, got: {sexp}",);
+        // $y must be a separate argument, not part of the declaration initializer
+        // The sexp should contain both the declaration and a separate variable for $y
+        assert!(
+            sexp.contains("(variable $ y)"),
+            "Expected separate (variable $ y) in sexp, got: {sexp}",
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // List declaration in args: `foo(my ($a, $b) = @_)`
+    // ---------------------------------------------------------------
+    #[test]
+    fn my_list_declaration_in_call_args() {
+        let code = "foo(my ($a, $b) = @_);";
+        assert_no_errors(code);
+
+        let stmt = first_stmt(code);
+        let sexp = stmt.to_sexp();
+        // VariableListDeclaration sexp format should contain the declarator
+        assert!(sexp.contains("my"), "Expected 'my' in sexp, got: {sexp}",);
+        assert!(sexp.contains("(variable $ a)"), "Expected variable $a in sexp, got: {sexp}",);
+        assert!(sexp.contains("(variable $ b)"), "Expected variable $b in sexp, got: {sexp}",);
+    }
+}

--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -191,6 +191,104 @@ impl<'a> Parser<'a> {
         ))
     }
 
+    /// Parse an assignment expression or a variable declaration.
+    ///
+    /// When the current token is `my`, `our`, `local`, or `state`, this
+    /// delegates to [`parse_declaration_arg`] so that the declaration is
+    /// properly constructed and its initializer uses `parse_assignment()`
+    /// (not `parse_expression()`), preventing commas from being absorbed
+    /// into the initializer.  Otherwise, falls back to `parse_assignment()`.
+    fn parse_assignment_or_declaration(&mut self) -> ParseResult<Node> {
+        if matches!(
+            self.peek_kind(),
+            Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+        ) {
+            self.parse_declaration_arg()
+        } else {
+            self.parse_assignment()
+        }
+    }
+
+    /// Parse a variable declaration as a function argument.
+    ///
+    /// Handles `my $x`, `our @arr`, `local $var`, `state $count` inside
+    /// parenthesized argument lists (e.g. `foo(my $x, $y)`).
+    ///
+    /// Uses `parse_assignment()` for any initializer so that commas are
+    /// treated as argument separators rather than being consumed by the
+    /// comma operator.
+    fn parse_declaration_arg(&mut self) -> ParseResult<Node> {
+        let start = self.current_position();
+        let declarator_token = self.consume_token()?;
+        let declarator = declarator_token.text.to_string();
+
+        // Check if we have a list declaration like `my ($x, $y)`
+        if self.peek_kind() == Some(TokenKind::LeftParen) {
+            self.consume_token()?; // consume (
+
+            let mut variables = Vec::new();
+
+            while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
+                let var = self.parse_variable()?;
+                variables.push(var);
+
+                if self.peek_kind() == Some(TokenKind::Comma) {
+                    self.consume_token()?; // consume comma
+                } else if self.peek_kind() != Some(TokenKind::RightParen) {
+                    return Err(ParseError::syntax(
+                        "Expected comma or closing parenthesis in variable list",
+                        self.current_position(),
+                    ));
+                }
+            }
+
+            self.expect(TokenKind::RightParen)?; // consume )
+
+            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
+                self.tokens.next()?; // consume =
+                Some(Box::new(self.parse_assignment()?))
+            } else {
+                None
+            };
+
+            let end = self.previous_position();
+            Ok(Node::new(
+                NodeKind::VariableListDeclaration {
+                    declarator,
+                    variables,
+                    attributes: Vec::new(),
+                    initializer,
+                },
+                SourceLocation { start, end },
+            ))
+        } else {
+            // Single variable declaration
+            let variable = if declarator == "local" {
+                self.parse_assignment()?
+            } else {
+                self.parse_variable()?
+            };
+
+            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
+                self.tokens.next()?; // consume =
+                Some(Box::new(self.parse_assignment()?))
+            } else {
+                None
+            };
+
+            let end = self.previous_position();
+            Ok(Node::new(
+                NodeKind::VariableDeclaration {
+                    declarator,
+                    variable: Box::new(variable),
+                    attributes: Vec::new(),
+                    initializer,
+                },
+                SourceLocation { start, end },
+            ))
+        }
+    }
+
     /// Parse function arguments
     /// Handles both comma-separated and fat-comma-separated arguments.
     /// Fat comma (=>) auto-quotes bareword identifiers on its left side.
@@ -200,8 +298,9 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // Handle variable declarations (my/our/local/state) inside argument lists,
+                // otherwise parse as a normal assignment expression.
+                let mut arg = s.parse_assignment_or_declaration()?;
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -466,10 +466,10 @@ impl<'a> Parser<'a> {
                 // to handle operators like 'or', 'and' etc.
                 let first = if self.peek_kind() == Some(TokenKind::RightParen) {
                     // Simple case - just one element
-                    self.parse_assignment()?
+                    self.parse_assignment_or_declaration()?
                 } else {
                     // Peek ahead to see if this is a list or a complex expression
-                    let expr = self.parse_assignment()?;
+                    let expr = self.parse_assignment_or_declaration()?;
 
                     // Check what comes after
                     match self.peek_kind() {
@@ -509,7 +509,7 @@ impl<'a> Parser<'a> {
                             );
                         }
                         self.tokens.next()?; // consume =>
-                        elements.push(self.parse_assignment()?);
+                        elements.push(self.parse_assignment_or_declaration()?);
                     }
 
                     while self.peek_kind() == Some(TokenKind::Comma)
@@ -523,7 +523,7 @@ impl<'a> Parser<'a> {
                             break;
                         }
 
-                        let mut elem = self.parse_assignment()?;
+                        let mut elem = self.parse_assignment_or_declaration()?;
 
                         // Check for fat arrow after element — auto-quote bare identifiers
                         if self.peek_kind() == Some(TokenKind::FatArrow) {
@@ -537,7 +537,7 @@ impl<'a> Parser<'a> {
                             self.consume_token()?; // consume =>
                             elements.push(elem);
                             if self.peek_kind() != Some(TokenKind::RightParen) {
-                                elements.push(self.parse_assignment()?);
+                                elements.push(self.parse_assignment_or_declaration()?);
                             }
                         } else {
                             elements.push(elem);

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -414,6 +414,8 @@ mod error_recovery_tests;
 #[cfg(test)]
 mod builtin_expansion_tests;
 #[cfg(test)]
+mod declaration_in_args_tests;
+#[cfg(test)]
 mod format_comprehensive_tests;
 #[cfg(test)]
 mod format_tests;

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -476,7 +476,7 @@ impl<'a> Parser<'a> {
                             if (func_name.as_ref() == "open"
                                 || func_name.as_ref() == "pipe"
                                 || func_name.as_ref() == "socket")
-                                && (self.peek_kind() == Some(TokenKind::My) 
+                                && (self.peek_kind() == Some(TokenKind::My)
                                     || self.peek_kind() == Some(TokenKind::Our)
                                     || self.peek_kind() == Some(TokenKind::Local)
                                     || self.peek_kind() == Some(TokenKind::State))
@@ -497,8 +497,9 @@ impl<'a> Parser<'a> {
                                 self.tokens.relex_as_term();
                                 args.push(self.parse_assignment()?);
                             } else {
-                                // For builtins, use parse_assignment to avoid consuming comma operators
-                                args.push(self.parse_assignment()?);
+                                // For builtins, use parse_assignment_or_declaration to handle
+                                // my/our/local/state declarations inside argument lists
+                                args.push(self.parse_assignment_or_declaration()?);
                             }
 
                             // Handle map/grep/sort { block } LIST case where no comma separates block and list
@@ -536,7 +537,7 @@ impl<'a> Parser<'a> {
                                         | Some(TokenKind::Until)
                                         | Some(TokenKind::For)
                                         | Some(TokenKind::Foreach) => break,
-                                        _ => args.push(self.parse_assignment()?),
+                                        _ => args.push(self.parse_assignment_or_declaration()?),
                                     }
                                 }
                             }


### PR DESCRIPTION
Parse my/our/local/state variable declarations inside parenthesized function call argument lists. Previously these keywords were treated as bare identifiers producing ERROR nodes. 8 new tests, all 153 pass.