### PR TITLE
chore(perl-lsp): decouple DAP bridge from crates.io packaging path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "perl-content-length-framing",
- "perl-dap",
  "perl-keywords",
  "perl-lsp-cancellation",
  "perl-lsp-code-actions",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -22,7 +22,6 @@ include = [
 ]
 
 [dependencies]
-perl-dap = { workspace = true, optional = true }
 perl-parser = { workspace = true, features = ["test-performance"] }
 perl-lsp-providers = { workspace = true, features = ["lsp-compat"] }
 perl-lsp-formatting = { workspace = true }
@@ -100,7 +99,7 @@ lsp-advanced = []  # Advanced LSP features (profiling, git integration, etc.)
 expose_lsp_test_api = ["perl-parser/expose_lsp_test_api"]  # Expose test helpers for integration tests
 lsp-extras = []  # Quarantined tests for unimplemented/aspirational LSP features
 strict-jsonrpc = []  # Strict JSON-RPC 2.0 protocol validation tests
-dap-phase1 = ["perl-dap"]  # DAP Phase 1: Bridge to Perl::LanguageServer (AC1-AC4)
+dap-phase1 = []  # Reserved for DAP bridge integration (kept empty for crates.io publishability)
 dap-phase3 = []  # DAP Phase 3: Non-regression tests (AC17)
 utf16-complete = ["perl-parser/utf16-complete"]  # Complete UTF-16 round-trip support
 

--- a/crates/perl-lsp/src/lib.rs
+++ b/crates/perl-lsp/src/lib.rs
@@ -283,7 +283,6 @@
 //! - `perl_parser`: Parsing engine and analysis infrastructure
 //! - `perl_lexer`: Context-aware Perl tokenizer
 //! - `perl_corpus`: Comprehensive test corpus
-//! - `perl_dap`: Debug Adapter Protocol implementation
 //!
 //! # Documentation
 //!
@@ -341,10 +340,6 @@ pub mod util;
 // Re-exports for key types
 pub use protocol::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 pub use server::LspServer;
-
-/// DAP bridge adapter re-export
-#[cfg(feature = "dap-phase1")]
-pub use perl_dap::BridgeAdapter;
 
 // =============================================================================
 // Internal compatibility re-exports (crate-internal, not API surface)


### PR DESCRIPTION
### Motivation
- Prepare the `perl-lsp` crate for crates.io packaging by removing direct coupling to an unpublished workspace crate so packaging metadata does not require unpublished dependencies.

### Description
- Removed the optional workspace dependency `perl-dap` from `crates/perl-lsp/Cargo.toml` so it is not included in the published dependency surface.
- Changed the `dap-phase1` feature to be an empty/reserved feature (`dap-phase1 = []`) to allow later opt-in without forcing registry resolution of `perl-dap`.
- Removed the `perl_dap::BridgeAdapter` public re-export and the `perl_dap` mention from the crate top-level docs in `crates/perl-lsp/src/lib.rs` to match the dependency change and avoid dangling feature-gated API.
- Updated the lockfile metadata and formatted code to reflect the dependency cleanup.

### Testing
- Ran `cargo check -p perl-lsp` which completed successfully.
- Ran `cargo check -p perl-lsp --features dap-phase1` which completed successfully to verify the reserved feature does not break local builds.
- Ran `cargo package -p perl-lsp --allow-dirty --no-verify` which still fails due to other unpublished workspace crates (e.g. `perl-keywords`), but the package is no longer blocked by `perl-dap` resolution.
- Ran `cargo fmt --all` to ensure formatting; the formatting command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2184f7874833396e109cda34beb5b)