### PR TITLE
chore(devex): improve doctor output visualization

### DIFF
--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -1,9 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pass() { printf '✅ %s\n' "$1"; }
-warn() { printf '⚠️  %s\n' "$1"; }
-fail() { printf '❌ %s\n' "$1"; }
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+DETAIL_LINES=()
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf '✅ %s\n' "$1"
+  DETAIL_LINES+=("✅ $1")
+}
+
+warn() {
+  WARN_COUNT=$((WARN_COUNT + 1))
+  printf '⚠️  %s\n' "$1"
+  DETAIL_LINES+=("⚠️  $1")
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf '❌ %s\n' "$1"
+  DETAIL_LINES+=("❌ $1")
+}
+
+print_header() {
+  local title="$1"
+  printf '\n%s\n' "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  printf ' %s\n' "$title"
+  printf '%s\n' "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+print_metric() {
+  local label="$1"
+  local value="$2"
+  printf '  %-18s %s\n' "$label" "$value"
+}
 
 check_cmd() {
   local cmd="$1"
@@ -30,18 +62,17 @@ show_version() {
 
 MISSING_REQUIRED=0
 
-echo "Repository: $(pwd)"
+print_header "Perl-LSP DevEx Doctor"
+print_metric "Repository" "$(pwd)"
 
-echo
-printf '== Required ==\n'
+print_header "Required Tooling"
 if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
 if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
 
 show_version "rustc" rustc --version
 show_version "cargo" cargo --version
 
-echo
-printf '== Recommended ==\n'
+print_header "Recommended Tooling"
 check_cmd just "just" || true
 check_cmd nix "nix" || true
 check_cmd cargo-audit "cargo-audit" || true
@@ -57,17 +88,26 @@ else
   warn "rust-toolchain.toml not found"
 fi
 
-echo
-printf '== Suggested next commands ==\n'
-echo "  just pr-fast"
-echo "  just ci-gate"
-echo "  nix develop -c just ci-gate"
+print_header "Suggested Next Commands"
+echo "  • just pr-fast"
+echo "  • just ci-gate"
+echo "  • nix develop -c just ci-gate"
 
 if [ "$MISSING_REQUIRED" -ne 0 ]; then
-  echo
+  print_header "Summary"
+  print_metric "Passed" "$PASS_COUNT"
+  print_metric "Warnings" "$WARN_COUNT"
+  print_metric "Failures" "$FAIL_COUNT"
+  print_metric "Overall" "❌ action required"
+
   fail "Missing required tools. Install Rust via https://rustup.rs"
   exit 1
 fi
 
-echo
+print_header "Summary"
+print_metric "Passed" "$PASS_COUNT"
+print_metric "Warnings" "$WARN_COUNT"
+print_metric "Failures" "$FAIL_COUNT"
+print_metric "Overall" "✅ healthy"
+
 pass "Doctor completed: required tooling is available"


### PR DESCRIPTION
### Motivation
- Make the devex doctor output easier to scan and understand by adding clear section dividers and aligned metrics. 
- Surface a concise health overview so contributors and CI can quickly see overall status and counts of passes/warnings/failures.

### Description
- Added counters `PASS_COUNT`, `WARN_COUNT`, `FAIL_COUNT` and a `DETAIL_LINES` array to track check results.
- Introduced `print_header` and `print_metric` helpers and replaced ad-hoc prints with sectioned headers and aligned key/value metrics.
- Improved suggested-commands formatting and added an explicit summary block on both success and failure paths with an overall status indicator.

### Testing
- Ran syntax check: `bash -n scripts/devex-doctor.sh` (passed).
- Executed the script: `bash scripts/devex-doctor.sh` (ran successfully and produced the new structured output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218ab46188333853a954c107e5715)