### PR TITLE
chore: remove unused serde dependency from perl-semantic-analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,6 @@ dependencies = [
  "lsp-types",
  "perl-feature-catalog",
  "perl-lsp-capability-map",
- "perl-lsp-feature-ids",
  "perl-tdd-support",
  "serde",
  "serde_json",
@@ -2096,17 +2095,13 @@ version = "0.11.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-document-links",
- "perl-lsp-symbol-query",
  "perl-lsp-workspace-symbols",
- "perl-module-import",
- "perl-module-path",
  "perl-parser-core",
  "perl-position-tracking",
  "perl-qualified-name",
  "perl-tdd-support",
  "serde",
  "serde_json",
- "url",
 ]
 
 [[package]]
@@ -2536,7 +2531,6 @@ dependencies = [
  "perl-workspace-index",
  "regex",
  "rustc-hash",
- "serde",
 ]
 
 [[package]]

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -17,8 +17,6 @@ include = ["src/**", "build.rs", "features_sot.toml", "Cargo.toml", "README.md"]
 [dependencies]
 serde = { workspace = true }
 lsp-types = "0.97.0"
-perl-feature-catalog = { workspace = true }
-perl-lsp-feature-ids = { workspace = true }
 perl-lsp-capability-map = { workspace = true }
 
 [build-dependencies]

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -21,13 +21,9 @@ perl-parser-core = { workspace = true }
 lsp-types = { version = "0.97.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-url = "2.5.8"
 perl-position-tracking = { workspace = true }
-perl-module-path = { workspace = true }
-perl-module-import = { workspace = true }
 perl-qualified-name = { workspace = true }
 perl-lsp-document-links = { workspace = true }
-perl-lsp-symbol-query = { workspace = true }
 perl-lsp-workspace-symbols = { workspace = true }
 
 [features]

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -28,7 +28,6 @@ perl-workspace-index = { workspace = true }
 perl-symbol-types = { workspace = true }
 regex = "1.12.2"
 rustc-hash = "2.1.1"
-serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }


### PR DESCRIPTION
## Summary
- Remove unused `serde` dependency from `perl-semantic-analyzer` Cargo.toml and Cargo.lock
- The crate does not use serde derives or serialization; this was a leftover dependency

## Test plan
- [x] `cargo test -p perl-semantic-analyzer` passes (all tests green)
- [x] `cargo build --workspace` succeeds with no errors