### PR TITLE
Improve DAP stack parsing for called-from frames

### DIFF
--- a/crates/perl-dap-stack/src/parser.rs
+++ b/crates/perl-dap-stack/src/parser.rs
@@ -40,7 +40,7 @@ static CONTEXT_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
 /// - `  #0  main::foo at script.pl line 10`
 static STACK_FRAME_RE: Lazy<Result<Regex, regex::Error>> = Lazy::new(|| {
     Regex::new(
-        r"^\s*#?\s*(?P<frame>\d+)?\s+(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+at\s+(?P<file>[^\s]+)\s+line\s+(?P<line>\d+)",
+        r"^\s*(?:(?:#?\s*(?P<frame>\d+)\s+)|(?:[\$\@\.]\s*=\s*))?(?P<func>[A-Za-z_][\w:]*+?)(?:\s+called)?\s+(?:at|called\s+from(?:\s+file)?)\s+[`']?(?P<file>[^\s'`]+)[`']?\s+line\s+(?P<line>\d+)",
     )
 });
 
@@ -338,6 +338,17 @@ mod tests {
         assert_eq!(frame.name, "main::foo");
         assert_eq!(frame.line, 10);
         assert_eq!(frame.file_path(), Some("script.pl"));
+    }
+
+    #[test]
+    fn test_parse_called_from_frame() {
+        use perl_tdd_support::must_some;
+        let mut parser = PerlStackParser::new();
+        let line = "  @ = Package::func called from file `path/file.pl' line 42";
+        let frame = must_some(parser.parse_frame(line, 0));
+        assert_eq!(frame.name, "Package::func");
+        assert_eq!(frame.line, 42);
+        assert_eq!(frame.file_path(), Some("path/file.pl"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The Perl DAP stack parser did not robustly handle debugger output that uses the `called from` form or lines prefixed with debugger sigils (`$ =`, `@ =`, `. =`), causing some frames to be unrecognized.

### Description
- Broadened the `STACK_FRAME_RE` regex in `crates/perl-dap-stack/src/parser.rs` to accept both `at ... line ...` and `called from ... line ...` variants and to handle optional quoted `file` tokens.
- Added support for optional debugger sigil/assignment prefixes and preserved frame-number capture when present.
- Added a unit test `test_parse_called_from_frame` to validate parsing of lines like `@ = Package::func called from file `path/file.pl' line 42`.

### Testing
- Ran `cargo test -p perl-dap-stack` and iterated until the new test passed, after which `cargo test -p perl-dap-stack` completed successfully. 
- Ran `cargo test -p perl-dap-stack --lib` and the crate's full test suites (unit/comprehensive/extended), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b218f1af9c8333859d9870449a171c)