### PR TITLE
docs: add Contributor Quick Gate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,30 @@ perl-dap
 cargo run -p perl-parser -- path/to/file.pl
 ```
 
+## Contributor Quick Gate
+
+Before opening a PR, run the same baseline checks used by local CI:
+
+```bash
+# format
+cargo fmt --all
+
+# lint (workspace)
+cargo clippy --workspace
+
+# tests (library targets)
+cargo test --workspace --lib
+
+# canonical local CI gate
+nix develop -c just ci-gate
+```
+
+If you want these checks to run automatically before each push, install the pre-push hook:
+
+```bash
+bash scripts/install-githooks.sh
+```
+
 ## Published Crates
 
 | Crate | Purpose |


### PR DESCRIPTION
### Motivation
- Provide a concise pre-PR checklist in the repository README so contributors can run the same baseline checks locally and reduce CI failures.

### Description
- Add a new `Contributor Quick Gate` section to `README.md` that documents the baseline commands `cargo fmt --all`, `cargo clippy --workspace`, `cargo test --workspace --lib`, `nix develop -c just ci-gate`, and the pre-push hook installation `bash scripts/install-githooks.sh`.

### Testing
- This is a docs-only change so no unit tests were required, and the change was validated by running `git diff -- README.md` and `nl -ba README.md | sed -n '168,220p'`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2186d42f083338b5311fb7123b046)