### PR TITLE
Improve fuzz corpus regression test discovery

### DIFF
--- a/crates/perl-parser/tests/fuzz_corpus_regression.rs
+++ b/crates/perl-parser/tests/fuzz_corpus_regression.rs
@@ -1,24 +1,70 @@
 /// Regression test against existing fuzzed corpus
 ///
-/// This test ensures that the substitution operator parsing improvements
-/// don't break parsing of the existing fuzzed corpus files.
+/// This test ensures parser improvements don't reintroduce panics when
+/// parsing known fuzz-generated and hand-curated stress inputs.
 use perl_parser::Parser;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+const MAX_CORPUS_FILES: usize = 200;
+
+fn collect_files_from_dir(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path);
+            }
+        }
+    }
+
+    files
+}
+
+fn candidate_corpus_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Ok(custom_dir) = std::env::var("PERL_FUZZ_CORPUS_DIR") {
+        let custom_path = PathBuf::from(custom_dir);
+        if custom_path.exists() {
+            dirs.push(custom_path);
+        }
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // Canonical repository corpus location.
+    let repo_corpus = manifest_dir.join("../perl-corpus/fuzz");
+    if repo_corpus.exists() {
+        dirs.push(repo_corpus);
+    }
+
+    // Legacy benchmark corpus location retained for compatibility.
+    let benchmark_corpus = manifest_dir.join("../../benchmark_tests/fuzzed");
+    if benchmark_corpus.exists() {
+        dirs.push(benchmark_corpus);
+    }
+
+    dirs
+}
 
 fn get_fuzzed_files() -> Vec<PathBuf> {
-    let fuzz_dir = "/home/steven/code/Rust/perl-lsp/review/benchmark_tests/fuzzed";
+    let mut files = Vec::new();
 
-    if let Ok(entries) = fs::read_dir(fuzz_dir) {
-        entries
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.path())
-            .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("pl"))
-            .take(20) // Limit to first 20 files for bounded testing
-            .collect()
-    } else {
-        Vec::new()
+    for dir in candidate_corpus_dirs() {
+        files.extend(collect_files_from_dir(&dir));
     }
+
+    files.sort();
+    files.dedup();
+
+    if files.len() > MAX_CORPUS_FILES {
+        files.truncate(MAX_CORPUS_FILES);
+    }
+
+    files
 }
 
 #[test]
@@ -32,28 +78,35 @@ fn test_fuzz_corpus_regression() {
 
     let mut parse_failures = 0;
     let mut parse_panics = 0;
+    let mut utf8_read_failures = 0;
     let mut total_files = 0;
 
     for file_path in fuzzed_files {
         total_files += 1;
 
-        if let Ok(content) = fs::read_to_string(&file_path) {
-            // Test that parser doesn't panic on existing fuzzed content
-            let result = std::panic::catch_unwind(|| {
-                let mut parser = Parser::new(&content);
-                parser.parse()
-            });
+        match fs::read_to_string(&file_path) {
+            Ok(content) => {
+                // Test that parser doesn't panic on existing fuzzed content.
+                let result = std::panic::catch_unwind(|| {
+                    let mut parser = Parser::new(&content);
+                    parser.parse()
+                });
 
-            match result {
-                Ok(parse_result) => {
-                    if parse_result.is_err() {
-                        parse_failures += 1;
+                match result {
+                    Ok(parse_result) => {
+                        if parse_result.is_err() {
+                            parse_failures += 1;
+                        }
+                    }
+                    Err(_) => {
+                        parse_panics += 1;
+                        eprintln!("Parser panicked on file: {:?}", file_path);
                     }
                 }
-                Err(_) => {
-                    parse_panics += 1;
-                    eprintln!("Parser panicked on file: {:?}", file_path);
-                }
+            }
+            Err(_) => {
+                // Some fuzz artifacts can be raw bytes and not valid UTF-8.
+                utf8_read_failures += 1;
             }
         }
     }
@@ -62,10 +115,11 @@ fn test_fuzz_corpus_regression() {
     println!("  Total files tested: {}", total_files);
     println!("  Parse failures: {}", parse_failures);
     println!("  Parse panics: {}", parse_panics);
+    println!("  UTF-8 read failures (skipped): {}", utf8_read_failures);
 
-    // The key invariant: parser should never panic, even on malformed input
+    // The key invariant: parser should never panic, even on malformed input.
     assert_eq!(parse_panics, 0, "Parser should never panic on fuzzed corpus");
 
-    // Parse failures are acceptable for malformed fuzzed input
-    // We're primarily checking for crashes/panics, not parse success
+    // Parse failures are acceptable for malformed fuzzed input.
+    // We're primarily checking for crashes/panics, not parse success.
 }


### PR DESCRIPTION
### Motivation
- Make the fuzz corpus regression test portable by removing a machine-specific hardcoded path.
- Ensure the test exercises the repository-maintained fuzz corpus (and legacy locations) instead of often being skipped.
- Increase robustness when encountering raw-byte fuzz artifacts that are not valid UTF-8.

### Description
- Replace the single hardcoded corpus path with discovery of candidate directories from `PERL_FUZZ_CORPUS_DIR`, `crates/perl-corpus/fuzz`, and `benchmark_tests/fuzzed`.
- Add `collect_files_from_dir` and `candidate_corpus_dirs` helpers to gather files across directories, then sort, deduplicate, and cap results to `MAX_CORPUS_FILES` for deterministic bounded runs.
- Update the test to count and skip files that cannot be read as UTF-8 instead of silently dropping them, while preserving the invariant that parser panics must be zero.
- Improve test reporting to print totals for files tested, parse failures, parse panics, and UTF-8 read failures.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_corpus_regression`, which completed successfully (`test_fuzz_corpus_regression ... ok`).
- Ran `cargo fmt --all` to format changes without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218dc0ce48333b6fb6f9eb2686bdb)