### PR TITLE
docs: add slash commands and fix VS Code extension ID

### DIFF
--- a/.claude/commands/bulk-pr.md
+++ b/.claude/commands/bulk-pr.md
@@ -1,0 +1,50 @@
+---
+description: PR all worktrees with uncommitted changes
+argument-hint: "[--dry-run] [--filter <pattern>]"
+---
+
+# Bulk PR Worktrees
+
+Scan all agent worktrees for uncommitted changes and create PRs for each. Context: **$ARGUMENTS**
+
+## Steps
+
+### 1. Scan worktrees
+```bash
+cd /home/steven/code/Rust/perl-lsp/tree-sitter-perl-rs/.claude/worktrees
+for d in agent-*; do
+  changes=$(cd "$d" && git diff --stat HEAD 2>/dev/null | tail -1)
+  if [ -n "$changes" ]; then
+    files=$(cd "$d" && git diff --name-only HEAD 2>/dev/null | tr '\n' ', ')
+    echo "READY: $d | $changes | $files"
+  fi
+done
+```
+
+### 2. For each worktree with changes
+
+Launch a parallel Agent (with `run_in_background: true`) for each worktree that:
+
+1. cd to the worktree
+2. Examines `git diff HEAD` to understand the changes
+3. Runs `cargo fmt --all -- --check` (fix if needed)
+4. Runs `cargo clippy --workspace --lib` (fix if needed)
+5. Runs appropriate `cargo test` for changed crates
+6. Creates a descriptive feature branch
+7. Commits with conventional commit message
+8. Pushes and creates PR via `gh pr create`
+9. Returns the PR URL
+
+### 3. Report
+
+Collect all PR URLs and report:
+
+| Worktree | Branch | PR URL | Status |
+|----------|--------|--------|--------|
+| agent-xxx | fix/... | #1234 | Created |
+| ... | | | |
+
+### Tips
+- Group small related changes (e.g., multiple `mod.rs` test additions) if they're logically related
+- Skip worktrees where the diff is just 1-2 lines of uncommitted debugging artifacts
+- Use `--dry-run` to preview without creating PRs

--- a/.claude/commands/corpus-ratchet.md
+++ b/.claude/commands/corpus-ratchet.md
@@ -1,0 +1,61 @@
+---
+description: Run corpus sweep, compare baseline, update manifests
+argument-hint: "[--system|--cpan|--common] [--update]"
+---
+
+# Corpus Ratchet
+
+Run parser corpus sweep and ratchet the baseline forward. Mode: **$ARGUMENTS**
+
+## Commands
+
+### System corpus (default)
+```bash
+just corpus-sweep
+```
+
+### Compare against baseline
+```bash
+just corpus-sweep-check
+```
+
+### Common corpus (CI gate — strict)
+```bash
+just common-corpus-check
+```
+
+### CPAN corpus
+```bash
+just cpan-corpus-sweep
+```
+
+### Update baseline after improvements
+```bash
+# 1. Run sweep to see current state
+just corpus-sweep
+
+# 2. If clean files increased, update baseline
+just corpus-sweep-update
+
+# 3. Check for newly-clean modules to add to manifest
+# (manually review which modules are now clean)
+
+# 4. Verify the ratchet holds
+just corpus-sweep-check
+just common-corpus-check
+
+# 5. Commit baseline + manifest updates
+git add .ci/parser-corpus-baseline.json .ci/common-corpus-manifest.txt
+git commit -m "ci: ratchet corpus baseline after parser improvements"
+```
+
+### CPAN corpus ratchet
+```bash
+just cpan-corpus-ratchet
+```
+
+## Key files
+- `.ci/parser-corpus-baseline.json` — system corpus baseline (ratchet floor)
+- `.ci/common-corpus-manifest.txt` — modules that MUST parse cleanly (CI gate)
+- `.ci/cpan-corpus-manifest.txt` — CPAN modules that must parse cleanly
+- `.ci/cpan-top-1000-distributions.txt` — pinned distribution list

--- a/.claude/commands/parser-fix.md
+++ b/.claude/commands/parser-fix.md
@@ -1,0 +1,54 @@
+---
+description: TDD parser fix (failing test → fix → verify → PR)
+argument-hint: "<bug description> e.g. '$Pkg::Var[0] not parsed as subscript'"
+---
+
+# Parser Fix (TDD)
+
+Fix a parser bug using test-driven development. Bug: **$ARGUMENTS**
+
+## Launch an agent in a worktree to do this work:
+
+Use the Agent tool with `isolation: "worktree"` and `mode: "auto"` to:
+
+### 1. Find the root cause
+- Search `crates/perl-parser-core/src/engine/parser/` for relevant parsing logic
+- Key files: `variables.rs`, `statements.rs`, `expressions/postfix.rs`, `expressions/precedence.rs`, `declarations.rs`
+- Understand WHY the construct fails to parse
+
+### 2. Write failing tests FIRST
+- Add tests in the appropriate test file under `crates/perl-parser-core/`
+- Each test should parse a Perl snippet and assert no ERROR nodes:
+```rust
+#[test]
+fn test_description() -> Result<()> {
+    let source = r#"<perl code>"#;
+    let mut parser = Parser::new(source);
+    let ast = parser.parse()?;
+    // Assert no errors
+    Ok(())
+}
+```
+
+### 3. Implement minimal fix
+- Change as little code as possible
+- Follow coding standards: NO `unwrap()`, `expect()`, `panic!()`, `todo!()` in production code
+
+### 4. Verify
+```bash
+cargo fmt --all
+cargo clippy -p perl-parser-core --lib
+cargo test -p perl-parser-core
+cargo test -p perl-parser
+```
+
+### 5. Create PR
+- Branch, commit, push, `gh pr create`
+- Title: `fix(parser): <description>`
+- Return PR URL
+
+## Coding Standards Reminder
+- No fatal constructs (`unwrap`, `expect`, `panic!`, `todo!`, `unimplemented!`)
+- Use `?`, `.ok_or_else()`, pattern matching
+- In tests: `Result<()>` return types
+- `cargo fmt` + `cargo clippy` must be clean

--- a/.claude/commands/wave.md
+++ b/.claude/commands/wave.md
@@ -1,0 +1,60 @@
+---
+description: Launch a wave of parallel agents for codebase improvement
+argument-hint: "<category> e.g. 'parser-fixes', 'test-coverage', 'doc-updates', 'cleanup'"
+---
+
+# Wave: Parallel Agent Dispatch
+
+Launch a wave of agents for: **$ARGUMENTS**
+
+## Categories
+
+### `parser-fixes`
+For each known parser bug from `.ci/parser-corpus-baseline.json` error buckets:
+- Launch an agent per fix using `/parser-fix` pattern
+- Each in its own worktree (`isolation: "worktree"`)
+- TDD: failing test → fix → verify
+- Reference `docs/project/PARSER_EDGE_CASE_ROADMAP.md` for known issues
+
+### `test-coverage`
+Launch agents to improve test coverage across crates:
+- `perl-parser-core` — CPAN-pattern tests (Moose, DBI, Try::Tiny)
+- `perl-lexer` / `perl-tokenizer` — edge case coverage
+- `perl-semantic-analyzer` — scope/import tests
+- `perl-workspace-index` — dual indexing tests
+- `perl-lsp` — LSP feature integration tests
+- `perl-refactoring` — rename/extract tests
+- `perl-dap` — DAP protocol tests
+
+### `doc-updates`
+Launch agents to update documentation:
+- `COMMANDS_REFERENCE.md` — new commands
+- `CLAUDE.md` — new tooling
+- `CONTRIBUTING.md` — current practices
+- `README.md` — feature claims freshness
+- New project docs for undocumented architecture
+
+### `cleanup`
+Launch agents for codebase hygiene:
+- `cargo machete` — unused dependencies
+- `cargo clippy` — lint warnings
+- Dead code removal
+- Obsolete script deletion
+- `.gitignore` updates
+
+## Pattern
+
+For each item in the category:
+```
+Agent(
+  prompt: "<specific task>",
+  mode: "auto",
+  isolation: "worktree",
+  run_in_background: true,
+  name: "<descriptive-name>"
+)
+```
+
+## After wave completes
+
+Run `/bulk-pr` to create PRs for all worktrees with changes.

--- a/.claude/commands/worktree-pr.md
+++ b/.claude/commands/worktree-pr.md
@@ -1,0 +1,64 @@
+---
+description: PR a worktree's changes (validate → branch → commit → push → PR)
+argument-hint: "<worktree-path> [commit message]"
+---
+
+# Worktree PR
+
+Create a PR from a worktree's uncommitted changes. Context: **$ARGUMENTS**
+
+## Steps
+
+1. **Identify the worktree** — parse $ARGUMENTS for the worktree path. If not provided, list available worktrees with changes:
+```bash
+cd /home/steven/code/Rust/perl-lsp/tree-sitter-perl-rs/.claude/worktrees && for d in agent-*; do changes=$(cd "$d" && git diff --stat HEAD 2>/dev/null | tail -1); [ -n "$changes" ] && echo "$d: $changes"; done
+```
+
+2. **Understand the changes** — cd to the worktree and examine:
+```bash
+git diff --stat HEAD
+git diff HEAD
+```
+
+3. **Validate** — run checks in the worktree:
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --lib 2>&1 | tail -5
+cargo test --workspace --lib 2>&1 | tail -10
+```
+Fix any issues before proceeding.
+
+4. **Branch** — create a descriptive feature branch:
+- `fix/...` for parser fixes
+- `test/...` for test additions
+- `docs/...` for documentation
+- `chore/...` for cleanup
+```bash
+git checkout -b <branch-name>
+```
+
+5. **Commit** — stage relevant files and commit with conventional commit message:
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <description>
+EOF
+)"
+```
+
+6. **Push and PR**:
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+## Summary
+<what and why>
+
+## Evidence
+- `cargo test` — passes
+- `cargo clippy` — clean
+- `cargo fmt` — clean
+EOF
+)"
+```
+
+7. **Return the PR URL**.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.
 
 ### VS Code
 
-Install the **Perl Language Server** extension (`effortlesssteven.perl-lsp`) from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlesssteven.perl-lsp), or build from [source](vscode-extension/).
+Install the **Perl Language Server** extension (`effortlessmetrics.perl-lsp-rs`) from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlessmetrics.perl-lsp-rs), or build from [source](vscode-extension/).
 
 ### Neovim (nvim-lspconfig)
 


### PR DESCRIPTION
## Summary
- Add five Claude Code slash commands for common workflows: `/worktree-pr`, `/parser-fix`, `/bulk-pr`, `/wave`, and `/corpus-ratchet`
- Fix VS Code extension ID in README.md (`effortlesssteven.perl-lsp` -> `effortlessmetrics.perl-lsp-rs`)

## Test plan
- [ ] Verify slash commands appear in Claude Code with `/` completion
- [ ] Verify README marketplace link resolves correctly