### PR TITLE
docs(changelog): add v0.10.1 release prep scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Prep (v0.10.1 candidate)
+
+#### Added
+- _No user-visible additions yet._
+
+#### Changed
+- _No user-visible changes yet._
+
+#### Fixed
+- _No user-visible fixes yet._
+
+#### Security
+- _No security advisories yet._
+
+#### Infrastructure
+- _Release candidate validation in progress._
+
 ## [0.10.0] - 2026-02-28
 
 A major release campaign spanning 60+ PRs (#845–#911) focused on build reliability,


### PR DESCRIPTION
### Motivation
- Prepare the `CHANGELOG.md` to collect and structure release notes for an upcoming `v0.10.1` candidate by adding a dedicated scaffold under the `Unreleased` section.

### Description
- Add a `Release Prep (v0.10.1 candidate)` section to `CHANGELOG.md` with standard subsections (`Added`, `Changed`, `Fixed`, `Security`, `Infrastructure`) containing placeholder entries to guide release-note curation, and commit the documentation change on branch `work`.

### Testing
- No automated tests were required for this documentation-only change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21848ccd08333ab45f73b35eca9c1)