### PR TITLE
Add developer watch workflows with bacon

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,26 @@
+# Bacon configuration for fast local feedback loops.
+# Install with: cargo install --locked bacon
+
+default_job = "check"
+
+[jobs.check]
+command = ["cargo", "check", "--workspace", "--all-targets", "--locked"]
+need_stdout = false
+
+[jobs.clippy-core]
+command = ["cargo", "clippy", "-p", "perl-parser", "-p", "perl-lexer", "--locked", "--", "-D", "warnings", "-A", "missing_docs"]
+need_stdout = false
+
+[jobs.test-core]
+command = ["cargo", "test", "-p", "perl-parser", "-p", "perl-lexer", "--lib", "--locked"]
+need_stdout = true
+
+[jobs.test-lsp-smoke]
+command = ["cargo", "test", "-p", "perl-lsp", "--test", "cli_smoke", "--locked", "--", "--test-threads=1"]
+need_stdout = true
+
+[keybindings]
+"c" = "job:check"
+"l" = "job:clippy-core"
+"t" = "job:test-core"
+"s" = "job:test-lsp-smoke"

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -725,6 +725,19 @@ cargo test --doc                      # Documentation tests
 # cargo xtask fmt                     # xtask excluded from workspace
 ```
 
+### Local Developer Watch Commands
+```bash
+# Install bacon once for interactive watch mode
+cargo install --locked bacon
+
+# Fast watch loop from justfile
+just dev-watch            # default: workspace check
+just dev-watch-clippy     # core clippy loop
+just dev-watch-tests      # core test loop
+```
+
+The watch recipes use `bacon.toml` with project-tuned jobs for faster local feedback loops.
+
 ## Dual-Scanner Corpus Comparison (*Diataxis: How-to Guide* - Testing procedures)
 
 ### Running Dual-Scanner Corpus Tests (v0.8.8+)

--- a/justfile
+++ b/justfile
@@ -115,6 +115,33 @@ fmt-check:
     cargo fmt --all -- --check
     @echo "Format check passed"
 
+# Developer watch mode using bacon (optional local DX tool)
+dev-watch:
+    @if command -v bacon >/dev/null 2>&1; then \
+        bacon; \
+    else \
+        echo "SKIP: bacon not installed (run: cargo install --locked bacon)"; \
+        exit 1; \
+    fi
+
+# Developer watch mode focused on clippy for core crates
+dev-watch-clippy:
+    @if command -v bacon >/dev/null 2>&1; then \
+        bacon clippy-core; \
+    else \
+        echo "SKIP: bacon not installed (run: cargo install --locked bacon)"; \
+        exit 1; \
+    fi
+
+# Developer watch mode focused on fast core tests
+dev-watch-tests:
+    @if command -v bacon >/dev/null 2>&1; then \
+        bacon test-core; \
+    else \
+        echo "SKIP: bacon not installed (run: cargo install --locked bacon)"; \
+        exit 1; \
+    fi
+
 # Clippy core crates only (fast, for PR iterations)
 clippy-core:
     @echo "Running clippy (core crates: perl-parser, perl-lexer)..."


### PR DESCRIPTION
### Motivation
- Provide fast, standardized local feedback loops to improve developer experience and maintainability. 
- Make common fast checks (workspace check, core clippy, core tests, LSP smoke) easy to run interactively. 
- Keep CI behaviors unchanged while offering an ergonomic local watch workflow for contributors.

### Description
- Add `bacon.toml` with tuned `jobs` (`check`, `clippy-core`, `test-core`, `test-lsp-smoke`) and `keybindings` for quick interactive runs using `bacon`.
- Add `just` recipes `dev-watch`, `dev-watch-clippy`, and `dev-watch-tests` that call `bacon` and emit a clear install hint when `bacon` is not present.
- Document the new local watch commands in `docs/reference/COMMANDS_REFERENCE.md` under a "Local Developer Watch Commands" section with install and usage instructions.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully.
- Attempted to list `just` targets (`just --list | rg 'dev-watch|pr-fast|merge-gate'`) but the environment lacks `just` so the command failed with `bash: command not found: just`.
- No changes to CI gates or automated test scripts were made, and the new recipes are gated behind the optional `bacon` tool to avoid impacting CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218c115d88333a80bc5298d15efd2)