### PR TITLE
Allow `my` declarations inside parenthesized function call arguments and add regression test

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -200,8 +200,16 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // Allow declarations like `foo(my $x)` in parenthesized argument lists.
+                let mut arg = if matches!(
+                    s.peek_kind(),
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+                ) {
+                    s.parse_variable_declaration()?
+                } else {
+                    // Use parse_assignment instead of parse_expression to avoid comma operator handling
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -151,6 +151,22 @@ fn test_qualified_function_call() {
 }
 
 #[test]
+fn test_my_declaration_in_function_call_parentheses() {
+    let mut parser = Parser::new("foo(my $x);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse my declaration in function call parens");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("(ERROR"), "Expected parse without syntax errors, got: {}", sexp);
+    assert!(
+        sexp.contains("my_declaration") || sexp.contains("var_decl my"),
+        "Expected my variable declaration argument, got: {}",
+        sexp
+    );
+}
+
+#[test]
 fn test_issue_461_variable_length_lookbehind() {
     // Variable-length lookbehind
     let code = r#"my $pattern = qr/(?<=\d{1,1000})\w+/;"#;


### PR DESCRIPTION
### Motivation
- Parenthesized function call arguments like `foo(my $x);` were mis-parsed as errors or ambiguous nodes because `parse_args` always invoked assignment parsing, which prevented variable-declaration forms from being accepted inside `(...)` call lists.

### Description
- Update `parse_args` in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` to detect `my|our|local|state` and call `parse_variable_declaration()` for that argument instead of unconditionally calling `parse_assignment()`.
- Add regression test `test_my_declaration_in_function_call_parentheses` in `crates/perl-parser-core/src/engine/parser/tests.rs` that parses `foo(my $x);` and asserts there are no syntax error nodes and that the declaration is present in the AST.
- Run `cargo fmt --all` to normalize formatting after the change.

### Testing
- Ran `cargo test -p perl-parser-core test_my_declaration_in_function_call_parentheses` and the targeted test passed (`ok`).
- Verified `cargo test -p perl-parser-core test_qualified_function_call` and `cargo test -p perl-parser-core test_list_declarations` both passed (`ok`).
- Ran `cargo fmt --all --check` after formatting and it passed with no diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e68b88333b532c90d87ff8681)