### PR TITLE
docs(book): add Storybooking Playbook to Casebook and link from Introduction

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -64,6 +64,7 @@ This documentation is organized to serve different audiences:
 - **Developers**: Understand the architecture and contribute to the project
 - **LSP Implementers**: Dive deep into the LSP provider system and protocols
 - **Quality Engineers**: Explore testing, benchmarking, and CI infrastructure
+- **Maintainers**: Use process guides such as [Casebook](./process/casebook.md) to capture end-to-end user journeys
 
 ## Documentation Structure
 

--- a/book/src/process/casebook.md
+++ b/book/src/process/casebook.md
@@ -28,6 +28,44 @@ Each exhibit shows:
 
 ---
 
+
+## Storybooking Playbook
+
+To improve storybooking quality, treat each exhibit as a reusable end-to-end story that can be re-run by reviewers and CI.
+
+### Story template
+
+Each story should include:
+
+1. **Goal** - the user or maintainer outcome.
+2. **Trigger** - exact action taken (command, editor action, or request type).
+3. **Expected behavior** - parser/LSP/DAP outcome in observable terms.
+4. **Failure signals** - diagnostics, logs, or protocol symptoms that indicate regressions.
+5. **Validation** - tests and commands that prove the story still works.
+
+### Example story skeleton
+
+```text
+Story: Safe symbol rename across workspace
+Goal: Rename a symbol without missing qualified/bare references
+Trigger: textDocument/rename on a cross-file symbol
+Expected behavior: all intended references updated; no unrelated edits
+Failure signals: unresolved references, parse diagnostics spike, incorrect workspace edits
+Validation: targeted rename tests + workspace smoke checks
+```
+
+### Story quality checklist
+
+- **Task-oriented:** describes what a user is trying to achieve.
+- **Observable:** names concrete success/failure signals.
+- **Repeatable:** can be executed by another engineer without hidden context.
+- **Scoped:** narrow enough that failures are actionable.
+- **Traceable:** linked to a PR, issue, and proof bundle in this casebook.
+
+Use this playbook when adding new exhibits so the casebook doubles as a high-signal regression narrative, not just a historical record.
+
+---
+
 ## Exhibits
 
 ### Exhibit 1: Semantic Analyzer Phase 1 (Issue #188 → PRs #231/232/234)


### PR DESCRIPTION
### Motivation

- Make the Casebook actionable by turning exhibits into reusable end-to-end stories that reviewers and CI can re-run. 
- Provide a simple, consistent template so story entries are observable, repeatable, and narrow enough to produce actionable failures. 
- Surface this guidance to maintainers via the main documentation so process-level storytelling is discoverable.

### Description

- Add a `Storybooking Playbook` section to `book/src/process/casebook.md` that includes a practical story template (Goal / Trigger / Expected behavior / Failure signals / Validation). 
- Include an example end-to-end story skeleton (`Safe symbol rename across workspace`) and a story quality checklist to guide authors. 
- Update `book/src/introduction.md` to direct maintainers to the Casebook for end-to-end journey and story guidance. 
- This is documentation-only and does not change runtime behavior.

### Testing

- Ran formatting check with `cargo fmt --all -- --check`, which succeeded. 
- Attempted to build the book with `mdbook build book`, but `mdbook` is not installed in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21906abe0833382d6b3df07975ede)