### PR TITLE
Refactor subprocess runtime tests to avoid panic paths

### DIFF
--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mock_runtime() {
+    fn test_mock_runtime() -> Result<(), String> {
         use mock::*;
 
         let runtime = MockSubprocessRuntime::new();
@@ -290,9 +290,8 @@ mod tests {
         let result = runtime.run_command("perltidy", &["-st"], Some(b"my $x = 1;"));
 
         assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
+        let Ok(output) = result else {
+            return Err("expected ok subprocess output".to_string());
         };
         assert!(output.success());
         assert_eq!(output.stdout_lossy(), "formatted code");
@@ -302,21 +301,24 @@ mod tests {
         assert_eq!(invocations[0].program, "perltidy");
         assert_eq!(invocations[0].args, vec!["-st"]);
         assert_eq!(invocations[0].stdin, Some(b"my $x = 1;".to_vec()));
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_os_runtime_echo() {
+    fn test_os_runtime_echo() -> Result<(), String> {
         let runtime = OsSubprocessRuntime::new();
         let result = runtime.run_command("echo", &["hello"], None);
 
         assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
+        let Ok(output) = result else {
+            return Err("expected ok subprocess output".to_string());
         };
         assert!(output.success());
         assert!(output.stdout_lossy().trim() == "hello");
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Motivation
- Replace panic-prone test arms with Result-style returns to comply with the workspace lint policy discouraging panic/unwrap/expect in code paths and to make tests more robust.

### Description
- Update `crates/perl-subprocess-runtime/src/lib.rs` tests `test_mock_runtime` and `test_os_runtime_echo` to return `Result<(), String>`, replace the `match ... panic!` arms with `let Ok(...) = ... else { return Err(...) };` and add `Ok(())` on success.

### Testing
- Ran `cargo test -p perl-subprocess-runtime` and all tests passed (unit and extended test suites succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219cb42d483338ebaadcb67fd690c)