### PR TITLE
Recognize `x` string-repetition operator in multiplicative precedence

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -617,8 +617,26 @@ impl<'a> Parser<'a> {
         let mut expr = self.parse_power()?;
 
         while let Some(kind) = self.peek_kind() {
+            let is_repeat_operator = kind == TokenKind::Identifier
+                && self.peek_token().map(|token| token.text.as_ref() == "x").unwrap_or(false);
+
             match kind {
-                TokenKind::Star | TokenKind::Slash | TokenKind::Percent => {
+                TokenKind::Star | TokenKind::Slash | TokenKind::Percent if !is_repeat_operator => {
+                    let op_token = self.tokens.next()?;
+                    let right = self.parse_unary()?;
+                    let start = expr.location.start;
+                    let end = right.location.end;
+
+                    expr = Node::new(
+                        NodeKind::Binary {
+                            op: op_token.text.to_string(),
+                            left: Box::new(expr),
+                            right: Box::new(right),
+                        },
+                        SourceLocation { start, end },
+                    );
+                }
+                TokenKind::Identifier if is_repeat_operator => {
                     let op_token = self.tokens.next()?;
                     let right = self.parse_unary()?;
                     let start = expr.location.start;

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -417,3 +417,26 @@ fn test_catastrophic_backtracking_detection() {
         assert!(found, "Should have found specific error in: {:?}", errors);
     }
 }
+
+#[test]
+fn test_string_repetition_operator_x() {
+    let mut parser = Parser::new("$a x 3;");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse x repetition operator: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST, got: {}", sexp);
+}
+
+#[test]
+fn test_string_repetition_precedence_with_additive() {
+    let mut parser = Parser::new("\"a\" . \"b\" x 2;");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse expression with x repetition operator");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("binary_x"), "Expected binary_x in AST, got: {}", sexp);
+    assert!(sexp.contains("binary_."), "Expected binary_. in AST, got: {}", sexp);
+}


### PR DESCRIPTION
### Motivation
- The lexer can emit the Perl repetition operator `x` as an `Identifier`, so the parser must treat an identifier whose text is `x` as a multiplicative-precedence binary operator to parse constructs like `$a x 3` correctly.
- Without recognizing `x` at multiplicative precedence, expressions mixing repetition with other operators (e.g. concatenation) were parsed incorrectly.

### Description
- In `parse_multiplicative` added a `is_repeat_operator` check that detects `TokenKind::Identifier` whose token text is `"x"` and treats it as a multiplicative operator when building `NodeKind::Binary` nodes in `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs`.
- Kept original handling for `*`, `/`, and `%` unchanged and ensured the `*`/`/`/`%` branch does not trigger for the `x` identifier.
- Added two regression tests in `crates/perl-parser-core/src/engine/parser/tests.rs` to cover basic `$a x 3` parsing and precedence interaction in `"a" . "b" x 2`.

### Testing
- Ran `cargo fmt --all` to format the changes and ensure style consistency, which completed successfully.
- Ran `cargo test -p perl-parser-core test_string_repetition_` and observed both new tests (`test_string_repetition_operator_x` and `test_string_repetition_precedence_with_additive`) pass.
- The `perl-parser-core` crate compiled successfully during testing with the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2182977b483338e73f5aabe777233)