### PR TITLE
chore: clean up .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,10 @@ SHA256SUMS
 
 # Property test regression files
 **/tests/_proptest-regressions/
-scripts/__pycache__/
 
 # Python cache files
 scripts/__pycache__/
 *.pyc
-releases/
 
 # Claude — agents/ is gitignored to allow swapping the active agents symlink.
 # agents2/, agents3/, agents4/ etc. are version-tracked.


### PR DESCRIPTION
## Summary
- Remove duplicate `scripts/__pycache__/` entry (was listed twice under different comment sections)
- Remove stale `releases/` ignore entry that is no longer needed