### PR TITLE
docs: prep 0.11.0 release references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Release Prep**: Updated primary version references to `0.11.0` across user-facing docs and feature SoT catalogs.
+- **Documentation Snapshot Refresh**: Synced workspace member/family counts in `docs/README.md` with current workspace state.
+
 ## [0.10.0] - 2026-02-28
 
 A major release campaign spanning 60+ PRs (#845–#911) focused on build reliability,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.92%2B-orange.svg)](https://www.rust-lang.org/)
 [![Downloads](https://img.shields.io/crates/d/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
 
-A fast, native **Perl language server** and **parser toolkit** written in Rust — bringing modern IDE features to Perl. The workspace currently contains **over 115 Rust crates** and is in **Initial Public Alpha (v0.10.0)**.
+A fast, native **Perl language server** and **parser toolkit** written in Rust — bringing modern IDE features to Perl. The workspace currently contains **over 115 Rust crates** and is in **Initial Public Alpha (v0.11.0)**.
 
 > **Full LSP coverage** · **fast incremental parsing** · **zero runtime Perl dependency**
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -38,9 +38,9 @@ perl-lsp is a Language Server Protocol (LSP) implementation for Perl 5, offering
 
 ## Project Status
 
-**Latest Release**: v0.10.0
+**Latest Release**: v0.11.0
 **API Stability**: See [Stability Statement](./reference/stability.md)
-**Current Milestone**: v0.10.0 (Initial Public Alpha)
+**Current Milestone**: v0.11.0 (Initial Public Alpha)
 
 The project is actively developed with a focus on correctness, comprehensive testing, and thorough quality assurance. A formal Stability Contract is targeted for v0.15.0.
 

--- a/crates/perl-lsp-feature-contracts/features_sot.toml
+++ b/crates/perl-lsp-feature-contracts/features_sot.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.11.0"
 lsp_version = "3.18"
 compliance_percent = 65  # Auto-calculated in future
 

--- a/crates/perl-lsp/features_sot.toml
+++ b/crates/perl-lsp/features_sot.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.11.0"
 lsp_version = "3.18"
 compliance_percent = 65  # Auto-calculated in future
 

--- a/docs/EDITORS/COC_NEOVIM_SETUP.md
+++ b/docs/EDITORS/COC_NEOVIM_SETUP.md
@@ -79,7 +79,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ### Install coc.nvim

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -80,7 +80,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ---

--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -74,7 +74,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ---

--- a/docs/EDITORS/NEOVIM_SETUP.md
+++ b/docs/EDITORS/NEOVIM_SETUP.md
@@ -80,7 +80,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ### Install Required Plugins

--- a/docs/EDITORS/SUBLIME_SETUP.md
+++ b/docs/EDITORS/SUBLIME_SETUP.md
@@ -91,7 +91,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ---

--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -77,7 +77,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 # Perl LSP Documentation
 
-Documentation for Perl LSP v0.10.0 — a Language Server Protocol implementation for Perl.
+Documentation for Perl LSP v0.11.0 — a Language Server Protocol implementation for Perl.
 
 ## Repository snapshot
 
-- Workspace version: **v0.10.0**
-- Workspace members: **112 crates**
+- Workspace version: **v0.11.0**
+- Workspace members: **116 crates**
 - Family counts (from `crates/`):
   - `perl-module-*`: 13
-  - `perl-lsp-*`: 38
+  - `perl-lsp-*`: 41
   - `perl-lsp-feature-*`: 8
   - `perl-dap-*`: 9
   - `perl-ts-*`: 5
@@ -124,4 +124,4 @@ nix develop -c just status-check  # Verify metrics haven't drifted
 
 ---
 
-Version: v0.10.0
+Version: v0.11.0

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Perl Language Server (perl-lsp) v0.10.0 provides a high-performance Language Server Protocol implementation for Perl with ~100% syntax coverage.
+Perl Language Server (perl-lsp) v0.11.0 provides a high-performance Language Server Protocol implementation for Perl with ~100% syntax coverage.
 
 ## Install from crates.io
 
@@ -18,41 +18,41 @@ cargo install perl-lsp
 
 #### Linux x86_64
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.10.0-x86_64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.10.0-x86_64-unknown-linux-gnu/perl-lsp /usr/local/bin/
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.11.0/perl-lsp-0.11.0-x86_64-unknown-linux-gnu.tar.gz
+tar xzf perl-lsp-0.11.0-x86_64-unknown-linux-gnu.tar.gz
+sudo cp perl-lsp-0.11.0-x86_64-unknown-linux-gnu/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
 #### Linux aarch64
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-aarch64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.10.0-aarch64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.10.0-aarch64-unknown-linux-gnu/perl-lsp /usr/local/bin/
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.11.0/perl-lsp-0.11.0-aarch64-unknown-linux-gnu.tar.gz
+tar xzf perl-lsp-0.11.0-aarch64-unknown-linux-gnu.tar.gz
+sudo cp perl-lsp-0.11.0-aarch64-unknown-linux-gnu/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
 #### macOS x86_64
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.10.0-x86_64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.10.0-x86_64-apple-darwin/perl-lsp /usr/local/bin/
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.11.0/perl-lsp-0.11.0-x86_64-apple-darwin.tar.gz
+tar xzf perl-lsp-0.11.0-x86_64-apple-darwin.tar.gz
+sudo cp perl-lsp-0.11.0-x86_64-apple-darwin/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
 #### macOS aarch64 (Apple Silicon)
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-aarch64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.10.0-aarch64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.10.0-aarch64-apple-darwin/perl-lsp /usr/local/bin/
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.11.0/perl-lsp-0.11.0-aarch64-apple-darwin.tar.gz
+tar xzf perl-lsp-0.11.0-aarch64-apple-darwin.tar.gz
+sudo cp perl-lsp-0.11.0-aarch64-apple-darwin/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
 #### Windows x86_64
 ```powershell
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-pc-windows-msvc.zip
-Expand-Archive perl-lsp-0.10.0-x86_64-pc-windows-msvc.zip
-Copy-Item perl-lsp-0.10.0-x86_64-pc-windows-msvc\perl-lsp.exe C:\Program Files\perl-lsp\
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.11.0/perl-lsp-0.11.0-x86_64-pc-windows-msvc.zip
+Expand-Archive perl-lsp-0.11.0-x86_64-pc-windows-msvc.zip
+Copy-Item perl-lsp-0.11.0-x86_64-pc-windows-msvc\perl-lsp.exe C:\Program Files\perl-lsp\
 ```
 
 ### Build from Source
@@ -78,7 +78,7 @@ perl-lsp --version
 
 Expected output:
 ```
-perl-lsp 0.10.0
+perl-lsp 0.11.0
 ```
 
 ## Editor Configuration
@@ -183,7 +183,7 @@ export PATH="$PATH:$HOME/.local/bin"
 3. Look for error messages in your editor's LSP logs
 
 #### Slow performance
-1. Ensure you're using the latest version (v0.10.0)
+1. Ensure you're using the latest version (v0.11.0)
 2. Check if your workspace has very large Perl files (>100KB)
 3. Consider using `.perl-lspignore` to exclude unnecessary files
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -41,7 +41,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.11.0
 ```
 
 ## Quick Editor Setup


### PR DESCRIPTION
### Motivation
- Prepare user-facing documentation and feature catalogs for an upcoming `0.11.0` release by updating displayed release/version metadata. 
- Ensure documentation repository snapshots and single-source-of-truth (SoT) catalogs accurately reflect the current workspace state. 
- Provide an `Unreleased` changelog note documenting the doc/catalog release-prep work.

### Description
- Updated top-level user-facing release/version references from `0.10.0` to `0.11.0` in `README.md`, `book/src/introduction.md`, `docs/how-to/INSTALLATION.md`, `docs/tutorials/GETTING_STARTED.md`, and editor setup docs under `docs/EDITORS/*`. 
- Bumped the `[meta].version` field to `0.11.0` in the LSP feature SoT files `crates/perl-lsp/features_sot.toml` and `crates/perl-lsp-feature-contracts/features_sot.toml`. 
- Synced the repository snapshot values in `docs/README.md` (workspace version and family counts) to the current workspace state. 
- Added an `Unreleased` entry to `CHANGELOG.md` describing the release-prep and snapshot refresh.

### Testing
- Verified workspace member and crate counts with the `python` + `tomllib` snippet that reads `Cargo.toml` and `find crates` to confirm `members:116` and `dirs:121`, and validated family counts with `find`/`wc -l`; this check succeeded. 
- Searched for remaining `0.10.0` occurrences in the edited files using `rg -n "0\.10\.0" ...` to ensure replacements landed (historical changelog entries excluded); the search passed. 
- Inspected diffs for all changed files with `git diff -- <files>` and validated the intended changes; the diffs matched expectations. 
- Ran `git status --short` and `git show --name-only --pretty=format:'%h %s' -1` to list the modified files and validate the final change set; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21848ccd08333ab45f73b35eca9c1)