### PR TITLE
Improve dev environment doctor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ cargo clippy --workspace --lib && cargo fmt --all
 # Check local tooling (dev environment doctor)
 just doctor
 
+# Install pre-push hook (runs ci-gate automatically on push)
+bash scripts/install-githooks.sh
+
 # Full local gate (requires Nix)
 nix develop -c just ci-gate
 ```

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -100,6 +100,16 @@ The xtask crate is excluded from the workspace to maintain clean builds while pr
 - **Benefits**: Workspace builds remain system-dependency-free
 - **Advanced features**: Dual-scanner corpus comparison requires libclang-dev
 
+## Developer Environment Commands
+
+```bash
+# Check required/recommended local tooling and repo setup
+just doctor
+
+# Install git hooks (pre-push runs ci-gate)
+bash scripts/install-githooks.sh
+```
+
 ## Test Commands
 
 ### Workspace Testing (v0.8.8)

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -29,13 +29,29 @@ show_version() {
 }
 
 MISSING_REQUIRED=0
+MISSING_RECOMMENDED=0
+
+REPO_ROOT=""
+if command -v git >/dev/null 2>&1; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+fi
 
 echo "Repository: $(pwd)"
+
+if [ -n "$REPO_ROOT" ]; then
+  pass "Git repository root: $REPO_ROOT"
+  if [ "$(pwd)" != "$REPO_ROOT" ]; then
+    warn "Run doctor from repository root for best results"
+  fi
+else
+  warn "Not inside a Git repository (or git not installed)"
+fi
 
 echo
 printf '== Required ==\n'
 if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
 if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
+if ! check_cmd rustc "rustc"; then MISSING_REQUIRED=1; fi
 
 show_version "rustc" rustc --version
 show_version "cargo" cargo --version
@@ -45,6 +61,29 @@ printf '== Recommended ==\n'
 check_cmd just "just" || true
 check_cmd nix "nix" || true
 check_cmd cargo-audit "cargo-audit" || true
+
+if check_cmd rustup "rustup"; then
+  if rustup component list --installed | rg -q '^clippy'; then
+    pass "rustup component: clippy installed"
+  else
+    warn "rustup component: clippy missing (install with: rustup component add clippy)"
+    MISSING_RECOMMENDED=1
+  fi
+
+  if rustup component list --installed | rg -q '^rustfmt'; then
+    pass "rustup component: rustfmt installed"
+  else
+    warn "rustup component: rustfmt missing (install with: rustup component add rustfmt)"
+    MISSING_REQUIRED=1
+  fi
+fi
+
+if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.git/hooks/pre-push" ]; then
+  pass "Git pre-push hook installed"
+else
+  warn "Git pre-push hook missing (install with: bash scripts/install-githooks.sh)"
+  MISSING_RECOMMENDED=1
+fi
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
@@ -70,4 +109,8 @@ if [ "$MISSING_REQUIRED" -ne 0 ]; then
 fi
 
 echo
-pass "Doctor completed: required tooling is available"
+if [ "$MISSING_RECOMMENDED" -ne 0 ]; then
+  warn "Doctor completed: required tools available, but some recommended setup is missing"
+else
+  pass "Doctor completed: required tooling is available"
+fi


### PR DESCRIPTION
### Motivation
- Provide clearer, repo-aware developer environment diagnostics so contributors get actionable setup guidance before running gates. 
- Surface common missing items (toolchain components and git hooks) that cause CI/push friction and wasted time. 
- Make the `doctor` helper discoverable from docs and the README to improve onboarding.

### Description
- Enhanced `scripts/devex-doctor.sh` to detect the Git repository root and warn when the script is run outside the repo root. 
- Added explicit required check for `rustc` and introduced `MISSING_RECOMMENDED` to distinguish required vs recommended tooling. 
- Added `rustup` component checks for `clippy` and `rustfmt` and detection for a `.git/hooks/pre-push` hook, with actionable install guidance. 
- Documented the developer environment commands in `docs/reference/COMMANDS_REFERENCE.md` and added a pre-push hook install hint to the `README.md` developer commands block.

### Testing
- Ran `bash scripts/devex-doctor.sh` locally in the workspace and the script executed successfully, reporting required and recommended items. 
- Attempted `just doctor` but it failed in the environment because the `just` binary was not installed (this is an external dependency, not a regression). 
- Verified file diffs and script output formatting to ensure the new checks and messages appear as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218a21ab48333bf419b63608df12a)