### PR TITLE
Tighten crates.io dry-run patching to target crate dependency graph

### DIFF
--- a/scripts/cargo-package-workspace-dry-run.sh
+++ b/scripts/cargo-package-workspace-dry-run.sh
@@ -11,19 +11,52 @@ WORKSPACE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${WORKSPACE_ROOT}"
 
-PATCH_OUTPUT="$(
-  cargo metadata --format-version=1 --no-deps | python3 -c '
+NO_VERIFY="${CARGO_PACKAGE_NO_VERIFY:-0}"
+
+for crate in "$@"; do
+  PATCH_OUTPUT="$(
+    cargo metadata --format-version=1 --all-features | TARGET_CRATE="${crate}" python3 -c '
 import json
 import os
 import sys
 
 meta = json.load(sys.stdin)
+target_name = os.environ["TARGET_CRATE"]
 workspace_members = set(meta["workspace_members"])
 workspace_root = meta["workspace_root"]
+packages_by_id = {pkg["id"]: pkg for pkg in meta["packages"]}
 
-for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
-    if pkg["id"] not in workspace_members:
+resolve = meta.get("resolve") or {}
+nodes = resolve.get("nodes") or []
+
+deps_by_id = {
+    node["id"]: [dep["pkg"] for dep in node.get("deps", [])]
+    for node in nodes
+}
+
+start_ids = [
+    pkg_id
+    for pkg_id in workspace_members
+    if packages_by_id[pkg_id]["name"] == target_name
+]
+
+if not start_ids:
+    print(f"Unknown workspace crate: {target_name}", file=sys.stderr)
+    sys.exit(2)
+
+reachable = set()
+stack = list(start_ids)
+while stack:
+    pkg_id = stack.pop()
+    if pkg_id in reachable:
         continue
+    reachable.add(pkg_id)
+    stack.extend(deps_by_id.get(pkg_id, []))
+
+for pkg_id in sorted(reachable, key=lambda i: packages_by_id[i]["name"]):
+    if pkg_id not in workspace_members:
+        continue
+    pkg = packages_by_id[pkg_id]
     publish = pkg.get("publish")
     if publish is not None and len(publish) == 0:
         continue
@@ -31,13 +64,10 @@ for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
     rel_path = os.path.relpath(crate_dir, workspace_root)
     print("--config=patch.crates-io.{}.path=\"{}\"".format(pkg["name"], rel_path))
 '
-)"
+  )"
 
-mapfile -t PATCH_ARGS <<< "${PATCH_OUTPUT}"
+  mapfile -t PATCH_ARGS <<< "${PATCH_OUTPUT}"
 
-NO_VERIFY="${CARGO_PACKAGE_NO_VERIFY:-0}"
-
-for crate in "$@"; do
   echo "==> cargo package -p ${crate}"
   CMD=(cargo package -p "${crate}" "${PATCH_ARGS[@]}")
   if [[ "${NO_VERIFY}" == "1" ]]; then


### PR DESCRIPTION
### Motivation

- Reduce noisy `patch ... was not used in the crate graph` output produced when generating `patch.crates-io` entries for every publishable workspace crate.
- Ensure `cargo package` dry-runs include workspace dependencies that are actually reachable from the target crate, including optional-feature paths.
- Preserve existing `CARGO_PACKAGE_NO_VERIFY` behavior while making patching crate-specific.

### Description

- Reworked `scripts/cargo-package-workspace-dry-run.sh` to generate `patch.crates-io` overrides per target crate inside the loop instead of one global patch list.
- Use `cargo metadata --all-features` and a dependency-graph traversal (via embedded Python) to compute the reachable workspace crates for the given target crate and only emit patches for those crates.
- Keep `CARGO_PACKAGE_NO_VERIFY` support and apply the computed per-crate patch args to the invoked `cargo package` command.
- Fixed Python string/formatting issues and made the script robust to unknown workspace crates by exiting with an error when appropriate.

### Testing

- Ran `CARGO_PACKAGE_NO_VERIFY=1 scripts/cargo-package-workspace-dry-run.sh perl-lexer` and the packaging dry-run completed successfully (packaged output produced). — ✅
- Ran `bash scripts/prep-crates-io-launch.sh --core` which executed `cargo check` and per-crate `cargo package` dry-runs for the core set and completed successfully (no packaging failures). — ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2184f7874833396e109cda34beb5b)