### PR TITLE
Fix parsing of arrow-brace hash deref and indirect-call heuristic; add tie regression tests

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -110,8 +110,9 @@ impl<'a> Parser<'a> {
 
         // AC1: General indirect method call heuristic: method $object
         // Lowercase identifier followed by a sigiled variable ($x, @arr, %hash)
-        if name.chars().next().is_some_and(|c| c.is_lowercase()) 
-           && !matches!(name, "tie" | "untie") 
+        if name.chars().next().is_some_and(|c| c.is_lowercase())
+            && !Self::is_builtin_function(name)
+            && !Self::is_keyword_handled_builtin(name)
         {
             if let Ok(next) = self.tokens.peek_second() {
                 let next_text = &next.text;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -173,6 +173,25 @@ impl<'a> Parser<'a> {
                             );
                         }
 
+                        Some(TokenKind::LeftBrace) => {
+                            // Hash dereference key access: $ref->{$key}
+                            self.tokens.next()?; // consume {
+                            let key = self.parse_expression()?;
+                            self.expect(TokenKind::RightBrace)?;
+
+                            let start = expr.location.start;
+                            let end = self.previous_position();
+
+                            expr = Node::new(
+                                NodeKind::Binary {
+                                    op: "->{}".to_string(),
+                                    left: Box::new(expr),
+                                    right: Box::new(key),
+                                },
+                                SourceLocation { start, end },
+                            );
+                        }
+
                         _ => {
                             // Just the arrow by itself - could be an error or incomplete
                             // For now, we'll leave expr unchanged

--- a/crates/perl-parser/tests/parser_tie_interface_tests.rs
+++ b/crates/perl-parser/tests/parser_tie_interface_tests.rs
@@ -158,6 +158,55 @@ tie my %hash, 'Tie::StdHash';
 }
 
 #[test]
+fn parser_tie_our_declaration_no_recovery() {
+    let code = r#"tie our %config, 'Config::Tie';"#;
+    let mut parser = Parser::new(code);
+    let output = parser.parse_with_recovery();
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "Expected clean parse for tie+our declaration, diagnostics: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn parser_tie_local_special_variable_no_recovery() {
+    let code = r#"tie local $/, 'Tie::Scalar', \$custom_rs;"#;
+    let mut parser = Parser::new(code);
+    let output = parser.parse_with_recovery();
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "Expected clean parse for tie+local special variable, diagnostics: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn parser_hash_deref_delete_exists_no_recovery() {
+    let code = r#"
+sub DELETE {
+    my ($self, $key) = @_;
+    delete $self->{$key};
+}
+
+sub EXISTS {
+    my ($self, $key) = @_;
+    return exists $self->{$key};
+}
+"#;
+    let mut parser = Parser::new(code);
+    let output = parser.parse_with_recovery();
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "Expected clean parse for hash deref delete/exists, diagnostics: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn parser_tie_with_usage() {
     let code = r#"
 tie my %cache, 'Tie::StdHash';


### PR DESCRIPTION
### Motivation

- Real-world corpus cases (tie interface methods and class-style access) produced recovery diagnostics for expressions like `delete $self->{$key}` and made some `untie` cases fragile due to an overly-aggressive indirect-call heuristic.
- The parser needed explicit handling for arrow+brace hash dereference (`$ref->{$key}`) and a safer indirect-call check to avoid misclassifying builtin/keyword-handled names as indirect calls.

### Description

- Adjust indirect-call heuristic in `calls.rs` so lowercase identifiers are not treated as indirect calls when they are builtin functions or keyword-handled builtins by adding checks with `Self::is_builtin_function(name)` and `Self::is_keyword_handled_builtin(name)`. (`crates/perl-parser-core/src/engine/parser/expressions/calls.rs`)
- Add explicit postfix parsing for arrow+brace hash-dereference access to produce a structured `Binary` node with `op: "->{}"` instead of leaving the arrow unhandled. (`crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`)
- Add focused regression tests exercising real-world tie-interface patterns to lock the fix: `tie our %config, ...`, `tie local $/, ...`, and `delete/exists $self->{$key}` inside `DELETE`/`EXISTS`. (`crates/perl-parser/tests/parser_tie_interface_tests.rs`)

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser --test parser_tie_interface_tests -- --nocapture`, and all tests in that suite passed (29 passed, 0 failed).
- Ran corpus coverage test `cargo test -p perl-parser --test corpus_nodekind_coverage_test test_corpus_nodekind_coverage -- --nocapture`, which passed and reported improved corpus parsing (informational `INFO`/`WARN` output as part of the test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c53d16c8333ad0f61775eb3d1a2)