### PR TITLE
chore(devex): strengthen doctor checks and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ You **must** run the local CI gate before pushing. The canonical command uses Ni
 # Canonical local gate (REQUIRED before push)
 nix develop -c just ci-gate
 
+# Quick environment diagnostics (recommended when onboarding/troubleshooting)
+just doctor
+
 # Fallback without `just`/Nix: run the Rust-native local mirror
 cargo run -p perl-ci-hygiene -- check-local
 

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -5,15 +5,44 @@ pass() { printf '✅ %s\n' "$1"; }
 warn() { printf '⚠️  %s\n' "$1"; }
 fail() { printf '❌ %s\n' "$1"; }
 
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
 check_cmd() {
   local cmd="$1"
   local label="$2"
-  if command -v "$cmd" >/dev/null 2>&1; then
+  if has_cmd "$cmd"; then
     pass "$label: found ($(command -v "$cmd"))"
     return 0
   fi
   warn "$label: not found"
   return 1
+}
+
+check_rust_component() {
+  local component="$1"
+  if ! has_cmd rustup; then
+    warn "rustup unavailable; cannot verify component '$component'"
+    return 1
+  fi
+
+  if rustup component list --installed 2>/dev/null | awk '{print $1}' | grep -Eq "^${component}(-|$)"; then
+    pass "rustup component installed: $component"
+    return 0
+  fi
+
+  warn "rustup component missing: $component (install: rustup component add $component)"
+  return 1
+}
+
+check_githook() {
+  local hook_path=".git/hooks/pre-push"
+  if [ -x "$hook_path" ]; then
+    pass "pre-push git hook installed: $hook_path"
+  else
+    warn "pre-push git hook not installed (run: bash scripts/install-githooks.sh)"
+  fi
 }
 
 show_version() {
@@ -36,6 +65,7 @@ echo
 printf '== Required ==\n'
 if ! check_cmd cargo "cargo"; then MISSING_REQUIRED=1; fi
 if ! check_cmd rustfmt "rustfmt"; then MISSING_REQUIRED=1; fi
+if ! check_cmd rustup "rustup"; then MISSING_REQUIRED=1; fi
 
 show_version "rustc" rustc --version
 show_version "cargo" cargo --version
@@ -45,6 +75,12 @@ printf '== Recommended ==\n'
 check_cmd just "just" || true
 check_cmd nix "nix" || true
 check_cmd cargo-audit "cargo-audit" || true
+check_githook
+
+echo
+printf '== Rust components ==\n'
+check_rust_component rustfmt || true
+check_rust_component clippy || true
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)


### PR DESCRIPTION
### Motivation

- Improve developer onboarding and local CI readiness by surfacing missing tooling and automations earlier and reducing duplication in the doctor script.
- Make the doctor script easier to maintain by introducing reusable helpers and adding actionable checks for common Rust components and git hooks.

### Description

- Introduce a reusable `has_cmd` helper and switch existing command checks to use it to reduce duplicated `command -v` logic in `scripts/devex-doctor.sh`.
- Add `rustup` to the required tooling checks and add `check_rust_component` to verify `rustfmt` and `clippy` via `rustup component list` with actionable install hints.
- Add `check_githook` to warn when the `.git/hooks/pre-push` hook is not installed and report when it is present.
- Update `CONTRIBUTING.md` to recommend running `just doctor` in the Local CI Validation section for quicker environment diagnostics.

### Testing

- Ran `bash -n scripts/devex-doctor.sh` to verify the script is syntactically valid and it succeeded.
- Ran `bash scripts/devex-doctor.sh` to exercise the checks and it completed successfully while reporting missing recommended items as expected.
- Attempted `just doctor` in this environment which failed because `just` is not installed, demonstrating the script/doc suggestion is useful for environments with `just` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218c115d88333a80bc5298d15efd2)