### PR TITLE
Support coderef calls after arrow (e.g. $code->(...))

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -173,6 +173,25 @@ impl<'a> Parser<'a> {
                             );
                         }
 
+                        Some(TokenKind::LeftParen) => {
+                            // Coderef call syntax: $code->(...)
+                            // Represent as a MethodCall with an empty method name to preserve
+                            // call structure while distinguishing it from direct function calls.
+                            let args = self.parse_args()?;
+
+                            let start = expr.location.start;
+                            let end = self.previous_position();
+
+                            expr = Node::new(
+                                NodeKind::MethodCall {
+                                    object: Box::new(expr),
+                                    method: String::new(),
+                                    args,
+                                },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         _ => {
                             // Just the arrow by itself - could be an error or incomplete
                             // For now, we'll leave expr unchanged

--- a/crates/perl-parser/tests/postfix_deref_complex_test.rs
+++ b/crates/perl-parser/tests/postfix_deref_complex_test.rs
@@ -11,6 +11,7 @@ fn test_complex_postfix_deref() -> TestResult {
         ("my %hash = $hashref->%*;", "unary_->%*"),
         ("my $scalar = $scalarref->$*;", "unary_->$*"),
         ("my $result = $coderef->&*;", "unary_->&*"),
+        ("my $invoke = $coderef->();", "method_call"),
         ("my $glob = $globref->**;", "unary_->**"),
         // Array and hash slices
         ("my @slice = $arrayref->@[0..2];", "binary_->@[]"),
@@ -58,6 +59,8 @@ fn test_postfix_deref_edge_cases() -> TestResult {
         ("$ref->@*->%*", vec!["unary_->@*", "unary_->%*"]),
         // Postfix deref with method calls (use simpler example for now)
         ("$ref->@*->length()", vec!["unary_->@*", "method_call"]),
+        // Coderef call syntax after arrow
+        ("$code->($x, $y)", vec!["method_call"]),
         // In ternary expressions
         ("$flag ? $ref->@* : ()", vec!["ternary", "unary_->@*"]),
         // With string interpolation (the parser should handle the variable, not the string)


### PR DESCRIPTION
### Motivation

- Fix a parser regression where coderef calls written as `$code->(...)` were not recognized as call expressions and thus not represented in the AST.

### Description

- Add handling in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` to detect `LeftParen` immediately after `->` and construct a `MethodCall` node with an empty `method` name and parsed arguments to represent coderef invocation.
- Update `crates/perl-parser/tests/postfix_deref_complex_test.rs` to include positive test cases for `$coderef->()` and `$code->($x, $y)` and to assert the parser emits the expected node patterns.
- The change preserves existing method call behavior and distinguishes coderef calls by using an empty method string while keeping the call arguments in the AST.

### Testing

- Ran `cargo test -p perl-parser postfix_deref_complex_test` in this environment which completed compilation but the test execution was interrupted in this session before a final pass/fail could be recorded; test execution should be re-run locally or in CI to validate.
- The updated unit tests covering postfix dereference and coderef-call cases were added to ensure continued coverage of postfix deref and coderef invocation scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21761abc08333971183e29cbfd1b1)