### PR TITLE
Improve launcher CLI UX for port errors and help output

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -249,9 +249,60 @@ where
                 });
             }
 
-            Err(LaunchParseError::UnknownOption { option: err.to_string() })
+            Err(map_clap_error(err))
         }
     }
+}
+
+fn map_clap_error(err: clap::Error) -> LaunchParseError {
+    let rendered = err.to_string();
+
+    if rendered.contains("--port")
+        && (rendered.contains("requires a value") || rendered.contains("value is required"))
+    {
+        return LaunchParseError::MissingValue {
+            option: extract_wrapped_token(&rendered).unwrap_or_else(|| "--port".to_string()),
+        };
+    }
+
+    if rendered.contains("--port")
+        && (rendered.contains("invalid value")
+            || rendered.contains("invalid digit")
+            || rendered.contains("out of range"))
+    {
+        return LaunchParseError::InvalidPort {
+            raw_port: extract_wrapped_token(&rendered).unwrap_or_else(|| "<unknown>".to_string()),
+            reason: "Expected an integer between 1 and 65535".to_string(),
+        };
+    }
+
+    match err.kind() {
+        clap::error::ErrorKind::MissingRequiredArgument
+        | clap::error::ErrorKind::TooFewValues
+        | clap::error::ErrorKind::WrongNumberOfValues => LaunchParseError::MissingValue {
+            option: extract_wrapped_token(&rendered)
+                .unwrap_or_else(|| "<unknown option>".to_string()),
+        },
+        clap::error::ErrorKind::InvalidSubcommand
+        | clap::error::ErrorKind::UnknownArgument
+        | clap::error::ErrorKind::InvalidValue
+        | clap::error::ErrorKind::InvalidUtf8
+        | clap::error::ErrorKind::TooManyValues
+        | clap::error::ErrorKind::ValueValidation => {
+            LaunchParseError::UnknownOption { option: rendered }
+        }
+        _ => LaunchParseError::UnknownOption { option: rendered },
+    }
+}
+
+fn extract_wrapped_token(input: &str) -> Option<String> {
+    extract_token(input, '\'').or_else(|| extract_token(input, '`'))
+}
+
+fn extract_token(input: &str, delimiter: char) -> Option<String> {
+    let mut parts = input.split(delimiter);
+    let _ = parts.next();
+    parts.next().map(ToString::to_string)
 }
 
 /// Human-readable CLI help text shared by CLI consumers.
@@ -266,7 +317,7 @@ Usage: perl-lsp [options]\n\
 Options:\n\
   --stdio          Use stdio for communication (default)\n\
   --socket         Use TCP socket for communication\n\
-  --port           Port to listen on (default: {DEFAULT_LSP_PORT})\n\
+  --port           Port to listen on (implies --socket, default: {DEFAULT_LSP_PORT})\n\
   --log            Enable logging to stderr\n\
   --health         Quick health check (prints \'ok <version>\')\n\
   --version        Show version information\n\
@@ -286,7 +337,11 @@ Examples:\n\
   perl-lsp --stdio --log\n\
 \
   # Run in socket mode\n\
-  perl-lsp --socket --port 9257\n"
+  perl-lsp --socket --port 9257\n\
+  # Check server health in scripts/CI\n\
+  perl-lsp --health\n\
+  # Inspect the active feature catalog\n\
+  perl-lsp --features-json --feature-profile=prod\n"
     )
 }
 

--- a/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-launcher/tests/comprehensive_unit_tests.rs
@@ -315,6 +315,31 @@ fn parse_empty_feature_profile_returns_error() {
     assert!(result.is_err());
 }
 
+#[test]
+fn parse_missing_port_value_is_classified() {
+    let result = parse_args(["perl-lsp", "--port"]);
+    match result {
+        Err(LaunchParseError::MissingValue { option }) => {
+            assert!(option.contains("--port") || option.contains("port"));
+        }
+        Err(other) => panic!("expected MissingValue, got: {other:?}"),
+        Ok(_) => panic!("expected parse failure for missing --port value"),
+    }
+}
+
+#[test]
+fn parse_invalid_port_is_classified() {
+    let result = parse_args(["perl-lsp", "--port", "abc"]);
+    match result {
+        Err(LaunchParseError::InvalidPort { raw_port, reason }) => {
+            assert!(raw_port.contains("abc") || raw_port.contains("PORT"));
+            assert!(reason.contains("integer") || reason.contains("Expected"));
+        }
+        Err(other) => panic!("expected InvalidPort, got: {other:?}"),
+        Ok(_) => panic!("expected parse failure for invalid --port"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Module: LaunchParseError display formatting
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Make the CLI experience clearer and more actionable by classifying common `clap` parsing failures (especially around `--port`) into specific `LaunchParseError` variants instead of returning a generic unknown-option error.
- Surface the relevant argument/value from `clap` diagnostics so error messages point to the offending token and are easier to act on.
- Improve discoverability of useful runtime actions by clarifying help text and adding practical examples for `--health` and `--features-json`.

### Description
- Add `map_clap_error`, `extract_wrapped_token`, and `extract_token` helpers to map `clap::Error` into `LaunchParseError::MissingValue` or `LaunchParseError::InvalidPort` when appropriate and to extract the offending token from rendered diagnostics.
- Update `parse_args` to use `map_clap_error` so parse failures are classified with richer error variants instead of a catch-all unknown option.
- Update `help_text` to state that `--port` implies socket mode and to include examples for `--health` and `--features-json` usage.
- Add regression tests `parse_missing_port_value_is_classified` and `parse_invalid_port_is_classified` to `tests/comprehensive_unit_tests.rs` to ensure missing and invalid `--port` cases are classified correctly.

### Testing
- Ran `cargo fmt --all` with no formatting issues reported.
- Ran `cargo test -p perl-lsp-launcher` and the launcher test suite passed (all relevant unit tests completed successfully: 64 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219963b8c8333924b6a86a90b596d)