### PR TITLE
Clean up VS Code marketplace documentation

### DIFF
--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -98,9 +98,9 @@ vsce login <publisher-id>
 npm run publish
 
 # Or with version bump
-vsce publish minor  # 0.5.0 -> 0.6.0
-vsce publish major  # 0.5.0 -> 0.9.x
-vsce publish 0.5.1  # Specific version
+vsce publish minor  # e.g. 0.11.0 -> 0.12.0
+vsce publish major  # e.g. 0.11.0 -> 1.0.0
+vsce publish 0.11.1 # Specific version
 ```
 
 ## Post-Publishing
@@ -116,7 +116,7 @@ vsce publish 0.5.1  # Specific version
    - Update CHANGELOG.md
 
 3. **Create GitHub Release**
-   - Tag the release: `git tag vscode-extension-v0.5.0`
+   - Tag the release: `git tag vscode-extension-v0.11.0`
    - Create release on GitHub
    - Attach the .vsix file
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,138 +1,74 @@
 # Perl Language Server
 
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/effortlesssteven.perl-lsp?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
+[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/effortlesssteven.perl-lsp?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
 [![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/effortlesssteven.perl-lsp)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
 
-Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
+Perl language support for VS Code, powered by the native `perl-lsp` server.
 
-## ✨ Features
+## Features
 
-### 🎯 Core Intelligence
-- **Go to Definition** - Jump to any symbol declaration
-- **Find References** - Find all usages across your project
-- **Hover Documentation** - Instant docs for functions and variables
-- **Auto-completion** - Smart suggestions for variables, functions, modules
-- **Signature Help** - Real-time parameter hints while typing
-- **Symbol Navigation** - Outline view and breadcrumbs
+- Go to Definition, Find References, Rename Symbol
+- Hover, Signature Help, Auto Completion, Document Symbols
+- Diagnostics for syntax and semantic issues
+- Semantic highlighting and inlay hints
+- Refactor commands (Extract Variable/Subroutine, Inline Variable)
+- Test runner command for `.t` and `.pl` files
+- Perl debug adapter integration (launch + attach)
+- Optional formatting integration (`perltidy`)
 
-### 🔧 Refactoring & Code Actions
-- **Rename** - Safe renaming across files
-- **Extract Variable** - Pull out expressions into variables
-- **Extract Subroutine** - Create functions from code blocks
-- **Convert Loops** - Transform between for/while/foreach
-- **Add Error Checking** - Insert error handling automatically
-- **Organize Imports** - Sort and clean use statements
-
-### 📊 Advanced Features
-- **Semantic Highlighting** - Context-aware syntax coloring
-- **Type Hierarchy** - Navigate inheritance with @ISA
-- **Call Hierarchy** - Trace function calls up and down
-- **CodeLens** - Inline reference counts
-- **Inlay Hints** - Type annotations in editor
-- **Document Highlights** - Highlight symbol occurrences
-
-### 🐛 Diagnostics & Quality
-- **Real-time Errors** - Syntax and semantic error detection
-- **Undefined Variables** - Catch typos under `use strict`
-- **Unused Variables** - Find dead code
-- **Missing Pragmas** - Suggest strict/warnings
-- **Code Folding** - Collapse code blocks
-- **Format on Type** - Auto-formatting as you code
-
-## 🚀 Performance
-
-- **1-150μs** typical parse times
-- **<50ms response time** for all operations
-- **100% Perl 5 coverage** including edge cases
-- **Sub-millisecond** position conversions (v0.8.0)
-
-## 📦 Installation
+## Installation
 
 Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp).
 
-The extension automatically downloads the correct language server for your platform:
-- Windows (x64, ARM64)
-- macOS (Intel, Apple Silicon)
-- Linux (x64, ARM64)
+On first activation the extension can auto-download a matching `perl-lsp` binary for your platform.
 
-Manual installation options:
-```bash
-# Homebrew (macOS/Linux)
-brew tap tree-sitter-perl/tap
-brew install perl-lsp
-
-# One-liner (Linux/macOS)
-curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
-
-# From source
-cargo install --git https://github.com/EffortlessMetrics/perl-lsp --bin perl-lsp
-```
-
-## ⚙️ Configuration
+## Quick configuration
 
 ```json
 {
-  // Auto-download server if not found
   "perl-lsp.autoDownload": true,
-
-  // Custom server path (optional)
-  "perl-lsp.serverPath": "/usr/local/bin/perl-lsp",
-
-  // Enable real-time syntax diagnostics
+  "perl-lsp.serverPath": "",
   "perl-lsp.enableDiagnostics": true,
-
-  // Enable semantic syntax highlighting
   "perl-lsp.enableSemanticTokens": true,
-
-  // Enable document formatting (requires perltidy)
-  "perl-lsp.enableFormatting": true,
-
-  // Additional library include paths
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
-
-  // LSP trace level for debugging
-  "perl-lsp.trace.server": "off"
+  "perl-lsp.enableFormatting": false,
+  "perl-lsp.includePaths": ["lib", "local/lib/perl5"]
 }
 ```
 
-## 🎯 Supported Perl Features
+## Common settings
 
-### Modern Perl (5.38+)
-- `class/method/field` keywords
-- `try/catch/finally` blocks  
-- `defer` blocks
-- Subroutine signatures
-- Type constraints
+- `perl-lsp.autoDownload`: Download server binary automatically if needed.
+- `perl-lsp.serverPath`: Absolute path to a local `perl-lsp` binary.
+- `perl-lsp.enableDiagnostics`: Enable parser + semantic diagnostics.
+- `perl-lsp.enableSemanticTokens`: Enable semantic token highlighting.
+- `perl-lsp.enableFormatting`: Enable formatting support (requires formatter tooling).
+- `perl-lsp.perltidyConfig`: Path to `.perltidyrc`.
+- `perl-lsp.includePaths`: Additional include paths for module resolution.
 
-### Complete Syntax Support
-- Regular expressions with any delimiter (`m!pattern!`, `s{}{}`)
-- Heredocs (all variants including indented)
-- Unicode identifiers (`my $café = 'coffee'`)
-- Postfix dereferencing (`$ref->@*`)
-- Smart match operator (`~~`)
-- Indirect object syntax
+## Commands
 
-### Built-in Functions
-Complete signatures for 150+ Perl built-ins with parameter documentation.
+- `Perl: Restart Perl Language Server`
+- `Perl: Show Server Version`
+- `Perl: Show Output Channel`
+- `Perl: Show Status Menu`
+- `Perl: Organize Use Statements`
+- `Perl: Run Tests in Current File`
+- `Perl Refactor: Extract Subroutine`
+- `Perl Refactor: Extract Variable`
+- `Perl Refactor: Inline Variable`
 
-## 🤝 Compatibility
+## Requirements
 
-Works with any LSP-compatible editor:
-- Visual Studio Code
-- VSCodium  
-- Cursor
-- Gitpod
-- GitHub Codespaces
-- Neovim (via nvim-lspconfig)
-- Emacs (via lsp-mode)
+- VS Code `1.88.0+`
+- Perl runtime available on PATH for running/debugging scripts
+- `perltidy` installed if formatting is enabled
 
-## 📚 Resources
+## Resources
 
-- [Documentation](https://github.com/EffortlessMetrics/perl-lsp#readme)
-- [Issue Tracker](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose)
-- [Changelog](https://github.com/EffortlessMetrics/perl-lsp/blob/master/CHANGELOG.md)
-- [Migration Guide](https://github.com/EffortlessMetrics/perl-lsp/blob/master/MIGRATION.md)
+- [Project repository](https://github.com/EffortlessMetrics/perl-lsp)
+- [Issue tracker](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose)
+- [Extension changelog](https://github.com/EffortlessMetrics/perl-lsp/blob/master/vscode-extension/CHANGELOG.md)
 
-## 📄 License
+## License
 
 MIT © Steven Zimmerman


### PR DESCRIPTION
### Motivation

- Make the VS Code extension documentation concise and marketplace-friendly to improve discoverability and reduce marketing noise.
- Replace stale publish examples and tag instructions in the publishing guide so they reflect the current release line.

### Description

- Rewrote `vscode-extension/README.md` to a compact, marketplace-focused README with a short feature list, quick configuration snippet, common settings, commands, requirements, and resource links.
- Updated `vscode-extension/PUBLISHING.md` to modernize `vsce publish` examples and the release tag example (now referencing `0.11.x`).
- Removed long-form marketing/feature deep-dives from the README to keep the package listing scannable and appropriate for marketplace viewers.
- Changes are limited to `vscode-extension/README.md` and `vscode-extension/PUBLISHING.md`.

### Testing

- Ran the extension TypeScript compile in the extension directory using `npm run compile` (which runs `tsc -p ./`) and it completed successfully.
- No other automated tests were required for documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21858be88833380a8a0b13616d325)