### PR TITLE
docs: split P0 resolution plans and ADR updates from lexer work

### DIFF
--- a/docs/issues/resolution-plans/P0-ambiguous-slash-division-regex.md
+++ b/docs/issues/resolution-plans/P0-ambiguous-slash-division-regex.md
@@ -3,6 +3,7 @@
 ## Issue Summary
 
 The slash `/` character has dual meaning in Perl, creating a fundamental parsing ambiguity:
+
 - **Division operator**: `$a / $b`
 - **Regex delimiter**: `/pattern/`
 
@@ -14,10 +15,10 @@ This ambiguity requires context-aware tokenization to correctly interpret the sl
 
 | Feature | Status | Location |
 |---------|--------|----------|
-| Mode-aware lexer | ✅ Implemented | [`crates/perl-lexer/src/mode.rs:36-69`](../../../../crates/perl-lexer/src/mode.rs) |
-| Slash disambiguation | ✅ Implemented | [`crates/perl-lexer/src/lib.rs:1999-2070`](../../../../crates/perl-lexer/src/lib.rs) |
-| Budget guards | ✅ Implemented | `MAX_REGEX_BYTES =64KB` |
-| Test coverage | ✅ 21 test cases | [`crates/perl-lexer/tests/lexer_slash_timeout_tests.rs`](../../../../crates/perl-lexer/tests/lexer_slash_timeout_tests.rs) |
+| Mode-aware lexer | ✅ Implemented | [`crates/perl-lexer/src/mode.rs`](../../../crates/perl-lexer/src/mode.rs) |
+| Slash disambiguation | ✅ Implemented | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
+| Budget guards | ✅ Implemented | `MAX_REGEX_BYTES = 64KB` |
+| Test coverage | ✅ 21 test cases | [`crates/perl-lexer/tests/lexer_slash_timeout_tests.rs`](../../../crates/perl-lexer/tests/lexer_slash_timeout_tests.rs) |
 
 ### LexerMode Tracking System
 
@@ -64,7 +65,7 @@ The ambiguous slash issue is **fully implemented** with comprehensive test cover
 ### Remaining Tasks
 
 1. **Complete ADR Documentation**
-   - Location: [`docs/adr/0014-mode-aware-lexer.md`](../../../../adr/0014-mode-aware-lexer.md)
+   - Location: [`docs/adr/0014-mode-aware-lexer.md`](../../adr/0014-mode-aware-lexer.md)
    - Action: Document the design decision and implementation details
 
 2. **Add Fuzz Testing**
@@ -77,9 +78,9 @@ The ambiguous slash issue is **fully implemented** with comprehensive test cover
 
 | Test File | Coverage |
 |-----------|----------|
-| [`lexer_slash_timeout_tests.rs`](../../../../crates/perl-lexer/tests/lexer_slash_timeout_tests.rs) | 21 test cases for slash disambiguation |
-| [`hang_risk_slash_ambiguity_tests.rs`](../../../../crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs) | Comprehensive slash ambiguity tests |
-| [`comprehensive_unit_tests.rs`](../../../../crates/perl-lexer/tests/comprehensive_unit_tests.rs) | Context-sensitive slash disambiguation |
+| [`lexer_slash_timeout_tests.rs`](../../../crates/perl-lexer/tests/lexer_slash_timeout_tests.rs) | 21 test cases for slash disambiguation |
+| [`hang_risk_slash_ambiguity_tests.rs`](../../../crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs) | Comprehensive slash ambiguity tests |
+| [`comprehensive_unit_tests.rs`](../../../crates/perl-lexer/tests/comprehensive_unit_tests.rs) | Context-sensitive slash disambiguation |
 
 ### Validation Steps
 
@@ -106,5 +107,5 @@ None - implementation is complete.
 ## References
 
 - [Issue Documentation](../corpus/gaps/timeout-hang-risks/ambiguous-slash-division-regex.md)
-- [Lexer Mode Implementation](../../../../crates/perl-lexer/src/mode.rs)
-- [Slash Disambiguation Logic](../../../../crates/perl-lexer/src/lib.rs)
+- [Lexer Mode Implementation](../../../crates/perl-lexer/src/mode.rs)
+- [Slash Disambiguation Logic](../../../crates/perl-lexer/src/lib.rs)

--- a/docs/issues/resolution-plans/P0-catastrophic-regex-backtracking.md
+++ b/docs/issues/resolution-plans/P0-catastrophic-regex-backtracking.md
@@ -19,16 +19,18 @@ Complex regex patterns pose a **P0 critical risk** for catastrophic backtracking
 
 | Protection | Value | Location |
 |------------|-------|----------|
-| `MAX_REGEX_BYTES` | 64KB | [`crates/perl-lexer/src/lib.rs:172`](../../../../crates/perl-lexer/src/lib.rs) |
-| `MAX_DELIM_NEST` | 128 | [`crates/perl-lexer/src/lib.rs:174`](../../../../crates/perl-lexer/src/lib.rs) |
-| `MAX_HEREDOC_DEPTH` | 100 | [`crates/perl-lexer/src/lib.rs:175`](../../../../crates/perl-lexer/src/lib.rs) |
-| `MAX_HEREDOC_BYTES` | 256KB | [`crates/perl-lexer/src/lib.rs:173`](../../../../crates/perl-lexer/src/lib.rs) |
+| `MAX_REGEX_BYTES` | 64KB | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
+| `MAX_REGEX_PARSE_STEPS` | 32K | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
+| `MAX_DELIM_NEST` | 128 | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
+| `MAX_HEREDOC_DEPTH` | 100 | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
+| `MAX_HEREDOC_BYTES` | 256KB | [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) |
 
 ### Current Implementation
 
 ```rust
-// From crates/perl-lexer/src/lib.rs:171-175
+// From crates/perl-lexer/src/lib.rs
 const MAX_REGEX_BYTES: usize = 64 * 1024;  // 64KB max for regex patterns
+pub const MAX_REGEX_PARSE_STEPS: usize = 32 * 1024;
 const MAX_HEREDOC_BYTES: usize = 256 * 1024; // 256KB max for heredoc bodies
 const MAX_DELIM_NEST: usize = 128;         // Max nesting depth for delimiters
 const MAX_HEREDOC_DEPTH: usize = 100;      // Max nesting depth for heredocs
@@ -46,19 +48,20 @@ const MAX_HEREDOC_DEPTH: usize = 100;      // Max nesting depth for heredocs
 
 | Gap | Severity | Description |
 |-----|----------|-------------|
-| No backtracking limit | **High** | No limit on backtracking steps during parsing |
-| No pattern analysis | **High** | Cannot detect pathological patterns like `(a+)+` |
-| No timeout protection | Medium | No time-based limit for regex parsing |
-| No user warnings | Medium | No LSP diagnostics for risky patterns |
+| No pattern analysis | **High** | The lexer does not statically detect risky patterns such as nested quantifiers |
+| No engine-risk diagnostics | **High** | Users do not get warnings about regex-engine catastrophic backtracking risks |
+| No timeout protection | Medium | There is no separate time-based defense-in-depth budget |
+| No user warnings | Medium | No LSP diagnostics surface risky regex constructs yet |
 
 ### Test Coverage Status
 
 - [x] Byte limit enforcement (64KB)
+- [x] Parse-step budget enforcement (32K)
 - [x] Delimiter nesting limit (128)
 - [x] Heredoc depth limit (100)
+- [x] Graceful degradation to `UnknownRest`
 - [ ] **Pattern analysis for nested quantifiers**
-- [ ] **Timeout on pathological patterns**
-- [ ] **Performance: rejection within 100ms**
+- [ ] **Risk diagnostics for pathological patterns**
 - [ ] **Memory bounded during parsing**
 
 ### Pathological Patterns to Detect
@@ -67,56 +70,54 @@ const MAX_HEREDOC_DEPTH: usize = 100;      // Max nesting depth for heredocs
 |---------|------------|-----------------|
 | `(a+)+` | Critical | O(2^n) |
 | `(a*)*` | Critical | O(2^n) |
-| `(a|aa)+` | High | O(2^n) |
+| `(a or aa)+` | High | O(2^n) |
 | `(a?){n}` | High | O(2^n) |
 | `(.*)\1` | Medium | O(n^2) |
 
 ## Proposed Solution
 
-### Phase 1: Backtracking Step Limit (Required)
+### Phase 1: Lexer Parse Budget Hardening (Delivered)
 
-**Objective**: Implement a step-based limit for regex parsing operations
+**Objective**: Bound regex literal scanning in the lexer before the byte budget trips
 
-**Rationale**: The current byte-size limit (64KB) doesn't prevent exponential backtracking on small but pathological patterns. A step counter provides deterministic protection.
+**Rationale**: The lexer now enforces a parse-step budget that is reachable before the 64KB byte ceiling, which prevents runaway literal scanning without pretending to solve regex-engine runtime backtracking.
 
 **Tasks**:
 
-1. Add `MAX_BACKTRACK_STEPS` constant
-2. Implement step counter in regex parsing loop
-3. Return error when limit exceeded
-4. Add test coverage
+1. Add `MAX_REGEX_PARSE_STEPS`
+2. Enforce the parse-step guard in `parse_regex()`
+3. Degrade to `UnknownRest` when the budget is exceeded
+4. Add sub-64KB tests that prove the guard triggers before the byte budget
 
 **Implementation**:
 
 ```rust
-// Add to crates/perl-lexer/src/lib.rs
-const MAX_BACKTRACK_STEPS: usize = 100_000; // 100K steps max
+pub const MAX_REGEX_PARSE_STEPS: usize = 32 * 1024;
 
-struct RegexParser {
-    steps: Cell<usize>,
-}
+while let Some(ch) = self.current_char() {
+    regex_parse_steps += 1;
+    if regex_parse_steps > MAX_REGEX_PARSE_STEPS {
+        self.position = self.input.len();
+        return Some(Token {
+            token_type: TokenType::UnknownRest,
+            text: empty_arc(),
+            start,
+            end: self.position,
+        });
+    }
 
-impl RegexParser {
-    fn step(&self) -> ParseResult<()> {
-        let steps = self.steps.get() + 1;
-        if steps > MAX_BACKTRACK_STEPS {
-            return Err(ParseError::RegexBacktrackLimit {
-                steps,
-                max_steps: MAX_BACKTRACK_STEPS,
-            });
-        }
-        self.steps.set(steps);
-        Ok(())
+    if let Some(token) = self.budget_guard(start, 0) {
+        return Some(token);
     }
 }
 ```
 
-**Files to Modify**:
+**Files Updated in Phase 1**:
 
 | File | Changes |
 |------|---------|
-| [`crates/perl-lexer/src/lib.rs`](../../../../crates/perl-lexer/src/lib.rs) | Add constant and step counter |
-| [`crates/perl-error/src/lib.rs`](../../../../crates/perl-error/src/lib.rs) | Add `RegexBacktrackLimit` error type |
+| [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) | Add `MAX_REGEX_PARSE_STEPS` and enforce the parse budget |
+| [`crates/perl-lexer/tests/lexer_catastrophic_regex_test.rs`](../../../crates/perl-lexer/tests/lexer_catastrophic_regex_test.rs) | Add sub-64KB parse-budget tests |
 
 ### Phase 2: Pattern Analysis (Recommended)
 
@@ -176,8 +177,8 @@ impl RegexAnalyzer {
 
 | File | Action |
 |------|--------|
-| [`crates/perl-lexer/src/regex_analysis.rs`](../../../../crates/perl-lexer/src/regex_analysis.rs) | Create new module |
-| [`crates/perl-lexer/src/lib.rs`](../../../../crates/perl-lexer/src/lib.rs) | Import and use analyzer |
+| [`crates/perl-lexer/src/regex_analysis.rs`](../../../crates/perl-lexer/src/regex_analysis.rs) | Create new module |
+| [`crates/perl-lexer/src/lib.rs`](../../../crates/perl-lexer/src/lib.rs) | Import and use analyzer |
 
 ### Phase 3: Timeout Protection (Optional)
 
@@ -251,17 +252,16 @@ fn check_regex_pattern(&self, pattern: &str) -> Vec<Diagnostic> {
 
 | Test File | Purpose |
 |-----------|---------|
-| [`lexer_catastrophic_regex_test.rs`](../../../../crates/perl-lexer/tests/lexer_catastrophic_regex_test.rs) | Catastrophic backtracking tests |
-| [`hang_risk_regex_literal_tests.rs`](../../../../crates/perl-lexer/tests/hang_risk_regex_literal_tests.rs) | Regex literal hang risks |
+| [`lexer_catastrophic_regex_test.rs`](../../../crates/perl-lexer/tests/lexer_catastrophic_regex_test.rs) | Regex parse-budget enforcement tests |
+| [`hang_risk_regex_literal_tests.rs`](../../../crates/perl-lexer/tests/hang_risk_regex_literal_tests.rs) | Regex literal hang risks |
 
 ### New Tests Required
 
 | Test | Purpose | Priority |
 |------|---------|----------|
-| `backtrack_limit_enforced` | Verify step limit works | High |
 | `nested_quantifier_detected` | Verify pattern analysis | High |
 | `timeout_protection_works` | Verify timeout limit | Medium |
-| `performance_rejection_100ms` | Verify fast rejection | High |
+| `risk_diagnostics_emitted` | Verify risky patterns surface diagnostics | High |
 
 ### Test Patterns to Cover
 
@@ -300,9 +300,10 @@ cargo test -p perl-lexer -- --test-threads=1 regex
 
 | Dependency | Status | Notes |
 |------------|--------|-------|
+| `MAX_REGEX_PARSE_STEPS` | ✅ Exists | Phase 1 lexer hardening is merged separately |
 | `regex` crate | ✅ Available | For pattern analysis |
 | `Instant` | ✅ Available | For timeout protection |
-| `ParseError` enum | ✅ Exists | May need new variants |
+| LSP diagnostics pipeline | ✅ Exists | Needed to surface regex warnings |
 
 ## Risk Assessment
 
@@ -317,24 +318,23 @@ cargo test -p perl-lexer -- --test-threads=1 regex
 
 ### Immediate (Required)
 
-1. [ ] Add `MAX_BACKTRACK_STEPS` constant to [`lib.rs`](../../../../crates/perl-lexer/src/lib.rs)
-2. [ ] Implement step counter in regex parsing loop
-3. [ ] Add `RegexBacktrackLimit` error type to [`perl-error`](../../../../crates/perl-error/src/lib.rs)
-4. [ ] Create test for backtracking limit enforcement
+1. [ ] Create [`regex_analysis.rs`](../../../crates/perl-lexer/src/regex_analysis.rs) module
+2. [ ] Implement nested quantifier detection
+3. [ ] Add LSP diagnostics for high-risk patterns
+4. [ ] Add risk-analysis regression coverage
 
 ### Short-term (Recommended)
 
-5. [ ] Create [`regex_analysis.rs`](../../../../crates/perl-lexer/src/regex_analysis.rs) module
-6. [ ] Implement nested quantifier detection
-7. [ ] Add LSP diagnostic for high-risk patterns
-8. [ ] Add performance test for100ms rejection
+1. [ ] Implement overlapping alternative detection
+2. [ ] Evaluate timeout protection as defense-in-depth
+3. [ ] Add documentation for regex best practices
+4. [ ] Add telemetry for repeated parse-budget hits
 
 ### Long-term (Optional)
 
-9. [ ] Implement timeout protection
-10. [ ] Add overlapping alternative detection
-11. [ ] Create configuration options for limits
-12. [ ] Add documentation for regex best practices
+1. [ ] Create configuration options for diagnostics and limits
+2. [ ] Consider deeper regex-engine risk modeling
+3. [ ] Add user-facing suppressions for intentional high-risk patterns
 
 ## Implementation Priority
 
@@ -352,12 +352,12 @@ flowchart TD
 
 ## Conclusion
 
-**Status: PARTIAL IMPLEMENTATION** - Byte and nesting limits are in place, but backtracking step limit and pattern analysis are missing. The most critical gap is the lack of a backtracking step limit, which should be implemented first.
+**Status: PHASE 1 COMPLETE** - Byte, nesting, and parse-step budgets are in place for lexer safety. The remaining gap is static analysis and diagnostics for regex-engine catastrophic backtracking risk.
 
 ## References
 
 - [Issue Documentation](../corpus/gaps/timeout-hang-risks/catastrophic-regex-backtracking.md)
-- [Lexer Implementation](../../../../crates/perl-lexer/src/lib.rs)
+- [Lexer Implementation](../../../crates/perl-lexer/src/lib.rs)
 - [CWE-1333: Inefficient Regular Expression Complexity](https://cwe.mitre.org/data/definitions/1333.html)
 - [OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
 - [Runaway Regular Expressions](https://www.regular-expressions.info/catastrophic.html)

--- a/docs/issues/resolution-plans/P0-deep-nesting-stack-overflow.md
+++ b/docs/issues/resolution-plans/P0-deep-nesting-stack-overflow.md
@@ -14,9 +14,9 @@ Deep nesting constructs pose a **P0 critical risk** for parser stack overflow. W
 
 | Protection | Value | Location |
 |------------|-------|----------|
-| `MAX_RECURSION_DEPTH` | 128 | [`crates/perl-parser-core/src/engine/parser/mod.rs:106`](../../../../crates/perl-parser-core/src/engine/parser/mod.rs) |
-| Error type | `NestingTooDeep` | [`crates/perl-error/`](../../../../crates/perl-error/) |
-| Guard pattern | `with_recursion_guard()` | [`crates/perl-parser-core/src/engine/parser/helpers.rs:65`](../../../../crates/perl-parser-core/src/engine/parser/helpers.rs) |
+| `MAX_RECURSION_DEPTH` | 128 | [`crates/perl-parser-core/src/engine/parser/mod.rs`](../../../crates/perl-parser-core/src/engine/parser/mod.rs) |
+| Error type | `NestingTooDeep` | [`crates/perl-error/`](../../../crates/perl-error/) |
+| Guard pattern | `with_recursion_guard()` | [`crates/perl-parser-core/src/engine/parser/helpers.rs`](../../../crates/perl-parser-core/src/engine/parser/helpers.rs) |
 
 ### Implementation Details
 
@@ -47,7 +47,7 @@ fn with_recursion_guard<T>(
 
 ### Stack Safety Calculation
 
-```
+```text
 Typical stack frames between checks: ~20-30 (precedence parsing chain)
 Maximum safe depth: 128 * 30 = ~3840 frames
 OS stack limit: typically 1-8MB
@@ -85,6 +85,7 @@ Safe frames: ~500-4000
 **Objective**: Add missing memory bounded usage test
 
 **Tasks**:
+
 1. Create test for memory usage at extreme nesting depths
 2. Verify parser memory stays bounded when hitting limit
 3. Add assertion for maximum heap allocation
@@ -108,7 +109,7 @@ fn parser_hang_risk_memory_bounded_at_extreme_depth() {
     
     // Memory should not grow significantly even at extreme depths
     let memory_growth = memory_after.saturating_sub(memory_before);
-    assert!(memory_growth <1024*1024, // <1MB growth
+    assert!(memory_growth < 1024 * 1024, // <1MB growth
         "Memory should be bounded: grew by {} bytes", memory_growth);
     
     assert!(result.is_err(), "Should fail at extreme depth");
@@ -120,6 +121,7 @@ fn parser_hang_risk_memory_bounded_at_extreme_depth() {
 **Objective**: Ensure all parsing paths increment depth counter
 
 **Tasks**:
+
 1. Audit all recursive parsing functions
 2. Add `with_recursion_guard()` to any missing paths
 3. Add tests for each nesting type
@@ -128,16 +130,17 @@ fn parser_hang_risk_memory_bounded_at_extreme_depth() {
 
 | File | Functions to Check |
 |------|-------------------|
-| [`expressions/hashes.rs`](../../../../crates/perl-parser-core/src/engine/parser/expressions/hashes.rs) | `parse_hash_or_block_inner()` |
-| [`expressions/calls.rs`](../../../../crates/perl-parser-core/src/engine/parser/expressions/calls.rs) | Indirect call nesting |
-| [`expressions/arrays.rs`](../../../../crates/perl-parser-core/src/engine/parser/expressions/arrays.rs) | Array nesting |
-| [`statements.rs`](../../../../crates/perl-parser-core/src/engine/parser/statements.rs) | Statement nesting |
+| [`expressions/hashes.rs`](../../../crates/perl-parser-core/src/engine/parser/expressions/hashes.rs) | `parse_hash_or_block_inner()` |
+| [`expressions/calls.rs`](../../../crates/perl-parser-core/src/engine/parser/expressions/calls.rs) | Indirect call nesting |
+| [`expressions/arrays.rs`](../../../crates/perl-parser-core/src/engine/parser/expressions/arrays.rs) | Array nesting |
+| [`statements.rs`](../../../crates/perl-parser-core/src/engine/parser/statements.rs) | Statement nesting |
 
 ### Phase 3: Configurable Limits (Optional)
 
 **Objective**: Allow users to configure `MAX_RECURSION_DEPTH`
 
 **Tasks**:
+
 1. Add `ParserConfig` struct with configurable limits
 2. Update parser initialization to accept config
 3. Add LSP configuration option for limit
@@ -172,11 +175,11 @@ impl Parser {
 
 | Test File | Purpose |
 |-----------|---------|
-| [`parser_boundary_validation_tests.rs`](../../../../crates/perl-parser/tests/parser_boundary_validation_tests.rs) | Tests limit at exactly 128 |
-| [`parser_resource_exhaustion_tests.rs`](../../../../crates/perl-parser/tests/parser_resource_exhaustion_tests.rs) | Tests behavior above limit |
-| [`hang_risk_deep_nesting_tests.rs`](../../../../crates/perl-parser/tests/hang_risk_deep_nesting_tests.rs) | Security-focused nesting tests |
-| [`parser_depth_limit_test.rs`](../../../../crates/perl-parser/tests/parser_depth_limit_test.rs) | Depth limit validation |
-| [`parser_hardening_tests.rs`](../../../../crates/perl-parser/tests/parser_hardening_tests.rs) | General hardening tests |
+| [`parser_boundary_validation_tests.rs`](../../../crates/perl-parser/tests/parser_boundary_validation_tests.rs) | Tests limit at exactly 128 |
+| [`parser_resource_exhaustion_tests.rs`](../../../crates/perl-parser/tests/parser_resource_exhaustion_tests.rs) | Tests behavior above limit |
+| [`hang_risk_deep_nesting_tests.rs`](../../../crates/perl-parser/tests/hang_risk_deep_nesting_tests.rs) | Security-focused nesting tests |
+| [`parser_depth_limit_test.rs`](../../../crates/perl-parser/tests/parser_depth_limit_test.rs) | Depth limit validation |
+| [`parser_hardening_tests.rs`](../../../crates/perl-parser/tests/parser_hardening_tests.rs) | General hardening tests |
 
 ### New Tests Required
 
@@ -235,29 +238,29 @@ sub { sub { sub { ... } } }
 
 ### Immediate (Required)
 
-1. [ ] Add memory bounded usage test to [`hang_risk_deep_nesting_tests.rs`](../../../../crates/perl-parser/tests/hang_risk_deep_nesting_tests.rs)
+1. [ ] Add memory bounded usage test to [`hang_risk_deep_nesting_tests.rs`](../../../crates/perl-parser/tests/hang_risk_deep_nesting_tests.rs)
 2. [ ] Run full test suite: `cargo test -p perl-parser --test hang_risk_deep_nesting_tests`
 3. [ ] Verify all nesting patterns are covered
 
 ### Short-term (Recommended)
 
-4. [ ] Audit all recursive parsing functions for depth tracking
-5. [ ] Add test cases for each nesting type
-6. [ ] Document stack safety calculation in code comments
+1. [ ] Audit all recursive parsing functions for depth tracking
+2. [ ] Add test cases for each nesting type
+3. [ ] Document stack safety calculation in code comments
 
 ### Long-term (Optional)
 
-7. [ ] Implement configurable limits via `ParserConfig`
-8. [ ] Add LSP configuration option for recursion limit
-9. [ ] Consider iterative parsing for extreme cases
+1. [ ] Implement configurable limits via `ParserConfig`
+2. [ ] Add LSP configuration option for recursion limit
+3. [ ] Consider iterative parsing for extreme cases
 
 ## Conclusion
 
-**Status: MOSTLY COMPLETE** - Core protection is implemented and tested. Missing only memory bounded usage test. The `MAX_RECURSION_DEPTH =128` limit provides strong protection against stack overflow attacks.
+**Status: MOSTLY COMPLETE** - Core protection is implemented and tested. Missing only memory bounded usage test. The `MAX_RECURSION_DEPTH = 128` limit provides strong protection against stack overflow attacks.
 
 ## References
 
 - [Issue Documentation](../corpus/gaps/timeout-hang-risks/deep-nesting-stack-overflow.md)
-- [Parser Core Implementation](../../../../crates/perl-parser-core/src/engine/parser/mod.rs)
-- [Recursion Guard Helpers](../../../../crates/perl-parser-core/src/engine/parser/helpers.rs)
+- [Parser Core Implementation](../../../crates/perl-parser-core/src/engine/parser/mod.rs)
+- [Recursion Guard Helpers](../../../crates/perl-parser-core/src/engine/parser/helpers.rs)
 - [CWE-674: Uncontrolled Recursion](https://cwe.mitre.org/data/definitions/674.html)

--- a/docs/issues/resolution-plans/README.md
+++ b/docs/issues/resolution-plans/README.md
@@ -47,21 +47,23 @@ The mode-aware lexer fully implements slash disambiguation with comprehensive te
 
 **Status**: ⚠️ NEARLY COMPLETE
 
-The `MAX_RECURSION_DEPTH =128` limit is implemented with RAII guard pattern. Most test coverage is in place.
+The `MAX_RECURSION_DEPTH = 128` limit is implemented with RAII guard pattern. Most test coverage is in place.
 
 **Remaining Work**:
+
 - Add memory bounded usage test
 - Audit all recursive parsing paths
 
 ### 3. Catastrophic Regex Backtracking
 
-**Status**: ⚠️ PARTIAL IMPLEMENTATION
+**Status**: ⚠️ PHASE 1 COMPLETE
 
-Byte limits (64KB) and nesting limits (128) are in place, but critical gaps remain:
+Byte limits (64KB), nesting limits (128), and the lexer parse budget are in place, but critical gaps remain:
 
 **Missing Protections**:
-- No backtracking step limit
+
 - No pattern analysis for pathological patterns
+- No diagnostics for regex-engine catastrophic backtracking risk
 - No timeout protection
 
 **Priority**: This is the highest priority issue requiring immediate attention.
@@ -72,19 +74,19 @@ Byte limits (64KB) and nesting limits (128) are in place, but critical gaps rema
 
 | # | Action | Issue | Effort |
 |---|--------|-------|--------|
-| 1 | Add `MAX_BACKTRACK_STEPS` constant | Regex Backtracking | Small |
-| 2 | Implement step counter in regex parsing | Regex Backtracking | Medium |
-| 3 | Add `RegexBacktrackLimit` error type | Regex Backtracking | Small |
-| 4 | Create backtracking limit test | Regex Backtracking | Small |
+| 1 | Create `regex_analysis.rs` module | Regex Backtracking | Medium |
+| 2 | Implement nested quantifier detection | Regex Backtracking | Medium |
+| 3 | Add LSP diagnostics for risky patterns | Regex Backtracking | Medium |
+| 4 | Add risk-analysis regression coverage | Regex Backtracking | Small |
 | 5 | Add memory bounded usage test | Deep Nesting | Small |
 
 ### Short-term Actions (Recommended)
 
 | # | Action | Issue | Effort |
 |---|--------|-------|--------|
-| 6 | Create `regex_analysis.rs` module | Regex Backtracking | Medium |
-| 7 | Implement nested quantifier detection | Regex Backtracking | Medium |
-| 8 | Add LSP diagnostic for risky patterns | Regex Backtracking | Medium |
+| 6 | Implement overlapping alternative detection | Regex Backtracking | Medium |
+| 7 | Evaluate timeout protection as defense-in-depth | Regex Backtracking | Medium |
+| 8 | Add telemetry for repeated parse-budget hits | Regex Backtracking | Medium |
 | 9 | Audit all recursive parsing paths | Deep Nesting | Medium |
 | 10 | Complete ADR documentation | Ambiguous Slash | Small |
 


### PR DESCRIPTION
This is the docs half split out of #1454.

It intentionally keeps planning and resolution-plan documents separate from lexer behavior changes so the code fix can be reviewed on its own merits.

Relative to current master, the remaining docs delta from #1454 is the resolution-plan set in docs/issues/resolution-plans/.