### PR TITLE
Fix parsing of map/grep/sort block+list forms in postfix expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -257,38 +257,22 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_comma()?);
                                 }
                             } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // Parse block expression as first argument
-                                let block_start = self.current_position();
-                                self.expect(TokenKind::LeftBrace)?;
+                                // These builtins should parse {} as blocks, not hashes.
+                                // They accept both BLOCK LIST and BLOCK, LIST forms.
+                                args.push(self.parse_builtin_block()?);
 
-                                // Parse the expression inside the block (if any)
-                                let mut statements = Vec::new();
-                                if self.peek_kind() != Some(TokenKind::RightBrace) {
-                                    statements.push(self.parse_expression()?);
-                                }
+                                while !self.is_at_statement_end() {
+                                    // Skip optional comma between block and list.
+                                    if self.peek_kind() == Some(TokenKind::Comma) {
+                                        self.consume_token()?;
+                                    }
 
-                                self.expect(TokenKind::RightBrace)?;
-                                let block_end = self.previous_position();
-
-                                // Wrap the expression in a block node
-                                let block = Node::new(
-                                    NodeKind::Block { statements },
-                                    SourceLocation { start: block_start, end: block_end },
-                                );
-
-                                args.push(block);
-
-                                // Parse remaining arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
                                     if self.is_at_statement_end() {
                                         break;
                                     }
-                                    args.push(self.parse_comma()?);
+
+                                    args.push(self.parse_ternary()?);
                                 }
-                            } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // These builtins should parse {} as blocks, not hashes
-                                args.push(self.parse_builtin_block()?);
                             } else {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);

--- a/crates/perl-parser/tests/builtin_empty_blocks_test.rs
+++ b/crates/perl-parser/tests/builtin_empty_blocks_test.rs
@@ -78,16 +78,22 @@ mod builtin_empty_blocks_tests {
 
     #[test]
     fn test_return_sort_empty_block() {
-        parse_and_check("return sort {} @array", "(return (call sort ((block ))");
+        parse_and_check(
+            "return sort {} @array",
+            "(return (call sort ((block ) (variable @ array)))",
+        );
     }
 
     #[test]
     fn test_return_map_empty_block() {
-        parse_and_check("return map {} @array", "(return (call map ((block ))");
+        parse_and_check("return map {} @array", "(return (call map ((block ) (variable @ array)))");
     }
 
     #[test]
     fn test_return_grep_empty_block() {
-        parse_and_check("return grep {} @array", "(return (call grep ((block ))");
+        parse_and_check(
+            "return grep {} @array",
+            "(return (call grep ((block ) (variable @ array)))",
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- The postfix-expression parser had duplicated/incorrect handling for builtins `map`, `grep`, and `sort` when the first argument is a block (`{ ... }`), causing inconsistent parsing of the `BLOCK LIST` and `BLOCK, LIST` Perl forms.

### Description
- Route `{ ... }` parsing for `sort`/`map`/`grep` through the existing `parse_builtin_block()` helper and unify handling so both `BLOCK LIST` and `BLOCK, LIST` (optional comma) are accepted in expression/postfix contexts.
- Replace the duplicated special-case block parsing in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` with a single branch that calls `parse_builtin_block()` and then consumes optional commas while parsing list arguments with `parse_ternary()`.
- Update expectations in `crates/perl-parser/tests/builtin_empty_blocks_test.rs` to reflect the corrected AST shape for `return sort/map/grep {} @array` (block plus list argument).

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser --test builtin_empty_blocks_test` and all tests passed.
- Ran `cargo test -p perl-parser-core hash_vs_block -- --nocapture` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e6dd083338c0e9aef96556e65)