### PR TITLE
Fix keyword autoquoting before fat arrow

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -153,12 +153,6 @@ impl<'a> Parser<'a> {
             return self.parse_word_not_expr();
         }
 
-        // Handle 'return' as an expression in expression context
-        // This allows patterns like: open $fh, $file or return;
-        if self.peek_kind() == Some(TokenKind::Return) {
-            return self.parse_return();
-        }
-
         let mut expr = self.parse_ternary()?;
 
         // Check for assignment operators

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -263,9 +263,41 @@ impl<'a> Parser<'a> {
                 ))
             }
 
-            TokenKind::Eval => self.parse_eval(),
+            TokenKind::Return => {
+                if self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_return()
+                }
+            }
 
-            TokenKind::Do => self.parse_do(),
+            TokenKind::Eval => {
+                if self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_eval()
+                }
+            }
+
+            TokenKind::Do => {
+                if self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_do()
+                }
+            }
 
             // Note: TokenKind::Sub is handled in the keyword-as-identifier case below
             // This allows 'sub' to be used as a hash key or identifier in expressions
@@ -545,56 +577,50 @@ impl<'a> Parser<'a> {
                 ))
             }
 
-            // Handle 'sub' specially - it might be an anonymous subroutine
-            TokenKind::Sub => {
-                // Check if the token AFTER 'sub' is { or ( (anonymous subroutine)
-                // We use peek_second() because peek() is still 'sub' (unconsumed)
-                let next = self.tokens.peek_second().ok().map(|t| t.kind);
-                if matches!(next, Some(k) if matches!(k, TokenKind::LeftBrace | TokenKind::LeftParen))
-                {
-                    // It's an anonymous subroutine
-                    self.parse_subroutine()
-                } else {
-                    // It's used as an identifier
+            // Handle keywords/barewords as identifiers in autoquoting contexts like
+            // `keyword => $value` and similar hash key positions.
+            kind if Self::is_autoquotable_keyword(kind) => {
+                if self.tokens.peek_second().ok().map(|t| t.kind) == Some(TokenKind::FatArrow) {
                     let token = self.tokens.next()?;
-                    Ok(Node::new(
+                    return Ok(Node::new(
                         NodeKind::Identifier { name: token.text.to_string() },
                         SourceLocation { start: token.start, end: token.end },
-                    ))
+                    ));
                 }
-            }
 
-            // Handle keywords that can be used as identifiers in certain contexts
-            // Note: Statement-level keywords (if, unless, while, return, etc.) should NOT be here
-            TokenKind::My
-            | TokenKind::Our
-            | TokenKind::Local
-            | TokenKind::State
-            | TokenKind::Package
-            | TokenKind::Use
-            | TokenKind::No
-            | TokenKind::Begin
-            | TokenKind::End
-            | TokenKind::Check
-            | TokenKind::Init
-            | TokenKind::Unitcheck
-            | TokenKind::Given
-            | TokenKind::When
-            | TokenKind::Default
-            | TokenKind::Catch
-            | TokenKind::Finally
-            | TokenKind::Continue
-            | TokenKind::Class
-            | TokenKind::Method
-            | TokenKind::Format => {
-                // In expression context, some keywords can be used as barewords/identifiers
-                // This happens in hash keys, method names, etc.
-                // But NOT for statement modifiers like if, unless, while, etc.
-                let token = self.tokens.next()?;
-                Ok(Node::new(
-                    NodeKind::Identifier { name: token.text.to_string() },
-                    SourceLocation { start: token.start, end: token.end },
-                ))
+                match kind {
+                    // Handle 'sub' specially - it might be an anonymous subroutine
+                    TokenKind::Sub => {
+                        // Check if the token AFTER 'sub' is { or ( (anonymous subroutine)
+                        // We use peek_second() because peek() is still 'sub' (unconsumed)
+                        let next = self.tokens.peek_second().ok().map(|t| t.kind);
+                        if matches!(next, Some(k) if matches!(k, TokenKind::LeftBrace | TokenKind::LeftParen))
+                        {
+                            // It's an anonymous subroutine
+                            self.parse_subroutine()
+                        } else {
+                            // In expression context, allow keyword as identifier/bareword
+                            let token = self.tokens.next()?;
+                            Ok(Node::new(
+                                NodeKind::Identifier { name: token.text.to_string() },
+                                SourceLocation { start: token.start, end: token.end },
+                            ))
+                        }
+                    }
+                    // Keep dedicated statement/expression handlers for these keywords unless
+                    // we're in explicit autoquoting (`=>`) context (handled above).
+                    TokenKind::Return => {
+                        let pos = self.current_position();
+                        Err(ParseError::unexpected("expression", format!("{:?}", kind), pos))
+                    }
+                    _ => {
+                        let token = self.tokens.next()?;
+                        Ok(Node::new(
+                            NodeKind::Identifier { name: token.text.to_string() },
+                            SourceLocation { start: token.start, end: token.end },
+                        ))
+                    }
+                }
             }
 
             TokenKind::DoubleColon => {

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -283,6 +283,52 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Returns true when a token is a keyword/bareword that Perl autoquotes
+    /// in `key => value` contexts.
+    fn is_autoquotable_keyword(kind: TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::My
+                | TokenKind::Our
+                | TokenKind::Local
+                | TokenKind::State
+                | TokenKind::Sub
+                | TokenKind::If
+                | TokenKind::Elsif
+                | TokenKind::Else
+                | TokenKind::Unless
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::For
+                | TokenKind::Foreach
+                | TokenKind::Return
+                | TokenKind::Package
+                | TokenKind::Use
+                | TokenKind::No
+                | TokenKind::Begin
+                | TokenKind::End
+                | TokenKind::Check
+                | TokenKind::Init
+                | TokenKind::Unitcheck
+                | TokenKind::Eval
+                | TokenKind::Do
+                | TokenKind::Given
+                | TokenKind::When
+                | TokenKind::Default
+                | TokenKind::Try
+                | TokenKind::Catch
+                | TokenKind::Finally
+                | TokenKind::Continue
+                | TokenKind::Next
+                | TokenKind::Last
+                | TokenKind::Redo
+                | TokenKind::Class
+                | TokenKind::Method
+                | TokenKind::Format
+                | TokenKind::Undef
+        )
+    }
+
     /// Record a parse error for later retrieval
     fn record_error(&mut self, error: ParseError) {
         self.errors.push(error);

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3094,6 +3094,35 @@ mod line_index_extended_tests {
         Ok(())
     }
 
+    #[test]
+    fn wave2b_keyword_autoquote_before_fat_arrow_in_list() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut parser = Parser::new("my %h = (if => 1, while => 2, sub => 3);");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "keywords before => should autoquote in list context, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_keyword_autoquote_before_fat_arrow_in_braces()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new(
+            "my $h = { if => 1, while => 2, sub => 3 };
+",
+        );
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "keywords before => should autoquote in brace hash context, got: {sexp}"
+        );
+        Ok(())
+    }
+
     // ---- Wave 2C: split /regex/ ----
 
     #[test]


### PR DESCRIPTION
### Motivation
- Perl treats many keywords as barewords (autoquoted) when they appear as the left side of a fat-arrow (`=>`), and the parser currently failed to handle several such cases causing syntax errors for constructs like `if => 1` used as hash keys.

### Description
- Add a shared helper `is_autoquotable_keyword` to centralize which `TokenKind` values may be treated as bareword keys in `key => value` contexts (new in `helpers.rs`).
- Update primary-expression parsing so autoquotable keywords are parsed as `Identifier` nodes when immediately followed by `FatArrow` while preserving normal keyword behavior otherwise (changes in `expressions/primary.rs`).
- Special-case `sub` to still recognize anonymous subs, and keep dedicated handling for `return`, `eval`, and `do` unless they appear in the fat-arrow autoquote position (adjusted logic between `precedence.rs` and `primary.rs`).
- Add regression tests that validate keyword autoquoting both in parenthesized list contexts and brace/hash contexts (tests added to `comprehensive_unit_tests.rs`).

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test -p perl-parser-core wave2b_keyword_autoquote_before_fat_arrow -- --nocapture` and the test passed.
- Ran `cargo test -p perl-parser-core wave2b_ -- --nocapture` which exercised related fat-arrow regression tests and all affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21835acc48333966b1cee656d2dbc)