### PR TITLE
tests: improve semantic NodeKind coverage for Eval/Do expression forms

### DIFF
--- a/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
+++ b/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
@@ -133,6 +133,13 @@ EOF
             "#,
         ),
         (
+            "eval_and_do_expression_forms",
+            r#"
+                my $eval_result = eval "40 + 2";
+                my $do_result = do "./maybe_load.pl";
+            "#,
+        ),
+        (
             "given_when_default",
             r#"
                 use feature 'switch';


### PR DESCRIPTION
### Motivation
- Ensure `NodeKind::Eval` and `NodeKind::Do` are observed by the semantic NodeKind total-coverage test by adding expression-style examples in the fixture set.

### Description
- Add a new fixture case `eval_and_do_expression_forms` in `crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs` that includes `my $eval_result = eval "40 + 2";` and `my $do_result = do "./maybe_load.pl";` to exercise expression forms of `eval` and `do`.

### Testing
- Ran `cargo test -p perl-parser --test semantic_nodekind_coverage_tests` and the suite passed.
- Ran `cargo test -p perl-parser --test corpus_nodekind_coverage_test` and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218e6f4a083338e61a3bd215938e1)