### PR TITLE
Fix parsing of coderef arrow calls like `$code->()`

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -154,6 +154,26 @@ impl<'a> Parser<'a> {
                             }
                         }
 
+                        Some(TokenKind::LeftParen) => {
+                            // Coderef call: $code->(...)
+                            //
+                            // We model this as a method-like call with an empty method name so
+                            // downstream passes still see a call node and arguments.
+                            let args = self.parse_args()?;
+
+                            let start = expr.location.start;
+                            let end = self.previous_position();
+
+                            expr = Node::new(
+                                NodeKind::MethodCall {
+                                    object: Box::new(expr),
+                                    method: String::new(),
+                                    args,
+                                },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         Some(TokenKind::Identifier | TokenKind::Method) => {
                             // Method call
                             let method = self.tokens.next()?.text.to_string();

--- a/crates/perl-parser/tests/postfix_deref_complex_test.rs
+++ b/crates/perl-parser/tests/postfix_deref_complex_test.rs
@@ -58,6 +58,9 @@ fn test_postfix_deref_edge_cases() -> TestResult {
         ("$ref->@*->%*", vec!["unary_->@*", "unary_->%*"]),
         // Postfix deref with method calls (use simpler example for now)
         ("$ref->@*->length()", vec!["unary_->@*", "method_call"]),
+        // Coderef invocation through arrow syntax
+        ("$coderef->()", vec!["method_call"]),
+        ("$coderef->($x, $y)", vec!["method_call", "(variable $ x)", "(variable $ y)"]),
         // In ternary expressions
         ("$flag ? $ref->@* : ()", vec!["ternary", "unary_->@*"]),
         // With string interpolation (the parser should handle the variable, not the string)


### PR DESCRIPTION
### Motivation
- Postfix arrow calls that directly invoke coderefs (syntax like `$code->()` and `$code->($x,$y)`) were not being recognized as call expressions, leaving the AST incomplete and breaking downstream analyses.

### Description
- Add a `TokenKind::LeftParen` branch inside `parse_postfix` to handle `->(...)` after an expression and parse the argument list with `parse_args`, modelling the construct as a `MethodCall` with an empty `method` name so argument structure is preserved (file: `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`).
- Add regression cases for zero-arg and multi-arg coderef arrow calls to `postfix_deref_complex_test.rs` to ensure the parser emits call-shaped nodes for `$coderef->()` and `$coderef->($x, $y)`.
- Keep the existing method-call handling intact so ordinary `->method()` continues to parse as before.

### Testing
- Ran `cargo test -p perl-parser --test postfix_deref_complex_test` and the test binary executed both tests with all assertions passing (`2 passed; 0 failed`).
- Ran `cargo fmt --all` to apply formatting without breaking tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21761abc08333971183e29cbfd1b1)