### PR TITLE
Parse `x` string repetition operator at multiplicative precedence

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -633,6 +633,21 @@ impl<'a> Parser<'a> {
                         SourceLocation { start, end },
                     );
                 }
+                TokenKind::Identifier if self.tokens.peek()?.text.as_ref() == "x" => {
+                    let op_token = self.tokens.next()?;
+                    let right = self.parse_unary()?;
+                    let start = expr.location.start;
+                    let end = right.location.end;
+
+                    expr = Node::new(
+                        NodeKind::Binary {
+                            op: op_token.text.to_string(),
+                            left: Box::new(expr),
+                            right: Box::new(right),
+                        },
+                        SourceLocation { start, end },
+                    );
+                }
                 _ => break,
             }
         }

--- a/crates/perl-parser/tests/x_repeat_operator_test.rs
+++ b/crates/perl-parser/tests/x_repeat_operator_test.rs
@@ -1,0 +1,60 @@
+use perl_parser::{NodeKind, Parser};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn test_x_repeat_operator_binary_expression() -> TestResult {
+    let mut parser = Parser::new("'x' x 3");
+    let ast = parser.parse()?;
+
+    if let NodeKind::Program { statements } = &ast.kind {
+        assert_eq!(statements.len(), 1);
+        if let NodeKind::ExpressionStatement { expression } = &statements[0].kind {
+            if let NodeKind::Binary { op, .. } = &expression.kind {
+                assert_eq!(op, "x");
+            } else {
+                return Err("expected binary expression for x repetition operator".into());
+            }
+        } else {
+            return Err("expected expression statement".into());
+        }
+    } else {
+        return Err("expected program node".into());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_x_repeat_operator_precedence_between_concat_and_multiply() -> TestResult {
+    let mut parser = Parser::new("'a' . 'b' x 3");
+    let ast = parser.parse()?;
+
+    if let NodeKind::Program { statements } = &ast.kind {
+        assert_eq!(statements.len(), 1);
+        if let NodeKind::ExpressionStatement { expression } = &statements[0].kind {
+            if let NodeKind::Binary { op, left, right } = &expression.kind {
+                assert_eq!(op, ".");
+                if let NodeKind::String { .. } = &left.kind {
+                    // expected
+                } else {
+                    return Err("expected string literal on left of concatenation".into());
+                }
+
+                if let NodeKind::Binary { op, .. } = &right.kind {
+                    assert_eq!(op, "x");
+                } else {
+                    return Err("expected x repetition on right of concatenation".into());
+                }
+            } else {
+                return Err("expected top-level concatenation binary expression".into());
+            }
+        } else {
+            return Err("expected expression statement".into());
+        }
+    } else {
+        return Err("expected program node".into());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The parser was not treating the Perl `x` string repetition operator (lexed as an identifier) as a multiplicative-level binary operator, causing incorrect ASTs for expressions like `'x' x 3` and wrong precedence interactions with concatenation.

### Description
- In `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs` the `parse_multiplicative` loop was extended to recognize `TokenKind::Identifier` whose text is `"x"` and to build a `NodeKind::Binary` node for it using the existing multiplicative parsing flow.
- Existing handling for `*`, `/`, and `%` was preserved and the same `parse_unary` call and `Node` construction are reused for the `x` case.
- Added regression tests in `crates/perl-parser/tests/x_repeat_operator_test.rs` verifying that `'x' x 3` parses as a single binary expression with operator `x` and that `"'a' . 'b' x 3"` preserves `.` at top-level with `x` as the right-hand binary expression.
- Ran code formatting with `cargo fmt --all` to keep style consistent.

### Testing
- Ran `cargo test -p perl-parser --test x_repeat_operator_test -- --nocapture` and the new tests passed (`2 passed`).
- Ran `cargo test -p perl-parser --test comprehensive_operator_precedence_test` to ensure no regressions and it passed (`9 passed`).
- Ran `cargo fmt --all` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2182977b483338e73f5aabe777233)