### PR TITLE
Improve perl-lsp runtime logging context

### DIFF
--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -10,8 +10,27 @@ use perl_lsp_launcher::{LaunchAction, LaunchConfig, TransportMode, help_text, pa
 use std::env;
 use std::process;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
+
+fn log_info(enabled: bool, message: impl std::fmt::Display) {
+    if enabled {
+        eprintln!("{} [INFO] {message}", log_prefix());
+    }
+}
+
+fn log_error(message: impl std::fmt::Display) {
+    eprintln!("{} [ERROR] {message}", log_prefix());
+}
+
+fn log_prefix() -> String {
+    let seconds_since_epoch = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(_) => 0,
+    };
+    format!("perl-lsp pid={} ts={seconds_since_epoch}", process::id())
+}
 
 fn main() {
     let launch_plan = match parse_args(env::args()) {
@@ -45,21 +64,25 @@ fn main() {
 }
 
 fn run_server(launch_config: LaunchConfig) {
-    if launch_config.enable_logging {
-        eprintln!("Perl Language Server starting...");
-        eprintln!("Mode: {}", launch_config.transport.label());
-        if let Some(port) = launch_config.transport.port() {
-            eprintln!("Port: {port}");
-        }
-        eprintln!("Feature profile: {}", launch_config.feature_profile.as_str());
+    log_info(launch_config.enable_logging, "Perl Language Server starting");
+    log_info(
+        launch_config.enable_logging,
+        format!("transport={}", launch_config.transport.label()),
+    );
+    if let Some(port) = launch_config.transport.port() {
+        log_info(launch_config.enable_logging, format!("port={port}"));
     }
+    log_info(
+        launch_config.enable_logging,
+        format!("feature_profile={}", launch_config.feature_profile.as_str()),
+    );
 
     match launch_config.transport {
         TransportMode::Stdio => {
             let mut server = LspServer::new_with_feature_profile(launch_config.feature_profile);
 
             if let Err(e) = server.run() {
-                eprintln!("LSP server error: {}", e);
+                log_error(format!("lsp_server_error: {e}"));
                 process::exit(1);
             }
         }
@@ -69,7 +92,7 @@ fn run_server(launch_config: LaunchConfig) {
             let rt = match Runtime::new() {
                 Ok(rt) => rt,
                 Err(e) => {
-                    eprintln!("Failed to create Tokio runtime: {e}");
+                    log_error(format!("failed_to_create_tokio_runtime: {e}"));
                     process::exit(1);
                 }
             };
@@ -78,34 +101,42 @@ fn run_server(launch_config: LaunchConfig) {
                 let listener = match TcpListener::bind(&addr).await {
                     Ok(l) => l,
                     Err(e) => {
-                        eprintln!("Failed to bind to {addr}: {e}");
+                        log_error(format!("failed_to_bind addr={addr}: {e}"));
                         process::exit(1);
                     }
                 };
                 let local_addr = match listener.local_addr() {
                     Ok(a) => a,
                     Err(e) => {
-                        eprintln!("Failed to get local address: {e}");
+                        log_error(format!("failed_to_get_local_address: {e}"));
                         process::exit(1);
                     }
                 };
-                eprintln!("Perl LSP listening on {}", local_addr);
+                log_info(launch_config.enable_logging, format!("listening_on={local_addr}"));
 
                 loop {
                     match listener.accept().await {
                         Ok((stream, peer_addr)) => {
-                            eprintln!("Accepted connection from {peer_addr}");
+                            log_info(
+                                launch_config.enable_logging,
+                                format!("accepted_connection peer={peer_addr}"),
+                            );
+                            let logging_enabled = launch_config.enable_logging;
                             tokio::spawn(async move {
                                 if let Ok(std_stream) = stream.into_std() {
                                     if let Err(e) = std_stream.set_nonblocking(false) {
-                                        eprintln!("Failed to set blocking mode: {}", e);
+                                        log_error(format!(
+                                            "failed_to_set_blocking_mode peer={peer_addr}: {e}"
+                                        ));
                                         return;
                                     }
 
                                     let writer = match std_stream.try_clone() {
                                         Ok(w) => w,
                                         Err(e) => {
-                                            eprintln!("Failed to clone stream: {e}");
+                                            log_error(format!(
+                                                "failed_to_clone_stream peer={peer_addr}: {e}"
+                                            ));
                                             return;
                                         }
                                     };
@@ -122,19 +153,30 @@ fn run_server(launch_config: LaunchConfig) {
                                         );
                                         let mut buf_reader = std::io::BufReader::new(reader);
                                         if let Err(e) = server.serve(&mut buf_reader) {
-                                            eprintln!("Connection error: {e}");
+                                            log_error(format!(
+                                                "connection_error peer={peer_addr}: {e}"
+                                            ));
+                                        } else {
+                                            log_info(
+                                                logging_enabled,
+                                                format!("connection_closed peer={peer_addr}"),
+                                            );
                                         }
                                     })
                                     .await
                                     {
-                                        eprintln!("Task panic: {e}");
+                                        log_error(format!(
+                                            "connection_task_panic peer={peer_addr}: {e}"
+                                        ));
                                     }
                                 } else {
-                                    eprintln!("Failed to convert stream to std");
+                                    log_error(format!(
+                                        "failed_to_convert_stream_to_std peer={peer_addr}"
+                                    ));
                                 }
                             });
                         }
-                        Err(e) => eprintln!("Failed to accept: {e}"),
+                        Err(e) => log_error(format!("failed_to_accept_connection: {e}")),
                     }
                 }
             });


### PR DESCRIPTION
### Motivation

- Standardize and improve runtime logging to make server startup and socket lifecycle events easier to diagnose across concurrent sessions.  
- Include minimal structured metadata (process id and unix timestamp) to correlate logs from multiple server instances and tasks.  
- Preserve existing behavior by keeping noisy info logs optional while ensuring errors are always visible.

### Description

- Added centralized logging helpers `log_info`, `log_error`, and `log_prefix` in `crates/perl-lsp/src/main.rs` to unify formatting and severity labels.  
- `log_prefix` emits `pid` and a Unix `ts` (seconds since epoch) using `SystemTime` for each log line.  
- Replaced ad-hoc `eprintln!` calls with the new helpers across `run_server` to emit structured messages for `transport`, `port`, `feature_profile`, listener lifecycle, accepted connections, connection errors, and task panics; info-level messages are gated by `launch_config.enable_logging`.  
- Kept error logging unconditional so failures remain visible even without `--log`.

### Testing

- Ran formatter: `cargo fmt --all` and it completed successfully.  
- Ran unit tests for the launcher: `cargo test -p perl-lsp-launcher` and all tests passed.  
- Built and ran binary tests: `cargo test -p perl-lsp --bin perl-lsp` and the run completed with no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219858dd08333bda87c44d86f80d3)