### PR TITLE
Add clean corpus fixture to cover previously recovery-only NodeKinds

### DIFF
--- a/test_corpus/clean_nodekind_coverage_burndown.pl
+++ b/test_corpus/clean_nodekind_coverage_burndown.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Test: Clean coverage for recovery-only NodeKinds
+# NodeKinds: Eval, NamedParameter, Tie, Untie, VariableWithAttributes
+
+use strict;
+use warnings;
+
+sub accepts_named (:$name, $count = 1) {
+    my ($x :Shared, $y) = ($count, $count + 1);
+
+    tie my $slot, 'Tie::StdScalar';
+    $slot = $x + $y;
+
+    my $result = eval {
+        return "$name:$slot";
+    };
+
+    untie $slot;
+    return $result;
+}
+
+accepts_named(name => 'demo', 2);


### PR DESCRIPTION
### Motivation
- Ensure previously recovery-only NodeKinds (`Eval`, `NamedParameter`, `Tie`, `Untie`, `VariableWithAttributes`) are exercised by a clean, deterministic corpus fixture so corpus coverage/angle checks are not fragile.

### Description
- Add `test_corpus/clean_nodekind_coverage_burndown.pl`, a small Perl sample that includes a named signature parameter, a variable with attributes, `tie`/`untie` usage, and an `eval` block to exercise the targeted `NodeKind`s in non-recovery parses.

### Testing
- Ran `cargo test -p perl-parser --test corpus_nodekind_coverage_test -- --nocapture`, which reported the recovery-only kind count dropped to `0` and the corpus coverage/angle tests completed successfully (both tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218e6f4a083338e61a3bd215938e1)