### PR TITLE
Improve parse diagnostic error messages and range safety

### DIFF
--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -38,11 +38,13 @@ impl DiagnosticsProvider {
         source: &str,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
+        let source_len = source.len();
 
         // Convert parse errors to diagnostics
         for error in parse_errors {
             let (location, message) = match error {
                 ParseError::UnexpectedToken { location, expected, found } => {
+                    let found = format_found_token(found);
                     (*location, format!("Expected {expected}, found {found}"))
                 }
                 ParseError::SyntaxError { location, message } => (*location, message.clone()),
@@ -51,8 +53,11 @@ impl DiagnosticsProvider {
                 _ => (0, error.to_string()),
             };
 
+            let range_start = location.min(source_len);
+            let range_end = range_start.saturating_add(1).min(source_len.saturating_add(1));
+
             diagnostics.push(Diagnostic {
-                range: (location, location.saturating_add(1)),
+                range: (range_start, range_end),
                 severity: DiagnosticSeverity::Error,
                 code: Some("parse-error".to_string()),
                 message,
@@ -68,5 +73,13 @@ impl DiagnosticsProvider {
         diagnostics.extend(scope_issues_to_diagnostics(scope_issues));
 
         diagnostics
+    }
+}
+
+fn format_found_token(found: &str) -> String {
+    if found.is_empty() || found == "<EOF>" {
+        "end of input".to_string()
+    } else {
+        format!("`{found}`")
     }
 }

--- a/crates/perl-lsp-diagnostics/tests/unit_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unit_tests.rs
@@ -202,8 +202,52 @@ fn provider_unexpected_token_error() -> Result<(), Box<dyn std::error::Error>> {
     let first = &parse_diags[0];
     assert_eq!(first.severity, DiagnosticSeverity::Error);
     assert!(first.message.contains("Expected expression"));
-    assert!(first.message.contains(";"));
+    assert!(first.message.contains("`;`"));
     assert_eq!(first.range.0, 8);
+    Ok(())
+}
+
+#[test]
+fn provider_unexpected_token_formats_end_of_input() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = Arc::new(program(vec![]));
+    let source = "my $x = ";
+    let errors = vec![ParseError::UnexpectedToken {
+        location: source.len(),
+        expected: "expression".to_string(),
+        found: "<EOF>".to_string(),
+    }];
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    let diagnostics = provider.get_diagnostics(&ast, &errors, source);
+
+    let parse_diags: Vec<_> =
+        diagnostics.iter().filter(|d| d.code.as_deref() == Some("parse-error")).collect();
+    assert!(!parse_diags.is_empty());
+
+    let first = &parse_diags[0];
+    assert!(first.message.contains("Expected expression"));
+    assert!(first.message.contains("end of input"));
+    Ok(())
+}
+
+#[test]
+fn provider_clamps_out_of_bounds_ranges() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = Arc::new(program(vec![]));
+    let source = "short";
+    let errors = vec![ParseError::UnexpectedToken {
+        location: 999,
+        expected: "statement".to_string(),
+        found: "foo".to_string(),
+    }];
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    let diagnostics = provider.get_diagnostics(&ast, &errors, source);
+
+    let parse_diags: Vec<_> =
+        diagnostics.iter().filter(|d| d.code.as_deref() == Some("parse-error")).collect();
+    assert!(!parse_diags.is_empty());
+
+    let first = &parse_diags[0];
+    assert_eq!(first.range.0, source.len());
+    assert_eq!(first.range.1, source.len().saturating_add(1));
     Ok(())
 }
 
@@ -278,7 +322,7 @@ fn provider_multiple_errors() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn provider_error_range_uses_saturating_add() -> Result<(), Box<dyn std::error::Error>> {
+fn provider_error_range_is_clamped_to_source_bounds() -> Result<(), Box<dyn std::error::Error>> {
     let ast = Arc::new(program(vec![]));
     let source = "x";
     let errors = vec![ParseError::UnexpectedToken {
@@ -292,8 +336,8 @@ fn provider_error_range_uses_saturating_add() -> Result<(), Box<dyn std::error::
     let parse_diags: Vec<_> =
         diagnostics.iter().filter(|d| d.code.as_deref() == Some("parse-error")).collect();
     assert!(!parse_diags.is_empty());
-    // saturating_add should prevent overflow
-    assert_eq!(parse_diags[0].range.1, usize::MAX);
+    assert_eq!(parse_diags[0].range.0, source.len());
+    assert_eq!(parse_diags[0].range.1, source.len().saturating_add(1));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Make parse error diagnostics clearer by rendering the actual unexpected token in a human-friendly way and normalizing EOF markers.
- Prevent diagnostics from producing out-of-range positions when parser locations are beyond the current source buffer.

### Description

- Render `UnexpectedToken` `found` values with `format_found_token(found)`, quoting concrete tokens as `` `;` `` and mapping `"<EOF>"`/empty to `"end of input"`.
- Clamp diagnostic ranges to the source bounds by computing `source.len()` and using `location.min(source_len)` with `saturating_add` and `.min(...)` to avoid overflow or out-of-bounds ranges.
- Add and update unit tests in `crates/perl-lsp-diagnostics/tests/unit_tests.rs` to assert token quoting, EOF formatting, and clamped range behavior (including extreme `usize::MAX` locations).

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp-diagnostics --test unit_tests` and all tests passed (`42 passed; 0 failed`).
- Ran `cargo test -p perl-lsp-diagnostics` and the package tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21b0b78f88333acffbb496a4a9657)