### PR TITLE
Fix grep/map/sort block+list parsing in nested expression contexts

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -278,17 +278,17 @@ impl<'a> Parser<'a> {
 
                                 args.push(block);
 
-                                // Parse remaining arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // Parse remaining list arguments (comma optional for these builtins)
+                                while !self.is_at_statement_end() {
+                                    // Skip optional comma
+                                    if self.peek_kind() == Some(TokenKind::Comma) {
+                                        self.consume_token()?;
+                                    }
                                     if self.is_at_statement_end() {
                                         break;
                                     }
-                                    args.push(self.parse_comma()?);
+                                    args.push(self.parse_assignment()?);
                                 }
-                            } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // These builtins should parse {} as blocks, not hashes
-                                args.push(self.parse_builtin_block()?);
                             } else {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);
@@ -429,7 +429,7 @@ impl<'a> Parser<'a> {
                                         if self.is_at_statement_end() {
                                             break;
                                         }
-                                        args.push(self.parse_ternary()?);
+                                        args.push(self.parse_assignment()?);
                                     }
                                 } else if name == "bless"
                                     && self.peek_kind() == Some(TokenKind::LeftBrace)

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -379,7 +379,7 @@ impl<'a> Parser<'a> {
                             // For map/grep/sort, parse list arguments without requiring commas
                             if matches!(func_name.as_ref(), "map" | "grep" | "sort") {
                                 // Parse list arguments until statement boundary
-                                while !Self::is_statement_terminator(self.peek_kind())
+                                while !self.is_at_statement_end()
                                     && !self.is_statement_modifier_keyword()
                                 {
                                     // Skip optional comma

--- a/crates/perl-parser/tests/builtin_empty_blocks_test.rs
+++ b/crates/perl-parser/tests/builtin_empty_blocks_test.rs
@@ -78,16 +78,22 @@ mod builtin_empty_blocks_tests {
 
     #[test]
     fn test_return_sort_empty_block() {
-        parse_and_check("return sort {} @array", "(return (call sort ((block ))");
+        parse_and_check(
+            "return sort {} @array",
+            "(return (call sort ((block ) (variable @ array)))",
+        );
     }
 
     #[test]
     fn test_return_map_empty_block() {
-        parse_and_check("return map {} @array", "(return (call map ((block ))");
+        parse_and_check("return map {} @array", "(return (call map ((block ) (variable @ array)))");
     }
 
     #[test]
     fn test_return_grep_empty_block() {
-        parse_and_check("return grep {} @array", "(return (call grep ((block ))");
+        parse_and_check(
+            "return grep {} @array",
+            "(return (call grep ((block ) (variable @ array)))",
+        );
     }
 }

--- a/crates/perl-parser/tests/grep_map_sort_block_list_regression_test.rs
+++ b/crates/perl-parser/tests/grep_map_sort_block_list_regression_test.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod grep_map_sort_block_list_regression_tests {
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn assert_parses_with_block_list_and_trailing_arg(code: &str, builtin_name: &str) {
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let sexp = ast.to_sexp();
+
+        assert!(!sexp.contains("(ERROR"), "unexpected parse error in: {sexp}");
+        assert!(
+            sexp.contains(&format!("(call {builtin_name}")),
+            "expected builtin call in: {sexp}"
+        );
+        assert!(sexp.contains("(block"), "expected block arg for {builtin_name} in: {sexp}");
+        assert!(
+            sexp.contains("(variable @ items)"),
+            "expected list arg for {builtin_name} in: {sexp}"
+        );
+        assert!(sexp.contains("(number 42)"), "expected trailing argument after list in: {sexp}");
+    }
+
+    #[test]
+    fn map_block_list_inside_parenthesized_call() {
+        assert_parses_with_block_list_and_trailing_arg("foo(map { $_ } @items, 42);", "map");
+    }
+
+    #[test]
+    fn grep_block_list_inside_parenthesized_call() {
+        assert_parses_with_block_list_and_trailing_arg("foo(grep { $_ > 1 } @items, 42);", "grep");
+    }
+
+    #[test]
+    fn sort_block_list_inside_parenthesized_call() {
+        assert_parses_with_block_list_and_trailing_arg(
+            "foo(sort { $a <=> $b } @items, 42);",
+            "sort",
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Correct parsing of `map`/`grep`/`sort` in `BLOCK LIST` form when used inside nested expressions so the builtin does not consume trailing arguments from the outer call. 
- Ensure the list-argument loop respects expression boundaries (such as `)` and `]`) and preserves proper operator/argument grouping.

### Description
- Stop builtin list-argument consumption at statement/expression boundaries by switching to the parser-wide `is_at_statement_end()` check in statement-level builtin handling (`crates/perl-parser-core/src/engine/parser/statements.rs`).
- In postfix builtin-call handling (`crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`) parse remaining `map`/`grep`/`sort` list items until statement boundary (comma optional) and use `parse_assignment()` for each list element so outer separators are preserved.
- Replace uses of `parse_ternary()` / `parse_comma()` with `parse_assignment()` in relevant builtin argument paths to avoid over-consuming comma-operator expressions.
- Add a targeted regression test file `crates/perl-parser/tests/grep_map_sort_block_list_regression_test.rs` covering `foo(map { ... } @items, 42)`, `foo(grep { ... } @items, 42)`, and `foo(sort { ... } @items, 42)`.
- Update expectations in existing `builtin_empty_blocks_test.rs` to assert the full parsed argument list for `return map/grep/sort {} @array` to match parser behavior after the fix.

### Testing
- Ran formatting: `cargo fmt --all` and it completed successfully.
- Ran targeted parser tests: `cargo test -p perl-parser --test grep_map_sort_block_list_regression_test -- --nocapture` and all tests passed.
- Ran existing builtin tests: `cargo test -p perl-parser --test builtin_empty_blocks_test -- --nocapture` and all tests passed.
- Ran core unit test validating hash-vs-block behavior: `cargo test -p perl-parser-core hash_vs_block_tests::tests::test_map_grep_sort_blocks -- --nocapture` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e6dd083338c0e9aef96556e65)