### PR TITLE
Strengthen workspace discovery test assertions and fallback coverage

### DIFF
--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -161,8 +161,8 @@ fn log_discovery(result: &DiscoveryResult) {
 #[cfg(test)]
 mod tests {
     use super::{
-        DiscoveryMethod, parse_git_ls_files_output, path_contains_skipped_component,
-        should_skip_dir, walk_discovery,
+        DiscoveryMethod, discover_perl_files, parse_git_ls_files_output,
+        path_contains_skipped_component, should_skip_dir, walk_discovery,
     };
     use std::fs;
     use std::path::Path;
@@ -416,7 +416,13 @@ mod tests {
         create_file(root, "app/main.psgi")?;
 
         let result = walk_discovery(root, Instant::now());
+        assert_eq!(result.method, DiscoveryMethod::Walk);
         assert_eq!(result.files.len(), 4);
+        assert_eq!(result.excluded_count, 0);
+        assert!(result.files.iter().any(|p| p.ends_with("lib/Foo.pm")));
+        assert!(result.files.iter().any(|p| p.ends_with("bin/run.pl")));
+        assert!(result.files.iter().any(|p| p.ends_with("t/basic.t")));
+        assert!(result.files.iter().any(|p| p.ends_with("app/main.psgi")));
 
         Ok(())
     }
@@ -461,8 +467,28 @@ mod tests {
     fn walk_discovery_records_duration() -> TestResult {
         let tmp = tempfile::tempdir()?;
         let result = walk_discovery(tmp.path(), Instant::now());
-        // Duration should be non-zero (or at least not panic)
-        let _ = result.duration.as_nanos();
+
+        assert_eq!(result.method, DiscoveryMethod::Walk);
+        assert_eq!(result.files.len(), 0);
+        assert_eq!(result.excluded_count, 0);
+        assert!(result.duration >= std::time::Duration::ZERO);
+
+        Ok(())
+    }
+
+    #[test]
+    fn discover_perl_files_falls_back_to_walk_outside_git_repo() -> TestResult {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+
+        create_file(root, "lib/Fallback.pm")?;
+
+        let result = discover_perl_files(root);
+
+        assert_eq!(result.method, DiscoveryMethod::Walk);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("lib/Fallback.pm"));
+        assert_eq!(result.excluded_count, 0);
 
         Ok(())
     }
@@ -545,9 +571,8 @@ mod tests {
 
         assert_eq!(git, git2);
         assert_ne!(git, walk);
-        // Debug is derivable, just verify it doesn't panic
-        let _ = format!("{git:?}");
-        let _ = format!("{walk:?}");
+        assert_eq!(format!("{git:?}"), "Git");
+        assert_eq!(format!("{walk:?}"), "Walk");
     }
 
     #[test]
@@ -574,8 +599,12 @@ mod tests {
         assert_eq!(cloned.files.len(), result.files.len());
         assert_eq!(cloned.method, result.method);
         assert_eq!(cloned.excluded_count, result.excluded_count);
-        // Debug format should not panic
-        let _ = format!("{result:?}");
+        assert_eq!(cloned.duration, result.duration);
+
+        let debug = format!("{result:?}");
+        assert!(debug.contains("DiscoveryResult"));
+        assert!(debug.contains("method"));
+        assert!(debug.contains("excluded_count"));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

- Improve confidence in the workspace discovery behavior by replacing weak/non-assertive checks with explicit assertions and by adding a test that verifies the `discover_perl_files` fallback when git is unavailable.

### Description

- Tightened `walk_discovery_finds_all_perl_extensions` to assert the `DiscoveryMethod`, `excluded_count`, and presence of each expected path for the discovered Perl files.
- Replaced the loose duration-access check in `walk_discovery_records_duration` with explicit metadata assertions for `method`, `files`, `excluded_count`, and a non-negative duration check.
- Added `discover_perl_files_falls_back_to_walk_outside_git_repo` to validate that `discover_perl_files` falls back to `Walk` and returns expected files outside a git repository.
- Hardened debug/clone tests by asserting concrete `Debug` output for `DiscoveryMethod` and validating `DiscoveryResult` cloning and debug string contents.
- Modified file: `crates/perl-workspace-discovery/src/lib.rs` (tests section enhancements and a new test). 

### Testing

- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-workspace-discovery` and all tests passed (`31 passed`, then full suite in the crate and integration/property tests all passed).
- The modified test suite exercises `walk_discovery`, `parse_git_ls_files_output`, `path_contains_skipped_component`, `discover_perl_files` fallback behavior, and metadata/`Debug` expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21a0711f88333b8c78e6e005bee24)