### PR TITLE
Strengthen breakpoint validator edge-case assertions

### DIFF
--- a/crates/perl-dap-breakpoint/tests/extended_unit_tests.rs
+++ b/crates/perl-dap-breakpoint/tests/extended_unit_tests.rs
@@ -117,8 +117,9 @@ fn validation_adjusted_all_reasons() -> Result<(), Box<dyn std::error::Error>> {
 fn validator_with_single_character() -> Result<(), Box<dyn std::error::Error>> {
     let v = must(AstBreakpointValidator::new("1"));
     let result = v.validate(1);
-    // Single character could be executable code
-    assert!(result.verified || !result.verified); // Just no crash
+    assert!(result.verified);
+    assert_eq!(result.line, 1);
+    assert_eq!(result.reason, None);
     Ok(())
 }
 
@@ -224,8 +225,11 @@ fn validate_with_column_large_column_numbers() -> Result<(), Box<dyn std::error:
 fn validate_with_column_negative_line() -> Result<(), Box<dyn std::error::Error>> {
     let v = must(AstBreakpointValidator::new("my $x = 1;\n"));
     let result = v.validate_with_column(-10, Some(5));
-    // Negative line → clamped to 0 → maps to line 1
-    assert!(result.verified || !result.verified); // Just no crash
+    // Negative line is clamped for lookup and validated against first source line.
+    assert!(result.verified);
+    assert_eq!(result.line, -10);
+    assert_eq!(result.column, Some(5));
+    assert_eq!(result.reason, None);
     Ok(())
 }
 
@@ -233,8 +237,11 @@ fn validate_with_column_negative_line() -> Result<(), Box<dyn std::error::Error>
 fn validate_with_column_zero_line() -> Result<(), Box<dyn std::error::Error>> {
     let v = must(AstBreakpointValidator::new("my $x = 1;\n"));
     let result = v.validate_with_column(0, Some(1));
-    // Line 0 → clamped to index 0 → may be valid or not
-    assert!(result.verified || !result.verified);
+    // Line 0 is clamped for lookup and validated against first source line.
+    assert!(result.verified);
+    assert_eq!(result.line, 0);
+    assert_eq!(result.column, Some(1));
+    assert_eq!(result.reason, None);
     Ok(())
 }
 
@@ -252,9 +259,8 @@ fn is_executable_line_boundary_large_line() -> Result<(), Box<dyn std::error::Er
 #[test]
 fn is_executable_line_negative() -> Result<(), Box<dyn std::error::Error>> {
     let v = must(AstBreakpointValidator::new("my $x = 1;\n"));
-    // Negative line should not be executable
     let result = v.is_executable_line(-5);
-    assert!(result || !result); // Just ensure no crash
+    assert!(result);
     Ok(())
 }
 
@@ -590,10 +596,10 @@ fn blank_line_with_newline() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn blank_line_with_carriage_return() -> Result<(), Box<dyn std::error::Error>> {
-    let _v = must(AstBreakpointValidator::new("my $x = 1;\n\r\nmy $y = 2;\n"));
-    // The line should still be blank regardless of line ending style
-    // Note: parser may handle this differently
-    assert!(true); // Just ensure no crash
+    let v = must(AstBreakpointValidator::new("my $x = 1;\n\r\nmy $y = 2;\n"));
+    let result = v.validate(2);
+    assert!(!result.verified);
+    assert_eq!(result.reason, Some(ValidationReason::BlankLine));
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Tests in `crates/perl-dap-breakpoint/tests/extended_unit_tests.rs` included tautological or no-op assertions that did not verify intended behavior for edge cases. 
- Make these tests assert concrete, expected semantics so test coverage actually enforces behavior for boundary inputs.

### Description
- Replaced no-op/tautological assertions with explicit expectations in `validator_with_single_character` to assert the line is verified and fields are correct. 
- Tightened `validate_with_column` tests for negative and zero line inputs to assert the function returns `verified` and preserves the provided `column`. 
- Changed `is_executable_line` negative-line test to assert expected executability instead of a no-op. 
- Expanded the CRLF blank-line test to validate that a `\r\n` blank line is rejected with `ValidationReason::BlankLine` rather than using a placeholder assertion.

### Testing
- Ran `cargo test -p perl-dap-breakpoint` and all unit tests passed with no failures. 
- Ran `cargo test -p perl-dap-breakpoint --test extended_unit_tests` and all 71 tests passed. 
- Ran `cargo fmt --all` to ensure formatting consistency with no changes required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21a0711f88333b8c78e6e005bee24)