### PR TITLE
Strengthen LSP integration test assertions

### DIFF
--- a/crates/perl-lsp/tests/lsp_integration_tests.rs
+++ b/crates/perl-lsp/tests/lsp_integration_tests.rs
@@ -209,21 +209,21 @@ sub TestPackage::test_method {
 
     let lenses_array = lenses.as_array().ok_or("Expected lenses array")?;
 
-    // Code lenses may be empty if parsing failed or no test functions found
-    // Just check that we got a valid array response
-    assert!(lenses_array.is_empty() || !lenses_array.is_empty());
+    // Integration test coverage: ensure shebang-backed scripts expose an executable lens.
+    // This guards against regressions where the shebang detector is bypassed in end-to-end
+    // request handling.
+    let run_script_lens = lenses_array.iter().find(|lens| {
+        lens.get("command").and_then(|command| command.get("title")).and_then(Value::as_str)
+            == Some("▶ Run Script")
+    });
+    assert!(run_script_lens.is_some(), "expected shebang document to yield a Run Script code lens");
 
-    // Check shebang lens is first
-    if !lenses_array.is_empty() {
-        let first_lens = &lenses_array[0];
-        if let Some(cmd) = first_lens.get("command") {
-            if let Some(title) = cmd.get("title") {
-                if title.as_str() == Some("▶ Run Script") {
-                    assert_eq!(cmd["command"], "perl.runScript");
-                }
-            }
-        }
-    }
+    let run_script_command = run_script_lens
+        .and_then(|lens| lens.get("command"))
+        .and_then(|command| command.get("command"))
+        .and_then(Value::as_str)
+        .ok_or("Expected command string for shebang code lens")?;
+    assert_eq!(run_script_command, "perl.runScript");
     Ok(())
 }
 
@@ -403,10 +403,14 @@ fn test_document_updates() -> TestResult {
     let symbols = result.ok_or("Failed to get workspace symbols")?;
     let symbols_array = symbols.as_array().ok_or("Expected symbols array")?;
 
-    // Should find both new functions
+    // Should find both new functions. Ordering isn't guaranteed, so assert by set contents.
     assert_eq!(symbols_array.len(), 2);
-    assert_eq!(symbols_array[0]["name"], "new_function");
-    assert_eq!(symbols_array[1]["name"], "another_new");
+    let names: Vec<&str> = symbols_array
+        .iter()
+        .map(|symbol| symbol["name"].as_str().ok_or("Expected symbol name string"))
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(names.contains(&"new_function"));
+    assert!(names.contains(&"another_new"));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Make LSP integration tests meaningful by replacing a tautological assertion with a real behavioral check for shebang-based code lenses.
- Reduce flakiness by making document update symbol assertions robust to response ordering.

### Description
- Tighten `test_code_lens_integration` to assert a code lens with title `▶ Run Script` is present and that its command string equals `perl.runScript` instead of relying on a no-op assertion.
- Remove the previous tautological `assert!(lenses_array.is_empty() || !lenses_array.is_empty())` and replace it with a deterministic lookup of the shebang lens.
- Make `test_document_updates` validate symbol names as a set by collecting `name` values and asserting the presence of `new_function` and `another_new`, removing ordering assumptions.
- Ran `cargo fmt --all` and committed the test updates to keep formatting consistent.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp --test lsp_integration_tests` and all tests passed: `22 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219606c5883339f6c1da2d8dbe93d)