### PR TITLE
Fix parser handling of `my` declarations inside function call parentheses

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -267,6 +267,12 @@ impl<'a> Parser<'a> {
 
             TokenKind::Do => self.parse_do(),
 
+            // Lexical declarations are valid expressions in Perl (e.g. if (my $x = foo()) { ... })
+            // and can appear inside function call parentheses (e.g. foo(my $x)).
+            TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State => {
+                self.parse_variable_declaration()
+            }
+
             // Note: TokenKind::Sub is handled in the keyword-as-identifier case below
             // This allows 'sub' to be used as a hash key or identifier in expressions
             TokenKind::Try => self.parse_try(),
@@ -566,11 +572,7 @@ impl<'a> Parser<'a> {
 
             // Handle keywords that can be used as identifiers in certain contexts
             // Note: Statement-level keywords (if, unless, while, return, etc.) should NOT be here
-            TokenKind::My
-            | TokenKind::Our
-            | TokenKind::Local
-            | TokenKind::State
-            | TokenKind::Package
+            TokenKind::Package
             | TokenKind::Use
             | TokenKind::No
             | TokenKind::Begin

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -151,6 +151,40 @@ fn test_qualified_function_call() {
 }
 
 #[test]
+fn test_my_declaration_in_function_call_parens() {
+    let mut parser = Parser::new("foo(my $x);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Should parse lexical declaration in call args: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(function"), "Should parse function target, got: {}", sexp);
+    assert!(sexp.contains("(my_declaration"), "Should parse my declaration as arg, got: {}", sexp);
+}
+
+#[test]
+fn test_my_list_declaration_in_function_call_parens() {
+    let mut parser = Parser::new("foo(my ($x, $y));");
+    let result = parser.parse();
+    assert!(
+        result.is_ok(),
+        "Should parse lexical list declaration in call args: {:?}",
+        result.err()
+    );
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(function"), "Should parse function target, got: {}", sexp);
+    assert!(
+        sexp.contains("(my_declaration")
+            && sexp.contains("(variable $ x)")
+            && sexp.contains("(variable $ y)"),
+        "Should parse my list declaration as arg, got: {}",
+        sexp
+    );
+}
+
+#[test]
 fn test_issue_461_variable_length_lookbehind() {
     // Variable-length lookbehind
     let code = r#"my $pattern = qr/(?<=\d{1,1000})\w+/;"#;


### PR DESCRIPTION
### Motivation
- Calls like `foo(my $x)` or `foo(my ($x, $y))` were being parsed incorrectly (ambiguous function-call node) because lexical-declaration keywords were not treated as valid primary expressions inside call parentheses.

### Description
- Treat lexical declaration keywords (`my`, `our`, `local`, `state`) as primary expressions by dispatching them to `parse_variable_declaration()` in `parse_primary_inner`.
- Remove those declaration keywords from the keyword-as-identifier fallback so they are not misinterpreted as bare identifiers in expression context.
- Added regression tests `test_my_declaration_in_function_call_parens` and `test_my_list_declaration_in_function_call_parens` in `crates/perl-parser-core/src/engine/parser/tests.rs` to cover scalar and list lexical declarations as call arguments.
- Modified file: `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` and tests file: `crates/perl-parser-core/src/engine/parser/tests.rs`.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran targeted tests `test_my_declaration_in_function_call_parens` and `test_my_list_declaration_in_function_call_parens` which passed.
- Ran full crate tests `cargo test -p perl-parser-core --lib` and observed all tests passing (147 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e68b88333b532c90d87ff8681)