### PR TITLE
Fix hash-literal fat-arrow branch and add mutation-hardening tests

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
@@ -130,7 +130,7 @@ impl<'a> Parser<'a> {
             // Parse as hash
             _is_hash = true;
 
-            if self.peek_kind() != /* ~ changed by cargo-mutants ~ */ Some(TokenKind::FatArrow) {
+            if self.peek_kind() == Some(TokenKind::FatArrow) {
                 // key => value pattern
                 self.tokens.next()?; // consume =>
                 let value = self.parse_expression()?;

--- a/crates/perl-parser-core/tests/hash_literal_mutation_hardening.rs
+++ b/crates/perl-parser-core/tests/hash_literal_mutation_hardening.rs
@@ -1,0 +1,63 @@
+//! Mutation hardening tests for hash literal parsing.
+//!
+//! These tests specifically protect the `=>`/`,` branch selection logic in
+//! `parse_braced_expression` so hash literals are not misparsed as blocks.
+
+use perl_parser_core::{Node, NodeKind, Parser};
+
+fn parse_single_initializer(source: &str) -> Result<Node, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(source);
+    let ast = parser.parse()?;
+
+    if let NodeKind::Program { statements } = ast.kind {
+        if statements.len() != 1 {
+            return Err(format!(
+                "expected exactly one top-level statement, got {}",
+                statements.len()
+            )
+            .into());
+        }
+
+        if let NodeKind::VariableDeclaration { initializer: Some(init), .. } = &statements[0].kind {
+            return Ok(*init.clone());
+        }
+    }
+
+    Err("expected variable declaration with initializer".into())
+}
+
+#[test]
+fn hash_literal_with_fat_arrow_is_not_parsed_as_block() -> Result<(), Box<dyn std::error::Error>> {
+    let initializer = parse_single_initializer("my $h = { foo => 1, bar => 2 };")?;
+
+    if let NodeKind::HashLiteral { pairs } = initializer.kind {
+        assert_eq!(pairs.len(), 2, "expected two hash pairs");
+        assert!(
+            matches!(pairs[0].0.kind, NodeKind::Identifier { .. }),
+            "first key should be an identifier"
+        );
+        assert!(
+            matches!(pairs[0].1.kind, NodeKind::Number { .. }),
+            "first value should be numeric"
+        );
+        return Ok(());
+    }
+
+    Err("expected HashLiteral initializer".into())
+}
+
+#[test]
+fn hash_literal_with_comma_pairs_stays_hash_literal() -> Result<(), Box<dyn std::error::Error>> {
+    let initializer = parse_single_initializer("my $h = { foo, 1, bar, 2 };")?;
+
+    if let NodeKind::HashLiteral { pairs } = initializer.kind {
+        assert_eq!(pairs.len(), 2, "expected two hash pairs");
+        assert!(
+            pairs.iter().all(|(_, value)| matches!(value.kind, NodeKind::Number { .. })),
+            "all values should be numbers"
+        );
+        return Ok(());
+    }
+
+    Err("expected HashLiteral initializer".into())
+}


### PR DESCRIPTION
### Motivation
- Restore correct parsing for braced expressions so `{ key => value }` is recognized as a `HashLiteral` rather than mis-parsed as a `Block` due to a flipped predicate that could survive mutation testing.
- Harden the parser against the same class of mutation survivors by adding focused integration tests that assert AST shape for both `=>` and comma-pair hash forms.

### Description
- Fixed the branch condition in `parse_braced_expression` by changing the `FatArrow` check back to `if self.peek_kind() == Some(TokenKind::FatArrow)` in `crates/perl-parser-core/src/engine/parser/expressions/hashes.rs` so the `=>` path is handled as a hash pair.
- Added `crates/perl-parser-core/tests/hash_literal_mutation_hardening.rs` with helper `parse_single_initializer` and two tests that validate `HashLiteral` AST shape for `foo => 1, bar => 2` and `foo, 1, bar, 2` forms.
- Tests explicitly inspect `NodeKind::HashLiteral` and pair/value kinds to ensure future mutations affecting the branch selection are killed by the test suite.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser-core --test hash_literal_mutation_hardening` and the new test binary ran `2` tests which both passed (`2 passed; 0 failed`).
- Ran `cargo clippy -p perl-parser-core --tests -- -D warnings` which completed without warnings (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21914ef7c8333a9aa3d53821c69b1)