### PR TITLE
test: strengthen workspace discovery assertions

### DIFF
--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -165,7 +165,7 @@ mod tests {
         should_skip_dir, walk_discovery,
     };
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::time::Instant;
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -177,6 +177,20 @@ mod tests {
         }
         fs::write(path, "# synthetic\n")?;
         Ok(())
+    }
+
+    fn relative_file_set(root: &Path, files: &[PathBuf]) -> Vec<String> {
+        let mut relative = files
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root).ok().map_or_else(
+                    || path.to_string_lossy().to_string(),
+                    |p| p.to_string_lossy().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        relative.sort();
+        relative
     }
 
     #[test]
@@ -416,7 +430,20 @@ mod tests {
         create_file(root, "app/main.psgi")?;
 
         let result = walk_discovery(root, Instant::now());
+        assert_eq!(result.method, DiscoveryMethod::Walk);
         assert_eq!(result.files.len(), 4);
+        assert_eq!(result.excluded_count, 0);
+
+        let relative = relative_file_set(root, &result.files);
+        assert_eq!(
+            relative,
+            vec![
+                "app/main.psgi".to_string(),
+                "bin/run.pl".to_string(),
+                "lib/Foo.pm".to_string(),
+                "t/basic.t".to_string(),
+            ]
+        );
 
         Ok(())
     }
@@ -461,8 +488,10 @@ mod tests {
     fn walk_discovery_records_duration() -> TestResult {
         let tmp = tempfile::tempdir()?;
         let result = walk_discovery(tmp.path(), Instant::now());
-        // Duration should be non-zero (or at least not panic)
-        let _ = result.duration.as_nanos();
+        assert_eq!(result.method, DiscoveryMethod::Walk);
+        assert!(result.duration <= std::time::Duration::from_secs(1));
+        assert_eq!(result.files.len(), 0);
+        assert_eq!(result.excluded_count, 0);
 
         Ok(())
     }
@@ -545,9 +574,8 @@ mod tests {
 
         assert_eq!(git, git2);
         assert_ne!(git, walk);
-        // Debug is derivable, just verify it doesn't panic
-        let _ = format!("{git:?}");
-        let _ = format!("{walk:?}");
+        assert_eq!(format!("{git:?}"), "Git");
+        assert_eq!(format!("{walk:?}"), "Walk");
     }
 
     #[test]
@@ -574,8 +602,9 @@ mod tests {
         assert_eq!(cloned.files.len(), result.files.len());
         assert_eq!(cloned.method, result.method);
         assert_eq!(cloned.excluded_count, result.excluded_count);
-        // Debug format should not panic
-        let _ = format!("{result:?}");
+        let debug = format!("{result:?}");
+        assert!(debug.contains("DiscoveryResult"));
+        assert!(debug.contains("method: Walk"));
 
         Ok(())
     }
@@ -612,5 +641,6 @@ mod tests {
         assert_eq!(files.len(), 4);
         // README.md + Makefile (non-perl) + node_modules/e.pm (skipped dir)
         assert_eq!(excluded_count, 3);
+        assert!(files.iter().all(|path| path.starts_with(root)));
     }
 }


### PR DESCRIPTION
### Motivation
- Improve test rigor for `perl-workspace-discovery` so tests assert concrete behavior instead of no-op or “does not panic” checks.
- Ensure discovered file lists are deterministic and validated as relative to the workspace root to prevent regressions in path handling.
- Replace loose debug/smoke checks with explicit assertions to catch changes in formatting or enum/debug behavior early.

### Description
- Added a `relative_file_set` helper and updated `walk_discovery_finds_all_perl_extensions` to assert the exact set of discovered relative paths for extension coverage tests and verify `excluded_count` is `0`.
- Added assertions for `DiscoveryResult` metadata in walk-based tests, including `method == DiscoveryMethod::Walk`, `excluded_count`, `files.len()`, and a conservative `duration` upper bound using `std::time::Duration`.
- Tightened debug-related assertions by checking `format!("{..:?}")` for `DiscoveryMethod` values and validating that `DiscoveryResult` debug output contains expected tokens.
- Added a path-prefix invariant in `parse_git_ls_files_output` mixed-content tests to assert parsed file paths are rooted under the provided workspace `root`.
- Updated imports to include `PathBuf` for relative-path computations.

### Testing
- Ran `cargo test -p perl-workspace-discovery` and all crate tests passed (66 passed; 0 failed).  
- Ran `cargo fmt --all` to ensure formatting consistency and no formatting failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21a0711f88333b8c78e6e005bee24)