### PR TITLE
Improve perl-lexer Unicode identifier handling for emoji sequences

### DIFF
--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -61,8 +61,20 @@ pub fn is_perl_identifier_start(ch: char) -> bool {
 /// Check if a character can continue a Perl identifier
 pub fn is_perl_identifier_continue(ch: char) -> bool {
     // For continuation, we accept identifier start chars, XID_Continue chars,
-    // and the single quote (for old-style package separators like Foo'Bar)
-    is_perl_identifier_start(ch) || is_xid_continue(ch) || ch == '\''
+    // the single quote (for old-style package separators like Foo'Bar),
+    // and emoji continuation code points used by ZWJ grapheme sequences.
+    is_perl_identifier_start(ch)
+        || is_xid_continue(ch)
+        || ch == '\''
+        || matches!(
+            ch as u32,
+            // Unicode join controls used in emoji and script shaping.
+            0x200C | 0x200D |
+            // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
+            0xFE00..=0xFE0F |
+            // Fitzpatrick skin-tone modifiers.
+            0x1F3FB..=0x1F3FF
+        )
 }
 
 /// Validate Unicode string complexity for performance monitoring

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -1402,6 +1402,34 @@ fn cjk_identifier() -> R {
 }
 
 #[test]
+fn emoji_zwj_identifier() -> R {
+    let input = "my $👨‍💻dev = 1;";
+    let toks = tokens(input);
+    let has_ident = toks.iter().any(|t| {
+        matches!(
+            &t.token_type,
+            TokenType::Identifier(id) if id.as_ref().contains("👨‍💻dev")
+        )
+    });
+    assert!(has_ident, "expected emoji ZWJ identifier token");
+    Ok(())
+}
+
+#[test]
+fn emoji_variation_selector_identifier() -> R {
+    let input = "my $☕️_count = 1;";
+    let toks = tokens(input);
+    let has_ident = toks.iter().any(|t| {
+        matches!(
+            &t.token_type,
+            TokenType::Identifier(id) if id.as_ref().contains("☕️_count")
+        )
+    });
+    assert!(has_ident, "expected variation-selector emoji identifier token");
+    Ok(())
+}
+
+#[test]
 fn empty_input_eof_position() -> R {
     let toks = tokens("");
     let eof = toks.first().ok_or("no eof")?;


### PR DESCRIPTION
### Motivation

- Some emoji grapheme components (ZWJ/ZWNJ, variation selectors, skin-tone modifiers) were splitting identifiers into multiple tokens; treating these as identifier continuation improves real-world tokenization for emoji-containing identifiers. 
- Maintain existing behavior for Unicode XID start/continue semantics and the historical Perl package separator `'` while addressing practical emoji use-cases. 

### Description

- Extend `is_perl_identifier_continue` in `crates/perl-lexer/src/unicode.rs` to accept U+200C and U+200D (join controls), U+FE00..=U+FE0F (variation selectors), and U+1F3FB..=U+1F3FF (Fitzpatrick skin-tone modifiers) as valid continuation code points. 
- Preserve existing checks for `is_perl_identifier_start`, `is_xid_continue`, and the single-quote package separator. 
- Add two regression tests in `crates/perl-lexer/tests/comprehensive_unit_tests.rs` to verify tokenization of emoji identifiers: `emoji_zwj_identifier` (`$👨‍💻dev`) and `emoji_variation_selector_identifier` (`$☕️_count`). 

### Testing

- Ran targeted tests with `cargo test -p perl-lexer --test comprehensive_unit_tests emoji_zwj_identifier` and `emoji_variation_selector_identifier`, and both tests passed. 
- Ran the full crate test suite with `cargo test -p perl-lexer` and all lexer tests passed. 
- Ran lint checks with `cargo clippy -p perl-lexer -- -D warnings` and there were no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2194b9f74833395c9cdfc1f1d802f)