### PR TITLE
Remove panic-style test helpers in parser-core and subprocess runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,9 @@ version = "0.11.0"
 [[package]]
 name = "perl-subprocess-runtime"
 version = "0.11.0"
+dependencies = [
+ "perl-tdd-support",
+]
 
 [[package]]
 name = "perl-symbol-cursor"

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -784,27 +784,24 @@ mod prototype_heuristic_tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic)]
 mod code_dereference_tests {
     use super::*;
+    use perl_tdd_support::{must, must_some};
 
     /// Helper: parse code and return the full AST.
     fn parse_program(code: &str) -> Node {
         let mut parser = Parser::new(code);
-        match parser.parse() {
-            Ok(ast) => ast,
-            Err(e) => panic!("Parse failed for `{code}`: {e:?}"),
-        }
+        must(parser.parse())
     }
 
     /// Helper: parse code and return the first statement node.
-    fn parse_first_stmt(code: &str) -> Node {
+    fn parse_first_stmt(code: &str) -> Option<Node> {
         let ast = parse_program(code);
         match ast.kind {
             NodeKind::Program { mut statements } if !statements.is_empty() => {
-                statements.swap_remove(0)
+                Some(statements.swap_remove(0))
             }
-            _ => panic!("Expected Program with statements, got: {}", ast.to_sexp()),
+            _ => None,
         }
     }
 
@@ -916,42 +913,45 @@ mod code_dereference_tests {
     fn code_deref_produces_correct_ast_structure() {
         // Verify the AST structure for &{$coderef}($x, $y)
         let code = "&{$coderef}($x, $y);";
-        let stmt = parse_first_stmt(code);
+        let stmt = must_some(parse_first_stmt(code));
 
         // The statement should be an ExpressionStatement wrapping a FunctionCall
-        if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
-            match &expression.kind {
-                NodeKind::FunctionCall { name, args } => {
-                    assert_eq!(name, "&{}", "Function call name should be &{{}}");
-                    // First arg is the Unary dereference node (&{$coderef}),
-                    // remaining args are the actual arguments (may be combined into
-                    // a single list node depending on comma parsing)
-                    assert!(
-                        !args.is_empty(),
-                        "Expected at least 1 arg (the deref node)",
-                    );
-                    // First arg should be the Unary &{} dereference
-                    assert_eq!(
-                        args.first().map(|a| a.kind.kind_name()),
-                        Some("Unary"),
-                        "First arg should be a Unary dereference node: {:?}",
-                        args.iter().map(|a| a.kind.kind_name()).collect::<Vec<_>>(),
-                    );
-                }
-                _ => {
-                    panic!(
-                        "Expected FunctionCall, got {} (sexp: {})",
-                        expression.kind.kind_name(),
-                        expression.to_sexp()
-                    );
-                }
-            }
-        } else {
-            panic!(
+        let NodeKind::ExpressionStatement { expression } = &stmt.kind else {
+            assert_eq!(
+                stmt.kind.kind_name(),
+                "ExpressionStatement",
                 "Expected ExpressionStatement, got {} (sexp: {})",
                 stmt.kind.kind_name(),
-                stmt.to_sexp()
+                stmt.to_sexp(),
             );
+            return;
+        };
+
+        match &expression.kind {
+            NodeKind::FunctionCall { name, args } => {
+                assert_eq!(name, "&{}", "Function call name should be &{{}}");
+                // First arg is the Unary dereference node (&{$coderef}),
+                // remaining args are the actual arguments (may be combined into
+                // a single list node depending on comma parsing)
+                assert!(
+                    !args.is_empty(),
+                    "Expected at least 1 arg (the deref node)",
+                );
+                // First arg should be the Unary &{} dereference
+                assert_eq!(
+                    args.first().map(|a| a.kind.kind_name()),
+                    Some("Unary"),
+                    "First arg should be a Unary dereference node: {:?}",
+                    args.iter().map(|a| a.kind.kind_name()).collect::<Vec<_>>(),
+                );
+            }
+            _ => assert_eq!(
+                expression.kind.kind_name(),
+                "FunctionCall",
+                "Expected FunctionCall, got {} (sexp: {})",
+                expression.kind.kind_name(),
+                expression.to_sexp(),
+            ),
         }
     }
 }

--- a/crates/perl-subprocess-runtime/Cargo.toml
+++ b/crates/perl-subprocess-runtime/Cargo.toml
@@ -16,5 +16,8 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 
+[dev-dependencies]
+perl-tdd-support = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -290,10 +290,7 @@ mod tests {
         let result = runtime.run_command("perltidy", &["-st"], Some(b"my $x = 1;"));
 
         assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = perl_tdd_support::must(result);
         assert!(output.success());
         assert_eq!(output.stdout_lossy(), "formatted code");
 
@@ -311,10 +308,7 @@ mod tests {
         let result = runtime.run_command("echo", &["hello"], None);
 
         assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = perl_tdd_support::must(result);
         assert!(output.success());
         assert!(output.stdout_lossy().trim() == "hello");
     }


### PR DESCRIPTION
### Motivation
- Tests in the workspace must avoid `panic!`/`unwrap()`/`expect()` style helpers to satisfy CI hygiene and workspace lint rules. 
- Convert explicit panics to the established `perl_tdd_support` helpers to ensure consistent, non-panicking test failure reporting.

### Description
- Replaced panic-based parse helper in `crates/perl-parser-core/src/engine/parser/variables.rs` by using `perl_tdd_support::must` in `parse_program` and returning `Option<Node>` from `parse_first_stmt`, then using `must_some` at call sites. 
- Reworked the AST structure test to use `let ... else` and `assert_eq!`/`assert!` assertions instead of `panic!` so failures still print diagnostic info without panicking. 
- Replaced manual `match` branches that invoked `panic!` on `Err` in `crates/perl-subprocess-runtime/src/lib.rs` with `perl_tdd_support::must(result)`. 
- Added `perl-tdd-support` as a `dev-dependency` in `crates/perl-subprocess-runtime/Cargo.toml` and updated `Cargo.lock`, and ran `cargo fmt --all` for formatting.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perl-parser-core code_deref_produces_correct_ast_structure` and the specific test passed. 
- Ran `cargo test -p perl-subprocess-runtime` and the full test suite passed. 
- Verified with `rg` that the modified test files no longer contain `panic!`/`unwrap()`/`expect()` panic-site patterns in the changed locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219cb42d483338ebaadcb67fd690c)