### PR TITLE
Fix regex validator brace quantifier false positives

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -91,7 +91,7 @@ impl RegexValidator {
         // Type: 0=other, 1=quantifier, 2=group_end
         let mut last_type = 0;
 
-        while let Some((_, ch)) = chars.next() {
+        while let Some((idx, ch)) = chars.next() {
             match ch {
                 '\\' => {
                     chars.next(); // skip escaped
@@ -123,17 +123,18 @@ impl RegexValidator {
                     }
                 }
                 '+' | '*' | '?' | '{' => {
+                    let is_quantifier =
+                        if ch == '{' { Self::is_brace_quantifier(pattern, idx) } else { true };
+
+                    if !is_quantifier {
+                        last_type = 0;
+                        continue;
+                    }
+
                     // If we just closed a group that had a quantifier inside,
                     // and now we see another quantifier, that's a nested quantifier!
                     if last_type == 2 {
-                        // Check if it's really a quantifier or literal {
-                        if ch == '{' {
-                            // Only count as quantifier if it looks like {n} or {n,m}
-                            // peek ahead... (simplified for now)
-                            return true; // Assume { is quantifier for safety heuristic
-                        } else {
-                            return true;
-                        }
+                        return true;
                     }
 
                     // Mark current group as having a quantifier
@@ -148,6 +149,33 @@ impl RegexValidator {
             }
         }
         false
+    }
+
+    fn is_brace_quantifier(pattern: &str, open_brace_idx: usize) -> bool {
+        let mut iter = pattern[open_brace_idx + 1..].chars().peekable();
+
+        // Perl quantifiers need at least a lower bound, e.g. {2}, {2,}, {2,5}
+        let mut lower_digits = 0;
+        while matches!(iter.peek(), Some(c) if c.is_ascii_digit()) {
+            iter.next();
+            lower_digits += 1;
+        }
+
+        if lower_digits == 0 {
+            return false;
+        }
+
+        match iter.peek() {
+            Some('}') => true,
+            Some(',') => {
+                iter.next();
+                while matches!(iter.peek(), Some(c) if c.is_ascii_digit()) {
+                    iter.next();
+                }
+                matches!(iter.peek(), Some('}'))
+            }
+            _ => false,
+        }
     }
 
     fn check_complexity(&self, pattern: &str, start_pos: usize) -> Result<(), RegexError> {

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -752,3 +752,13 @@ fn no_false_positive_lookaround_without_inner_quantifier() -> Result<(), Box<dyn
     assert!(!v.detect_nested_quantifiers("(?<!abc)+"));
     Ok(())
 }
+
+#[test]
+fn no_false_positive_literal_braces_after_quantified_group()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    // Literal braces after a quantified group should not be treated as {n,m} quantifier syntax
+    assert!(!v.detect_nested_quantifiers("(a+){foo}"));
+    v.validate("(a+){foo}", 0)?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The nested-quantifier heuristic treated any `{` after a group as a quantifier, causing false positives for literal brace text like `(a+){foo}`.
- The intent is to only consider `{` a quantifier when it matches real Perl quantifier forms (`{n}`, `{n,}`, `{n,m}`) to avoid misclassifying safe patterns.

### Description
- Update `RegexValidator::detect_nested_quantifiers` to inspect the byte index and call a new helper instead of assuming `{` is always a quantifier.
- Add `fn is_brace_quantifier(pattern: &str, open_brace_idx: usize) -> bool` which scans forward to verify `{n}`, `{n,}` or `{n,m}` forms and rejects `{...}` with non-numeric contents.
- Mark groups as having quantifiers only when the helper confirms a brace quantifier, preventing `(a+){foo}` from being flagged.
- Add a regression test `no_false_positive_literal_braces_after_quantified_group` in `crates/perl-regex/tests/comprehensive_unit_tests.rs` to ensure `(a+){foo}` is not reported and still validates.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-regex` which passed (`83` tests passed; `0` failed).
- Ran `cargo clippy -p perl-regex --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218413b9483339249546b1292231c)