### PR TITLE
Strengthen import management integration coverage

### DIFF
--- a/crates/perl-lsp-import-management/src/lib.rs
+++ b/crates/perl-lsp-import-management/src/lib.rs
@@ -81,7 +81,7 @@ pub fn find_imports_range(source: &str, lines: &[String]) -> Option<(usize, usiz
 
     let first = source.find(imports.first()?)?;
     let last_line = imports.last()?;
-    let last = source.find(last_line)?;
+    let last = source.rfind(last_line)?;
     let last_end = last + last_line.len();
 
     Some((first, last_end))

--- a/crates/perl-lsp-import-management/tests/import_management_tests.rs
+++ b/crates/perl-lsp-import-management/tests/import_management_tests.rs
@@ -48,3 +48,23 @@ fn finds_import_block_range() {
         assert_eq!(&source[start..end], "use strict;\nuse warnings;");
     }
 }
+
+#[test]
+fn finds_import_block_range_when_import_line_repeats_later() {
+    let source = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'ok';\nuse warnings;\n";
+    let lines = source.lines().map(str::to_string).collect::<Vec<_>>();
+
+    let range = find_imports_range(source, &lines);
+    assert!(range.is_some());
+    if let Some((start, end)) = range {
+        assert_eq!(&source[start..end], "use strict;\nuse warnings;\nprint 'ok';\nuse warnings;");
+    }
+}
+
+#[test]
+fn returns_none_for_sources_without_imports() {
+    let source = "#!/usr/bin/perl\nmy $x = 1;\nprint $x;\n";
+    let lines = source.lines().map(str::to_string).collect::<Vec<_>>();
+
+    assert_eq!(find_imports_range(source, &lines), None);
+}


### PR DESCRIPTION
### Motivation
- Prevent incorrect import-block ranges when an import line repeats later in the file by anchoring the end boundary to the final occurrence.
- Add integration-style tests to guard the behavior and ensure `find_imports_range` behaves correctly for edge cases.

### Description
- Change `find_imports_range` to use `rfind` for locating the last import line in the source so the end bound corresponds to the final matching occurrence (`source.rfind(last_line)`).
- Add a test `finds_import_block_range_when_import_line_repeats_later` that verifies the computed byte range covers the intended block when an import repeats later in the file.
- Add a test `returns_none_for_sources_without_imports` to verify that `find_imports_range` returns `None` when there are no `use`/`require` statements.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-lsp-import-management` and all tests passed (`6 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b219606c5883339f6c1da2d8dbe93d)