### PR TITLE
Fix parsing of Perl `x` repetition operator

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -617,8 +617,26 @@ impl<'a> Parser<'a> {
         let mut expr = self.parse_power()?;
 
         while let Some(kind) = self.peek_kind() {
+            let is_repetition = kind == TokenKind::Identifier
+                && self.tokens.peek()?.text.as_ref() == "x";
+
             match kind {
-                TokenKind::Star | TokenKind::Slash | TokenKind::Percent => {
+                TokenKind::Star | TokenKind::Slash | TokenKind::Percent if !is_repetition => {
+                    let op_token = self.tokens.next()?;
+                    let right = self.parse_unary()?;
+                    let start = expr.location.start;
+                    let end = right.location.end;
+
+                    expr = Node::new(
+                        NodeKind::Binary {
+                            op: op_token.text.to_string(),
+                            left: Box::new(expr),
+                            right: Box::new(right),
+                        },
+                        SourceLocation { start, end },
+                    );
+                }
+                TokenKind::Identifier if is_repetition => {
                     let op_token = self.tokens.next()?;
                     let right = self.parse_unary()?;
                     let start = expr.location.start;

--- a/crates/perl-parser-core/src/engine/parser/slash_ambiguity_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/slash_ambiguity_tests.rs
@@ -84,4 +84,26 @@ mod tests {
         let sexp = ast.to_sexp();
         assert!(sexp.contains("binary_/"), "Should be division after nullary function: {}", sexp);
     }
+
+    #[test]
+    fn test_repetition_operator_parses_as_binary_x() {
+        let code = "'ab' x 3;";
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        assert!(result.is_ok(), "Failed to parse repetition operator");
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("binary_x"), "Should parse x as repetition operator: {}", sexp);
+    }
+
+    #[test]
+    fn test_repetition_operator_chain_left_associative() {
+        let code = "'a' x 2 x 3;";
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        assert!(result.is_ok(), "Failed to parse chained repetition operators");
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        assert!(sexp.matches("binary_x").count() >= 2, "Should parse two x operators: {}", sexp);
+    }
 }


### PR DESCRIPTION
### Motivation

- The parser did not recognize the Perl bareword repetition operator `x` at multiplicative precedence, causing expressions like `"ab" x 3` and chained `"a" x 2 x 3` to be mis-parsed.

### Description

- Treat a bareword `x` token (an `Identifier` whose text is `"x"`) as a multiplicative-precedence binary operator in `parse_multiplicative` while preserving existing `*`, `/`, and `%` handling by guarding those branches when the token is the repetition `x` operator (file: `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs`).
- Add two regression tests to `slash_ambiguity_tests.rs` that assert a simple repetition (`'ab' x 3`) parses as `binary_x` and that chained repetition (`'a' x 2 x 3`) is parsed as multiple left-associative `binary_x` nodes (file: `crates/perl-parser-core/src/engine/parser/slash_ambiguity_tests.rs`).
- Keep AST construction and location tracking unchanged (reuses existing `NodeKind::Binary` construction path).

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran the targeted tests with `cargo test -p perl-parser-core slash_ambiguity_tests` and observed all tests pass (`6 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2182977b483338e73f5aabe777233)