### PR TITLE
Improve BDD profile payload canonicalization

### DIFF
--- a/crates/perl-lsp-feature-grid/src/lib.rs
+++ b/crates/perl-lsp-feature-grid/src/lib.rs
@@ -45,7 +45,7 @@ pub fn to_json_for_profile(profile: FeatureProfile) -> String {
 
 /// BDD-compatible feature catalog JSON for an explicit profile set.
 pub fn to_json_for_profiles(profiles: &[FeatureProfile]) -> String {
-    feature_grid_payload(profiles, None).to_string()
+    feature_grid_payload(&canonical_profiles(profiles), None).to_string()
 }
 
 /// BDD-compatible feature catalog JSON with all canonical profiles.
@@ -122,6 +122,16 @@ fn feature_grid_payload(
     }
 
     payload
+}
+
+fn canonical_profiles(profiles: &[FeatureProfile]) -> Vec<FeatureProfile> {
+    let mut canonical = Vec::new();
+    for profile in profiles.iter().copied() {
+        if !canonical.contains(&profile) {
+            canonical.push(profile);
+        }
+    }
+    canonical
 }
 
 fn profile_summary(profile: FeatureProfile) -> Value {

--- a/crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs
@@ -643,8 +643,8 @@ fn duplicate_profiles_in_to_json_for_profiles_handled() -> Result<(), Box<dyn st
     let payload = to_json_for_profiles(&[FeatureProfile::All, FeatureProfile::All]);
     let value = serde_json::from_str::<Value>(&payload)?;
     let profiles = must_some(value.get("profiles").and_then(|p| p.as_array()));
-    // May have duplicates or not - both are acceptable, just ensure structure is valid
-    assert!(!profiles.is_empty());
+    assert_eq!(profiles.len(), 1, "duplicate profiles should be de-duplicated");
+    assert_eq!(profiles[0]["profile"].as_str(), Some("all"));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Ensure BDD JSON payloads produced by `to_json_for_profiles` are deterministic and free of duplicate profile entries for tooling consumption.
- Keep multi-profile projections stable and preserve first-seen ordering when callers accidentally pass duplicate profiles.

### Description
- Canonicalize profile input for `to_json_for_profiles` by de-duplicating the input list while preserving first-seen order via a new helper `canonical_profiles`. (edit: `crates/perl-lsp-feature-grid/src/lib.rs`)
- Replace the direct call to `feature_grid_payload(profiles, None)` with `feature_grid_payload(&canonical_profiles(profiles), None)` to centralize canonicalization. (edit: `crates/perl-lsp-feature-grid/src/lib.rs`)
- Strengthen the duplicate-profile test to assert explicit de-duplication semantics (`profiles.len() == 1` and expected profile key) rather than permitting ambiguous behavior. (edit: `crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs`)

### Testing
- Ran formatting with `cargo fmt --all` and then executed `cargo test -p perl-lsp-feature-grid`.
- All tests in the crate passed: unit tests and extended/comprehensive suites completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218d4816083338f54234f993254e6)