### PR TITLE
Improve socket transport error handling in perl-lsp main loop

### DIFF
--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -12,6 +12,7 @@ use std::process;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
+use tokio::time::{Duration, sleep};
 
 fn main() {
     let launch_plan = match parse_args(env::args()) {
@@ -96,45 +97,51 @@ fn run_server(launch_config: LaunchConfig) {
                         Ok((stream, peer_addr)) => {
                             eprintln!("Accepted connection from {peer_addr}");
                             tokio::spawn(async move {
-                                if let Ok(std_stream) = stream.into_std() {
-                                    if let Err(e) = std_stream.set_nonblocking(false) {
-                                        eprintln!("Failed to set blocking mode: {}", e);
+                                let std_stream = match stream.into_std() {
+                                    Ok(std_stream) => std_stream,
+                                    Err(error) => {
+                                        eprintln!("Failed to convert stream to std: {error}");
                                         return;
                                     }
+                                };
 
-                                    let writer = match std_stream.try_clone() {
-                                        Ok(w) => w,
-                                        Err(e) => {
-                                            eprintln!("Failed to clone stream: {e}");
-                                            return;
-                                        }
-                                    };
-                                    let reader = std_stream;
-                                    let profile = feature_profile;
+                                if let Err(e) = std_stream.set_nonblocking(false) {
+                                    eprintln!("Failed to set blocking mode: {}", e);
+                                    return;
+                                }
 
-                                    let output = Arc::new(parking_lot::Mutex::new(
-                                        Box::new(writer) as Box<dyn std::io::Write + Send>,
-                                    ));
-
-                                    if let Err(e) = tokio::task::spawn_blocking(move || -> () {
-                                        let mut server = LspServer::with_output_and_feature_profile(
-                                            output, profile,
-                                        );
-                                        let mut buf_reader = std::io::BufReader::new(reader);
-                                        if let Err(e) = server.serve(&mut buf_reader) {
-                                            eprintln!("Connection error: {e}");
-                                        }
-                                    })
-                                    .await
-                                    {
-                                        eprintln!("Task panic: {e}");
+                                let writer = match std_stream.try_clone() {
+                                    Ok(w) => w,
+                                    Err(e) => {
+                                        eprintln!("Failed to clone stream: {e}");
+                                        return;
                                     }
-                                } else {
-                                    eprintln!("Failed to convert stream to std");
+                                };
+                                let reader = std_stream;
+                                let profile = feature_profile;
+
+                                let output = Arc::new(parking_lot::Mutex::new(
+                                    Box::new(writer) as Box<dyn std::io::Write + Send>
+                                ));
+
+                                if let Err(e) = tokio::task::spawn_blocking(move || -> () {
+                                    let mut server =
+                                        LspServer::with_output_and_feature_profile(output, profile);
+                                    let mut buf_reader = std::io::BufReader::new(reader);
+                                    if let Err(e) = server.serve(&mut buf_reader) {
+                                        eprintln!("Connection error: {e}");
+                                    }
+                                })
+                                .await
+                                {
+                                    eprintln!("Task panic: {e}");
                                 }
                             });
                         }
-                        Err(e) => eprintln!("Failed to accept: {e}"),
+                        Err(e) => {
+                            eprintln!("Failed to accept: {e}");
+                            sleep(Duration::from_millis(100)).await;
+                        }
                     }
                 }
             });


### PR DESCRIPTION
### Motivation
- Make socket-mode connection failures more observable by surfacing concrete conversion errors instead of a generic message.
- Reduce the risk of partial or unclear connection setup paths by clearly bounding early failure points before launching the blocking server task.
- Prevent tight error-loop spinning when `accept()` transiently fails by adding a small async backoff.

### Description
- Add `tokio::time::{Duration, sleep}` and await a short backoff after `listener.accept()` errors to avoid busy error loops.
- Replace the previous `if let Ok(...)` branch for `stream.into_std()` with an explicit `match` that logs the concrete conversion error and returns early on failure.
- Refactor connection setup to use early-return checks for `set_nonblocking(false)` and `try_clone()` so failures are handled before spawning the blocking server work.
- Preserve existing serving behavior by continuing to create the `LspServer` and run it inside `tokio::task::spawn_blocking` once setup succeeds.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp --lib` and all tests passed (`135 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2198e06c8833387a2eec6bab728d4)