### PR TITLE
Increase crates publish timeout

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -165,7 +165,7 @@ jobs:
     name: Publish crates
     needs: compute-order
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 360
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- increase the crates publish job timeout from 120 minutes to 360 minutes

## Why
- the `0.11.0` crates publish lane is timing out on wall clock, not failing on a new crate-level error
- the publish loop already has per-crate retries, sparse-index propagation waits, and final verification
- raising the job timeout is the smallest safe release fix

## Notes
- no publish-order or retry behavior changed
- this is a release unblocker for `v0.11.0`
