### PR TITLE
chore(devex): improve doctor output visualization with health snapshot

### DIFF
--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -5,14 +5,99 @@ pass() { printf '✅ %s\n' "$1"; }
 warn() { printf '⚠️  %s\n' "$1"; }
 fail() { printf '❌ %s\n' "$1"; }
 
+STATUS_REQUIRED=()
+STATUS_RECOMMENDED=()
+
+record_status() {
+  local bucket="$1"
+  local label="$2"
+  local status="$3"
+  local value="$4"
+  local entry="${label}|${status}|${value}"
+
+  if [ "$bucket" = "required" ]; then
+    STATUS_REQUIRED+=("$entry")
+    return
+  fi
+  STATUS_RECOMMENDED+=("$entry")
+}
+
+render_summary() {
+  local total_required=${#STATUS_REQUIRED[@]}
+  local total_recommended=${#STATUS_RECOMMENDED[@]}
+  local total=$((total_required + total_recommended))
+  local ok=0
+  local warn_count=0
+  local item status
+
+  for item in "${STATUS_REQUIRED[@]}" "${STATUS_RECOMMENDED[@]}"; do
+    [ -z "$item" ] && continue
+    status=${item#*|}
+    status=${status%%|*}
+    if [ "$status" = "ok" ]; then
+      ok=$((ok + 1))
+    else
+      warn_count=$((warn_count + 1))
+    fi
+  done
+
+  local width=20
+  local filled=0
+  if [ "$total" -gt 0 ]; then
+    filled=$((ok * width / total))
+  fi
+  local bar
+  bar=$(printf '%*s' "$filled" '' | tr ' ' '#')
+  bar+=$(printf '%*s' "$((width - filled))" '' | tr ' ' '.')
+
+  echo
+  printf '== DevEx Health Snapshot ==\n'
+  printf '  Score: [%s] %d/%d checks passing\n' "$bar" "$ok" "$total"
+  printf '  Required:    %d/%d\n' "$((total_required - MISSING_REQUIRED))" "$total_required"
+  printf '  Recommended: %d/%d\n' "$((total_recommended - MISSING_RECOMMENDED))" "$total_recommended"
+  printf '  Needs attention: %d\n' "$warn_count"
+}
+
+render_table() {
+  local title="$1"
+  shift
+  local entries=("$@")
+  local entry label status value icon
+
+  echo
+  printf '== %s ==\n' "$title"
+  printf '  %-18s | %-6s | %s\n' "Check" "Status" "Details"
+  printf '  -------------------+--------+------------------------------\n'
+  for entry in "${entries[@]}"; do
+    [ -z "$entry" ] && continue
+    label=${entry%%|*}
+    status=${entry#*|}
+    status=${status%%|*}
+    value=${entry##*|}
+
+    if [ "$status" = "ok" ]; then
+      icon="✅"
+    else
+      icon="⚠️"
+    fi
+
+    printf '  %-18s | %-6s | %s\n' "$label" "$icon" "$value"
+  done
+}
+
 check_cmd() {
   local cmd="$1"
   local label="$2"
+  local bucket="${3:-recommended}"
   if command -v "$cmd" >/dev/null 2>&1; then
-    pass "$label: found ($(command -v "$cmd"))"
+    local found
+    found=$(command -v "$cmd")
+    pass "$label: found ($found)"
+    record_status "$bucket" "$label" "ok" "$found"
     return 0
   fi
   warn "$label: not found"
+  record_status "$bucket" "$label" "warn" "not found"
   return 1
 }
 
@@ -29,22 +114,23 @@ show_version() {
 }
 
 MISSING_REQUIRED=0
+MISSING_RECOMMENDED=0
 
 echo "Repository: $(pwd)"
 
 echo
 printf '== Required ==\n'
-if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
-if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
+if ! check_cmd cargo "cargo" required; then MISSING_REQUIRED=1; fi
+if ! check_cmd rustfmt "rustfmt" required; then MISSING_REQUIRED=1; fi
 
 show_version "rustc" rustc --version
 show_version "cargo" cargo --version
 
 echo
 printf '== Recommended ==\n'
-check_cmd just "just" || true
-check_cmd nix "nix" || true
-check_cmd cargo-audit "cargo-audit" || true
+if ! check_cmd just "just" recommended; then MISSING_RECOMMENDED=$((MISSING_RECOMMENDED + 1)); fi
+if ! check_cmd nix "nix" recommended; then MISSING_RECOMMENDED=$((MISSING_RECOMMENDED + 1)); fi
+if ! check_cmd cargo-audit "cargo-audit" recommended; then MISSING_RECOMMENDED=$((MISSING_RECOMMENDED + 1)); fi
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
@@ -62,6 +148,10 @@ printf '== Suggested next commands ==\n'
 echo "  just pr-fast"
 echo "  just ci-gate"
 echo "  nix develop -c just ci-gate"
+
+render_table "Required Tooling" "${STATUS_REQUIRED[@]}"
+render_table "Recommended Tooling" "${STATUS_RECOMMENDED[@]}"
+render_summary
 
 if [ "$MISSING_REQUIRED" -ne 0 ]; then
   echo


### PR DESCRIPTION
### Motivation
- Make the developer environment `doctor` output easier to scan by surfacing structured status for required and recommended checks. 
- Provide a quick, at-a-glance DevEx health snapshot (pass ratio, totals, attention count) for faster onboarding and troubleshooting. 

### Description
- Add structured status tracking arrays `STATUS_REQUIRED` and `STATUS_RECOMMENDED` and a `record_status` helper to capture check results and details. 
- Add `render_table` to print readable ASCII tables for required/recommended tooling and `render_summary` to show a compact health snapshot with an ASCII progress bar. 
- Update `check_cmd` to accept a bucket parameter (`required`/`recommended`), record results, and return the same exit semantics as before. 
- Wire rendering into the script flow, introduce `MISSING_RECOMMENDED`, and preserve existing behavior where missing required tools cause non-zero exit. 

### Testing
- Run `bash scripts/devex-doctor.sh` and verified the script prints required/recommended tables and the DevEx health snapshot (succeeded). 
- Run `bash -n scripts/devex-doctor.sh` to confirm syntax correctness (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218ab46188333853a954c107e5715)