### PR TITLE
Improve mutation-testing resilience with regression fallback

### DIFF
--- a/justfile
+++ b/justfile
@@ -229,7 +229,17 @@ mutation-subset:
         cargo mutants --workspace -j 2 --timeout 60 2>&1 || echo "Mutation testing completed (some mutants may survive)"; \
     else \
         echo "SKIP: cargo-mutants not installed (run: cargo install cargo-mutants)"; \
+        echo "Running mutation regression harnesses instead..."; \
+        just mutation-regression; \
     fi
+
+# Mutation regression harness (fast fallback + PR guardrail)
+mutation-regression:
+    @echo "🧪 Running mutation regression harnesses..."
+    @cargo test -p perl-parser --test mutation_hardening_tests
+    @cargo test -p perl-parser --test parser_boolean_logic_mutation_hardening
+    @cargo test -p perl-lsp --test mutation_survivors_elimination
+    @echo "✅ Mutation regression harnesses passed"
 
 # Bounded fuzz run (quick fuzzing for CI/nightly)
 fuzz-bounded:


### PR DESCRIPTION
### Motivation
- Ensure mutation-oriented validation still runs in environments where the external mutation runner (`cargo-mutants`) is not available by providing a fast fallback harness.

### Description
- Updated the `mutation-subset` recipe in the `justfile` to run a fallback harness when `cargo-mutants` is not found instead of silently skipping mutation checks.
- Added a new `mutation-regression` `just` target that runs targeted hardening test suites via `cargo test` against `perl-parser` and `perl-lsp` as a pragmatic, fast guardrail.

### Testing
- Ran `cargo test -p perl-parser --test mutation_hardening_tests` and it completed successfully (`147 passed`).
- Ran `cargo test -p perl-parser --test parser_boolean_logic_mutation_hardening` and it completed successfully (`6 passed`).
- Ran `cargo test -p perl-lsp --test mutation_survivors_elimination` and it completed successfully (`13 passed`).
- Attempted `just mutation-regression` in this environment but it failed because the `just` binary is not installed (expected in this CI/dev shell).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21914ef7c8333a9aa3d53821c69b1)