### PR TITLE
Fix parsing of coderef arrow calls ($code->())

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -173,6 +173,33 @@ impl<'a> Parser<'a> {
                             );
                         }
 
+                        Some(TokenKind::LeftParen) => {
+                            // Code reference call: $code_ref->(...)
+                            let args = self.parse_args()?;
+
+                            // Keep compatibility with existing dereference-call shape (&{}):
+                            // the first argument is the callee expression.
+                            let mut all = vec![expr];
+                            all.extend(args);
+
+                            let start = all
+                                .first()
+                                .ok_or_else(|| {
+                                    ParseError::syntax(
+                                        "Empty coderef call argument vector",
+                                        self.previous_position(),
+                                    )
+                                })?
+                                .location
+                                .start;
+                            let end = self.previous_position();
+
+                            expr = Node::new(
+                                NodeKind::FunctionCall { name: "->()".to_string(), args: all },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         _ => {
                             // Just the arrow by itself - could be an error or incomplete
                             // For now, we'll leave expr unchanged

--- a/crates/perl-parser/tests/postfix_coderef_call_test.rs
+++ b/crates/perl-parser/tests/postfix_coderef_call_test.rs
@@ -1,0 +1,39 @@
+use perl_parser::{Node, NodeKind, Parser};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn has_arrow_coderef_call(node: &Node) -> bool {
+    if let NodeKind::FunctionCall { name, .. } = &node.kind {
+        if name == "->()" {
+            return true;
+        }
+    }
+
+    node.children().iter().any(|child| has_arrow_coderef_call(child))
+}
+
+#[test]
+fn parses_arrow_coderef_call_with_empty_args() -> TestResult {
+    let mut parser = Parser::new("my $result = $code->();");
+    let ast = parser.parse()?;
+
+    assert!(
+        has_arrow_coderef_call(&ast),
+        "Expected a FunctionCall node named ->() for coderef invocation",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parses_arrow_coderef_call_with_args() -> TestResult {
+    let mut parser = Parser::new("my $result = $code->($x, 42);");
+    let ast = parser.parse()?;
+
+    assert!(
+        has_arrow_coderef_call(&ast),
+        "Expected a FunctionCall node named ->() for coderef invocation",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Calls like `$code->()` and `$code->($x, 42)` were not parsed as coderef invocations and fell through into ambiguous function-call shapes, losing the call information in the AST.

### Description
- Add explicit handling in `parse_postfix` to detect `->(` following an expression and parse it as a coderef arrow call.
- Represent coderef arrow calls as `NodeKind::FunctionCall { name: "->()", args: [...] }` where the callee expression is preserved as the first argument to keep compatibility with existing dereference-call shapes (e.g. `&{}` patterns).
- Add regression tests in `crates/perl-parser/tests/postfix_coderef_call_test.rs` to cover both empty-arg and arg-list variants (`$code->()` and `$code->($x, 42)`).
- Run `cargo fmt --all` to normalize formatting.

### Testing
- Ran `cargo fmt --all` (succeeded).
- Ran `cargo test -p perl-parser --test postfix_coderef_call_test -- --nocapture` and the two new tests passed.
- Ran `cargo test -p perl-parser --test postfix_deref_complex_test -- --nocapture` and existing postfix-dereference tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21761abc08333971183e29cbfd1b1)