### PR TITLE
test(path-normalize): expand normalization edge-case coverage

### DIFF
--- a/crates/perl-path-normalize/src/lib.rs
+++ b/crates/perl-path-normalize/src/lib.rs
@@ -94,4 +94,47 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn allows_parent_dir_that_stays_within_workspace() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let normalized = normalize_path_within_workspace(
+            &PathBuf::from("src/lib/../main.pl"),
+            &workspace,
+        )?;
+
+        assert_eq!(normalized, workspace.join("src").join("main.pl"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_absolute_paths() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let absolute = std::env::temp_dir().join("outside_workspace.pl");
+        let result = normalize_path_within_workspace(&absolute, &workspace);
+
+        assert!(matches!(result, Err(NormalizePathError::PathTraversalAttempt(_))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_current_directory_components() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let normalized = normalize_path_within_workspace(
+            &PathBuf::from("./src/./module/../main.pl"),
+            &workspace,
+        )?;
+
+        assert_eq!(normalized, workspace.join("src").join("main.pl"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for the workspace-relative path normalization logic to exercise edge cases around `..`, absolute paths, and `.` components.

### Description

- Add three unit tests to `crates/perl-path-normalize/src/lib.rs` that cover `..` sequences which remain inside the workspace, rejection of absolute paths passed as relative inputs, and ignoring `.` components during normalization. 
- The new tests exercise `normalize_path_within_workspace` behavior for normalization correctness and traversal-prevention semantics.

### Testing

- Ran `cargo test -p perl-path-normalize` and all tests passed with five successful unit tests. 
- Test run result: `5 passed; 0 failed; 0 ignored`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219c03e148333b1ad96eed75e1b34)