### PR TITLE
Fix `my` declarations in function call parentheses

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -587,9 +587,35 @@ impl<'a> Parser<'a> {
             | TokenKind::Class
             | TokenKind::Method
             | TokenKind::Format => {
-                // In expression context, some keywords can be used as barewords/identifiers
+                // `my/our/local/state` can also appear inside expression contexts,
+                // e.g. function call parens: `foo(my $x)`.
+                // Parse these as declarations when followed by a variable/list start.
+                if matches!(
+                    token_kind,
+                    TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State
+                ) {
+                    let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+                    if matches!(
+                        next_kind,
+                        Some(
+                            TokenKind::LeftParen
+                                | TokenKind::ScalarSigil
+                                | TokenKind::ArraySigil
+                                | TokenKind::HashSigil
+                                | TokenKind::SubSigil
+                                | TokenKind::GlobSigil
+                                | TokenKind::Percent
+                                | TokenKind::BitwiseAnd
+                                | TokenKind::Star
+                                | TokenKind::Identifier
+                        )
+                    ) {
+                        return self.parse_variable_declaration();
+                    }
+                }
+
+                // In expression context, some keywords can be used as barewords/identifiers.
                 // This happens in hash keys, method names, etc.
-                // But NOT for statement modifiers like if, unless, while, etc.
                 let token = self.tokens.next()?;
                 Ok(Node::new(
                     NodeKind::Identifier { name: token.text.to_string() },

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -281,6 +281,21 @@ fn test_source_filter_detection() {
 }
 
 #[test]
+fn test_my_declaration_inside_function_call_parens() {
+    let mut parser = Parser::new("foo(my $x);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse my declaration in call parens: {result:?}");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(my_declaration"), "AST missing declaration: {sexp}");
+    assert!(
+        sexp.contains("(ambiguous_function_call_expression") || sexp.contains("(call foo"),
+        "AST missing function call: {sexp}"
+    );
+}
+
+#[test]
 fn test_regex_code_execution_detection() {
     // Regex with code execution
     let code = r#"my $re = qr/(?{ print "hi" })/;"#;


### PR DESCRIPTION
### Motivation
- The parser treated `my`/`our`/`local`/`state` as bare identifiers in expression contexts, which broke cases like `foo(my $x)` where the inner token sequence is a variable declaration.
- The intent is to correctly recognize declaration-shaped tokens when these keywords appear inside function-call parentheses and produce a proper variable declaration node in the AST.

### Description
- Update `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` to detect when `my`/`our`/`local`/`state` is followed by a declaration-shaped token (via `peek_second`) and call `parse_variable_declaration()` in that case. 
- Preserve the previous behavior of treating those keywords as bare identifiers when the following tokens do not match a declaration shape by falling back to the original identifier path.
- Add a regression test `test_my_declaration_inside_function_call_parens` in `crates/perl-parser-core/src/engine/parser/tests.rs` that parses `foo(my $x);` and asserts the AST contains both the call and the inner `my` declaration.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser-core test_my_declaration_inside_function_call_parens` which passed (the new regression test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e567c833396eff80a82dc0b68)