### PR TITLE
Fix qualified `new` indirect constructor parsing

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -10,7 +10,7 @@ impl<'a> Parser<'a> {
     fn is_indirect_call_pattern(&mut self, name: &str) -> bool {
         // Only check for indirect objects at statement start to avoid false positives
         // in contexts like: my $x = 1; if (1) { print $x; }
-        if !self.at_stmt_start {
+        if !self.at_stmt_start && name != "new" {
             return false;
         }
 

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -417,6 +417,42 @@ impl<'a> Parser<'a> {
                                 SourceLocation { start, end },
                             ))
                         }
+                        "new" => {
+                            let new_token = self.tokens.next()?;
+                            let start = new_token.start;
+
+                            // Constructor target can be qualified (e.g. IO::Handle)
+                            let object = Box::new(self.parse_qualified_identifier()?);
+                            let mut args = Vec::new();
+
+                            // In expression context, stop at common delimiters to avoid
+                            // consuming surrounding list/argument separators.
+                            while !self.tokens.is_eof()
+                                && !matches!(
+                                    self.peek_kind(),
+                                    Some(
+                                        TokenKind::Semicolon
+                                            | TokenKind::RightParen
+                                            | TokenKind::RightBracket
+                                            | TokenKind::RightBrace
+                                            | TokenKind::Comma
+                                            | TokenKind::FatArrow
+                                    )
+                                )
+                            {
+                                args.push(self.parse_assignment()?);
+                            }
+
+                            let end = self.previous_position();
+                            Ok(Node::new(
+                                NodeKind::IndirectCall {
+                                    method: String::from("new"),
+                                    object,
+                                    args,
+                                },
+                                SourceLocation { start, end },
+                            ))
+                        }
                         _ => {
                             // Regular identifier (possibly qualified with ::)
                             self.parse_qualified_identifier()

--- a/crates/perl-parser/tests/parser_regressions.rs
+++ b/crates/perl-parser/tests/parser_regressions.rs
@@ -120,6 +120,21 @@ fn new_constructor_pattern() {
 }
 
 #[test]
+fn new_qualified_constructor_indirect_call() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"my $obj = new IO::Handle $fh;"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let sexp = ast.to_sexp();
+
+    assert!(
+        sexp.contains("indirect_call"),
+        "qualified constructor should parse as indirect call: {sexp}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn statement_modifier_inside_block_if() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
     {


### PR DESCRIPTION
### Motivation
- The parser was splitting qualified constructor expressions like `my $obj = new IO::Handle $fh;` into separate identifiers instead of recognizing them as indirect constructor calls, causing incorrect ASTs for real-world Perl code.

### Description
- Allow `new` to be considered for indirect-call detection even when not at statement start by adjusting `is_indirect_call_pattern` in `expressions/calls.rs`.
- Add expression-context handling for `new` in `expressions/primary.rs` so `new Foo::Bar ...` parses as `NodeKind::IndirectCall { method: "new", object, args }` with support for qualified targets and safe argument termination.
- Add a regression test `new_qualified_constructor_indirect_call` to `crates/perl-parser/tests/parser_regressions.rs` that asserts `my $obj = new IO::Handle $fh;` yields an `indirect_call` node.
- Run `cargo fmt --all` to keep formatting consistent.

### Testing
- Ran `cargo test -p perl-parser --test parser_regressions -- --nocapture` and all tests passed, including the new regression test (`new_qualified_constructor_indirect_call`).
- Ran `cargo test -p perl-parser --test corpus_gap_tests -- --nocapture` and the corpus gap suite passed successfully.
- Executed the single-test run `cargo test -p perl-parser --test parser_regressions new_qualified_constructor_indirect_call -- --nocapture` which passed.
- Ran `cargo fmt --all` with no formatting errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c53d16c8333ad0f61775eb3d1a2)