### PR TITLE
fix(parser-core): add fallback path for heredoc attachment

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/heredoc.rs
+++ b/crates/perl-parser-core/src/engine/parser/heredoc.rs
@@ -177,7 +177,13 @@ impl<'a> Parser<'a> {
 
         // Zip 1:1 in order (collector preserves input order)
         for (decl, body) in pending.into_iter().zip(out.contents.into_iter()) {
-            let _attached = self.try_attach_heredoc_at_node(root, decl.decl_span, &body);
+            let mut attached = self.try_attach_heredoc_at_node(root, decl.decl_span, &body);
+            if !attached {
+                // Fallback: when statement recovery mutates span boundaries, the exact
+                // decl-span match may miss the placeholder node. In that case, attach to
+                // the next unresolved Heredoc node in source order.
+                attached = self.try_attach_next_unresolved_heredoc(root, &body);
+            }
 
             if !body.terminated {
                 let label = if decl.label.is_empty() { "<empty>" } else { decl.label.as_ref() };
@@ -189,7 +195,7 @@ impl<'a> Parser<'a> {
 
             // Defensive guardrail: warn if heredoc node wasn't found at expected span
             #[cfg(debug_assertions)]
-            if !_attached {
+            if !attached {
                 eprintln!(
                     "[WARNING] drain_pending_heredocs: Failed to attach heredoc content at span {}..{} - no matching Heredoc node found in AST",
                     decl.decl_span.start, decl.decl_span.end
@@ -270,6 +276,53 @@ impl<'a> Parser<'a> {
             );
         }
 
+        found
+    }
+
+    /// Fallback attachment strategy used when exact declaration-span matching fails.
+    ///
+    /// This can happen when error recovery shifts statement boundaries around the
+    /// heredoc declaration. The collector output still preserves FIFO order, so
+    /// attaching to the next unresolved Heredoc node keeps body/placeholder pairing
+    /// stable while avoiding dropped heredoc bodies.
+    fn try_attach_next_unresolved_heredoc(&self, root: &mut Node, body: &HeredocContent) -> bool {
+        self.try_attach_at_next_unresolved_node(root, body)
+    }
+
+    fn try_attach_at_next_unresolved_node(&self, node: &mut Node, body: &HeredocContent) -> bool {
+        if let NodeKind::Heredoc { content, body_span, .. } = &mut node.kind {
+            let unresolved = content.is_empty() && body_span.is_none();
+            if unresolved {
+                let mut text = String::new();
+                for (i, seg) in body.segments.iter().enumerate() {
+                    if seg.end > seg.start {
+                        let bytes = &self.src_bytes[seg.start..seg.end];
+                        text.push_str(std::str::from_utf8(bytes).unwrap_or_default());
+                    }
+                    if i + 1 < body.segments.len() {
+                        text.push('\n');
+                    }
+                }
+
+                *content = text;
+                *body_span = if body.full_span.start < body.full_span.end {
+                    Some(SourceLocation {
+                        start: body.full_span.start,
+                        end: body.full_span.end,
+                    })
+                } else {
+                    None
+                };
+                return true;
+            }
+        }
+
+        let mut found = false;
+        node.for_each_child_mut(|child| {
+            if !found && self.try_attach_at_next_unresolved_node(child, body) {
+                found = true;
+            }
+        });
         found
     }
 


### PR DESCRIPTION
### Motivation
- Error-recovery can shift statement/span boundaries so exact declaration-span matching sometimes fails to find the Heredoc placeholder and leaves collected heredoc bodies unattached. 
- Unattached heredoc bodies cause downstream parse/diagnostic noise and reduce corpus cleanliness in audits. 
- Provide a robust fallback that preserves FIFO pairing of declarations and collected bodies without changing the primary matching behavior.

### Description
- Added a fallback in `drain_pending_heredocs` that, after attempting the existing span-exact attachment via `try_attach_heredoc_at_node`, invokes `try_attach_next_unresolved_heredoc` when the exact match fails. 
- Implemented `try_attach_next_unresolved_heredoc` / `try_attach_at_next_unresolved_node` which DFS for the next unresolved `NodeKind::Heredoc` (`content.is_empty()` && `body_span.is_none()`), reifies the collected `HeredocContent` segments into `content`, and sets `body_span`. 
- Preserved original behavior and debug warnings so the guardrail only logs when both exact and fallback attachment attempts fail, and normalized line breaks when concatenating segments.
- Change is contained to `crates/perl-parser-core/src/engine/parser/heredoc.rs` and is targeted to reduce dropped heredoc bodies in recovery scenarios.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully. 
- Ran `cargo test -p perl-parser-core` and all `perl-parser-core` tests passed. 
- Ran `target/debug/perl-ci-hygiene check-parse-errors` and the audit invocation completed successfully. 
- Ran `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt` and the common-corpus sweep passed (13/13 clean). 
- Ran `cargo run -p xtask -- parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` which reported ratchet violations due to the available system corpus differing from the committed baseline (this is an environment/baseline mismatch and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21898141483338b789c68c7264395)