### PR TITLE
Improve pest parser handling of postfix statement modifiers

### DIFF
--- a/crates/perl-parser-pest/src/grammar.pest
+++ b/crates/perl-parser-pest/src/grammar.pest
@@ -935,8 +935,10 @@ goto_statement = { "goto" ~ (goto_target | expression) ~ statement_modifier? ~ s
 
 // Statement modifiers (postfix if/unless/while/until/for/foreach)
 statement_modifier = {
-    ("if" | "unless" | "while" | "until" | "for" | "foreach") ~ expression
+    statement_modifier_keyword ~ expression
 }
+
+statement_modifier_keyword = @{ "if" | "unless" | "while" | "until" | "for" | "foreach" }
 
 // POD
 pod_section = @{ 

--- a/crates/perl-parser-pest/src/pure_rust_parser.rs
+++ b/crates/perl-parser-pest/src/pure_rust_parser.rs
@@ -578,66 +578,52 @@ impl PureRustPerlParser {
             Rule::modified_statement => {
                 let mut inner = pair.into_inner();
                 let expr_pair = inner.next().ok_or("Missing expression in modified statement")?;
-                let expr = self.build_node(expr_pair)?;
-                let modifier = inner.next().ok_or("Missing modifier in modified statement")?;
+                let expr = self
+                    .build_node(expr_pair)?
+                    .ok_or("Failed to build expression in modified statement")?;
+                let modifier_pair = inner.next().ok_or("Missing modifier in modified statement")?;
 
-                // Extract modifier type and condition from the statement_modifier
-                let modifier_str = modifier.as_str();
-                let (modifier_type, condition_expr) =
-                    if let Some(rest) = modifier_str.strip_prefix("if ") {
-                        ("if", rest)
-                    } else if let Some(rest) = modifier_str.strip_prefix("unless ") {
-                        ("unless", rest)
-                    } else if let Some(rest) = modifier_str.strip_prefix("while ") {
-                        ("while", rest)
-                    } else if let Some(rest) = modifier_str.strip_prefix("until ") {
-                        ("until", rest)
-                    } else if let Some(rest) = modifier_str.strip_prefix("for ") {
-                        ("for", rest)
-                    } else if let Some(rest) = modifier_str.strip_prefix("foreach ") {
-                        ("foreach", rest)
-                    } else {
-                        return Ok(expr);
-                    };
+                let mut modifier_inner = modifier_pair.into_inner();
+                let modifier_type = modifier_inner
+                    .next()
+                    .ok_or("Missing modifier keyword in modified statement")?
+                    .as_str();
+                let condition_pair =
+                    modifier_inner.next().ok_or("Missing condition in modified statement")?;
+                let condition = self
+                    .build_node(condition_pair)?
+                    .ok_or("Failed to build condition in modified statement")?;
 
-                // For now, create a simple identifier for the condition
-                // In a real implementation, we'd parse the condition expression
-                let condition = Some(AstNode::Identifier(Arc::from(condition_expr.trim())));
-
-                if let (Some(expr), Some(condition)) = (expr, condition) {
-                    match modifier_type {
-                        "if" => Ok(Some(AstNode::IfStatement {
-                            condition: Box::new(condition),
-                            then_block: Box::new(expr),
-                            elsif_clauses: Vec::new(),
-                            else_block: None,
-                        })),
-                        "unless" => Ok(Some(AstNode::UnlessStatement {
-                            condition: Box::new(condition),
-                            block: Box::new(expr),
-                            else_block: None,
-                        })),
-                        "while" => Ok(Some(AstNode::WhileStatement {
-                            label: None,
-                            condition: Box::new(condition),
-                            block: Box::new(expr),
-                        })),
-                        "until" => Ok(Some(AstNode::UntilStatement {
-                            label: None,
-                            condition: Box::new(condition),
-                            block: Box::new(expr),
-                        })),
-                        "for" | "foreach" => Ok(Some(AstNode::ForStatement {
-                            init: None,
-                            condition: Some(Box::new(condition)),
-                            update: None,
-                            block: Box::new(expr),
-                            label: None,
-                        })),
-                        _ => Ok(Some(AstNode::Statement(Box::new(expr)))),
-                    }
-                } else {
-                    Ok(None)
+                match modifier_type {
+                    "if" => Ok(Some(AstNode::IfStatement {
+                        condition: Box::new(condition),
+                        then_block: Box::new(expr),
+                        elsif_clauses: Vec::new(),
+                        else_block: None,
+                    })),
+                    "unless" => Ok(Some(AstNode::UnlessStatement {
+                        condition: Box::new(condition),
+                        block: Box::new(expr),
+                        else_block: None,
+                    })),
+                    "while" => Ok(Some(AstNode::WhileStatement {
+                        label: None,
+                        condition: Box::new(condition),
+                        block: Box::new(expr),
+                    })),
+                    "until" => Ok(Some(AstNode::UntilStatement {
+                        label: None,
+                        condition: Box::new(condition),
+                        block: Box::new(expr),
+                    })),
+                    "for" | "foreach" => Ok(Some(AstNode::ForStatement {
+                        init: None,
+                        condition: Some(Box::new(condition)),
+                        update: None,
+                        block: Box::new(expr),
+                        label: None,
+                    })),
+                    _ => Ok(Some(AstNode::Statement(Box::new(expr)))),
                 }
             }
             Rule::expression_statement => {
@@ -2782,5 +2768,33 @@ mod tests {
         let sexp = parser.to_sexp(&ast);
         println!("Hash assignment AST: {:?}", ast);
         println!("S-expression: {}", sexp);
+    }
+
+    #[test]
+    fn test_modified_statement_if_parses_expression_condition() {
+        let mut parser = PureRustPerlParser::new();
+        let source = "print 'ok' if $x > 2;";
+        let ast = must(parser.parse(source));
+        let sexp = parser.to_sexp(&ast);
+
+        assert!(sexp.contains("(if_statement"), "Expected if_statement in AST: {sexp}");
+        assert!(
+            !sexp.contains("(identifier $x > 2)"),
+            "Condition should not be preserved as a raw identifier: {sexp}"
+        );
+    }
+
+    #[test]
+    fn test_modified_statement_unless_parses_expression_condition() {
+        let mut parser = PureRustPerlParser::new();
+        let source = "print 'ok' unless $x > 2;";
+        let ast = must(parser.parse(source));
+        let sexp = parser.to_sexp(&ast);
+
+        assert!(sexp.contains("(unless_statement"), "Expected unless_statement in AST: {sexp}");
+        assert!(
+            !sexp.contains("(identifier $x > 2)"),
+            "Condition should not be preserved as a raw identifier: {sexp}"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- The pest-based parser was treating postfix statement modifiers by slicing raw rule text, which produced condition expressions as raw identifiers instead of proper expression AST nodes.
- This made it hard to analyze or transform modified statements reliably and prevented downstream tools from seeing a structured condition.

### Description
- Updated `crates/perl-parser-pest/src/grammar.pest` so `statement_modifier` exposes a `statement_modifier_keyword` token instead of embedding the keyword in text. (`statement_modifier_keyword = @{ "if" | "unless" | "while" | "until" | "for" | "foreach" }`)
- Refactored `Rule::modified_statement` in `crates/perl-parser-pest/src/pure_rust_parser.rs` to read the modifier keyword and condition from pest `Pair`s, build a real condition AST node via `build_node`, and dispatch to `IfStatement`/`UnlessStatement`/`WhileStatement`/`UntilStatement`/`ForStatement` cases accordingly.
- Removed the fallback that created a raw `Identifier` from the modifier string and replaced it with proper AST construction for the condition.
- Added two regression tests to `pure_rust_parser` to ensure postfix `if` and `unless` parse into statement nodes and that the condition is not preserved as a raw identifier.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-parser-pest` and all tests passed (12 passed; 0 failed) after the fix.
- Ran `cargo clippy -p perl-parser-pest --all-targets -- -D warnings` and linting completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2193f12808333a326adcbd332b89e)