### PR TITLE
Parse declaration keywords inside function call parentheses

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -200,8 +200,18 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // Allow declaration arguments like: foo(my $x)
+                // Parse declarations as declarations instead of treating `my` as an identifier.
+                let mut arg = match s.peek_kind() {
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::State) => {
+                        s.parse_variable_declaration()?
+                    }
+                    Some(TokenKind::Local) => s.parse_local_statement()?,
+                    _ => {
+                        // Use parse_assignment instead of parse_expression to avoid comma operator handling
+                        s.parse_assignment()?
+                    }
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/indirect_call_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/indirect_call_tests.rs
@@ -90,4 +90,30 @@ $method $object;
             sexp2
         );
     }
+
+    #[test]
+    fn test_function_call_accepts_my_declaration_argument() {
+        let code = "foo(my $x);";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+
+        assert!(sexp.contains("function_call"), "Expected function_call in: {}", sexp);
+        assert!(sexp.contains("my_declaration"), "Expected my declaration argument in: {}", sexp);
+    }
+
+    #[test]
+    fn test_function_call_accepts_my_list_declaration_argument() {
+        let code = "foo(my ($x, $y));";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+
+        assert!(sexp.contains("function_call"), "Expected function_call in: {}", sexp);
+        assert!(
+            sexp.contains("my_declaration"),
+            "Expected my list declaration argument in: {}",
+            sexp
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix a parser bug where declaration keywords like `my` were being treated as bare identifiers when appearing inside function call parentheses (e.g. `foo(my $x);`).
- Allow legitimate use of declarations as arguments so the AST represents them as `VariableDeclaration`/`VariableListDeclaration` nodes instead of identifiers.

### Description
- Update `parse_args` in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` to dispatch on `peek_kind()` and call `parse_variable_declaration()` for `my|our|state` and `parse_local_statement()` for `local`, falling back to `parse_assignment()` otherwise.
- Add two focused regression tests to `crates/perl-parser-core/src/engine/parser/indirect_call_tests.rs` that validate `foo(my $x);` and `foo(my ($x, $y));` are parsed as a `function_call` containing `my` declarations.
- Run `cargo fmt --all` to normalize formatting.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser-core indirect_call_tests -- --nocapture` and the suite passed (all tests succeeded).
- The added tests exercise scalar and list `my` declarations inside call parentheses and both passed under the `indirect_call_tests` target.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e68b88333b532c90d87ff8681)