### PR TITLE
Improve devex doctor guidance and repository hygiene checks

### DIFF
--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 pass() { printf '✅ %s\n' "$1"; }
 warn() { printf '⚠️  %s\n' "$1"; }
 fail() { printf '❌ %s\n' "$1"; }
@@ -29,8 +32,26 @@ show_version() {
 }
 
 MISSING_REQUIRED=0
+MISSING_RECOMMENDED=0
 
-echo "Repository: $(pwd)"
+check_git_hook() {
+  local hook_path="$REPO_ROOT/.git/hooks/pre-push"
+  if [ -x "$hook_path" ]; then
+    pass "pre-push hook: installed ($hook_path)"
+    return 0
+  fi
+
+  warn "pre-push hook: not installed"
+  echo "   Install with: bash scripts/install-githooks.sh"
+  return 1
+}
+
+echo "Repository: $REPO_ROOT"
+
+if [ "$(pwd)" != "$REPO_ROOT" ]; then
+  warn "Running outside repo root: $(pwd)"
+  echo "   Tip: cd $REPO_ROOT"
+fi
 
 echo
 printf '== Required ==\n'
@@ -43,8 +64,12 @@ show_version "cargo" cargo --version
 echo
 printf '== Recommended ==\n'
 check_cmd just "just" || true
-check_cmd nix "nix" || true
-check_cmd cargo-audit "cargo-audit" || true
+if ! check_cmd nix "nix"; then MISSING_RECOMMENDED=1; fi
+if ! check_cmd cargo-audit "cargo-audit"; then MISSING_RECOMMENDED=1; fi
+
+echo
+printf '== Repository hygiene ==\n'
+check_git_hook || true
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
@@ -59,9 +84,17 @@ fi
 
 echo
 printf '== Suggested next commands ==\n'
-echo "  just pr-fast"
+if command -v just >/dev/null 2>&1; then
+  echo "  just pr-fast"
+else
+  echo "  cargo test --workspace --lib"
+fi
 echo "  just ci-gate"
-echo "  nix develop -c just ci-gate"
+if command -v nix >/dev/null 2>&1; then
+  echo "  nix develop -c just ci-gate"
+else
+  echo "  (optional) install Nix for canonical gate: https://nixos.org/download.html"
+fi
 
 if [ "$MISSING_REQUIRED" -ne 0 ]; then
   echo
@@ -71,3 +104,7 @@ fi
 
 echo
 pass "Doctor completed: required tooling is available"
+
+if [ "$MISSING_RECOMMENDED" -ne 0 ]; then
+  warn "Doctor completed with missing recommended tools"
+fi


### PR DESCRIPTION
### Motivation
- Make the developer onboarding and local troubleshooting script clearer about repository context and actionable next steps.  
- Surface repository hygiene (pre-push hook) so contributors are nudged to install local hooks for the canonical pre-push gate.  
- Distinguish required vs recommended tools so the doctor can warn about non-fatal tooling gaps and still succeed.

### Description
- Resolve and display repository root via `SCRIPT_DIR`/`REPO_ROOT` and warn when the script is run outside the repo root in `scripts/devex-doctor.sh`.  
- Add `check_git_hook()` to detect an executable `.git/hooks/pre-push` and print remediation (`bash scripts/install-githooks.sh`) when missing.  
- Introduce `MISSING_RECOMMENDED` to track non-fatal recommended tools and emit a final warning if any are absent.  
- Make suggested next commands adaptive by falling back to `cargo test --workspace --lib` when `just` is unavailable and by printing a suggested Nix install hint when `nix` is missing.

### Testing
- Ran the updated script with `bash scripts/devex-doctor.sh`, which completed successfully and printed the expected warnings and suggestions.  
- Observed output includes repository root, missing recommended-tool warnings, and the repository hygiene message for the pre-push hook (exit status 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218a21ab48333bf419b63608df12a)