### PR TITLE
docs: add a clear storybooking workflow and acceptance checklist to the casebook

### DIFF
--- a/book/src/process/casebook.md
+++ b/book/src/process/casebook.md
@@ -28,6 +28,46 @@ Each exhibit shows:
 
 ---
 
+## Storybooking Workflow
+
+Use this lightweight workflow when turning raw PR history into a high-signal casebook exhibit:
+
+1. **Select the right PR**
+   - Prefer PRs with clear user-visible impact or architecture change.
+   - Skip mechanical-only PRs unless they establish a reusable governance pattern.
+
+2. **Gather receipts first (before writing narrative)**
+   - Capture exact commands and outputs (`cargo test`, `just ci-gate`, benchmarks, ignored-test deltas).
+   - Record before/after numbers with units and source.
+
+3. **Write the scar story as a causal chain**
+   - `Wrong` → concrete failure mode.
+   - `Caught` → detector (mutation test, CI failure, protocol test, review finding).
+   - `Fix` → code or architecture intervention.
+   - `Prevention` → reusable guardrail (test, lint, checklist, gate).
+
+4. **Score quality surfaces explicitly**
+   - Assign +2/+1/0/-1/-2 for Maintainability, Correctness, Governance, Reproducibility.
+   - Keep notes evidence-linked; avoid intuition-only scoring.
+
+5. **Close with reusable factory deltas**
+   - Prefer wording that future contributors can apply as a pattern.
+   - If no durable delta exists, state that explicitly.
+
+### Exhibit Acceptance Checklist
+
+An exhibit is ready when all checks pass:
+
+- [ ] **One-line proof claim** is specific and falsifiable.
+- [ ] **Review map** names the highest-impact files/components.
+- [ ] **Proof bundle** includes reproducible receipts (commands + outcomes).
+- [ ] **Scar story** includes wrongness and prevention (or clearly says N/A).
+- [ ] **Quality deltas** are scored for all four surfaces with notes.
+- [ ] **Budget row** includes provenance fields (`kind`, `coverage`, `confidence`).
+- [ ] **Dossier link** exists in `forensics/` and resolves correctly.
+
+---
+
 ## Exhibits
 
 ### Exhibit 1: Semantic Analyzer Phase 1 (Issue #188 → PRs #231/232/234)

--- a/docs/project/CASEBOOK.md
+++ b/docs/project/CASEBOOK.md
@@ -28,6 +28,46 @@ Each exhibit shows:
 
 ---
 
+## Storybooking Workflow
+
+Use this lightweight workflow when turning raw PR history into a high-signal casebook exhibit:
+
+1. **Select the right PR**
+   - Prefer PRs with clear user-visible impact or architecture change.
+   - Skip mechanical-only PRs unless they establish a reusable governance pattern.
+
+2. **Gather receipts first (before writing narrative)**
+   - Capture exact commands and outputs (`cargo test`, `just ci-gate`, benchmarks, ignored-test deltas).
+   - Record before/after numbers with units and source.
+
+3. **Write the scar story as a causal chain**
+   - `Wrong` → concrete failure mode.
+   - `Caught` → detector (mutation test, CI failure, protocol test, review finding).
+   - `Fix` → code or architecture intervention.
+   - `Prevention` → reusable guardrail (test, lint, checklist, gate).
+
+4. **Score quality surfaces explicitly**
+   - Assign +2/+1/0/-1/-2 for Maintainability, Correctness, Governance, Reproducibility.
+   - Keep notes evidence-linked; avoid intuition-only scoring.
+
+5. **Close with reusable factory deltas**
+   - Prefer wording that future contributors can apply as a pattern.
+   - If no durable delta exists, state that explicitly.
+
+### Exhibit Acceptance Checklist
+
+An exhibit is ready when all checks pass:
+
+- [ ] **One-line proof claim** is specific and falsifiable.
+- [ ] **Review map** names the highest-impact files/components.
+- [ ] **Proof bundle** includes reproducible receipts (commands + outcomes).
+- [ ] **Scar story** includes wrongness and prevention (or clearly says N/A).
+- [ ] **Quality deltas** are scored for all four surfaces with notes.
+- [ ] **Budget row** includes provenance fields (`kind`, `coverage`, `confidence`).
+- [ ] **Dossier link** exists in `forensics/` and resolves correctly.
+
+---
+
 ## Exhibits
 
 ### Exhibit 1: Semantic Analyzer Phase 1 (Issue #188 → PRs #231/232/234)


### PR DESCRIPTION
### Motivation
- Make the casebook authoring process explicit and reproducible by giving contributors a lightweight, evidence-first workflow for turning PR history into high-signal exhibits.

### Description
- Add a new `Storybooking Workflow` section plus an `Exhibit Acceptance Checklist` to `docs/project/CASEBOOK.md` and the mirrored `book/src/process/casebook.md`, documenting steps for selecting PRs, gathering receipts, writing scar stories, scoring quality surfaces, and capturing reusable factory deltas.

### Testing
- No code tests required for this documentation-only change; validation was automated by verifying the two files are identical with `cmp -s docs/project/CASEBOOK.md book/src/process/casebook.md` and recording the commit `a9acbac` after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21906abe0833382d6b3df07975ede)