### PR TITLE
Fix parsing of coderef arrow calls ($code->())

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -173,6 +173,31 @@ impl<'a> Parser<'a> {
                             );
                         }
 
+                        Some(TokenKind::LeftParen) => {
+                            // Coderef invocation via arrow: $code->(...)
+                            // Represent as function_call("->", [unary("->", callee), ...args])
+                            // to preserve both call semantics and arrow operator identity.
+                            let call_args = self.parse_args()?;
+                            let start = expr.location.start;
+                            let end = self.previous_position();
+
+                            let deref = Node::new(
+                                NodeKind::Unary {
+                                    op: "->".to_string(),
+                                    operand: Box::new(expr),
+                                },
+                                SourceLocation { start, end },
+                            );
+
+                            let mut args = vec![deref];
+                            args.extend(call_args);
+
+                            expr = Node::new(
+                                NodeKind::FunctionCall { name: "->".to_string(), args },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         _ => {
                             // Just the arrow by itself - could be an error or incomplete
                             // For now, we'll leave expr unchanged

--- a/crates/perl-parser/tests/parser_regressions.rs
+++ b/crates/perl-parser/tests/parser_regressions.rs
@@ -112,6 +112,32 @@ fn print_scalar_vs_indirect_object() {
 }
 
 #[test]
+fn coderef_arrow_call_parses() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"$code->();"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let sexp = ast.to_sexp();
+
+    assert!(
+        sexp.contains("function") || sexp.contains("function_call"),
+        "Expected coderef arrow invocation to parse as a call expression, got: {}",
+        sexp
+    );
+    assert!(
+        sexp.contains("unary_->"),
+        "Expected coderef arrow unary node in call target, got: {}",
+        sexp
+    );
+    assert!(
+        !sexp.contains("(array )"),
+        "Coderef call should not be split into a standalone empty array node: {}",
+        sexp
+    );
+
+    Ok(())
+}
+
+#[test]
 fn new_constructor_pattern() {
     assert_parses("new Class");
     assert_parses("new Class()");


### PR DESCRIPTION
### Motivation
- Coderef invocations using the arrow with parentheses (e.g. `$code->()`) were being parsed incorrectly (split into ambiguous/array-like nodes) and lost the arrow-call semantics.
- The parser needs to represent this form as a true call expression while preserving the `->` operator identity so downstream consumers see the correct AST shape.

### Description
- Extend the postfix parser to handle a `LeftParen` immediately after an arrow target and parse it as a coderef invocation by building a `Unary` `->` node for the callee and a `FunctionCall` node with name `"->"` whose first arg is that unary deref and remaining args are the call arguments.
- Add a regression test `coderef_arrow_call_parses` in `crates/perl-parser/tests/parser_regressions.rs` that asserts the `$code->();` form is parsed as a call, contains the `unary_->` callee marker, and does not produce a stray empty array node.
- Run `cargo fmt --all` to normalize formatting.

### Testing
- Ran `cargo test -p perl-parser --test parser_regressions coderef_arrow_call_parses`, which passed.
- Ran the full `cargo test -p perl-parser --test parser_regressions`, which executed 27 tests and all passed.
- Ran `cargo fmt --all` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21761abc08333971183e29cbfd1b1)