### PR TITLE
Handle `my` declarations inside parenthesized builtin calls

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -200,8 +200,16 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // Allow declarations like `my $x` in call parens (e.g. open(my $fh, ...)).
+                // Otherwise, parse as assignment to avoid comma-operator grouping.
+                let mut arg = if matches!(
+                    s.peek_kind(),
+                    Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
+                ) {
+                    s.parse_variable_declaration()?
+                } else {
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -333,6 +333,16 @@ impl<'a> Parser<'a> {
                             ))
                         }
                         _ => {
+                            // Parenthesized call form: builtin(arg1, arg2, ...)
+                            if self.peek_kind() == Some(TokenKind::LeftParen) {
+                                let args = self.parse_args()?;
+                                let end = self.previous_position();
+                                return Ok(Node::new(
+                                    NodeKind::FunctionCall { name: func_name.to_string(), args },
+                                    SourceLocation { start, end },
+                                ));
+                            }
+
                             // Has arguments - parse them as a comma-separated list
                             let mut args = vec![];
 

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -151,6 +151,21 @@ fn test_qualified_function_call() {
 }
 
 #[test]
+fn test_builtin_call_with_my_declaration_in_parentheses() {
+    let mut parser = Parser::new("open(my $fh, '<', $path);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse builtin call with my declaration");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("(call open") && sexp.contains("(my_declaration"),
+        "Expected open(...) call with my declaration argument, got: {}",
+        sexp
+    );
+}
+
+#[test]
 fn test_issue_461_variable_length_lookbehind() {
     // Variable-length lookbehind
     let code = r#"my $pattern = qr/(?<=\d{1,1000})\w+/;"#;


### PR DESCRIPTION
### Motivation

- The parser rejected lexical declarations placed inside parenthesized builtin call arguments (e.g. `open(my $fh, '<', $path)`), producing spurious parse errors. 
- Parenthesized builtin-call forms should accept the same argument shapes as unparenthesized forms, including `my`/`our`/`local`/`state` declarations.

### Description

- Teach `parse_args()` (in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs`) to accept a leading lexical declarator by invoking `parse_variable_declaration()` when the next token is `My|Our|Local|State`, otherwise fall back to `parse_assignment()`.
- Route builtin `name(...)` forms in `parse_simple_statement()` (in `crates/perl-parser-core/src/engine/parser/statements.rs`) through `parse_args()` when a `LeftParen` follows the builtin name so parenthesized builtin calls use the parenthesized-args path.
- Add a regression test `test_builtin_call_with_my_declaration_in_parentheses` (in `crates/perl-parser-core/src/engine/parser/tests.rs`) that parses `open(my $fh, '<', $path);` and asserts the AST contains the call and the `my` declaration argument.
- Run code formatting (`cargo fmt --all`) on the modified files.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser-core test_builtin_call_with_my_declaration_in_parentheses` and the new test passed (`ok`).
- Ran `cargo test -p perl-parser-core test_qualified_function_call` and that existing test passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e68b88333b532c90d87ff8681)