### PR TITLE
fix(parser): implement x string repetition operator

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -2277,6 +2277,9 @@ fn format_binary_operator(op: &str) -> String {
         "%" => "binary_%".to_string(),
         "**" => "binary_**".to_string(),
 
+        // String/list repetition
+        "x" => "binary_x".to_string(),
+
         // Comparison operators
         "==" => "binary_==".to_string(),
         "!=" => "binary_!=".to_string(),

--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -633,6 +633,26 @@ impl<'a> Parser<'a> {
                         SourceLocation { start, end },
                     );
                 }
+                // Perl `x` string/list repetition operator (same precedence as *, /, %)
+                TokenKind::Identifier => {
+                    if self.tokens.peek()?.text.as_ref() == "x" {
+                        let op_token = self.tokens.next()?;
+                        let right = self.parse_unary()?;
+                        let start = expr.location.start;
+                        let end = right.location.end;
+
+                        expr = Node::new(
+                            NodeKind::Binary {
+                                op: op_token.text.to_string(),
+                                left: Box::new(expr),
+                                right: Box::new(right),
+                            },
+                            SourceLocation { start, end },
+                        );
+                    } else {
+                        break;
+                    }
+                }
                 _ => break,
             }
         }

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -417,3 +417,65 @@ fn test_catastrophic_backtracking_detection() {
         assert!(found, "Should have found specific error in: {:?}", errors);
     }
 }
+
+// ===== String repetition operator `x` tests =====
+
+#[test]
+fn test_x_string_repeat_literal() {
+    let mut parser = Parser::new(r#""abc" x 3;"#);
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST: {}", sexp);
+}
+
+#[test]
+fn test_x_string_repeat_dash() {
+    let mut parser = Parser::new(r#""-" x 80;"#);
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST: {}", sexp);
+}
+
+#[test]
+fn test_x_list_repeat() {
+    let mut parser = Parser::new("my @a = (0) x 10;");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST: {}", sexp);
+}
+
+#[test]
+fn test_x_repeat_with_variable() {
+    let mut parser = Parser::new(r#"print "ha" x $count;"#);
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST: {}", sexp);
+}
+
+#[test]
+fn test_x_repeat_in_assignment() {
+    let mut parser = Parser::new(r#"my $line = "-" x 80;"#);
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST: {}", sexp);
+    assert!(
+        sexp.contains("my_declaration"),
+        "Expected my_declaration in AST: {}",
+        sexp
+    );
+}


### PR DESCRIPTION
## Summary

- Implement the Perl `x` string/list repetition operator as an infix binary operator at multiplicative precedence (same level as `*`, `/`, `%`)
- Previously, `"abc" x 3` was parsed as three separate statements: a string `"abc"`, identifier `x`, and number `3`. Now it correctly parses as `(binary_x (string "abc") (number 3))`
- Add explicit `"x" => "binary_x"` mapping in `format_binary_operator` for clear S-expression output

## Test plan

- [x] `"abc" x 3` parses as binary_x expression
- [x] `"-" x 80` parses as binary_x expression
- [x] `my @a = (0) x 10` parses as binary_x in assignment
- [x] `print "ha" x $count` parses with variable repetition count
- [x] `my $line = "-" x 80` parses as variable declaration with binary_x
- [x] `cargo test -p perl-parser-core --lib` -- all 150 tests pass
- [x] `cargo test -p perl-parser --lib` -- all 12 tests pass
- [x] `cargo clippy -p perl-parser-core` -- clean
- [x] `cargo fmt --check -p perl-parser-core` -- clean