### PR TITLE
docs: clean up Diataxis labeling across documentation guides

### DIFF
--- a/docs/benchmarks/BENCHMARK_FRAMEWORK.md
+++ b/docs/benchmarks/BENCHMARK_FRAMEWORK.md
@@ -1,10 +1,10 @@
-# Benchmark Framework Documentation (*Diataxis: Reference* - Complete benchmarking system specification)
+# Benchmark Framework Documentation
 
-## Overview (*Diataxis: Explanation* - Understanding the benchmarking system)
+## Overview
 
 This document describes the comprehensive benchmarking framework for comparing C and Rust parser implementations. The framework provides statistical analysis, configurable performance gates, and detailed reporting capabilities.
 
-### Purpose and Design Goals (*Diataxis: Explanation* - Why this framework exists)
+### Purpose and Design Goals
 - **Performance Validation**: Ensure Rust implementation meets or exceeds C parser performance
 - **Regression Detection**: Automatically detect performance regressions during development
 - **Statistical Rigor**: Provide confidence intervals and significance testing for reliable comparisons
@@ -39,23 +39,23 @@ This document describes the comprehensive benchmarking framework for comparing C
    - **Memory estimation** for subprocess operations with size-based heuristics
    - **Comprehensive validation** with workload simulation testing
 
-6. **Corpus Comparison Infrastructure** (v0.8.8+) ⭐ **NEW** (**Diataxis: Reference**)
+6. **Corpus Comparison Infrastructure** (v0.8.8+) ⭐ **NEW**
    - **C vs V3 Scanner Comparison**: Direct benchmarking between legacy C scanner and V3 native parser
    - **Performance Optimization Validation**: Measure improvements from lexer optimizations (PR #102)
    - **Multi-implementation Analysis**: Compare performance characteristics across different parser versions
    - **Regression Detection**: Automated detection of performance degradation across parser implementations
 
-7. **LSP Performance Benchmarking (PR #140)** (v0.8.8+) (**Diataxis: Reference**)
+7. **LSP Performance Benchmarking (PR #140)** (v0.8.8+)
    - **LSP Behavioral Tests**: 1560s+ → 0.31s validation
    - **User Story Tests**: 1500s+ → 0.32s measurement
 
-8. **Substitution Operator Performance Validation (PR #158)** (v0.8.8+) ⭐ **NEW** (**Diataxis: Reference**)
+8. **Substitution Operator Performance Validation (PR #158)** (v0.8.8+) ⭐ **NEW**
    - **Zero Performance Impact**: Comprehensive substitution operator parsing with no measurable overhead
    - **<10µs Parsing Time**: Typical substitution operators (`s/old/new/g`) parse in under 10 microseconds
    - **Minimal Memory Overhead**: Reuses existing AST structures without additional memory allocation
    - **Regression Prevention**: Continuous monitoring ensures substitution parsing doesn't impact overall parser performance
 
-9. **Security-Performance Validation Framework (PR #153)** ⭐ **SECURITY-ENHANCED** (**Diataxis: Reference**)
+9. **Security-Performance Validation Framework (PR #153)** ⭐ **SECURITY-ENHANCED**
    - **Comprehensive Security Benchmarking**: UTF-16 position conversion security with zero performance regression
    - **Mutation Testing Integration**: Quality validation (87% score) with performance preservation verification
    - **Security Boundary Testing**: UTF-16 boundary validation benchmarks with overflow protection measurement
@@ -67,14 +67,14 @@ This document describes the comprehensive benchmarking framework for comparing C
    - **Enhanced Test Harness**: Real JSON-RPC protocol performance validation
    - **CI Reliability**: 100% pass rate validation
 
-8. **Traditional LSP Performance Benchmarking** (v0.8.8+) (**Diataxis: Reference**)
+8. **Traditional LSP Performance Benchmarking** (v0.8.8+)
    - **Workspace Symbol Search Optimization**: 99.5% performance improvement measurement
    - **Test Timeout Reduction**: Validation of 60s+ → 0.26s improvements
    - **Cooperative Yielding Validation**: Measure non-blocking behavior in symbol processing
    - **Memory Usage Profiling**: Track bounded processing and memory consumption limits
    - **Fast Mode Benchmarking**: Performance validation with LSP_TEST_FALLBACKS configuration
 
-9. **Dual Function Call Indexing Benchmarking** (v0.8.8+) ⭐ **NEW** (**Diataxis: Reference**)
+9. **Dual Function Call Indexing Benchmarking** (v0.8.8+) ⭐ **NEW**
    - **98% Reference Coverage Validation**: Measure comprehensive function call detection improvements
    - **Dual Indexing Performance**: Benchmark O(1) lookup performance for bare + qualified function names
    - **Unicode Processing Enhancement**: Atomic performance counter validation with emoji/character processing
@@ -82,13 +82,13 @@ This document describes the comprehensive benchmarking framework for comparing C
    - **Thread-Safe Indexing**: Benchmark concurrent workspace indexing with zero race conditions
    - **Memory Overhead Analysis**: Validate ~2x index memory usage vs. reference coverage trade-off
 
-## Security-Performance Validation Methodology (PR #153) (*Diataxis: Explanation* - Comprehensive security benchmarking)
+## Security-Performance Validation Methodology (PR #153)
 
 ### Overview
 
 PR #153 introduces a security-performance validation framework that ensures security enhancements maintain the performance achievements from PR #140. This methodology validates that security improvements introduce zero performance regression while providing comprehensive vulnerability protection.
 
-### Security-Performance Balance Validation (*Diataxis: Reference* - Validation specifications)
+### Security-Performance Balance Validation
 
 #### UTF-16 Position Conversion Security Benchmarking
 
@@ -142,7 +142,7 @@ cargo test -p perl-parser --test mutation_hardening_tests --release -- --nocaptu
 - **Coverage Analysis**: <5s for complete mutation score calculation
 - **Memory Efficiency**: <100MB additional memory for mutation testing infrastructure
 
-#### Performance Preservation (*Diataxis: Reference* - Performance regression prevention)
+#### Performance Preservation
 
 **Comprehensive Regression Prevention:**
 
@@ -158,7 +158,7 @@ cargo test -p perl-parser --test lsp_comprehensive_e2e_test
 # Target: 0.26s (maintained workspace improvement)
 ```
 
-### Security Benchmarking Framework (*Diataxis: How-to* - Implementing security benchmarks)
+### Security Benchmarking Framework
 
 #### Security Validation Tests
 
@@ -224,7 +224,7 @@ cargo xtask bench --security-enhanced --performance-regression-detection
 # 5. Zero regression tolerance: Any performance degradation fails validation
 ```
 
-### Performance Metrics Integration (*Diataxis: Reference* - Security-enhanced metrics)
+### Performance Metrics Integration
 
 **Enhanced Metrics Collection:**
 - **Security Validation Overhead**: Measure performance impact of UTF-16 security checks
@@ -239,7 +239,7 @@ cargo xtask bench --security-enhanced --performance-regression-detection
 - **Quality-Performance Balance**: Track 87% mutation score achievement with performance preservation
 - **Compliance Metrics**: Security compliance validation with performance impact measurement
 
-### Implementation Guidelines (*Diataxis: How-to* - Security-performance best practices)
+### Implementation Guidelines
 
 1. **Security-First Performance**: Always benchmark security enhancements for performance impact
 2. **Zero Regression Tolerance**: Security improvements must not degrade performance
@@ -274,7 +274,7 @@ echo '{"iterations": 200, "warmup_iterations": 20}' > benchmark_config.json
 cargo run -p tree-sitter-perl --bin ts_benchmark_parsers --features pure-rust
 ```
 
-#### LSP Test Performance Benchmarking (**Diataxis: How-to**)
+#### LSP Test Performance Benchmarking
 
 ```bash
 # Performance validation (PR #140)
@@ -294,7 +294,7 @@ echo "After PR #140: 0.31s behavioral tests"
 echo "Result: sub-second behavioral tests"
 ```
 
-#### Corpus Comparison Benchmarking ⭐ **NEW** (**Diataxis: How-to**)
+#### Corpus Comparison Benchmarking ⭐ **NEW**
 
 ```bash
 # Run V3 vs C scanner comparison
@@ -316,7 +316,7 @@ python3 scripts/generate_comparison.py \
 cargo run -p perl-lexer --example whitespace_benchmark
 cargo run -p perl-lexer --example operator_disambiguation_benchmark
 
-#### Dual Indexing Performance Benchmarking ⭐ **NEW** (**Diataxis: How-to**)
+#### Dual Indexing Performance Benchmarking ⭐ **NEW**
 
 ```bash
 # Benchmark dual function call indexing performance
@@ -444,7 +444,7 @@ The framework includes configurable performance gates that automatically detect 
 - **Status**: WARNING/FAIL for memory increases
 - **Action**: Warns on memory regressions
 
-### LSP Performance Gates (v0.8.8+) (**Diataxis: Reference**)
+### LSP Performance Gates (v0.8.8+)
 - **Test Timeout Threshold**: Validates 99.5% timeout reduction (60s+ → 0.26s)
 - **Workspace Symbol Search**: Validates bounded processing (MAX_PROCESS: 1000)
 - **Cooperative Yielding**: Validates non-blocking behavior (yield every 32 symbols)
@@ -568,7 +568,7 @@ Tests are automatically categorized by:
 - **Success rate**: >99% for valid Perl code
 - **Memory usage**: <1MB peak memory for typical files (measured with dual-mode tracking)
 
-### Lexer Optimization Targets (v0.8.8+) ⭐ **NEW** (**Diataxis: Reference**)
+### Lexer Optimization Targets (v0.8.8+) ⭐ **NEW**
 
 **Achieved Performance Improvements (PR #102):**
 - **Whitespace Processing**: 18.779% improvement through batch processing
@@ -583,13 +583,13 @@ Tests are automatically categorized by:
 - **Operator-Heavy Expressions**: 14-16% improvement in disambiguation
 - **Template/Interpolation Code**: 20-22% faster variable extraction
 
-### Unicode Processing Performance Instrumentation (v0.8.8+) ⭐ **NEW** (*Diataxis: Reference* - Unicode performance monitoring)
+### Unicode Processing Performance Instrumentation (v0.8.8+) ⭐ **NEW**
 
-#### Overview (*Diataxis: Explanation* - Understanding Unicode processing costs)
+#### Overview
 
 The v0.8.8+ release introduces comprehensive performance instrumentation for Unicode character processing in the lexer. This enables monitoring of Unicode-heavy codebases and optimization of character classification performance.
 
-#### Performance Counters (*Diataxis: Reference* - Atomic instrumentation API)
+#### Performance Counters
 
 The lexer maintains atomic performance counters for Unicode operations:
 
@@ -615,7 +615,7 @@ pub fn reset_unicode_stats() {
 }
 ```
 
-#### Instrumented Unicode Classification (*Diataxis: Reference* - Performance-monitored character classification)
+#### Instrumented Unicode Classification
 
 Each Unicode character classification is instrumented with performance tracking:
 
@@ -645,7 +645,7 @@ pub fn is_perl_identifier_start(ch: char) -> bool {
 }
 ```
 
-#### Benchmarking Unicode Performance (*Diataxis: How-to* - Measuring Unicode processing costs)
+#### Benchmarking Unicode Performance
 
 Use the instrumentation API to benchmark Unicode-heavy codebases:
 
@@ -678,7 +678,7 @@ my $𝓾𝓷𝓲𝓬𝓸𝓭𝓮_math = "fancy";
 }
 ```
 
-#### Performance Analysis Features (*Diataxis: Reference* - Unicode complexity analysis)
+#### Performance Analysis Features
 
 Enhanced Unicode analysis for comprehensive performance monitoring:
 
@@ -711,7 +711,7 @@ pub struct UnicodeStats {
 }
 ```
 
-#### Performance Targets (*Diataxis: Reference* - Unicode processing benchmarks)
+#### Performance Targets
 
 **Unicode Processing Performance Targets:**
 - **ASCII-Heavy Files**: <1μs per 1000 character checks
@@ -725,7 +725,7 @@ pub struct UnicodeStats {
 - Unicode timeout: <30s for any single file
 - Memory efficiency: <1MB additional overhead for Unicode stats
 
-#### Integration with LSP Testing (*Diataxis: How-to* - Unicode performance in LSP tests)
+#### Integration with LSP Testing
 
 The Unicode instrumentation integrates with LSP testing for performance validation:
 
@@ -912,7 +912,7 @@ cargo xtask compare --report  # Includes memory metrics in output
 - **Minimum Guarantees**: Ensures at least 0.1MB reported for tiny files
 - **Fallback Values**: Returns 0.5MB default for inaccessible files
 
-### LSP Performance Benchmarking (v0.8.8+) (**Diataxis: How-to Guide**)
+### LSP Performance Benchmarking (v0.8.8+)
 
 The framework now includes specialized LSP performance benchmarking to validate workspace optimization improvements:
 

--- a/docs/explanation/BUILTIN_FUNCTION_PARSING.md
+++ b/docs/explanation/BUILTIN_FUNCTION_PARSING.md
@@ -13,7 +13,7 @@ This guide covers the tree-sitter-perl parser's enhanced builtin function parsin
 - **Issue Reference**: #110
 - **Status**: Complete and Production Ready
 
-## The Problem (*Diataxis: Explanation*)
+## The Problem
 
 Perl's ambiguous syntax presents unique challenges when parsing constructs like `{}`. The same syntax can represent either an empty hash reference or an empty code block, depending on context:
 
@@ -26,7 +26,7 @@ Both expressions use identical `{}` syntax, but they have fundamentally differen
 - `map` expects a code block that transforms array elements
 - `ref` expects a hash reference to check the reference type
 
-## Solution Implementation (*Diataxis: How-to Guide*)
+## Solution Implementation
 
 ### Enhanced Parser Method
 
@@ -69,7 +69,7 @@ The enhanced parser recognizes specific builtin functions and applies appropriat
 }
 ```
 
-## Supported Functions (*Diataxis: Reference*)
+## Supported Functions
 
 ### Block-Expecting Functions
 
@@ -91,7 +91,7 @@ These functions treat `{}` as empty hash references:
 | `defined` | `defined {}` | `(call defined ((hash )))` |
 | `scalar` | `scalar {}` | `(call scalar ((hash )))` |
 
-## Examples (*Diataxis: Tutorial*)
+## Examples
 
 ### Before Enhancement
 
@@ -126,7 +126,7 @@ my @ordered = sort { $a cmp $b } @values;
 (call sort ((block (statements ...)) (variable @ values)))
 ```
 
-## Testing (*Diataxis: How-to Guide*)
+## Testing
 
 ### Running Tests
 
@@ -186,7 +186,7 @@ fn test_new_function_empty_block() {
 }
 ```
 
-## Benefits (*Diataxis: Explanation*)
+## Benefits
 
 ### Parser Accuracy Improvements
 
@@ -199,7 +199,7 @@ fn test_new_function_empty_block() {
 
 This enhancement contributes to the parser's ~100% Perl syntax coverage by handling one of Perl's most ambiguous constructs correctly.
 
-## Performance Impact (*Diataxis: Reference*)
+## Performance Impact
 
 The enhanced parsing logic has minimal performance impact:
 
@@ -208,7 +208,7 @@ The enhanced parsing logic has minimal performance impact:
 - **Memory**: No additional memory allocation required
 - **Compatibility**: Zero breaking changes to existing API
 
-## Edge Cases (*Diataxis: Reference*)
+## Edge Cases
 
 ### Supported Complex Cases
 
@@ -236,7 +236,7 @@ my $map_ref = \&map;
 $map_ref->({}, @array);   # ❌ Reference call loses context
 ```
 
-## Migration Notes (*Diataxis: How-to Guide*)
+## Migration Notes
 
 ### For Parser Users
 
@@ -267,7 +267,7 @@ match node.kind() {
 }
 ```
 
-## Implementation Details (*Diataxis: Explanation*)
+## Implementation Details
 
 ### Context-Aware Parsing
 

--- a/docs/explanation/CONDITIONAL_DOCS_COMPILATION_STRATEGY.md
+++ b/docs/explanation/CONDITIONAL_DOCS_COMPILATION_STRATEGY.md
@@ -1,6 +1,6 @@
 # Conditional Documentation Compilation Strategy
 
-*Diataxis: Explanation* - Performance-optimized documentation enforcement strategy for perl-parser crate.
+Performance-optimized documentation enforcement strategy for perl-parser crate.
 
 ## Overview
 

--- a/docs/explanation/ERROR_HANDLING_STRATEGY.md
+++ b/docs/explanation/ERROR_HANDLING_STRATEGY.md
@@ -1,4 +1,4 @@
-# Error Handling Strategy Guide (*Diataxis: Explanation*)
+# Error Handling Strategy Guide
 
 **Issue**: #178 (GitHub #204) - Eliminate Fragile unreachable!() Macros
 **Related**: [issue-178-spec.md](issue-178-spec.md), [ERROR_HANDLING_API_CONTRACTS.md](../reference/ERROR_HANDLING_API_CONTRACTS.md)

--- a/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
+++ b/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
@@ -1,4 +1,4 @@
-# ExecuteCommand Configuration and Troubleshooting Guide (*Diataxis: How-to Guide* - Problem-oriented executeCommand solutions)
+# ExecuteCommand Configuration and Troubleshooting Guide
 
 *Comprehensive guide for configuring, troubleshooting, and optimizing executeCommand functionality in Perl LSP server. This guide provides solutions for common problems and advanced configuration scenarios.*
 

--- a/docs/explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md
+++ b/docs/explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md
@@ -1,6 +1,6 @@
 # Parser Robustness Improvements - PR #160 Advanced Testing Infrastructure Integration
 
-*Diataxis: Explanation & Reference* - Comprehensive documentation of parser robustness enhancements and testing infrastructure integration implemented in PR #160 (SPEC-149).
+Comprehensive documentation of parser robustness enhancements and testing infrastructure integration implemented in PR #160 (SPEC-149).
 
 ## Overview
 

--- a/docs/explanation/SLASH_DISAMBIGUATION.md
+++ b/docs/explanation/SLASH_DISAMBIGUATION.md
@@ -11,7 +11,7 @@ Perl's use of delimiter characters for multiple purposes creates a context-sensi
 - Transliteration: `tr/abc/xyz/`
 - Quote-regex: `qr/pattern/`
 
-**Single-Quote Delimiters (`'`) (*Diataxis: Reference* - Supported delimiter variations)**:
+**Single-Quote Delimiters (`'`)**:
 - Substitution operator: `s'pattern'replacement'modifiers`
 - Transliteration operators: `y'from'to'modifiers`, `tr'from'to'modifiers`
 - Edge cases: Escaped quotes (`s'it\'s'it is'`), empty patterns (`s''replacement'`), empty replacements (`s'pattern''`)
@@ -75,7 +75,7 @@ The implementation correctly handles all edge cases from the reference document:
 1. **Division after identifier**: `x / 2` → Division
 2. **Regex after operator**: `=~ /foo/` → Regex
 3. **Mixed expressions**: `1/ /abc/` → Division then Regex
-4. **Substitution variants (*Diataxis: Reference* - Complete delimiter support)**: 
+4. **Substitution variants**:
    - Slash delimiters: `s/a/b/`, `tr/abc/xyz/`
    - Brace delimiters: `s{a}{b}`, `tr{from}{to}`
    - **Single-quote delimiters**: `s'a'b'`, `y'abc'xyz'`, `tr'from'to'`

--- a/docs/how-to/IMPORT_OPTIMIZER_GUIDE.md
+++ b/docs/how-to/IMPORT_OPTIMIZER_GUIDE.md
@@ -264,7 +264,7 @@ fn generate_import_fix_actions(&self, analysis: &ImportAnalysis) -> Vec<CodeActi
 
 Recent improvements address critical regression issues in bare import analysis:
 
-#### Regression Fix for Object-Oriented Modules (*Diataxis: Explanation* - Understanding the bare import logic)
+#### Regression Fix for Object-Oriented Modules
 
 The import optimizer now correctly distinguishes between:
 
@@ -279,7 +279,7 @@ The import optimizer now correctly distinguishes between:
    use strict;          # Pragma modules automatically excluded
    ```
 
-#### Technical Implementation (*Diataxis: Reference* - Bare import analysis algorithm)
+#### Technical Implementation
 
 ```rust
 // Enhanced logic for marking bare imports as unused
@@ -294,7 +294,7 @@ fn should_flag_bare_import_as_unused(&self, module: &str) -> bool {
 }
 ```
 
-#### Test Coverage for Regression Prevention (*Diataxis: Tutorial* - Testing bare import scenarios)
+#### Test Coverage for Regression Prevention
 
 The enhanced test suite includes specific coverage for regression prevention:
 

--- a/docs/how-to/INCREMENTAL_PARSING_GUIDE.md
+++ b/docs/how-to/INCREMENTAL_PARSING_GUIDE.md
@@ -114,7 +114,7 @@ println!("After edit: Reparsed={}, Reused={} (efficiency: {:.1}%)",
 // Production scenarios: Reused efficiency often reaches 96.8-99.7%
 ```
 
-## Statistical Validation Framework (**Diataxis: Explanation**)
+## Statistical Validation Framework
 
 The incremental parser includes a comprehensive statistical validation system for production reliability:
 
@@ -160,7 +160,7 @@ cargo test -p perl-parser incremental_edge_cases_test --features incremental
 - **Key Modules**: `textdoc.rs`, `position_mapper.rs`, `incremental_*.rs` modules
 - **NOT Internal Test Harnesses**: Avoid modifying `/crates/tree-sitter-perl-rs/` or other internal test code
 
-## Intelligent Cache Management (*Diataxis: Explanation*)
+## Intelligent Cache Management
 
 ### Symbol Priority System
 
@@ -177,7 +177,7 @@ pub enum SymbolPriority {
 }
 ```
 
-### Symbol Classification (*Diataxis: Reference*)
+### Symbol Classification
 
 **Critical Priority** - Essential for LSP functionality:
 - `NodeKind::Package` - Package declarations for namespace resolution
@@ -198,7 +198,7 @@ pub enum SymbolPriority {
 - `NodeKind::Number` / `NodeKind::String` - Literal values
 - `NodeKind::Binary` / `NodeKind::Unary` - Simple expressions
 
-### Cache Eviction Strategy (*Diataxis: Explanation*)
+### Cache Eviction Strategy
 
 When cache size exceeds the configured limit (`max_size`, default 1000 entries), the eviction algorithm follows these steps:
 
@@ -226,7 +226,7 @@ fn find_least_important_entry(&self) -> Option<u64> {
 }
 ```
 
-### Cache Configuration (*Diataxis: How-to Guide*)
+### Cache Configuration
 
 **Workload-Specific Cache Sizing**:
 
@@ -252,7 +252,7 @@ doc.subtree_cache.set_max_size(5000);
 
 *Memory usage varies based on AST complexity and symbol types cached*
 
-### Performance Impact (*Diataxis: Explanation*)
+### Performance Impact
 
 The intelligent cache eviction provides these benefits:
 

--- a/docs/how-to/LSP_ERROR_HANDLING_MONITORING_GUIDE.md
+++ b/docs/how-to/LSP_ERROR_HANDLING_MONITORING_GUIDE.md
@@ -1,4 +1,4 @@
-# LSP Error Handling and Monitoring How-To Guide (*Diataxis: How-to Guide*)
+# LSP Error Handling and Monitoring How-To Guide
 
 *Problem-oriented task instructions for using enhanced LSP error handling and CI monitoring capabilities implemented in Issue #144.*
 

--- a/docs/how-to/PERFORMANCE_PRESERVATION_GUIDE.md
+++ b/docs/how-to/PERFORMANCE_PRESERVATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Performance Preservation Guide - PR #160 Baseline Maintenance
 
-*Diataxis: Explanation & How-to Guide* - Understanding and maintaining revolutionary performance characteristics during quality infrastructure implementation.
+Understanding and maintaining revolutionary performance characteristics during quality infrastructure implementation.
 
 ## Overview
 

--- a/docs/how-to/THREADING_CONFIGURATION_GUIDE.md
+++ b/docs/how-to/THREADING_CONFIGURATION_GUIDE.md
@@ -1,4 +1,4 @@
-# Threading Configuration Guide (*Diataxis: Explanation* - Understanding adaptive threading and concurrency management)
+# Threading Configuration Guide
 
 > This guide follows the **[Diataxis framework](https://diataxis.fr/)** for comprehensive technical documentation:
 > - **Tutorial sections**: Hands-on learning with examples
@@ -6,7 +6,7 @@
 > - **Reference sections**: Complete technical specifications
 > - **Explanation sections**: Design concepts and architectural decisions
 
-## Architecture Overview (*Diataxis: Explanation* - Adaptive threading design)
+## Architecture Overview
 
 The LSP server implements sophisticated adaptive threading configuration that automatically scales timeouts and concurrency based on available system resources and environment constraints. This ensures reliable operation across diverse execution environments, from single-core CI runners to high-end development workstations.
 
@@ -29,7 +29,7 @@ The LSP server implements sophisticated adaptive threading configuration that au
 └─────────────────────────────────────────────────────────┘
 ```
 
-## Core Implementation (*Diataxis: Reference* - Technical specifications)
+## Core Implementation
 
 ### Thread Detection and Scaling
 
@@ -52,7 +52,7 @@ pub fn max_concurrent_threads() -> usize {
 
 The adaptive timeout system uses multiple strategies based on the PR #140 revolutionary performance improvements:
 
-#### LSP Harness Adaptive Timeout (*Diataxis: Reference* - Fine-grained timeout control)
+#### LSP Harness Adaptive Timeout
 
 ```rust
 /// Get adaptive timeout based on RUST_TEST_THREADS environment variable
@@ -71,7 +71,7 @@ fn get_adaptive_timeout(&self) -> Duration {
 }
 ```
 
-#### Comprehensive Adaptive Timeout (*Diataxis: Reference* - Full test suite timeout scaling)
+#### Comprehensive Adaptive Timeout
 
 ```rust
 /// Get adaptive timeout based on thread constraints
@@ -131,7 +131,7 @@ pub fn adaptive_sleep_ms(base_ms: u64) -> Duration {
 }
 ```
 
-#### Enhanced Idle Detection (*Diataxis: Reference* - Optimized wait cycles)
+#### Enhanced Idle Detection
 
 ```rust
 /// Optimized idle detection with shorter cycles
@@ -159,9 +159,9 @@ pub fn wait_for_idle_optimized(&mut self, timeout: Duration) -> Result<(), Strin
 }
 ```
 
-## Environment Configuration (*Diataxis: How-to Guide* - Setting up different testing environments)
+## Environment Configuration
 
-### CI/CD Environment Setup (*Diataxis: Tutorial* - GitHub Actions configuration)
+### CI/CD Environment Setup
 
 ```yaml
 # .github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
       timeout-minutes: 15
 ```
 
-### Local Development Setup (*Diataxis: How-to Guide* - Development environment configuration)
+### Local Development Setup
 
 ```bash
 # High-performance workstation (default)
@@ -198,7 +198,7 @@ RUST_TEST_THREADS=1 cargo test -p perl-lsp --test specific_test -- --nocapture
 LSP_TEST_TIMEOUT_MS=30000 cargo test -p perl-lsp  # Force 30-second timeouts
 ```
 
-### Docker Container Configuration (*Diataxis: How-to Guide* - Containerized testing)
+### Docker Container Configuration
 
 ```dockerfile
 # Dockerfile for constrained testing
@@ -213,9 +213,9 @@ ENV LSP_TEST_TIMEOUT_MS=20000
 RUN cargo test -p perl-lsp
 ```
 
-## Threading Configuration Reference (*Diataxis: Reference* - Complete configuration matrix)
+## Threading Configuration Reference
 
-### Performance Improvements (*Diataxis: Reference* - PR #140 performance gains)
+### Performance Improvements
 
 #### Before vs. After Performance Matrix
 
@@ -235,7 +235,7 @@ RUN cargo test -p perl-lsp
 | **Light Constraint** | 5-8 | 200ms | 7.5s | 1.5x | 200ms cycles | Modern development machines |
 | **Full Workstation** | >8 | 200ms | 5s | 1x | 200ms cycles | High-performance development |
 
-### Environment Variables (*Diataxis: Reference* - Configuration options)
+### Environment Variables
 
 ```bash
 # Threading Configuration
@@ -253,14 +253,14 @@ RUST_LOG=debug               # Enable debug logging for timeout analysis
 LSP_TEST_FALLBACKS=1         # Enable fast testing mode (75% timeout reduction)
 ```
 
-### Thread Detection Logic (*Diataxis: Reference* - Detection priority order)
+### Thread Detection Logic
 
 1. **RUST_TEST_THREADS**: Explicit environment variable (highest priority)
 2. **System Parallelism**: `std::thread::available_parallelism()` hardware detection
 3. **Fallback Default**: Conservative default of 8 threads
 4. **Minimum Enforcement**: Ensures at least 1 thread (`max(1)`)
 
-## Performance Impact Analysis (*Diataxis: Explanation* - Benchmarking and optimization results)
+## Performance Impact Analysis
 
 ### Before Adaptive Threading
 
@@ -282,7 +282,7 @@ CI Environment Improvements:
 - Reliability: 100% test pass rate
 ```
 
-### Performance Characteristics (*Diataxis: Reference* - Post-PR #140 benchmark data)
+### Performance Characteristics
 
 #### Performance Metrics
 
@@ -317,9 +317,9 @@ Workspace integration tests   | 60s+      | 0.26s
 - **Enhanced Test Harness**: Mock responses and graceful degradation
 - **Thread-Aware Sleep Scaling**: Sophisticated concurrency management
 
-## Troubleshooting (*Diataxis: How-to Guide* - Common issues and solutions)
+## Troubleshooting
 
-### Common Threading Issues (*Diataxis: How-to Guide* - Debugging guide)
+### Common Threading Issues
 
 #### Timeout Failures in CI
 
@@ -360,7 +360,7 @@ for threads in 1 2 4 8; do
 done
 ```
 
-## Integration with LSP Features (*Diataxis: Explanation* - How threading affects LSP functionality)
+## Integration with LSP Features
 
 ### Thread-Safe Components
 
@@ -371,7 +371,7 @@ All LSP providers are designed to be thread-safe and benefit from adaptive threa
 - **DiagnosticsProvider**: Concurrent error checking with bounded execution time
 - **WorkspaceSymbolProvider**: Thread-aware symbol indexing and search
 
-### Concurrency Patterns (*Diataxis: Reference* - Thread-safe implementation patterns)
+### Concurrency Patterns
 
 ```rust
 // Thread-safe provider pattern
@@ -404,7 +404,7 @@ impl ThreadSafeProvider {
 }
 ```
 
-## Future Enhancements (*Diataxis: Explanation* - Roadmap and planned improvements)
+## Future Enhancements
 
 ### Planned Threading Improvements
 
@@ -420,7 +420,7 @@ impl ThreadSafeProvider {
 - **Memory Efficiency**: Scale memory usage linearly with thread count
 - **Latency Optimization**: <1ms LSP response times with adaptive threading
 
-## Best Practices (*Diataxis: How-to Guide* - Recommended patterns and practices)
+## Best Practices
 
 ### For Library Users
 

--- a/docs/how-to/WORKSPACE_REFACTORING_GUIDE.md
+++ b/docs/how-to/WORKSPACE_REFACTORING_GUIDE.md
@@ -6,14 +6,14 @@ The tree-sitter-perl project provides comprehensive workspace refactoring capabi
 
 ## Table of Contents
 
-1. [Getting Started](#getting-started) (**Diataxis: Tutorial**)
-2. [Core Operations](#core-operations) (**Diataxis: How-to**)
-3. [API Reference](#api-reference) (**Diataxis: Reference**)
-4. [Architecture](#architecture) (**Diataxis: Explanation**)
+1. [Getting Started](#getting-started)
+2. [Core Operations](#core-operations)
+3. [API Reference](#api-reference)
+4. [Architecture](#architecture)
 5. [Contributing](#contributing)
 6. [Troubleshooting](#troubleshooting)
 
-## Getting Started (**Diataxis: Tutorial**)
+## Getting Started
 
 ### Prerequisites
 
@@ -64,7 +64,7 @@ for file_edit in result.file_edits {
 }
 ```
 
-## Core Operations (**Diataxis: How-to**)
+## Core Operations
 
 ### Symbol Renaming
 
@@ -235,7 +235,7 @@ let result = refactor.inline_variable(
 - Handles complex initializer expressions
 - Removes original variable declaration
 
-## API Reference (**Diataxis: Reference**)
+## API Reference
 
 ### WorkspaceRefactor
 
@@ -332,7 +332,7 @@ pub enum RefactorError {
 }
 ```
 
-## Architecture (**Diataxis: Explanation**)
+## Architecture
 
 ### Design Principles
 

--- a/docs/reference/API_DOCUMENTATION_STANDARDS.md
+++ b/docs/reference/API_DOCUMENTATION_STANDARDS.md
@@ -1,6 +1,6 @@
 # API Documentation Standards - perl-parser crate
 
-*Diataxis: How-to Guide* - Comprehensive API documentation requirements for production-quality perl-parser crate.
+Comprehensive API documentation requirements for production-quality perl-parser crate.
 
 ## Overview
 

--- a/docs/reference/ARCHITECTURE_OVERVIEW.md
+++ b/docs/reference/ARCHITECTURE_OVERVIEW.md
@@ -36,7 +36,7 @@
 
 ## Workspace Configuration Strategy (v0.8.8+)
 
-### Exclusion Architecture (**Diataxis: Explanation** - Design decisions)
+### Exclusion Architecture
 
 The workspace uses a **production-focused exclusion strategy** to ensure reliable builds:
 
@@ -69,7 +69,7 @@ See [WORKSPACE_TEST_REPORT.md](../WORKSPACE_TEST_REPORT.md) for current workspac
 - Tree-sitter compatible node types
 - Position tracking for all nodes
 
-### 3. Incremental Parsing (**Diataxis: Explanation**)
+### 3. Incremental Parsing
 - **IncrementalParserV2**: Advanced incremental parser with intelligent node reuse
 - **Statistical Validation**: Comprehensive performance analysis framework
   - Performance metrics: 65µs average (Excellent), 205µs moderate (Very Good), 538µs large (Good)
@@ -255,7 +255,7 @@ See `HEREDOC_IMPLEMENTATION.md` for full details.
 
 See `docs/reference/EDGE_CASES.md` for comprehensive documentation.
 
-## Thread-Safety Architecture (**Diataxis: Explanation**)
+## Thread-Safety Architecture
 
 ### Thread-Safety Design Principles
 
@@ -263,7 +263,7 @@ The tree-sitter-perl architecture implements comprehensive thread-safety through
 
 #### Core Thread-Safety Patterns
 
-1. **Immutable Provider Pattern** (**Diataxis: Reference**)
+1. **Immutable Provider Pattern**
    ```rust
    // Thread-safe provider with immutable data
    pub struct SemanticTokensProvider {
@@ -280,7 +280,7 @@ The tree-sitter-perl architecture implements comprehensive thread-safety through
    }
    ```
 
-2. **Local State Collector Pattern** (**Diataxis: Reference**)
+2. **Local State Collector Pattern**
    ```rust
    // Each operation creates fresh local state
    struct TokenCollector<'a> {
@@ -298,7 +298,7 @@ The tree-sitter-perl architecture implements comprehensive thread-safety through
    }
    ```
 
-3. **Arc-Based Node Sharing** (**Diataxis: Reference**)
+3. **Arc-Based Node Sharing**
    ```rust
    // AST nodes use Arc for safe concurrent access
    pub struct Node {
@@ -322,7 +322,7 @@ The tree-sitter-perl architecture implements comprehensive thread-safety through
 - **Efficient cleanup**: Local state automatically dropped after operation
 - **No locks required**: Immutable data eliminates need for synchronization
 
-#### Thread-Safety Validation (**Diataxis: How-to**)
+#### Thread-Safety Validation
 
 The architecture includes comprehensive thread-safety testing:
 
@@ -345,7 +345,7 @@ fn test_concurrent_semantic_token_access() {
 }
 ```
 
-#### Integration with LSP Server (**Diataxis: How-to**)
+#### Integration with LSP Server
 
 The thread-safe design enables high-performance LSP operations:
 
@@ -364,7 +364,7 @@ fn handle_semantic_tokens_full(&self, params: SemanticTokensParams) -> Result<Re
 }
 ```
 
-#### Benefits of Thread-Safe Architecture (**Diataxis: Explanation**)
+#### Benefits of Thread-Safe Architecture
 
 1. **Eliminated Race Conditions**: No shared mutable state prevents data races
 2. **Exceptional Performance**: Local state management avoids synchronization overhead  
@@ -373,7 +373,7 @@ fn handle_semantic_tokens_full(&self, params: SemanticTokensParams) -> Result<Re
 5. **Consistency**: Identical results guaranteed for same inputs across threads
 6. **Maintainability**: Clear ownership and lifetime semantics reduce complexity
 
-#### Future Thread-Safety Extensions (**Diataxis: Reference**)
+#### Future Thread-Safety Extensions
 
 The thread-safe patterns established for semantic tokens provide a template for future LSP features:
 
@@ -384,7 +384,7 @@ The thread-safe patterns established for semantic tokens provide a template for 
 
 This architecture ensures all LSP features can achieve similar performance and safety characteristics as the semantic token provider.
 
-### Adaptive Timeout System Design (PR #140) (**Diataxis: Explanation** - Testing architecture)
+### Adaptive Timeout System Design (PR #140)
 
 PR #140 introduces an adaptive timeout system that delivers significant performance improvements:
 

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -1,8 +1,8 @@
-# Commands Reference (*Diataxis: Reference* - Complete command specifications)
+# Commands Reference
 
 *This reference provides all available commands for building, testing, and using the tree-sitter-perl ecosystem.*
 
-## Installation Commands (*Diataxis: How-to Guide* - Step-by-step installation)
+## Installation Commands
 
 ### LSP Server
 ```bash
@@ -36,7 +36,7 @@ cargo install --path crates/perl-parser --bin perl-dap
 perl-dap --stdio  # Standard DAP transport
 ```
 
-## Build Commands (*Diataxis: How-to Guide* - Development builds)
+## Build Commands
 
 ### Published Crates
 ```bash
@@ -93,7 +93,7 @@ cargo check  # Should build cleanly without system dependencies
 - **Production Focus**: Tests only published crate APIs
 - **Platform Independence**: Works without tree-sitter C toolchain
 
-### xtask Exclusion Strategy (*Diataxis: Explanation* - Design decisions)
+### xtask Exclusion Strategy
 The xtask crate is excluded from the workspace to maintain clean builds while preserving advanced functionality:
 - **Why excluded**: xtask depends on excluded crates (tree-sitter-perl-rs with libclang)
 - **How to use**: Run from xtask directory: `cd xtask && cargo run <command>`
@@ -162,7 +162,7 @@ cargo test -p perl-parser workspace_index workspace_rename
 cargo test -p perl-parser tdd_basic
 ```
 
-### WSL-Safe Local Gate (*Diataxis: How-to Guide* - Resource-constrained testing)
+### WSL-Safe Local Gate
 
 The local gate script provides a reliable test workflow for WSL, containers, and resource-constrained environments by controlling parallelism to prevent OOM crashes.
 
@@ -201,7 +201,7 @@ CARGO_BUILD_JOBS=4 RUST_TEST_THREADS=2 ./scripts/gate-local.sh
 | `RUST_TEST_THREADS` | 1 | Test parallelism (1 = serial) |
 | `GATE_RELEASE` | unset | Set to "1" for release builds |
 
-### Performance Testing (PR #140) (*Diataxis: How-to Guide* - Test reliability)
+### Performance Testing (PR #140)
 
 PR #140 delivers significant performance optimizations for test speed and reliability:
 
@@ -233,7 +233,7 @@ LSP_TEST_ECHO_STDERR=1 RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --nocapture
 RUST_LOG=debug cargo test -p perl-lsp -- --nocapture    # Monitor timeout scaling
 ```
 
-#### Performance Matrix (*Diataxis: Reference* - PR #140 achievements)
+#### Performance Matrix
 
 | Test Suite | Before PR #140 | After PR #140 |
 |------------|----------------|----------------|
@@ -243,7 +243,7 @@ RUST_LOG=debug cargo test -p perl-lsp -- --nocapture    # Monitor timeout scalin
 | **lsp_golden_tests** | 45s | 2.1s |
 | **Overall test suite** | 60s+ | <10s |
 
-#### Enhanced Thread Configuration Reference (*Diataxis: Reference* - Multi-tier timeout scaling)
+#### Enhanced Thread Configuration Reference
 
 | Environment | Thread Count | LSP Harness | Comprehensive | Idle Detection | Use Case |
 |------------|-------------|-------------|--------------|----------------|----------|
@@ -252,7 +252,7 @@ RUST_LOG=debug cargo test -p perl-lsp -- --nocapture    # Monitor timeout scalin
 | **Light Constraint** | 5-8 | 200ms | 7.5s | 200ms cycles | Modern development machines |
 | **Full Workstation** | >8 | 200ms | 5s | 200ms cycles | High-performance development |
 
-#### Thread-Aware Test Examples (*Diataxis: Tutorial* - Common testing patterns)
+#### Thread-Aware Test Examples
 
 ```bash
 # GitHub Actions CI configuration
@@ -292,7 +292,7 @@ cargo run -p perl-parser --example lsp_capabilities
 
 ## LSP Development Commands
 
-### Core LSP Testing (*Diataxis: How-to Guide* - Development workflows)
+### Core LSP Testing
 
 ```bash
 # Run LSP tests with performance optimizations (v0.8.8+)
@@ -332,7 +332,7 @@ PERL_LSP_INCREMENTAL=1 perl-lsp --stdio < test_requests.jsonrpc
 perl-lsp --stdio < test_requests.jsonrpc
 ```
 
-### LSP Testing Environment Variables (*Diataxis: Reference* - Configuration options)
+### LSP Testing Environment Variables
 
 **RUST_TEST_THREADS** (**Enhanced in PR #140**):
 ```bash
@@ -389,13 +389,13 @@ perl-lsp --stdio
 # - Enterprise-grade workspace refactoring support
 ```
 
-### LSP executeCommand Integration ⭐ **NEW: Issue #145** (*Diataxis: How-to Guide* - Execute command usage)
+### LSP executeCommand Integration ⭐ **NEW: Issue #145**
 
 The LSP server now supports comprehensive `workspace/executeCommand` functionality with integrated perlcritic analysis and advanced code actions.
 
 #### perl.runCritic Command Usage ⭐ **NEW: Issue #145**
 
-**Dual Analyzer Strategy Overview** (*Diataxis: Explanation* - Architecture design):
+**Dual Analyzer Strategy Overview**:
 
 The `perl.runCritic` command implements a sophisticated dual analyzer strategy ensuring 100% availability:
 
@@ -404,7 +404,7 @@ The `perl.runCritic` command implements a sophisticated dual analyzer strategy e
 3. **Seamless Transition**: Automatic fallback with no user intervention required
 4. **Performance Target**: <2s execution time for typical Perl files
 
-**Basic Usage** (*Diataxis: Tutorial* - Getting started with code quality analysis):
+**Basic Usage**:
 ```bash
 # Test perl.runCritic command integration
 cargo test -p perl-lsp --test lsp_behavioral_tests -- test_execute_command_perlcritic
@@ -422,7 +422,7 @@ cargo test -p perl-parser --test execute_command_tests -- test_execute_command_r
 cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_missing_file
 ```
 
-**Advanced Configuration** (*Diataxis: How-to Guide* - Optimizing perlcritic integration):
+**Advanced Configuration**:
 
 **External Perlcritic Setup**:
 ```bash
@@ -439,7 +439,7 @@ perlcritic --version                    # Check version
 cargo test -p perl-parser --test execute_command_tests -- test_command_exists_behavior
 ```
 
-**Built-in Analyzer Capabilities** (*Diataxis: Reference* - Policy coverage):
+**Built-in Analyzer Capabilities**:
 ```rust
 // Built-in analyzer policies (always available)
 - RequireUseStrict: "Missing 'use strict' pragma"
@@ -449,7 +449,7 @@ cargo test -p perl-parser --test execute_command_tests -- test_command_exists_be
 - Parse-error resilient: Continues analysis even with syntax errors
 ```
 
-**Performance Specifications** (*Diataxis: Reference* - Timing requirements):
+**Performance Specifications**:
 | Analyzer Type | File Size | Analysis Time | Policy Coverage | Availability |
 |---------------|-----------|---------------|-----------------|--------------|
 | External perlcritic | <10KB | <0.5s | 150+ policies | Requires installation |
@@ -457,7 +457,7 @@ cargo test -p perl-parser --test execute_command_tests -- test_command_exists_be
 | Built-in analyzer | <10KB | <0.1s | Core policies | 100% availability |
 | Built-in analyzer | <100KB | <0.3s | Core policies | Parse-error resilient |
 
-**Troubleshooting** (*Diataxis: How-to Guide* - Common issues and solutions):
+**Troubleshooting**:
 
 **Issue: External perlcritic not found**
 ```bash
@@ -489,7 +489,7 @@ perl -c your_file.pl                   # Check syntax separately
 cargo test -p perl-parser --test execute_command_tests # Built-in handles syntax errors
 ```
 
-**Integration with LSP Diagnostics** (*Diataxis: How-to Guide* - Diagnostic workflow):
+**Integration with LSP Diagnostics**:
 ```bash
 # Test diagnostic integration with executeCommand
 cargo test -p perl-lsp --test lsp_behavioral_tests -- test_execute_command_perlcritic
@@ -501,7 +501,7 @@ cargo test -p perl-lsp --test lsp_comprehensive_e2e_test -- test_execute_command
 cargo test -p perl-lsp --test lsp_performance_tests -- test_execute_command_latency
 ```
 
-**LSP Protocol Integration** (*Diataxis: Reference* - executeCommand specifications):
+**LSP Protocol Integration**:
 ```json
 // Client request format for perl.runCritic
 {
@@ -536,7 +536,7 @@ cargo test -p perl-lsp --test lsp_performance_tests -- test_execute_command_late
 }
 ```
 
-#### Supported executeCommand Operations (*Diataxis: Reference* - Complete command list)
+#### Supported executeCommand Operations
 
 **Core Commands** (Available since v0.8.8+):
 ```bash
@@ -556,9 +556,9 @@ cargo test -p perl-lsp --test lsp_behavioral_tests -- test_execute_command_debug
 - ✅ `perl.debugTests` - Debug test execution with breakpoint support
 - ✅ `perl.runCritic` - **NEW**: Perl::Critic analysis with dual analyzer strategy
 
-### Advanced Code Actions Testing ⭐ **NEW: Issue #145** (*Diataxis: How-to Guide* - Code action workflows)
+### Advanced Code Actions Testing ⭐ **NEW: Issue #145**
 
-**Refactoring Operations** (*Diataxis: Tutorial* - Using code actions for refactoring):
+**Refactoring Operations**:
 ```bash
 # Test comprehensive code action integration
 cargo test -p perl-lsp --test lsp_code_actions_tests
@@ -573,7 +573,7 @@ cargo test -p perl-lsp --test lsp_code_actions_tests -- test_modernize_code_acti
 cargo test -p perl-lsp --test lsp_code_actions_tests -- test_add_missing_pragmas_action # Code modernization
 ```
 
-**Performance Testing** (*Diataxis: How-to Guide* - Code action performance validation):
+**Performance Testing**:
 ```bash
 # Validate <50ms response time requirement
 cargo test -p perl-lsp --test lsp_performance_tests -- test_code_actions_response_time
@@ -585,7 +585,7 @@ cargo test -p perl-lsp --test lsp_code_actions_tests -- test_code_action_caching
 cargo test -p perl-lsp --test lsp_code_actions_tests -- test_cross_file_extract_subroutine
 ```
 
-**LSP Protocol Compliance** (*Diataxis: Reference* - Code action specifications):
+**LSP Protocol Compliance**:
 ```json
 // Client request for code actions
 {
@@ -622,7 +622,7 @@ cargo test -p perl-lsp --test lsp_code_actions_tests -- test_cross_file_extract_
 }
 ```
 
-#### Integration Testing (*Diataxis: How-to Guide* - End-to-end validation)
+#### Integration Testing
 
 **Complete Workflow Testing**:
 ```bash
@@ -725,7 +725,7 @@ cargo test --doc                      # Documentation tests
 # cargo xtask fmt                     # xtask excluded from workspace
 ```
 
-## Dual-Scanner Corpus Comparison (*Diataxis: How-to Guide* - Testing procedures)
+## Dual-Scanner Corpus Comparison
 
 ### Running Dual-Scanner Corpus Tests (v0.8.8+)
 ```bash
@@ -745,7 +745,7 @@ cargo run -p xtask --features legacy -- corpus --scanner v2-pest-microcrate   # 
 cargo run -p xtask --features legacy -- corpus --scanner v2-parity --diagnose # v2<->v2 drift detector
 cargo run -p xtask --features legacy -- corpus --scanner v3                   # V3 parser only
 
-# Diagnostic analysis (*Diataxis: Reference* - detailed comparison)
+# Diagnostic analysis
 cargo run -p xtask --features legacy -- corpus --diagnose  # Analyze first failing test
 cargo run -p xtask --features legacy -- corpus --test      # Test current parser behavior
 
@@ -753,7 +753,7 @@ cargo run -p xtask --features legacy -- corpus --test      # Test current parser
 cargo run -p xtask --features legacy -- corpus --path tree-sitter-perl/test/corpus
 ```
 
-### Dual-Scanner Output Analysis (*Diataxis: Explanation* - Understanding results)
+### Dual-Scanner Output Analysis
 ```bash
 # Scanner mismatch tracking
 # When using --scanner both, the system tracks:
@@ -773,7 +773,7 @@ cargo run -p xtask --features legacy -- corpus --path tree-sitter-perl/test/corp
 #    corpus_file.txt: test_case_name  # Specific mismatch location
 ```
 
-### Structural Analysis Features (*Diataxis: Reference* - Analysis capabilities)
+### Structural Analysis Features
 ```bash
 # The dual-scanner system provides:
 # - Node count comparison between C and Rust scanners
@@ -792,7 +792,7 @@ cargo run -p xtask --features legacy -- corpus --path tree-sitter-perl/test/corp
 #   - different_node_type
 ```
 
-### xtask corpus Command Reference (*Diataxis: Reference* - Complete command specification)
+### xtask corpus Command Reference
 
 ```bash
 # Basic corpus command structure
@@ -835,7 +835,7 @@ both    # Compare C scanner vs V3 parser output before corpus expectation check
 #    filename: test_name
 ```
 
-### Corpus Test File Structure (*Diataxis: Reference* - Test format specification)
+### Corpus Test File Structure
 
 ```
 Test Case Name
@@ -851,9 +851,9 @@ more source code
 (expected_output)
 ```
 
-## Highlight Testing Commands (*Diataxis: Reference* - Tree-Sitter Highlight Test Runner)
+## Highlight Testing Commands
 
-### Basic Highlight Testing (*Diataxis: Tutorial* - Getting started with highlight tests)
+### Basic Highlight Testing
 
 ```bash
 # Prerequisites: Navigate to xtask directory for highlight testing
@@ -869,7 +869,7 @@ cargo run --no-default-features -- highlight --path ../crates/tree-sitter-perl/t
 cargo run --no-default-features -- highlight --scanner v3
 ```
 
-### Highlight Integration Testing (*Diataxis: How-to Guide* - Running comprehensive tests)
+### Highlight Integration Testing
 
 ```bash
 # Run perl-corpus highlight integration tests (4 comprehensive tests)
@@ -885,7 +885,7 @@ cargo test -p perl-corpus highlight_integration_test::test_highlight_performance
 cargo test -p perl-corpus highlight_integration_test::test_highlight_performance -- --nocapture
 ```
 
-### Creating Highlight Test Fixtures (*Diataxis: How-to Guide* - Adding new test cases)
+### Creating Highlight Test Fixtures
 
 ```bash
 # Navigate to highlight test fixture directory
@@ -929,7 +929,7 @@ cd ../../../../xtask
 cargo run --no-default-features -- highlight --path ../crates/tree-sitter-perl/test/highlight
 ```
 
-### Highlight Test Runner Reference (*Diataxis: Reference* - Complete command specification)
+### Highlight Test Runner Reference
 
 ```bash
 # Command structure
@@ -958,7 +958,7 @@ cd xtask && cargo run --no-default-features -- highlight [OPTIONS]
 # - Secure path handling with WalkDir max_depth protection
 ```
 
-### Highlight Test Architecture (*Diataxis: Explanation* - System design and integration)
+### Highlight Test Architecture
 
 The highlight test runner integrates deeply with the perl-parser AST generation system:
 
@@ -995,7 +995,7 @@ The highlight test runner integrates deeply with the perl-parser AST generation 
 - HashMap-based node counting for fast scope matching
 - Progress indication with `indicatif` for user feedback
 
-### Advanced Diagnostic Features (*Diataxis: Reference* - Analysis capabilities)
+### Advanced Diagnostic Features
 
 ```bash
 # Structural analysis when using --diagnose:
@@ -1020,11 +1020,11 @@ V3 scanner nodes: 14
   - literal
 ```
 
-## Scanner Architecture Testing (*Diataxis: How-to Guide* - Unified scanner validation)
+## Scanner Architecture Testing
 
 The project uses a unified scanner architecture where both `c-scanner` and `rust-scanner` features use the same Rust implementation, with `CScanner` serving as a compatibility wrapper that delegates to `RustScanner`.
 
-### Scanner Implementation Testing (*Diataxis: Reference* - Scanner validation commands)
+### Scanner Implementation Testing
 
 ```bash
 # Test core Rust scanner implementation directly
@@ -1040,7 +1040,7 @@ cargo test -p tree-sitter-perl-rs rust_scanner_smoke
 cargo test -p tree-sitter-perl-rs scanner_state
 ```
 
-### Scanner Compatibility Validation (*Diataxis: How-to Guide* - Ensuring backward compatibility)
+### Scanner Compatibility Validation
 
 ```bash
 # Verify both scanner interfaces work correctly
@@ -1054,7 +1054,7 @@ cargo bench -p tree-sitter-perl-rs --features rust-scanner
 cargo bench -p tree-sitter-perl-rs --features c-scanner
 ```
 
-### Scanner Build Configuration (*Diataxis: Reference* - Feature flag usage)
+### Scanner Build Configuration
 
 ```bash
 # Build with Rust scanner only (direct usage)
@@ -1067,7 +1067,7 @@ cargo build -p tree-sitter-perl-rs --features c-scanner
 cargo build -p tree-sitter-perl-rs --features rust-scanner,c-scanner
 ```
 
-### Understanding Scanner Architecture (*Diataxis: Explanation* - Design rationale)
+### Understanding Scanner Architecture
 
 The unified scanner architecture provides:
 

--- a/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
+++ b/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
@@ -149,12 +149,12 @@
   - **`src/scanner/c_scanner.rs`**: C API compatibility wrapper that delegates to RustScanner
   - **`src/scanner/mod.rs`**: Unified scanner interface and feature flags
 
-### `/xtask/` - Development Automation (*Diataxis: Explanation* - Design decisions)
+### `/xtask/` - Development Automation
 - **Exclusion Reason**: Circular dependency with excluded crates
 - **Purpose**: Advanced testing and development tools requiring system dependencies
 - **Architecture**: Excluded from workspace to maintain clean builds while preserving functionality
 
-## xtask Architecture (*Diataxis: Explanation* - Advanced testing design)
+## xtask Architecture
 
 ### Dual-Scanner Corpus Comparison (v0.8.8+)
 
@@ -189,14 +189,14 @@ struct CorpusTestResults {
 }
 ```
 
-#### **Structural Analysis Features** (*Diataxis: Reference* - Technical capabilities)
+#### **Structural Analysis Features**
 - **Node Count Comparison**: Tracks structural differences between scanner outputs
 - **Missing Node Detection**: Identifies nodes present in C but missing in Rust output
 - **Extra Node Detection**: Identifies nodes present in Rust but missing in C output
 - **S-expression Normalization**: Whitespace-independent comparison for accurate results
 - **Diagnostic Analysis**: Detailed structural breakdown for debugging parser differences
 
-#### **Usage Pattern** (*Diataxis: How-to Guide* - Implementation approach)
+#### **Usage Pattern**
 ```bash
 # Run corpus comparison modes (requires legacy feature)
 cargo run -p xtask --features legacy -- corpus                          # Default scanner: v3
@@ -206,7 +206,7 @@ cargo run -p xtask --features legacy -- corpus --scanner v2-parity --diagnose
 
 ## Key Components
 
-### ModuleResolver Component (NEW v0.8.8) - (*Diataxis: Reference*)
+### ModuleResolver Component (NEW v0.8.8)
 
 The ModuleResolver provides a reusable, generic module resolution system for LSP features requiring Perl module path resolution.
 
@@ -274,13 +274,13 @@ let provider = CompletionProvider::new_with_index_and_source(
 - **Reliable**: Comprehensive error handling and timeout protection
 - **Standard Compliant**: Follows Perl module path conventions and LSP URI requirements
 
-## Unified Scanner Architecture (*Diataxis: Explanation* - Scanner design and implementation)
+## Unified Scanner Architecture
 
 ### Design Overview
 
 The scanner implementation follows a unified architecture pattern that consolidates multiple scanner interfaces into a single Rust implementation while maintaining full backward compatibility.
 
-#### Core Components (*Diataxis: Reference* - Technical architecture)
+#### Core Components
 
 **`/crates/tree-sitter-perl-rs/src/scanner/mod.rs`**:
 ```rust
@@ -320,7 +320,7 @@ impl PerlScanner for CScanner {
 }
 ```
 
-### Architecture Benefits (*Diataxis: Explanation* - Design decisions)
+### Architecture Benefits
 
 #### **Simplified Maintenance**
 - **Single Source of Truth**: One scanner implementation for all functionality
@@ -340,9 +340,9 @@ impl PerlScanner for CScanner {
 - **Simplified Feature Addition**: New token types added once, available everywhere
 - **Reduced Testing Complexity**: Test coverage for single implementation covers all interfaces
 
-### Implementation Strategy (*Diataxis: How-to Guide* - Using the unified scanner)
+### Implementation Strategy
 
-#### **For New Code** (*Diataxis: Tutorial* - Recommended approach)
+#### **For New Code**
 ```rust
 use tree_sitter_perl_rs::RustScanner;
 
@@ -350,7 +350,7 @@ let mut scanner = RustScanner::new();
 let token = scanner.scan(input)?;
 ```
 
-#### **For Legacy Code** (*Diataxis: How-to Guide* - Migration approach)
+#### **For Legacy Code**
 ```rust
 use tree_sitter_perl_rs::CScanner;  // Drop-in replacement
 
@@ -358,7 +358,7 @@ let mut scanner = CScanner::new();  // Same API as before
 let token = scanner.scan(input)?;   // Delegates to RustScanner internally
 ```
 
-#### **Feature Flag Configuration** (*Diataxis: Reference* - Build configuration)
+#### **Feature Flag Configuration**
 ```toml
 # Cargo.toml - Choose scanner interface
 [features]
@@ -367,7 +367,7 @@ rust-scanner = []           # Direct RustScanner access
 c-scanner = []              # CScanner wrapper (delegates to RustScanner)
 ```
 
-### Testing Strategy (*Diataxis: Reference* - Quality assurance)
+### Testing Strategy
 
 #### **Unified Test Coverage**
 - **`tests/rust_scanner_smoke.rs`**: Validates core scanner functionality
@@ -375,7 +375,7 @@ c-scanner = []              # CScanner wrapper (delegates to RustScanner)
 - **API Compatibility Tests**: Verifies legacy API contracts remain unchanged
 - **Performance Tests**: Confirms no performance regression from delegation pattern
 
-#### **Build Validation** (*Diataxis: How-to Guide* - Development workflow)
+#### **Build Validation**
 ```bash
 # Test both scanner interfaces
 cargo test --features rust-scanner
@@ -385,7 +385,7 @@ cargo test --features c-scanner
 cargo test -p tree-sitter-perl-rs rust_scanner_smoke
 ```
 
-### Migration Implications (*Diataxis: Explanation* - Understanding the changes)
+### Migration Implications
 
 #### **What Changed**
 - **Implementation**: `CScanner` now delegates to `RustScanner` instead of implementing separately
@@ -435,7 +435,7 @@ cargo test -p tree-sitter-perl-rs rust_scanner_smoke
 ### Cross-File Reference Resolution
 The workspace indexing system implements a dual indexing strategy for comprehensive cross-file navigation with 98% reference coverage:
 
-#### Core Architecture Pattern (*Diataxis: Reference*)
+#### Core Architecture Pattern
 ```rust
 // Dual indexing: index function calls under both forms
 let qualified = format!("{}::{}", package, bare_name);
@@ -449,7 +449,7 @@ file_index.references.entry(qualified)
     .or_default().push(symbol_ref);
 ```
 
-#### Enhanced Reference Search (*Diataxis: Reference*)
+#### Enhanced Reference Search
 ```rust
 pub fn find_references(&self, symbol_name: &str) -> Vec<Location> {
     let mut locations = Vec::new();
@@ -477,7 +477,7 @@ pub fn find_references(&self, symbol_name: &str) -> Vec<Location> {
 - **Definition Exclusion**: Function definitions properly excluded from "Find All References" 
 - **LSP Compliance**: Results match LSP specification for reference vs definition separation
 
-#### Key Benefits (*Diataxis: Explanation*)
+#### Key Benefits
 - **98% Reference Coverage**: Handles both `Package::function` and `function` call patterns
 - **Performance Optimized**: Dual lookups with efficient HashSet deduplication
 - **Backward Compatible**: Existing code continues to work with enhanced indexing
@@ -570,13 +570,13 @@ pub fn get_code_actions(&self, ast: &Node, range: (usize, usize), diagnostics: &
 - Tree-sitter compatible error nodes and diagnostics
 - Performance optimized (<5% overhead for normal code)
 
-## Agent Ecosystem Integration (PR #153) (*Diataxis: Explanation* - Specialized workflow automation)
+## Agent Ecosystem Integration (PR #153)
 
 ### 94 Specialized Agents Architecture
 
 **Workflow Enhancement**: PR #153 introduces a comprehensive agent ecosystem with 94 specialized agents designed specifically for the tree-sitter-perl parsing ecosystem.
 
-#### Agent Directory Structure (*Diataxis: Reference* - Agent organization)
+#### Agent Directory Structure
 
 ```
 .claude/agents2/                          # 94 specialized agents (vs. 53 generic)
@@ -602,7 +602,7 @@ pub fn get_code_actions(&self, ast: &Node, range: (usize, usize), diagnostics: &
     └── workflow-orchestrator.md         # Agent coordination patterns
 ```
 
-#### Specialized Agent Capabilities (*Diataxis: Explanation* - Domain expertise integration)
+#### Specialized Agent Capabilities
 
 **Parser Ecosystem Context Integration:**
 - **Multi-crate Architecture**: Understanding of 5 published crates and their interdependencies
@@ -619,7 +619,7 @@ SecurityScanner → MutationTester → PerformanceValidator → GovernanceGate
 CodeEnhancer → TestCreator → DocGenerator → ReviewPrep
 ```
 
-#### Agent Customization Framework (*Diataxis: Reference* - Self-adapting architecture)
+#### Agent Customization Framework
 
 **Contextual Adaptation Engine:**
 ```markdown
@@ -636,7 +636,7 @@ CodeEnhancer → TestCreator → DocGenerator → ReviewPrep
 - **Security Awareness**: UTF-16 position conversion security and enterprise patterns
 - **Workflow Intelligence**: Context-aware routing between specialized agents
 
-#### Quality and Security Integration (*Diataxis: Explanation* - Enterprise-grade validation)
+#### Quality and Security Integration
 
 **Mutation Testing Coordination:**
 - **Real Bug Discovery**: Agents coordinate mutation testing that discovered UTF-16 security vulnerabilities
@@ -648,7 +648,7 @@ CodeEnhancer → TestCreator → DocGenerator → ReviewPrep
 - **Security-Performance Balance**: Enhanced security without performance regression
 - **Adaptive Threading**: CI environment optimization through intelligent agent coordination
 
-#### Integration Points (*Diataxis: Reference* - Agent ecosystem interfaces)
+#### Integration Points
 
 **Crate Integration:**
 - **`/crates/perl-parser/`**: Core parser logic enhanced by generative agents (test creation, performance optimization)
@@ -661,7 +661,7 @@ CodeEnhancer → TestCreator → DocGenerator → ReviewPrep
 - **ADRs**: Architecture decisions documented and validated by governance agents
 - **Security Guides**: Enterprise security patterns maintained by security-focused agents
 
-#### Workflow Orchestration Patterns (*Diataxis: How-to* - Agent coordination)
+#### Workflow Orchestration Patterns
 
 **Review Workflow:**
 ```bash
@@ -716,9 +716,9 @@ generative-doc-writer       # Documentation synchronization
 - **`/crates/tree-sitter-perl-rs/`**: Legacy test harnesses with outdated Rope usage
 - **Internal test infrastructure**: Focus on production code, not test utilities
 
-## Dual Indexing Architecture (v0.8.8+) (*Diataxis: Explanation* - Workspace navigation design)
+## Dual Indexing Architecture (v0.8.8+)
 
-### Problem Statement (*Diataxis: Explanation* - Why dual indexing is needed)
+### Problem Statement
 
 Perl's flexible function calling conventions create significant challenges for static analysis and IDE features:
 
@@ -741,11 +741,11 @@ Traditional LSP servers index functions under a single name form, leading to:
 - **Inconsistent go-to-definition**: Works for some call styles but not others
 - **Poor find-references coverage**: Only finds references matching the indexing style
 
-### Solution: Dual Indexing Strategy (*Diataxis: Reference* - Technical implementation)
+### Solution: Dual Indexing Strategy
 
 The dual indexing strategy solves this by indexing every function under **both** its qualified and bare name forms.
 
-#### Core Algorithm (*Diataxis: Reference* - Implementation specification)
+#### Core Algorithm
 
 **Indexing Phase** (`/crates/perl-parser/src/workspace_index.rs`):
 ```rust
@@ -798,7 +798,7 @@ pub fn find_references(&self, symbol_name: &str) -> Vec<Location> {
 }
 ```
 
-### Performance Impact (*Diataxis: Reference* - Performance characteristics)
+### Performance Impact
 
 | Metric | Before Dual Indexing | After Dual Indexing | Change |
 |--------|---------------------|---------------------|---------|
@@ -808,7 +808,7 @@ pub fn find_references(&self, symbol_name: &str) -> Vec<Location> {
 | **Search Performance** | Fast | Fast (dual lookup) | Maintained |
 | **Go-to-Definition Success** | ~83% | ~98% | +18% |
 
-### Integration with Lexer (*Diataxis: Reference* - Supporting infrastructure)
+### Integration with Lexer
 
 The lexer enhancement in `/crates/perl-lexer/src/lib.rs` supports dual indexing by properly tokenizing package-qualified identifiers:
 
@@ -830,7 +830,7 @@ while self.current_char() == Some(':') && self.peek_char(1) == Some(':') {
 }
 ```
 
-### Benefits (*Diataxis: Explanation* - Architectural advantages)
+### Benefits
 
 1. **Comprehensive Coverage**: Finds all references regardless of calling style
 2. **Consistent Behavior**: Go-to-definition works from any reference form

--- a/docs/reference/EDGE_CASES.md
+++ b/docs/reference/EDGE_CASES.md
@@ -28,7 +28,7 @@ The Pure Rust Perl parser provides comprehensive support for most Perl construct
 
 ### Recent Improvements - Regex/Substitution Parsing
 
-**PR #124 - Single-Quote Delimiter Support (*Diataxis: Reference* - Latest parser enhancements)**:
+**PR #124 - Single-Quote Delimiter Support**:
 - ✅ **Single-Quote Substitution Delimiters**: Complete support for `s'pattern'replacement'modifiers` syntax variations
 - ✅ **Enhanced Lexical Recognition**: Intelligent parsing distinguishes single-quote delimiters from string literals
 - ✅ **Complete Operator Coverage**: Full support for `s'`, `y'`, and `tr'` with single-quote delimiters

--- a/docs/reference/ERROR_HANDLING_API_CONTRACTS.md
+++ b/docs/reference/ERROR_HANDLING_API_CONTRACTS.md
@@ -1,4 +1,4 @@
-# Error Handling API Contracts (*Diataxis: Reference*)
+# Error Handling API Contracts
 
 **Issue**: #178 (GitHub #204) - Eliminate Fragile unreachable!() Macros
 **Related Specs**: [issue-178-spec.md](issue-178-spec.md), [PARSER_ERROR_HANDLING_SPEC.md](PARSER_ERROR_HANDLING_SPEC.md), [LEXER_ERROR_HANDLING_SPEC.md](LEXER_ERROR_HANDLING_SPEC.md)

--- a/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
+++ b/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
@@ -1,4 +1,4 @@
-# LSP Implementation Technical Guide (*Diataxis: Explanation* - Understanding LSP architecture and design decisions)
+# LSP Implementation Technical Guide
 
 > This guide follows the **[Diataxis framework](https://diataxis.fr/)** for comprehensive technical documentation:
 > - **Tutorial sections**: Hands-on learning with examples
@@ -6,9 +6,9 @@
 > - **Reference sections**: Complete technical specifications
 > - **Explanation sections**: Design concepts and architectural decisions
 
-## Architecture Overview (*Diataxis: Explanation* - LSP design concepts)
+## Architecture Overview
 
-### UTF-16 Position Security Enhancement (PR #153) (*Diataxis: Explanation* - Security-first position mapping)
+### UTF-16 Position Security Enhancement (PR #153)
 
 **Critical Security Update**: PR #153 introduces comprehensive UTF-16 position conversion security enhancements that eliminate boundary violations and ensure symmetric position handling. This is important for LSP implementations processing Unicode-rich Perl code.
 
@@ -41,7 +41,7 @@
                                       └──────────────────┘
 ```
 
-## Documentation Requirements for LSP Providers (*Diataxis: How-to Guide* - Enterprise API documentation standards)
+## Documentation Requirements for LSP Providers
 
 ### Missing Documentation Infrastructure (SPEC-149) ✅ **IMPLEMENTED**
 
@@ -180,13 +180,13 @@ cargo test -p perl-parser --test missing_docs_ac_tests -- test_performance_docum
    - Dual indexing strategy usage and benefits
    - Cross-file navigation and workspace management
 
-## Secure UTF-16 Position Mapping (PR #153) (*Diataxis: Reference* - Position conversion API and security patterns)
+## Secure UTF-16 Position Mapping (PR #153)
 
 ### Security-Enhanced Position Conversion API
 
 **Critical Implementation**: All LSP position operations must use the security-enhanced conversion methods to prevent UTF-16 boundary violations and ensure correct Unicode handling.
 
-#### Core Position Conversion Methods (*Diataxis: Reference* - Secure conversion API)
+#### Core Position Conversion Methods
 
 ```rust
 impl PositionConverter {
@@ -233,7 +233,7 @@ impl PositionConverter {
 }
 ```
 
-#### Security Validation Examples (*Diataxis: Tutorial* - Implementing secure position handling)
+#### Security Validation Examples
 
 ```rust
 // SECURE PATTERN: Always validate before processing
@@ -264,7 +264,7 @@ fn handle_lsp_request_securely(
 }
 ```
 
-### Unicode Safety Implementation (*Diataxis: Explanation* - Understanding Unicode security requirements)
+### Unicode Safety Implementation
 
 **Multi-byte Character Handling**: The enhanced position mapping correctly handles Unicode edge cases that previously caused boundary violations:
 
@@ -292,7 +292,7 @@ for i in 0..=text.len() {
 - **Overflow Protection**: Safe arithmetic prevents integer overflow in position calculations
 - **Unicode Compliance**: Proper handling of multi-byte sequences and emoji
 
-### Testing Security Requirements (*Diataxis: Reference* - Security test specifications)
+### Testing Security Requirements
 
 **Mandatory Security Tests:**
 ```rust
@@ -321,11 +321,11 @@ fn test_position_conversion_security() {
 }
 ```
 
-## Enhanced Workspace Indexing (v0.8.8+) - Dual Indexing Strategy (*Diataxis: Explanation* - Understanding the dual reference approach)
+## Enhanced Workspace Indexing (v0.8.8+) - Dual Indexing Strategy
 
 The v0.8.8+ releases introduce a breakthrough dual indexing strategy for function call references that dramatically improves cross-file LSP navigation. This enhancement indexes functions under both qualified (`Package::function`) and bare (`function`) names, enabling comprehensive reference finding regardless of how functions are called.
 
-### Architectural Decision: Why Dual Indexing? (*Diataxis: Explanation* - Design rationale)
+### Architectural Decision: Why Dual Indexing?
 
 Perl's flexible function call syntax creates a fundamental challenge for static analysis:
 
@@ -345,9 +345,9 @@ process_data();          # Bare call (via import or same package)
 
 Traditional indexing approaches fail because they only index functions under one name form, missing references that use alternative calling conventions. The dual indexing strategy solves this by maintaining references under both forms.
 
-### Technical Implementation (*Diataxis: Reference* - Dual indexing algorithm)
+### Technical Implementation
 
-#### Indexing Phase (*Diataxis: Reference* - Reference storage specification)
+#### Indexing Phase
 
 When a function call is encountered during workspace indexing:
 
@@ -369,7 +369,7 @@ file_index.references.entry(qualified).or_default().push(SymbolReference {
 });
 ```
 
-#### Search Phase (*Diataxis: Reference* - Reference retrieval algorithm)
+#### Search Phase
 
 When searching for references to a qualified symbol:
 
@@ -413,7 +413,7 @@ pub fn find_references(&self, symbol_name: &str) -> Vec<Location> {
 }
 ```
 
-#### Deduplication Strategy (*Diataxis: Reference* - Duplicate elimination)
+#### Deduplication Strategy
 
 The enhanced `find_refs` method ensures each location appears only once even when indexed under multiple name forms:
 
@@ -429,7 +429,7 @@ pub fn find_refs(&self, key: &SymbolKey) -> Vec<Location> {
 }
 ```
 
-### Lexer Enhancements (*Diataxis: Reference* - Package-qualified identifier support)
+### Lexer Enhancements
 
 The lexer has been enhanced to properly handle package-qualified segments:
 
@@ -441,13 +441,13 @@ while self.current_char() == Some(':') && self.peek_char(1) == Some(':') {
 }
 ```
 
-## Hash Key Context Detection (v0.8.6) - Advanced Diagnostics (*Diataxis: Explanation* - Understanding the bareword analysis breakthrough)
+## Hash Key Context Detection (v0.8.6) - Advanced Diagnostics
 
 The v0.8.6 release introduces breakthrough hash key context detection that eliminates false positives in bareword analysis under `use strict`. This represents a significant advancement in Perl static analysis.
 
-### Technical Implementation (*Diataxis: Reference* - Algorithm specifications)
+### Technical Implementation
 
-#### Core Algorithm (*Diataxis: Reference* - Implementation details)
+#### Core Algorithm
 
 ```rust
 fn is_in_hash_key_context(
@@ -606,7 +606,7 @@ print INVALID;                         // ❌ Should warn about 'INVALID'
 4. **Performance Optimized**: Fast analysis with early termination
 5. **Backward Compatible**: Existing functionality unchanged
 
-## Using the ModuleResolver Component (**Diataxis: Tutorial**)
+## Using the ModuleResolver Component
 
 ### Getting Started with ModuleResolver Integration
 
@@ -941,7 +941,7 @@ fn setup_multi_workspace_resolver(workspace_roots: Vec<String>) -> Arc<dyn Fn(&s
 
 This tutorial provides a comprehensive guide to integrating the ModuleResolver component into your LSP features, ensuring reliable and performant Perl module resolution.
 
-## Using the Thread-Safe Semantic Token API (**Diataxis: Tutorial**)
+## Using the Thread-Safe Semantic Token API
 
 ### Getting Started with Semantic Tokens
 
@@ -1188,7 +1188,7 @@ The thread-safe semantic token provider achieves exceptional performance:
 
 This makes it suitable for real-time LSP operations and high-frequency syntax highlighting updates.
 
-## Import Optimization Integration (**Diataxis: Reference**)
+## Import Optimization Integration
 
 ### Overview
 
@@ -1346,11 +1346,11 @@ print "Hello World\n";
 4. **Workspace-wide**: Can be applied across entire Perl codebases
 5. **Non-destructive**: Preview changes before applying optimizations
 
-## Enhanced LSP Cancellation System Integration (*Diataxis: Explanation* - Understanding enhanced cancellation architecture for responsive LSP operations)
+## Enhanced LSP Cancellation System Integration
 
 The Enhanced LSP Cancellation System provides cancellation capabilities across all LSP operations, ensuring responsive user interactions and optimal performance. This system integrates seamlessly with existing parser infrastructure.
 
-### Architecture Overview (*Diataxis: Explanation* - Core cancellation components)
+### Architecture Overview
 
 The cancellation system consists of four primary components working together to provide comprehensive operation cancellation:
 
@@ -1373,7 +1373,7 @@ The cancellation system consists of four primary components working together to 
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Key Components (*Diataxis: Reference* - Cancellation system components)
+### Key Components
 
 #### 1. CancellationToken
 Thread-safe atomic token for operation cancellation with <100μs check latency:
@@ -1412,7 +1412,7 @@ pub struct ProviderCleanupContext<T> {
 }
 ```
 
-### Performance Characteristics (*Diataxis: Reference* - Production performance specifications)
+### Performance Characteristics
 
 The Enhanced LSP Cancellation System maintains consistent performance across all operations:
 
@@ -1424,7 +1424,7 @@ The Enhanced LSP Cancellation System maintains consistent performance across all
 | **Memory Overhead** | <1MB additional per 1000 operations | Baseline + cancellation infrastructure |
 | **Navigation Success Rate** | ≥98% with cancellation | Maintains dual indexing performance |
 
-### Integration with Core LSP Features (*Diataxis: Explanation* - Cancellation integration patterns)
+### Integration with Core LSP Features
 
 #### Enhanced Workspace Indexing Compatibility
 The cancellation system integrates seamlessly with the dual indexing strategy, maintaining 98% reference coverage:
@@ -1471,7 +1471,7 @@ pub fn incremental_parse_with_cancellation(
 }
 ```
 
-### Provider Integration (*Diataxis: Reference* - LSP provider cancellation patterns)
+### Provider Integration
 
 All 11 LSP providers integrate with the Enhanced Cancellation System using consistent patterns:
 
@@ -1516,7 +1516,7 @@ impl DefinitionProvider {
 }
 ```
 
-### Threading and Concurrency (*Diataxis: Explanation* - Thread-safe cancellation design)
+### Threading and Concurrency
 
 The Enhanced LSP Cancellation System integrates with Perl LSP's threading improvements (PR #140):
 
@@ -1530,7 +1530,7 @@ The Enhanced LSP Cancellation System integrates with Perl LSP's threading improv
 - **User Story Tests**: 1500s+ → 0.32s preserved with cancellation overhead
 - **Individual Workspace Tests**: 60s+ → 0.26s sustained performance
 
-### Usage Examples (*Diataxis: Tutorial* - Implementing cancellation-aware LSP operations)
+### Usage Examples
 
 #### Basic Cancellation Pattern
 ```rust
@@ -1570,7 +1570,7 @@ impl LanguageServer for PerlLspServer {
 }
 ```
 
-### Integration Testing (*Diataxis: How-to* - Testing cancellation functionality)
+### Integration Testing
 
 Comprehensive test coverage ensures reliable cancellation behavior:
 
@@ -1586,7 +1586,7 @@ cargo test -p perl-lsp --test lsp_cancellation_performance_tests
 RUST_TEST_THREADS=2 cargo test -p perl-lsp --test cancellation_thread_safety_tests
 ```
 
-### Detailed Documentation References (*Diataxis: Reference* - Complete cancellation system documentation)
+### Detailed Documentation References
 
 For comprehensive implementation details, architecture specifications, and advanced usage patterns, see the dedicated cancellation documentation:
 
@@ -1596,7 +1596,7 @@ For comprehensive implementation details, architecture specifications, and advan
 - **[LSP Cancellation Test Strategy](LSP_CANCELLATION_TEST_STRATEGY.md)** - Comprehensive testing approach and validation methods
 - **[LSP Cancellation Integration Schema](LSP_CANCELLATION_INTEGRATION_SCHEMA.md)** - Provider integration patterns and implementation schemas
 
-### Migration and Adoption (*Diataxis: How-to* - Upgrading to cancellation-aware operations)
+### Migration and Adoption
 
 #### Enabling Cancellation in Existing Code
 ```rust
@@ -1615,7 +1615,7 @@ let result = provider.provide_completion_with_cancellation(params, token);
 
 The Enhanced LSP Cancellation System improves Perl LSP responsiveness and user experience, providing cancellation capabilities while preserving performance characteristics.
 
-## Enhanced executeCommand and Code Actions Integration (*Diataxis: Explanation* - Recently Implemented LSP Features)
+## Enhanced executeCommand and Code Actions Integration
 
 ### executeCommand Method Implementation ⭐ **NEW: Issue #145**
 
@@ -1637,7 +1637,7 @@ pub static SUPPORTED_COMMANDS: &[&str] = &[
 
 #### perl.runCritic Command Integration
 
-**Dual Analyzer Strategy** (*Diataxis: How-to* - Using perlcritic with fallback):
+**Dual Analyzer Strategy**:
 ```rust
 // Comprehensive perlcritic integration with fallback
 impl ExecuteCommandProvider {
@@ -1671,7 +1671,7 @@ pub struct CriticCommandResult {
 
 #### Protocol Compliance Integration
 
-**Capability Advertisement** (*Diataxis: Reference* - Server capabilities):
+**Capability Advertisement**:
 ```json
 {
   "capabilities": {
@@ -1712,7 +1712,7 @@ The `textDocument/codeAction` LSP method now provides sophisticated refactoring 
 
 #### Code Action Categories
 
-**RefactorExtract Operations** (*Diataxis: How-to* - Extract refactoring patterns):
+**RefactorExtract Operations**:
 ```rust
 // Extract variable with intelligent naming
 pub fn create_extract_variable_action(&self, node: &Node) -> CodeAction {
@@ -1761,7 +1761,7 @@ pub fn create_organize_imports_action(&self, document_uri: &str) -> CodeAction {
 }
 ```
 
-**RefactorRewrite Operations** (*Diataxis: How-to* - Code quality improvements):
+**RefactorRewrite Operations**:
 ```rust
 // Modernize Perl patterns
 pub fn create_modernize_code_actions(&self, ast: &Node) -> Vec<CodeAction> {
@@ -1783,7 +1783,7 @@ pub fn create_modernize_code_actions(&self, ast: &Node) -> Vec<CodeAction> {
 
 #### Performance Optimization Architecture
 
-**Multi-tier Caching System** (*Diataxis: Explanation* - Performance design):
+**Multi-tier Caching System**:
 ```rust
 // Code action caching with incremental invalidation
 pub struct CodeActionCache {
@@ -1868,7 +1868,7 @@ impl ExecuteCommandProvider {
 
 #### Quality Assurance and Testing
 
-**Test-Driven Development Pattern** (*Diataxis: How-to* - Testing new LSP features):
+**Test-Driven Development Pattern**:
 ```bash
 # Comprehensive test suite for executeCommand and code actions
 cargo test -p perl-lsp --test lsp_execute_command_tests        # Execute command protocol compliance
@@ -1891,7 +1891,7 @@ cargo test -p perl-lsp --test lsp_comprehensive_e2e_test      # Full workflow va
 
 The enhanced executeCommand and code actions integration completes the advertised LSP feature set to **100% user-visible coverage (53/53)** while maintaining performance and reliability.
 
-## LSP Feature Status Matrix (*Diataxis: Reference* - Complete feature overview)
+## LSP Feature Status Matrix
 
 The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **100% protocol compliance (97/97)** with comprehensive workspace support:
 
@@ -1937,7 +1937,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | **Multi-root Workspace** | ✅ Complete | Full support | Scalable indexing architecture |
 | **Workspace Refactoring** | ✅ Complete | Cross-file safe | Extract variable/subroutine |
 
-### executeCommand Operations (*Diataxis: Reference* - Command specifications)
+### executeCommand Operations
 | Command | Status | Analyzer | Response Time | Integration |
 |---------|---------|----------|---------------|-------------|
 | `perl.runTests` | ✅ Complete | Native | <3s | TAP output parsing |
@@ -1946,7 +1946,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | `perl.debugTests` | ✅ Complete | Native | <1s | Debug adapter preparation |
 | `perl.runCritic` | ✅ Complete | Dual strategy | <2s | External perlcritic + built-in fallback |
 
-### Code Action Categories (*Diataxis: Reference* - Refactoring capabilities)
+### Code Action Categories
 | Category | Operations | Status | Performance | Cross-file Support |
 |----------|------------|---------|-------------|-------------------|
 | **RefactorExtract** | Variable, Subroutine | ✅ Complete | <50ms | ✅ Dual indexing aware |
@@ -1954,7 +1954,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | **SourceOrganizeImports** | Remove unused, Add missing, Sort | ✅ Complete | <100ms | ✅ Cross-file dependency tracking |
 | **QuickFix** | Syntax corrections, Policy fixes | ✅ Complete | <25ms | ✅ Integrated with diagnostics |
 
-### Performance Achievements (*Diataxis: Explanation* - PR #140 impact)
+### Performance Achievements
 | Test Category | Before PR #140 | After PR #140 |
 |---------------|-----------------|---------------|
 | **LSP Behavioral** | 1560s+ | 0.31s |
@@ -1962,7 +1962,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | **Workspace Tests** | 60s+ | 0.26s |
 | **Overall Suite** | 60s+ | <10s |
 
-### Protocol Compliance (*Diataxis: Reference* - LSP 3.17+ support)
+### Protocol Compliance
 - ✅ **LSP 3.17+ Protocol**: Coverage is currently tracked against protocol method implementation in `features.toml`; remaining protocol parity goals are tracked in ROADMAP.md
 - ✅ **JSON-RPC 2.0**: Complete request/response/notification support
 - ✅ **UTF-16 Position Mapping**: Symmetric conversion with vulnerability fixes
@@ -2355,15 +2355,15 @@ impl LspServer {
 4. **Integration**: Clean conversion between internal types and LSP format
 5. **Extensibility**: Easy to add new refactoring operations
 
-## Enhanced Cross-File Navigation with Dual Indexing Strategy (v0.8.8+) (*Diataxis: Explanation* - Understanding advanced function call indexing)
+## Enhanced Cross-File Navigation with Dual Indexing Strategy (v0.8.8+)
 
-### Overview (*Diataxis: Explanation* - Design decisions and concepts)
+### Overview
 
 The v0.8.8+ release introduces a **production-stable dual indexing strategy** for function calls that achieves **98% reference coverage improvement** and significantly improves cross-file navigation and reference finding. This enhancement addresses the complexity of Perl's flexible function call syntax where functions can be called with bare names or fully qualified package names, ensuring comprehensive detection across all usage patterns with enhanced Unicode processing and atomic performance tracking.
 
-### Technical Implementation (*Diataxis: Reference* - Algorithm specifications)
+### Technical Implementation
 
-#### Dual Function Call Indexing (*Diataxis: Reference* - Implementation details)
+#### Dual Function Call Indexing
 
 The workspace index now maintains dual references for function calls, indexing both bare and qualified forms:
 
@@ -2404,7 +2404,7 @@ impl IndexVisitor {
 }
 ```
 
-#### Enhanced Reference Finding (*Diataxis: Reference* - Enhanced search algorithms)
+#### Enhanced Reference Finding
 
 The `find_references` method implements intelligent dual lookup with deduplication:
 
@@ -2444,7 +2444,7 @@ impl WorkspaceIndex {
 }
 ```
 
-#### Intelligent Deduplication (*Diataxis: Reference* - Reference deduplication algorithm)
+#### Intelligent Deduplication
 
 The system automatically deduplicates references while excluding definitions:
 
@@ -2475,7 +2475,7 @@ pub fn find_refs(&self, key: &SymbolKey) -> Vec<Location> {
 }
 ```
 
-### Benefits for LSP Users (*Diataxis: Explanation* - User experience improvements)
+### Benefits for LSP Users
 
 1. **Comprehensive Reference Finding**: Finds all references regardless of whether they use bare names (`foo()`) or qualified names (`Package::foo()`)
 2. **Smart Deduplication**: Eliminates duplicate references that occur from dual indexing
@@ -2483,7 +2483,7 @@ pub fn find_refs(&self, key: &SymbolKey) -> Vec<Location> {
 4. **Cross-File Consistency**: Maintains consistent reference finding across the entire workspace
 5. **Performance Optimized**: Uses HashSet-based deduplication for efficient processing
 
-### Testing and Validation (*Diataxis: How-to* - Testing dual indexing)
+### Testing and Validation
 
 The dual indexing strategy includes comprehensive test coverage with **98% reference coverage improvement** validation:
 
@@ -2549,7 +2549,7 @@ Unicode::Module::🚀process_data();
 }
 ```
 
-### Integration with LSP Features (*Diataxis: How-to* - Using dual indexing in LSP)
+### Integration with LSP Features
 
 The dual indexing strategy seamlessly integrates with existing LSP features, achieving **98% reference coverage improvement**:
 
@@ -2564,7 +2564,7 @@ The dual indexing strategy seamlessly integrates with existing LSP features, ach
 
 ## API Reference Documentation
 
-### CompletionProvider API Reference (**Diataxis: Reference**)
+### CompletionProvider API Reference
 
 The CompletionProvider has been enhanced with pluggable module resolver support in v0.8.8. This section provides comprehensive API documentation for the updated interface.
 
@@ -2765,7 +2765,7 @@ let provider = CompletionProvider::new_with_index_and_source(
 
 ## Complex Feature Examples
 
-### Thread-Safe Semantic Tokens Implementation (**Diataxis: Reference**)
+### Thread-Safe Semantic Tokens Implementation
 
 The semantic tokens provider has been redesigned for thread-safety with exceptional performance. The new implementation eliminates race conditions while achieving 2.826µs average performance (35x better than 100µs target).
 
@@ -2841,7 +2841,7 @@ impl<'a> TokenCollector<'a> {
 }
 ```
 
-#### Performance Characteristics (**Diataxis: Reference**)
+#### Performance Characteristics
 
 **Performance Benchmarks** (production measurements):
 - **Average execution time**: 2.826µs 
@@ -2856,7 +2856,7 @@ impl<'a> TokenCollector<'a> {
 - **Efficient Position Mapping**: Optimized byte-to-position conversion
 - **Delta Encoding**: LSP-compliant delta encoding for minimal network overhead
 
-#### LSP Server Integration (**Diataxis: How-to**)
+#### LSP Server Integration
 
 ```rust
 // In lsp_server.rs - Thread-safe semantic tokens handler
@@ -2917,7 +2917,7 @@ pub fn encode_semantic_tokens(tokens: &[SemanticToken]) -> Vec<u32> {
 }
 ```
 
-#### Thread-Safety Testing (**Diataxis: How-to**)
+#### Thread-Safety Testing
 
 The implementation includes comprehensive thread-safety testing:
 
@@ -2976,7 +2976,7 @@ fn bench_semantic_tokens_performance(b: &mut Bencher) {
 }
 ```
 
-#### Migration Guide (**Diataxis: How-to**)
+#### Migration Guide
 
 **From Legacy Implementation**:
 
@@ -2996,7 +2996,7 @@ let tokens = provider.extract(&ast); // Takes &self, safe for concurrent access
 3. No functional changes needed - same return types and behavior
 4. Significant performance improvement with thread safety
 
-#### Benefits of Thread-Safe Design (**Diataxis: Explanation**)
+#### Benefits of Thread-Safe Design
 
 1. **Eliminated Race Conditions**: No shared mutable state between calls
 2. **Exceptional Performance**: 35x better than target with 2.826µs average
@@ -3005,7 +3005,7 @@ let tokens = provider.extract(&ast); // Takes &self, safe for concurrent access
 5. **Memory Safety**: Local state prevents use-after-free and data races
 6. **Scalability**: Supports high-concurrency LSP server environments
 
-### Performance Improvements (PR #140) (**Diataxis: Explanation** - Test reliability)
+### Performance Improvements (PR #140)
 
 PR #140 delivers significant performance optimizations for test reliability and speed, maintaining 100% functional compatibility:
 
@@ -3014,11 +3014,11 @@ PR #140 delivers significant performance optimizations for test reliability and 
 - **Individual workspace tests**: 60s+ → 0.26s
 - **Overall test suite**: 60s+ → <10s
 
-### Adaptive Threading Configuration (**Diataxis: Explanation** - Enhanced thread-aware timeout management)
+### Adaptive Threading Configuration
 
 Building on these performance gains, the LSP server includes adaptive threading configuration that automatically scales timeouts and concurrency based on available system resources and environment constraints. This ensures reliable operation across diverse environments from CI runners to development workstations.
 
-#### Core Threading Architecture (**Diataxis: Reference** - Implementation details)
+#### Core Threading Architecture
 
 ```rust
 /// Get the maximum number of concurrent threads to use in tests
@@ -3063,7 +3063,7 @@ fn get_adaptive_timeout() -> Duration {
 }
 ```
 
-#### Test Infrastructure Enhancement (**Diataxis: Explanation** - PR #140 optimizations)
+#### Test Infrastructure Enhancement
 
 The PR #140 enhancements introduce multiple optimization strategies:
 
@@ -3077,7 +3077,7 @@ The PR #140 enhancements introduce multiple optimization strategies:
 - **After**: 200ms wait cycles (**5x improvement**)
 - **Adaptive polling**: Initial rapid → medium → stable polling strategy
 
-#### Enhanced Timeout Scaling Strategy (**Diataxis: Explanation** - Multi-tier approach)
+#### Enhanced Timeout Scaling Strategy
 
 The adaptive timeout system implements sophisticated scaling:
 
@@ -3092,7 +3092,7 @@ The adaptive timeout system implements sophisticated scaling:
 - **Thread Count 5-8**: **7.5-second timeouts** (1.5x multiplier) - Modern machines
 - **Thread Count >8**: **5-second timeouts** - High-performance workstations
 
-#### Thread-Aware Testing (**Diataxis: How-to** - Running tests in constrained environments)
+#### Thread-Aware Testing
 
 ```bash
 # CI environment testing with extended timeouts
@@ -3108,7 +3108,7 @@ cargo test -p perl-lsp
 LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp  # Override adaptive timeouts
 ```
 
-#### Adaptive Sleep Configuration (**Diataxis: Reference** - Helper functions)
+#### Adaptive Sleep Configuration
 
 ```rust
 /// Adaptive sleep duration based on thread constraints
@@ -3126,7 +3126,7 @@ pub fn adaptive_sleep_ms(base_ms: u64) -> Duration {
 }
 ```
 
-#### CI Test Configuration (**Diataxis: How-to** - Production testing practices)
+#### CI Test Configuration
 
 **Thread Limiting for CI Reliability (v0.8.8+)**:
 
@@ -3168,7 +3168,7 @@ cargo test -p perl-lsp --test lsp_integration_tests -- --test-threads=2
 **Local Development**: Can use higher thread counts for faster feedback loops
 **CI Environments**: Should use `RUST_TEST_THREADS=2` for optimal reliability
 
-#### Environment Detection (**Diataxis: Explanation** - Automatic adaptation)
+#### Environment Detection
 
 The system automatically detects thread constraints through multiple mechanisms:
 
@@ -3178,7 +3178,7 @@ The system automatically detects thread constraints through multiple mechanisms:
 
 This ensures that LSP tests pass reliably regardless of the execution environment, from single-core CI runners to high-end development workstations.
 
-#### Performance Impact (**Diataxis: Reference** - PR #140 benchmark data)
+#### Performance Impact
 
 **Test Suite Performance Gains**:
 - **lsp_behavioral_tests.rs**: 1560s+ → 0.31s
@@ -3245,7 +3245,7 @@ vscode.commands.registerCommand('perl.extractVariable', async (args) => {
 
 ## Performance Considerations
 
-### Comprehensive LSP Performance Optimizations (v0.8.8+ with PR #140) (**Diataxis: Explanation**)
+### Comprehensive LSP Performance Optimizations (v0.8.8+ with PR #140)
 
 The v0.8.8 release enhanced by PR #140 introduces significant performance optimizations for test reliability and speed. These optimizations maintain 100% API compatibility:
 
@@ -3306,7 +3306,7 @@ pub fn search_with_limit(
 }
 ```
 
-#### Performance Testing Configuration (**Diataxis: How-to**)
+#### Performance Testing Configuration
 
 **Environment Variable Configuration**:
 ```bash
@@ -3432,11 +3432,11 @@ async fn handle_workspace_symbol_async(
 }
 ```
 
-## Text-Based Fallback Mechanisms (v0.8.8+) (*Diataxis: Explanation* - Robust LSP reliability through intelligent fallbacks)
+## Text-Based Fallback Mechanisms (v0.8.8+)
 
 The v0.8.8+ release introduces comprehensive text-based fallback mechanisms that ensure LSP functionality remains available even when AST parsing fails or encounters errors. This architectural enhancement significantly improves reliability and user experience across all LSP features.
 
-### Architecture Design (*Diataxis: Explanation* - Understanding fallback strategy)
+### Architecture Design
 
 The text-based fallback system operates on a three-tier hierarchy:
 
@@ -3461,9 +3461,9 @@ The text-based fallback system operates on a three-tier hierarchy:
 └─────────────────┘                └─────────────────┘
 ```
 
-### Feature-Specific Fallback Implementations (*Diataxis: Reference* - Complete fallback specification)
+### Feature-Specific Fallback Implementations
 
-#### 1. Workspace Symbol Fallback (*Diataxis: Reference*)
+#### 1. Workspace Symbol Fallback
 
 **Text-Based Symbol Extraction**:
 ```rust
@@ -3504,7 +3504,7 @@ fn extract_text_based_symbols(&self, text: &str, uri: &str, query: &str) -> Vec<
 - ✅ Use/require statement analysis
 - ⚠️ Limited scope analysis (no AST context)
 
-#### 2. Code Lens Fallback (*Diataxis: Reference*)
+#### 2. Code Lens Fallback
 
 **Text-Based Reference Counting**:
 ```rust
@@ -3547,7 +3547,7 @@ fn extract_text_based_code_lenses(&self, text: &str, _uri: &str) -> Vec<Value> {
 - ⚠️ Limited to text-based pattern matching
 - ⚠️ No cross-file reference detection
 
-#### 3. Document Symbol Fallback (*Diataxis: Reference*)
+#### 3. Document Symbol Fallback
 
 **Hierarchical Symbol Extraction**:
 ```rust
@@ -3601,7 +3601,7 @@ fn extract_symbols_fallback(&self, content: &str) -> Vec<Value> {
 }
 ```
 
-#### 4. Folding Range Fallback (*Diataxis: Reference*)
+#### 4. Folding Range Fallback
 
 **Syntax-Aware Folding Detection**:
 ```rust
@@ -3644,7 +3644,7 @@ fn extract_folding_fallback(&self, content: &str) -> Vec<Value> {
 }
 ```
 
-### Intelligent Degradation Patterns (*Diataxis: How-to* - Implementing graceful degradation)
+### Intelligent Degradation Patterns
 
 #### Pattern 1: AST-First with Immediate Fallback
 
@@ -3697,7 +3697,7 @@ For comprehensive testing, fallbacks can be forced using environment variables:
 }
 ```
 
-### Performance Characteristics (*Diataxis: Reference*)
+### Performance Characteristics
 
 #### Fallback Performance Metrics
 
@@ -3714,7 +3714,7 @@ For comprehensive testing, fallbacks can be forced using environment variables:
 - **Text-Based Fallback**: 850KB average (-60% reduction)
 - **Regex Compilation**: One-time 120KB overhead per pattern
 
-### Testing Fallback Mechanisms (*Diataxis: How-to*)
+### Testing Fallback Mechanisms
 
 #### Unit Testing Fallbacks
 
@@ -3783,7 +3783,7 @@ fn test_fallback_integration_comprehensive() {
 }
 ```
 
-### Error Handling and Recovery (*Diataxis: How-to*)
+### Error Handling and Recovery
 
 #### Graceful Error Recovery
 
@@ -3810,7 +3810,7 @@ impl LspServer {
 }
 ```
 
-#### Enhanced JSON-RPC Error Handling (*Diataxis: How-to* - Issue #144 Implementation)
+#### Enhanced JSON-RPC Error Handling
 
 **Malformed Frame Recovery** (*NEW: Issue #144*): The LSP server now implements comprehensive error recovery for malformed JSON-RPC frames:
 
@@ -3869,7 +3869,7 @@ echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perl-lsp --
 // Error recovery maintains pipeline integrity at each stage
 ```
 
-### Benefits for LSP Users (*Diataxis: Explanation*)
+### Benefits for LSP Users
 
 #### Enhanced Reliability
 
@@ -3892,7 +3892,7 @@ echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perl-lsp --
 3. **Performance Predictability**: Known performance characteristics for both modes
 4. **Scalable Architecture**: Fallbacks can be enhanced independently
 
-### Migration Guide for Custom LSP Features (*Diataxis: How-to*)
+### Migration Guide for Custom LSP Features
 
 #### Step 1: Implement Text-Based Fallback
 
@@ -3998,7 +3998,7 @@ fn test_semantic_tokens_full() {
 }
 ```
 
-## Enhanced Signature Parsing and Parameter Extraction (v0.8.8+) (**Diataxis: Explanation**)
+## Enhanced Signature Parsing and Parameter Extraction (v0.8.8+)
 
 ### Overview
 
@@ -4207,7 +4207,7 @@ fn test_nested_calls() {
 
 This enhancement significantly improves the developer experience by providing accurate, real-time parameter assistance for both built-in and user-defined functions.
 
-## ModuleResolver Architecture Benefits (**Diataxis: Explanation**)
+## ModuleResolver Architecture Benefits
 
 ### Design Rationale and Architectural Decisions
 
@@ -4554,7 +4554,7 @@ print INVALID_BAREWORD;
 4. **Backward Compatibility**: Only add logic, don't change existing behavior
 5. **Test Coverage**: Comprehensive tests for all hash key scenarios
 
-## DAP Integration Architecture (*Diataxis: Explanation* - Debug Adapter Protocol support)
+## DAP Integration Architecture
 
 ### Current Adapter Modes (Native CLI + BridgeAdapter)
 
@@ -4594,7 +4594,7 @@ The `perl-dap` crate ships a native adapter that talks directly to `perl -d` (de
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Key Components (*Diataxis: Reference* - DAP implementation modules)
+### Key Components
 
 #### DebugAdapter (`src/debug_adapter.rs`)
 
@@ -4691,7 +4691,7 @@ let env = setup_environment(&[
 - **WSL**: Automatic path translation (`/mnt/c/Users` → `C:\Users`)
 - **macOS/Linux**: Symlink canonicalization, proper `PATH`/`PERL5LIB` separator (`:`)
 
-### Integration with LSP Workflow (*Diataxis: Explanation* - LSP + DAP unified experience)
+### Integration with LSP Workflow
 
 The DAP implementation integrates seamlessly with the existing LSP workflow:
 
@@ -4719,7 +4719,7 @@ Parse → Index → Navigate → Complete → Analyze → Debug
    - <1ms breakpoint validation on file changes
    - Leverage 70-99% node reuse efficiency
 
-### Configuration Examples (*Diataxis: How-to* - Common debugging scenarios)
+### Configuration Examples
 
 #### Basic Launch Configuration
 
@@ -4766,7 +4766,7 @@ Parse → Index → Navigate → Complete → Analyze → Debug
 }
 ```
 
-### Performance Characteristics (*Diataxis: Reference* - DAP performance metrics)
+### Performance Characteristics
 
 **Phase 1 Bridge Performance** (measured in Issue #207):
 
@@ -4782,7 +4782,7 @@ Parse → Index → Navigate → Complete → Analyze → Debug
 - Message proxying: Zero-copy stdio forwarding
 - Configuration validation: <5ms path resolution and normalization
 
-### Security Considerations (*Diataxis: Explanation* - DAP security design)
+### Security Considerations
 
 The DAP implementation follows enterprise security practices:
 
@@ -4806,7 +4806,7 @@ The DAP implementation follows enterprise security practices:
    - Default timeout prevents infinite hangs
    - Graceful cleanup on abnormal termination
 
-### Testing Strategy (*Diataxis: Reference* - DAP test coverage)
+### Testing Strategy
 
 **Comprehensive Test Suite** (71/71 tests passing):
 
@@ -4832,7 +4832,7 @@ cargo test -p perl-dap -- test_setup_environment_path_separator
 - Environment variable merging and PERL5LIB construction
 - Empty argument lists and include paths
 
-### Future Roadmap (*Diataxis: Explanation* - Phase 2/3 native implementation)
+### Future Roadmap
 
 **Phase 2: Native Rust Adapter** (Planned):
 
@@ -4855,7 +4855,7 @@ VS Code ↔ perl-dap (Rust) ↔ Devel::TSPerlDAP (Perl shim) ↔ perl -d
 - Multi-editor support (Neovim, Emacs, Helix)
 - Comprehensive security audit and fuzzing
 
-### See Also (*Diataxis: Reference* - Related documentation)
+### See Also
 
 - **[DAP User Guide](../tutorials/DAP_USER_GUIDE.md)**: Step-by-step setup and debugging tutorials
 - **[DAP Implementation Specification](DAP_IMPLEMENTATION_SPECIFICATION.md)**: Comprehensive technical specification
@@ -4980,7 +4980,7 @@ When adding LSP features involving:
 
 These security practices ensure the LSP implementation serves as a reference for secure development practices in the Perl ecosystem.
 
-## Code Formatting Implementation (*Diataxis: Explanation*)
+## Code Formatting Implementation
 
 The LSP server provides enhanced code formatting capabilities with robust external tool dependency handling. As of v0.8.8+, formatting capabilities are always advertised regardless of external tool availability, providing a consistent user experience across different development environments.
 
@@ -4993,7 +4993,7 @@ The LSP server provides enhanced code formatting capabilities with robust extern
 3. **Test Suite Robustness**: Integration tests pass reliably across CI/CD environments
 4. **Future-Proof Design**: Built-in formatters can be added without capability changes
 
-### Implementation Details (*Diataxis: Reference*)
+### Implementation Details
 
 #### Capability Advertising
 
@@ -5030,7 +5030,7 @@ let perltidy_cmd = self.find_perltidy_command();
 // 3. Fallback to built-in settings
 ```
 
-#### Error Handling and User Guidance (*Diataxis: How-to*)
+#### Error Handling and User Guidance
 
 When `perltidy` is unavailable, the server provides comprehensive installation guidance:
 
@@ -5045,7 +5045,7 @@ To install perltidy:
   - Windows: cpan Perl::Tidy
 ```
 
-### Test Suite Robustness (*Diataxis: How-to*)
+### Test Suite Robustness
 
 #### Handling Missing Dependencies
 
@@ -5071,7 +5071,7 @@ if let Some(res) = result {
 **CI/CD Environments**: Tests pass without external dependencies  
 **Production Deployments**: Clear error messages guide users to install required tools
 
-### Future Enhancements (*Diataxis: Explanation*)
+### Future Enhancements
 
 The architecture supports planned enhancements:
 
@@ -5092,7 +5092,7 @@ impl BuiltInFormatter {
 
 **Integration Path**: Future versions can seamlessly add built-in formatting without changing capability advertising or client expectations.
 
-### Configuration Options (*Diataxis: Reference*)
+### Configuration Options
 
 #### LSP Formatting Parameters
 
@@ -5117,7 +5117,7 @@ impl BuiltInFormatter {
 - Falls back to user home directory configuration
 - Uses built-in defaults when no configuration found
 
-### Performance Characteristics (*Diataxis: Reference*)
+### Performance Characteristics
 
 **Formatting Speed**: 
 - Small files (< 1KB): < 100ms including perltidy startup

--- a/docs/reference/MISSING_DOCUMENTATION_GUIDE.md
+++ b/docs/reference/MISSING_DOCUMENTATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Missing Documentation Guide - SPEC-149 Implementation
 
-*Diataxis: How-to Guide* - Systematic documentation resolution strategy for perl-parser crate comprehensive API documentation compliance.
+Systematic documentation resolution strategy for perl-parser crate comprehensive API documentation compliance.
 
 ## Overview
 

--- a/docs/reference/MODERN_ARCHITECTURE.md
+++ b/docs/reference/MODERN_ARCHITECTURE.md
@@ -47,7 +47,7 @@ Advanced pattern recognition for dynamic delimiter detection:
 - **All declaration types**: `my`, `our`, `local`, `state` variable declarations
 - **Multiple recovery strategies**: Conservative, BestGuess, Interactive modes
 
-### Performance Optimization Engine (v0.8.8+) ⭐ **NEW** (**Diataxis: Explanation**)
+### Performance Optimization Engine (v0.8.8+) ⭐ **NEW**
 
 **PR #102 Lexer Optimizations** deliver significant performance improvements through intelligent algorithm optimization:
 
@@ -211,7 +211,7 @@ python3 scripts/generate_comparison.py \
   --memory-threshold 15.0
 ```
 
-This framework enables data-driven performance optimization and ensures no performance regressions across implementations (**Diataxis: How-to**).
+This framework enables data-driven performance optimization and ensures no performance regressions across implementations.
 
 ## Integration Points
 
@@ -285,7 +285,7 @@ The perl-parser crate includes a comprehensive **Rope-based document management 
                             └─────────────────┘         └─────────────────┘
 ```
 
-### Key Components (**Diataxis: Reference**)
+### Key Components
 
 #### Rope-based Position Management
 - **`textdoc.rs`**: Core `Doc` struct with `ropey::Rope` for efficient text storage
@@ -298,7 +298,7 @@ The perl-parser crate includes a comprehensive **Rope-based document management 
 - **`incremental_handler_v2.rs`**: Enhanced document change processing using Rope operations
 - **Automatic fallback**: Graceful degradation to full parsing when needed
 
-### Benefits (**Diataxis: Explanation**)
+### Benefits
 - **Efficient text operations**: Rope's piece table architecture optimizes insertions/deletions
 - **Accurate position mapping**: Eliminates UTF-16/UTF-8 conversion bugs common in LSP servers  
 - **Real-time editing support**: Sub-millisecond document updates with incremental parsing

--- a/docs/reference/ROPE_INTEGRATION_GUIDE.md
+++ b/docs/reference/ROPE_INTEGRATION_GUIDE.md
@@ -6,11 +6,11 @@
 - **Reference**: API documentation and specifications
 - **Explanation**: Design decisions and concepts
 
-## Overview (*Diataxis: Explanation* - Design concepts)
+## Overview
 
 The perl-parser crate includes comprehensive Rope support for efficient document management, enabling sub-millisecond position conversions and scalable text manipulation for large Perl files. Rope integration provides the foundation for LSP performance with UTF-16/UTF-8 compatibility.
 
-## Core Rope Modules (*Diataxis: Reference* - API specifications)
+## Core Rope Modules
 
 The perl-parser crate includes comprehensive Rope support for document management:
 
@@ -19,7 +19,7 @@ The perl-parser crate includes comprehensive Rope support for document managemen
 - **`incremental_integration.rs`**: Bridge between LSP server and incremental parsing with Rope
 - **`incremental_handler_v2.rs`**: Enhanced incremental document updates using Rope
 
-## Getting Started (*Diataxis: Tutorial* - Learning-oriented guidance)
+## Getting Started
 
 ### Basic Rope Usage
 
@@ -38,7 +38,7 @@ let char_count = doc.rope.len_chars();
 println!("Document has {} lines and {} characters", line_count, char_count);
 ```
 
-## Position Conversion API (*Diataxis: Reference* - API specifications)
+## Position Conversion API
 
 ```rust
 // UTF-16/UTF-8 position conversion
@@ -55,7 +55,7 @@ let byte_offset = lsp_pos_to_byte(&doc.rope, pos, PosEnc::Utf16);
 let lsp_pos = byte_to_lsp_pos(&doc.rope, byte_offset, PosEnc::Utf16);
 ```
 
-## Advanced Features (*Diataxis: Explanation* - Understanding the capabilities)
+## Advanced Features
 
 ### Line Ending Support
 - **CRLF handling**: Proper Windows line ending support with automatic detection
@@ -69,7 +69,7 @@ let lsp_pos = byte_to_lsp_pos(&doc.rope, byte_offset, PosEnc::Utf16);
 - **Incremental updates**: Only affected text ranges are re-parsed during edits
 - **Unicode safety**: All position conversions handle multibyte UTF-8 sequences correctly
 
-## Implementation Guide (*Diataxis: How-to Guide* - Step-by-step implementation tasks)
+## Implementation Guide
 
 ### Integrating Rope with LSP Providers
 
@@ -129,7 +129,7 @@ pub fn handle_document_change(
 }
 ```
 
-## Development Guidelines (*Diataxis: How-to Guide* - Development practices)
+## Development Guidelines
 
 **Where to Make Rope Improvements**:
 - **Production Code**: `/crates/perl-parser/src/` - All Rope enhancements should target this crate
@@ -143,7 +143,7 @@ pub fn handle_document_change(
 3. **Performance**: Cache position conversions when processing multiple operations on the same range
 4. **Unicode Safety**: Never assume single-byte characters - use Rope's Unicode-aware methods
 
-## Testing and Validation (*Diataxis: How-to Guide* - Testing procedures)
+## Testing and Validation
 
 ### Comprehensive Test Suite
 

--- a/docs/reference/TEST_INFRASTRUCTURE_GUIDE.md
+++ b/docs/reference/TEST_INFRASTRUCTURE_GUIDE.md
@@ -21,7 +21,7 @@
 
 ## Test Categories
 
-### Overview (*Diataxis: Reference*)
+### Overview
 
 The Perl LSP project uses a comprehensive multi-tiered testing strategy with ~720 baseline tests across unit, integration, property-based, and E2E categories:
 
@@ -45,7 +45,7 @@ The Perl LSP project uses a comprehensive multi-tiered testing strategy with ~72
 
 **5% Drop Threshold**: If test count falls below 684 tests (720 × 0.95), investigate for accidentally disabled or deleted tests.
 
-### 1. Unit Tests (*Diataxis: Tutorial*)
+### 1. Unit Tests
 
 **Purpose**: Fast, isolated component testing with millisecond execution times.
 
@@ -74,7 +74,7 @@ cargo test -p perl-parser semantic::tests
 - Lexer unit tests: `/crates/perl-lexer/src/lib.rs` (tokenization, Unicode handling)
 - LSP unit tests: `/crates/perl-lsp/src/lib.rs` (protocol handling, state management)
 
-### 2. Integration Tests (*Diataxis: Tutorial*)
+### 2. Integration Tests
 
 **Purpose**: Test component interactions, LSP protocol compliance, and cross-module behavior.
 
@@ -104,7 +104,7 @@ cargo test -p perl-parser --test substitution_fixed_tests
 - `lsp_full_coverage_user_stories.rs`: User story validation (0.32s with RUST_TEST_THREADS=2)
 - `semantic_definition.rs`: Semantic-aware go-to-definition tests
 
-### 3. Property-Based Tests (*Diataxis: Tutorial*)
+### 3. Property-Based Tests
 
 **Purpose**: Validate invariants across randomly generated inputs using proptest framework.
 
@@ -152,7 +152,7 @@ proptest! {
 }
 ```
 
-### 4. End-to-End (E2E) Tests (*Diataxis: Tutorial*)
+### 4. End-to-End (E2E) Tests
 
 **Purpose**: Full workflow validation including LSP server lifecycle, client communication, and workspace operations.
 
@@ -187,7 +187,7 @@ RUST_LOG=debug RUST_TEST_THREADS=1 cargo test -p perl-lsp --test lsp_comprehensi
 
 ## Test Discovery Protocol
 
-### Baseline Verification (*Diataxis: Reference*)
+### Baseline Verification
 
 **Current Baseline**: 720 tests (workspace lib tests: 382 tests)
 
@@ -211,7 +211,7 @@ running 9 tests     # perl-dap
 running 324 tests   # perl-parser
 ```
 
-### Test Count Monitoring (*Diataxis: How-to*)
+### Test Count Monitoring
 
 **5% Drop Threshold**: Investigate if total test count falls below 684 tests.
 
@@ -250,7 +250,7 @@ fi
 
 ## Timeout Strategy
 
-### Adaptive Timeout Architecture (*Diataxis: Explanation*)
+### Adaptive Timeout Architecture
 
 The LSP server implements **adaptive timeout scaling** based on thread count detection (PR #140):
 
@@ -269,7 +269,7 @@ The LSP server implements **adaptive timeout scaling** based on thread count det
 * LSP harness millisecond-precision timeouts (see get_adaptive_timeout)
 ```
 
-### Multi-Tier Timeout System (*Diataxis: Reference*)
+### Multi-Tier Timeout System
 
 #### 1. LSP Harness Timeouts (Millisecond Precision)
 
@@ -347,7 +347,7 @@ pub fn wait_for_idle(&self) {
 }
 ```
 
-### Timeout Configuration Best Practices (*Diataxis: How-to*)
+### Timeout Configuration Best Practices
 
 **For CI Environments**:
 ```bash
@@ -377,7 +377,7 @@ RUST_TEST_THREADS=8 cargo test --workspace
 
 ## Nextest Configuration
 
-### Overview (*Diataxis: Reference*)
+### Overview
 
 The project uses **cargo-nextest** for enhanced test execution with retry support, slow test detection, and thread management.
 
@@ -388,7 +388,7 @@ The project uses **cargo-nextest** for enhanced test execution with retry suppor
 cargo install cargo-nextest
 ```
 
-### Profiles (*Diataxis: Reference*)
+### Profiles
 
 #### 1. Default Profile (Local Development)
 
@@ -456,7 +456,7 @@ retries = 3
 
 **Rationale**: Cancellation tests require careful thread management to validate race condition handling.
 
-### Flaky Test Retry Configuration (*Diataxis: Reference*)
+### Flaky Test Retry Configuration
 
 ```toml
 # Known flaky BrokenPipe tests get extra retries
@@ -486,7 +486,7 @@ cargo nextest run --profile local-fast --workspace
 
 ## Known Flaky Tests
 
-### Overview (*Diataxis: Explanation*)
+### Overview
 
 Most historical "BrokenPipe" test failures were environmental/timing issues, now fully resolved by:
 1. Adaptive threading configuration (RUST_TEST_THREADS=2)
@@ -498,7 +498,7 @@ Most historical "BrokenPipe" test failures were environmental/timing issues, now
 - **Non-default lanes**: Feature-gated tests run with `--all-features` or specific feature flags
 - **Baseline**: `scripts/.ignored-baseline`
 
-### Known Flaky Test Categories (*Diataxis: Reference*)
+### Known Flaky Test Categories
 
 #### 1. LSP Document Symbols (`lsp_document_symbols_test.rs`)
 
@@ -563,7 +563,7 @@ retries = 3
 cargo test -p perl-lsp --test lsp_encoding_edge_cases -- --nocapture
 ```
 
-### BrokenPipe Error Handling (*Diataxis: How-to*)
+### BrokenPipe Error Handling
 
 **Understanding BrokenPipe Errors**:
 ```rust
@@ -605,7 +605,7 @@ cargo test -p perl-lsp --test lsp_init_torture_test -- --nocapture
 
 ## Environment Variables
 
-### RUST_TEST_THREADS (*Diataxis: Reference*)
+### RUST_TEST_THREADS
 
 **Enhanced in PR #140**: Adaptive threading achieving significant performance gains in CI.
 
@@ -642,7 +642,7 @@ pub fn max_concurrent_threads() -> usize {
 }
 ```
 
-### LSP_TEST_FALLBACKS (*Diataxis: Reference*)
+### LSP_TEST_FALLBACKS
 
 **NEW in v0.8.8**: Fast testing mode reducing timeouts by 75% (2000ms → 500ms).
 
@@ -682,7 +682,7 @@ if use_fallback {
 - CI gate validation (2-5 min total)
 - Development iteration (rapid test cycles)
 
-### RUN_REAL_WORLD (*Diataxis: Reference*)
+### RUN_REAL_WORLD
 
 **Purpose**: Enable expensive real-world corpus testing (disabled by default).
 
@@ -704,7 +704,7 @@ RUN_REAL_WORLD=1 RUST_TEST_THREADS=8 cargo test -p perl-corpus
 - ~5MB+ of Perl source code
 - Edge case coverage: heredocs, Unicode, operator precedence
 
-### CI (*Diataxis: Reference*)
+### CI
 
 **Purpose**: Detect CI environment and adjust test behavior.
 
@@ -733,7 +733,7 @@ env:
   RUST_TEST_THREADS: 2
 ```
 
-### LSP_TEST_ECHO_STDERR (*Diataxis: Reference*)
+### LSP_TEST_ECHO_STDERR
 
 **Purpose**: Echo LSP server stderr to test output for debugging.
 
@@ -750,7 +750,7 @@ LSP_TEST_ECHO_STDERR=1 RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --nocapture
 RUST_LOG=debug LSP_TEST_ECHO_STDERR=1 cargo test -p perl-lsp --test specific_test -- --nocapture
 ```
 
-### RUST_LOG (*Diataxis: Reference*)
+### RUST_LOG
 
 **Purpose**: Control tracing/logging output level.
 
@@ -777,7 +777,7 @@ RUST_LOG=perl_parser::semantic=debug cargo test -p perl-parser
 
 ## Running Tests Locally vs CI
 
-### Local Development (*Diataxis: How-to*)
+### Local Development
 
 #### Quick Iteration Workflow
 
@@ -824,7 +824,7 @@ done
 cargo nextest run --profile local-fast --workspace
 ```
 
-### CI Environment (*Diataxis: How-to*)
+### CI Environment
 
 #### GitHub Actions Configuration
 
@@ -909,7 +909,7 @@ test:
       junit: target/nextest/ci/junit.xml
 ```
 
-### Justfile Recipes (*Diataxis: How-to*)
+### Justfile Recipes
 
 The project provides **justfile** recipes for standardized test execution:
 
@@ -960,7 +960,7 @@ cargo doc -p perl-parser -p perl-lsp --no-deps
 
 ## Test Quality Assurance
 
-### Mutation Testing (*Diataxis: Tutorial*)
+### Mutation Testing
 
 **Purpose**: Validate test effectiveness by introducing code mutations and ensuring tests fail.
 
@@ -992,7 +992,7 @@ RUST_TEST_THREADS=2 cargo test -p perl-parser --test mutation_hardening_tests
 - `cancellation_atomic_operations_hardening.rs`: Concurrency mutations
 - `documentation_validation_mutation_hardening.rs`: API documentation mutations
 
-### Fuzz Testing (*Diataxis: Tutorial*)
+### Fuzz Testing
 
 **Purpose**: Property-based testing with crash detection and AST invariant validation.
 
@@ -1018,7 +1018,7 @@ cargo test -p perl-parser --test substitution_fuzz_tests
 - `fuzz_incremental_parsing.rs`: Incremental parser stress testing
 - `fuzz_documentation_infrastructure_pr159.rs`: Documentation infrastructure fuzzing
 
-### Test Coverage Tracking (*Diataxis: How-to*)
+### Test Coverage Tracking
 
 **Installation**:
 ```bash
@@ -1043,7 +1043,7 @@ cargo tarpaulin --workspace --exclude-files '**/prop_*.rs' --out Html
 - **Integration tests**: 70-75% feature coverage
 - **Property tests**: 95%+ invariant coverage
 
-### Test Hygiene Metrics (*Diataxis: Reference*)
+### Test Hygiene Metrics
 
 **Health Scoreboard** (`just health`):
 ```bash
@@ -1077,7 +1077,7 @@ cargo tarpaulin --workspace --exclude-files '**/prop_*.rs' --out Html
   ...
 ```
 
-### Test Documentation Standards (*Diataxis: Reference*)
+### Test Documentation Standards
 
 **Acceptance Criteria Validation**:
 ```bash
@@ -1106,7 +1106,7 @@ cargo test -p perl-parser --test missing_docs_ac_tests -- --nocapture
 
 ## Summary
 
-### Quick Reference Card (*Diataxis: Reference*)
+### Quick Reference Card
 
 ```bash
 # Fastest validation (2-5 min)

--- a/docs/reference/WORKSPACE_NAVIGATION_GUIDE.md
+++ b/docs/reference/WORKSPACE_NAVIGATION_GUIDE.md
@@ -26,11 +26,11 @@ The v0.8.8+ releases introduce production-stable workspace navigation with compr
 - **Cross-File Call Analysis**: Improved workspace-wide call relationship tracking with accurate reference resolution
 - **Advanced Symbol Navigation**: Enhanced go-to-definition and find-references with comprehensive workspace indexing
 
-## Enhanced Cross-File Function Reference Navigation (*Diataxis: Explanation* - Understanding dual indexing benefits)
+## Enhanced Cross-File Function Reference Navigation
 
 The dual indexing strategy revolutionizes cross-file navigation by indexing function calls under both qualified and bare names, enabling comprehensive reference finding regardless of calling convention.
 
-### Key Enhancement: Dual Pattern Matching (*Diataxis: Reference* - Feature specification)
+### Key Enhancement: Dual Pattern Matching
 
 When you use "Find References" on a function, the LSP server now:
 
@@ -39,7 +39,7 @@ When you use "Find References" on a function, the LSP server now:
 3. **Automatic Deduplication**: Ensures each location appears only once in results
 4. **Cross-Package Resolution**: Handles imports, same-package calls, and explicit qualification
 
-## Tutorial: Using Enhanced Workspace Features (*Diataxis: Tutorial* - Hands-on learning)
+## Tutorial: Using Enhanced Workspace Features
 
 ### Step 1: Enhanced Function Reference Navigation
 
@@ -78,7 +78,7 @@ sub main_handler {
 1;
 ```
 
-### Step 2: Testing Dual Indexing in Your Editor (*Diataxis: How-to* - Step-by-step usage)
+### Step 2: Testing Dual Indexing in Your Editor
 
 1. **Right-click on `process_data` in Utils.pm**
    - Select "Find All References"
@@ -92,7 +92,7 @@ sub main_handler {
    - Works consistently regardless of qualified vs bare usage
    - Maintains 98% success rate with multi-tier fallback
 
-### Performance Impact of Dual Indexing (*Diataxis: Reference* - Performance characteristics)
+### Performance Impact of Dual Indexing
 
 The dual indexing strategy provides significant benefits with minimal performance overhead:
 
@@ -104,7 +104,7 @@ The dual indexing strategy provides significant benefits with minimal performanc
 | Search Speed | Fast | Fast (dual lookup) | Maintained performance |
 | Memory Usage | Baseline | +10-15% | Efficient deduplication |
 
-### Advanced Reference Patterns (*Diataxis: Reference* - Comprehensive coverage examples)
+### Advanced Reference Patterns
 
 The dual indexing strategy handles complex Perl reference patterns:
 
@@ -130,7 +130,7 @@ sub main_function {     # Found via workspace/symbol search
 }
 ```
 
-### Step 4: Cross-File Navigation Patterns (*Diataxis: How-to* - Advanced usage patterns)
+### Step 4: Cross-File Navigation Patterns
 ```perl
 # File: lib/Utils.pm
 our $GLOBAL_CONFIG = {};   # Workspace-wide rename support
@@ -146,7 +146,7 @@ $Utils::GLOBAL_CONFIG = {};  # Cross-file reference resolution
 Utils::utility_function();  # Enhanced call hierarchy navigation
 ```
 
-### Step 3: Dual Function Call Indexing (v0.8.8+) (*Diataxis: Tutorial* - Understanding enhanced cross-file navigation)
+### Step 3: Dual Function Call Indexing (v0.8.8+)
 
 The enhanced workspace navigation now supports **production-stable dual indexing** for function calls, achieving **98% reference coverage improvement** and dramatically improving cross-file reference finding:
 
@@ -182,7 +182,7 @@ my $result3 = MyModule::transformed("test");    # Qualified call
 #    of all function usage patterns across the entire workspace
 ```
 
-#### How Dual Indexing Works (*Diataxis: Explanation* - Technical implementation)
+#### How Dual Indexing Works
 
 1. **Bare Name Indexing**: Every function call like `foo()` is indexed under the bare name "foo"
 2. **Qualified Name Indexing**: The same call is also indexed under its qualified name like "MyModule::foo"
@@ -192,7 +192,7 @@ my $result3 = MyModule::transformed("test");    # Qualified call
 6. **Unicode Processing Enhancement**: Optimized Unicode character and emoji processing with performance instrumentation
 7. **Atomic Performance Tracking**: Real-time monitoring of indexing operations for performance regression detection
 
-#### Benefits for Workspace Navigation (*Diataxis: Explanation* - User experience improvements)
+#### Benefits for Workspace Navigation
 
 - **98% Reference Coverage**: Dramatically improved reference finding with comprehensive function call detection
 - **Cross-Package Navigation**: Seamlessly navigate between bare and qualified function calls  

--- a/docs/reference/WORKSPACE_REFACTOR_API_REFERENCE.md
+++ b/docs/reference/WORKSPACE_REFACTOR_API_REFERENCE.md
@@ -1,4 +1,4 @@
-# WorkspaceRefactor API Reference (**Diataxis: Reference**)
+# WorkspaceRefactor API Reference
 
 This document provides comprehensive API reference for the WorkspaceRefactor system introduced in v0.8.8, covering all methods, types, and error handling patterns.
 
@@ -107,7 +107,7 @@ pub enum RefactorError {
 }
 ```
 
-## Enhanced Workspace Symbol Resolution (v0.8.8+) (**Diataxis: Reference** - Dual indexing API)
+## Enhanced Workspace Symbol Resolution (v0.8.8+)
 
 ### Overview
 

--- a/docs/tutorials/COMPREHENSIVE_TESTING_GUIDE.md
+++ b/docs/tutorials/COMPREHENSIVE_TESTING_GUIDE.md
@@ -1,6 +1,6 @@
 # Comprehensive Testing Guide - PR #160 Parser Robustness & Documentation Infrastructure
 
-*Diataxis: How-to Guide* - Complete testing framework for perl-parser comprehensive quality assurance and documentation validation.
+Complete testing framework for perl-parser comprehensive quality assurance and documentation validation.
 
 ## Overview
 

--- a/docs/tutorials/EXECUTE_COMMAND_TUTORIAL.md
+++ b/docs/tutorials/EXECUTE_COMMAND_TUTORIAL.md
@@ -1,4 +1,4 @@
-# ExecuteCommand Tutorial (*Diataxis: Tutorial* - Learning-oriented executeCommand guide)
+# ExecuteCommand Tutorial
 
 *Get started with the new executeCommand functionality in Perl LSP server. This tutorial walks you through using perl.runCritic and other commands to enhance your Perl development workflow.*
 

--- a/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
+++ b/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
@@ -17,7 +17,7 @@ SignatureHelpProvider::new(ast)  // uses empty source
 SymbolExtractor::new()  // no documentation extraction
 ```
 
-### ModuleResolver Integration (NEW v0.8.8) - (*Diataxis: How-to Guide*)
+### ModuleResolver Integration (NEW v0.8.8)
 
 The CompletionProvider now supports pluggable module resolution for enhanced Perl module completion. This allows LSP features to resolve module names to file paths for improved functionality.
 
@@ -69,7 +69,7 @@ let completions = provider.get_completions_with_path(&doc.text, offset, Some(uri
 - **Caching Strategy**: Fast path checks open documents first
 - **Generic Design**: Works with any document representation for flexibility
 
-## Enhanced Cross-File Definition Resolution (v0.8.8+) (*Diataxis: How-to Guide* - Advanced LSP Development)
+## Enhanced Cross-File Definition Resolution (v0.8.8+)
 
 The v0.8.8+ releases introduce comprehensive Package::subroutine pattern resolution with sophisticated fallback mechanisms for robust cross-file navigation.
 
@@ -312,7 +312,7 @@ sub foo {  # Not documentation
 }
 ```
 
-## Cross-File Reference Handling (*Diataxis: Reference* - Enhanced package-qualified identifier support v0.8.8+)
+## Cross-File Reference Handling
 
 The v0.8.8+ release includes significant improvements to cross-file reference handling, particularly for package-qualified identifiers and reference deduplication.
 
@@ -428,7 +428,7 @@ When implementing new LSP features, follow this structure:
    - **Symbol documentation tests** for comment extraction features
    - User story tests for real-world scenarios
 
-## Testing Procedures (*Diataxis: How-to Guide* - Testing procedures)
+## Testing Procedures
 
 ### Dual-Scanner Corpus Validation (v0.8.8+)
 
@@ -455,7 +455,7 @@ cargo run -p xtask --features legacy -- corpus --diagnose  # Analyze first faili
 cargo run -p xtask --features legacy -- corpus --test      # Test simple expressions
 ```
 
-### Understanding Scanner Mismatch Reports (*Diataxis: Reference* - Output interpretation)
+### Understanding Scanner Mismatch Reports
 
 When scanner outputs differ (primarily legacy testing since C scanner now delegates to Rust), the system provides detailed analysis:
 ```
@@ -499,7 +499,7 @@ The refactoring system has two layers:
    - Alphabetical sorting and clean formatting
    - LSP code action integration with "Organize Imports"
 
-### Import Optimization Development Pattern (*Diataxis: How-to* - Import feature development)
+### Import Optimization Development Pattern
 
 Implementing import optimization features follows this pattern:
 
@@ -683,13 +683,13 @@ fn your_refactoring(&self, node: &Node) -> Option<CodeAction> {
 }
 ```
 
-### Enhanced executeCommand Integration ⭐ **NEW: Issue #145** (*Diataxis: How-to Guide* - executeCommand development patterns)
+### Enhanced executeCommand Integration ⭐ **NEW: Issue #145**
 
 The LSP server now supports comprehensive executeCommand functionality with robust error handling and tool integration patterns.
 
 #### executeCommand Provider Development Pattern
 
-**Core Provider Architecture** (*Diataxis: How-to* - Building executeCommand providers):
+**Core Provider Architecture**:
 ```rust
 // In execute_command.rs - Central command dispatcher pattern
 pub struct ExecuteCommandProvider {
@@ -713,7 +713,7 @@ impl ExecuteCommandProvider {
 }
 ```
 
-**Dual Analyzer Strategy Pattern** (*Diataxis: How-to* - Tool integration with fallback):
+**Dual Analyzer Strategy Pattern**:
 ```rust
 // perl.runCritic implementation with graceful degradation
 impl ExecuteCommandProvider {
@@ -756,7 +756,7 @@ impl ExecuteCommandProvider {
 }
 ```
 
-**Error Handling Pattern** (*Diataxis: How-to* - Robust error responses):
+**Error Handling Pattern**:
 ```rust
 // Structured error responses with user-friendly messages
 impl ExecuteCommandProvider {
@@ -788,7 +788,7 @@ impl ExecuteCommandProvider {
 
 #### LSP Server Integration Pattern
 
-**Server Handler Integration** (*Diataxis: How-to* - Wiring executeCommand to LSP protocol):
+**Server Handler Integration**:
 ```rust
 // In lsp_server.rs - Protocol integration
 impl LspServer {
@@ -835,7 +835,7 @@ Enhanced code actions now provide sophisticated refactoring with AST integration
 
 #### Enhanced Provider Architecture Pattern
 
-**Multi-tier Code Action Provider** (*Diataxis: How-to* - Advanced refactoring architecture):
+**Multi-tier Code Action Provider**:
 ```rust
 // In code_actions_enhanced.rs - Sophisticated refactoring provider
 pub struct EnhancedCodeActionsProvider {
@@ -971,7 +971,7 @@ fn create_extract_subroutine_action(&self, node: &Node) -> Option<CodeAction> {
 
 #### Performance Optimization Patterns
 
-**Multi-tier Caching Strategy** (*Diataxis: How-to* - Code action performance):
+**Multi-tier Caching Strategy**:
 ```rust
 // High-performance caching with incremental invalidation
 pub struct CodeActionCache {
@@ -1029,7 +1029,7 @@ The project includes test infrastructure with significant performance optimizati
 - **Enhanced Test Harness**: Graceful degradation for CI environments
 - **Optimized Idle Detection**: 1000ms → 200ms cycles (**5x improvement**)
 
-### Performance Testing Configuration (PR #140) (v0.8.8+) (**Diataxis: How-to Guide** - Performance testing)
+### Performance Testing Configuration (PR #140) (v0.8.8+)
 
 The PR #140 enhancements deliver comprehensive performance optimizations:
 
@@ -1076,7 +1076,7 @@ RUST_TEST_THREADS=2 LSP_TEST_FALLBACKS=1 cargo test -p perl-lsp test_workspace_s
 LSP_TEST_FALLBACKS=1 cargo check --workspace
 ```
 
-#### Timeout Configuration Modes (**Diataxis: Reference**)
+#### Timeout Configuration Modes
 
 **Adaptive Mode (PR #140)** - Enhanced adaptive configuration:
 ```rust
@@ -1227,11 +1227,11 @@ impl LineStartsCache {
 }
 ```
 
-## Error Recovery and Fallback Mechanisms (*Diataxis: Explanation* - Enhanced reliability architecture v0.8.8+)
+## Error Recovery and Fallback Mechanisms
 
 The LSP server includes comprehensive, production-tested fallback mechanisms that ensure 99.9% feature availability even during parser failures, incomplete code, or AST unavailability. The v0.8.8+ release significantly enhances these systems with intelligent text-based analysis and robust error handling.
 
-### Three-Tier Reliability Architecture (*Diataxis: Explanation* - Understanding the reliability strategy)
+### Three-Tier Reliability Architecture
 
 ```
 ┌─────────────────┐    Primary      ┌─────────────────┐
@@ -1254,9 +1254,9 @@ The LSP server includes comprehensive, production-tested fallback mechanisms tha
 └─────────────────┘                 └─────────────────┘
 ```
 
-### Core Fallback Mechanisms (*Diataxis: Reference* - Complete fallback specification)
+### Core Fallback Mechanisms
 
-#### 1. Enhanced Workspace Symbol Fallback (*Diataxis: Reference* - v0.8.8+)
+#### 1. Enhanced Workspace Symbol Fallback
 
 **Comprehensive Text-Based Symbol Detection**:
 ```rust
@@ -1307,7 +1307,7 @@ fn extract_text_based_symbols(&self, text: &str, uri: &str, query: &str) -> Vec<
 - ✅ Method vs subroutine differentiation
 - ✅ Namespace-aware symbol resolution
 
-#### 2. Advanced Code Lens Fallback (*Diataxis: Reference* - v0.8.8+)
+#### 2. Advanced Code Lens Fallback
 
 **Intelligent Reference Counting with Method Detection**:
 ```rust
@@ -1355,7 +1355,7 @@ fn extract_text_based_code_lenses(&self, text: &str, _uri: &str) -> Vec<Value> {
 - ✅ Detailed reference breakdown in lens titles
 - ✅ Better handling of complex call patterns
 
-#### 3. Robust Document Symbol Fallback (*Diataxis: Reference* - v0.8.8+)
+#### 3. Robust Document Symbol Fallback
 
 **Hierarchical Symbol Extraction with Improved Accuracy**:
 ```rust
@@ -1420,7 +1420,7 @@ fn extract_symbols_fallback(&self, content: &str) -> Vec<Value> {
 }
 ```
 
-#### 4. Enhanced Signature Help Fallback (*Diataxis: Reference* - v0.8.8+)
+#### 4. Enhanced Signature Help Fallback
 
 **Context-Aware Function Detection**:
 - Enhanced backward scanning for function context
@@ -1429,7 +1429,7 @@ fn extract_symbols_fallback(&self, content: &str) -> Vec<Value> {
 - Support for complex function call patterns
 - Fallback signatures for unknown functions with parameter hints
 
-#### 5. Advanced Folding Range Fallback (*Diataxis: Reference* - v0.8.8+)
+#### 5. Advanced Folding Range Fallback
 
 **Multi-Pattern Folding Detection**:
 ```rust
@@ -1479,7 +1479,7 @@ fn extract_folding_fallback(&self, content: &str) -> Vec<Value> {
 }
 ```
 
-#### 6. Production-Stable Enhanced Scope Analysis (*Diataxis: Reference* - v0.8.7+)
+#### 6. Production-Stable Enhanced Scope Analysis
 
 **Industry-Leading Variable Resolution with Hash Context Detection**:
 - **Advanced Variable Resolution Patterns**: Hash access (`$hash{key}` → `%hash`), array access (`$array[idx]` → `@array`)  
@@ -1492,7 +1492,7 @@ fn extract_folding_fallback(&self, content: &str) -> Vec<Value> {
 - Context-aware bareword detection with 99.8% accuracy
 - **38 comprehensive test cases** with full edge case coverage
 
-### Enhanced Error Handling Patterns (*Diataxis: How-to* - Implementing robust error handling)
+### Enhanced Error Handling Patterns
 
 #### Pattern 1: Graceful Degradation with Logging
 
@@ -1538,7 +1538,7 @@ fn handle_with_test_fallbacks(&self, params: Option<Value>) -> Result<Option<Val
 }
 ```
 
-### Performance Impact and Monitoring (*Diataxis: Reference* - Fallback performance characteristics)
+### Performance Impact and Monitoring
 
 #### Fallback Performance Metrics (v0.8.8+)
 
@@ -1557,7 +1557,7 @@ fn handle_with_test_fallbacks(&self, params: Option<Value>) -> Result<Option<Val
 - **Regex Compilation**: 120KB one-time overhead per pattern set
 - **Cache Efficiency**: 85-95% hit rate maintained during fallbacks
 
-### Testing Fallback Reliability (*Diataxis: How-to* - Comprehensive fallback testing)
+### Testing Fallback Reliability
 
 #### Comprehensive Fallback Test Suite
 
@@ -1604,7 +1604,7 @@ mod fallback_tests {
 }
 ```
 
-### Production Benefits and Reliability (*Diataxis: Explanation* - Understanding the reliability improvements)
+### Production Benefits and Reliability
 
 #### Enhanced User Experience
 
@@ -1629,11 +1629,11 @@ mod fallback_tests {
 
 These comprehensive fallback mechanisms ensure the LSP remains highly functional and reliable during all phases of development, from initial code writing through complex refactoring scenarios.
 
-## Troubleshooting Text-Based Fallbacks (*Diataxis: How-to* - Debugging and resolving fallback issues)
+## Troubleshooting Text-Based Fallbacks
 
 This section provides comprehensive guidance for diagnosing and resolving issues with text-based fallback mechanisms in the LSP server.
 
-### Common Fallback Scenarios (*Diataxis: Reference* - When fallbacks activate)
+### Common Fallback Scenarios
 
 #### **Automatic Fallback Triggers**
 
@@ -1672,7 +1672,7 @@ This section provides comprehensive guidance for diagnosing and resolving issues
    server.set_fallback_mode(fallback_mode);
    ```
 
-### Diagnostic Techniques (*Diataxis: How-to* - Identifying fallback issues)
+### Diagnostic Techniques
 
 #### **1. Fallback Activation Logging**
 
@@ -1746,7 +1746,7 @@ fn validate_fallback_accuracy() {
 }
 ```
 
-### Resolving Common Issues (*Diataxis: How-to* - Fix specific fallback problems)
+### Resolving Common Issues
 
 #### **Issue 1: Missing Symbols in Fallback Mode**
 
@@ -1894,7 +1894,7 @@ fn count_references_enhanced(&self, text: &str, symbol_name: &str) -> (usize, us
 }
 ```
 
-### Advanced Troubleshooting (*Diataxis: How-to* - Complex debugging scenarios)
+### Advanced Troubleshooting
 
 #### **Scenario 1: Fallbacks Working But Results Inconsistent**
 
@@ -1949,7 +1949,7 @@ fn count_references_enhanced(&self, text: &str, symbol_name: &str) -> (usize, us
    }
    ```
 
-### Configuration and Optimization (*Diataxis: Reference* - Fallback tuning parameters)
+### Configuration and Optimization
 
 #### **Environment Variables**
 
@@ -1993,7 +1993,7 @@ impl Default for FallbackConfig {
 }
 ```
 
-### Success Metrics and Validation (*Diataxis: Reference* - Measuring fallback effectiveness)
+### Success Metrics and Validation
 
 #### **Key Performance Indicators (KPIs)**
 
@@ -2025,11 +2025,11 @@ impl FallbackMetrics {
 
 This comprehensive troubleshooting guide ensures that text-based fallback mechanisms can be effectively debugged, optimized, and monitored in production environments.
 
-## Enhanced LSP Workflow Integration ⭐ **NEW: Issue #145** (*Diataxis: Explanation* - Complete workflow architecture)
+## Enhanced LSP Workflow Integration ⭐ **NEW: Issue #145**
 
 The Perl LSP server now implements a comprehensive **Parse → Index → Navigate → Complete → Analyze → Execute** workflow pipeline that provides complete language server functionality.
 
-### Workflow Pipeline Architecture (*Diataxis: Explanation* - System design)
+### Workflow Pipeline Architecture
 
 **Complete LSP Workflow Pipeline**:
 ```
@@ -2039,7 +2039,7 @@ Parse → Index → Navigate → Complete → Analyze → Execute
 ~1ms   ~10ms   ~40ms     ~50ms     ~100ms     ~2s
 ```
 
-#### Phase 1: Parse (*Diataxis: Reference* - AST generation)
+#### Phase 1: Parse
 ```rust
 // Enhanced parsing with incremental support
 pub struct EnhancedParser {
@@ -2060,7 +2060,7 @@ impl EnhancedParser {
 }
 ```
 
-#### Phase 2: Index (*Diataxis: Reference* - Symbol indexing)
+#### Phase 2: Index
 ```rust
 // Dual indexing strategy for comprehensive coverage
 pub struct WorkspaceIndexer {
@@ -2083,7 +2083,7 @@ impl WorkspaceIndexer {
 }
 ```
 
-#### Phase 3: Navigate (*Diataxis: Reference* - Definition/reference resolution)
+#### Phase 3: Navigate
 ```rust
 // Enhanced cross-file navigation with dual pattern matching
 pub struct NavigationProvider {
@@ -2114,7 +2114,7 @@ impl NavigationProvider {
 }
 ```
 
-#### Phase 4: Complete (*Diataxis: Reference* - Code completion)
+#### Phase 4: Complete
 ```rust
 // Enhanced completion with context awareness and module resolution
 pub struct CompletionProvider {
@@ -2145,7 +2145,7 @@ impl CompletionProvider {
 }
 ```
 
-#### Phase 5: Analyze (*Diataxis: Reference* - Diagnostic analysis)
+#### Phase 5: Analyze
 ```rust
 // Enhanced analysis with performance monitoring
 pub struct DiagnosticAnalyzer {
@@ -2173,7 +2173,7 @@ impl DiagnosticAnalyzer {
 }
 ```
 
-#### Phase 6: Execute ⭐ **NEW: Issue #145** (*Diataxis: Reference* - Command execution)
+#### Phase 6: Execute ⭐ **NEW: Issue #145**
 ```rust
 // Enhanced executeCommand with dual analyzer strategy
 pub struct ExecuteCommandProvider {
@@ -2210,7 +2210,7 @@ impl ExecuteCommandProvider {
 }
 ```
 
-### Integration Patterns (*Diataxis: How-to Guide* - Development best practices)
+### Integration Patterns
 
 #### **Workflow State Management**
 ```rust
@@ -2276,7 +2276,7 @@ impl WorkflowPerformanceConfig {
 }
 ```
 
-### Quality Assurance Integration (*Diataxis: How-to Guide* - Testing complete workflows)
+### Quality Assurance Integration
 
 #### **End-to-End Workflow Testing**
 ```bash

--- a/docs/tutorials/WORKSPACE_REFACTORING_TUTORIAL.md
+++ b/docs/tutorials/WORKSPACE_REFACTORING_TUTORIAL.md
@@ -1,4 +1,4 @@
-# Workspace Refactoring Tutorial (**Diataxis: Tutorial**)
+# Workspace Refactoring Tutorial
 
 This tutorial provides step-by-step guidance on using the comprehensive workspace refactoring capabilities introduced in v0.8.8. These features enable safe cross-file refactoring operations for Perl codebases.
 
@@ -79,7 +79,7 @@ let refactor = WorkspaceRefactor::new(index);
 - ✅ Indexed multiple Perl files with their content
 - ✅ Initialized the WorkspaceRefactor system
 
-## Step 1.5: Understanding Dual Function Call Indexing (v0.8.8+) (**Diataxis: Tutorial**)
+## Step 1.5: Understanding Dual Function Call Indexing (v0.8.8+)
 
 Before diving into refactoring operations, let's understand the enhanced dual indexing strategy that makes comprehensive cross-file navigation possible:
 


### PR DESCRIPTION
### Motivation
- Reduce visual noise in documentation headings by removing inline "(Diataxis: …)" suffixes so guides, references, and tutorials read as plain headings.
- Improve consistency across tutorials, how‑to guides, references, and explanations without altering substantive content.
- Correct small artifacts introduced during normalization (dangling punctuation and trailing whitespace) to keep docs lint-clean.

### Description
- Removed inline Diataxis labels such as `(*Diataxis: How-to*)`, `(**Diataxis: Reference**)`, and standalone `Diataxis:` tagline lines across multiple docs while preserving original text and structure.
- Normalized affected headings and table-of-contents entries to remove trailing punctuation left behind after label removal and fixed one trailing-whitespace occurrence.
- Applied the cleanup across ~30 documentation files (tutorials, how-to, reference, explanation, benchmarks) while keeping examples, code blocks, and API text intact.
- Performed small automated fixes (whitespace trimming) and ensured headings that contained an extra dash or punctuation were corrected.

### Testing
- Verified no remaining inline markers with `rg -n "Diataxis:" docs`, which returned no matches after the change.
- Ran `git diff --check` to detect and fix trailing-whitespace issues and ensure no diff-check errors remained.
- Performed an automated sweep script to remove labels and inspected the list of modified files; affected files were validated for structure and formatting (changes limited to documentation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2187780b4833389bd1f80ce9a802c)