### PR TITLE
Improve launcher CLI UX with clearer value validation errors

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -211,7 +211,10 @@ where
     I: IntoIterator,
     I::Item: Into<std::ffi::OsString> + Clone,
 {
-    match LspArgs::try_parse_from(args) {
+    let collected_args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+    prevalidate_cli_values(&collected_args)?;
+
+    match LspArgs::try_parse_from(collected_args) {
         Ok(parsed_args) => {
             let mut config = LaunchConfig::new(FeatureProfile::current());
 
@@ -252,6 +255,70 @@ where
             Err(LaunchParseError::UnknownOption { option: err.to_string() })
         }
     }
+}
+
+fn prevalidate_cli_values(args: &[std::ffi::OsString]) -> Result<(), LaunchParseError> {
+    let mut index = 1usize;
+
+    while index < args.len() {
+        let token = args[index].to_string_lossy();
+
+        if token == "--port" {
+            let next = args.get(index + 1).map(|value| value.to_string_lossy().to_string());
+            let Some(raw_port) = next else {
+                return Err(LaunchParseError::MissingValue { option: "--port".to_string() });
+            };
+
+            if raw_port.starts_with("--") {
+                return Err(LaunchParseError::MissingValue { option: "--port".to_string() });
+            }
+
+            raw_port.parse::<u16>().map_err(|reason| LaunchParseError::InvalidPort {
+                raw_port: raw_port.clone(),
+                reason: reason.to_string(),
+            })?;
+
+            index += 2;
+            continue;
+        }
+
+        if let Some(raw_port) = token.strip_prefix("--port=") {
+            if raw_port.is_empty() {
+                return Err(LaunchParseError::MissingValue { option: "--port".to_string() });
+            }
+
+            raw_port.parse::<u16>().map_err(|reason| LaunchParseError::InvalidPort {
+                raw_port: raw_port.to_string(),
+                reason: reason.to_string(),
+            })?;
+        }
+
+        if token == "--feature-profile" {
+            let next = args.get(index + 1).map(|value| value.to_string_lossy().to_string());
+            let Some(raw_profile) = next else {
+                return Err(LaunchParseError::MissingValue {
+                    option: "--feature-profile".to_string(),
+                });
+            };
+
+            if raw_profile.starts_with("--") {
+                return Err(LaunchParseError::MissingValue {
+                    option: "--feature-profile".to_string(),
+                });
+            }
+
+            index += 2;
+            continue;
+        }
+
+        if token == "--feature-profile=" {
+            return Err(LaunchParseError::MissingValue { option: "--feature-profile".to_string() });
+        }
+
+        index += 1;
+    }
+
+    Ok(())
 }
 
 /// Human-readable CLI help text shared by CLI consumers.

--- a/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
@@ -310,6 +310,33 @@ fn parse_invalid_feature_profile_returns_error() {
 }
 
 #[test]
+fn parse_port_missing_value_returns_missing_value_error() {
+    let result = parse_args(["perl-lsp", "--port"]);
+    assert!(matches!(
+        result,
+        Err(LaunchParseError::MissingValue { option }) if option == "--port"
+    ));
+}
+
+#[test]
+fn parse_port_invalid_value_returns_invalid_port_error() {
+    let result = parse_args(["perl-lsp", "--port", "70000"]);
+    assert!(matches!(
+        result,
+        Err(LaunchParseError::InvalidPort { raw_port, .. }) if raw_port == "70000"
+    ));
+}
+
+#[test]
+fn parse_feature_profile_missing_value_returns_missing_value_error() {
+    let result = parse_args(["perl-lsp", "--feature-profile"]);
+    assert!(matches!(
+        result,
+        Err(LaunchParseError::MissingValue { option }) if option == "--feature-profile"
+    ));
+}
+
+#[test]
 fn parse_empty_feature_profile_returns_error() {
     let result = parse_args(["perl-lsp", "--feature-profile", ""]);
     assert!(result.is_err());


### PR DESCRIPTION
### Motivation
- Users received generic parse failures for common mistakes like missing `--port`/`--feature-profile` values or invalid port numbers, which hindered UX.
- Provide clearer, typed error feedback so callers and automation can handle CLI errors programmatically.

### Description
- Add early CLI prevalidation by collecting `args` and calling `prevalidate_cli_values()` before invoking `clap` parsing in `parse_args()`; this maps value-related issues to `LaunchParseError` variants.
- Implement `prevalidate_cli_values()` to detect and return `LaunchParseError::MissingValue` for `--port` and `--feature-profile` when values are absent or look like flags, and `LaunchParseError::InvalidPort` when `--port` values are not valid `u16` (covers `--port=<value>` form too).
- Keep existing help/version handling and fallback to `UnknownOption` for other clap errors.
- Add regression tests in `crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs` covering missing `--port`, invalid `--port` (`70000`), and missing `--feature-profile` value.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-lsp-launcher` and all launcher unit tests passed (crate tests completed; comprehensive suite passed: total 72 tests, 0 failed).
- Ran `cargo clippy -p perl-lsp-launcher --all-targets -- -D warnings` and lints passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219963b8c8333924b6a86a90b596d)