### PR TITLE
pest: improve recovery for incomplete blocks and add regression test

### DIFF
--- a/crates/perl-parser-pest/src/pure_rust_parser.rs
+++ b/crates/perl-parser-pest/src/pure_rust_parser.rs
@@ -394,11 +394,13 @@ impl PureRustPerlParser {
                             }
                         }
                         current_block.clear();
+                        brace_count = 0;
                         in_single_quote = false;
                         in_double_quote = false;
                     } else {
                         // If that fails, skip and continue
                         current_block.clear();
+                        brace_count = 0;
                         in_single_quote = false;
                         in_double_quote = false;
                     }
@@ -406,6 +408,7 @@ impl PureRustPerlParser {
                     // Handle comments
                     statements.push(AstNode::Comment(Arc::from(trimmed)));
                     current_block.clear();
+                    brace_count = 0;
                 }
             }
         }
@@ -2782,5 +2785,20 @@ mod tests {
         let sexp = parser.to_sexp(&ast);
         println!("Hash assignment AST: {:?}", ast);
         println!("S-expression: {}", sexp);
+    }
+
+    #[test]
+    fn test_recovery_keeps_parsing_after_incomplete_block() {
+        let mut parser = PureRustPerlParser::new();
+        let source = "if ($x) {\n\nmy $y = 1;\n";
+
+        let result = parser.parse(source);
+        assert!(result.is_ok(), "Expected recovery to parse trailing statement");
+
+        let sexp = parser.to_sexp(&must(result));
+        assert!(
+            sexp.contains("$y") && sexp.contains("(number 1)"),
+            "Recovered AST should include trailing declaration, got: {sexp}"
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Improve the pest-based parser's ability to recover and continue parsing after encountering an incomplete/unterminated block so trailing statements are not lost.

### Description

- Reset `brace_count` whenever `current_block` is cleared in the interactive/recovery parsing flow in `crates/perl-parser-pest/src/pure_rust_parser.rs` so parser state does not incorrectly carry over between blocks.
- Ensure `in_single_quote` and `in_double_quote` are also reset when a block is cleared to avoid quote-state leakage.
- Add a regression unit test `test_recovery_keeps_parsing_after_incomplete_block` to verify that a trailing declaration inside an incomplete block is recovered and included in the produced AST.

### Testing

- Ran `cargo test -p perl-parser-pest` to exercise the parser crate's unit tests, including the new recovery regression test, and the test suite completed successfully.
- Existing `test_array_assignment` and `test_hash_assignment` remain in place and were executed as part of the same test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2193f12808333a326adcbd332b89e)