### PR TITLE
feat(signature-help): enrich builtin socket and deprecated docs

### DIFF
--- a/crates/perl-builtins/src/builtin_signatures.rs
+++ b/crates/perl-builtins/src/builtin_signatures.rs
@@ -1007,7 +1007,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "socket",
             BuiltinSignature {
                 signatures: vec!["socket SOCKET, DOMAIN, TYPE, PROTOCOL"],
-                documentation: "Creates a socket",
+                documentation:
+                    "Creates a socket. Returns true on success or undef on failure. See perldoc -f socket",
             },
         );
 
@@ -1015,7 +1016,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "bind",
             BuiltinSignature {
                 signatures: vec!["bind SOCKET, NAME"],
-                documentation: "Binds address to socket",
+                documentation:
+                    "Binds a packed address to a socket. Returns true on success or false on failure. See perldoc -f bind",
             },
         );
 
@@ -1023,7 +1025,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "listen",
             BuiltinSignature {
                 signatures: vec!["listen SOCKET, QUEUESIZE"],
-                documentation: "Listens for connections",
+                documentation:
+                    "Marks a socket as accepting incoming connections. Returns true on success or false on failure. See perldoc -f listen",
             },
         );
 
@@ -1031,7 +1034,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "accept",
             BuiltinSignature {
                 signatures: vec!["accept NEWSOCKET, GENERICSOCKET"],
-                documentation: "Accepts socket connection",
+                documentation:
+                    "Accepts an incoming socket connection. Returns the packed peer address on success or false on failure. See perldoc -f accept",
             },
         );
 
@@ -1039,7 +1043,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "connect",
             BuiltinSignature {
                 signatures: vec!["connect SOCKET, NAME"],
-                documentation: "Connects to socket",
+                documentation:
+                    "Connects a socket to a packed peer address. Returns true on success or false on failure. See perldoc -f connect",
             },
         );
 
@@ -1047,7 +1052,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "shutdown",
             BuiltinSignature {
                 signatures: vec!["shutdown SOCKET, HOW"],
-                documentation: "Shuts down socket",
+                documentation:
+                    "Disables reads, writes, or both on a socket. Returns true on success or false on failure. See perldoc -f shutdown",
             },
         );
 
@@ -1055,7 +1061,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "send",
             BuiltinSignature {
                 signatures: vec!["send SOCKET, MSG, FLAGS, TO", "send SOCKET, MSG, FLAGS"],
-                documentation: "Sends message on socket",
+                documentation:
+                    "Sends a message on a socket. Returns the number of bytes sent or undef on failure. See perldoc -f send",
             },
         );
 
@@ -1063,7 +1070,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "recv",
             BuiltinSignature {
                 signatures: vec!["recv SOCKET, SCALAR, LENGTH, FLAGS"],
-                documentation: "Receives message from socket",
+                documentation:
+                    "Receives a message from a socket into a scalar buffer. Returns the sender address or an empty string at end of stream. See perldoc -f recv",
             },
         );
 
@@ -1071,7 +1079,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "getsockopt",
             BuiltinSignature {
                 signatures: vec!["getsockopt SOCKET, LEVEL, OPTNAME"],
-                documentation: "Gets socket options",
+                documentation:
+                    "Reads a socket option value. Returns the packed option value or undef on failure. See perldoc -f getsockopt",
             },
         );
 
@@ -1079,7 +1088,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "setsockopt",
             BuiltinSignature {
                 signatures: vec!["setsockopt SOCKET, LEVEL, OPTNAME, OPTVAL"],
-                documentation: "Sets socket options",
+                documentation:
+                    "Sets a socket option value. Returns true on success or false on failure. See perldoc -f setsockopt",
             },
         );
 
@@ -1087,7 +1097,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "socketpair",
             BuiltinSignature {
                 signatures: vec!["socketpair SOCKET1, SOCKET2, DOMAIN, TYPE, PROTOCOL"],
-                documentation: "Creates a pair of connected sockets",
+                documentation:
+                    "Creates a pair of connected sockets. Returns true on success or false on failure. See perldoc -f socketpair",
             },
         );
 
@@ -1607,7 +1618,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "reset",
             BuiltinSignature {
                 signatures: vec!["reset EXPR", "reset"],
-                documentation: "Resets variables and searches",
+                documentation:
+                    "Resets one-character variables and search state. Returns the reset expression. See perldoc -f reset",
             },
         );
 
@@ -1674,7 +1686,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "dump",
             BuiltinSignature {
                 signatures: vec!["dump LABEL", "dump"],
-                documentation: "Creates core dump",
+                documentation:
+                    "Creates an immediate core dump and resumes at an optional label when possible. Does not return normally. See perldoc -f dump",
             },
         );
 
@@ -1682,7 +1695,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "dbmopen",
             BuiltinSignature {
                 signatures: vec!["dbmopen HASH, DBNAME, MASK"],
-                documentation: "Opens DBM file (deprecated, use tie instead)",
+                documentation:
+                    "Opens a DBM file and ties it to a hash. Returns true on success or false on failure. Deprecated; see perldoc -f dbmopen",
             },
         );
 
@@ -1690,7 +1704,8 @@ pub fn create_builtin_signatures() -> &'static HashMap<&'static str, BuiltinSign
             "dbmclose",
             BuiltinSignature {
                 signatures: vec!["dbmclose HASH"],
-                documentation: "Closes DBM file (deprecated, use untie instead)",
+                documentation:
+                    "Closes a DBM file previously opened with dbmopen. Returns true on success or false on failure. Deprecated; see perldoc -f dbmclose",
             },
         );
 

--- a/crates/perl-lsp-providers/src/ide/lsp_compat/signature_help.rs
+++ b/crates/perl-lsp-providers/src/ide/lsp_compat/signature_help.rs
@@ -258,7 +258,10 @@ impl SignatureHelpProvider {
                 .collect();
 
             for part in parts {
-                params.push(ParameterInfo { label: part.to_string(), documentation: None });
+                params.push(ParameterInfo {
+                    label: part.to_string(),
+                    documentation: builtin_parameter_documentation(part),
+                });
             }
         }
 
@@ -400,6 +403,38 @@ impl SignatureHelpProvider {
 
         actual_comma_count
     }
+}
+
+fn builtin_parameter_documentation(label: &str) -> Option<String> {
+    let doc = match label {
+        "SOCKET" => "Socket handle to create or operate on",
+        "SOCKET1" => "First socket handle in the connected pair",
+        "SOCKET2" => "Second socket handle in the connected pair",
+        "NEWSOCKET" => "Socket handle that receives the accepted connection",
+        "GENERICSOCKET" => "Listening socket that accepts the incoming connection",
+        "DOMAIN" => "Socket domain such as AF_INET or AF_UNIX",
+        "TYPE" => "Socket type such as SOCK_STREAM or SOCK_DGRAM",
+        "PROTOCOL" => "Protocol number, often 0 for the default",
+        "NAME" => "Packed socket address for the peer or local endpoint",
+        "QUEUESIZE" => "Maximum number of pending incoming connections",
+        "HOW" => "Shutdown mode: 0 for reads, 1 for writes, 2 for both",
+        "MSG" => "Message buffer to send",
+        "FLAGS" => "Bitmask of send or receive flags",
+        "TO" => "Optional packed destination socket address",
+        "SCALAR" => "Scalar buffer or value passed to the builtin",
+        "LENGTH" => "Number of bytes to read or receive",
+        "LEVEL" => "Socket option level such as SOL_SOCKET",
+        "OPTNAME" => "Socket option name constant",
+        "OPTVAL" => "Packed socket option value",
+        "LABEL" => "Optional label to resume execution from",
+        "EXPR" => "Expression controlling the builtin operation",
+        "HASH" => "Hash variable tied to the DBM file",
+        "DBNAME" => "DBM database file name",
+        "MASK" => "File permission mask for the DBM file",
+        _ => return None,
+    };
+
+    Some(doc.to_string())
 }
 
 /// Context of a function call

--- a/crates/perl-lsp/tests/builtin_signatures_edge_cases_test.rs
+++ b/crates/perl-lsp/tests/builtin_signatures_edge_cases_test.rs
@@ -575,3 +575,81 @@ fn test_builtin_count_threshold() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_socket_signature_help_docs_quality() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "socket($sock, ";
+    let ast = Parser::new(code).parse().or_else(|_| Parser::new("").parse())?;
+    let provider = SignatureHelpProvider::new(&ast);
+
+    let help =
+        provider.get_signature_help(code, code.len()).ok_or("No signature help for socket")?;
+    let signature = help.signatures.first().ok_or("Missing socket signature")?;
+
+    assert!(
+        signature
+            .documentation
+            .as_deref()
+            .is_some_and(|doc| doc.contains("Returns") && doc.contains("perldoc -f socket")),
+        "socket documentation should include return details and perldoc reference"
+    );
+    assert_eq!(signature.parameters.first().map(|p| p.label.as_str()), Some("SOCKET"));
+    assert!(
+        signature
+            .parameters
+            .first()
+            .and_then(|p| p.documentation.as_deref())
+            .is_some_and(|doc| doc.contains("Socket handle")),
+        "socket parameter documentation should describe the socket handle"
+    );
+    assert_eq!(signature.parameters.get(1).map(|p| p.label.as_str()), Some("DOMAIN"));
+    assert!(
+        signature
+            .parameters
+            .get(1)
+            .and_then(|p| p.documentation.as_deref())
+            .is_some_and(|doc| doc.contains("AF_INET") || doc.contains("AF_UNIX")),
+        "socket parameter documentation should describe the socket domain"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_deprecated_signature_help_docs_quality() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = Parser::new("").parse()?;
+    let provider = SignatureHelpProvider::new(&ast);
+
+    let dump_sig = provider.get_builtin_signature("dump").ok_or("Missing dump signature")?;
+    assert!(
+        dump_sig.documentation.contains("Does not return normally")
+            && dump_sig.documentation.contains("perldoc -f dump"),
+        "dump documentation should include return behavior and perldoc reference"
+    );
+
+    let code = "reset($pattern";
+    let reset_ast = Parser::new(code).parse().or_else(|_| Parser::new("").parse())?;
+    let reset_provider = SignatureHelpProvider::new(&reset_ast);
+    let help =
+        reset_provider.get_signature_help(code, code.len()).ok_or("No signature help for reset")?;
+    let signature = help.signatures.first().ok_or("Missing reset signature")?;
+
+    assert!(
+        signature
+            .documentation
+            .as_deref()
+            .is_some_and(|doc| doc.contains("Returns") && doc.contains("perldoc -f reset")),
+        "reset documentation should include return details and perldoc reference"
+    );
+    assert_eq!(signature.parameters.first().map(|p| p.label.as_str()), Some("EXPR"));
+    assert!(
+        signature
+            .parameters
+            .first()
+            .and_then(|p| p.documentation.as_deref())
+            .is_some_and(|doc| doc.contains("Expression")),
+        "reset parameter documentation should describe the controlling expression"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Implements the smallest shippable slice of #418.

## Changes
- add return-value and perldoc reference text for the socket and deprecated builtin signatures called out by #418
- populate builtin parameter documentation for the signature-help placeholders used by those signatures
- add integration tests that verify docs quality through signature help, not just raw builtin presence

## Verification
- cargo fmt --all
- cargo clippy -p perl-lsp --tests -- -D warnings
- cargo test -p perl-lsp --test builtin_signatures_edge_cases_test
- cargo test -p perl-lsp --test builtin_signatures_test

## Scope control
This PR intentionally does not include:
- unrelated feature snapshot updates
- broader hover/completion refactors
- non-builtin signature help changes

Closes #418.