### PR TITLE
test(lsp): strengthen BDD rename edit assertions

### DIFF
--- a/crates/perl-lsp/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp/tests/lsp_bdd_workflows.rs
@@ -76,6 +76,42 @@ fn workspace_edit_uris(edit: &Value) -> BTreeSet<String> {
     uris
 }
 
+fn workspace_edit_new_texts_for_uri(edit: &Value, target_uri: &str) -> Vec<String> {
+    let mut new_texts = Vec::new();
+
+    if let Some(changes) = edit.get("changes").and_then(Value::as_object)
+        && let Some(edits) = changes.get(target_uri).and_then(Value::as_array)
+    {
+        new_texts.extend(
+            edits
+                .iter()
+                .filter_map(|entry| entry.get("newText").and_then(Value::as_str))
+                .map(ToOwned::to_owned),
+        );
+    }
+
+    if let Some(doc_changes) = edit.get("documentChanges").and_then(Value::as_array) {
+        for change in doc_changes {
+            let uri_matches =
+                change.pointer("/textDocument/uri").and_then(Value::as_str) == Some(target_uri);
+            if !uri_matches {
+                continue;
+            }
+
+            if let Some(edits) = change.get("edits").and_then(Value::as_array) {
+                new_texts.extend(
+                    edits
+                        .iter()
+                        .filter_map(|entry| entry.get("newText").and_then(Value::as_str))
+                        .map(ToOwned::to_owned),
+                );
+            }
+        }
+    }
+
+    new_texts
+}
+
 fn first_location_uri(response: &Value) -> Option<String> {
     if let Some(arr) = response.as_array() {
         arr.first().and_then(|v| v.get("uri").and_then(Value::as_str)).map(ToOwned::to_owned)
@@ -315,6 +351,18 @@ my $also = process_data();
     let uris = workspace_edit_uris(&edit);
     assert!(uris.contains(&module_uri), "rename should edit module file");
     assert!(uris.contains(&main_uri), "rename should edit main script file");
+
+    scenario.then("rename edits include the new symbol text in both files");
+    let module_texts = workspace_edit_new_texts_for_uri(&edit, &module_uri);
+    let main_texts = workspace_edit_new_texts_for_uri(&edit, &main_uri);
+    assert!(
+        module_texts.iter().any(|text| text.contains("process_records")),
+        "module edits should contain new function name; got {module_texts:?}"
+    );
+    assert!(
+        main_texts.iter().any(|text| text.contains("process_records")),
+        "main edits should contain new function name; got {main_texts:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Improve the BDD test coverage for rename refactorings by validating not only which files are edited but also that the edits contain the expected new symbol text.
- Make the workspace-edit validation more semantic so the test can catch rename payload regressions where URIs are present but contents are incorrect.

### Description
- Add a helper `workspace_edit_new_texts_for_uri(edit: &Value, target_uri: &str) -> Vec<String>` to extract `newText` values for a specific URI from both `changes` and `documentChanges` in workspace edits in `crates/perl-lsp/tests/lsp_bdd_workflows.rs`.
- Extend the `bdd_rename_updates_workspace_edits` test to assert that the rename workspace edits for both the module and the script include the new function name (`process_records`).
- Preserve existing assertions that the rename touches both files while adding content-level checks for better semantic verification.

### Testing
- Ran formatting with `cargo fmt --all`, which completed successfully.
- Ran the targeted test suite with `cargo test -p perl-lsp --test lsp_bdd_workflows`, and the test binary reported: `10 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218d4816083338f54234f993254e6)