### PR TITLE
Fix regex validator false positives for literal braces

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -32,6 +32,45 @@ pub struct RegexValidator {
 }
 
 impl RegexValidator {
+    fn is_brace_quantifier(pattern: &str, open_brace_idx: usize) -> bool {
+        let Some(mut rest) = pattern.get(open_brace_idx + 1..) else {
+            return false;
+        };
+
+        let mut digits = 0;
+        while let Some(ch) = rest.chars().next() {
+            if ch.is_ascii_digit() {
+                digits += 1;
+                rest = &rest[ch.len_utf8()..];
+            } else {
+                break;
+            }
+        }
+
+        if digits == 0 {
+            return false;
+        }
+
+        if rest.starts_with('}') {
+            return true;
+        }
+
+        if !rest.starts_with(',') {
+            return false;
+        }
+
+        rest = &rest[1..];
+        while let Some(ch) = rest.chars().next() {
+            if ch.is_ascii_digit() {
+                rest = &rest[ch.len_utf8()..];
+            } else {
+                break;
+            }
+        }
+
+        rest.starts_with('}')
+    }
+
     /// Create a new validator with default safety limits
     pub fn new() -> Self {
         Self {
@@ -91,7 +130,7 @@ impl RegexValidator {
         // Type: 0=other, 1=quantifier, 2=group_end
         let mut last_type = 0;
 
-        while let Some((_, ch)) = chars.next() {
+        while let Some((idx, ch)) = chars.next() {
             match ch {
                 '\\' => {
                     chars.next(); // skip escaped
@@ -123,17 +162,16 @@ impl RegexValidator {
                     }
                 }
                 '+' | '*' | '?' | '{' => {
+                    let is_quantifier = ch != '{' || Self::is_brace_quantifier(pattern, idx);
+                    if !is_quantifier {
+                        last_type = 0;
+                        continue;
+                    }
+
                     // If we just closed a group that had a quantifier inside,
                     // and now we see another quantifier, that's a nested quantifier!
                     if last_type == 2 {
-                        // Check if it's really a quantifier or literal {
-                        if ch == '{' {
-                            // Only count as quantifier if it looks like {n} or {n,m}
-                            // peek ahead... (simplified for now)
-                            return true; // Assume { is quantifier for safety heuristic
-                        } else {
-                            return true;
-                        }
+                        return true;
                     }
 
                     // Mark current group as having a quantifier

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -288,6 +288,14 @@ fn validate_rejects_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn
     Ok(())
 }
 
+#[test]
+fn validate_allows_literal_braces_after_quantified_group() -> Result<(), Box<dyn std::error::Error>>
+{
+    let v = RegexValidator::new();
+    assert!(v.validate("(a+){foo}", 0).is_ok());
+    Ok(())
+}
+
 // ── detect_nested_quantifiers() direct tests ────────────────────────────
 
 #[test]
@@ -327,6 +335,13 @@ fn nested_quantifiers_escaped_paren_not_group() -> Result<(), Box<dyn std::error
 fn nested_quantifiers_non_capturing_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
     assert!(v.detect_nested_quantifiers("(?:a+)+"));
+    Ok(())
+}
+
+#[test]
+fn nested_quantifiers_literal_brace_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers("(a+){foo}"));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- The nested-quantifier heuristic treated every `{` as a quantifier and produced false positives for literal brace content (e.g. `(a+){foo}`), causing valid patterns to be rejected. 

### Description

- Add `RegexValidator::is_brace_quantifier` to recognize numeric brace-quantifier forms (`{n}`, `{n,}`, `{n,m}`) and distinguish them from literal brace text. 
- Update `detect_nested_quantifiers` to consult `is_brace_quantifier` before treating `{` as a quantifier so literal braces are ignored by the heuristic. 
- Preserve existing true-positive behavior for real brace quantifiers and other nested-quantifier cases. 
- Add regression tests in `crates/perl-regex/tests/comprehensive_unit_tests.rs` to verify `(a+){foo}` is accepted by both `validate()` and `detect_nested_quantifiers()`.

### Testing

- Ran `cargo fmt --all` to apply formatting, which completed successfully. 
- Ran `cargo test -p perl-regex`, and the regex test suite passed (all tests passed with no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218413b9483339249546b1292231c)