### PR TITLE
Fix parser handling for Perl `x` repetition operator

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -633,6 +633,21 @@ impl<'a> Parser<'a> {
                         SourceLocation { start, end },
                     );
                 }
+                TokenKind::Identifier if self.tokens.peek()?.text.as_ref() == "x" => {
+                    let op_token = self.tokens.next()?;
+                    let right = self.parse_unary()?;
+                    let start = expr.location.start;
+                    let end = right.location.end;
+
+                    expr = Node::new(
+                        NodeKind::Binary {
+                            op: op_token.text.to_string(),
+                            left: Box::new(expr),
+                            right: Box::new(right),
+                        },
+                        SourceLocation { start, end },
+                    );
+                }
                 _ => break,
             }
         }

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -760,6 +760,7 @@ mod tests {
             ("$a % $b", "%"),   // Modulo (not hash sigil)
             ("$a ** $b", "**"), // Exponent (not glob)
             ("$a // $b", "//"), // Defined-or (not regex)
+            ("'a' x 3", "x"),   // String repetition operator
         ];
 
         for (code, expected_op) in cases {


### PR DESCRIPTION
### Motivation
- The parser did not treat the bare identifier `x` (Perl string repetition operator) as a binary operator at the same precedence as `*`, `/`, and `%`, causing mis-parsing of expressions like `'a' x 3`.
- Add a small, targeted change so repetition expressions are recognized and parsed consistently with other multiplicative operators.

### Description
- In `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs` update `parse_multiplicative` to accept `TokenKind::Identifier` when the identifier text is the literal `"x"`, and build a `NodeKind::Binary` node for it at multiplicative precedence.
- Add a regression case to `test_operators_with_context` in `crates/perl-parser/src/lib.rs` to cover the repetition expression `"'a' x 3"` expecting operator `"x"`.
- Run `cargo fmt --all` to format changes.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser --lib test_operators_with_context -- --nocapture` and the test passed (`1 passed; 0 failed`).
- Ran `cargo test -p perl-parser-core slash_ambiguity_tests::test_division_chain -- --nocapture` (parser-core test invocation completed successfully; no relevant tests were filtered to run in that invocation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2182977b483338e73f5aabe777233)