### PR TITLE
test(lsp): refresh advertised features snapshot

### DIFF
--- a/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
@@ -16,6 +16,7 @@ caps:
   - lsp.document_symbol
   - lsp.execute_command
   - lsp.folding_range
+  - lsp.formatting
   - lsp.hover
   - lsp.implementation
   - lsp.inlay_hint
@@ -25,6 +26,7 @@ caps:
   - lsp.notebook_document_sync
   - lsp.on_type_formatting
   - lsp.pull_diagnostics
+  - lsp.range_formatting
   - lsp.references
   - lsp.rename
   - lsp.selection_range


### PR DESCRIPTION
## Summary
Implements the smallest shippable slice of the current housekeeping drift.

## Changes
- refresh the advertised-vs-capabilities snapshot that is stale on clean origin/master

## Verification
- cargo fmt --all
- just ci-policy
- env -u RUSTC_WRAPPER cargo test -p perl-lsp --test lsp_features_snapshot_test

## Scope control
This PR intentionally does not include:
- docs/project/CURRENT_STATUS.md regeneration
- #417 completion changes
- #418 builtin signature changes