### PR TITLE
docs: clean up Diátaxis documentation pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Precise, complete information for lookup.
 - [Configuration](reference/CONFIG.md) — Configuration options
 - [FAQ](reference/FAQ.md) — Frequently asked questions
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md) — Current constraints and workarounds
-- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diataxis framework and standards
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diátaxis structure and writing guidance
 
 ## Explanation — understand why
 
@@ -91,7 +91,6 @@ Process, metrics, and project health.
 | [design/](design/) | Semantic analyzer design |
 | [EDITORS/](EDITORS/) | Editor-specific setup |
 | [forensics/](forensics/) | PR archaeology |
-| [internal/](internal/) | Internal working docs |
 | [issues/](issues/) | Corpus gap tracking |
 | [semantic/](semantic/) | Semantic validation |
 | [specs/](specs/) | Specification documents |

--- a/docs/reference/DOCUMENTATION_GUIDE.md
+++ b/docs/reference/DOCUMENTATION_GUIDE.md
@@ -1,334 +1,73 @@
-> For the documentation hub, see [README.md](../README.md). This page describes documentation standards and the Diataxis structure.
+> For the documentation hub, see [docs/README.md](../README.md).
 
-# Documentation Guide
+# Documentation Guide (Diátaxis)
 
-> **Main entry point for all perl-lsp documentation** - Navigate this guide to find exactly what you need.
+This repository organizes user-facing documentation using the [Diátaxis framework](https://diataxis.fr/):
 
-## Quick Start
+- **Tutorials**: learning-oriented, step-by-step guides.
+- **How-to guides**: task-oriented instructions for a specific outcome.
+- **Reference**: factual lookup material and specifications.
+- **Explanation**: conceptual background and design rationale.
 
-New to perl-lsp? Start here:
+## Where content belongs
 
-1. **[CLAUDE.md](../../CLAUDE.md)** - Project overview, installation, essential commands
-2. **[COMMANDS_REFERENCE.md](COMMANDS_REFERENCE.md)** - Comprehensive build/test commands
-3. **[LSP_IMPLEMENTATION_GUIDE.md](LSP_IMPLEMENTATION_GUIDE.md)** - LSP server architecture overview
+### 1) Tutorials (`docs/tutorials/`)
+Use tutorials when a reader needs guided practice.
 
-**Need help now?** Jump to:
-- [Installation & Setup](#tutorials-learning-oriented) for getting started
-- [Common Tasks](#how-to-guides-problem-oriented) for specific problems
-- [API Reference](#reference-documentation-information-oriented) for technical specs
-- [Architecture](#explanation-understanding-oriented) for understanding design
+Examples:
+- [Getting Started](../tutorials/GETTING_STARTED.md)
+- [LSP Development Guide](../tutorials/LSP_DEVELOPMENT_GUIDE.md)
+- [Execute Command Tutorial](../tutorials/EXECUTE_COMMAND_TUTORIAL.md)
 
----
+### 2) How-to guides (`docs/how-to/`)
+Use how-to guides when a reader already knows what they want to accomplish.
 
-## Documentation Structure (Diataxis Framework)
+Examples:
+- [Installation](../how-to/INSTALLATION.md)
+- [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Troubleshooting](../how-to/TROUBLESHOOTING.md)
 
-This documentation follows the [Diataxis framework](https://diataxis.fr/), organizing content into four distinct categories:
+### 3) Reference (`docs/reference/`)
+Use reference docs for contracts, schemas, command catalogs, and exact behavior.
 
-### 🎓 Tutorials (Learning-Oriented)
+Examples:
+- [Commands Reference](COMMANDS_REFERENCE.md)
+- [LSP Features](LSP_FEATURES.md)
+- [Stability Policy](STABILITY.md)
+- [Configuration](CONFIG.md)
 
-**Goal**: Learn by doing through step-by-step guided experiences.
+### 4) Explanation (`docs/explanation/`)
+Use explanation docs to describe design decisions and trade-offs.
 
-**Core Learning Paths**:
-- **[EXECUTE_COMMAND_TUTORIAL.md](../tutorials/EXECUTE_COMMAND_TUTORIAL.md)** - Build custom LSP commands from scratch
-- **[WORKSPACE_REFACTORING_TUTORIAL.md](../tutorials/WORKSPACE_REFACTORING_TUTORIAL.md)** - Master workspace-wide refactoring operations
-- **[COMPREHENSIVE_TESTING_GUIDE.md](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md)** - Test-driven development workflows
+Examples:
+- [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
+- [Error Handling Strategy](../explanation/ERROR_HANDLING_STRATEGY.md)
+- [Slash Disambiguation](../explanation/SLASH_DISAMBIGUATION.md)
 
-**Feature-Specific Tutorials**:
-- **[DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md)** - Set up debugging with Debug Adapter Protocol
-- **[LSP_DEVELOPMENT_GUIDE.md](../tutorials/LSP_DEVELOPMENT_GUIDE.md)** - Develop LSP features with source threading
-- **[AI_BUILD_GUIDE.md](../tutorials/AI_BUILD_GUIDE.md)** - AI-assisted development workflows
+## Writing rules
 
-**Validation**: All tutorials include testable code examples validated with `cargo test --doc`.
+When adding or updating documentation:
 
----
+1. **Choose one primary Diátaxis type** for the page.
+2. **Keep intent pure**:
+   - Tutorials teach by doing.
+   - How-to guides solve one concrete problem.
+   - Reference pages avoid narrative and opinion.
+   - Explanations focus on why, trade-offs, and context.
+3. **Cross-link instead of mixing styles** (for example, a how-to can link to reference for exact flags).
+4. **Use descriptive titles** that match user intent (e.g. “How to debug flaky LSP tests”).
 
-### 🔧 How-to Guides (Problem-Oriented)
+## Quick placement checklist
 
-**Goal**: Solve specific problems with task-oriented instructions.
+If the answer to the question is mainly...
 
-**Development Tasks**:
-- **[IMPORT_OPTIMIZER_GUIDE.md](../how-to/IMPORT_OPTIMIZER_GUIDE.md)** - Remove unused imports, add missing ones, sort alphabetically
-- **[FILE_COMPLETION_GUIDE.md](../how-to/FILE_COMPLETION_GUIDE.md)** - Implement enterprise-secure path completion
-- **[INCREMENTAL_PARSING_GUIDE.md](../how-to/INCREMENTAL_PARSING_GUIDE.md)** - Optimize parsing performance with <1ms updates
-- **[SOURCE_THREADING_GUIDE.md](../how-to/SOURCE_THREADING_GUIDE.md)** - Extract documentation from source comments
+- “**Teach me**” → `docs/tutorials/`
+- “**How do I**” → `docs/how-to/`
+- “**What is / what are the exact details**” → `docs/reference/`
+- “**Why is it designed this way**” → `docs/explanation/`
 
-**Testing & Debugging**:
-- **[THREADING_CONFIGURATION_GUIDE.md](../how-to/THREADING_CONFIGURATION_GUIDE.md)** - Adaptive threading for CI environments
-- **[LSP_ERROR_HANDLING_MONITORING_GUIDE.md](../how-to/LSP_ERROR_HANDLING_MONITORING_GUIDE.md)** - Monitor and debug LSP errors
-- **[DAP_BREAKPOINT_VALIDATION_GUIDE.md](../how-to/DAP_BREAKPOINT_VALIDATION_GUIDE.md)** - Validate breakpoint positioning
+## Maintenance
 
-**Optimization**:
-- **[PERFORMANCE_PRESERVATION_GUIDE.md](../how-to/PERFORMANCE_PRESERVATION_GUIDE.md)** - Maintain performance baselines
-- **[benchmarks/BENCHMARK_FRAMEWORK.md](../benchmarks/BENCHMARK_FRAMEWORK.md)** - Cross-language performance analysis
-
-**Security**:
-- **[SECURITY_DEVELOPMENT_GUIDE.md](../how-to/SECURITY_DEVELOPMENT_GUIDE.md)** - Security development practices
-
-**Commands**: All guides include proper cargo command specifications (`cargo test -p perl-parser`, `RUST_TEST_THREADS=2 cargo test -p perl-lsp`).
-
----
-
-### 📚 Reference Documentation (Information-Oriented)
-
-**Goal**: Look up precise technical information and API contracts.
-
-**API Documentation**:
-- **[COMMANDS_REFERENCE.md](COMMANDS_REFERENCE.md)** - Complete command reference with threading patterns
-- **[WORKSPACE_REFACTOR_API_REFERENCE.md](WORKSPACE_REFACTOR_API_REFERENCE.md)** - Refactoring API contracts
-- **[ERROR_HANDLING_API_CONTRACTS.md](ERROR_HANDLING_API_CONTRACTS.md)** - Error handling specifications
-- **[API_DOCUMENTATION_STANDARDS.md](API_DOCUMENTATION_STANDARDS.md)** - Documentation requirements (PR #160)
-
-**Architecture References**:
-- **[CRATE_ARCHITECTURE_GUIDE.md](CRATE_ARCHITECTURE_GUIDE.md)** - System design and component organization
-- **[CRATE_ARCHITECTURE_DAP.md](CRATE_ARCHITECTURE_DAP.md)** - DAP-specific architecture
-- **[ARCHITECTURE_OVERVIEW.md](ARCHITECTURE_OVERVIEW.md)** - High-level system architecture
-- **[MODERN_ARCHITECTURE.md](MODERN_ARCHITECTURE.md)** - Current architectural patterns
-
-**Protocol Specifications**:
-- **[LSP_CANCELLATION_PROTOCOL_SPECIFICATION.md](LSP_CANCELLATION_PROTOCOL.md)** - JSON-RPC 2.0 cancellation protocol
-
-**Technical Specifications**:
-- **[ROPE_INTEGRATION_GUIDE.md](ROPE_INTEGRATION_GUIDE.md)** - Document management implementation
-- **[POSITION_TRACKING_GUIDE.md](POSITION_TRACKING_GUIDE.md)** - UTF-16/UTF-8 position mapping
-- **[VARIABLE_RESOLUTION_GUIDE.md](VARIABLE_RESOLUTION_GUIDE.md)** - Scope analysis algorithms
-- **[WORKSPACE_NAVIGATION_GUIDE.md](WORKSPACE_NAVIGATION_GUIDE.md)** - Cross-file navigation patterns
-
-**Standards & Validation**:
-- **[VALIDATION-149-acceptance-criteria.md](VALIDATION-149-acceptance-criteria.md)** - API documentation quality gates
-- **[MISSING_DOCUMENTATION_GUIDE.md](MISSING_DOCUMENTATION_GUIDE.md)** - Documentation enforcement strategy
-- **[STABILITY.md](STABILITY.md)** - API stability guarantees
-
-**Doctests**: All reference documentation validated with `cargo test --doc` and `cargo doc --no-deps --package perl-parser`.
-
----
-
-### 💡 Explanation (Understanding-Oriented)
-
-**Goal**: Understand concepts, design decisions, and architectural choices.
-
-**Core Concepts**:
-- **[CANCELLATION_ARCHITECTURE_GUIDE.md](../explanation/CANCELLATION_ARCHITECTURE_GUIDE.md)** - LSP cancellation system design (PR #165)
-- **[ERROR_HANDLING_STRATEGY.md](../explanation/ERROR_HANDLING_STRATEGY.md)** - Defensive programming principles (Issue #178)
-- **[CONDITIONAL_DOCS_COMPILATION_STRATEGY.md](../explanation/CONDITIONAL_DOCS_COMPILATION_STRATEGY.md)** - Performance-optimized documentation enforcement
-
-**Parsing Theory**:
-- **[BUILTIN_FUNCTION_PARSING.md](../explanation/BUILTIN_FUNCTION_PARSING.md)** - Enhanced empty block parsing for map/grep/sort
-- **[SLASH_DISAMBIGUATION.md](../explanation/SLASH_DISAMBIGUATION.md)** - Division vs. regex disambiguation
-- **[TREE_SITTER_COMPATIBILITY.md](../explanation/TREE_SITTER_COMPATIBILITY.md)** - Tree-sitter integration patterns
-
-**LSP Architecture**:
-- **[LSP_CRATE_SEPARATION_GUIDE.md](../explanation/LSP_CRATE_SEPARATION_GUIDE.md)** - Crate organization rationale
-- **[EXECUTE_COMMAND_CONFIGURATION_GUIDE.md](../explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md)** - executeCommand integration design
-- **[LSP_DOCUMENTATION.md](../explanation/LSP_DOCUMENTATION.md)** - LSP feature implementation philosophy
-
-**Design Decisions** (Architecture Decision Records):
-- **[adr/ADR_001_AGENT_ARCHITECTURE.md](../adr/ADR_001_AGENT_ARCHITECTURE.md)** - 97 specialized agents (PR #153)
-- **[adr/ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md](../adr/ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md)** - Documentation enforcement (PR #160)
-
-**Implementation Context**:
-- **[PARSER_ROBUSTNESS_IMPROVEMENTS.md](../explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md)** - Fuzz testing and mutation hardening
-
----
-
-## Feature Index
-
-Map features to their documentation:
-
-### Parser Features
-| Feature | Tutorial | How-to | Reference | Explanation |
-|---------|----------|--------|-----------|-------------|
-| **Incremental Parsing** | [COMPREHENSIVE_TESTING_GUIDE](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md) | [INCREMENTAL_PARSING_GUIDE](../how-to/INCREMENTAL_PARSING_GUIDE.md) | [PERFORMANCE_PRESERVATION_GUIDE](../how-to/PERFORMANCE_PRESERVATION_GUIDE.md) | [ARCHITECTURE_OVERVIEW](ARCHITECTURE_OVERVIEW.md) |
-| **Builtin Functions** | - | [COMMANDS_REFERENCE](COMMANDS_REFERENCE.md#testing) | [BUILTIN_FUNCTION_PARSING](../explanation/BUILTIN_FUNCTION_PARSING.md) | [BUILTIN_FUNCTION_PARSING](../explanation/BUILTIN_FUNCTION_PARSING.md) |
-| **UTF-16/UTF-8** | - | [POSITION_TRACKING_GUIDE](POSITION_TRACKING_GUIDE.md) | [POSITION_TRACKING_GUIDE](POSITION_TRACKING_GUIDE.md) | [ROPE_INTEGRATION_GUIDE](ROPE_INTEGRATION_GUIDE.md) |
-
-### LSP Features
-| Feature | Tutorial | How-to | Reference | Explanation |
-|---------|----------|--------|-----------|-------------|
-| **Cross-File Navigation** | [WORKSPACE_REFACTORING_TUTORIAL](../tutorials/WORKSPACE_REFACTORING_TUTORIAL.md) | [WORKSPACE_NAVIGATION_GUIDE](WORKSPACE_NAVIGATION_GUIDE.md) | [WORKSPACE_REFACTOR_API_REFERENCE](WORKSPACE_REFACTOR_API_REFERENCE.md) | [LSP_CRATE_SEPARATION_GUIDE](../explanation/LSP_CRATE_SEPARATION_GUIDE.md) |
-| **Import Optimization** | - | [IMPORT_OPTIMIZER_GUIDE](../how-to/IMPORT_OPTIMIZER_GUIDE.md) | [IMPORT_OPTIMIZER_GUIDE](../how-to/IMPORT_OPTIMIZER_GUIDE.md) | - |
-| **File Completion** | - | [FILE_COMPLETION_GUIDE](../how-to/FILE_COMPLETION_GUIDE.md) | [FILE_COMPLETION_GUIDE](../how-to/FILE_COMPLETION_GUIDE.md) | [SECURITY_DEVELOPMENT_GUIDE](../how-to/SECURITY_DEVELOPMENT_GUIDE.md) |
-| **executeCommand** | [EXECUTE_COMMAND_TUTORIAL](../tutorials/EXECUTE_COMMAND_TUTORIAL.md) | [EXECUTE_COMMAND_CONFIGURATION_GUIDE](../explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md) | [WORKSPACE_REFACTOR_API_REFERENCE](WORKSPACE_REFACTOR_API_REFERENCE.md) | [LSP_IMPLEMENTATION_GUIDE](LSP_IMPLEMENTATION_GUIDE.md) |
-| **Cancellation** | - | [LSP_ERROR_HANDLING_MONITORING_GUIDE](../how-to/LSP_ERROR_HANDLING_MONITORING_GUIDE.md) | [LSP_CANCELLATION_PROTOCOL_SPECIFICATION](LSP_CANCELLATION_PROTOCOL.md) | [CANCELLATION_ARCHITECTURE_GUIDE](../explanation/CANCELLATION_ARCHITECTURE_GUIDE.md) |
-
-### DAP Features
-| Feature | Tutorial | How-to | Reference | Explanation |
-|---------|----------|--------|-----------|-------------|
-| **Debug Setup** | [DAP_USER_GUIDE](../tutorials/DAP_USER_GUIDE.md) | [DAP_USER_GUIDE](../tutorials/DAP_USER_GUIDE.md) | [CRATE_ARCHITECTURE_DAP](CRATE_ARCHITECTURE_DAP.md) | - |
-| **Breakpoints** | [DAP_USER_GUIDE](../tutorials/DAP_USER_GUIDE.md) | [DAP_BREAKPOINT_VALIDATION_GUIDE](../how-to/DAP_BREAKPOINT_VALIDATION_GUIDE.md) | [CRATE_ARCHITECTURE_DAP](CRATE_ARCHITECTURE_DAP.md) | - |
-
-### Testing Features
-| Feature | Tutorial | How-to | Reference | Explanation |
-|---------|----------|--------|-----------|-------------|
-| **Adaptive Threading** | [COMPREHENSIVE_TESTING_GUIDE](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md) | [THREADING_CONFIGURATION_GUIDE](../how-to/THREADING_CONFIGURATION_GUIDE.md) | [COMMANDS_REFERENCE](COMMANDS_REFERENCE.md) | - |
-| **Mutation Testing** | - | [COMPREHENSIVE_TESTING_GUIDE](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md) | [PARSER_ROBUSTNESS_IMPROVEMENTS](../explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md) | [PARSER_ROBUSTNESS_IMPROVEMENTS](../explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md) |
-| **Benchmarking** | - | [BENCHMARK_FRAMEWORK](../benchmarks/BENCHMARK_FRAMEWORK.md) | [BENCHMARK_FRAMEWORK](../benchmarks/BENCHMARK_FRAMEWORK.md) | [BENCHMARK_DESIGN](../benchmarks/BENCHMARK_DESIGN.md) |
-
----
-
-## Progressive Learning Paths
-
-### Path 1: LSP Developer (New to Project)
-1. Start: [CLAUDE.md](../../CLAUDE.md) - Project overview and quick start
-2. Setup: [AI_BUILD_GUIDE.md](../tutorials/AI_BUILD_GUIDE.md) - Development environment
-3. Architecture: [LSP_IMPLEMENTATION_GUIDE.md](LSP_IMPLEMENTATION_GUIDE.md) - System design
-4. First Feature: [EXECUTE_COMMAND_TUTORIAL.md](../tutorials/EXECUTE_COMMAND_TUTORIAL.md) - Build custom command
-5. Advanced: [WORKSPACE_REFACTORING_TUTORIAL.md](../tutorials/WORKSPACE_REFACTORING_TUTORIAL.md) - Cross-file features
-
-### Path 2: Parser Contributor
-1. Start: [CLAUDE.md](../../CLAUDE.md) - Project overview
-2. Architecture: [CRATE_ARCHITECTURE_GUIDE.md](CRATE_ARCHITECTURE_GUIDE.md) - Component design
-3. Testing: [COMPREHENSIVE_TESTING_GUIDE.md](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md) - TDD workflow
-4. Performance: [INCREMENTAL_PARSING_GUIDE.md](../how-to/INCREMENTAL_PARSING_GUIDE.md) - Optimization
-5. Quality: [PARSER_ROBUSTNESS_IMPROVEMENTS.md](../explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md) - Hardening
-
-### Path 3: API Documentation Maintainer
-1. Standards: [API_DOCUMENTATION_STANDARDS.md](API_DOCUMENTATION_STANDARDS.md) - Requirements
-2. Validation: [VALIDATION-149-acceptance-criteria.md](VALIDATION-149-acceptance-criteria.md) - Quality gates
-3. Strategy: [MISSING_DOCUMENTATION_GUIDE.md](MISSING_DOCUMENTATION_GUIDE.md) - Enforcement
-4. Implementation: [adr/ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md](../adr/ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md) - Design
-
-### Path 4: Debugging Integration
-1. Setup: [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md) - Installation and configuration
-2. Architecture: [CRATE_ARCHITECTURE_DAP.md](CRATE_ARCHITECTURE_DAP.md) - System design
-3. Validation: [DAP_BREAKPOINT_VALIDATION_GUIDE.md](../how-to/DAP_BREAKPOINT_VALIDATION_GUIDE.md) - Testing
-
----
-
-## Navigation Hints
-
-### Finding Information by Type
-
-**"How do I...?"** → [How-to Guides](#how-to-guides-problem-oriented)
-- Specific task-oriented instructions with cargo commands
-- Example: "How do I optimize imports?" → [IMPORT_OPTIMIZER_GUIDE.md](../how-to/IMPORT_OPTIMIZER_GUIDE.md)
-
-**"What is...?"** → [Reference Documentation](#reference-documentation-information-oriented)
-- Precise technical specifications and API contracts
-- Example: "What is the cancellation protocol?" → [LSP_CANCELLATION_PROTOCOL_SPECIFICATION.md](LSP_CANCELLATION_PROTOCOL.md)
-
-**"Why does...?"** → [Explanation](#explanation-understanding-oriented)
-- Conceptual understanding and design rationale
-- Example: "Why use dual indexing?" → [WORKSPACE_NAVIGATION_GUIDE.md](WORKSPACE_NAVIGATION_GUIDE.md)
-
-**"Teach me..."** → [Tutorials](#tutorials-learning-oriented)
-- Step-by-step learning experiences
-- Example: "Teach me workspace refactoring" → [WORKSPACE_REFACTORING_TUTORIAL.md](../tutorials/WORKSPACE_REFACTORING_TUTORIAL.md)
-
-### Finding Information by Component
-
-**Parser** (`/crates/perl-parser/`):
-- Reference: [CRATE_ARCHITECTURE_GUIDE.md](CRATE_ARCHITECTURE_GUIDE.md)
-- Performance: [INCREMENTAL_PARSING_GUIDE.md](../how-to/INCREMENTAL_PARSING_GUIDE.md)
-- Robustness: [PARSER_ROBUSTNESS_IMPROVEMENTS.md](../explanation/PARSER_ROBUSTNESS_IMPROVEMENTS.md)
-
-**LSP Server** (`/crates/perl-lsp/`):
-- Tutorial: [EXECUTE_COMMAND_TUTORIAL.md](../tutorials/EXECUTE_COMMAND_TUTORIAL.md)
-- Reference: [LSP_IMPLEMENTATION_GUIDE.md](LSP_IMPLEMENTATION_GUIDE.md)
-- Explanation: [LSP_CRATE_SEPARATION_GUIDE.md](../explanation/LSP_CRATE_SEPARATION_GUIDE.md)
-
-**DAP Server** (`/crates/perl-dap/`):
-- Tutorial: [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md)
-- Reference: [CRATE_ARCHITECTURE_DAP.md](CRATE_ARCHITECTURE_DAP.md)
-- How-to: [DAP_BREAKPOINT_VALIDATION_GUIDE.md](../how-to/DAP_BREAKPOINT_VALIDATION_GUIDE.md)
-
-**Testing** (`/tests/`):
-- Tutorial: [COMPREHENSIVE_TESTING_GUIDE.md](../tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
-- How-to: [THREADING_CONFIGURATION_GUIDE.md](../how-to/THREADING_CONFIGURATION_GUIDE.md)
-- Reference: [COMMANDS_REFERENCE.md](COMMANDS_REFERENCE.md)
-
----
-
-## Documentation Quality Standards
-
-All documentation in this project follows comprehensive quality standards:
-
-### Validation Requirements
-```bash
-# All code examples must pass doctests
-cargo test --doc
-
-# API documentation must build without warnings
-cargo doc --no-deps --package perl-parser
-
-# Documentation quality gates
-cargo test -p perl-parser --test missing_docs_ac_tests
-```
-
-### Content Standards
-- **Executable Examples**: All code blocks tested via doctests or integration tests
-- **Cargo Commands**: Proper package specifications (`cargo test -p perl-parser`)
-- **Threading Patterns**: Adaptive threading examples (`RUST_TEST_THREADS=2 cargo test -p perl-lsp`)
-- **LSP Workflow Integration**: Parse → Index → Navigate → Complete → Analyze pipeline references
-- **Cross-References**: Proper Rust documentation linking (`[`function_name`]`)
-
-### Diataxis Compliance
-- **Clear Separation**: No mixing of tutorial/how-to/reference/explanation concerns
-- **Consistent Terminology**: Perl LSP, workspace structure, parser/lsp/lexer references
-- **Progressive Disclosure**: Learning paths guide users from basics to advanced topics
-
----
-
-## Contributing to Documentation
-
-When adding new features, update documentation systematically:
-
-1. **Analyze Impact**: Identify affected Diataxis categories
-2. **Update Tutorials**: Add step-by-step learning experiences
-3. **Enhance How-tos**: Create task-oriented instructions
-4. **Revise Reference**: Update API docs and specifications
-5. **Expand Explanations**: Add conceptual context
-
-See [API_DOCUMENTATION_STANDARDS.md](API_DOCUMENTATION_STANDARDS.md) for detailed requirements.
-
----
-
-## Additional Resources
-
-### Project Management
-- **[CURRENT_STATUS.md](../project/CURRENT_STATUS.md)** - Real-time project health dashboard
-- **[CURRENT_STATUS.md](../project/CURRENT_STATUS.md)** - Real-time project health dashboard
-- **[STABILITY.md](STABILITY.md)** - API stability guarantees
-
-### Archived Documentation
-- **[archive/](../archive/)** - Historical documentation for reference
-
-### Benchmark Reports
-- **[benchmarks/](../benchmarks/)** - Performance analysis and cross-language comparisons
-
----
-
-## Quick Command Reference
-
-```bash
-# Build & Install
-cargo build -p perl-lsp --release        # LSP server
-cargo install perl-lsp                   # Install globally
-
-# Testing (Adaptive Threading)
-cargo test                               # All tests
-RUST_TEST_THREADS=2 cargo test -p perl-lsp  # LSP with thread constraints
-
-# Documentation Validation
-cargo test --doc                         # Validate doctests
-cargo doc --no-deps --package perl-parser   # Generate docs
-cargo test -p perl-parser --test missing_docs_ac_tests  # Quality gates
-
-# Development Server (Hot-Reload)
-cd xtask && cargo run --no-default-features -- dev --watch
-
-# Performance Testing
-cd xtask && cargo run --no-default-features -- optimize-tests
-
-# Highlight Testing (Tree-Sitter)
-cd xtask && cargo run --no-default-features -- highlight
-```
-
----
-
-**Need Help?** If you can't find what you need:
-1. Check the [Feature Index](#feature-index) for your specific feature
-2. Follow a [Progressive Learning Path](#progressive-learning-paths) for your role
-3. Use [Navigation Hints](#navigation-hints) to find information by type
-4. Review [CLAUDE.md](../../CLAUDE.md) for project-wide context
-
-**Found Missing Documentation?** See [MISSING_DOCUMENTATION_GUIDE.md](MISSING_DOCUMENTATION_GUIDE.md) for contribution guidelines.
+- Keep [docs/README.md](../README.md) aligned with the main, high-value pages in each Diátaxis category.
+- Prefer stable links and avoid linking to non-existent directories.
+- When moving docs between categories, update inbound links in `docs/README.md` and relevant section indexes.


### PR DESCRIPTION
### Motivation

- Reduce noise and remove stale/mixed-purpose content from the existing documentation guide so readers can quickly find the correct Diátaxis category. 
- Ensure repository documentation uses stable relative links and does not point to non-existent directories. 

### Description

- Replace the lengthy, mixed `docs/reference/DOCUMENTATION_GUIDE.md` with a focused Diátaxis guide that defines the four categories (Tutorials, How-to, Reference, Explanation) and gives clear placement rules. 
- Update `docs/README.md` to use the improved Diátaxis wording and remove the stale `internal/` directory entry from the directory table. 
- Add a concise placement checklist, explicit writing rules for contributors, and guidance to prefer stable relative links in the new guide. 
- Clean up cross-links and inline examples so the guide points to existing files under `docs/tutorials/`, `docs/how-to/`, `docs/reference/`, and `docs/explanation/`.

### Testing

- Ran a local link-existence check (Python script) against `docs/README.md` and `docs/reference/DOCUMENTATION_GUIDE.md` to verify relative links resolve, and the script reported no missing file links. 
- No code/runtime changes were made so no crate tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2187780b4833389bd1f80ce9a802c)