### PR TITLE
Fix keyword autoquoting before fat arrow in call args

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -1,4 +1,48 @@
 impl<'a> Parser<'a> {
+    fn is_autoquotable_keyword(kind: TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::My
+                | TokenKind::Our
+                | TokenKind::Local
+                | TokenKind::State
+                | TokenKind::Sub
+                | TokenKind::If
+                | TokenKind::Elsif
+                | TokenKind::Else
+                | TokenKind::Unless
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::For
+                | TokenKind::Foreach
+                | TokenKind::Return
+                | TokenKind::Package
+                | TokenKind::Use
+                | TokenKind::No
+                | TokenKind::Begin
+                | TokenKind::End
+                | TokenKind::Check
+                | TokenKind::Init
+                | TokenKind::Unitcheck
+                | TokenKind::Eval
+                | TokenKind::Do
+                | TokenKind::Given
+                | TokenKind::When
+                | TokenKind::Default
+                | TokenKind::Try
+                | TokenKind::Catch
+                | TokenKind::Finally
+                | TokenKind::Continue
+                | TokenKind::Next
+                | TokenKind::Last
+                | TokenKind::Redo
+                | TokenKind::Class
+                | TokenKind::Method
+                | TokenKind::Format
+                | TokenKind::Undef
+        )
+    }
+
     /// Check if this might be an indirect call pattern
     /// We only consider this at statement start to avoid ambiguous mid-expression cases.
     ///
@@ -200,6 +244,32 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
+                let arg_kind = s.tokens.peek().ok().map(|t| t.kind);
+                let lookahead_is_fat_arrow = s
+                    .tokens
+                    .peek_second()
+                    .ok()
+                    .map(|t| t.kind == TokenKind::FatArrow)
+                    .unwrap_or(false);
+
+                if lookahead_is_fat_arrow
+                    && arg_kind.is_some_and(Self::is_autoquotable_keyword)
+                {
+                    let keyword = s.tokens.next()?;
+                    args.push(Node::new(
+                        NodeKind::String {
+                            value: keyword.text.to_string(),
+                            interpolated: false,
+                        },
+                        SourceLocation {
+                            start: keyword.start,
+                            end: keyword.end,
+                        },
+                    ));
+                    s.tokens.next()?; // consume =>
+                    continue;
+                }
+
                 // Use parse_assignment instead of parse_expression to avoid comma operator handling
                 let mut arg = s.parse_assignment()?;
 

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -417,3 +417,27 @@ fn test_catastrophic_backtracking_detection() {
         assert!(found, "Should have found specific error in: {:?}", errors);
     }
 }
+
+#[test]
+fn test_keyword_autoquoting_before_fat_arrow_in_call_args() {
+    let mut parser = Parser::new("foo(if => 1, while => 2, default => 3);");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Parser should accept keywords before fat arrow in call args");
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(string \"if\")"), "Expected autoquoted 'if': {}", sexp);
+    assert!(sexp.contains("(string \"while\")"), "Expected autoquoted 'while': {}", sexp);
+    assert!(sexp.contains("(string \"default\")"), "Expected autoquoted 'default': {}", sexp);
+}
+
+#[test]
+fn test_identifier_autoquoting_before_fat_arrow_still_works() {
+    let mut parser = Parser::new("foo(key => 1);");
+    let result = parser.parse();
+    assert!(result.is_ok());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(string \"key\")"), "Expected autoquoted identifier key: {}", sexp);
+}


### PR DESCRIPTION
### Motivation
- The parser auto-quoted bare identifiers on the left-hand side of `=>` in call argument lists but treated reserved keywords (e.g. `if`, `while`, `default`) as non-autoquotable, causing incorrect ASTs for `foo(if => 1)`-style calls.

### Description
- Add `is_autoquotable_keyword` helper and a targeted pre-check in `parse_args` to convert keyword tokens immediately followed by `FatArrow` into `NodeKind::String` nodes before normal argument parsing.
- Preserve the existing identifier auto-quoting path so `key => 1` behavior remains unchanged.
- Modify `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` and add regression tests in `crates/perl-parser-core/src/engine/parser/tests.rs` for keyword and identifier auto-quoting cases.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran the parser unit tests with `cargo test -p perl-parser-core autoquoting_before_fat_arrow` and the new tests `test_keyword_autoquoting_before_fat_arrow_in_call_args` and `test_identifier_autoquoting_before_fat_arrow_still_works` passed (all tests in that run passed).
- Verified the new tests exercise both keyword-to-string conversion and that existing identifier autoquoting remains working.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21835acc48333966b1cee656d2dbc)