### PR TITLE
Auto-quote bareword keys before fat-arrow in call argument parsing; add tests for hash-style callback args

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -200,8 +200,36 @@ impl<'a> Parser<'a> {
             let mut args = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightParen) && !s.tokens.is_eof() {
-                // Use parse_assignment instead of parse_expression to avoid comma operator handling
-                let mut arg = s.parse_assignment()?;
+                // For fat-arrow pairs, Perl auto-quotes bareword keys, including keywords
+                // like `close => sub { ... }`. Parsing those as expressions can fail because
+                // keyword tokens are not valid expression starters in this position.
+                let mut arg = if s.tokens.peek_second().map(|t| t.kind) == Ok(TokenKind::FatArrow)
+                {
+                    let token = s.tokens.peek()?.clone();
+                    if token
+                        .text
+                        .as_bytes()
+                        .first()
+                        .is_some_and(|b| *b == b'_' || b.is_ascii_alphabetic())
+                    {
+                        s.consume_token()?;
+                        Node::new(
+                            NodeKind::String {
+                                value: token.text.to_string(),
+                                interpolated: false,
+                            },
+                            SourceLocation { start: token.start, end: token.end },
+                        )
+                    } else {
+                        // Use parse_assignment instead of parse_expression to avoid comma
+                        // operator handling.
+                        s.parse_assignment()?
+                    }
+                } else {
+                    // Use parse_assignment instead of parse_expression to avoid comma
+                    // operator handling.
+                    s.parse_assignment()?
+                };
 
                 // Check for fat arrow after the argument
                 // If we see =>, the argument should be auto-quoted if it's a bare identifier

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -226,6 +226,31 @@ fn test_unicode_property_complexity() {
 }
 
 #[test]
+fn test_hash_style_callback_args_in_parenthesized_call() {
+    let mut parser = Parser::new("$handle->on(close => sub { 1; });");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse callback args with fat arrow");
+    assert!(
+        parser.errors().is_empty(),
+        "Expected no parse recovery errors, got: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
+fn test_hash_style_callback_args_with_keyword_keys() {
+    let mut parser =
+        Parser::new("$self->emit(unless => sub { 1; }, close => sub { 2; }, read => sub { 3; });");
+    let result = parser.parse();
+    assert!(result.is_ok(), "Failed to parse keyword-like fat-arrow keys");
+    assert!(
+        parser.errors().is_empty(),
+        "Expected no parse recovery errors, got: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
 fn test_deep_nesting_stack_overflow() {
     // Issue #423: Deep nesting stack overflow
     // Nested if statements


### PR DESCRIPTION
### Motivation

- Fix parse failures when a parenthesized call contains hash-style callback args using a fat arrow where the key is a bareword (including keyword-like names such as `close`, `read`, `unless`).

### Description

- Update `parse_args` in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs` to detect a bareword followed by `=>` and auto-quote it into a `NodeKind::String` when appropriate, falling back to `parse_assignment` otherwise.
- Preserve the existing separator handling and recovery behavior for both `,` and `=>` after the change.
- Add two unit tests in `crates/perl-parser-core/src/engine/parser/tests.rs`: `test_hash_style_callback_args_in_parenthesized_call` and `test_hash_style_callback_args_with_keyword_keys` to cover parenthesized calls with fat-arrow callback pairs and keyword-like keys.

### Testing

- Ran the parser unit tests with `cargo test -p perl-parser`, including the added tests, and the new tests `test_hash_style_callback_args_in_parenthesized_call` and `test_hash_style_callback_args_with_keyword_keys` passed.
- Ran the broader `perl-parser` test suite as part of the same test run and observed no new regressions in parser tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21bfdc77c83339e53a06e6b9314ff)