### PR TITLE
fix(parser): autoquote keywords before fat comma =>

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -238,8 +238,12 @@ impl<'a> Parser<'a> {
 
                 Some(TokenKind::LeftBrace) => {
                     // Check if this is a builtin function that needs special handling
+                    // But NOT when followed by `=>` (fat comma autoquoting)
                     if let NodeKind::Identifier { name } = &expr.kind {
-                        if Self::is_builtin_function(name) {
+                        if Self::is_builtin_function(name)
+                            && self.tokens.peek_second().ok().map(|t| t.kind)
+                                != Some(TokenKind::FatArrow)
+                        {
                             // This is a builtin function with {} as argument
                             // Parse arguments without parentheses
                             let mut args = Vec::new();
@@ -373,7 +377,9 @@ impl<'a> Parser<'a> {
                         if matches!(name.as_str(), "q" | "qq" | "qw" | "qr" | "qx" | "m" | "s") {
                             // This was already parsed as a quote operator in parse_primary
                             // Don't try to parse arguments
-                        } else if Self::is_builtin_function(name) {
+                        } else if Self::is_builtin_function(name)
+                            && self.peek_kind() != Some(TokenKind::FatArrow)
+                        {
                             // Builtins always become function calls, even with no arguments
                             // This ensures they work correctly in expressions like "return $x or die"
                             //

--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -155,7 +155,10 @@ impl<'a> Parser<'a> {
 
         // Handle 'return' as an expression in expression context
         // This allows patterns like: open $fh, $file or return;
-        if self.peek_kind() == Some(TokenKind::Return) {
+        // But NOT when followed by `=>` (fat comma autoquoting: `return => 1`)
+        if self.peek_kind() == Some(TokenKind::Return)
+            && self.tokens.peek_second().ok().map(|t| t.kind) != Some(TokenKind::FatArrow)
+        {
             return self.parse_return();
         }
 

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -50,6 +50,19 @@ impl<'a> Parser<'a> {
         let token = self.tokens.peek()?;
         let token_kind = token.kind;
 
+        // Fat comma autoquoting: any keyword followed by `=>` is treated as a
+        // bareword string identifier.  This must be checked before the keyword
+        // match arms below so that `eval => 1`, `do => 2`, etc. work.
+        if Self::is_keyword_kind(token_kind)
+            && self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow)
+        {
+            let token = self.tokens.next()?;
+            return Ok(Node::new(
+                NodeKind::Identifier { name: token.text.to_string() },
+                SourceLocation { start: token.start, end: token.end },
+            ));
+        }
+
         match token_kind {
             TokenKind::Number => {
                 let token = self.tokens.next()?;

--- a/crates/perl-parser-core/src/engine/parser/fat_comma_autoquote_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/fat_comma_autoquote_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for fat comma autoquoting of keywords.
+//!
+//! In Perl, the fat comma `=>` autoquotes the left-hand side, treating it as
+//! a bareword string even if it is a reserved keyword or builtin function name.
+//! For example, `(delete => 1)` should parse `delete` as a string key, not as
+//! the `delete` builtin.
+
+use crate::Parser;
+
+fn parses_without_errors(code: &str) -> bool {
+    let mut parser = Parser::new(code);
+    let output = parser.parse_with_recovery();
+    let sexp = output.ast.to_sexp();
+    !sexp.contains("ERROR")
+}
+
+fn sexp(code: &str) -> String {
+    let mut parser = Parser::new(code);
+    match parser.parse() {
+        Ok(ast) => ast.to_sexp(),
+        Err(e) => format!("PARSE_ERROR: {}", e),
+    }
+}
+
+// ── Keyword TokenKind autoquoting ──────────────────────────────────────
+
+#[test]
+fn fat_comma_if_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (if => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_for_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (for => 2);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_while_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (while => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_unless_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (unless => 0);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_return_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (return => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_eval_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (eval => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_do_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (do => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_sub_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (sub => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_use_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (use => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_next_last_redo_keys() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (next => 1, last => 2, redo => 3);"));
+    Ok(())
+}
+
+// ── Builtin function name autoquoting ──────────────────────────────────
+
+#[test]
+fn fat_comma_delete_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (delete => 1);"));
+    let s = sexp("my %h = (delete => 1);");
+    assert!(s.contains("delete"), "Expected delete as identifier: {}", s);
+    Ok(())
+}
+
+#[test]
+fn fat_comma_die_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %dispatch = (die => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_print_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %dispatch = (print => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_push_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (push => 1);"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_keys_key() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (keys => 3);"));
+    Ok(())
+}
+
+// ── Multiple keyword keys ──────────────────────────────────────────────
+
+#[test]
+fn fat_comma_multiple_keyword_keys() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my %h = (if => 1, for => 2, keys => 3);"));
+    Ok(())
+}
+
+// ── Function call context ──────────────────────────────────────────────
+
+#[test]
+fn fat_comma_unless_in_function_call() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my_func(unless => 0);"));
+    Ok(())
+}
+
+// ── Hash literal / anonymous hash contexts ─────────────────────────────
+
+#[test]
+fn fat_comma_keywords_in_hash_literal() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my $h = {if => 1, unless => 0, for => 2};"));
+    Ok(())
+}
+
+#[test]
+fn fat_comma_keywords_in_anon_hash() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("my $ref = {delete => 1, die => 2};"));
+    Ok(())
+}
+
+// ── Regression: keywords still work normally without => ────────────────
+
+#[test]
+fn keyword_if_still_works_as_statement() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("if (1) { print 1; }"));
+    Ok(())
+}
+
+#[test]
+fn keyword_for_still_works_as_statement() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("for my $i (1..10) { print $i; }"));
+    Ok(())
+}
+
+#[test]
+fn keyword_delete_still_works_as_builtin() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("delete $hash{key};"));
+    Ok(())
+}
+
+#[test]
+fn keyword_return_still_works_in_sub() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(parses_without_errors("sub foo { return 42; }"));
+    Ok(())
+}

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -96,6 +96,53 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Check if a `TokenKind` is a keyword that has a dedicated parser handler.
+    /// Used for fat-comma autoquoting: `keyword => value` treats the keyword
+    /// as a bareword string rather than invoking its parser.
+    fn is_keyword_kind(kind: TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::My
+                | TokenKind::Our
+                | TokenKind::Local
+                | TokenKind::State
+                | TokenKind::Sub
+                | TokenKind::If
+                | TokenKind::Elsif
+                | TokenKind::Else
+                | TokenKind::Unless
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::For
+                | TokenKind::Foreach
+                | TokenKind::Return
+                | TokenKind::Package
+                | TokenKind::Use
+                | TokenKind::No
+                | TokenKind::Begin
+                | TokenKind::End
+                | TokenKind::Check
+                | TokenKind::Init
+                | TokenKind::Unitcheck
+                | TokenKind::Eval
+                | TokenKind::Do
+                | TokenKind::Given
+                | TokenKind::When
+                | TokenKind::Default
+                | TokenKind::Try
+                | TokenKind::Catch
+                | TokenKind::Finally
+                | TokenKind::Continue
+                | TokenKind::Next
+                | TokenKind::Last
+                | TokenKind::Redo
+                | TokenKind::Class
+                | TokenKind::Method
+                | TokenKind::Format
+                | TokenKind::Undef
+        )
+    }
+
     /// Check if an identifier is a nullary builtin that can stand alone without arguments.
     /// These builtins work on implicit variables like @_ when called without arguments.
     fn is_nullary_builtin(name: &str) -> bool {

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -441,3 +441,5 @@ mod slash_ambiguity_tests;
 mod tests;
 #[cfg(test)]
 mod tie_tests;
+#[cfg(test)]
+mod fat_comma_autoquote_tests;

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -65,10 +65,22 @@ impl<'a> Parser<'a> {
 
         let kind = self.tokens.peek()?.kind;
 
+        // Fat comma autoquoting: if a keyword is followed by `=>`, Perl treats
+        // the keyword as a bareword string (e.g., `delete => 1`, `if => 1`).
+        // Check this before the keyword dispatch so we fall through to
+        // expression parsing instead.
+        let fat_arrow_follows = Self::is_keyword_kind(kind)
+            && self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow);
+
         // Don't check for labels here - it breaks regular identifier parsing
         // Labels will be handled differently
 
         let mut stmt = match kind {
+            // Fat comma autoquoting: when `=>` follows a keyword, treat it as
+            // an expression (bareword identifier) rather than dispatching the
+            // keyword's dedicated parser.
+            _ if fat_arrow_follows => self.parse_expression_statement(),
+
             // Empty statement (lone semicolon) - just consume and return a no-op
             TokenKind::Semicolon => {
                 let pos = self.current_position();
@@ -235,6 +247,12 @@ impl<'a> Parser<'a> {
 
     /// Parse simple statement (print, die, next, last, etc. with their arguments)
     fn parse_simple_statement(&mut self) -> ParseResult<Node> {
+        // Fat comma autoquoting: if the current identifier is followed by `=>`,
+        // treat it as a bareword expression, not a builtin function call.
+        if self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow) {
+            return self.parse_expression();
+        }
+
         // Check if it's a builtin that can take arguments without parens
         if let Ok(token) = self.tokens.peek() {
             match token.text.as_ref() {


### PR DESCRIPTION
## Summary

- Fix parser bug where Perl keywords and builtin function names before `=>` (fat comma) were not autoquoted, causing parse errors for valid Perl like `(delete => 1)`, `(if => 1, for => 2)`, or `my_func(unless => 0)`
- Add `=>` lookahead checks at five parsing layers: statement dispatch, simple statement dispatch, primary expression, assignment (return keyword), and postfix (builtin function conversion)
- Add `is_keyword_kind()` helper covering all keyword `TokenKind` variants for centralized keyword detection

## Test plan

- [x] 23 new tests covering keyword TokenKinds, builtin function names, multiple keys, function call context, hash literals, and regression tests
- [x] Full `cargo test -p perl-parser-core` passes (all 437 tests green)
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] `cargo fmt` clean