### PR TITLE
Improve fuzz target robustness for arbitrary byte input

### DIFF
--- a/fuzz/fuzz_targets/builtin_functions.rs
+++ b/fuzz/fuzz_targets/builtin_functions.rs
@@ -1,44 +1,55 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
 use perl_parser::Parser;
 
 fuzz_target!(|data: &[u8]| {
-    // Convert fuzz input to string, handling invalid UTF-8 gracefully
-    if let Ok(input) = std::str::from_utf8(data) {
-        // Skip overly long inputs to prevent timeout
-        if input.len() > 1000 {
-            return;
-        }
+    let input = bounded_utf8_lossy(data);
 
-        // Focus on builtin function edge cases
-        // Test map/grep/sort with {} blocks that PR #153 enhanced
-        let builtin_prefixes = ["map{", "grep{", "sort{", "map {", "grep {", "sort {"];
+    // Focus on builtin function edge cases
+    // Test map/grep/sort with {} blocks that PR #153 enhanced
+    let builtin_prefixes = ["map{", "grep{", "sort{", "map {", "grep {", "sort {"];
 
-        for prefix in &builtin_prefixes {
-            let test_input = format!("{}{}", prefix, input);
+    for prefix in &builtin_prefixes {
+        let test_input = format!("{}{}", prefix, input);
 
-            // Test parser with builtin function constructs
-            let mut parser = Parser::new(&test_input);
-            let _result = parser.parse();
+        // Test parser with builtin function constructs
+        let mut parser = Parser::new(&test_input);
+        let _result = parser.parse();
 
-            // We don't assert on parse success/failure since many fuzz inputs
-            // will be malformed, but the parser should never crash or panic
-        }
+        // We don't assert on parse success/failure since many fuzz inputs
+        // will be malformed, but the parser should never crash or panic
+    }
 
-        // Test empty block edge cases that were specifically enhanced in PR #153
-        let empty_block_tests = [
-            format!("map{{{}}}", input),
-            format!("grep{{{}}}", input),
-            format!("sort{{{}}}", input),
-            format!("map{{}}{}", input),
-            format!("grep{{}}{}", input),
-            format!("sort{{}}{}", input),
-        ];
+    // Test empty block edge cases that were specifically enhanced in PR #153
+    let empty_block_tests = [
+        format!("map{{{}}}", input),
+        format!("grep{{{}}}", input),
+        format!("sort{{{}}}", input),
+        format!("map{{}}{}", input),
+        format!("grep{{}}{}", input),
+        format!("sort{{}}{}", input),
+    ];
 
-        for test_case in &empty_block_tests {
-            let mut parser = Parser::new(test_case);
-            let _result = parser.parse();
-        }
+    for test_case in &empty_block_tests {
+        let mut parser = Parser::new(test_case);
+        let _result = parser.parse();
     }
 });

--- a/fuzz/fuzz_targets/heredoc_parsing.rs
+++ b/fuzz/fuzz_targets/heredoc_parsing.rs
@@ -1,81 +1,86 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
 use perl_parser::Parser;
 
 fuzz_target!(|data: &[u8]| {
-    // Convert fuzz input to string, handling invalid UTF-8 gracefully
-    if let Ok(input) = std::str::from_utf8(data) {
-        // Skip overly long inputs to prevent timeout
-        if input.len() > 1000 {
-            return;
-        }
+    let input = bounded_utf8_lossy(data);
 
-        // Test heredoc patterns that specifically target the boundary fix in cd7a2442
-        // This focuses on the off-by-one error that was fixed in parse_heredoc_delimiter
-        let heredoc_patterns = [
-            // Double-quoted heredoc delimiters (line 5267 fix)
-            format!("<<\"{}\"", input),
-            format!("<<\"{}\"\nEND\n{}\nEND", input, input),
-            format!("<<\"{}\"", input.chars().take(1).collect::<String>()), // Single char - edge case
-            format!("<<\"\""), // Empty delimiter - critical edge case
+    // Test heredoc patterns that specifically target the boundary fix in cd7a2442
+    // This focuses on the off-by-one error that was fixed in parse_heredoc_delimiter
+    let heredoc_patterns = [
+        // Double-quoted heredoc delimiters (line 5267 fix)
+        format!("<<\"{}\"", input),
+        format!("<<\"{}\"\nEND\n{}\nEND", input, input),
+        format!("<<\"{}\"", input.chars().take(1).collect::<String>()), // Single char - edge case
+        "<<\"\"".to_string(), // Empty delimiter - critical edge case
+        // Single-quoted heredoc delimiters (line 5270 fix)
+        format!("<<'{}'", input),
+        format!("<<'{}'\nEND\n{}\nEND", input, input),
+        format!("<<'{}'", input.chars().take(1).collect::<String>()), // Single char - edge case
+        "<<''".to_string(), // Empty delimiter - critical edge case
+        // Bare heredoc delimiters (should be unaffected but test anyway)
+        format!("<<{}", input),
+        format!("<<{}\nEND\n{}\nEND", input, input),
+        // Malformed heredoc constructs that could trigger boundary issues
+        "<<\"".to_string(), // Unterminated quote - crash condition
+        "<<'".to_string(),   // Unterminated quote - crash condition
+        format!("<<\"{}", input), // Missing closing quote
+        format!("<<'{}", input), // Missing closing quote
+        format!("<<\"{}", input.chars().take(1).collect::<String>()), // Short input, missing quote
+    ];
 
-            // Single-quoted heredoc delimiters (line 5270 fix)
-            format!("<<'{}'", input),
-            format!("<<'{}'\nEND\n{}\nEND", input, input),
-            format!("<<'{}'", input.chars().take(1).collect::<String>()), // Single char - edge case
-            format!("<<''"), // Empty delimiter - critical edge case
+    for pattern in &heredoc_patterns {
+        // Test parser with heredoc constructs
+        // The boundary fix should prevent crashes on malformed delimiters
+        let mut parser = Parser::new(pattern);
+        let _result = parser.parse();
+    }
 
-            // Bare heredoc delimiters (should be unaffected but test anyway)
-            format!("<<{}", input),
-            format!("<<{}\nEND\n{}\nEND", input, input),
-
-            // Malformed heredoc constructs that could trigger boundary issues
-            "<<\"".to_string(), // Unterminated quote - crash condition
-            "<<'".to_string(), // Unterminated quote - crash condition
-            format!("<<\"{}", input), // Missing closing quote
-            format!("<<'{}", input), // Missing closing quote
-            format!("<<\"{}", input.chars().take(1).collect::<String>()), // Short input, missing quote
+    // Test specific edge cases that could trigger the original off-by-one error.
+    // Use Unicode-safe single-char extraction so arbitrary fuzz input never panics.
+    if let Some(first_char) = input.chars().next() {
+        let first = first_char.to_string();
+        let edge_cases = [
+            format!("<<\"{}\"", first), // Single character
+            format!("<<'{}'", first),   // Single character
         ];
 
-        for pattern in &heredoc_patterns {
-            // Test parser with heredoc constructs
-            // The boundary fix should prevent crashes on malformed delimiters
-            let mut parser = Parser::new(pattern);
+        for case in &edge_cases {
+            let mut parser = Parser::new(case);
             let _result = parser.parse();
-
-            // We don't assert on parse success/failure since many fuzz inputs
-            // will be malformed, but the parser should never crash or panic
         }
+    }
 
-        // Test specific edge cases that could trigger the original off-by-one error.
-        // Use Unicode-safe single-char extraction so arbitrary fuzz input never panics.
-        if let Some(first_char) = input.chars().next() {
-            let first = first_char.to_string();
-            let edge_cases = [
-                format!("<<\"{}\"", first), // Single character
-                format!("<<'{}'", first),   // Single character
-            ];
+    // Test combinations with other Perl constructs to ensure heredoc parsing
+    // doesn't break when integrated with complex syntax
+    let integration_tests = [
+        format!("my $var = <<\"{}\";\n{}\nEOF", input, input),
+        format!("print <<'{}';\n{}\nEOF", input, input),
+        format!("my @array = (<<\"{}\", 'other');\n{}\nEOF", input, input),
+    ];
 
-            for case in &edge_cases {
-                let mut parser = Parser::new(&case);
-                let _result = parser.parse();
-            }
-        }
-
-        // Test combinations with other Perl constructs to ensure heredoc parsing
-        // doesn't break when integrated with complex syntax
-        let integration_tests = [
-            format!("my $var = <<\"{}\";\n{}\nEOF", input, input),
-            format!("print <<'{}';\n{}\nEOF", input, input),
-            format!("my @array = (<<\"{}\", 'other');\n{}\nEOF", input, input),
-        ];
-
-        for test in &integration_tests {
-            if test.len() <= 1000 {
-                let mut parser = Parser::new(&test);
-                let _result = parser.parse();
-            }
+    for test in &integration_tests {
+        if test.len() <= MAX_INPUT_BYTES {
+            let mut parser = Parser::new(test);
+            let _result = parser.parse();
         }
     }
 });

--- a/fuzz/fuzz_targets/lsp_navigation.rs
+++ b/fuzz/fuzz_targets/lsp_navigation.rs
@@ -1,54 +1,65 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
 use perl_parser::Parser;
 
 fuzz_target!(|data: &[u8]| {
-    // Convert fuzz input to string, handling invalid UTF-8 gracefully
-    if let Ok(input) = std::str::from_utf8(data) {
-        // Skip overly long inputs to prevent timeout
-        if input.len() > 1000 {
-            return;
-        }
+    let input = bounded_utf8_lossy(data);
 
-        // Test dual indexing patterns that were enhanced in PR #153
-        let package_patterns = [
-            format!("Package::{}", input),
-            format!("{}::function", input),
-            format!("{}::{}", input, input),
-            format!("my $pkg = {}; $pkg::method()", input),
-        ];
+    // Test dual indexing patterns that were enhanced in PR #153
+    let package_patterns = [
+        format!("Package::{}", input),
+        format!("{}::function", input),
+        format!("{}::{}", input, input),
+        format!("my $pkg = {}; $pkg::method()", input),
+    ];
 
-        for pattern in &package_patterns {
-            // Test parser with dual indexing patterns
-            let mut parser = Parser::new(pattern);
-            let _result = parser.parse();
-        }
+    for pattern in &package_patterns {
+        // Test parser with dual indexing patterns
+        let mut parser = Parser::new(pattern);
+        let _result = parser.parse();
+    }
 
-        // Test file path completion patterns that could cause path traversal
-        let path_patterns = [
-            format!("use ../../../{}", input),
-            format!("require '{}'", input.replace('/', "\\").replace("\\", "/")),
-            format!("do '{}'", input),
-            format!("use lib '{}'", input),
-        ];
+    // Test file path completion patterns that could cause path traversal
+    let path_patterns = [
+        format!("use ../../../{}", input),
+        format!("require '{}'", input.replace('/', "\\").replace("\\", "/")),
+        format!("do '{}'", input),
+        format!("use lib '{}'", input),
+    ];
 
-        for pattern in &path_patterns {
-            // Test parser with potentially malicious path constructs
-            let mut parser = Parser::new(pattern);
-            let _result = parser.parse();
-        }
+    for pattern in &path_patterns {
+        // Test parser with potentially malicious path constructs
+        let mut parser = Parser::new(pattern);
+        let _result = parser.parse();
+    }
 
-        // Test workspace navigation edge cases
-        let navigation_patterns = [
-            format!("sub {}::method {{}}", input),
-            format!("package {}; sub method {{}}", input),
-            format!("use {}::{{}}", input),
-        ];
+    // Test workspace navigation edge cases
+    let navigation_patterns = [
+        format!("sub {}::method {{}}", input),
+        format!("package {}; sub method {{}}", input),
+        format!("use {}::{{}}", input),
+    ];
 
-        for pattern in &navigation_patterns {
-            let mut parser = Parser::new(pattern);
-            let _result = parser.parse();
-        }
+    for pattern in &navigation_patterns {
+        let mut parser = Parser::new(pattern);
+        let _result = parser.parse();
     }
 });

--- a/fuzz/fuzz_targets/substitution_parsing.rs
+++ b/fuzz/fuzz_targets/substitution_parsing.rs
@@ -1,38 +1,49 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
 use perl_parser::quote_parser::extract_substitution_parts;
 use perl_parser::Parser;
 
 fuzz_target!(|data: &[u8]| {
-    // Convert fuzz input to string, handling invalid UTF-8 gracefully
-    if let Ok(input) = std::str::from_utf8(data) {
-        // Skip overly long inputs to prevent timeout
-        if input.len() > 1000 {
-            return;
-        }
+    let input = bounded_utf8_lossy(data);
 
-        // Test quote_parser::extract_substitution_parts directly
-        // This targets the core substitution parsing logic
-        if input.starts_with('s') {
-            let (pattern, replacement, modifiers) = extract_substitution_parts(input);
+    // Test quote_parser::extract_substitution_parts directly
+    // This targets the core substitution parsing logic
+    if input.starts_with('s') {
+        let (pattern, replacement, modifiers) = extract_substitution_parts(&input);
 
-            // Basic invariant checks - these should never panic or crash
-            let _ = pattern.len() <= input.len();
-            let _ = replacement.len() <= input.len();
-            let _ = modifiers.len() <= input.len();
+        // Basic invariant checks - these should never panic or crash
+        let _ = pattern.len() <= input.len();
+        let _ = replacement.len() <= input.len();
+        let _ = modifiers.len() <= input.len();
 
-            // Observe unknown modifier chars without panicking; fuzzing should keep running.
-            let _has_nonstandard_modifier =
-                modifiers.chars().any(|ch| !matches!(ch, 'g' | 'i' | 'm' | 's' | 'x' | 'o' | 'e' | 'r'));
-        }
-
-        // Test full parser with substitution inputs
-        // This tests the complete parsing pipeline
-        let mut parser = Parser::new(input);
-        let _result = parser.parse();
-
-        // We don't assert on parse success/failure since many fuzz inputs
-        // will be malformed, but the parser should never crash or panic
+        // Observe unknown modifier chars without panicking; fuzzing should keep running.
+        let _has_nonstandard_modifier =
+            modifiers.chars().any(|ch| !matches!(ch, 'g' | 'i' | 'm' | 's' | 'x' | 'o' | 'e' | 'r'));
     }
+
+    // Test full parser with substitution inputs
+    // This tests the complete parsing pipeline
+    let mut parser = Parser::new(&input);
+    let _result = parser.parse();
+
+    // We don't assert on parse success/failure since many fuzz inputs
+    // will be malformed, but the parser should never crash or panic
 });

--- a/fuzz/fuzz_targets/unicode_positions.rs
+++ b/fuzz/fuzz_targets/unicode_positions.rs
@@ -1,62 +1,73 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
 use perl_parser::Parser;
 
 fuzz_target!(|data: &[u8]| {
-    // Convert fuzz input to string, handling invalid UTF-8 gracefully
-    if let Ok(input) = std::str::from_utf8(data) {
-        // Skip overly long inputs to prevent timeout
-        if input.len() > 1000 {
-            return;
-        }
+    let input = bounded_utf8_lossy(data);
 
-        // Test Unicode handling and emoji identifiers that were security-hardened in PR #153
-        let unicode_test_patterns = [
-            format!("my $🦀_var = {}", input),
-            format!("sub λ_{} {{}}", input),
-            format!("package 日本語::{}", input),
-            format!("use utf8; my $var = '{}'", input),
-            format!("my $emoji = '🚀{}'", input),
+    // Test Unicode handling and emoji identifiers that were security-hardened in PR #153
+    let unicode_test_patterns = [
+        format!("my $🦀_var = {}", input),
+        format!("sub λ_{} {{}}", input),
+        format!("package 日本語::{}", input),
+        format!("use utf8; my $var = '{}'", input),
+        format!("my $emoji = '🚀{}'", input),
+    ];
+
+    for pattern in &unicode_test_patterns {
+        // Test parser with Unicode content - this exercises UTF-16 position mapping
+        let mut parser = Parser::new(pattern);
+        let _result = parser.parse();
+    }
+
+    // Test specifically with Unicode characters that can cause position conversion issues
+    if input.chars().any(|c| c > '\u{007F}') {
+        // Test with the original input containing Unicode
+        let mut parser = Parser::new(&input);
+        let _result = parser.parse();
+
+        // Test with combinations that stress UTF-16 boundary handling
+        let boundary_tests = [
+            format!("# Comment with {}\nmy $var = 1;", input),
+            format!("my $var = q{{{}}};", input),
+            format!("my $str = \"{}\";", input.replace('"', "\\\"")),
         ];
 
-        for pattern in &unicode_test_patterns {
-            // Test parser with Unicode content - this exercises UTF-16 position mapping
-            let mut parser = Parser::new(pattern);
+        for test in &boundary_tests {
+            let mut parser = Parser::new(test);
             let _result = parser.parse();
         }
+    }
 
-        // Test specifically with Unicode characters that can cause position conversion issues
-        if input.chars().any(|c| c > '\u{007F}') {
-            // Test with the original input containing Unicode
-            let mut parser = Parser::new(input);
+    // Test edge cases that could trigger the UTF-16 security fixes from PR #153
+    let position_stress_tests = [
+        format!("{}\n{}\n{}", input, input, input), // Multi-line stress
+        format!("'{}'", input.repeat(10)),             // Repeated patterns
+        input.chars().rev().collect::<String>(),       // Reversed input
+    ];
+
+    for test in &position_stress_tests {
+        if test.len() <= MAX_INPUT_BYTES {
+            let mut parser = Parser::new(test);
             let _result = parser.parse();
-
-            // Test with combinations that stress UTF-16 boundary handling
-            let boundary_tests = [
-                format!("# Comment with {}\nmy $var = 1;", input),
-                format!("my $var = q{{{}}};", input),
-                format!("my $str = \"{}\";", input.replace('"', "\\\"")),
-            ];
-
-            for test in &boundary_tests {
-                let mut parser = Parser::new(test);
-                let _result = parser.parse();
-            }
-        }
-
-        // Test edge cases that could trigger the UTF-16 security fixes from PR #153
-        let position_stress_tests = [
-            format!("{}\n{}\n{}", input, input, input), // Multi-line stress
-            format!("'{}'", input.repeat(10)),           // Repeated patterns
-            input.chars().rev().collect::<String>(),     // Reversed input
-        ];
-
-        for test in &position_stress_tests {
-            if test.len() <= 1000 {
-                let mut parser = Parser::new(&test);
-                let _result = parser.parse();
-            }
         }
     }
 });


### PR DESCRIPTION
### Motivation

- Fuzz targets were frequently skipping non-UTF-8 inputs and early-returning, reducing coverage for malformed byte streams.
- Arbitrary libFuzzer bytes should still exercise parser code paths even when they contain invalid UTF-8, while keeping runs bounded to avoid timeouts.

### Description

- Added a bounded lossy UTF-8 conversion and `MAX_INPUT_BYTES` constant into the fuzz targets so arbitrary byte sequences are converted to a safe, testable `String` instead of being rejected.
- Replaced `if let Ok(input) = std::str::from_utf8(data) { ... }` early-return patterns with `let input = bounded_utf8_lossy(data);` in the parser-oriented targets (`substitution_parsing`, `builtin_functions`, `heredoc_parsing`, `lsp_navigation`, `unicode_positions`).
- Replaced hardcoded length checks with the `MAX_INPUT_BYTES` constant and routed all domain-specific pattern generation (substitution extraction, builtin blocks, heredoc constructs, navigation/path patterns, and Unicode/UTF-16 stress cases) through the new preprocessing.
- Kept existing invariants and non-asserting parse calls so fuzz inputs drive the parser without introducing new crash assertions.

### Testing

- Ran `cargo fmt --all` to format modified files and it completed successfully.
- Ran `cargo check` in the `fuzz/` crate and the check finished successfully (dev profile built without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218dc0ce48333b6fb6f9eb2686bdb)