### PR TITLE
docs: add perl-lsp marketing ad copy playbook

### DIFF
--- a/docs/project/MARKETING_ADS.md
+++ b/docs/project/MARKETING_ADS.md
@@ -1,0 +1,146 @@
+# Marketing Ads for perl-lsp
+
+This document provides ready-to-use ad copy aligned with the project's current positioning: native Rust performance, full LSP coverage, comprehensive Perl 5 syntax support, and zero runtime Perl dependency for parsing and LSP.
+
+## Messaging anchors (derived from repository docs)
+
+- Fast, native Rust language server and parser toolkit
+- Full LSP coverage and broad protocol support
+- Comprehensive Perl 5 syntax support (regex, heredocs, quotes, etc.)
+- Built-in debug adapter (`perl-dap`)
+- Zero runtime Perl dependency for parsing/LSP workflows
+
+---
+
+## Search ad variants
+
+### Ad Set A — "Modern Perl IDE"
+
+**Headline options**
+
+1. Modern Perl LSP in Rust
+2. Full Perl IDE Features, Fast
+3. perl-lsp: Native, Fast, Complete
+4. Perl Autocomplete + Navigation
+
+**Description options**
+
+1. Upgrade Perl development with native Rust performance, diagnostics, hover, rename, and refactors.
+2. Get full LSP coverage for Perl with fast incremental parsing and cross-file symbol navigation.
+
+**CTA options**
+
+- Install via Cargo
+- View Docs
+- Start in 2 Minutes
+
+### Ad Set B — "Performance + Coverage"
+
+**Headline options**
+
+1. Full LSP Coverage for Perl
+2. Fast Incremental Parsing
+3. Native Perl Language Server
+4. Better Perl Tooling Starts Here
+
+**Description options**
+
+1. Run `perl-lsp --stdio` in any LSP editor and get completion, diagnostics, definitions, and references.
+2. Built for real-world Perl codebases: Unicode-safe positions, dual indexing, and broad syntax support.
+
+**CTA options**
+
+- Try perl-lsp
+- Connect Your Editor
+- Install Now
+
+### Ad Set C — "Debug + Parse"
+
+**Headline options**
+
+1. LSP + DAP for Perl
+2. Parse, Navigate, Debug Perl
+3. Rust-Powered Perl Toolchain
+4. One Toolkit for Perl Dev
+
+**Description options**
+
+1. Use `perl-lsp` for IDE intelligence and `perl-dap` for breakpoints, stepping, and variable inspection.
+2. Native Rust parser and language server built for modern editor workflows.
+
+**CTA options**
+
+- Install perl-lsp
+- Use perl-dap
+- Explore the Workspace
+
+---
+
+## Social ad variants
+
+### X / LinkedIn (short)
+
+1. Perl deserves modern tooling. `perl-lsp` brings fast native LSP features—completion, hover, diagnostics, rename, refs, and more. Rust-powered. Editor-friendly. #perl #lsp #rust
+2. Shipping Perl at scale? Use `perl-lsp` for cross-file navigation, incremental parsing, and full-featured IDE support across LSP editors. #devtools #perl
+3. `perl-dap` + `perl-lsp` = Perl debugging + rich editor intelligence in one ecosystem. Install with Cargo and connect your editor in minutes. #debugging #opensource
+
+### Reddit / forum post copy (medium)
+
+If you work in Perl and want modern IDE behavior, check out `perl-lsp`.
+
+- Native Rust language server
+- Full-featured Perl editor capabilities (completion, diagnostics, references, rename, formatting)
+- Comprehensive Perl syntax handling
+- Built-in debug adapter option with `perl-dap`
+
+Install:
+
+```bash
+cargo install perl-lsp
+```
+
+Run:
+
+```bash
+perl-lsp --stdio
+```
+
+Works with VS Code, Neovim, Emacs, and other LSP-capable editors.
+
+---
+
+## Landing page hero copy
+
+### Hero option 1
+
+**Headline**: Modern Perl language intelligence, built in Rust.
+
+**Subheadline**: `perl-lsp` delivers full-featured Perl IDE workflows with fast incremental parsing and zero runtime Perl dependency for parsing/LSP.
+
+**Primary CTA**: Install `perl-lsp`
+
+**Secondary CTA**: Read documentation
+
+### Hero option 2
+
+**Headline**: Full LSP tooling for Perl teams.
+
+**Subheadline**: Completion, diagnostics, navigation, refactoring, and debugging support from one cohesive ecosystem.
+
+**Primary CTA**: Get started
+
+**Secondary CTA**: Compare features
+
+---
+
+## Brand-safe claims checklist
+
+Use these as high-confidence claims in campaigns:
+
+- "Native Rust Perl language server"
+- "Full-featured LSP support for Perl"
+- "Fast incremental parsing"
+- "Zero runtime Perl dependency for parsing/LSP"
+- "Works with VS Code, Neovim, Emacs, and LSP-compatible editors"
+
+Avoid unbounded superlatives without context (for example, "the fastest ever") unless supported by benchmark citations.


### PR DESCRIPTION
### Motivation
- Provide ready-to-use, brand-aligned ad copy and messaging variants to support outreach while keeping claims consistent with the project's documented capabilities.

### Description
- Add `docs/project/MARKETING_ADS.md` containing messaging anchors, search ad sets, social/forum post variants, landing-page hero options, and a brand-safe claims checklist aligned to `perl-lsp` features.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded; this is a documentation-only change so no crate tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2192fb3f883339fc9940691838b38)