### PR TITLE
Expand fuzz automation coverage across CI and just targets

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -368,6 +368,7 @@ jobs:
         target: [
           builtin_functions,
           heredoc_parsing,
+          lsp_cancellation_registry,
           lsp_navigation,
           substitution_parsing,
           unicode_positions

--- a/justfile
+++ b/justfile
@@ -236,7 +236,10 @@ fuzz-bounded:
     @echo "🔥 Running bounded fuzz testing (60 seconds per target)..."
     @cargo +nightly fuzz run builtin_functions -- -max_total_time=60 || echo "  Builtin functions fuzzing complete"
     @cargo +nightly fuzz run heredoc_parsing -- -max_total_time=60 || echo "  Heredoc fuzzing complete"
+    @cargo +nightly fuzz run lsp_cancellation_registry -- -max_total_time=60 || echo "  LSP cancellation registry fuzzing complete"
+    @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
+    @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
     @echo "✅ Fuzz testing complete"
 
 # Benchmarks (requires criterion) - legacy target, prefer 'just bench'
@@ -1269,6 +1272,7 @@ fuzz-regression duration='30':
     @echo "🔥 Running fuzz regression tests ({{duration}}s per target)..."
     @just fuzz builtin_functions {{duration}} || true
     @just fuzz heredoc_parsing {{duration}} || true
+    @just fuzz lsp_cancellation_registry {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true


### PR DESCRIPTION
### Motivation
- Ensure the repository's bounded fuzzing workflows (local `just` targets and nightly CI) include the LSP cancellation target so cancellation/token behavior is exercised by automated fuzz runs.

### Description
- Add `lsp_cancellation_registry` to the nightly fuzz matrix in `.github/workflows/ci-nightly.yml` so scheduled/dispatch nightly fuzz jobs run this target.
- Expand `fuzz-bounded` in `justfile` to run the full set of maintained bounded fuzz targets (`builtin_functions`, `heredoc_parsing`, `lsp_cancellation_registry`, `lsp_navigation`, `substitution_parsing`, `unicode_positions`).
- Include `lsp_cancellation_registry` in `just fuzz-regression` so short local regression sweeps cover the same target set.

### Testing
- Ran `cargo +nightly fuzz list` and observed the expected targets including `lsp_cancellation_registry`, so the fuzz targets are discoverable (success).
- Attempted `just --summary` in this environment but `just` was not installed, so `just`-based validation could not be executed here (failure due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218dc0ce48333b6fb6f9eb2686bdb)