### PR TITLE
test: expand perl-lsp-input-validation unit coverage

### DIFF
--- a/crates/perl-lsp-input-validation/src/lib.rs
+++ b/crates/perl-lsp-input-validation/src/lib.rs
@@ -213,6 +213,30 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_file_path_disallowed_extension() {
+        use perl_tdd_support::must;
+        let temp_dir = must(TempDir::new());
+        let workspace_root = temp_dir.path();
+        let file_path = workspace_root.join("notes.txt");
+        must(fs::write(&file_path, "not perl"));
+
+        let result = validate_file_path(&file_path, workspace_root);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_path_too_long() {
+        use perl_tdd_support::must;
+        let temp_dir = must(TempDir::new());
+        let workspace_root = temp_dir.path();
+        let long_name = "a".repeat(MAX_PATH_LENGTH + 1);
+        let file_path = workspace_root.join(format!("{long_name}.pl"));
+
+        let result = validate_file_path(&file_path, workspace_root);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_validate_file_content_valid() {
         let content = "print 'Hello, World!';";
         let file_path = Path::new("test.pl");
@@ -236,6 +260,24 @@ mod tests {
     fn test_validate_file_content_null_bytes() {
         let content = "print 'Hello';\0";
         let file_path = Path::new("null.pl");
+
+        let result = validate_file_content(content, file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_content_too_long_line() {
+        let content = "x".repeat(100_001);
+        let file_path = Path::new("long_line.pl");
+
+        let result = validate_file_content(&content, file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_file_content_suspicious_pattern() {
+        let content = "print q{<script>alert('x')</script>};";
+        let file_path = Path::new("suspicious.pl");
 
         let result = validate_file_content(content, file_path);
         assert!(result.is_err());
@@ -274,6 +316,31 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_lsp_request_invalid_text_document_uri_scheme() {
+        let method = "textDocument/didOpen";
+        let params = serde_json::json!({
+            "textDocument": {
+                "uri": "http:///test.pl",
+                "text": "print 'Hello';"
+            }
+        });
+
+        let result = validate_lsp_request(method, &params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_lsp_request_rejects_suspicious_unknown_method_params() {
+        let method = "workspace/symbol";
+        let params = serde_json::json!({
+            "query": "javascript:alert(1)"
+        });
+
+        let result = validate_lsp_request(method, &params);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_validate_execute_command_allowed() {
         let method = "workspace/executeCommand";
         let params = serde_json::json!({
@@ -294,6 +361,24 @@ mod tests {
         });
 
         let result = validate_lsp_request(method, &params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_workspace_root_requires_existing_directory() {
+        let missing = Path::new("/path/that/does/not/exist");
+        let result = validate_workspace_root(missing);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_workspace_root_rejects_file() {
+        use perl_tdd_support::must;
+        let temp_dir = must(TempDir::new());
+        let file_path = temp_dir.path().join("workspace.pl");
+        must(fs::write(&file_path, "print 'not dir';"));
+
+        let result = validate_workspace_root(&file_path);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
### Motivation

- Improve robustness and coverage of the input validation crate by adding negative-path unit tests for edge cases and suspicious input patterns.

### Description

- Add new unit tests in `crates/perl-lsp-input-validation/src/lib.rs` that exercise `validate_file_path` rejection for disallowed extensions and overly long paths. 
- Add tests for `validate_file_content` to cover excessively long lines and detection of suspicious patterns such as `"<script"`.
- Add tests for `validate_lsp_request` to verify rejection of invalid `textDocument` URI schemes and suspicious payloads for non-special-cased methods. 
- Add tests for `validate_workspace_root` to ensure missing paths and file (non-directory) paths are rejected. 

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran unit tests with `cargo test -p perl-lsp-input-validation` and observed `18 passed; 0 failed` for the crate's test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219afae60833399664d99609f8b8f)