### PR TITLE
Fix regex validator nested quantifier false positives

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -91,10 +91,22 @@ impl RegexValidator {
         // Type: 0=other, 1=quantifier, 2=group_end
         let mut last_type = 0;
 
-        while let Some((_, ch)) = chars.next() {
+        while let Some((idx, ch)) = chars.next() {
             match ch {
                 '\\' => {
                     chars.next(); // skip escaped
+                    last_type = 0;
+                }
+                '[' => {
+                    // Skip character class contents so quantifier-like characters
+                    // inside [...] are not treated as real quantifiers.
+                    while let Some((_, c)) = chars.next() {
+                        if c == '\\' {
+                            chars.next();
+                        } else if c == ']' {
+                            break;
+                        }
+                    }
                     last_type = 0;
                 }
                 '(' => {
@@ -123,24 +135,24 @@ impl RegexValidator {
                     }
                 }
                 '+' | '*' | '?' | '{' => {
+                    let is_quantifier =
+                        ch != '{' || Self::looks_like_brace_quantifier(pattern, idx);
+
                     // If we just closed a group that had a quantifier inside,
                     // and now we see another quantifier, that's a nested quantifier!
-                    if last_type == 2 {
-                        // Check if it's really a quantifier or literal {
-                        if ch == '{' {
-                            // Only count as quantifier if it looks like {n} or {n,m}
-                            // peek ahead... (simplified for now)
-                            return true; // Assume { is quantifier for safety heuristic
-                        } else {
-                            return true;
-                        }
+                    if is_quantifier && last_type == 2 {
+                        return true;
                     }
 
                     // Mark current group as having a quantifier
-                    if let Some(last) = group_stack.last_mut() {
-                        *last = true;
+                    if is_quantifier {
+                        if let Some(last) = group_stack.last_mut() {
+                            *last = true;
+                        }
+                        last_type = 1;
+                    } else {
+                        last_type = 0;
                     }
-                    last_type = 1;
                 }
                 _ => {
                     last_type = 0;
@@ -148,6 +160,42 @@ impl RegexValidator {
             }
         }
         false
+    }
+
+    fn looks_like_brace_quantifier(pattern: &str, open_brace_idx: usize) -> bool {
+        let bytes = pattern.as_bytes();
+        let mut i = open_brace_idx + 1;
+        let mut has_digits_before_comma = false;
+        let mut has_digits_after_comma = false;
+
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            has_digits_before_comma = true;
+            i += 1;
+        }
+
+        if i >= bytes.len() {
+            return false;
+        }
+
+        if bytes[i] == b'}' {
+            return has_digits_before_comma;
+        }
+
+        if bytes[i] != b',' {
+            return false;
+        }
+
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            has_digits_after_comma = true;
+            i += 1;
+        }
+
+        if i >= bytes.len() || bytes[i] != b'}' {
+            return false;
+        }
+
+        has_digits_before_comma || has_digits_after_comma
     }
 
     fn check_complexity(&self, pattern: &str, start_pos: usize) -> Result<(), RegexError> {

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -752,3 +752,21 @@ fn no_false_positive_lookaround_without_inner_quantifier() -> Result<(), Box<dyn
     assert!(!v.detect_nested_quantifiers("(?<!abc)+"));
     Ok(())
 }
+
+#[test]
+fn no_false_positive_brace_literals_after_quantified_group()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers("(a+){foo}"));
+    assert!(!v.detect_nested_quantifiers("(a+){,}"));
+    Ok(())
+}
+
+#[test]
+fn no_false_positive_quantifier_chars_inside_character_class()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers("([+*?{}])+"));
+    v.validate("([+*?{}])+", 0)?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Reduce spurious nested-quantifier detections where the validator treated literal brace tokens or characters inside character classes as quantifiers, which produced false positives for safe patterns.

### Description

- Update `RegexValidator::detect_nested_quantifiers` to skip character class contents (`[...]`) so literal `+*?{}` inside classes are ignored during scanning.
- Add `looks_like_brace_quantifier` helper to only treat a `{` as a quantifier when it matches real brace-quantifier shapes like `{n}`, `{n,}`, `{,m}`, or `{n,m}`.
- Change quantifier-handling logic to use the new helper and only mark groups as quantified when a real quantifier is detected.
- Add regression tests `no_false_positive_brace_literals_after_quantified_group` and `no_false_positive_quantifier_chars_inside_character_class` to `tests/comprehensive_unit_tests.rs` and run `cargo fmt` on changes.

### Testing

- Ran `cargo test -p perl-regex`, which passed all tests (84 passed; 0 failed).
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo clippy -p perl-regex --all-targets -- -D warnings`, which completed without errors for the crate.
- Ran `cargo clippy --workspace --all-targets`, which completed; unrelated pre-existing warnings were reported in other crates' tests but did not block this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218413b9483339249546b1292231c)