### PR TITLE
Remove panic-based test handling in perl-subprocess-runtime

### DIFF
--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mock_runtime() {
+    fn test_mock_runtime() -> Result<(), SubprocessError> {
         use mock::*;
 
         let runtime = MockSubprocessRuntime::new();
@@ -289,11 +289,7 @@ mod tests {
 
         let result = runtime.run_command("perltidy", &["-st"], Some(b"my $x = 1;"));
 
-        assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = result?;
         assert!(output.success());
         assert_eq!(output.stdout_lossy(), "formatted code");
 
@@ -302,21 +298,21 @@ mod tests {
         assert_eq!(invocations[0].program, "perltidy");
         assert_eq!(invocations[0].args, vec!["-st"]);
         assert_eq!(invocations[0].stdin, Some(b"my $x = 1;".to_vec()));
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
-    fn test_os_runtime_echo() {
+    fn test_os_runtime_echo() -> Result<(), SubprocessError> {
         let runtime = OsSubprocessRuntime::new();
         let result = runtime.run_command("echo", &["hello"], None);
 
-        assert!(result.is_ok());
-        let output = match result {
-            Ok(output) => output,
-            Err(_) => panic!("expected ok subprocess output"),
-        };
+        let output = result?;
         assert!(output.success());
         assert!(output.stdout_lossy().trim() == "hello");
+
+        Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Motivation
- Remove panic-family constructs in tests to comply with the workspace "no unwrap/expect/panic/todo/unimplemented" policy and improve ergonomic error propagation in test code.

### Description
- Converted two unit tests (`test_mock_runtime` and `test_os_runtime_echo`) to return `Result<(), SubprocessError>` and replaced manual `match`/`panic!` branches with `?` propagation, adding `Ok(())` at the end.

### Testing
- Ran `cargo test -p perl-subprocess-runtime` and all package tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219cb42d483338ebaadcb67fd690c)