### PR TITLE
feat(parser): parse return/next/last/redo as control flow in expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -363,6 +363,46 @@ impl<'a> Parser<'a> {
         Ok(Node::new(NodeKind::Return { value }, SourceLocation { start, end }))
     }
 
+    /// Parse return in expression context (e.g. ternary branches, short-circuit).
+    ///
+    /// Unlike `parse_return` (statement level), this variant is aware of
+    /// expression boundaries such as `:` (ternary colon), `)`, `]`, and `,`
+    /// so it does not greedily consume tokens that belong to the enclosing
+    /// expression.
+    fn parse_return_expr(&mut self) -> ParseResult<Node> {
+        let start = self.current_position();
+        self.tokens.next()?; // consume 'return'
+
+        // Determine whether there is a return value.
+        // Stop at all expression-level boundaries as well as statement-level ones.
+        let value = if Self::is_statement_terminator(self.peek_kind())
+            || matches!(
+                self.peek_kind(),
+                Some(TokenKind::RightBrace)
+                    | Some(TokenKind::RightParen)
+                    | Some(TokenKind::RightBracket)
+                    | Some(TokenKind::Colon)
+                    | Some(TokenKind::Comma)
+            )
+            || matches!(self.peek_kind(), Some(k) if Self::is_stmt_modifier_kind(k))
+        {
+            None
+        } else {
+            // Parse the return value at assignment precedence so we do not
+            // accidentally consume a surrounding comma list or ternary colon.
+            Some(Box::new(self.parse_assignment()?))
+        };
+
+        let end = value
+            .as_ref()
+            .map(|v| v.location.end)
+            .unwrap_or(self.previous_position());
+        Ok(Node::new(
+            NodeKind::Return { value },
+            SourceLocation { start, end },
+        ))
+    }
+
     /// Parse eval expression/block
     fn parse_eval(&mut self) -> ParseResult<Node> {
         let start = self.consume_token()?.start; // consume 'eval'

--- a/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
@@ -1,0 +1,490 @@
+#[cfg(test)]
+mod tests {
+    use crate::engine::parser::Parser;
+    use perl_ast::ast::NodeKind;
+
+    fn parse_code(input: &str) -> Option<perl_ast::ast::Node> {
+        let mut parser = Parser::new(input);
+        parser.parse().ok()
+    }
+
+    /// Check that the parsed AST does not contain any ERROR nodes, meaning the
+    /// code parsed cleanly without recovery.
+    fn assert_no_errors(input: &str, ast: &perl_ast::ast::Node) {
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "Parse of {:?} produced ERROR nodes:\n{}", input, sexp);
+    }
+
+    // ---------------------------------------------------------------
+    // return / next / last in ternary expression branches
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_return_in_ternary_then_branch() {
+        // $cond ? return $x : $y
+        let input = "$cond ? return $x : $y;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        let ast = ast.as_ref().map(|a| a).filter(|_| true);
+        let ast_ref = ast.as_ref();
+        assert_no_errors(
+            input,
+            ast_ref.map(|a| *a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        // Verify structure: the then branch should be a Return node
+        let ast = parse_code(input);
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                // Unwrap ExpressionStatement
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                // Should be a Ternary
+                if let NodeKind::Ternary { then_expr, .. } = &expr.kind {
+                    assert!(
+                        matches!(then_expr.kind, NodeKind::Return { .. }),
+                        "Expected Return in then branch, got {:?}",
+                        then_expr.kind
+                    );
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_next_in_ternary_else_branch() {
+        // $cond ? $x : next
+        let input = "$cond ? $x : next;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Ternary { else_expr, .. } = &expr.kind {
+                    assert!(
+                        matches!(else_expr.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl in else branch, got {:?}",
+                        else_expr.kind
+                    );
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_return_and_next_in_ternary() {
+        // $cond ? return $x : next
+        let input = "$cond ? return $x : next;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Ternary { then_expr, else_expr, .. } = &expr.kind {
+                    assert!(
+                        matches!(then_expr.kind, NodeKind::Return { .. }),
+                        "Expected Return in then branch, got {:?}",
+                        then_expr.kind
+                    );
+                    assert!(
+                        matches!(else_expr.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl in else branch, got {:?}",
+                        else_expr.kind
+                    );
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_last_in_ternary_else_branch() {
+        // $cond ? $x : last
+        let input = "$cond ? $x : last;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Ternary { else_expr, .. } = &expr.kind {
+                    assert!(
+                        matches!(else_expr.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl in else branch, got {:?}",
+                        else_expr.kind
+                    );
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // return / next / last with short-circuit operators (&& / ||)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_short_circuit_and_return() {
+        // $cond && return
+        let input = "$cond && return;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Binary { op, right, .. } = &expr.kind {
+                    assert_eq!(op, "&&");
+                    assert!(
+                        matches!(right.kind, NodeKind::Return { value: None }),
+                        "Expected Return with no value on RHS, got {:?}",
+                        right.kind
+                    );
+                } else {
+                    panic!("Expected Binary(&&), got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_circuit_or_last() {
+        // $cond || last
+        let input = "$cond || last;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Binary { op, right, .. } = &expr.kind {
+                    assert_eq!(op, "||");
+                    assert!(
+                        matches!(right.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl on RHS, got {:?}",
+                        right.kind
+                    );
+                } else {
+                    panic!("Expected Binary(||), got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_circuit_and_next() {
+        // $cond && next
+        let input = "$cond && next;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Binary { op, right, .. } = &expr.kind {
+                    assert_eq!(op, "&&");
+                    assert!(
+                        matches!(right.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl on RHS, got {:?}",
+                        right.kind
+                    );
+                } else {
+                    panic!("Expected Binary(&&), got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_short_circuit_defined_or_return() {
+        // $cond // return $x
+        let input = "$cond // return $x;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Binary { op, right, .. } = &expr.kind {
+                    assert_eq!(op, "//");
+                    assert!(
+                        matches!(right.kind, NodeKind::Return { .. }),
+                        "Expected Return on RHS, got {:?}",
+                        right.kind
+                    );
+                } else {
+                    panic!("Expected Binary(//), got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // return in do block
+    // ---------------------------------------------------------------
+
+    // Pre-existing parser limitation: `return $x if $cond` inside a
+    // do-block triggers an error because the `if` keyword is consumed
+    // as an if-statement rather than a statement modifier. Tracked
+    // separately from the expression-context fix.
+    #[test]
+    #[ignore = "pre-existing: statement modifier after return inside do-block"]
+    fn test_return_inside_do_block() {
+        // do { return $x if $cond; $y }
+        let input = "do { return $x if $cond; $y };";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // return in ternary inside do block
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_return_in_ternary_in_do_block() {
+        // my $x = do { $cond ? return : $val }
+        let input = "my $x = do { $cond ? return : $val };";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // return with no value in ternary (bare return before colon)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_bare_return_in_ternary_then() {
+        // $cond ? return : $y
+        let input = "$cond ? return : $y;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Ternary { then_expr, .. } = &expr.kind {
+                    assert!(
+                        matches!(then_expr.kind, NodeKind::Return { value: None }),
+                        "Expected bare Return (no value) in then branch, got {:?}",
+                        then_expr.kind
+                    );
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // loop control with label in expression context
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_next_with_label_in_ternary() {
+        // $cond ? next OUTER : $y
+        let input = "$cond ? next OUTER : $y;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Ternary { then_expr, .. } = &expr.kind {
+                    if let NodeKind::LoopControl { op, label } = &then_expr.kind {
+                        assert_eq!(op, "next");
+                        assert_eq!(label.as_deref(), Some("OUTER"));
+                    } else {
+                        panic!("Expected LoopControl in then branch, got {:?}", then_expr.kind);
+                    }
+                } else {
+                    panic!("Expected Ternary, got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // redo in expression context
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_redo_in_short_circuit() {
+        // $cond || redo
+        let input = "$cond || redo;";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+
+        if let Some(ref node) = ast {
+            if let NodeKind::Program { ref statements } = node.kind {
+                let stmt = &statements[0];
+                let expr = match &stmt.kind {
+                    NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+                    other => panic!("Expected ExpressionStatement, got {:?}", other),
+                };
+                if let NodeKind::Binary { op, right, .. } = &expr.kind {
+                    assert_eq!(op, "||");
+                    assert!(
+                        matches!(right.kind, NodeKind::LoopControl { .. }),
+                        "Expected LoopControl on RHS, got {:?}",
+                        right.kind
+                    );
+                } else {
+                    panic!("Expected Binary(||), got {:?}", expr.kind);
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Keyword before fat arrow should still autoquote (regression guard)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_return_before_fat_arrow_still_autoquotes() {
+        // (return => 1) should autoquote "return" as a hash key
+        let input = "my %h = (return => 1);";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+    }
+
+    #[test]
+    fn test_next_before_fat_arrow_still_autoquotes() {
+        // (next => 1) should autoquote "next" as a hash key
+        let input = "my %h = (next => 1);";
+        let ast = parse_code(input);
+        assert!(ast.is_some(), "Failed to parse: {}", input);
+        assert_no_errors(
+            input,
+            ast.as_ref().map(|a| a).unwrap_or_else(|| {
+                panic!("no ast");
+            }),
+        );
+    }
+}

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -695,11 +695,7 @@ impl<'a> Parser<'a> {
             | TokenKind::While
             | TokenKind::Until
             | TokenKind::For
-            | TokenKind::Foreach
-            | TokenKind::Return
-            | TokenKind::Next
-            | TokenKind::Last
-            | TokenKind::Redo => {
+            | TokenKind::Foreach => {
                 // In expression context, keywords are used as barewords/identifiers
                 // This happens in hash keys, method names, etc.
                 let token = self.tokens.next()?;
@@ -707,6 +703,34 @@ impl<'a> Parser<'a> {
                     NodeKind::Identifier { name: token.text.to_string() },
                     SourceLocation { start: token.start, end: token.end },
                 ))
+            }
+
+            // return / next / last / redo — when followed by `=>` they are
+            // autoquoted hash keys (e.g. `return => 1`).  Otherwise they are
+            // real control-flow expressions that can appear inside ternary
+            // branches, short-circuit operators, etc.
+            TokenKind::Return => {
+                if self.is_keyword_before_fat_arrow() {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_return_expr()
+                }
+            }
+
+            TokenKind::Next | TokenKind::Last | TokenKind::Redo => {
+                if self.is_keyword_before_fat_arrow() {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_loop_control()
+                }
             }
 
             TokenKind::DoubleColon => {

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -420,6 +420,8 @@ mod chained_deref_method_tests;
 #[cfg(test)]
 mod coderef_invocation_tests;
 #[cfg(test)]
+mod control_flow_expr_tests;
+#[cfg(test)]
 mod declaration_in_args_tests;
 #[cfg(test)]
 mod for_builtin_block_tests;


### PR DESCRIPTION
## Summary

- **Fixes expression-context parsing** of `return`, `next`, `last`, and `redo` keywords. Previously these were incorrectly treated as bareword identifiers in expression context (ternary branches, short-circuit RHS, do-blocks), causing incorrect AST nodes.
- **Adds `parse_return_expr()`** — an expression-aware variant of `parse_return` that respects expression boundaries (`:`, `)`, `]`, `,`, statement modifiers) so it does not greedily consume surrounding tokens.
- **Dispatches `next`/`last`/`redo` to `parse_loop_control()`** in expression context, preserving label support (e.g. `$cond ? next OUTER : $y`).
- **Preserves fat-arrow autoquoting** — `return => 1`, `next => 1` etc. still parse as hash keys via `is_keyword_before_fat_arrow()` check.

## Changed files

| File | Change |
|------|--------|
| `control_flow.rs` | Add `parse_return_expr()` method |
| `expressions/primary.rs` | Split `return`/`next`/`last`/`redo` out of bareword arm; dispatch to control-flow parsers |
| `mod.rs` | Register `control_flow_expr_tests` module |
| `control_flow_expr_tests.rs` | 15 tests covering ternary, short-circuit, do-block, labeled, and autoquoting cases |

## Test plan

- [x] `cargo test -p perl-parser-core` — 275 pass, 1 pre-existing failure (unrelated `my`/`use` autoquoting)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p perl-parser-core --lib` — clean
- [x] New tests cover: ternary then/else branches, bare return, return with value, next/last/redo in short-circuit (`&&`, `||`, `//`), do-block nesting, labeled loop control in ternary, fat-arrow autoquoting regression