### PR TITLE
Remove panic-style test handling in perl-subprocess-runtime

### DIFF
--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mock_runtime() {
+    fn test_mock_runtime() -> Result<(), SubprocessError> {
         use mock::*;
 
         let runtime = MockSubprocessRuntime::new();
@@ -289,11 +289,7 @@ mod tests {
 
         let result = runtime.run_command("perltidy", &["-st"], Some(b"my $x = 1;"));
 
-        assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = result?;
         assert!(output.success());
         assert_eq!(output.stdout_lossy(), "formatted code");
 
@@ -302,21 +298,21 @@ mod tests {
         assert_eq!(invocations[0].program, "perltidy");
         assert_eq!(invocations[0].args, vec!["-st"]);
         assert_eq!(invocations[0].stdin, Some(b"my $x = 1;".to_vec()));
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_os_runtime_echo() {
+    fn test_os_runtime_echo() -> Result<(), SubprocessError> {
         let runtime = OsSubprocessRuntime::new();
         let result = runtime.run_command("echo", &["hello"], None);
 
-        assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = result?;
         assert!(output.success());
         assert!(output.stdout_lossy().trim() == "hello");
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Motivation
- Align tests with the repository policy that bans panic-style constructs by eliminating manual `match` + `panic!` branches in subprocess-runtime tests and using idiomatic `Result`-returning tests instead.

### Description
- Converted `test_mock_runtime` and `test_os_runtime_echo` in `crates/perl-subprocess-runtime/src/lib.rs` to return `Result<(), SubprocessError>` and replaced manual `match`/`panic!` extraction with the `?` operator to propagate errors.
- Kept all original assertions and behavior for subprocess output validation and invocation recording.

### Testing
- Ran `cargo test -p perl-subprocess-runtime` and all tests in the crate passed (`132` passed; `0` failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219cb42d483338ebaadcb67fd690c)