### PR TITLE
fix(parser): allow my/our/local declarations in function call arguments

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -200,8 +200,17 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // Check for variable declarations (my/our/local/state) in argument position.
+                // This is a common Perl idiom: open(my $fh, "<", $file)
+                let mut arg = if matches!(
+                    s.peek_kind(),
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+                ) {
+                    s.parse_variable_declaration()?
+                } else {
+                    // Use parse_assignment instead of parse_expression to avoid comma operator handling
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -332,6 +332,17 @@ impl<'a> Parser<'a> {
                                 SourceLocation { start, end },
                             ))
                         }
+                        Some(TokenKind::LeftParen) => {
+                            // Parenthesized argument list: builtin(args...)
+                            // Delegate to parse_args which handles my/our/local/state
+                            // declarations in argument position.
+                            let args = self.parse_args()?;
+                            let end = self.previous_position();
+                            Ok(Node::new(
+                                NodeKind::FunctionCall { name: func_name.to_string(), args },
+                                SourceLocation { start, end },
+                            ))
+                        }
                         _ => {
                             // Has arguments - parse them as a comma-separated list
                             let mut args = vec![];
@@ -342,7 +353,7 @@ impl<'a> Parser<'a> {
                             if (func_name.as_ref() == "open"
                                 || func_name.as_ref() == "pipe"
                                 || func_name.as_ref() == "socket")
-                                && (self.peek_kind() == Some(TokenKind::My) 
+                                && (self.peek_kind() == Some(TokenKind::My)
                                     || self.peek_kind() == Some(TokenKind::Our)
                                     || self.peek_kind() == Some(TokenKind::Local)
                                     || self.peek_kind() == Some(TokenKind::State))
@@ -368,9 +379,9 @@ impl<'a> Parser<'a> {
                             }
 
                             // Handle map/grep/sort { block } LIST case where no comma separates block and list
-                            if parsed_block_arg 
-                                && self.peek_kind() != Some(TokenKind::Comma) 
-                                && !self.is_at_statement_end() 
+                            if parsed_block_arg
+                                && self.peek_kind() != Some(TokenKind::Comma)
+                                && !self.is_at_statement_end()
                             {
                                 args.push(self.parse_assignment()?);
                             }

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -417,3 +417,68 @@ fn test_catastrophic_backtracking_detection() {
         assert!(found, "Should have found specific error in: {:?}", errors);
     }
 }
+
+// ===== Variable declarations inside function call argument lists =====
+// This covers a very common Perl idiom: open(my $fh, "<", $file)
+
+/// Helper: parse and assert no ERROR nodes in the AST.
+fn assert_parses_clean(code: &str) {
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+    assert!(result.is_ok(), "Parse failed for `{}`: {:?}", code, result.err());
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "Parse of `{}` produced ERROR nodes: {}", code, sexp,);
+}
+
+#[test]
+fn test_my_declaration_in_function_call_args() {
+    assert_parses_clean(r#"open(my $fh, "<", "file.txt");"#);
+}
+
+#[test]
+fn test_my_array_in_function_call_args() {
+    assert_parses_clean("push(my @arr, 1, 2, 3);");
+}
+
+#[test]
+fn test_my_in_call_args_with_outer_assignment() {
+    assert_parses_clean(r#"my $x = open(my $fh, "<", $file);"#);
+}
+
+#[test]
+fn test_our_declaration_in_function_call_args() {
+    assert_parses_clean(r#"open(our $fh, "<", "file.txt");"#);
+}
+
+#[test]
+fn test_local_declaration_in_function_call_args() {
+    assert_parses_clean(r#"open(local $fh, "<", "file.txt");"#);
+}
+
+#[test]
+fn test_state_declaration_in_function_call_args() {
+    assert_parses_clean(r#"open(state $fh, "<", "file.txt");"#);
+}
+
+#[test]
+fn test_my_with_initializer_in_call_args() {
+    assert_parses_clean("chomp(my $line = <STDIN>);");
+}
+
+#[test]
+fn test_my_declaration_in_method_call_args() {
+    assert_parses_clean(r#"$obj->method(my $x, $y);"#);
+}
+
+#[test]
+fn test_my_declaration_produces_variable_declaration_node() {
+    let mut parser = Parser::new(r#"open(my $fh, "<", "file.txt");"#);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("(my"),
+        "AST should contain a variable declaration node for `my $fh`, got: {}",
+        sexp,
+    );
+}


### PR DESCRIPTION
## Summary

- Fixes parsing of common Perl idioms like `open(my $fh, "<", $file)` which previously failed with "expected RightParen, found Identifier"
- In `parse_args()`, detect `my`/`our`/`local`/`state` keywords and dispatch to `parse_variable_declaration()` instead of `parse_assignment()`, which was treating them as bare identifiers
- In `parse_simple_statement()`, when a builtin function is followed by `(`, delegate to `parse_args()` so declarations inside parenthesized argument lists are handled correctly
- Adds 9 tests covering all declaration types (`my`, `our`, `local`, `state`), different variable types (scalar, array), initializers, method calls, and outer assignments

## Test plan

- [x] `cargo test -p perl-parser-core --lib` -- all 154 tests pass (0 failures)
- [x] `cargo test -p perl-parser --lib` -- all 12 downstream tests pass
- [x] `cargo clippy -p perl-parser-core --lib` -- zero warnings
- [x] `cargo fmt -p perl-parser-core -- --check` -- clean