### PR TITLE
Parse `my` declarations inside parenthesized function calls

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -201,7 +201,14 @@ impl<'a> Parser<'a> {
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
                 // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                let mut arg = if matches!(
+                    s.peek_kind(),
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+                ) {
+                    s.parse_variable_declaration()?
+                } else {
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -333,6 +333,15 @@ impl<'a> Parser<'a> {
                             ))
                         }
                         _ => {
+                            if self.peek_kind() == Some(TokenKind::LeftParen) {
+                                let args = self.parse_args()?;
+                                let end = self.previous_position();
+                                return Ok(Node::new(
+                                    NodeKind::FunctionCall { name: func_name.to_string(), args },
+                                    SourceLocation { start, end },
+                                ));
+                            }
+
                             // Has arguments - parse them as a comma-separated list
                             let mut args = vec![];
 

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -151,6 +151,21 @@ fn test_qualified_function_call() {
 }
 
 #[test]
+fn test_my_declaration_in_function_call_parens() {
+    let mut parser = Parser::new("open(my $fh, '<', $file);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "failed to parse call with my declaration in parens");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(call open"), "expected function call, got: {sexp}");
+    assert!(
+        sexp.contains("(my_declaration") || sexp.contains("(variable_declaration my"),
+        "expected variable declaration argument, got: {sexp}"
+    );
+}
+
+#[test]
 fn test_issue_461_variable_length_lookbehind() {
     // Variable-length lookbehind
     let code = r#"my $pattern = qr/(?<=\d{1,1000})\w+/;"#;


### PR DESCRIPTION
### Motivation
- Fix a parser regression where declaration keywords like `my`/`our`/`local`/`state` used as arguments inside parenthesized function/builtin calls (e.g. `open(my $fh, ...)`) were mis-parsed or produced errors. 

### Description
- Update `parse_args` in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` to treat a leading `my`/`our`/`local`/`state` token as a variable declaration by calling `parse_variable_declaration()` instead of `parse_assignment()` when parsing parenthesized argument lists. 
- Update builtin function parsing in `crates/perl-parser-core/src/engine/parser/statements.rs` to route explicit parenthesized calls to `parse_args()` so parenthesized builtins get consistent argument parsing. 
- Add a regression test `test_my_declaration_in_function_call_parens` in `crates/perl-parser-core/src/engine/parser/tests.rs` that verifies `open(my $fh, '<', $file);` parses as a call with a declaration argument. 
- Ran `cargo fmt --all` to normalize formatting.

### Testing
- Ran the new unit test with `cargo test -p perl-parser-core test_my_declaration_in_function_call_parens`, which passed. 
- Ran formatting via `cargo fmt --all` successfully. 
- Local unit test run for the crate completed with the new test passing and no regressions observed for the exercised test scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e567c833396eff80a82dc0b68)