### PR TITLE
Fix map/grep/sort block+list parsing in postfix expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -397,26 +397,10 @@ impl<'a> Parser<'a> {
                                 if matches!(name.as_str(), "sort" | "map" | "grep")
                                     && self.peek_kind() == Some(TokenKind::LeftBrace)
                                 {
-                                    // Parse block expression as first argument
-                                    let block_start = self.current_position();
-                                    self.expect(TokenKind::LeftBrace)?;
-
-                                    // Parse the expression inside the block (if any)
-                                    let mut statements = Vec::new();
-                                    if self.peek_kind() != Some(TokenKind::RightBrace) {
-                                        statements.push(self.parse_expression()?);
-                                    }
-
-                                    self.expect(TokenKind::RightBrace)?;
-                                    let block_end = self.previous_position();
-
-                                    // Wrap the expression in a block node
-                                    let block = Node::new(
-                                        NodeKind::Block { statements },
-                                        SourceLocation { start: block_start, end: block_end },
-                                    );
-
-                                    args.push(block);
+                                    // Parse block first argument using dedicated builtin logic.
+                                    // This correctly handles statement-list blocks like:
+                                    // map { my $x = $_; $x * 2 } @list
+                                    args.push(self.parse_builtin_block()?);
 
                                     // Parse remaining arguments for map/grep/sort without requiring commas
                                     // But respect statement boundaries including ] and )
@@ -429,7 +413,7 @@ impl<'a> Parser<'a> {
                                         if self.is_at_statement_end() {
                                             break;
                                         }
-                                        args.push(self.parse_ternary()?);
+                                        args.push(self.parse_assignment()?);
                                     }
                                 } else if name == "bless"
                                     && self.peek_kind() == Some(TokenKind::LeftBrace)

--- a/crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs
@@ -72,5 +72,36 @@ sub my_sub {
             "map should take a block even with hash-like content: {}",
             sexp2
         );
+
+        // map/grep/sort block with a statement list followed by list args
+        let code3 = "map { my $x = $_; $x * 2 } @list;";
+        let mut parser3 = Parser::new(code3);
+        let result3 = parser3.parse();
+        assert!(result3.is_ok(), "map block+list should parse: {:?}", result3.err());
+
+        let code4 = "grep { my $x = $_; $x > 0 } @list;";
+        let mut parser4 = Parser::new(code4);
+        let result4 = parser4.parse();
+        assert!(result4.is_ok(), "grep block+list should parse: {:?}", result4.err());
+
+        let code5 = "sort { my $x = $a <=> $b; $x } @list;";
+        let mut parser5 = Parser::new(code5);
+        let result5 = parser5.parse();
+        assert!(result5.is_ok(), "sort block+list should parse: {:?}", result5.err());
+
+        let code6 = "my @m = map { my $x = $_; $x * 2 } @list;";
+        let mut parser6 = Parser::new(code6);
+        let result6 = parser6.parse();
+        assert!(result6.is_ok(), "map expression block+list should parse: {:?}", result6.err());
+
+        let code7 = "my @g = grep { my $x = $_; $x > 0 } @list;";
+        let mut parser7 = Parser::new(code7);
+        let result7 = parser7.parse();
+        assert!(result7.is_ok(), "grep expression block+list should parse: {:?}", result7.err());
+
+        let code8 = "my @s = sort { my $x = $a <=> $b; $x } @list;";
+        let mut parser8 = Parser::new(code8);
+        let result8 = parser8.parse();
+        assert!(result8.is_ok(), "sort expression block+list should parse: {:?}", result8.err());
     }
 }


### PR DESCRIPTION
### Motivation
- Postfix parsing for builtin list-operators (`map`, `grep`, `sort`) treated a `{ ... }` block as a single-expression block in expression context, which failed for real `BLOCK` statement-lists followed by a `LIST` (e.g. `map { my $x = $_; $x * 2 } @list`).

### Description
- In the postfix argument parser, replace the ad-hoc single-expression `{ ... }` handling with a call to the dedicated `parse_builtin_block()` to correctly parse statement-list blocks for builtins.
- After consuming the builtin block, parse trailing list arguments with `parse_assignment()` (instead of `parse_ternary()`) to align behavior with the statement-level path that already handled `BLOCK LIST` correctly.
- Add regression coverage in `crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs` with test cases exercising `map`/`grep`/`sort` in both statement and expression contexts (including blocks that contain local variable statements).
- Files changed: `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` and `crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs`.

### Testing
- Ran `cargo test -p perl-parser-core test_map_grep_sort_blocks -- --nocapture` and the test passed successfully.
- Ran `cargo fmt --all` to format changes and re-ran the same test to ensure no regressions, and it passed.
- Tests run were automated unit tests added/updated in `perl-parser-core` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e6dd083338c0e9aef96556e65)