### PR TITLE
Fix publish-extension workflow validity

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -7,14 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g., 0.x.y)'
+        description: "Version to publish (e.g., 0.x.y)"
         required: true
         type: string
 
-# Cancel in-flight runs
 concurrency:
   group: publish-extension-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
-  cancel-in-progress: false  # Don't cancel publishing
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -23,6 +22,9 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    env:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
     steps:
       - name: Checkout
@@ -31,8 +33,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: npm
           cache-dependency-path: vscode-extension/package-lock.json
 
       - name: Install dependencies
@@ -54,35 +56,32 @@ jobs:
               exit 1
             fi
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          npm version $VERSION --no-git-tag-version
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "release_tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          npm version "$VERSION" --no-git-tag-version
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build release VSIX
         working-directory: vscode-extension
         run: |
           npm run verify:marketplace
-          echo "VSIX_FILE=$(ls -1 *.vsix | head -n 1)" >> $GITHUB_ENV
+          echo "VSIX_FILE=$(ls -1 *.vsix | head -n 1)" >> "$GITHUB_ENV"
 
       - name: Publish to VSCode Marketplace
-        if: ${{ secrets.VSCE_PAT != '' }}
+        if: ${{ env.VSCE_PAT != '' }}
         working-directory: vscode-extension
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          vsce publish --pat $VSCE_PAT --packagePath ${{ env.VSIX_FILE }}
+          vsce publish --pat "$VSCE_PAT" --packagePath "${{ env.VSIX_FILE }}"
 
       - name: Publish to Open VSX
-        if: ${{ secrets.OVSX_PAT != '' }}
+        if: ${{ env.OVSX_PAT != '' }}
         working-directory: vscode-extension
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
-          ovsx publish ${{ env.VSIX_FILE }} --pat $OVSX_PAT
+          ovsx publish "${{ env.VSIX_FILE }}" --pat "$OVSX_PAT"
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: perl-lsp-${{ env.VERSION }}.vsix
           path: vscode-extension/${{ env.VSIX_FILE }}


### PR DESCRIPTION
## Summary\n- restore a valid  after release hardening\n- route marketplace tokens through job env instead of referencing  directly in step  expressions\n- keep the VSIX publish and GitHub release attachment flow intact\n\n## Notes\n- this unblocks the VS Code extension release workflow itself