### PR TITLE
Autoquote statement keywords before fat-comma keys (=>)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -148,6 +148,36 @@ impl<'a> Parser<'a> {
 
     /// Parse assignment expression
     fn parse_assignment(&mut self) -> ParseResult<Node> {
+        // Perl autoquotes bareword-like keywords on the LHS of fat comma: `if => 1`
+        if matches!(self.tokens.peek_second().map(|t| t.kind), Ok(TokenKind::FatArrow)) {
+            if let Some(kind) = self.peek_kind() {
+                if matches!(
+                    kind,
+                    TokenKind::If
+                        | TokenKind::Elsif
+                        | TokenKind::Else
+                        | TokenKind::Unless
+                        | TokenKind::While
+                        | TokenKind::Until
+                        | TokenKind::For
+                        | TokenKind::Foreach
+                        | TokenKind::Return
+                        | TokenKind::Eval
+                        | TokenKind::Do
+                        | TokenKind::Try
+                        | TokenKind::Next
+                        | TokenKind::Last
+                        | TokenKind::Redo
+                ) {
+                    let token = self.tokens.next()?;
+                    return Ok(Node::new(
+                        NodeKind::String { value: token.text.to_string(), interpolated: false },
+                        SourceLocation { start: token.start, end: token.end },
+                    ));
+                }
+            }
+        }
+
         // Check if we have a 'not' operator first
         if self.peek_kind() == Some(TokenKind::WordNot) {
             return self.parse_word_not_expr();

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -263,13 +263,46 @@ impl<'a> Parser<'a> {
                 ))
             }
 
-            TokenKind::Eval => self.parse_eval(),
+            TokenKind::Eval => {
+                let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+                if next_kind == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::String { value: token.text.to_string(), interpolated: false },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_eval()
+                }
+            }
 
-            TokenKind::Do => self.parse_do(),
+            TokenKind::Do => {
+                let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+                if next_kind == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::String { value: token.text.to_string(), interpolated: false },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_do()
+                }
+            }
 
             // Note: TokenKind::Sub is handled in the keyword-as-identifier case below
             // This allows 'sub' to be used as a hash key or identifier in expressions
-            TokenKind::Try => self.parse_try(),
+            TokenKind::Try => {
+                let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+                if next_kind == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::String { value: token.text.to_string(), interpolated: false },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_try()
+                }
+            }
 
             TokenKind::Less => {
                 // Could be diamond operator <> or <FILEHANDLE>
@@ -600,6 +633,33 @@ impl<'a> Parser<'a> {
             TokenKind::DoubleColon => {
                 // Absolute package path like ::Foo::Bar
                 self.parse_qualified_identifier()
+            }
+
+            // Statement-level keywords are normally parsed by statement handlers.
+            // In fat-comma key position (`keyword => value`), Perl autoquotes them.
+            TokenKind::If
+            | TokenKind::Elsif
+            | TokenKind::Else
+            | TokenKind::Unless
+            | TokenKind::While
+            | TokenKind::Until
+            | TokenKind::For
+            | TokenKind::Foreach
+            | TokenKind::Return
+            | TokenKind::Next
+            | TokenKind::Last
+            | TokenKind::Redo => {
+                let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+                if next_kind == Some(TokenKind::FatArrow) {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::String { value: token.text.to_string(), interpolated: false },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    let pos = self.current_position();
+                    Err(ParseError::unexpected("expression", format!("{:?}", token_kind), pos))
+                }
             }
 
             _ => {

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -136,6 +136,19 @@ fn test_block_vs_hash_context() {
 }
 
 #[test]
+fn test_keyword_autoquoting_before_fat_comma() {
+    let mut parser = Parser::new("my %h = ( if => 1, return => 2, for => 3 );");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse keyword fat-comma keys: {:?}", result.err());
+
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(string \"if\")"), "expected autoquoted if key, got: {}", sexp);
+    assert!(sexp.contains("(string \"return\")"), "expected autoquoted return key, got: {}", sexp);
+    assert!(sexp.contains("(string \"for\")"), "expected autoquoted for key, got: {}", sexp);
+}
+
+#[test]
 fn test_qualified_function_call() {
     let mut parser = Parser::new("return Data::Dumper::Dumper($param);");
     let result = parser.parse();


### PR DESCRIPTION
### Motivation

- Bare statement-level keywords (e.g. `if`, `return`, `for`) used as hash keys before the fat-comma (`=>`) were being treated as control keywords instead of auto-quoted bareword keys, causing parse errors.
- The parser must preserve normal keyword behavior in statement contexts while also supporting Perl's autoquoting behavior in fat-comma key position.

### Description

- Added an early check in `parse_assignment` to detect when the next token is `=>` and the current token is a statement-level keyword, and convert that keyword token into a `NodeKind::String` node (non-interpolated) so it becomes an autoquoted hash key (`crates/perl-parser-core/src/engine/parser/expressions/precedence.rs`).
- Updated `parse_primary` to allow `eval`, `do`, and `try` to parse normally, but to autoquote them when they appear immediately before `=>`, and added guarded handling for other statement-level keywords in `parse_primary` for `=>` key position (`crates/perl-parser-core/src/engine/parser/expressions/primary.rs`).
- Added a regression test `test_keyword_autoquoting_before_fat_comma` which asserts that `if => 1`, `return => 2`, and `for => 3` are parsed as string keys (`crates/perl-parser-core/src/engine/parser/tests.rs`).
- Changes touch `expressions/precedence.rs`, `expressions/primary.rs`, and `tests.rs` in the `perl-parser-core` crate.

### Testing

- Ran `cargo test -p perl-parser-core test_keyword_autoquoting_before_fat_comma -- --nocapture` and the new regression test passed.
- Ran `cargo test -p perl-parser-core test_block_vs_hash_context -- --nocapture` to ensure hash-vs-block behavior remained correct and it passed.
- Ran `cargo fmt --all` and repeated the targeted tests; formatting completed and the targeted parser tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21835acc48333966b1cee656d2dbc)