### PR TITLE
Improve highlight node kind coverage in perl-corpus integration tests

### DIFF
--- a/crates/perl-corpus/tests/highlight_integration_test.rs
+++ b/crates/perl-corpus/tests/highlight_integration_test.rs
@@ -51,6 +51,13 @@ fn test_complex_highlight_constructs() {
         // Use statements
         ("use strict;", "UseStatement"),
         ("use warnings;", "UseStatement"),
+        // Control flow and structural nodes
+        ("if ($ok) { return 1; }", "If"),
+        ("for (my $i = 0; $i < 3; $i = $i + 1) { print $i; }", "For"),
+        ("while ($running) { last; }", "While"),
+        // Package and declaration-level nodes
+        ("package My::Pkg;", "Package"),
+        ("sub greet { return 'hi'; }", "SubDeclaration"),
     ];
 
     for (source, expected_primary_kind) in test_cases {
@@ -184,48 +191,15 @@ fn collect_node_kinds(node: &Node, scopes: &mut HashMap<String, usize>) {
         NodeKind::Use { .. } => "UseStatement",
         NodeKind::FunctionCall { .. } => "FunctionCall",
         NodeKind::Heredoc { .. } => "HereDoc",
-        _ => "other", // Fallback for other node types
+        // Fall back to canonical AST node kind names for complete coverage.
+        _ => node.kind.kind_name(),
     }
     .to_string();
 
-    *scopes.entry(kind_name).or_insert(0) += 1;
+    *scopes.entry(kind_name).or_default() += 1;
 
-    // Manually recurse into child nodes based on NodeKind
-    match &node.kind {
-        NodeKind::Program { statements } => {
-            for stmt in statements {
-                collect_node_kinds(stmt, scopes);
-            }
-        }
-        NodeKind::ExpressionStatement { expression } => {
-            collect_node_kinds(expression, scopes);
-        }
-        NodeKind::VariableDeclaration { variable, initializer, .. } => {
-            collect_node_kinds(variable, scopes);
-            if let Some(init) = initializer {
-                collect_node_kinds(init, scopes);
-            }
-        }
-        NodeKind::Binary { left, right, .. } => {
-            collect_node_kinds(left, scopes);
-            collect_node_kinds(right, scopes);
-        }
-        NodeKind::Assignment { lhs, rhs, .. } => {
-            collect_node_kinds(lhs, scopes);
-            collect_node_kinds(rhs, scopes);
-        }
-        NodeKind::Subroutine { body, .. } => {
-            collect_node_kinds(body, scopes);
-        }
-        NodeKind::Use { .. } => {
-            // Note: module is a String, not a Node
-        }
-        NodeKind::FunctionCall { args, .. } => {
-            // Note: name is a String, not a Node
-            for arg in args {
-                collect_node_kinds(arg, scopes);
-            }
-        }
-        _ => {}
+    // Recurse through all direct children to avoid missing any NodeKind containers.
+    for child in node.children() {
+        collect_node_kinds(child, scopes);
     }
 }


### PR DESCRIPTION
### Motivation
- Increase AST node-kind coverage in the highlight integration test to avoid collapsing unhandled variants into a generic fallback and to better exercise structural/declaration node kinds.
- Make the test traversal robust against additions to `NodeKind` so highlight coverage checks remain accurate as the AST evolves.

### Description
- Updated `crates/perl-corpus/tests/highlight_integration_test.rs` to add fixtures covering structural and declaration nodes (`If`, `For`, `While`, `Package`, and a sub declaration).
- Replaced the previous `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218e6f4a083338e61a3bd215938e1)