### PR TITLE
Allow underscores in numeric exponents (perl-lexer)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1214,14 +1214,22 @@ impl<'a> PerlLexer<'a> {
                 pos += 1;
             }
 
-            // Must have at least one digit after exponent
-            let digit_start = pos;
-            while pos < bytes.len() && bytes[pos].is_ascii_digit() {
-                pos += 1;
+            // Must have at least one digit after exponent (underscores allowed between digits)
+            let mut saw_digit = false;
+            while pos < bytes.len() {
+                let byte = bytes[pos];
+                if byte.is_ascii_digit() {
+                    saw_digit = true;
+                    pos += 1;
+                } else if byte == b'_' {
+                    pos += 1;
+                } else {
+                    break;
+                }
             }
 
             // If no digits after exponent, backtrack
-            if pos == digit_start {
+            if !saw_digit {
                 pos = exp_start;
             }
 
@@ -1258,11 +1266,24 @@ impl<'a> PerlLexer<'a> {
                             self.advance();
                         }
                     }
-                    // Parse exponent digits
-                    while self.position < self.input_bytes.len()
-                        && self.input_bytes[self.position].is_ascii_digit()
-                    {
-                        self.position += 1;
+                    // Parse exponent digits (underscores allowed between digits)
+                    let exponent_start = self.position;
+                    let mut saw_digit = false;
+                    while self.position < self.input_bytes.len() {
+                        let byte = self.input_bytes[self.position];
+                        if byte.is_ascii_digit() {
+                            saw_digit = true;
+                            self.position += 1;
+                        } else if byte == b'_' {
+                            self.position += 1;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // No digits after exponent marker, rewind so caller treats `e` as separate token.
+                    if !saw_digit {
+                        self.position = exponent_start.saturating_sub(1);
                     }
                     break;
                 }

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -529,7 +529,7 @@ fn negative_number_is_operator_plus_number() -> R {
 
 #[test]
 fn float_literal() -> R {
-    for input in ["3.14", "0.5", ".25", "1.", "1e10", "2.5e-3", "1E+5"] {
+    for input in ["3.14", "0.5", ".25", "1.", "1e10", "2.5e-3", "1E+5", "1e1_0", "2.5e-1_0"] {
         let tok = first_token(input).ok_or_else(|| format!("no token for '{}'", input))?;
         match &tok.token_type {
             TokenType::Number(_) => {} // expected


### PR DESCRIPTION
### Motivation

- Numeric literals with underscores in exponent digits (e.g. `1e1_0`, `2.5e-1_0`) should be accepted and parsed as numbers by the lexer, and decimal-leading floats should follow the same behavior.

### Description

- Update exponent parsing in `crates/perl-lexer/src/lib.rs` to accept underscores between digits after the `e`/`E` marker and to still backtrack when no digits are present after the exponent marker.
- Apply the same underscore-tolerant exponent parsing to decimal-leading float parsing code paths and preserve rewind behavior for malformed exponents.
- Extend unit test coverage in `crates/perl-lexer/tests/comprehensive_unit_tests.rs` to include underscored exponent cases (`1e1_0`, `2.5e-1_0`).

### Testing

- Ran `cargo test -p perl-lexer --test comprehensive_unit_tests float_literal` and the targeted test passed; the test list was expanded to cover underscored exponent cases.
- Ran `cargo test -p perl-lexer --test comprehensive_integration_tests float_literals` and the integration float tests passed.
- Ran the full crate test suite with `cargo test -p perl-lexer` and all lexer tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2194b9f74833395c9cdfc1f1d802f)