### PR TITLE
docs(readme): add repository development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ perl-dap
 cargo run -p perl-parser -- path/to/file.pl
 ```
 
+## Development Commands
+
+Use these commands when working inside this repository:
+
+```bash
+# Build key binaries/libraries
+cargo build -p perl-lsp --release
+cargo build -p perl-parser --release
+
+# Run focused tests
+cargo test -p perl-parser
+cargo test -p perl-lsp
+
+# Thread-constrained LSP tests (CI-like behavior)
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
+
+# Full local quality gate (recommended before push)
+nix develop -c just ci-gate
+```
+
 ## Published Crates
 
 | Crate | Purpose |


### PR DESCRIPTION
### Motivation
- Provide a convenient, discoverable set of local development commands in the README so contributors can quickly build and test common crates and run the local quality gate.

### Description
- Added a new `Development Commands` section to `README.md` documenting `cargo build` and `cargo test` examples for `perl-lsp` and `perl-parser`, the CI-like threaded test invocation `RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2`, and the recommended local gate `nix develop -c just ci-gate`.

### Testing
- Ran `git diff --check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2186d42f083338b5311fb7123b046)