### PR TITLE
Improve perl-lsp CLI UX with structured parse error classification

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -205,6 +205,50 @@ impl fmt::Display for LaunchParseError {
 
 impl Error for LaunchParseError {}
 
+fn extract_option_token(message: &str) -> Option<String> {
+    message
+        .split_whitespace()
+        .find(|token| token.starts_with("--"))
+        .map(|token| token.trim_matches(|c: char| matches!(c, ',' | '.' | ':' | ';' | ')' | '(')))
+        .map(str::to_string)
+}
+
+fn extract_single_quoted_token(message: &str) -> Option<String> {
+    let mut chunks = message.split('\'');
+    chunks.next()?;
+    chunks.next().map(str::to_string)
+}
+
+fn classify_parse_error(err: clap::Error) -> LaunchParseError {
+    let message = err.to_string();
+
+    if message.contains("a value is required for") {
+        return LaunchParseError::MissingValue {
+            option: extract_option_token(&message).unwrap_or_else(|| "required argument".into()),
+        };
+    }
+
+    match err.kind() {
+        clap::error::ErrorKind::MissingRequiredArgument
+        | clap::error::ErrorKind::TooFewValues
+        | clap::error::ErrorKind::WrongNumberOfValues => LaunchParseError::MissingValue {
+            option: extract_option_token(&message).unwrap_or_else(|| "required argument".into()),
+        },
+        clap::error::ErrorKind::ValueValidation | clap::error::ErrorKind::InvalidValue => {
+            if message.contains("--port") {
+                LaunchParseError::InvalidPort {
+                    raw_port: extract_single_quoted_token(&message)
+                        .unwrap_or_else(|| "<unknown>".into()),
+                    reason: message,
+                }
+            } else {
+                LaunchParseError::UnknownOption { option: message }
+            }
+        }
+        _ => LaunchParseError::UnknownOption { option: message },
+    }
+}
+
 /// Parse command line arguments for the Perl LSP launcher.
 pub fn parse_args<I>(args: I) -> Result<LaunchPlan, LaunchParseError>
 where
@@ -249,7 +293,7 @@ where
                 });
             }
 
-            Err(LaunchParseError::UnknownOption { option: err.to_string() })
+            Err(classify_parse_error(err))
         }
     }
 }

--- a/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
@@ -310,6 +310,30 @@ fn parse_invalid_feature_profile_returns_error() {
 }
 
 #[test]
+fn parse_missing_value_for_feature_profile_classifies_error() {
+    let err =
+        parse_args(["perl-lsp", "--feature-profile"]).expect_err("missing value should error");
+    match err {
+        LaunchParseError::MissingValue { option } => {
+            assert!(option.contains("--feature-profile") || option.contains("required"));
+        }
+        other => panic!("expected MissingValue, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_invalid_port_value_classifies_error() {
+    let err = parse_args(["perl-lsp", "--port", "abc"]).expect_err("invalid port should error");
+    match err {
+        LaunchParseError::InvalidPort { raw_port, reason } => {
+            assert!(raw_port.contains("abc") || raw_port.contains("<unknown>"));
+            assert!(!reason.is_empty());
+        }
+        other => panic!("expected InvalidPort, got {other:?}"),
+    }
+}
+
+#[test]
 fn parse_empty_feature_profile_returns_error() {
     let result = parse_args(["perl-lsp", "--feature-profile", ""]);
     assert!(result.is_err());


### PR DESCRIPTION
### Motivation
- Provide clearer, actionable CLI error messages by classifying Clap parse failures into typed `LaunchParseError` variants instead of returning a generic unknown-option error.
- Surface the actual missing option or invalid token (especially for `--port`) so users can remediate invocation mistakes quickly.

### Description
- Add `extract_option_token` and `extract_single_quoted_token` helpers and a `classify_parse_error` function in `crates/perl-lsp-launcher/src/lib.rs` to parse Clap error text and map to `LaunchParseError` variants.
- Map missing-value style failures (help text like "a value is required for ...") and error kinds such as `MissingRequiredArgument`, `TooFewValues`, and `WrongNumberOfValues` to `LaunchParseError::MissingValue` with an extracted option name.
- Map value validation/invalid-value failures for `--port` to `LaunchParseError::InvalidPort` capturing the offending token and the parse reason.
- Replace the prior catch-all `UnknownOption` fallback in `parse_args` with `classify_parse_error(err)` while keeping existing help/version terminal handling unchanged.
- Add two regression tests in `crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs` to assert classification of missing `--feature-profile` and invalid `--port abc` behaviors.

### Testing
- Ran formatting with `cargo fmt --all` successfully.
- Ran unit tests for the launcher with `cargo test -p perl-lsp-launcher` and the dedicated suite with `cargo test -p perl-lsp-launcher --test comprehensive_unit_tests`, and all tests passed (previously failing classification tests now pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219963b8c8333924b6a86a90b596d)