### PR TITLE
Fix regex validator false positives in character classes

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -387,6 +387,20 @@ fn test_branch_reset_complexity() {
 }
 
 #[test]
+fn test_regex_validator_no_false_positive_for_character_class_quantifier_chars() {
+    let code = r#"qr/([+*?])+/;"#;
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+
+    assert!(
+        result.is_ok(),
+        "Regex with quantifier chars inside character class should parse: {:?}",
+        result.err()
+    );
+    assert!(parser.errors().is_empty(), "Unexpected parser errors: {:?}", parser.errors());
+}
+
+#[test]
 fn test_catastrophic_backtracking_detection() {
     // Nested quantifiers (a+)+
     let code = r#"qr/(a+)+/;"#;

--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -122,6 +122,18 @@ impl RegexValidator {
                         }
                     }
                 }
+                '[' => {
+                    // Character classes may contain quantifier characters literally.
+                    // Skip class contents to avoid false positives like ([+*?])+.
+                    while let Some((_, c)) = chars.next() {
+                        if c == '\\' {
+                            chars.next();
+                        } else if c == ']' {
+                            break;
+                        }
+                    }
+                    last_type = 0;
+                }
                 '+' | '*' | '?' | '{' => {
                     // If we just closed a group that had a quantifier inside,
                     // and now we see another quantifier, that's a nested quantifier!

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -346,6 +346,24 @@ fn nested_quantifiers_group_without_outer_quantifier() -> Result<(), Box<dyn std
     Ok(())
 }
 
+#[test]
+fn no_false_positive_quantifier_chars_inside_character_class()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers(r"([+*?])+"));
+    v.validate(r"([+*?])+", 0)?;
+    Ok(())
+}
+
+#[test]
+fn no_false_positive_brace_quantifier_chars_inside_character_class()
+-> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+    assert!(!v.detect_nested_quantifiers(r"([{}])+"));
+    v.validate(r"([{}])+", 0)?;
+    Ok(())
+}
+
 // ── detects_code_execution() ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
### Motivation
- The nested-quantifier heuristic in `RegexValidator` produced false positives when quantifier-looking characters inside a character class (e.g. `[+*?]`, `{}`) were interpreted as inner quantifiers.  
- This caused safe patterns such as `([+*?])+` or `([{}])+` to be flagged as potential catastrophic backtracking.  

### Description
- Update `RegexValidator::detect_nested_quantifiers` to skip over character classes (`'[' ... ']'`) and handle escapes inside classes so literal quantifier characters do not count as inner quantifiers, by advancing the char iterator until the closing `']'` (with backslash escape handling) and resetting `last_type` to `0` when exiting the class.  
- Add regression unit tests in `crates/perl-regex/tests/comprehensive_unit_tests.rs` to assert that `detect_nested_quantifiers(r"([+*?])+")` and `detect_nested_quantifiers(r"([{}])+")` return `false` and that `validate` accepts these patterns.  
- Add an integration test in `crates/perl-parser-core/src/engine/parser/tests.rs` to ensure `qr/([+*?])+/;` is parsed without emitting validator errors.  
- Run `cargo fmt --all` for formatting consistency.  

### Testing
- Ran `cargo test -p perl-regex`, which completed with all regex crate tests passing (`84 passed; 0 failed`).  
- Ran `cargo test -p perl-parser-core test_regex_validator_no_false_positive_for_character_class_quantifier_chars`, which passed the new parser integration test (`1 passed; 0 failed`).  
- Ran `cargo fmt --all` to ensure formatting; no formatting issues remained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218413b9483339249546b1292231c)