### PR TITLE
Respect perl-lexer max_lookahead in internal peek helpers

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -708,7 +708,11 @@ impl<'a> PerlLexer<'a> {
 
     #[inline(always)]
     fn peek_char(&self, offset: usize) -> Option<char> {
-        let pos = self.position + offset;
+        if offset > self.config.max_lookahead {
+            return None;
+        }
+
+        let pos = self.position.checked_add(offset)?;
         if pos < self.input_bytes.len() {
             // For ASCII, direct access is safe
             let byte = Self::byte_at(self.input_bytes, pos);
@@ -741,14 +745,29 @@ impl<'a> PerlLexer<'a> {
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
-        let pos = self.position + offset;
+        if offset > self.config.max_lookahead {
+            return None;
+        }
+
+        let pos = self.position.checked_add(offset)?;
         if pos < self.input_bytes.len() { Some(self.input_bytes[pos]) } else { None }
     }
 
     /// Check if the next bytes match a pattern (ASCII only)
     #[inline]
     fn matches_bytes(&self, pattern: &[u8]) -> bool {
-        let end = self.position + pattern.len();
+        let Some(end_offset) = pattern.len().checked_sub(1) else {
+            return true;
+        };
+
+        if end_offset > self.config.max_lookahead {
+            return false;
+        }
+
+        let Some(end) = self.position.checked_add(pattern.len()) else {
+            return false;
+        };
+
         if end <= self.input_bytes.len() {
             &self.input_bytes[self.position..end] == pattern
         } else {
@@ -1978,12 +1997,9 @@ impl<'a> PerlLexer<'a> {
                 // Examples: `$x / 2`, `$x // $y`, `10 / 3`
                 self.advance();
                 // Check for // or //= using byte-level operations for speed
-                if self.position < self.input_bytes.len() && self.input_bytes[self.position] == b'/'
-                {
+                if self.peek_byte(0) == Some(b'/') {
                     self.position += 1; // consume second / directly
-                    if self.position < self.input_bytes.len()
-                        && self.input_bytes[self.position] == b'='
-                    {
+                    if self.peek_byte(0) == Some(b'=') {
                         self.position += 1; // consume = directly
                         let text = &self.input[start..self.position];
                         self.mode = LexerMode::ExpectTerm;

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -308,6 +308,34 @@ fn with_config_custom_lookahead() -> R {
 }
 
 #[test]
+fn with_config_zero_lookahead_disables_decimal_number_peek() -> R {
+    let cfg = LexerConfig { max_lookahead: 0, ..LexerConfig::default() };
+    let mut lexer = PerlLexer::with_config(".5", cfg);
+
+    let dot = lexer.next_token().ok_or("expected dot operator")?;
+    assert_eq!(dot.text.as_ref(), ".");
+
+    let number = lexer.next_token().ok_or("expected number token")?;
+    assert!(matches!(number.token_type, TokenType::Number(_)));
+    assert_eq!(number.text.as_ref(), "5");
+    Ok(())
+}
+
+#[test]
+fn with_config_small_lookahead_limits_namespace_parsing() -> R {
+    let cfg = LexerConfig { max_lookahead: 0, ..LexerConfig::default() };
+    let mut lexer = PerlLexer::with_config("Foo::Bar", cfg);
+
+    let first = lexer.next_token().ok_or("expected first token")?;
+    assert!(matches!(first.token_type, TokenType::Identifier(_)));
+    assert_eq!(first.text.as_ref(), "Foo");
+
+    let colon = lexer.next_token().ok_or("expected colon token")?;
+    assert_eq!(colon.text.as_ref(), ":");
+    Ok(())
+}
+
+#[test]
 fn with_body_tokens_emits_heredoc_body() -> R {
     let input = "print <<EOF;\nhello world\nEOF\n";
     let mut lexer = PerlLexer::with_body_tokens(input);


### PR DESCRIPTION
### Motivation
- Ensure the lexer honors `LexerConfig::max_lookahead` during internal peeks to make lookahead-budgeting predictable and configurable.
- Harden hot-path index arithmetic to avoid overflow and out-of-bounds edge cases when peeking near the input end.

### Description
- Enforce `max_lookahead` in `peek_char` and `peek_byte`, and return `None` when the requested offset exceeds the configured budget. 
- Harden offset math using `checked_add`/`checked_sub` in the peek/match helpers and make `matches_bytes` respect the configured lookahead budget. 
- Update slash-operator disambiguation to use the lookahead-aware `peek_byte` so `/`, `//`, and `//=` parsing respects `max_lookahead`. 
- Add unit tests that verify zero-lookahead behavior for decimal-number disambiguation and namespace parsing (`Foo::Bar`), and run formatting/lint fixes.

### Testing
- Ran `cargo fmt --all` successfully. 
- Ran `cargo test -p perl-lexer` and all lexer tests passed (unit, integration, and specialized regression suites were executed). 
- Ran `cargo clippy -p perl-lexer --all-targets` with no blocking issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2194b9f74833395c9cdfc1f1d802f)