### PR TITLE
Improve perl-parser fuzz corpus regression coverage

### DIFF
--- a/crates/perl-parser/tests/fuzz_corpus_regression.rs
+++ b/crates/perl-parser/tests/fuzz_corpus_regression.rs
@@ -7,15 +7,29 @@ use std::fs;
 use std::path::PathBuf;
 
 fn get_fuzzed_files() -> Vec<PathBuf> {
-    let fuzz_dir = "/home/steven/code/Rust/perl-lsp/review/benchmark_tests/fuzzed";
+    let fuzz_dir =
+        std::env::var("PERL_PARSER_FUZZ_CORPUS_DIR").map(PathBuf::from).unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("perl-corpus").join("fuzz")
+        });
 
-    if let Ok(entries) = fs::read_dir(fuzz_dir) {
-        entries
+    let max_files = std::env::var("PERL_PARSER_FUZZ_CORPUS_LIMIT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(50);
+
+    if let Ok(entries) = fs::read_dir(&fuzz_dir) {
+        let mut files: Vec<_> = entries
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())
-            .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("pl"))
-            .take(20) // Limit to first 20 files for bounded testing
-            .collect()
+            .filter(|path| path.is_file())
+            .filter(|path| {
+                !matches!(path.extension().and_then(|extension| extension.to_str()), Some("md"))
+            })
+            .collect();
+
+        files.sort();
+        files.truncate(max_files);
+        files
     } else {
         Vec::new()
     }
@@ -37,7 +51,9 @@ fn test_fuzz_corpus_regression() {
     for file_path in fuzzed_files {
         total_files += 1;
 
-        if let Ok(content) = fs::read_to_string(&file_path) {
+        if let Ok(content_bytes) = fs::read(&file_path) {
+            let content = String::from_utf8_lossy(&content_bytes);
+
             // Test that parser doesn't panic on existing fuzzed content
             let result = std::panic::catch_unwind(|| {
                 let mut parser = Parser::new(&content);


### PR DESCRIPTION
### Motivation
- Remove a machine-specific hardcoded fuzz corpus path and make the corpus discovery portable and configurable. 
- Allow CI and developer environments to exercise more realistic fuzz artifacts (including non-UTF-8 outputs) while keeping test runtime bounded and deterministic. 

### Description
- Replace the hardcoded path with an optional `PERL_PARSER_FUZZ_CORPUS_DIR` environment override and a repository-local default of `crates/perl-corpus/fuzz` derived from `env!("CARGO_MANIFEST_DIR")`.
- Add `PERL_PARSER_FUZZ_CORPUS_LIMIT` to bound the number of files tested (default `50`) and make selection deterministic by sorting and truncating the file list.
- Broaden corpus ingestion by reading raw bytes with `fs::read` and converting via `String::from_utf8_lossy`, and exclude markdown files while accepting other non-markdown fuzz artifacts.
- Update the test to operate on file bytes and keep the original invariant that the parser must not panic while counting parse failures vs. panics.

### Testing
- Ran `cargo test -p perl-parser --test fuzz_corpus_regression`, which completed and reported the test `test_fuzz_corpus_regression` as `ok`.
- Ran `cargo fmt --all` to format the codebase, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218dc0ce48333b6fb6f9eb2686bdb)