### PR TITLE
test(lexer,tokenizer): add 140 edge case regression tests

### DIFF
--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -1,0 +1,1189 @@
+//! Edge case tests for the Perl lexer.
+//!
+//! Covers:
+//! - Heredoc variants: bare, double-quoted, single-quoted, backtick, indented (<<~)
+//! - Regex delimiters: m{}, s[][], tr|||, qr<>
+//! - Quote-like operators: q{}, qq(), qw[], qx``
+//! - Special variables: $_, @_, %ENV, $!, $@, $$, $1..$9
+//! - Unicode identifiers: my $cafe = 1;
+
+use perl_lexer::{PerlLexer, TokenType};
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tokens(input: &str) -> Vec<perl_lexer::Token> {
+    PerlLexer::new(input).collect_tokens()
+}
+
+fn significant(input: &str) -> Vec<perl_lexer::Token> {
+    tokens(input)
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect()
+}
+
+fn first_significant(input: &str) -> Option<perl_lexer::Token> {
+    significant(input).into_iter().next()
+}
+
+/// Assert that every token span is within the input and the lexer terminates.
+fn assert_terminates(input: &str) {
+    let toks = tokens(input);
+    for t in &toks {
+        assert!(
+            t.end <= input.len(),
+            "Token {:?} end {} exceeds input len {}",
+            t.token_type,
+            t.end,
+            input.len()
+        );
+        assert!(t.start <= t.end, "Token {:?} has start {} > end {}", t.token_type, t.start, t.end);
+    }
+    assert!(
+        toks.iter().any(|t| matches!(t.token_type, TokenType::EOF)),
+        "Expected EOF token in output"
+    );
+}
+
+// ===========================================================================
+// 1. Heredoc variants
+// ===========================================================================
+
+#[test]
+fn heredoc_bare_word() -> R {
+    let input = "<<EOF\nhello world\nEOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<EOF");
+    Ok(())
+}
+
+#[test]
+fn heredoc_double_quoted_delimiter() -> R {
+    let input = "<<\"EOF\"\nhello world\nEOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<\"EOF\"");
+    Ok(())
+}
+
+#[test]
+fn heredoc_single_quoted_delimiter() -> R {
+    let input = "<<'EOF'\nhello world\nEOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<'EOF'");
+    Ok(())
+}
+
+#[test]
+fn heredoc_backtick_delimiter() -> R {
+    let input = "<<`CMD`\necho hello\nCMD\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<`CMD`");
+    Ok(())
+}
+
+#[test]
+fn heredoc_indented_bare() -> R {
+    let input = "<<~EOF\n    hello\n    EOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<~EOF");
+    Ok(())
+}
+
+#[test]
+fn heredoc_indented_double_quoted() -> R {
+    let input = "<<~\"END\"\n    hello $world\n    END\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<~\"END\"");
+    Ok(())
+}
+
+#[test]
+fn heredoc_indented_single_quoted() -> R {
+    let input = "<<~'END'\n    hello $literal\n    END\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "<<~'END'");
+    Ok(())
+}
+
+#[test]
+fn heredoc_body_consumed_before_next_statement() -> R {
+    // After a heredoc, the next statement should be tokenized normally
+    let input = "<<EOF\nbody\nEOF\nmy $x = 1;\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    // Should contain HeredocStart, then my, $x, =, 1, ;
+    let has_heredoc = sig.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    let has_my =
+        sig.iter().any(|t| matches!(&t.token_type, TokenType::Keyword(k) if k.as_ref() == "my"));
+    assert!(has_heredoc, "expected HeredocStart");
+    assert!(has_my, "expected 'my' keyword after heredoc body");
+    Ok(())
+}
+
+#[test]
+fn heredoc_empty_body() -> R {
+    let input = "<<EOF\nEOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::HeredocStart),
+        "Expected HeredocStart, got {:?}",
+        first.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn heredoc_with_trailing_whitespace_on_terminator() -> R {
+    // Perl allows trailing whitespace on the terminator line
+    let input = "<<EOF\nhello\nEOF   \n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_heredoc = sig.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    assert!(has_heredoc, "expected HeredocStart");
+    Ok(())
+}
+
+// ===========================================================================
+// 2. Regex delimiters
+// ===========================================================================
+
+#[test]
+fn regex_m_brace_delimiter() -> R {
+    let input = "m{pattern}";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch for m{{...}}, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "m{pattern}");
+    Ok(())
+}
+
+#[test]
+fn regex_m_bracket_delimiter() -> R {
+    let input = "m[pattern]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch for m[...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "m[pattern]");
+    Ok(())
+}
+
+#[test]
+fn regex_m_angle_delimiter() -> R {
+    let input = "m<pattern>";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch for m<...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "m<pattern>");
+    Ok(())
+}
+
+#[test]
+fn regex_m_paren_delimiter() -> R {
+    let input = "m(pattern)";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch for m(...), got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "m(pattern)");
+    Ok(())
+}
+
+#[test]
+fn substitution_bracket_bracket() -> R {
+    let input = "s[old][new]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for s[...][...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s[old][new]");
+    Ok(())
+}
+
+#[test]
+fn substitution_angle_angle() -> R {
+    let input = "s<old><new>";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for s<...><...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s<old><new>");
+    Ok(())
+}
+
+#[test]
+fn substitution_mixed_paired_delimiters() -> R {
+    // Perl allows different paired delimiters for pattern and replacement: s{old}[new]
+    let input = "s{old}[new]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for s{{old}}[new], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s{old}[new]");
+    Ok(())
+}
+
+#[test]
+fn substitution_with_modifiers_ge() -> R {
+    let input = "s/foo/bar/ge";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "s/foo/bar/ge");
+    Ok(())
+}
+
+#[test]
+fn transliteration_pipe_delimiter() -> R {
+    let input = "tr|a-z|A-Z|";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration for tr|...|...|, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "tr|a-z|A-Z|");
+    Ok(())
+}
+
+#[test]
+fn transliteration_bracket_delimiter() -> R {
+    let input = "tr[a-z][A-Z]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration for tr[...][...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "tr[a-z][A-Z]");
+    Ok(())
+}
+
+#[test]
+fn transliteration_with_modifiers_cds() -> R {
+    let input = "tr/a-z/A-Z/cds";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "tr/a-z/A-Z/cds");
+    Ok(())
+}
+
+#[test]
+fn transliteration_y_alias() -> R {
+    let input = "y/a-z/A-Z/";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration for y///,  got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "y/a-z/A-Z/");
+    Ok(())
+}
+
+#[test]
+fn qr_angle_delimiter() -> R {
+    let input = "qr<pattern>i";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteRegex),
+        "Expected QuoteRegex for qr<...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qr<pattern>i");
+    Ok(())
+}
+
+#[test]
+fn qr_brace_delimiter() -> R {
+    let input = "qr{pattern}ms";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteRegex),
+        "Expected QuoteRegex for qr{{...}}, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qr{pattern}ms");
+    Ok(())
+}
+
+#[test]
+fn regex_with_escaped_delimiter() -> R {
+    let input = r"/foo\/bar/";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch with escaped delimiter, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), r"/foo\/bar/");
+    Ok(())
+}
+
+#[test]
+fn regex_with_modifiers_imsx() -> R {
+    let input = "/pattern/imsx";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "/pattern/imsx");
+    Ok(())
+}
+
+// ===========================================================================
+// 3. Quote-like operators
+// ===========================================================================
+
+#[test]
+fn q_brace_operator() -> R {
+    let input = "q{hello world}";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q{{...}}, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q{hello world}");
+    Ok(())
+}
+
+#[test]
+fn q_paren_operator() -> R {
+    let input = "q(hello world)";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q(...), got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q(hello world)");
+    Ok(())
+}
+
+#[test]
+fn q_bracket_operator() -> R {
+    let input = "q[hello world]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q[...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q[hello world]");
+    Ok(())
+}
+
+#[test]
+fn q_angle_operator() -> R {
+    let input = "q<hello world>";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q<...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q<hello world>");
+    Ok(())
+}
+
+#[test]
+fn q_pipe_operator() -> R {
+    let input = "q|hello world|";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q|...|, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q|hello world|");
+    Ok(())
+}
+
+#[test]
+fn qq_paren_operator() -> R {
+    let input = "qq(hello $world)";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble for qq(...), got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq(hello $world)");
+    Ok(())
+}
+
+#[test]
+fn qq_bracket_operator() -> R {
+    let input = "qq[hello $world]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble for qq[...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq[hello $world]");
+    Ok(())
+}
+
+#[test]
+fn qq_angle_operator() -> R {
+    let input = "qq<hello $world>";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble for qq<...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq<hello $world>");
+    Ok(())
+}
+
+#[test]
+fn qw_bracket_operator() -> R {
+    let input = "qw[foo bar baz]";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteWords),
+        "Expected QuoteWords for qw[...], got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qw[foo bar baz]");
+    Ok(())
+}
+
+#[test]
+fn qw_angle_operator() -> R {
+    let input = "qw<foo bar baz>";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteWords),
+        "Expected QuoteWords for qw<...>, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qw<foo bar baz>");
+    Ok(())
+}
+
+#[test]
+fn qw_pipe_operator() -> R {
+    let input = "qw|foo bar baz|";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteWords),
+        "Expected QuoteWords for qw|...|, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qw|foo bar baz|");
+    Ok(())
+}
+
+#[test]
+fn qx_brace_operator() -> R {
+    let input = "qx{ls -la}";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteCommand),
+        "Expected QuoteCommand for qx{{...}}, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qx{ls -la}");
+    Ok(())
+}
+
+#[test]
+fn qx_paren_operator() -> R {
+    let input = "qx(ls -la)";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteCommand),
+        "Expected QuoteCommand for qx(...), got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qx(ls -la)");
+    Ok(())
+}
+
+#[test]
+fn q_with_nested_delimiters() -> R {
+    let input = "q{hello {nested} world}";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for nested q{{...}}, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "q{hello {nested} world}");
+    Ok(())
+}
+
+#[test]
+fn qq_with_nested_parens() -> R {
+    let input = "qq(hello (nested) world)";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteDouble),
+        "Expected QuoteDouble for nested qq(...), got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "qq(hello (nested) world)");
+    Ok(())
+}
+
+#[test]
+fn q_with_escaped_delimiter() -> R {
+    let input = r"q|hello \| world|";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteSingle),
+        "Expected QuoteSingle for q|...\\|...|, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), r"q|hello \| world|");
+    Ok(())
+}
+
+// ===========================================================================
+// 4. Special variables
+// ===========================================================================
+
+#[test]
+fn special_var_dollar_underscore() -> R {
+    let tok = first_significant("$_").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$_"),
+        "Expected Identifier($_), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_at_underscore() -> R {
+    let tok = first_significant("@_").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "@_"),
+        "Expected Identifier(@_), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_percent_env() -> R {
+    let tok = first_significant("%ENV").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "%ENV"),
+        "Expected Identifier(%ENV), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_bang() -> R {
+    let tok = first_significant("$!").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$!"),
+        "Expected Identifier($!), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_at() -> R {
+    let tok = first_significant("$@").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$@"),
+        "Expected Identifier($@), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_dollar() -> R {
+    let tok = first_significant("$$").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$$"),
+        "Expected Identifier($$), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_backslash() -> R {
+    let tok = first_significant("$\\").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$\\"),
+        "Expected Identifier($\\), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_slash() -> R {
+    let tok = first_significant("$/").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$/"),
+        "Expected Identifier($/), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_pipe() -> R {
+    let tok = first_significant("$|").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$|"),
+        "Expected Identifier($|), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_bracket() -> R {
+    let tok = first_significant("$[").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$["),
+        "Expected Identifier($[), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn capture_variables_1_through_9() -> R {
+    for n in 1..=9 {
+        let var = format!("${}", n);
+        let toks = tokens(&var);
+        // The variable should be tokenized (may be as Identifier or as $ + Number)
+        assert!(!toks.is_empty(), "Expected at least one token for '{}'", var);
+        // Verify the lexer terminates and produces valid spans
+        for t in &toks {
+            assert!(
+                t.end <= var.len(),
+                "Token {:?} end {} exceeds input len {}",
+                t.token_type,
+                t.end,
+                var.len()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_question() -> R {
+    let tok = first_significant("$?").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$?"),
+        "Expected Identifier($?), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_dot() -> R {
+    let tok = first_significant("$.").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$."),
+        "Expected Identifier($.), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_plus() -> R {
+    let tok = first_significant("$+").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$+"),
+        "Expected Identifier($+), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_minus() -> R {
+    let tok = first_significant("$-").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$-"),
+        "Expected Identifier($-), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_ampersand() -> R {
+    let tok = first_significant("$&").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$&"),
+        "Expected Identifier($&), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_backtick() -> R {
+    let tok = first_significant("$`").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$`"),
+        "Expected Identifier($`), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_quote() -> R {
+    // $' is the post-match variable
+    let tok = first_significant("$'").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$'"),
+        "Expected Identifier($'), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_at_plus() -> R {
+    // @+ is the array of match end positions
+    let tok = first_significant("@+").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "@+"),
+        "Expected Identifier(@+), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_at_minus() -> R {
+    // @- is the array of match start positions
+    let tok = first_significant("@-").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "@-"),
+        "Expected Identifier(@-), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_percent_plus() -> R {
+    // %+ is the hash of named capture groups (last match)
+    let tok = first_significant("%+").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "%+"),
+        "Expected Identifier(%+), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_percent_minus() -> R {
+    // %- is the hash of named capture groups (all matches)
+    let tok = first_significant("%-").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "%-"),
+        "Expected Identifier(%-), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_hash_array() -> R {
+    // $#array gives the last index of @array
+    let tok = first_significant("$#array").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$#array"),
+        "Expected Identifier($#array), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn special_var_dollar_caret_match() -> R {
+    // ${^MATCH} is the special variable for the matched string
+    let tok = first_significant("${^MATCH}").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(_)),
+        "Expected Identifier for ${{^MATCH}}, got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn package_qualified_variable() -> R {
+    let tok = first_significant("$Foo::Bar::baz").ok_or("no token")?;
+    assert!(
+        matches!(&tok.token_type, TokenType::Identifier(id) if id.as_ref() == "$Foo::Bar::baz"),
+        "Expected Identifier($Foo::Bar::baz), got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+// ===========================================================================
+// 5. Unicode identifiers
+// ===========================================================================
+
+#[test]
+fn unicode_identifier_cafe() -> R {
+    let input = "my $caf\u{00e9} = 1;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_cafe = sig.iter().any(|t| {
+        matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref().contains("caf\u{00e9}"))
+    });
+    assert!(has_cafe, "expected unicode identifier $caf\u{00e9}");
+    Ok(())
+}
+
+#[test]
+fn unicode_identifier_accented_variable() -> R {
+    let input = "my $\u{00fc}ber = 42;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_uber = sig.iter().any(|t| {
+        matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref().contains("\u{00fc}ber"))
+    });
+    assert!(has_uber, "expected unicode identifier $\u{00fc}ber");
+    Ok(())
+}
+
+#[test]
+fn unicode_identifier_cjk() -> R {
+    // CJK characters are in XID_Start/XID_Continue
+    let input = "my $\u{4e16}\u{754c} = 1;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_cjk = sig.iter().any(|t| {
+        matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref().contains("\u{4e16}\u{754c}"))
+    });
+    assert!(has_cjk, "expected CJK unicode identifier");
+    Ok(())
+}
+
+#[test]
+fn unicode_identifier_cyrillic() -> R {
+    let input = "my $\u{043f}\u{0440}\u{0438}\u{0432}\u{0435}\u{0442} = 1;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_cyrillic = sig.iter().any(|t| {
+        matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref().contains("\u{043f}\u{0440}\u{0438}\u{0432}\u{0435}\u{0442}"))
+    });
+    assert!(has_cyrillic, "expected Cyrillic unicode identifier");
+    Ok(())
+}
+
+#[test]
+fn unicode_subroutine_name() -> R {
+    // Perl allows Unicode in subroutine names
+    let input = "sub caf\u{00e9} { }";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_name = sig.iter().any(
+        |t| matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref() == "caf\u{00e9}"),
+    );
+    assert!(has_name, "expected unicode subroutine name caf\u{00e9}");
+    Ok(())
+}
+
+// ===========================================================================
+// 6. Combined edge cases / integration-like tests
+// ===========================================================================
+
+#[test]
+fn heredoc_followed_by_regex() -> R {
+    let input = "<<EOF\nbody\nEOF\nif (/pattern/) { }\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_heredoc = sig.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    let has_regex = sig.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_heredoc, "expected HeredocStart");
+    assert!(has_regex, "expected RegexMatch after heredoc");
+    Ok(())
+}
+
+#[test]
+fn multiple_quote_operators_in_sequence() -> R {
+    let input = "my $a = q{one}; my $b = qq(two); my @c = qw[three four];";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_q = sig.iter().any(|t| matches!(t.token_type, TokenType::QuoteSingle));
+    let has_qq = sig.iter().any(|t| matches!(t.token_type, TokenType::QuoteDouble));
+    let has_qw = sig.iter().any(|t| matches!(t.token_type, TokenType::QuoteWords));
+    assert!(has_q, "expected QuoteSingle");
+    assert!(has_qq, "expected QuoteDouble");
+    assert!(has_qw, "expected QuoteWords");
+    Ok(())
+}
+
+#[test]
+fn special_variables_in_expressions() -> R {
+    let input = "if ($! && $@ eq '') { $_ = $1; }";
+    assert_terminates(input);
+    let sig = significant(input);
+    // Should produce several Identifier tokens for $!, $@, $_, $1
+    let ident_count =
+        sig.iter().filter(|t| matches!(t.token_type, TokenType::Identifier(_))).count();
+    assert!(ident_count >= 3, "expected at least 3 identifier tokens, got {}", ident_count);
+    Ok(())
+}
+
+#[test]
+fn regex_after_binding_operator() -> R {
+    // =~ should put lexer in ExpectTerm mode so / starts regex
+    let input = "$x =~ /pattern/i";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_regex = sig.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "expected RegexMatch after =~ binding operator");
+    Ok(())
+}
+
+#[test]
+fn division_after_variable() -> R {
+    // After a variable, / should be division, not regex
+    let input = "$x / 2";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_division = sig.iter().any(|t| matches!(t.token_type, TokenType::Division));
+    assert!(
+        has_division,
+        "expected Division after variable, got: {:?}",
+        sig.iter().map(|t| &t.token_type).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn division_after_closing_paren() -> R {
+    // After ), / should be division
+    let input = "($x) / 2";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_division = sig.iter().any(|t| matches!(t.token_type, TokenType::Division));
+    assert!(has_division, "expected Division after closing paren");
+    Ok(())
+}
+
+#[test]
+fn regex_after_keyword() -> R {
+    // After keyword like 'if', / should start regex
+    let input = "if /pattern/";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_regex = sig.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "expected RegexMatch after keyword 'if'");
+    Ok(())
+}
+
+#[test]
+fn backtick_string_basic() -> R {
+    let input = "`ls -la`";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::QuoteCommand),
+        "Expected QuoteCommand for backtick string, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "`ls -la`");
+    Ok(())
+}
+
+#[test]
+fn empty_regex() -> R {
+    let input = "//";
+    // At start of input, mode is ExpectTerm, so // is an empty regex
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::RegexMatch),
+        "Expected RegexMatch for empty regex //, got {:?}",
+        first.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn defined_or_after_variable() -> R {
+    // After variable, // should be defined-or operator
+    let input = "$x // $y";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_defined_or =
+        sig.iter().any(|t| matches!(&t.token_type, TokenType::Operator(op) if op.as_ref() == "//"));
+    assert!(has_defined_or, "expected // as defined-or operator after variable");
+    Ok(())
+}
+
+#[test]
+fn heredoc_with_expression_on_same_line() -> R {
+    // Perl allows expressions after heredoc marker on the same line
+    let input = "my $x = <<EOF . \"suffix\";\nhello\nEOF\n";
+    assert_terminates(input);
+    let sig = significant(input);
+    let has_heredoc = sig.iter().any(|t| matches!(t.token_type, TokenType::HeredocStart));
+    assert!(has_heredoc, "expected HeredocStart");
+    Ok(())
+}
+
+#[test]
+fn substitution_with_escaped_delimiters() -> R {
+    let input = r"s/foo\/bar/baz\/qux/";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution with escaped delimiters, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), r"s/foo\/bar/baz\/qux/");
+    Ok(())
+}
+
+#[test]
+fn transliteration_with_ranges() -> R {
+    let input = "tr/a-zA-Z/A-Za-z/";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Transliteration),
+        "Expected Transliteration, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "tr/a-zA-Z/A-Za-z/");
+    Ok(())
+}

--- a/crates/perl-tokenizer/tests/edge_case_tests.rs
+++ b/crates/perl-tokenizer/tests/edge_case_tests.rs
@@ -1,0 +1,521 @@
+//! Edge case tests for the perl-tokenizer crate.
+//!
+//! Verifies that the TokenStream correctly translates lexer tokens
+//! for edge-case Perl constructs: heredocs, regex delimiters,
+//! quote-like operators, special variables, and Unicode identifiers.
+
+use perl_tdd_support::must;
+use perl_tokenizer::TokenKind;
+use perl_tokenizer::token_stream::TokenStream;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn collect_kinds(src: &str) -> Vec<TokenKind> {
+    let mut s = TokenStream::new(src);
+    let mut kinds = Vec::new();
+    while let Ok(t) = s.next() {
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        kinds.push(t.kind);
+    }
+    kinds
+}
+
+fn collect_texts(src: &str) -> Vec<String> {
+    let mut s = TokenStream::new(src);
+    let mut texts = Vec::new();
+    while let Ok(t) = s.next() {
+        if t.kind == TokenKind::Eof {
+            break;
+        }
+        texts.push(t.text.to_string());
+    }
+    texts
+}
+
+fn first_kind(src: &str) -> TokenKind {
+    let mut s = TokenStream::new(src);
+    must(s.peek()).kind
+}
+
+fn first_text(src: &str) -> String {
+    let mut s = TokenStream::new(src);
+    must(s.peek()).text.to_string()
+}
+
+// ===========================================================================
+// 1. Heredoc variants through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_heredoc_bare_word() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<EOF\nhello\nEOF\n");
+    assert!(kinds.contains(&TokenKind::HeredocStart), "Expected HeredocStart in {:?}", kinds);
+    Ok(())
+}
+
+#[test]
+fn ts_heredoc_double_quoted() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<\"EOF\"\nhello\nEOF\n");
+    assert!(
+        kinds.contains(&TokenKind::HeredocStart),
+        "Expected HeredocStart for double-quoted heredoc"
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_heredoc_single_quoted() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<'EOF'\nhello\nEOF\n");
+    assert!(
+        kinds.contains(&TokenKind::HeredocStart),
+        "Expected HeredocStart for single-quoted heredoc"
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_heredoc_backtick() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<`CMD`\necho hello\nCMD\n");
+    assert!(kinds.contains(&TokenKind::HeredocStart), "Expected HeredocStart for backtick heredoc");
+    Ok(())
+}
+
+#[test]
+fn ts_heredoc_indented() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<~EOF\n    hello\n    EOF\n");
+    assert!(kinds.contains(&TokenKind::HeredocStart), "Expected HeredocStart for indented heredoc");
+    Ok(())
+}
+
+#[test]
+fn ts_heredoc_followed_by_statement() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<EOF\nbody\nEOF\nmy $x = 1;\n");
+    assert!(kinds.contains(&TokenKind::HeredocStart));
+    assert!(kinds.contains(&TokenKind::My), "Expected 'my' after heredoc body");
+    Ok(())
+}
+
+// ===========================================================================
+// 2. Regex delimiters through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_regex_m_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("m{pattern}");
+    assert_eq!(kind, TokenKind::Regex, "m{{...}} should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_regex_m_bracket() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("m[pattern]");
+    assert_eq!(kind, TokenKind::Regex, "m[...] should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_regex_m_angle() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("m<pattern>");
+    assert_eq!(kind, TokenKind::Regex, "m<...> should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_regex_m_paren() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("m(pattern)");
+    assert_eq!(kind, TokenKind::Regex, "m(...) should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_regex_m_pipe() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("m|pattern|");
+    assert_eq!(kind, TokenKind::Regex, "m|...| should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_regex_slash_with_modifiers() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text("/pattern/imsx");
+    assert_eq!(text, "/pattern/imsx");
+    let kind = first_kind("/pattern/imsx");
+    assert_eq!(kind, TokenKind::Regex);
+    Ok(())
+}
+
+#[test]
+fn ts_substitution_brackets() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("s[old][new]");
+    assert_eq!(kind, TokenKind::Substitution, "s[...][...] should be Substitution");
+    Ok(())
+}
+
+#[test]
+fn ts_substitution_angles() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("s<old><new>");
+    assert_eq!(kind, TokenKind::Substitution, "s<...><...> should be Substitution");
+    Ok(())
+}
+
+#[test]
+fn ts_substitution_with_modifiers() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text("s/foo/bar/ge");
+    assert_eq!(text, "s/foo/bar/ge");
+    let kind = first_kind("s/foo/bar/ge");
+    assert_eq!(kind, TokenKind::Substitution);
+    Ok(())
+}
+
+#[test]
+fn ts_transliteration_pipe() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("tr|a-z|A-Z|");
+    assert_eq!(kind, TokenKind::Transliteration, "tr|...|...| should be Transliteration");
+    Ok(())
+}
+
+#[test]
+fn ts_transliteration_y_alias() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("y/a-z/A-Z/");
+    assert_eq!(kind, TokenKind::Transliteration, "y/.../.../ should be Transliteration");
+    Ok(())
+}
+
+#[test]
+fn ts_qr_angle() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qr<pattern>i");
+    assert_eq!(kind, TokenKind::Regex, "qr<...> should be Regex");
+    Ok(())
+}
+
+#[test]
+fn ts_qr_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qr{pattern}");
+    assert_eq!(kind, TokenKind::Regex, "qr{{...}} should be Regex");
+    Ok(())
+}
+
+// ===========================================================================
+// 3. Quote-like operators through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_q_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("q{hello}");
+    assert_eq!(kind, TokenKind::QuoteSingle, "q{{...}} should be QuoteSingle");
+    Ok(())
+}
+
+#[test]
+fn ts_q_paren() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("q(hello)");
+    assert_eq!(kind, TokenKind::QuoteSingle, "q(...) should be QuoteSingle");
+    Ok(())
+}
+
+#[test]
+fn ts_q_bracket() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("q[hello]");
+    assert_eq!(kind, TokenKind::QuoteSingle, "q[...] should be QuoteSingle");
+    Ok(())
+}
+
+#[test]
+fn ts_q_angle() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("q<hello>");
+    assert_eq!(kind, TokenKind::QuoteSingle, "q<...> should be QuoteSingle");
+    Ok(())
+}
+
+#[test]
+fn ts_q_pipe() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("q|hello|");
+    assert_eq!(kind, TokenKind::QuoteSingle, "q|...| should be QuoteSingle");
+    Ok(())
+}
+
+#[test]
+fn ts_qq_paren() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qq(hello $world)");
+    assert_eq!(kind, TokenKind::QuoteDouble, "qq(...) should be QuoteDouble");
+    Ok(())
+}
+
+#[test]
+fn ts_qq_bracket() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qq[hello $world]");
+    assert_eq!(kind, TokenKind::QuoteDouble, "qq[...] should be QuoteDouble");
+    Ok(())
+}
+
+#[test]
+fn ts_qq_angle() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qq<hello $world>");
+    assert_eq!(kind, TokenKind::QuoteDouble, "qq<...> should be QuoteDouble");
+    Ok(())
+}
+
+#[test]
+fn ts_qw_bracket() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qw[foo bar baz]");
+    assert_eq!(kind, TokenKind::QuoteWords, "qw[...] should be QuoteWords");
+    Ok(())
+}
+
+#[test]
+fn ts_qw_angle() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qw<foo bar baz>");
+    assert_eq!(kind, TokenKind::QuoteWords, "qw<...> should be QuoteWords");
+    Ok(())
+}
+
+#[test]
+fn ts_qw_pipe() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qw|foo bar baz|");
+    assert_eq!(kind, TokenKind::QuoteWords, "qw|...| should be QuoteWords");
+    Ok(())
+}
+
+#[test]
+fn ts_qx_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qx{ls -la}");
+    assert_eq!(kind, TokenKind::QuoteCommand, "qx{{...}} should be QuoteCommand");
+    Ok(())
+}
+
+#[test]
+fn ts_qx_paren() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("qx(ls -la)");
+    assert_eq!(kind, TokenKind::QuoteCommand, "qx(...) should be QuoteCommand");
+    Ok(())
+}
+
+#[test]
+fn ts_backtick_string() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("`ls -la`");
+    assert_eq!(kind, TokenKind::QuoteCommand, "backtick string should be QuoteCommand");
+    Ok(())
+}
+
+#[test]
+fn ts_q_nested_delimiters() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text("q{hello {nested} world}");
+    assert_eq!(text, "q{hello {nested} world}");
+    let kind = first_kind("q{hello {nested} world}");
+    assert_eq!(kind, TokenKind::QuoteSingle);
+    Ok(())
+}
+
+// ===========================================================================
+// 4. Special variables through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_special_var_dollar_underscore() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$_");
+    assert!(
+        kinds.contains(&TokenKind::Identifier),
+        "$_ should tokenize to Identifier, got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_at_underscore() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("@_");
+    assert!(
+        kinds.contains(&TokenKind::Identifier),
+        "@_ should tokenize to Identifier, got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_percent_env() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("%ENV");
+    assert!(
+        kinds.contains(&TokenKind::Identifier) || kinds.contains(&TokenKind::HashSigil),
+        "%ENV should tokenize, got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_dollar_bang() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$!");
+    assert!(!kinds.is_empty(), "$! should produce at least one token");
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_dollar_at() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$@");
+    assert!(!kinds.is_empty(), "$@ should produce at least one token");
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_dollar_dollar() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$$");
+    assert!(!kinds.is_empty(), "$$ should produce at least one token");
+    Ok(())
+}
+
+#[test]
+fn ts_special_var_dollar_hash_array() -> Result<(), Box<dyn std::error::Error>> {
+    let texts = collect_texts("$#array");
+    assert!(
+        texts.iter().any(|t| t.contains("#array") || t == "$#array"),
+        "$#array should be in tokens, got {:?}",
+        texts
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_capture_variables() -> Result<(), Box<dyn std::error::Error>> {
+    for n in 1..=9 {
+        let var = format!("${}", n);
+        let kinds = collect_kinds(&var);
+        assert!(!kinds.is_empty(), "Expected at least one token for '{}'", var);
+    }
+    Ok(())
+}
+
+#[test]
+fn ts_package_qualified_var() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text("$Foo::Bar::baz");
+    assert_eq!(text, "$Foo::Bar::baz");
+    let kind = first_kind("$Foo::Bar::baz");
+    assert_eq!(kind, TokenKind::Identifier);
+    Ok(())
+}
+
+// ===========================================================================
+// 5. Unicode identifiers through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_unicode_identifier_cafe() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("my $caf\u{00e9} = 1;");
+    assert!(kinds.contains(&TokenKind::My));
+    assert!(kinds.contains(&TokenKind::Identifier));
+    assert!(kinds.contains(&TokenKind::Number));
+    Ok(())
+}
+
+#[test]
+fn ts_unicode_identifier_cjk() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("my $\u{4e16}\u{754c} = 1;");
+    assert!(kinds.contains(&TokenKind::My));
+    assert!(kinds.contains(&TokenKind::Identifier));
+    Ok(())
+}
+
+#[test]
+fn ts_unicode_subroutine_name() -> Result<(), Box<dyn std::error::Error>> {
+    let texts = collect_texts("sub caf\u{00e9} { }");
+    assert!(
+        texts.iter().any(|t| t.contains("caf\u{00e9}")),
+        "expected unicode sub name in texts: {:?}",
+        texts
+    );
+    Ok(())
+}
+
+// ===========================================================================
+// 6. Slash disambiguation through TokenStream
+// ===========================================================================
+
+#[test]
+fn ts_division_after_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$x / 2");
+    assert!(
+        kinds.contains(&TokenKind::Slash),
+        "/ after variable should be Slash (division), got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_regex_after_binding() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$x =~ /pattern/i");
+    assert!(kinds.contains(&TokenKind::Regex), "/ after =~ should be Regex, got {:?}", kinds);
+    Ok(())
+}
+
+#[test]
+fn ts_defined_or_after_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("$x // $y");
+    assert!(
+        kinds.contains(&TokenKind::DefinedOr),
+        "// after variable should be DefinedOr, got {:?}",
+        kinds
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_regex_at_statement_start() -> Result<(), Box<dyn std::error::Error>> {
+    let kind = first_kind("/pattern/");
+    assert_eq!(kind, TokenKind::Regex, "/ at statement start should be Regex");
+    Ok(())
+}
+
+// ===========================================================================
+// 7. Combined edge cases
+// ===========================================================================
+
+#[test]
+fn ts_heredoc_then_regex() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("<<EOF\nbody\nEOF\nif (/pattern/) { }\n");
+    assert!(kinds.contains(&TokenKind::HeredocStart));
+    assert!(kinds.contains(&TokenKind::Regex));
+    Ok(())
+}
+
+#[test]
+fn ts_multiple_quote_ops() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("my $a = q{one}; my $b = qq(two); my @c = qw[three four];");
+    assert!(kinds.contains(&TokenKind::QuoteSingle));
+    assert!(kinds.contains(&TokenKind::QuoteDouble));
+    assert!(kinds.contains(&TokenKind::QuoteWords));
+    Ok(())
+}
+
+#[test]
+fn ts_special_vars_in_expression() -> Result<(), Box<dyn std::error::Error>> {
+    let kinds = collect_kinds("if ($! && $@) { $_ = $0; }");
+    let id_count = kinds.iter().filter(|&&k| k == TokenKind::Identifier).count();
+    assert!(
+        id_count >= 3,
+        "expected at least 3 identifier tokens for special vars, got {}",
+        id_count
+    );
+    Ok(())
+}
+
+#[test]
+fn ts_substitution_escaped_delimiters() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text(r"s/foo\/bar/baz\/qux/");
+    assert_eq!(text, r"s/foo\/bar/baz\/qux/");
+    let kind = first_kind(r"s/foo\/bar/baz\/qux/");
+    assert_eq!(kind, TokenKind::Substitution);
+    Ok(())
+}
+
+#[test]
+fn ts_transliteration_with_ranges() -> Result<(), Box<dyn std::error::Error>> {
+    let text = first_text("tr/a-zA-Z/A-Za-z/");
+    assert_eq!(text, "tr/a-zA-Z/A-Za-z/");
+    let kind = first_kind("tr/a-zA-Z/A-Za-z/");
+    assert_eq!(kind, TokenKind::Transliteration);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds comprehensive edge case tests for perl-lexer (85) and perl-tokenizer (55) covering:
- **Heredocs**: bare, quoted, backtick, indented (<<~), empty body, trailing whitespace
- **Regex delimiters**: m{}, s[][], tr||, qr<>, mixed paired, modifiers, escapes
- **Quote-like operators**: q{}, qq(), qw[], qx{}, nested delimiters, escaped delimiters
- **Special variables**: $_, @_, %ENV, $!, $@, $$, $1-$9, ${^MATCH}, $Foo::Bar::baz
- **Unicode identifiers**: Latin accents, CJK, Cyrillic, unicode sub names
- **Slash disambiguation**: division vs regex in various contexts

All 140 tests pass. No production code changes — purely regression guards.