### PR TITLE
Add real-world CPAN corpus fixture and parser test

### DIFF
--- a/crates/perl-parser/tests/corpus_gap_tests.rs
+++ b/crates/perl-parser/tests/corpus_gap_tests.rs
@@ -137,6 +137,11 @@ mod corpus_gap_tests {
         test_corpus_file("tie_interface.pl")
     }
 
+    #[test]
+    fn test_real_world_cpan_patterns() -> Result<(), Box<dyn std::error::Error>> {
+        test_corpus_file("real_world_cpan_patterns.pl")
+    }
+
     /// Regression: anonymous sub as expression initializer (`my $c = sub { 1 };`)
     /// must produce a subroutine node inside the initializer (locks down peek_second() fix).
     #[test]

--- a/test_corpus/README.md
+++ b/test_corpus/README.md
@@ -22,6 +22,7 @@ This directory contains test files that cover gaps in the original test corpus. 
 11. **glob_expressions.pl** - Glob operators and angle bracket patterns
 12. **tie_interface.pl** - Tie/untie interface coverage for scalars, arrays, hashes, handles
 13. **parser_stress_cases.pl** - Ambiguity and boundedness cases (slash vs regex, hash vs block, indirect objects, deep nesting, complex delimiters, multiple heredocs)
+14. **real_world_cpan_patterns.pl** - Real CPAN idioms (Moo attributes, DBI transactions, Try::Tiny error handling, Mojolicious routes/hooks)
 
 ## Running Tests
 

--- a/test_corpus/real_world_cpan_patterns.pl
+++ b/test_corpus/real_world_cpan_patterns.pl
@@ -1,0 +1,176 @@
+#!/usr/bin/env perl
+use v5.24;
+use strict;
+use warnings;
+
+# Real-world CPAN ecosystem patterns collected from common production styles.
+# Exercises DSL-like APIs, method chaining, callback-heavy code, and pragma blocks.
+
+package MyApp::Model::User {
+    use Moo;
+    use Types::Standard qw(Str Int Maybe HashRef ArrayRef);
+    use namespace::clean;
+
+    has id => (
+        is       => 'ro',
+        isa      => Int,
+        required => 1,
+    );
+
+    has email => (
+        is       => 'rw',
+        isa      => Str,
+        required => 1,
+    );
+
+    has profile => (
+        is      => 'rw',
+        isa     => HashRef,
+        default => sub { +{} },
+    );
+
+    has roles => (
+        is      => 'rw',
+        isa     => ArrayRef[Str],
+        default => sub { ['user'] },
+    );
+
+    sub add_role ($self, $role) {
+        push @{ $self->roles }, $role if defined $role && length $role;
+        return $self;
+    }
+
+    sub as_hashref ($self) {
+        return {
+            id      => $self->id,
+            email   => $self->email,
+            profile => { %{ $self->profile } },
+            roles   => [ @{ $self->roles } ],
+        };
+    }
+}
+
+package MyApp::Service::UserRepo {
+    use DBI;
+    use Try::Tiny;
+    use Scalar::Util qw(blessed);
+
+    sub new ($class, %args) {
+        my $dsn  = $args{dsn}  // 'dbi:SQLite:dbname=:memory:';
+        my $user = $args{user} // q{};
+        my $pass = $args{pass} // q{};
+
+        my $dbh = DBI->connect(
+            $dsn,
+            $user,
+            $pass,
+            {
+                RaiseError => 1,
+                AutoCommit => 1,
+                PrintError => 0,
+            },
+        );
+
+        return bless { dbh => $dbh }, $class;
+    }
+
+    sub find_user_by_email ($self, $email) {
+        my $sql = q{
+            SELECT id, email
+            FROM users
+            WHERE email = ?
+            LIMIT 1
+        };
+
+        my $row = $self->{dbh}->selectrow_hashref($sql, undef, $email);
+        return unless $row;
+
+        return MyApp::Model::User->new(
+            id      => $row->{id},
+            email   => $row->{email},
+            profile => {},
+        );
+    }
+
+    sub with_transaction ($self, $callback) {
+        my $dbh = $self->{dbh};
+        $dbh->begin_work;
+
+        my $result;
+        try {
+            $result = $callback->($dbh);
+            $dbh->commit;
+        }
+        catch {
+            my $err = $_;
+            try { $dbh->rollback }
+            catch { warn "rollback failed: $_" };
+            die $err;
+        };
+
+        return $result;
+    }
+
+    sub describe_value ($self, $value) {
+        return 'undef' unless defined $value;
+        return 'object(' . blessed($value) . ')' if blessed $value;
+        return 'scalar(' . $value . ')';
+    }
+}
+
+package MyApp::Web {
+    use Mojolicious::Lite -signatures;
+
+    helper json_ok => sub ($c, $payload) {
+        $c->res->headers->content_type('application/json');
+        return $c->render(json => { ok => 1, %{$payload // {}} });
+    };
+
+    any [qw(GET POST)] => '/api/users/:id' => sub ($c) {
+        my $id = $c->param('id');
+        state $cache = {};
+
+        if (my $cached = $cache->{$id}) {
+            return $c->json_ok({ source => 'cache', user => $cached });
+        }
+
+        my $user = {
+            id    => $id + 0,
+            email => sprintf('user%s@example.test', $id),
+            tags  => [grep { defined } qw(active beta)],
+        };
+
+        $cache->{$id} = $user;
+        return $c->json_ok({ source => 'computed', user => $user });
+    };
+
+    app->hook(before_dispatch => sub ($c) {
+        $c->stash(started_at => time);
+    });
+
+    app->hook(after_dispatch => sub ($c) {
+        my $elapsed = time - ($c->stash('started_at') // time);
+        $c->res->headers->header('X-Elapsed' => $elapsed);
+    });
+}
+
+package main;
+
+sub build_pipeline ($input) {
+    my $step = sub ($v, $name) { +{ name => $name, value => $v } };
+
+    return $step->(
+        [
+            map { $_->{value} * 2 }
+            grep { $_->{value} % 2 == 0 }
+            map { $step->($_, 'stage_' . $_) }
+            @{ $input // [] }
+        ],
+        'done'
+    );
+}
+
+my $pipeline = build_pipeline([ 1 .. 10 ]);
+print $pipeline->{name}, "\n" if $pipeline->{name} eq 'done';
+
+1;


### PR DESCRIPTION
### Motivation

- Improve real-world Perl corpus coverage by adding representative CPAN-style code paths (Moo/Types, DBI, Try::Tiny, Mojolicious, callback-heavy pipelines) so the parser and LSP/DAP tooling are exercised against common production idioms.

### Description

- Add `test_corpus/real_world_cpan_patterns.pl` containing realistic CPAN ecosystem patterns (Moo attributes, `Types::Standard`, DBI transactions with `Try::Tiny`, Mojolicious::Lite routes/hooks, and pipeline-style `map`/`grep` usage). 
- Register an explicit regression test `test_real_world_cpan_patterns` in `crates/perl-parser/tests/corpus_gap_tests.rs` that parses the new fixture.
- Update `test_corpus/README.md` to document the new corpus file in the gap coverage list.

### Testing

- Ran `cargo test -p perl-parser test_real_world_cpan_patterns -- --test-threads=1` and the test passed.
- Ran `cargo test -p perl-parser corpus_gap_tests::test_all_corpus_files -- --test-threads=1` which parsed all discovered `.pl` corpus files successfully.
- No new test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c6be4288333979c0781c80aedaf)