### PR TITLE
perl-dap: standardize attach timeoutMs with legacy alias

### DIFF
--- a/crates/perl-dap/src/configuration.rs
+++ b/crates/perl-dap/src/configuration.rs
@@ -226,6 +226,10 @@ pub struct AttachConfiguration {
     pub port: u16,
 
     /// Connection timeout in milliseconds (optional)
+    ///
+    /// Accepts both `timeoutMs` (canonical) and legacy `timeout` during
+    /// deserialization for backward compatibility.
+    #[serde(alias = "timeout")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u32>,
 }
@@ -353,7 +357,7 @@ pub fn create_attach_json_snippet() -> String {
         "name": "Attach to Perl::LanguageServer",
         "host": "localhost",
         "port": 13603,
-        "timeout": 5000
+        "timeoutMs": 5000
     });
     serde_json::to_string_pretty(&json).unwrap_or_else(|e| {
         eprintln!("Failed to serialize attach.json snippet: {}", e);
@@ -408,6 +412,7 @@ mod tests {
         assert!(snippet.contains("\"request\""));
         assert!(snippet.contains("attach"));
         assert!(snippet.contains("13603"));
+        assert!(snippet.contains("timeoutMs"));
     }
 
     // Edge case tests for mutation testing hardening
@@ -707,7 +712,17 @@ mod tests {
         assert_eq!(parsed["request"], "attach");
         assert_eq!(parsed["host"], "localhost");
         assert_eq!(parsed["port"], 13603);
-        assert!(parsed["timeout"].is_number());
+        assert!(parsed["timeoutMs"].is_number());
+        Ok(())
+    }
+
+    #[test]
+    fn test_attach_config_deserializes_legacy_timeout_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let json = r#"{"host":"localhost","port":13603,"timeout":5000}"#;
+        let parsed: AttachConfiguration = serde_json::from_str(json)?;
+
+        assert_eq!(parsed.timeout_ms, Some(5000));
         Ok(())
     }
 

--- a/crates/perl-dap/src/debug_adapter.rs
+++ b/crates/perl-dap/src/debug_adapter.rs
@@ -1933,7 +1933,8 @@ impl DebugAdapter {
     /// For TCP attachment, the arguments should contain:
     /// - `host`: Hostname or IP address (default: "localhost")
     /// - `port`: Port number (default: 13603)
-    /// - `timeout`: Connection timeout in milliseconds (optional)
+    /// - `timeoutMs`: Connection timeout in milliseconds (optional, canonical)
+    /// - `timeout`: Connection timeout in milliseconds (optional, legacy alias)
     ///
     /// # Current Implementation
     ///
@@ -2012,7 +2013,11 @@ impl DebugAdapter {
                     };
                 }
                 let port = raw_port as u16;
-                let timeout = args.get("timeout").and_then(|t| t.as_u64()).map(|t| t as u32);
+                let timeout = args
+                    .get("timeoutMs")
+                    .and_then(|t| t.as_u64())
+                    .or_else(|| args.get("timeout").and_then(|t| t.as_u64()))
+                    .map(|t| t as u32);
 
                 // Validate arguments.
                 if host.trim().is_empty() {
@@ -5541,6 +5546,29 @@ mod tests {
                 assert!(!success); // Not yet implemented, but validates correctly
                 assert_eq!(command, "attach");
                 assert!(message.is_some());
+                let msg = message.ok_or("Expected message")?;
+                assert!(msg.contains("localhost:13603"));
+                assert!(msg.contains("5000ms timeout"));
+            }
+            _ => return Err("Expected response".into()),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_attach_tcp_valid_arguments_timeout_ms() -> Result<(), Box<dyn std::error::Error>> {
+        let mut adapter = DebugAdapter::new();
+        let args = json!({
+            "host": "localhost",
+            "port": 13603,
+            "timeoutMs": 5000
+        });
+        let response = adapter.handle_request(1, "attach", Some(args));
+
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert!(!success); // No running shim in unit test environment
+                assert_eq!(command, "attach");
                 let msg = message.ok_or("Expected message")?;
                 assert!(msg.contains("localhost:13603"));
                 assert!(msg.contains("5000ms timeout"));

--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -126,7 +126,7 @@ fn test_attach_configuration_json() -> Result<()> {
     assert!(snippet.contains("attach"));
     assert!(snippet.contains("localhost"));
     assert!(snippet.contains("13603"));
-    assert!(snippet.contains("timeout"));
+    assert!(snippet.contains("timeoutMs"));
 
     Ok(())
 }
@@ -309,7 +309,7 @@ fn test_attach_json_snippet_completeness() -> Result<()> {
     assert!(json.get("name").is_some(), "name field missing");
     assert!(json.get("host").is_some(), "host field missing");
     assert!(json.get("port").is_some(), "port field missing");
-    assert!(json.get("timeout").is_some(), "timeout field missing");
+    assert!(json.get("timeoutMs").is_some(), "timeoutMs field missing");
 
     // Verify field types and values
     assert_eq!(json["type"], "perl");
@@ -317,7 +317,7 @@ fn test_attach_json_snippet_completeness() -> Result<()> {
     assert!(json["name"].is_string());
     assert_eq!(json["host"], "localhost");
     assert_eq!(json["port"], 13603);
-    assert!(json["timeout"].is_number());
+    assert!(json["timeoutMs"].is_number());
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Standardize the attach timeout field name to `timeoutMs` (camelCase) for generated snippets and documentation.
- Preserve backward compatibility so older clients that send `timeout` continue to work.
- Make attach parsing and configuration validation consistent across the DAP adapter and configuration types.

### Description
- Added `#[serde(alias = "timeout")]` to `AttachConfiguration.timeout_ms` to accept legacy `timeout` during deserialization.
- Updated `create_attach_json_snippet()` to emit `"timeoutMs"` instead of `"timeout"` in generated attach snippets.
- Updated `DebugAdapter::handle_attach` to parse `timeoutMs` first and fall back to legacy `timeout` when present.
- Updated tests and bridge integration expectations to assert `timeoutMs` in generated JSON and added a unit test verifying legacy `timeout` deserializes into `timeout_ms` and a test exercising `timeoutMs` in attach requests.

### Testing
- `cargo test -p perl-dap attach_json_snippet -- --nocapture` — passed (snippet generation and related tests succeeded).
- `cargo test -p perl-dap timeout_ms -- --nocapture` — passed (unit test validating `timeoutMs` attach handling succeeded).
- One attempted command that passed multiple test names in a single `cargo test` invocation failed due to invalid CLI usage, not code issues (usage error reported by `cargo`).
- Ran `cargo fmt --all` to ensure formatting — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218f1af9c8333859d9870449a171c)