### PR TITLE
Improve semantic node kind coverage fixture

### DIFF
--- a/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
+++ b/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
@@ -107,6 +107,8 @@ EOF
         (
             "control_flow_and_modifiers",
             r#"
+                my $eval_result = eval "1 + 1";
+                my $do_result = do "script.pl";
                 eval { my $v = 0; };
                 do { my $w = 1; };
 


### PR DESCRIPTION
### Motivation
- Ensure the semantic node-kind coverage test observes expression-form `eval` and `do` so `NodeKind::Eval` and `NodeKind::Do` are counted by the total-coverage assertion.

### Description
- Extended the `control_flow_and_modifiers` fixture in `crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs` by adding `my $eval_result = eval "1 + 1";` and `my $do_result = do "script.pl";` while preserving the existing block-form `eval { ... }` and `do { ... }` cases.

### Testing
- Ran `cargo test -p perl-parser --test semantic_nodekind_coverage_tests -- --nocapture` and the suite passed (all tests green); also ran `cargo fmt --all` for formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218e6f4a083338e61a3bd215938e1)