### PR TITLE
Fix perl-lexer handling of single-quote quote-operator delimiters

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1589,6 +1589,19 @@ impl<'a> PerlLexer<'a> {
             }
 
             while let Some(ch) = self.current_char() {
+                // Single quote is usually allowed inside Perl identifiers (legacy package separator),
+                // but it can also be the delimiter for quote-like operators (q'..', qq'..', qr'..', m'..').
+                // If we've already read one of those operator words, stop before consuming the quote
+                // so the quote-operator path can handle it.
+                if ch == '\''
+                    && matches!(
+                        &self.input[start..self.position],
+                        "m" | "q" | "qq" | "qw" | "qx" | "qr"
+                    )
+                {
+                    break;
+                }
+
                 if is_perl_identifier_continue(ch) {
                     self.advance();
                 } else {

--- a/crates/perl-lexer/tests/comprehensive_integration_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_integration_tests.rs
@@ -362,6 +362,31 @@ fn backtick_literal() -> R {
 }
 
 #[test]
+fn quote_operators_with_single_quote_delimiter() -> R {
+    let cases = [
+        ("q'hello'", TokenType::QuoteSingle),
+        ("qq'hello'", TokenType::QuoteDouble),
+        ("qw'foo bar'", TokenType::QuoteWords),
+        ("qx'echo hi'", TokenType::QuoteCommand),
+        ("qr'foo+'", TokenType::QuoteRegex),
+        ("m'foo+'", TokenType::RegexMatch),
+    ];
+
+    for (input, expected_variant) in cases {
+        let toks = significant_tokens(input);
+        let first = toks.first().ok_or_else(|| format!("no tokens for '{input}'"))?;
+        assert!(
+            std::mem::discriminant(&first.token_type) == std::mem::discriminant(&expected_variant),
+            "input '{input}': expected {:?}, got {:?}",
+            expected_variant,
+            first.token_type
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn quote_operators_with_alternate_delimiters() -> R {
     let cases = [
         ("q<hello>", TokenType::QuoteSingle),


### PR DESCRIPTION
### Motivation
- Single-quote-delimited quote/regex operators like `q'...'`, `qq'...'`, `qr'...'` and `m'...'` were sometimes mis-tokenized because the identifier scanner consumed a `'` as an identifier continuation and prevented the quote-operator parsing path from running.

### Description
- Stop consuming a single-quote as an identifier continuation in `try_identifier_or_keyword` when the already-read identifier matches a quote-like operator word (`m`, `q`, `qq`, `qw`, `qx`, `qr`), allowing the quote-operator path to handle the `'` delimiter. (change in `crates/perl-lexer/src/lib.rs`)
- Add an integration test exercising single-quote-delimited forms for `q`, `qq`, `qw`, `qx`, `qr`, and `m` to prevent regressions. (added tests in `crates/perl-lexer/tests/comprehensive_integration_tests.rs`)
- No public APIs or token enums were changed; this is a narrowly scoped lexer behavior fix.

### Testing
- Ran `cargo fmt --all` to format changes; completed successfully.
- Ran `cargo test -p perl-lexer`; all lexer unit and integration tests passed (existing suite plus the new single-quote quote-operator test).
- Ran `cargo clippy -p perl-lexer --all-targets -- -D warnings`; linting completed without warnings (checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2194b9f74833395c9cdfc1f1d802f)