### PR TITLE
test: expand URI parser edge-case coverage

### DIFF
--- a/crates/perl-lsp-uri/src/lib.rs
+++ b/crates/perl-lsp-uri/src/lib.rs
@@ -34,6 +34,7 @@ pub fn parse_uri(s: &str) -> Uri {
 #[cfg(test)]
 mod tests {
     use super::parse_uri;
+    use lsp_types::Uri;
 
     #[test]
     fn parse_uri_returns_original_for_valid_uri() {
@@ -45,5 +46,25 @@ mod tests {
     fn parse_uri_falls_back_for_invalid_uri() {
         let uri = parse_uri("not a uri");
         assert!(!uri.as_str().is_empty());
+    }
+
+    #[test]
+    fn parse_uri_preserves_query_and_fragment_for_valid_uri() {
+        let uri = parse_uri("file:///tmp/test.pl?line=12#symbol");
+        assert_eq!(uri.as_str(), "file:///tmp/test.pl?line=12#symbol");
+    }
+
+    #[test]
+    fn parse_uri_accepts_empty_uri_reference() {
+        let uri = parse_uri("");
+        assert_eq!(uri.as_str(), "");
+        assert!(uri.as_str().parse::<Uri>().is_ok());
+    }
+
+    #[test]
+    fn parse_uri_falls_back_for_malformed_percent_encoding() {
+        let uri = parse_uri("file:///tmp/contains-%zz");
+        assert_ne!(uri.as_str(), "file:///tmp/contains-%zz");
+        assert!(uri.as_str().parse::<Uri>().is_ok());
     }
 }


### PR DESCRIPTION
### Motivation

- Improve unit-test coverage for the URI parsing helpers to document current behavior and protect fallback code paths for edge-case inputs.

### Description

- Add new unit tests in `crates/perl-lsp-uri/src/lib.rs` that verify preservation of query and fragment components for valid URIs.
- Add a test that documents and asserts current behavior for empty URI references returned by `parse_uri`.
- Add a test that ensures malformed percent-encoding input triggers the fallback path but still yields a parseable `Uri` and import `lsp_types::Uri` for assertions.

### Testing

- Ran `cargo test -p perl-lsp-uri`, and all tests passed (5 passed; 0 failed). 
- Ran `cargo fmt --all` to ensure formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219c03e148333b1ad96eed75e1b34)