### PR TITLE
Fix Intel macOS runner label in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
             use_cross: true
           # macOS
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             use_cross: false
           - target: aarch64-apple-darwin
             os: macos-14


### PR DESCRIPTION
## Summary\n- switch the Intel macOS release build from  to \n- align the release matrix with current GitHub-hosted runner labels\n- unblock the missing x86_64-apple-darwin asset for v0.11.0\n\n## Rationale\nThe current release run cancels the Intel macOS job before any steps execute, while the other matrix entries succeed.