### PR TITLE
Improve socket transport error reporting in perl-lsp main loop

### DIFF
--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -96,41 +96,44 @@ fn run_server(launch_config: LaunchConfig) {
                         Ok((stream, peer_addr)) => {
                             eprintln!("Accepted connection from {peer_addr}");
                             tokio::spawn(async move {
-                                if let Ok(std_stream) = stream.into_std() {
-                                    if let Err(e) = std_stream.set_nonblocking(false) {
-                                        eprintln!("Failed to set blocking mode: {}", e);
+                                let std_stream = match stream.into_std() {
+                                    Ok(std_stream) => std_stream,
+                                    Err(error) => {
+                                        eprintln!("Failed to convert stream to std: {error}");
                                         return;
                                     }
+                                };
 
-                                    let writer = match std_stream.try_clone() {
-                                        Ok(w) => w,
-                                        Err(e) => {
-                                            eprintln!("Failed to clone stream: {e}");
-                                            return;
-                                        }
-                                    };
-                                    let reader = std_stream;
-                                    let profile = feature_profile;
+                                if let Err(error) = std_stream.set_nonblocking(false) {
+                                    eprintln!("Failed to set blocking mode: {error}");
+                                    return;
+                                }
 
-                                    let output = Arc::new(parking_lot::Mutex::new(
-                                        Box::new(writer) as Box<dyn std::io::Write + Send>,
-                                    ));
-
-                                    if let Err(e) = tokio::task::spawn_blocking(move || -> () {
-                                        let mut server = LspServer::with_output_and_feature_profile(
-                                            output, profile,
-                                        );
-                                        let mut buf_reader = std::io::BufReader::new(reader);
-                                        if let Err(e) = server.serve(&mut buf_reader) {
-                                            eprintln!("Connection error: {e}");
-                                        }
-                                    })
-                                    .await
-                                    {
-                                        eprintln!("Task panic: {e}");
+                                let writer = match std_stream.try_clone() {
+                                    Ok(writer) => writer,
+                                    Err(error) => {
+                                        eprintln!("Failed to clone stream: {error}");
+                                        return;
                                     }
-                                } else {
-                                    eprintln!("Failed to convert stream to std");
+                                };
+                                let reader = std_stream;
+                                let profile = feature_profile;
+
+                                let output = Arc::new(parking_lot::Mutex::new(
+                                    Box::new(writer) as Box<dyn std::io::Write + Send>
+                                ));
+
+                                if let Err(error) = tokio::task::spawn_blocking(move || -> () {
+                                    let mut server =
+                                        LspServer::with_output_and_feature_profile(output, profile);
+                                    let mut buf_reader = std::io::BufReader::new(reader);
+                                    if let Err(error) = server.serve(&mut buf_reader) {
+                                        eprintln!("Connection error: {error}");
+                                    }
+                                })
+                                .await
+                                {
+                                    eprintln!("Task panic: {error}");
                                 }
                             });
                         }


### PR DESCRIPTION
### Motivation

- Make runtime errors in the socket transport path easier to diagnose by including concrete I/O errors instead of generic messages when per-connection setup fails.
- Replace a broad `if let Ok(...)` control flow with explicit `match`/`if let` branches so each failure case logs a helpful message and returns early without impacting other connections.

### Description

- Refactored the per-connection setup in `crates/perl-lsp/src/main.rs` to use `match stream.into_std()` and explicit error branches for `set_nonblocking(false)` and `try_clone()`.
- Improved diagnostics messages to include the underlying error, e.g. `Failed to convert stream to std: {error}` and consistently used `error` variable names in logging.
- Preserved the existing successful path and spawned-worker behavior while making each error path return early after logging.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran unit tests with `cargo test -p perl-lsp --lib` which completed successfully with all tests passing (`135 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2198e06c8833387a2eec6bab728d4)