### PR TITLE
Improve devex doctor diagnostics and onboarding guidance

### DIFF
--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -32,6 +32,11 @@ MISSING_REQUIRED=0
 
 echo "Repository: $(pwd)"
 
+if [ ! -f Cargo.toml ] || [ ! -d crates ]; then
+  warn "This does not look like the repository root (expected Cargo.toml and crates/)"
+  warn "Run 'just doctor' from the perl-lsp repo root for complete checks"
+fi
+
 echo
 printf '== Required ==\n'
 if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
@@ -42,9 +47,20 @@ show_version "cargo" cargo --version
 
 echo
 printf '== Recommended ==\n'
+check_cmd git "git" || true
 check_cmd just "just" || true
 check_cmd nix "nix" || true
 check_cmd cargo-audit "cargo-audit" || true
+
+if command -v rustup >/dev/null 2>&1; then
+  if rustup component list --installed 2>/dev/null | grep -Eq '^rustfmt-'; then
+    pass "rustup component installed: rustfmt"
+  else
+    warn "rustup component missing: rustfmt (install via: rustup component add rustfmt)"
+  fi
+else
+  warn "rustup not found (recommended for toolchain/component management)"
+fi
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
@@ -57,11 +73,40 @@ else
   warn "rust-toolchain.toml not found"
 fi
 
+if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ -x .git/hooks/pre-push ]; then
+    pass "Git pre-push hook installed (.git/hooks/pre-push)"
+  else
+    warn "Git pre-push hook missing (install via: bash scripts/install-githooks.sh)"
+  fi
+else
+  warn "Not inside a Git work tree; skipping hook checks"
+fi
+
+if [ -f Cargo.lock ]; then
+  NESTED_LOCKS=$(find . -name 'Cargo.lock' -type f \
+    -not -path './Cargo.lock' \
+    -not -path '*/target/*' \
+    -not -path '*/.runs/*' \
+    -not -path '*/archive/*' \
+    -not -path './fuzz/*' \
+    -not -path './tree-sitter-perl/*' 2>/dev/null)
+  if [ -z "$NESTED_LOCKS" ]; then
+    pass "No nested Cargo.lock files detected"
+  else
+    COUNT=$(printf '%s\n' "$NESTED_LOCKS" | sed '/^$/d' | wc -l | tr -d ' ')
+    warn "Detected $COUNT nested Cargo.lock file(s); run gates from repo root"
+    printf '%s\n' "$NESTED_LOCKS" | sed 's/^/  - /'
+  fi
+fi
+
 echo
 printf '== Suggested next commands ==\n'
 echo "  just pr-fast"
 echo "  just ci-gate"
-echo "  nix develop -c just ci-gate"
+if command -v nix >/dev/null 2>&1; then
+  echo "  nix develop -c just ci-gate"
+fi
 
 if [ "$MISSING_REQUIRED" -ne 0 ]; then
   echo


### PR DESCRIPTION
### Motivation
- Make the developer environment doctor more helpful for contributors by surfacing common footguns early and giving actionable remediation steps.
- Help developers detect when `just doctor` is run from the wrong directory so checks are not misleading.
- Reduce local CI failures caused by missing hooks, nested `Cargo.lock`s, or missing `rustfmt` components.

### Description
- Add repo-root detection to `scripts/devex-doctor.sh` and warn when `Cargo.toml` or `crates/` are missing.
- Expand recommended checks to include `git` and validate via `rustup` that the `rustfmt` component is installed (with a guidance message to run `rustup component add rustfmt`).
- Add Git pre-push hook detection with an actionable install hint (`bash scripts/install-githooks.sh`) when the hook is missing.
- Detect nested `Cargo.lock` files and print the list of offending paths to help avoid running gates from subdirectories.
- Make the suggested Nix onboarding command conditional so `nix develop -c just ci-gate` is only shown when `nix` is present.

### Testing
- Executed `bash scripts/devex-doctor.sh` in this repository and observed expected diagnostic output; the script completed successfully.
- Verified `rustup component list --installed` to confirm `rustfmt` detection behavior during runs.
- Ran a quick check for `shellcheck` with `command -v shellcheck || echo "shellcheck not installed"` which reported that `shellcheck` is not installed in the test environment (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218a21ab48333bf419b63608df12a)