### PR TITLE
Improve perl-parse error position handling

### DIFF
--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -359,11 +359,12 @@ fn print_error(error: &ParseError, source: &str) {
 }
 
 fn position_to_line_col(source: &str, position: usize) -> (usize, usize) {
+    let position = position.min(source.len());
     let mut line = 1;
     let mut col = 1;
 
-    for (i, ch) in source.chars().enumerate() {
-        if i >= position {
+    for (byte_offset, ch) in source.char_indices() {
+        if byte_offset >= position {
             break;
         }
         if ch == '\n' {
@@ -390,15 +391,37 @@ fn print_error_context(source: &str, position: usize, stderr: &mut io::Stderr) {
         }
 
         // Show error line
-        writeln!(stderr, "  {} | {}", line_num, lines[line_num - 1]).ok();
+        let error_line = lines[line_num - 1];
+        writeln!(stderr, "  {} | {}", line_num, error_line).ok();
 
         // Show error pointer
+        let pointer_col = col_num.min(error_line.chars().count().saturating_add(1));
         write!(stderr, "  {} | ", " ".repeat(line_num.to_string().len())).ok();
-        writeln!(stderr, "{}^", " ".repeat(col_num - 1)).ok();
+        writeln!(stderr, "{}^", " ".repeat(pointer_col.saturating_sub(1))).ok();
 
         // Show next line if available
         if line_num < lines.len() {
             writeln!(stderr, "  {} | {}", line_num + 1, lines[line_num]).ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::position_to_line_col;
+
+    #[test]
+    fn position_to_line_col_uses_byte_offsets_for_unicode_text() {
+        let source = "my $emoji = \"😀\";\nmy $broken = ;";
+        let broken_pos = source.find("broken").unwrap_or(source.len());
+
+        assert_eq!(position_to_line_col(source, broken_pos), (2, 5));
+    }
+
+    #[test]
+    fn position_to_line_col_clamps_positions_past_end_of_file() {
+        let source = "my $x = 1;";
+
+        assert_eq!(position_to_line_col(source, usize::MAX), (1, 11));
     }
 }


### PR DESCRIPTION
### Motivation
- Parsing locations are produced as byte offsets by the parser, but `perl-parse` previously iterated characters leading to incorrect line/column for multibyte (Unicode) text and mispositioned carets. 
- Out-of-range parser locations could produce panics or misleading diagnostics for CLI users. 
- The CLI error output should clamp the caret to the visible line width so pointers never extend past the line.

### Description
- Treat parser locations as byte offsets by clamping the incoming `position` to `source.len()` and iterating with `source.char_indices()` in `position_to_line_col`. 
- Improve error context rendering by capturing the `error_line` and computing a `pointer_col` clamped to the line's character width before printing the caret. 
- Add unit tests in `src/bin/perl-parse.rs` covering Unicode/byte-offset mapping (`position_to_line_col`) and clamping of positions past EOF. 
- Changes are contained in `crates/perl-parser/src/bin/perl-parse.rs` and include small refactors for clarity.

### Testing
- Ran `cargo fmt --all` which succeeded. 
- Ran `cargo test -p perl-parser --features cli --bin perl-parse` and the new tests passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21b0b78f88333acffbb496a4a9657)