### PR TITLE
chore(devex): improve doctor output visualization

### DIFF
--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -1,9 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pass() { printf '✅ %s\n' "$1"; }
-warn() { printf '⚠️  %s\n' "$1"; }
-fail() { printf '❌ %s\n' "$1"; }
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  BLUE='\033[34m'
+  GREEN='\033[32m'
+  YELLOW='\033[33m'
+  RED='\033[31m'
+  RESET='\033[0m'
+else
+  BOLD=''
+  DIM=''
+  BLUE=''
+  GREEN=''
+  YELLOW=''
+  RED=''
+  RESET=''
+fi
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf '%b✅ %-11s%b %s\n' "$GREEN" "PASS" "$RESET" "$1"
+}
+
+warn() {
+  WARN_COUNT=$((WARN_COUNT + 1))
+  printf '%b⚠️  %-11s%b %s\n' "$YELLOW" "WARN" "$RESET" "$1"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf '%b❌ %-11s%b %s\n' "$RED" "FAIL" "$RESET" "$1"
+}
+
+print_section() {
+  printf '\n%b%s%b\n' "$BOLD$BLUE" "$1" "$RESET"
+}
 
 check_cmd() {
   local cmd="$1"
@@ -30,18 +67,17 @@ show_version() {
 
 MISSING_REQUIRED=0
 
-echo "Repository: $(pwd)"
+printf '%bPerl LSP DevEx Doctor%b\n' "$BOLD" "$RESET"
+printf '%bRepository:%b %s\n' "$DIM" "$RESET" "$(pwd)"
 
-echo
-printf '== Required ==\n'
+print_section "== Required =="
 if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
 if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
 
 show_version "rustc" rustc --version
 show_version "cargo" cargo --version
 
-echo
-printf '== Recommended ==\n'
+print_section "== Recommended =="
 check_cmd just "just" || true
 check_cmd nix "nix" || true
 check_cmd cargo-audit "cargo-audit" || true
@@ -57,17 +93,19 @@ else
   warn "rust-toolchain.toml not found"
 fi
 
-echo
-printf '== Suggested next commands ==\n'
+print_section "== Suggested next commands =="
 echo "  just pr-fast"
 echo "  just ci-gate"
 echo "  nix develop -c just ci-gate"
 
+print_section "== Summary =="
+printf '%bPassed:%b  %d\n' "$GREEN" "$RESET" "$PASS_COUNT"
+printf '%bWarnings:%b %d\n' "$YELLOW" "$RESET" "$WARN_COUNT"
+printf '%bFailures:%b %d\n' "$RED" "$RESET" "$FAIL_COUNT"
+
 if [ "$MISSING_REQUIRED" -ne 0 ]; then
-  echo
   fail "Missing required tools. Install Rust via https://rustup.rs"
   exit 1
 fi
 
-echo
 pass "Doctor completed: required tooling is available"


### PR DESCRIPTION
### Motivation
- Make the devex "doctor" script easier to scan by adding labeled status lines and a compact summary so maintainers can quickly assess environment health.
- Provide a nicer terminal presentation when running interactively while preserving no-color behavior in non-TTY environments.

### Description
- Add TTY-aware ANSI styling with safe no-color fallback and a top-level heading plus repository line for clearer context.
- Replace simple `pass`/`warn`/`fail` printers with functions that increment `PASS_COUNT`, `WARN_COUNT`, and `FAIL_COUNT` and emit labeled `PASS`/`WARN`/`FAIL` lines with emojis and alignment.
- Add a reusable `print_section` helper and reorganize output into `Required`, `Recommended`, `Suggested next commands`, and `Summary` sections.
- Print a final summary block with counts for Passed, Warnings, and Failures while preserving the original check logic and exit behavior when required tools are missing.

### Testing
- Ran `bash scripts/devex-doctor.sh`, which completed successfully (exit code 0) and produced the new labeled output and summary counts.
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218ab46188333853a954c107e5715)