### PR TITLE
parser: accept non-UTF8 source in perl-parse CLI

### DIFF
--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -290,11 +290,25 @@ fn main() {
 
 fn read_input(input: &Input) -> io::Result<String> {
     match input {
-        Input::File(path) => fs::read_to_string(path),
+        Input::File(path) => read_source_bytes(fs::read(path)?),
         Input::Stdin => {
-            let mut buffer = String::new();
-            io::stdin().read_to_string(&mut buffer)?;
-            Ok(buffer)
+            let mut buffer = Vec::new();
+            io::stdin().read_to_end(&mut buffer)?;
+            read_source_bytes(buffer)
+        }
+    }
+}
+
+fn read_source_bytes(bytes: Vec<u8>) -> io::Result<String> {
+    match String::from_utf8(bytes) {
+        Ok(source) => Ok(source),
+        Err(err) => {
+            let raw = err.into_bytes();
+            let mut decoded = String::with_capacity(raw.len());
+            for byte in raw {
+                decoded.push(char::from(byte));
+            }
+            Ok(decoded)
         }
     }
 }
@@ -400,5 +414,25 @@ fn print_error_context(source: &str, position: usize, stderr: &mut io::Stderr) {
         if line_num < lines.len() {
             writeln!(stderr, "  {} | {}", line_num + 1, lines[line_num]).ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_source_bytes;
+
+    #[test]
+    fn read_source_bytes_preserves_utf8() -> Result<(), Box<dyn std::error::Error>> {
+        let decoded = read_source_bytes(b"use strict;\n".to_vec())?;
+        assert_eq!(decoded, "use strict;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn read_source_bytes_decodes_latin1_losslessly() -> Result<(), Box<dyn std::error::Error>> {
+        // "Sår" in ISO-8859-1 bytes
+        let decoded = read_source_bytes(vec![0x53, 0xE5, 0x72, 0x0A])?;
+        assert_eq!(decoded, "Sår\n");
+        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation
- The `perl-parse` CLI aborted early when encountering non-UTF-8 source files (common in older CPAN/system modules), preventing the parser from running on real-world inputs. 
- Allowing byte-oriented input and a safe fallback decode enables testing/validation against legacy Perl sources without changing parser internals.

### Description
- `read_input` now reads raw bytes for both file and stdin paths and delegates decoding to a new `read_source_bytes` helper in `crates/perl-parser/src/bin/perl-parse.rs`.
- Added `read_source_bytes` which first attempts `String::from_utf8` and falls back to a lossless byte->char mapping to preserve legacy single-byte encodings.
- Updated the CLI code paths to use byte reads (`fs::read` / `io::stdin().read_to_end`) so parsing proceeds even for non-UTF8 files.
- Added unit tests for the decoding helper to verify UTF-8 preservation and ISO-8859-1 (Latin-1) decoding behavior.

### Testing
- Ran formatting: `cargo fmt --all` (succeeded).
- Ran unit tests for the CLI: `cargo test -p perl-parser --features cli --bin perl-parse` and the new tests passed (`2 passed`).
- Ran corpus checks: `cargo test -p perl-parser --test corpus_gap_tests` and the suite passed (`15 passed`).
- Built CLI and validated parsing a real-world CPAN file with non-UTF8 bytes: `cargo build -p perl-parser --features cli --bin perl-parse && target/debug/perl-parse -q /usr/share/perl5/Date/Language/Swedish.pm` (now succeeds).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21bfdc77c83339e53a06e6b9314ff)