### PR TITLE
test(parser-core): add regression coverage for real-world `tie local $/` parsing

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/tie_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tie_tests.rs
@@ -313,4 +313,45 @@ mod tests {
             assert!(!statements.is_empty(), "tie with local should parse");
         }
     }
+
+    #[test]
+    fn test_tie_with_local_special_var_and_arg() {
+        // Real-world pattern from corpus: tie the input record separator.
+        let source = "tie local $/, 'Tie::Scalar', \\$custom_rs;";
+        let ast_opt = parse_code(source);
+        assert!(ast_opt.is_some());
+        let ast = ast_opt.unwrap_or_else(|| {
+            Node::new(NodeKind::UnknownRest, SourceLocation { start: 0, end: 0 })
+        });
+        if let NodeKind::Program { statements } = &ast.kind {
+            let stmt = &statements[0];
+            if let NodeKind::ExpressionStatement { expression } = &stmt.kind {
+                if let NodeKind::Tie { variable, package, args } = &expression.kind {
+                    if let NodeKind::VariableDeclaration { declarator, variable: inner, .. } =
+                        &variable.kind
+                    {
+                        assert_eq!(declarator, "local");
+                        if let NodeKind::Variable { sigil, name } = &inner.kind {
+                            assert_eq!(sigil, "$");
+                            assert_eq!(name, "/");
+                        } else {
+                            unreachable!("Expected inner Variable, got {:?}", inner.kind);
+                        }
+                    } else {
+                        unreachable!("Expected VariableDeclaration, got {:?}", variable.kind);
+                    }
+                    if let NodeKind::String { value, .. } = &package.kind {
+                        assert!(value.contains("Tie::Scalar"));
+                    } else {
+                        unreachable!("Expected String package, got {:?}", package.kind);
+                    }
+                    assert_eq!(args.len(), 1);
+                } else {
+                    unreachable!("Expected Tie node, got {:?}", expression.kind);
+                }
+            } else {
+                unreachable!("Expected ExpressionStatement, got {:?}", stmt.kind);
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- NodeKind coverage showed `Tie`/`Untie` as fragile/recovery-only and the corpus contains a real-world pattern `tie local $/, 'Tie::Scalar', \$custom_rs;` that should be locked down to prevent silent regressions.

### Description
- Added a regression test `test_tie_with_local_special_var_and_arg` in `crates/perl-parser-core/src/engine/parser/tie_tests.rs` that parses `tie local $/, 'Tie::Scalar', \$custom_rs;` and asserts the structure is a `NodeKind::Tie` with a `local` `VariableDeclaration`, an inner variable `$/`, a `Tie::Scalar` package string, and one argument.
- Made the `VariableDeclaration` destructuring robust for compilation by using `..` to ignore extra fields when matching the node.

### Testing
- Ran `cargo test -p perl-parser-core tie_tests -- --nocapture` and all tests passed. 
- Ran `cargo test -p perl-parser --test corpus_gap_tests test_tie_interface -- --nocapture` and the related corpus test passed. 
- Ran `cargo test -p perl-parser --test corpus_nodekind_coverage_test -- --nocapture` to validate nodekind coverage and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c53d16c8333ad0f61775eb3d1a2)