### PR TITLE
feat(completion): surface package member docs

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -995,6 +995,18 @@ sub internal_sub { }
             completions.iter().any(|c| c.label == "exported_sub"),
             "should suggest exported_sub"
         );
+        let exported_sub = completions
+            .iter()
+            .find(|completion| completion.label == "exported_sub")
+            .expect("expected exported_sub completion to be present");
+        let documentation = exported_sub
+            .documentation
+            .as_deref()
+            .expect("expected package member completion to include documentation");
+        assert!(
+            documentation.contains("MyModule::exported_sub"),
+            "expected package member doc to mention qualified symbol, got: {documentation:?}"
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-completion/src/completion/packages.rs
+++ b/crates/perl-lsp-completion/src/completion/packages.rs
@@ -3,8 +3,41 @@
 //! Provides completion for package members using workspace index integration.
 
 use super::{context::CompletionContext, items::CompletionItem};
-use perl_workspace_index::workspace_index::{SymbolKind as WsSymbolKind, WorkspaceIndex};
+use perl_workspace_index::workspace_index::{
+    SymbolKind as WsSymbolKind, WorkspaceIndex, WorkspaceSymbol,
+};
 use std::sync::Arc;
+
+fn fallback_member_documentation(package_name: &str, symbol: &WorkspaceSymbol) -> String {
+    let qualified_name =
+        symbol.qualified_name.clone().unwrap_or_else(|| format!("{package_name}::{}", symbol.name));
+
+    match symbol.kind {
+        WsSymbolKind::Export => {
+            format!("Exported function `{qualified_name}` from package `{package_name}`.")
+        }
+        WsSymbolKind::Subroutine => {
+            format!("Subroutine `{qualified_name}` defined in package `{package_name}`.")
+        }
+        WsSymbolKind::Method => {
+            format!("Method `{qualified_name}` defined in package `{package_name}`.")
+        }
+        WsSymbolKind::Variable(_) => {
+            format!("Package variable `{qualified_name}` declared in `{package_name}`.")
+        }
+        WsSymbolKind::Constant => {
+            format!("Constant `{qualified_name}` declared in `{package_name}`.")
+        }
+        _ => format!("Package member `{qualified_name}` from `{package_name}`."),
+    }
+}
+
+fn package_member_documentation(package_name: &str, symbol: &WorkspaceSymbol) -> Option<String> {
+    symbol
+        .documentation
+        .clone()
+        .or_else(|| Some(fallback_member_documentation(package_name, symbol)))
+}
 
 /// Add package member completions
 pub fn add_package_completions(
@@ -35,7 +68,7 @@ pub fn add_package_completions(
                         label: symbol.name.clone(),
                         kind: crate::completion::items::CompletionItemKind::Function,
                         detail: Some(package_name.clone()),
-                        documentation: symbol.documentation.clone(),
+                        documentation: package_member_documentation(&package_name, &symbol),
                         insert_text: Some(symbol.name.clone()),
                         sort_text: Some(format!("1_{}", symbol.name)),
                         filter_text: Some(symbol.name.clone()),
@@ -50,7 +83,7 @@ pub fn add_package_completions(
                         label: symbol.name.clone(),
                         kind: crate::completion::items::CompletionItemKind::Variable,
                         detail: Some(package_name.clone()),
-                        documentation: symbol.documentation.clone(),
+                        documentation: package_member_documentation(&package_name, &symbol),
                         insert_text: Some(symbol.name.clone()),
                         sort_text: Some(format!("1_{}", symbol.name)),
                         filter_text: Some(symbol.name.clone()),
@@ -65,7 +98,7 @@ pub fn add_package_completions(
                         label: symbol.name.clone(),
                         kind: crate::completion::items::CompletionItemKind::Constant,
                         detail: Some(package_name.clone()),
-                        documentation: symbol.documentation.clone(),
+                        documentation: package_member_documentation(&package_name, &symbol),
                         insert_text: Some(symbol.name.clone()),
                         sort_text: Some(format!("1_{}", symbol.name)),
                         filter_text: Some(symbol.name.clone()),

--- a/crates/perl-lsp/src/runtime/language/completion.rs
+++ b/crates/perl-lsp/src/runtime/language/completion.rs
@@ -37,6 +37,63 @@ fn get_snippet_simple_regex() -> Option<&'static Regex> {
 }
 
 impl LspServer {
+    fn workspace_symbol_qualified_name(symbol: &crate::workspace_index::WorkspaceSymbol) -> String {
+        symbol
+            .qualified_name
+            .clone()
+            .or_else(|| {
+                symbol
+                    .container_name
+                    .as_ref()
+                    .map(|container| format!("{container}::{}", symbol.name))
+            })
+            .unwrap_or_else(|| symbol.name.clone())
+    }
+
+    fn workspace_symbol_documentation(
+        symbol: &crate::workspace_index::WorkspaceSymbol,
+    ) -> Option<String> {
+        symbol.documentation.clone().or_else(|| {
+            let qualified_name = Self::workspace_symbol_qualified_name(symbol);
+
+            Some(match symbol.kind {
+                crate::workspace_index::SymbolKind::Package => {
+                    format!("Package `{qualified_name}` available in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Subroutine => {
+                    format!("Subroutine `{qualified_name}` defined in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Variable(_) => {
+                    format!("Variable `{qualified_name}` declared in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Class => {
+                    format!("Class `{qualified_name}` defined in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Method => {
+                    format!("Method `{qualified_name}` defined in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Constant => {
+                    format!("Constant `{qualified_name}` declared in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Role => {
+                    format!("Role `{qualified_name}` defined in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Import => {
+                    format!("Imported module `{qualified_name}` used in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Export => {
+                    format!("Exported function `{qualified_name}` available in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Label => {
+                    format!("Label `{qualified_name}` declared in the workspace.")
+                }
+                crate::workspace_index::SymbolKind::Format => {
+                    format!("Format `{qualified_name}` declared in the workspace.")
+                }
+            })
+        })
+    }
+
     /// Format type information concisely for completion detail
     pub(crate) fn format_type_for_detail(t: &crate::type_inference::PerlType) -> String {
         use perl_parser::type_inference::PerlType;
@@ -236,14 +293,17 @@ impl LspServer {
                                     }
                                 };
 
+                                let documentation = Self::workspace_symbol_documentation(&symbol);
+                                let label = symbol.name.clone();
+
                                 completions.push(crate::completion::CompletionItem {
-                                    label: symbol.name.clone(),
+                                    label: label.clone(),
                                     kind,
                                     detail: symbol.qualified_name,
-                                    insert_text: Some(symbol.name),
+                                    insert_text: Some(label),
                                     sort_text: None,
                                     filter_text: None,
-                                    documentation: None,
+                                    documentation,
                                     additional_edits: Vec::new(),
                                     text_edit_range: None, // Workspace completions don't need precise text edit
                                 });
@@ -303,6 +363,13 @@ impl LspServer {
                                 insert_text = Self::degrade_snippet_to_plaintext(&insert_text);
                             }
                             item["insertText"] = json!(insert_text);
+                        }
+
+                        if let Some(documentation) = c.documentation {
+                            item["documentation"] = json!({
+                                "kind": "markdown",
+                                "value": documentation
+                            });
                         }
 
                         // Only add commit characters for functions and variables, not keywords
@@ -473,6 +540,12 @@ impl LspServer {
                         }
                         if let Some(insert_text) = c.insert_text {
                             item["insertText"] = json!(insert_text);
+                        }
+                        if let Some(documentation) = c.documentation {
+                            item["documentation"] = json!({
+                                "kind": "markdown",
+                                "value": documentation
+                            });
                         }
 
                         Some(item)

--- a/crates/perl-lsp/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_completion_tests.rs
@@ -46,7 +46,6 @@ $cou
         }
         }),
     );
-
     let items = completion_items(&response);
     assert!(items.len() >= 2, "Should have at least 2 completions");
 
@@ -103,7 +102,6 @@ my @data = qw(a b c);
         }
         }),
     );
-
     let items = completion_items(&response);
     assert!(items.len() >= 2, "Should have at least 2 completions");
 
@@ -714,6 +712,17 @@ MyModule::"#
     // Package member completion should return available subroutines
     assert!(!items.is_empty(), "Package member completion should not be empty");
     assert!(items.iter().any(|i| i["label"] == "public_method"), "Should suggest public_method");
+    let public_method = items
+        .iter()
+        .find(|i| i["label"] == "public_method")
+        .ok_or("public_method completion should be present to verify documentation")?;
+    let documentation = public_method["documentation"]["value"]
+        .as_str()
+        .ok_or("public_method should include markdown documentation")?;
+    assert!(
+        documentation.contains("MyModule::public_method"),
+        "package member documentation should mention the qualified symbol, got: {documentation:?}"
+    );
 
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
@@ -187,6 +187,17 @@ my $result = DataProcessor::
         "Should suggest transform_data. Got: {:?}",
         labels
     );
+    let process_data = items
+        .iter()
+        .find(|item| item["label"].as_str() == Some("process_data"))
+        .ok_or("process_data completion should be present to verify documentation")?;
+    let documentation = process_data["documentation"]["value"]
+        .as_str()
+        .ok_or("process_data should include markdown documentation")?;
+    assert!(
+        documentation.contains("DataProcessor::process_data"),
+        "cross-file package completion should expose a qualified documentation snippet, got: {documentation:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
Implements the smallest real missing slice of #417.

## Changes
- add fallback documentation snippets for workspace-backed package members
- preserve completion documentation through both LSP completion response serializers
- add targeted LSP assertions for same-file and cross-file qualified package completion docs

## Verification
- cargo fmt --all
- cargo clippy -p perl-lsp --tests -- -D warnings
- cargo test -p perl-lsp --test lsp_completion_tests
- cargo test -p perl-lsp --test lsp_workspace_completion_tests
- just ci-policy

## Scope control
This PR intentionally does not include:
- built-in/core module member completion for external packages
- ranking or unrelated completion-provider refactors
- cross-file variable completion