### PR TITLE
Fix parser handling of `my` declarations inside function call parens

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -201,7 +201,14 @@ impl<'a> Parser<'a> {
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
                 // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                let mut arg = if matches!(
+                    s.peek_kind(),
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+                ) {
+                    s.parse_variable_declaration()?
+                } else {
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -151,6 +151,32 @@ fn test_qualified_function_call() {
 }
 
 #[test]
+fn test_my_declaration_in_function_call_parens() {
+    let mut parser = Parser::new("foo(my $x);");
+    let ast = must(parser.parse());
+
+    let NodeKind::Program { statements } = &ast.kind else {
+        unreachable!("Expected Program");
+    };
+    let Some(first_stmt) = statements.first() else {
+        unreachable!("Expected one statement");
+    };
+    let NodeKind::ExpressionStatement { expression } = &first_stmt.kind else {
+        unreachable!("Expected ExpressionStatement");
+    };
+    let NodeKind::FunctionCall { name, args } = &expression.kind else {
+        unreachable!("Expected FunctionCall");
+    };
+
+    assert_eq!(name, "foo");
+    assert_eq!(args.len(), 1);
+    assert!(matches!(
+        args[0].kind,
+        NodeKind::VariableDeclaration { ref declarator, .. } if declarator == "my"
+    ));
+}
+
+#[test]
 fn test_issue_461_variable_length_lookbehind() {
     // Variable-length lookbehind
     let code = r#"my $pattern = qr/(?<=\d{1,1000})\w+/;"#;


### PR DESCRIPTION
### Motivation

- Parenthesized function call arguments like `foo(my $x);` were parsed as regular expressions/assignments rather than variable declarations, causing incorrect AST nodes and downstream analysis issues.

### Description

- In `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` modified `parse_args` to treat leading declaration keywords (`my`, `our`, `local`, `state`) as the start of a variable declaration by calling `parse_variable_declaration()` instead of `parse_assignment()` when `peek_kind()` matches those tokens.
- Added a regression test `test_my_declaration_in_function_call_parens` in `crates/perl-parser-core/src/engine/parser/tests.rs` which parses `foo(my $x);` and asserts the call `name` is `"foo"` and the first argument is a `VariableDeclaration` with `declarator == "my"`.

### Testing

- Ran `cargo test -p perl-parser-core test_my_declaration_in_function_call_parens -- --nocapture` and the test passed.
- Ran `cargo test -p perl-parser-core test_qualified_function_call -- --nocapture` to ensure no regressions in qualified call parsing and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e567c833396eff80a82dc0b68)