### PR TITLE
Rename VS Code extension to perl-lsp-rs

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: perl-lsp-${{ env.VERSION }}.vsix
+          name: perl-lsp-rs-${{ env.VERSION }}.vsix
           path: vscode-extension/${{ env.VSIX_FILE }}
           retention-days: 30
 

--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -90,7 +90,7 @@ The official perl-lsp extension provides the best experience with automatic conf
 
 ```bash
 # Install from command line
-code --install-extension effortlesssteven.perl-lsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
 
 # Or search in VS Code Extensions marketplace:
 # 1. Press Ctrl+Shift+X (Cmd+Shift+X on macOS)
@@ -142,7 +142,7 @@ For project-specific settings, create `.vscode/settings.json` in your project ro
   "perl-lsp.useSystemInc": false,
   "perl-lsp.formatOnSave": true,
   "[perl]": {
-    "editor.defaultFormatter": "effortlesssteven.perl-lsp",
+    "editor.defaultFormatter": "EffortlessMetrics.perl-lsp-rs",
     "editor.formatOnSave": true
   }
 }
@@ -705,7 +705,7 @@ Here's a comprehensive example configuration for a typical Perl project:
 
   // Language-specific settings
   "[perl]": {
-    "editor.defaultFormatter": "effortlesssteven.perl-lsp",
+    "editor.defaultFormatter": "EffortlessMetrics.perl-lsp-rs",
     "editor.formatOnSave": true,
     "editor.tabSize": 4,
     "editor.insertSpaces": true,

--- a/docs/EXTENSION.md
+++ b/docs/EXTENSION.md
@@ -6,13 +6,13 @@
 1. Open VS Code.
 2. Open Extensions.
 3. Search for `Perl Language Server`.
-4. Install `effortlesssteven.perl-lsp`.
+4. Install `EffortlessMetrics.perl-lsp-rs`.
 
 ### From a VSIX
 Download the `.vsix` asset from the matching GitHub release and install it manually:
 
 ```bash
-code --install-extension perl-lsp-*.vsix
+code --install-extension perl-lsp-rs-*.vsix
 ```
 
 ## Server Resolution Order

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -285,16 +285,16 @@ docker run --rm -v ${PWD}:/workspace effortlessmetrics/perl-lsp:latest
 
 VSCode extension is published to:
 
-- VSCode Marketplace: `effortlesssteven.perl-lsp`
-- Open VSX: `effortlesssteven.perl-lsp`
+- VSCode Marketplace: `EffortlessMetrics.perl-lsp-rs`
+- Open VSX: `EffortlessMetrics.perl-lsp-rs`
 
 **Installation:**
 ```bash
 # From VSCode Marketplace
-code --install-extension effortlesssteven.perl-lsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
 
 # From Open VSX
-code --install-extension effortlesssteven.perl-lsp --extensions-dir ~/.vscode-oss/extensions
+code --install-extension EffortlessMetrics.perl-lsp-rs --extensions-dir ~/.vscode-oss/extensions
 ```
 
 ## Rollback Procedures

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -74,7 +74,7 @@ Create or edit `.vscode/settings.json` in your workspace:
 Install from the VS Code marketplace:
 
 ```bash
-code --install-extension effortlesssteven.perl-lsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
 ```
 
 ### Recommended Settings

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -84,7 +84,7 @@ perl-lsp 0.10.0
 ## Editor Configuration
 
 ### VS Code
-1. Install the [Perl LSP extension](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
+1. Install the [Perl LSP extension](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 2. Open a Perl file (.pl or .pm)
 3. The language server will start automatically
 

--- a/docs/how-to/UPGRADING.md
+++ b/docs/how-to/UPGRADING.md
@@ -536,7 +536,7 @@ cargo clippy --workspace
 code --uninstall-extension perl-language-server
 
 # Install new extension
-code --install-extension effortlesssteven.perl-lsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
 
 # Remove deprecated settings from settings.json
 # Delete: "perl-lsp.downloadBaseUrl"

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -50,7 +50,7 @@ perl-lsp --health
 
 1. Install the extension:
    ```bash
-   code --install-extension effortlesssteven.perl-lsp
+   code --install-extension EffortlessMetrics.perl-lsp-rs
    ```
 
 2. Open a `.pl` or `.pm` file - the server starts automatically.

--- a/vscode-extension/INTERNAL_DEPLOYMENT.md
+++ b/vscode-extension/INTERNAL_DEPLOYMENT.md
@@ -46,7 +46,7 @@ The simplest approach for internal deployment.
 
 4. **Install extension** on developer machines:
    ```bash
-   code --install-extension perl-lsp-0.8.3.vsix
+   code --install-extension perl-lsp-rs-0.8.3.vsix
    ```
 
 ### Benefits

--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -38,7 +38,7 @@ Install and test the extension locally:
 
 ```bash
 # Install the VSIX file
-code --install-extension perl-language-server-*.vsix
+code --install-extension perl-lsp-rs-*.vsix
 
 # Open test file
 code test/sample.pl

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,7 +1,7 @@
 # Perl Language Server
 
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/effortlesssteven.perl-lsp?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
-[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/effortlesssteven.perl-lsp)](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp)
+[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/EffortlessMetrics.perl-lsp-rs?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/EffortlessMetrics.perl-lsp-rs)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 
 Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
 
@@ -48,7 +48,7 @@ Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
 
 ## 📦 Installation
 
-Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp).
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs).
 
 The extension automatically downloads the correct language server for your platform:
 - Windows (x64, ARM64)

--- a/vscode-extension/build.sh
+++ b/vscode-extension/build.sh
@@ -24,10 +24,10 @@ npm run bundle-lsp
 echo "Packaging extension..."
 npm run package
 
-echo "Build complete! Extension packaged as perl-language-server-*.vsix"
+echo "Build complete! Extension packaged as perl-lsp-rs-*.vsix"
 echo ""
 echo "To install locally:"
-echo "  code --install-extension perl-language-server-*.vsix"
+echo "  code --install-extension perl-lsp-rs-*.vsix"
 echo ""
 echo "To publish to marketplace:"
 echo "  npm run publish"

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "perl-lsp",
+  "name": "perl-lsp-rs",
   "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "perl-lsp",
+      "name": "perl-lsp-rs",
       "version": "0.10.0",
       "license": "MIT",
       "dependencies": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "perl-lsp",
-  "displayName": "Perl Language Server",
+  "name": "perl-lsp-rs",
+  "displayName": "perl-lsp-rs",
   "description": "Comprehensive Perl language support powered by perl-lsp",
   "version": "0.11.0",
-  "publisher": "effortlesssteven",
+  "publisher": "EffortlessMetrics",
   "preview": false,
   "markdown": "github",
   "engines": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -214,7 +214,7 @@ export async function activate(context: vscode.ExtensionContext) {
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
-            { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:effortlesssteven.perl-lsp'] }
+            { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:EffortlessMetrics.perl-lsp-rs'] }
         ];
 
         const selection = await vscode.window.showQuickPick(items, {
@@ -335,7 +335,7 @@ function normalizeFeatureProfile(rawProfile: string): string | null {
 }
 
 function getSupportedFeatureProfiles(): string[] {
-    const extension = vscode.extensions.getExtension('effortlesssteven.perl-lsp');
+    const extension = vscode.extensions.getExtension('EffortlessMetrics.perl-lsp-rs');
     const schemaEnum =
         extension?.packageJSON?.contributes?.configuration?.properties?.['perl-lsp.featureProfile']?.enum;
 


### PR DESCRIPTION
## Summary
- rename the VS Code extension identity to `EffortlessMetrics.perl-lsp-rs`
- update runtime extension-id lookups and publish artifact naming
- update Marketplace, install, and VSIX documentation to the new identity

## Why
- `linus-bjorklund.perl-lsp` is unrelated third-party namespace
- the maintained extension needs a unique Marketplace identity under the correct publisher
- the repo docs and extension runtime must agree on the final published id

## Notes
- this changes extension metadata and docs only
- Marketplace publishing still requires `VSCE_PAT` and `OVSX_PAT`
