### PR TITLE
Parse map/grep/sort BLOCK followed by LIST correctly

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -257,38 +257,20 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_comma()?);
                                 }
                             } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // Parse block expression as first argument
-                                let block_start = self.current_position();
-                                self.expect(TokenKind::LeftBrace)?;
+                                // These builtins should parse {} as blocks, not hashes.
+                                // They also accept LIST arguments immediately after BLOCK
+                                // (with or without commas), e.g. `map { ... } @list`.
+                                args.push(self.parse_builtin_block()?);
 
-                                // Parse the expression inside the block (if any)
-                                let mut statements = Vec::new();
-                                if self.peek_kind() != Some(TokenKind::RightBrace) {
-                                    statements.push(self.parse_expression()?);
-                                }
-
-                                self.expect(TokenKind::RightBrace)?;
-                                let block_end = self.previous_position();
-
-                                // Wrap the expression in a block node
-                                let block = Node::new(
-                                    NodeKind::Block { statements },
-                                    SourceLocation { start: block_start, end: block_end },
-                                );
-
-                                args.push(block);
-
-                                // Parse remaining arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                while !self.is_at_statement_end() {
+                                    if self.peek_kind() == Some(TokenKind::Comma) {
+                                        self.consume_token()?;
+                                    }
                                     if self.is_at_statement_end() {
                                         break;
                                     }
-                                    args.push(self.parse_comma()?);
+                                    args.push(self.parse_ternary()?);
                                 }
-                            } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // These builtins should parse {} as blocks, not hashes
-                                args.push(self.parse_builtin_block()?);
                             } else {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);

--- a/crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/hash_vs_block_tests.rs
@@ -73,4 +73,29 @@ sub my_sub {
             sexp2
         );
     }
+
+    #[test]
+    fn test_map_grep_sort_block_plus_list_in_expression_context() {
+        let cases = [
+            "my @m = map { $_ * 2 } @list;",
+            "my @g = grep { $_ > 1 } @list;",
+            "my @s = sort { $a cmp $b } @list;",
+        ];
+
+        for code in cases {
+            let mut parser = Parser::new(code);
+            let result = parser.parse();
+            assert!(result.is_ok(), "Failed to parse: {code}");
+            let ast = must(result);
+            let sexp = ast.to_sexp();
+            assert!(
+                sexp.contains("(call map")
+                    || sexp.contains("(call grep")
+                    || sexp.contains("(call sort"),
+                "expected builtin call in AST for {code}: {sexp}"
+            );
+            assert!(sexp.contains("(block"), "expected block arg for {code}: {sexp}");
+            assert!(sexp.contains("(variable @ list)"), "expected list arg for {code}: {sexp}");
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix ambiguous parsing where builtins `map`/`grep`/`sort` that take a `{ BLOCK } LIST` form were not consistently recognizing the LIST argument in expression contexts.
- Ensure `{ ... }` is always treated as a block for these builtins and that subsequent LIST arguments (with or without commas) are parsed as arguments to the builtin call.

### Description
- Change builtin handling in `expressions/postfix.rs` so `sort|map|grep` use `parse_builtin_block()` to produce a `Block` node and then consume any following LIST arguments until a statement terminator, accepting optional commas and parsing each element with `parse_ternary()`.
- Remove the duplicated/inline block-parsing code path and unify the logic to avoid earlier regressions where the list was not attached to the call node.
- Add a new test `test_map_grep_sort_block_plus_list_in_expression_context` in `hash_vs_block_tests.rs` covering `map/grep/sort { ... } @list` in expression contexts and adjust an assertion to check for the `@list` variable node.
- Run `cargo fmt --all` to apply formatting.

### Testing
- Ran the focused unit test: `cargo test -p perl-parser-core hash_vs_block_tests::tests::test_map_grep_sort_blocks -- --nocapture` which passed.
- Ran the new targeted test `hash_vs_block_tests::test_map_grep_sort_block_plus_list_in_expression_context` and it passed during local runs.
- Ran the full crate test suite `cargo test -p perl-parser-core` after the change and `cargo fmt`, and all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2175e6dd083338c0e9aef96556e65)