### PR TITLE
fix(parser): consume trailing list in grep/map/sort block form

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -278,17 +278,17 @@ impl<'a> Parser<'a> {
 
                                 args.push(block);
 
-                                // Parse remaining arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // Parse trailing list for map/grep/sort
+                                // without requiring commas (Perl: `grep BLOCK LIST`)
+                                while !self.is_at_statement_end() {
+                                    if self.peek_kind() == Some(TokenKind::Comma) {
+                                        self.consume_token()?;
+                                    }
                                     if self.is_at_statement_end() {
                                         break;
                                     }
-                                    args.push(self.parse_comma()?);
+                                    args.push(self.parse_ternary()?);
                                 }
-                            } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // These builtins should parse {} as blocks, not hashes
-                                args.push(self.parse_builtin_block()?);
                             } else {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);

--- a/crates/perl-parser-core/src/engine/parser/grep_map_sort_block_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/grep_map_sort_block_tests.rs
@@ -1,0 +1,128 @@
+#[cfg(test)]
+mod tests {
+    use crate::engine::parser::Parser;
+
+    /// Helper: parse code, assert no errors, return s-expression.
+    fn parse_ok(input: &str) -> String {
+        let mut parser = Parser::new(input);
+        let output = parser.parse_with_recovery();
+        let sexp = output.ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "Expected no ERROR nodes for: {input}\nAST: {sexp}",
+        );
+        assert!(
+            output.diagnostics.is_empty(),
+            "Expected no diagnostics for: {input}\nDiagnostics: {:?}",
+            output.diagnostics,
+        );
+        sexp
+    }
+
+    /// Helper: count top-level statements in a Program node.
+    fn count_top_statements(input: &str) -> usize {
+        let mut parser = Parser::new(input);
+        let output = parser.parse_with_recovery();
+        if let perl_ast::NodeKind::Program { statements } = &output.ast.kind {
+            statements.len()
+        } else {
+            0
+        }
+    }
+
+    #[test]
+    fn grep_block_array_single_statement() {
+        let sexp = parse_ok("grep { $_ > 0 } @list;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert!(
+            sexp.contains("block"),
+            "should contain a block arg: {sexp}"
+        );
+        assert_eq!(count_top_statements("grep { $_ > 0 } @list;"), 1);
+    }
+
+    #[test]
+    fn grep_block_with_defined() {
+        let sexp = parse_ok("grep { defined } @items;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert_eq!(count_top_statements("grep { defined } @items;"), 1);
+    }
+
+    #[test]
+    fn map_block_array_single_statement() {
+        let sexp = parse_ok("map { $_ * 2 } @numbers;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert!(
+            sexp.contains("block"),
+            "should contain a block arg: {sexp}"
+        );
+        assert_eq!(count_top_statements("map { $_ * 2 } @numbers;"), 1);
+    }
+
+    #[test]
+    fn map_block_literal_list() {
+        let sexp = parse_ok("map { $_ * 2 } 1, 2, 3;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert_eq!(count_top_statements("map { $_ * 2 } 1, 2, 3;"), 1);
+    }
+
+    #[test]
+    fn sort_block_array_single_statement() {
+        let sexp = parse_ok("sort { $a <=> $b } @list;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert!(
+            sexp.contains("block"),
+            "should contain a block arg: {sexp}"
+        );
+        assert_eq!(count_top_statements("sort { $a <=> $b } @list;"), 1);
+    }
+
+    #[test]
+    fn grep_block_in_assignment() {
+        let sexp = parse_ok("my @r = grep { defined } @items;");
+        assert!(
+            sexp.contains("call"),
+            "grep should produce a call node: {sexp}"
+        );
+        assert_eq!(
+            count_top_statements("my @r = grep { defined } @items;"),
+            1
+        );
+    }
+
+    #[test]
+    fn map_block_in_assignment() {
+        let sexp = parse_ok("my @doubled = map { $_ * 2 } @numbers;");
+        assert!(
+            sexp.contains("call"),
+            "map should produce a call node: {sexp}"
+        );
+        assert_eq!(
+            count_top_statements("my @doubled = map { $_ * 2 } @numbers;"),
+            1
+        );
+    }
+
+    #[test]
+    fn sort_block_in_assignment() {
+        let sexp = parse_ok("my @sorted = sort { $a <=> $b } @list;");
+        assert!(
+            sexp.contains("call"),
+            "sort should produce a call node: {sexp}"
+        );
+        assert_eq!(
+            count_top_statements("my @sorted = sort { $a <=> $b } @list;"),
+            1
+        );
+    }
+
+    #[test]
+    fn grep_block_in_assignment_with_array() {
+        let sexp = parse_ok("my @pos = grep { $_ > 0 } @numbers;");
+        assert!(sexp.contains("call"), "should produce a call node: {sexp}");
+        assert_eq!(
+            count_top_statements("my @pos = grep { $_ > 0 } @numbers;"),
+            1
+        );
+    }
+}

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -424,6 +424,8 @@ mod glob_assignment_tests;
 #[cfg(test)]
 mod glob_tests;
 #[cfg(test)]
+mod grep_map_sort_block_tests;
+#[cfg(test)]
 mod hash_vs_block_tests;
 #[cfg(test)]
 mod heredoc_security_tests;


### PR DESCRIPTION
## Summary

- Fix parser bug where `grep { BLOCK } @list`, `map { BLOCK } @list`, and `sort { BLOCK } @list` did not consume the trailing list after the block argument
- The postfix expression parser's LeftBrace path only consumed comma-separated args, causing the trailing list (e.g., `@list`) to be parsed as a separate orphaned statement
- Replace the comma-only loop with one that handles both comma-separated and bare list elements, matching Perl's `BUILTIN BLOCK LIST` grammar
- Remove unreachable duplicate `else if` branch for sort/map/grep that was dead code

## Test plan

- [x] 9 new tests in `grep_map_sort_block_tests.rs` covering:
  - `grep { $_ > 0 } @list` (block + array)
  - `grep { defined } @items` (block with bareword)
  - `map { $_ * 2 } @numbers` (map block + array)
  - `map { $_ * 2 } 1, 2, 3` (map block + literal list)
  - `sort { $a <=> $b } @list` (sort block + array)
  - `my @r = grep { defined } @items` (assignment context)
  - `my @doubled = map { $_ * 2 } @numbers` (assignment context)
  - `my @sorted = sort { $a <=> $b } @list` (assignment context)
  - `my @pos = grep { $_ > 0 } @numbers` (assignment context)
- [x] All 154 existing `perl-parser-core` unit tests pass
- [x] All 252 comprehensive unit tests pass
- [x] `cargo clippy -p perl-parser-core` clean