### PR TITLE
Improve BDD profile-aware feature grid projection

### DIFF
--- a/crates/perl-lsp-feature-grid/src/lib.rs
+++ b/crates/perl-lsp-feature-grid/src/lib.rs
@@ -95,6 +95,7 @@ fn feature_grid_payload(
         None => (advertised_features().to_vec(), advertised_trackable_feature_count_for_grid()),
     };
     let trackable_feature_count = trackable_feature_count_for_grid();
+    let rows = selected_profile.map(bdd_feature_rows_for_profile).unwrap_or_else(bdd_feature_rows);
     let compliance_percent = if trackable_feature_count == 0 {
         0.0
     } else {
@@ -111,7 +112,7 @@ fn feature_grid_payload(
         "feature_profiles": feature_profile_contracts(),
         "feature_grid": {
             "columns": FEATURE_GRID_COLUMNS,
-            "rows": bdd_feature_rows(),
+            "rows": rows,
         },
         "profiles": profile_summaries,
         "feature_count": all_features().len(),
@@ -122,6 +123,20 @@ fn feature_grid_payload(
     }
 
     payload
+}
+
+/// BDD rows with `advertised` projected to a specific runtime profile.
+pub fn bdd_feature_rows_for_profile(profile: FeatureProfile) -> Vec<BddFeatureRow> {
+    let advertised = catalog_advertised_feature_ids(profile);
+    let advertised_set: std::collections::HashSet<&'static str> = advertised.into_iter().collect();
+
+    bdd_feature_rows()
+        .into_iter()
+        .map(|mut row| {
+            row.advertised = advertised_set.contains(row.id);
+            row
+        })
+        .collect()
 }
 
 fn profile_summary(profile: FeatureProfile) -> Value {
@@ -148,8 +163,8 @@ fn profile_summary(profile: FeatureProfile) -> Value {
 #[cfg(test)]
 mod tests {
     use super::{
-        FeatureProfile, compliance_percent_for_profile, to_json, to_json_for_all_profiles,
-        to_json_for_profile,
+        FeatureProfile, bdd_feature_rows_for_profile, catalog_advertised_feature_ids,
+        compliance_percent_for_profile, to_json, to_json_for_all_profiles, to_json_for_profile,
     };
     use perl_tdd_support::{must, must_some};
 
@@ -214,5 +229,36 @@ mod tests {
         assert!(keys.contains(&"ga-lock"));
         assert!(keys.contains(&"production"));
         assert!(keys.contains(&"all"));
+    }
+
+    #[test]
+    fn profile_payload_projects_bdd_row_advertised_flags() {
+        let payload = to_json_for_profile(FeatureProfile::GaLock);
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        let rows = must_some(
+            value
+                .get("feature_grid")
+                .and_then(|grid| grid.get("rows"))
+                .and_then(|rows| rows.as_array()),
+        );
+
+        let advertised_row_count = rows
+            .iter()
+            .filter(|row| row.get("advertised").and_then(|v| v.as_bool()) == Some(true))
+            .count();
+        let expected_advertised = catalog_advertised_feature_ids(FeatureProfile::GaLock);
+
+        assert_eq!(advertised_row_count, expected_advertised.len());
+    }
+
+    #[test]
+    fn bdd_rows_for_profile_match_advertised_catalog_ids() {
+        let rows = bdd_feature_rows_for_profile(FeatureProfile::GaLock);
+        let expected_advertised = catalog_advertised_feature_ids(FeatureProfile::GaLock);
+
+        for row in rows {
+            let is_expected = expected_advertised.contains(&row.id);
+            assert_eq!(row.advertised, is_expected, "row {} has incorrect advertised flag", row.id);
+        }
     }
 }

--- a/crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs
@@ -518,21 +518,34 @@ fn all_profiles_json_includes_all_profile() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
-fn feature_grid_is_same_across_all_payloads() -> Result<(), Box<dyn std::error::Error>> {
+fn feature_grid_row_identity_is_same_across_all_payloads() -> Result<(), Box<dyn std::error::Error>>
+{
     let payload1 = to_json();
-    let payload2 = to_json_for_profile(FeatureProfile::All);
+    let payload2 = to_json_for_profile(FeatureProfile::GaLock);
     let payload3 = to_json_for_all_profiles();
 
     let value1 = serde_json::from_str::<Value>(&payload1)?;
     let value2 = serde_json::from_str::<Value>(&payload2)?;
     let value3 = serde_json::from_str::<Value>(&payload3)?;
 
-    let grid1 = value1["feature_grid"]["rows"].to_string();
-    let grid2 = value2["feature_grid"]["rows"].to_string();
-    let grid3 = value3["feature_grid"]["rows"].to_string();
+    let rows1 = must_some(value1["feature_grid"]["rows"].as_array());
+    let rows2 = must_some(value2["feature_grid"]["rows"].as_array());
+    let rows3 = must_some(value3["feature_grid"]["rows"].as_array());
 
-    assert_eq!(grid1, grid2, "feature grid should be same in to_json and to_json_for_profile");
-    assert_eq!(grid1, grid3, "feature grid should be same in all payloads");
+    let key_of = |row: &Value| {
+        (
+            row["area"].as_str().unwrap_or_default().to_string(),
+            row["id"].as_str().unwrap_or_default().to_string(),
+            row["spec"].as_str().unwrap_or_default().to_string(),
+        )
+    };
+
+    let keys1: Vec<_> = rows1.iter().map(key_of).collect();
+    let keys2: Vec<_> = rows2.iter().map(key_of).collect();
+    let keys3: Vec<_> = rows3.iter().map(key_of).collect();
+
+    assert_eq!(keys1, keys2, "feature row identity should stay stable for profile payloads");
+    assert_eq!(keys1, keys3, "feature row identity should stay stable in all payloads");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Make `to_json_for_profile(...)` emit a BDD `feature_grid.rows` projection that reflects the runtime profile's advertised features so BDD consumers see profile-scoped advertised flags.
- Preserve canonical row ordering and global behavior for `to_json()` and multi-profile payloads while allowing profile-specific advertised projection.

### Description
- Update `feature_grid_payload` to use profile-projected rows when `selected_profile` is `Some(...)` by calling a new helper instead of always emitting `bdd_feature_rows()`.
- Add `bdd_feature_rows_for_profile(profile: FeatureProfile) -> Vec<BddFeatureRow>` which projects the `advertised` flag per-row from `catalog_advertised_feature_ids(...)` while preserving canonical ordering.
- Adjust tests: add unit tests in `crates/perl-lsp-feature-grid/src/lib.rs` to verify profile payload advertised counts and row-by-row advertised flags, and modify `crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs` to assert stable row identity (`area/id/spec`) across payloads instead of requiring byte-identical rows.
- Files changed: `crates/perl-lsp-feature-grid/src/lib.rs` and `crates/perl-lsp-feature-grid/tests/extended_unit_tests.rs`.

### Testing
- Ran `cargo test -p perl-lsp-feature-grid`; initial run surfaced a failing cross-payload equality test which was updated to check stable row identity instead of byte-for-byte equality, and subsequent test runs passed.
- After fixes ran `cargo test -p perl-lsp-feature-grid` again and all unit and extended tests in the crate passed (`0 failed`).
- Ran `cargo fmt --all` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218d4816083338f54234f993254e6)