### PR TITLE
fix(parser): consume trailing list after block in grep/map/sort

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/builtin_block_list_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/builtin_block_list_tests.rs
@@ -1,0 +1,229 @@
+//! Tests for grep/map/sort with block form followed by a trailing list.
+//!
+//! In Perl, `grep { BLOCK } LIST`, `map { BLOCK } LIST`, and
+//! `sort { BLOCK } LIST` do not require a comma between the block
+//! and the list.  These tests verify the parser handles this correctly
+//! in both statement and expression (assignment RHS) contexts.
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use crate::parser::Parser;
+    use perl_tdd_support::must;
+
+    // ---- grep ----
+
+    #[test]
+    fn grep_block_simple_comparison() {
+        let code = "grep { $_ > 5 } @array;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(call grep"), "should be a grep call: {}", sexp);
+        assert!(sexp.contains("(block"), "should contain a block: {}", sexp);
+        assert!(
+            sexp.contains("(variable @ array)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn grep_block_method_call_in_block() {
+        let code = "grep { $_->is_valid } @items;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("(variable @ items)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn grep_block_regex_in_block() {
+        let code = r#"grep { /pattern/ } @strings;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("(variable @ strings)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn grep_block_assigned_to_variable() {
+        let code = "my @result = grep { $_->is_valid } @items;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        // The trailing list must be inside the grep call, not a separate statement
+        assert!(
+            sexp.contains("(call grep") && sexp.contains("(variable @ items)"),
+            "trailing list should be inside the grep call: {}",
+            sexp
+        );
+    }
+
+    // ---- map ----
+
+    #[test]
+    fn map_block_with_range() {
+        let code = "map { $_ * 2 } 1..10;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(call map"), "should be a map call: {}", sexp);
+        assert!(sexp.contains(".."), "trailing range should be inside call: {}", sexp);
+    }
+
+    #[test]
+    fn map_block_array_subscript_in_block() {
+        let code = r#"map { $_->[0] + $_->[1] } @pairs;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("(variable @ pairs)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn map_block_assigned_to_variable() {
+        let code = r#"my @mapped = map { $_->[0] + $_->[1] } @pairs;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(
+            sexp.contains("(call map") && sexp.contains("(variable @ pairs)"),
+            "trailing list should be inside the map call: {}",
+            sexp
+        );
+    }
+
+    // ---- sort ----
+
+    #[test]
+    fn sort_block_numeric_comparison() {
+        let code = "sort { $a <=> $b } @numbers;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(call sort"), "should be a sort call: {}", sexp);
+        assert!(
+            sexp.contains("(variable @ numbers)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn sort_block_hash_access_in_block() {
+        let code = r#"sort { $a->{name} cmp $b->{name} } @records;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(
+            sexp.contains("(variable @ records)"),
+            "trailing list should be inside call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn sort_block_function_call_in_block() {
+        let code = r#"sort { length($a) <=> length($b) } keys %hash;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(call sort"), "should be a sort call: {}", sexp);
+        // keys %hash should be inside the sort call
+        assert!(sexp.contains("(call keys"), "keys should be inside sort call: {}", sexp);
+    }
+
+    #[test]
+    fn sort_block_assigned_to_variable() {
+        let code = r#"my @sorted = sort { $a->{name} cmp $b->{name} } @records;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(
+            sexp.contains("(call sort") && sexp.contains("(variable @ records)"),
+            "trailing list should be inside the sort call: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn sort_block_with_keys_hash_assigned() {
+        let code = r#"my @x = sort { length($a) <=> length($b) } keys %hash;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(
+            sexp.contains("(call sort") && sexp.contains("(call keys"),
+            "keys call should be inside the sort call: {}",
+            sexp
+        );
+    }
+
+    // ---- chained builtins ----
+
+    #[test]
+    fn chained_grep_map() {
+        let code = r#"grep { /pattern/ } map { lc $_ } @strings;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(sexp.contains("(call grep"), "outer should be grep: {}", sexp);
+        assert!(sexp.contains("(call map"), "inner should be map: {}", sexp);
+    }
+
+    #[test]
+    fn chained_sort_map() {
+        let code = r#"my @result = sort { $a cmp $b } map { lc } @strings;"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(sexp.contains("(call sort"), "outer should be sort: {}", sexp);
+        assert!(sexp.contains("(call map"), "inner should be map: {}", sexp);
+    }
+
+    // ---- edge cases ----
+
+    #[test]
+    fn grep_block_with_comma_before_list() {
+        // Perl also allows a comma: grep { ... }, @array
+        let code = "grep { $_ > 5 }, @array;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(call grep"), "should be a grep call: {}", sexp);
+        assert!(
+            sexp.contains("(variable @ array)"),
+            "trailing list with comma should work: {}",
+            sexp
+        );
+    }
+
+    #[test]
+    fn sort_block_empty_block() {
+        // sort {} @array -- empty block comparison
+        let code = "sort {} @array;";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+    }
+}

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -296,17 +296,24 @@ impl<'a> Parser<'a> {
 
                                 args.push(block);
 
-                                // Parse remaining arguments
+                                // Parse trailing list arguments for map/grep/sort.
+                                // In Perl, the block form does not require a comma
+                                // before the list: `grep { ... } @array`
+                                // First consume without a comma if present
+                                if !self.is_at_statement_end()
+                                    && self.peek_kind() != Some(TokenKind::Comma)
+                                {
+                                    args.push(self.parse_ternary()?);
+                                }
+
+                                // Then consume any remaining comma-separated arguments
                                 while self.peek_kind() == Some(TokenKind::Comma) {
                                     self.consume_token()?; // consume comma
                                     if self.is_at_statement_end() {
                                         break;
                                     }
-                                    args.push(self.parse_comma()?);
+                                    args.push(self.parse_ternary()?);
                                 }
-                            } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // These builtins should parse {} as blocks, not hashes
-                                args.push(self.parse_builtin_block()?);
                             } else {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -412,6 +412,8 @@ mod error_recovery_tests;
 // #[cfg(test)]
 // mod enhanced_recovery_tests;
 #[cfg(test)]
+mod builtin_block_list_tests;
+#[cfg(test)]
 mod builtin_expansion_tests;
 #[cfg(test)]
 mod declaration_in_args_tests;

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -387,6 +387,26 @@ fn test_branch_reset_complexity() {
 }
 
 #[test]
+fn test_builtin_block_list_in_assignment_context() {
+    // Verifies that grep/map/sort with block form correctly capture trailing
+    // list arguments even when used on the RHS of an assignment.
+    let test_cases = vec![
+        ("grep block array", "my @result = grep { $_ > 5 } @array;"),
+        ("sort block hash access", r#"my @sorted = sort { $a->{name} cmp $b->{name} } @records;"#),
+        ("map block subscript", r#"my @mapped = map { $_->[0] + $_->[1] } @pairs;"#),
+        ("sort block function call", r#"my @x = sort { length($a) <=> length($b) } keys %hash;"#),
+    ];
+
+    for (name, code) in test_cases {
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "{} should not contain ERROR: {}", name, sexp);
+    }
+}
+
+#[test]
 fn test_catastrophic_backtracking_detection() {
     // Nested quantifiers (a+)+ -- now recorded as a non-fatal diagnostic
     let code = r#"qr/(a+)+/;"#;


### PR DESCRIPTION
## Summary
- Fixes a bug where grep/map/sort with block form failed to capture trailing list in expression context
- The postfix LeftBrace handler only looked for comma-separated arguments after the block
- Removes an unreachable duplicate sort/map/grep branch

## Test plan
- 16 new tests covering grep/map/sort block form in statement and expression contexts
- All 445 existing tests pass
- cargo clippy and cargo fmt clean