### PR TITLE
Fix parser autoquoting for keyword barewords before fat arrow

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -148,6 +148,10 @@ impl<'a> Parser<'a> {
 
     /// Parse assignment expression
     fn parse_assignment(&mut self) -> ParseResult<Node> {
+        if let Some(autoquoted_key) = self.parse_autoquoted_fat_arrow_key()? {
+            return Ok(autoquoted_key);
+        }
+
         // Check if we have a 'not' operator first
         if self.peek_kind() == Some(TokenKind::WordNot) {
             return self.parse_word_not_expr();

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -47,6 +47,10 @@ impl<'a> Parser<'a> {
 
     /// Inner implementation of parse_primary (called under recursion guard)
     fn parse_primary_inner(&mut self) -> ParseResult<Node> {
+        if let Some(autoquoted_key) = self.parse_autoquoted_fat_arrow_key()? {
+            return Ok(autoquoted_key);
+        }
+
         let token = self.tokens.peek()?;
         let token_kind = token.kind;
 

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -1,4 +1,33 @@
 impl<'a> Parser<'a> {
+    /// Parse a bareword token that appears immediately before a fat arrow (`=>`).
+    ///
+    /// Perl auto-quotes barewords on the left-hand side of fat arrows, including
+    /// reserved keywords (e.g. `if => 1`). This helper detects that pattern and
+    /// returns a string node without invoking the regular expression parser.
+    fn parse_autoquoted_fat_arrow_key(&mut self) -> ParseResult<Option<Node>> {
+        if self.tokens.peek_second().map(|t| t.kind) != Ok(TokenKind::FatArrow) {
+            return Ok(None);
+        }
+
+        let token = self.tokens.peek()?;
+        let text = token.text.as_ref();
+        let is_bareword = text
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+            && text.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '_');
+
+        if !is_bareword {
+            return Ok(None);
+        }
+
+        let token = self.tokens.next()?;
+        Ok(Some(Node::new(
+            NodeKind::String { value: token.text.to_string(), interpolated: false },
+            SourceLocation { start: token.start, end: token.end },
+        )))
+    }
+
     #[inline]
     fn is_statement_terminator(kind: Option<TokenKind>) -> bool {
         matches!(kind, Some(TokenKind::Semicolon) | Some(TokenKind::Eof) | None)

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -136,6 +136,30 @@ fn test_block_vs_hash_context() {
 }
 
 #[test]
+fn test_keyword_autoquoted_before_fat_arrow() {
+    let cases = [
+        "my $x = { if => 1, return => 2 };",
+        "my $x = ( if => 1, return => 2 );",
+        "foo(if => 1, while => 2);",
+    ];
+
+    for code in cases {
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        assert!(result.is_ok(), "Failed to parse `{}`", code);
+
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(string \"if\")"), "Expected autoquoted `if` in AST: {}", sexp);
+        assert!(
+            sexp.contains("(string \"return\")") || sexp.contains("(string \"while\")"),
+            "Expected autoquoted keyword key in AST: {}",
+            sexp
+        );
+    }
+}
+
+#[test]
 fn test_qualified_function_call() {
     let mut parser = Parser::new("return Data::Dumper::Dumper($param);");
     let result = parser.parse();


### PR DESCRIPTION
### Motivation

- The parser failed to auto-quote bareword tokens that were reserved keywords when they appeared immediately left of a fat arrow (`=>`), causing parse errors for constructs like `if => 1` or `return => 2` used as hash keys or argument keys.

### Description

- Add helper `parse_autoquoted_fat_arrow_key` in `crates/perl-parser-core/src/engine/parser/helpers.rs` that recognizes a bareword token immediately followed by `=>` and returns a non-interpolated `String` node representing the auto-quoted key.
- Invoke the helper at the start of primary expression parsing in `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` to handle normal identifier/keyword primary positions.
- Invoke the helper at the start of assignment parsing in `crates/perl-parser-core/src/engine/parser/expressions/precedence.rs` to handle keyword-driven expression paths (e.g. `return => ...`).
- Add a regression unit test `test_keyword_autoquoted_before_fat_arrow` in `crates/perl-parser-core/src/engine/parser/tests.rs` that verifies auto-quoting for keywords in hash literals, parenthesized lists, and function argument lists.

### Testing

- Ran `cargo fmt --all` successfully to format changes.
- Ran `cargo test -p perl-parser-core test_keyword_autoquoted_before_fat_arrow -- --nocapture` and the new test passed.
- Ran `cargo test -p perl-parser-core fat_arrow -- --nocapture` (existing fat-arrow related tests) and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21835acc48333966b1cee656d2dbc)