### PR TITLE
Add CPAN distribution tooling real-world corpus fixture and parser test

### DIFF
--- a/crates/perl-parser/tests/corpus_gap_tests.rs
+++ b/crates/perl-parser/tests/corpus_gap_tests.rs
@@ -137,6 +137,11 @@ mod corpus_gap_tests {
         test_corpus_file("tie_interface.pl")
     }
 
+    #[test]
+    fn test_real_world_cpan_distribution_tooling() -> Result<(), Box<dyn std::error::Error>> {
+        test_corpus_file("real_world/cpan_distribution_tooling.pl")
+    }
+
     /// Regression: anonymous sub as expression initializer (`my $c = sub { 1 };`)
     /// must produce a subroutine node inside the initializer (locks down peek_second() fix).
     #[test]

--- a/test_corpus/README.md
+++ b/test_corpus/README.md
@@ -23,6 +23,10 @@ This directory contains test files that cover gaps in the original test corpus. 
 12. **tie_interface.pl** - Tie/untie interface coverage for scalars, arrays, hashes, handles
 13. **parser_stress_cases.pl** - Ambiguity and boundedness cases (slash vs regex, hash vs block, indirect objects, deep nesting, complex delimiters, multiple heredocs)
 
+### Real-World Corpus Fixtures
+
+14. **real_world/cpan_distribution_tooling.pl** - CPAN packaging and installer tooling patterns (WriteMakefile metadata, dynamic prereq probing, MY::postamble hooks)
+
 ## Running Tests
 
 ```bash

--- a/test_corpus/real_world/cpan_distribution_tooling.pl
+++ b/test_corpus/real_world/cpan_distribution_tooling.pl
@@ -1,0 +1,177 @@
+#!/usr/bin/env perl
+# CPAN Distribution Tooling Patterns - Makefile.PL / Build.PL / dzil-style hooks
+# Real-world style fixture covering installer metadata, version probing, and toolchain hooks.
+
+use strict;
+use warnings;
+use 5.014;
+
+package Local::Toolchain::Probe;
+
+use Config;
+use ExtUtils::MakeMaker;
+use File::Spec;
+use File::Basename qw(dirname);
+use JSON::PP qw(encode_json decode_json);
+
+our $VERSION = '0.001';
+
+my %meta_merge = (
+    resources => {
+        repository => {
+            type => 'git',
+            url  => 'https://example.invalid/repo.git',
+            web  => 'https://example.invalid/repo',
+        },
+        bugtracker => {
+            web => 'https://example.invalid/repo/issues',
+        },
+    },
+    no_index => {
+        directory => [qw(t xt inc maint)],
+    },
+);
+
+my %fallback_prereqs = (
+    'JSON::PP' => '2.97001',
+    'Try::Tiny' => '0.30',
+    'Path::Tiny' => '0.118',
+);
+
+my %suggested_features = (
+    dev => {
+        description => 'Developer tooling and lint commands',
+        prereqs => {
+            'Perl::Critic' => '1.150',
+            'Perl::Tidy' => '20240202',
+        },
+    },
+    coverage => {
+        description => 'Coverage reports in CI',
+        prereqs => {
+            'Devel::Cover' => '1.40',
+        },
+    },
+);
+
+sub _probe_prereq {
+    my ($module, $minimum) = @_;
+    my $ok = eval "use $module $minimum (); 1";
+    return $ok ? 1 : 0;
+}
+
+sub _collect_missing {
+    my (%spec) = @_;
+    my @missing;
+
+    for my $module (sort keys %spec) {
+        my $minimum = $spec{$module};
+        push @missing, "$module >= $minimum" unless _probe_prereq($module, $minimum);
+    }
+
+    return @missing;
+}
+
+sub _dynamic_prereqs {
+    my %dynamic = (
+        'Module::Metadata' => '1.000038',
+    );
+
+    if ($^O eq 'MSWin32') {
+        $dynamic{'Win32::Console::ANSI'} = '1.10';
+    } elsif ($^O =~ /darwin|linux/) {
+        $dynamic{'IO::Pty'} = '1.17';
+    }
+
+    return %dynamic;
+}
+
+sub _load_optional_config {
+    my $path = File::Spec->catfile(dirname(__FILE__), 'dist.config.json');
+    return {} unless -f $path;
+
+    open my $fh, '<', $path or die "Cannot read $path: $!";
+    local $/;
+    my $json = <$fh>;
+    close $fh;
+
+    return decode_json($json);
+}
+
+sub _emit_build_snapshot {
+    my (%args) = @_;
+    my $snapshot = {
+        perl => $],
+        archname => $Config{archname},
+        osname => $Config{osname},
+        cc => $Config{cc},
+        config_args => \%args,
+        generated_at => scalar gmtime,
+    };
+
+    my $target = File::Spec->catfile('maint', 'build-snapshot.json');
+    if (open my $out, '>', $target) {
+        print {$out} encode_json($snapshot);
+        close $out;
+    }
+}
+
+my %dynamic_prereqs = _dynamic_prereqs();
+my %all_prereqs = (%fallback_prereqs, %dynamic_prereqs);
+my @missing = _collect_missing(%all_prereqs);
+my $optional_config = _load_optional_config();
+
+warn "Optional prerequisites missing: @missing\n" if @missing;
+
+my %write_makefile_args = (
+    NAME => 'Local::Toolchain::Probe',
+    VERSION_FROM => 'lib/Local/Toolchain/Probe.pm',
+    ABSTRACT_FROM => 'lib/Local/Toolchain/Probe.pm',
+    LICENSE => 'perl',
+    EXE_FILES => [qw(script/toolchain-probe script/toolchain-report)],
+    PREREQ_PM => \%all_prereqs,
+    MIN_PERL_VERSION => '5.014',
+    META_MERGE => \%meta_merge,
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker' => '7.70',
+        'JSON::PP' => '2.97001',
+    },
+    TEST_REQUIRES => {
+        'Test2::V0' => '0.000145',
+        'Test::Warnings' => '0.038',
+    },
+    ($optional_config->{extra_makefile} ? %{$optional_config->{extra_makefile}} : ()),
+);
+
+if (@missing) {
+    $write_makefile_args{PREREQ_FATAL} = 0;
+    $write_makefile_args{realclean}{FILES} = 'MYMETA.*';
+}
+
+_write_feature_comments(%suggested_features);
+_emit_build_snapshot(%write_makefile_args);
+WriteMakefile(%write_makefile_args);
+
+sub MY::postamble {
+    return <<'POSTAMBLE';
+cover ::
+	$(FULLPERLRUN) -MDevel::Cover -Ilib -It/lib -e "do './t/author/coverage.t'"
+
+lint ::
+	$(FULLPERLRUN) -Mstrict -Mwarnings -e "print qq{lint ok\\n}"
+POSTAMBLE
+}
+
+sub _write_feature_comments {
+    my (%features) = @_;
+
+    for my $name (sort keys %features) {
+        my $entry = $features{$name};
+        my $desc  = $entry->{description} // 'no description';
+        my @mods  = sort keys %{$entry->{prereqs} || {}};
+
+        printf "# feature=%s desc=%s modules=%s\n", $name, $desc, join(',', @mods);
+    }
+}
+
+1;


### PR DESCRIPTION
### Motivation
- Improve real-world Perl corpus coverage by adding packaging/toolchain patterns that were missing from the gap fixtures. 
- Provide coverage for common CPAN constructs used in Makefile.PL/Build.PL workflows so the parser is validated against realistic installer metadata and build hooks. 

### Description
- Add a new fixture `test_corpus/real_world/cpan_distribution_tooling.pl` modeling `WriteMakefile` metadata, dynamic prerequisite probing, optional JSON config loading, and `MY::postamble` hooks. 
- Register the new fixture in `test_corpus/README.md` under a new "Real-World Corpus Fixtures" section. 
- Add a targeted parser regression test `test_real_world_cpan_distribution_tooling` to `crates/perl-parser/tests/corpus_gap_tests.rs` that verifies the fixture parses without error. 

### Testing
- Ran `cargo test -p perl-parser test_real_world_cpan_distribution_tooling` and the new test passed. 
- Ran `cargo test -p perl-parser corpus_gap_tests` and the suite completed with the new fixture test included and passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c6be4288333979c0781c80aedaf)