### PR TITLE
chore(deps): bump tree-sitter to 0.26.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,7 @@ perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.11.0" }
 # External dependencies
 tree-sitter-perl = { path = "crates/tree-sitter-perl-rs", features = ["pure-rust"] }
 tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c" }
-tree-sitter = "0.26.3"
+tree-sitter = "0.26.6"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tree-sitter", "perl", "parser", "grammar", "ffi"]
 categories = ["parsing", "text-processing"]
 
 [dependencies]
-tree-sitter = "0.26.3"
+tree-sitter = "0.26.6"
 serde = { version = "1.0.228", features = ["derive"] }
 # bincode removed - (bincode is deprecated)
 proptest = "1.9.0"

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["parsing", "development-tools"]
 perl-lexer = { path = "../perl-lexer" }
 perl-parser = { path = "../perl-parser" }
 perl-parser-pest = { path = "../perl-parser-pest", optional = true }
-tree-sitter = "0.26.3"
+tree-sitter = "0.26.6"
 serde = { version = "1.0.228", features = ["derive"] }
 postcard = { version = "1.1.3", features = ["alloc"] }
 proptest = "1.9.0"


### PR DESCRIPTION
### Motivation
- Keep the workspace aligned with the newer `tree-sitter` patch release to address upstream fixes and ensure the tree-sitter integration crates remain compatible.

### Description
- Bumped `tree-sitter` from `0.26.3` to `0.26.6` in the workspace `Cargo.toml` and updated the two integration crates `crates/tree-sitter-perl-rs/Cargo.toml` and `crates/tree-sitter-perl-c/Cargo.toml` to match.

### Testing
- Ran `cargo update`, `cargo update -p tree-sitter`, and `cargo check -p tree-sitter-perl`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218cf2f7883338c6ec131d1fcfec3)