### PR TITLE
chore(devex): add `just devex` alias for environment doctor

### DIFF
--- a/justfile
+++ b/justfile
@@ -273,6 +273,9 @@ doctor:
     @echo "=============================================="
     @bash scripts/devex-doctor.sh
 
+# Alias: shorter, discoverable DX command name
+devex: doctor
+
 # Tool availability check (basic tools for PR-fast)
 [private]
 _check-tools-basic:


### PR DESCRIPTION
### Motivation
- Improve discoverability and provide a shorter command name for the developer-environment diagnostic without duplicating logic.

### Description
- Add a `devex` recipe in `justfile` that aliases to the existing `doctor` target (`devex: doctor`).

### Testing
- Executed `bash scripts/devex-doctor.sh` which completed successfully; `just` is not installed in the environment so `just --list` could not be run to directly list the new alias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218a21ab48333bf419b63608df12a)