### PR TITLE
Improve mutation-subset targeting for quote parsing

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,7 +1,17 @@
-timeout_multiplier = 1.0
+timeout_multiplier = 1.25
+
+# Mutation hardening focus area: quote parsing logic now lives in perl-quote.
+# Keep this subset intentionally narrow so it stays usable in local/CI flows.
 examine_globs = [
-    "crates/perl-parser/src/quote_parser.rs"
+    "crates/perl-quote/src/lib.rs",
 ]
+
+# Exercise both direct crate tests and parser-level integration tests that consume
+# quote parsing helpers via re-exports.
 additional_cargo_test_args = [
-    "--test", "quote_operator_tests"
+    "-p", "perl-quote",
+    "--test", "comprehensive_unit_tests",
+    "-p", "perl-parser",
+    "--test", "quote_operator_tests",
+    "--test", "quote_parser_mutation_survivors_elimination",
 ]


### PR DESCRIPTION
### Motivation
- The quote-parsing implementation moved into the `perl-quote` crate, and the existing mutation subset targeted a stale path so local/CI mutation runs could miss the active code; the subset also needed a slightly higher timeout to reduce flaky timeouts.

### Description
- Update `.cargo/mutants.toml` to raise `timeout_multiplier` to `1.25`.
- Change `examine_globs` to target `crates/perl-quote/src/lib.rs` so mutants exercise the current quote parsing implementation.
- Expand `additional_cargo_test_args` to run `-p perl-quote --test comprehensive_unit_tests` and parser-level integration tests `-p perl-parser --test quote_operator_tests --test quote_parser_mutation_survivors_elimination`.

### Testing
- Ran `cargo test -p perl-quote --test comprehensive_unit_tests`, which completed successfully (`96 passed`).
- Ran `cargo test -p perl-parser --test quote_operator_tests --test quote_parser_mutation_survivors_elimination`, which completed successfully (`9 passed` and `9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21914ef7c8333a9aa3d53821c69b1)