### PR TITLE
fix(parser): accept fat arrow as list separator in builtin args

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -386,12 +386,25 @@ impl<'a> Parser<'a> {
                         Box::new(self.parse_assignment()?)
                     };
 
-                    self.expect(TokenKind::Comma)?;
+                    // Accept comma or fat arrow between variable and package
+                    // (Perl treats `=>` as a synonym for `,`)
+                    match self.peek_kind() {
+                        Some(TokenKind::Comma) | Some(TokenKind::FatArrow) => {
+                            self.consume_token()?;
+                        }
+                        _ => {
+                            return Err(ParseError::unexpected(
+                                "Comma".to_string(),
+                                format!("{:?}", self.peek_kind()),
+                                self.current_position(),
+                            ));
+                        }
+                    }
                     let package = Box::new(self.parse_assignment()?);
 
                     let mut args = vec![];
-                    while self.peek_kind() == Some(TokenKind::Comma) {
-                        self.consume_token()?; // consume ,
+                    while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                        self.consume_token()?; // consume , or =>
                         args.push(self.parse_assignment()?);
                     }
 
@@ -503,12 +516,16 @@ impl<'a> Parser<'a> {
                                 args.push(self.parse_assignment_or_declaration()?);
                             }
 
-                            // Handle map/grep/sort { block } LIST case where no comma separates block and list
-                            if parsed_block_arg 
-                                && self.peek_kind() != Some(TokenKind::Comma) 
-                                && !self.is_at_statement_end() 
-                            {
-                                args.push(self.parse_assignment()?);
+                            // Handle map/grep/sort { block } LIST case where no comma separates block and list.
+                            // Also skip an optional fat arrow (`=>`) which Perl treats as a comma synonym.
+                            if parsed_block_arg && !self.is_at_statement_end() {
+                                // Skip optional comma or fat arrow before the list
+                                if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    self.consume_token()?;
+                                }
+                                if !self.is_at_statement_end() {
+                                    args.push(self.parse_assignment()?);
+                                }
                             }
 
                             // Parse remaining arguments
@@ -518,8 +535,8 @@ impl<'a> Parser<'a> {
                                 while !Self::is_statement_terminator(self.peek_kind())
                                     && !self.is_statement_modifier_keyword()
                                 {
-                                    // Skip optional comma
-                                    if self.peek_kind() == Some(TokenKind::Comma) {
+                                    // Skip optional comma or fat arrow
+                                    if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
                                         self.consume_token()?;
                                     }
                                     args.push(self.parse_assignment()?);

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3094,6 +3094,85 @@ mod line_index_extended_tests {
         Ok(())
     }
 
+    #[test]
+    fn wave2b_unshift_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("unshift @arr => $val;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "unshift @arr => $val should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("call unshift"), "should be a function call");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_splice_mixed_comma_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        // `splice @a, 0, 1 => @replacement` — the `=>` after `1` is consumed by
+        // the builtin argument loop as a separator, exactly like a comma.
+        let mut parser = Parser::new("splice @a, 0, 1 => @replacement;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "splice @a, 0, 1 => @replacement should parse cleanly, got: {sexp}"
+        );
+        // splice uses the generic builtin path; the sexp uses ambiguous_function_call_expression
+        assert!(
+            sexp.contains("function_call_expression") || sexp.contains("call splice"),
+            "should be a function call, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_tie_fat_arrow_in_args() -> Result<(), Box<dyn std::error::Error>> {
+        // tie uses a dedicated AST handler; fat arrow must work in trailing args
+        let mut parser = Parser::new("tie %hash, 'MyModule' => @args;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "tie %hash, 'MyModule' => @args should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_map_fat_arrow_separator() -> Result<(), Box<dyn std::error::Error>> {
+        // map with block then fat arrow before list
+        let mut parser = Parser::new("map { $_ * 2 } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "map {{ $_ * 2 }} => @list should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_grep_fat_arrow_separator() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("grep { defined } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "grep {{ defined }} => @list should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_sort_fat_arrow_separator() -> Result<(), Box<dyn std::error::Error>> {
+        let mut parser = Parser::new("sort { $a <=> $b } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "sort {{ $a <=> $b }} => @list should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
     // ---- Wave 2C: split /regex/ ----
 
     #[test]


### PR DESCRIPTION
## Summary

- The parser now accepts `=>` (fat arrow) as a synonym for `,` in builtin function argument lists, matching Perl's actual behaviour where `=>` is just a comma that autoquotes the LHS.
- Three sites in `statements.rs` were updated: the `tie` dedicated handler (variable-to-package separator and trailing args), the `map`/`grep`/`sort` block-list handler (optional separator after a block arg), and the map/grep/sort remaining-arguments loop.
- The generic builtin argument loop already handled fat arrows; no changes were needed there.

## Test evidence

Six new tests added to `comprehensive_unit_tests.rs`, all passing:

| Test | Input |
|------|-------|
| `wave2b_unshift_fat_arrow` | `unshift @arr => $val;` |
| `wave2b_splice_mixed_comma_fat_arrow` | `splice @a, 0, 1 => @replacement;` |
| `wave2b_tie_fat_arrow_in_args` | `tie %hash, 'MyModule' => @args;` |
| `wave2b_map_fat_arrow_separator` | `map { $_ * 2 } => @list;` |
| `wave2b_grep_fat_arrow_separator` | `grep { defined } => @list;` |
| `wave2b_sort_fat_arrow_separator` | `sort { $a <=> $b } => @list;` |

Full `cargo test -p perl-parser-core` result: **281 passed, 1 failed** (the single failure `keyword_autoquoting_tests::my_and_use_before_fat_arrow` is pre-existing on `master`).

`cargo fmt --check` and `cargo clippy -p perl-parser-core --lib` both pass cleanly.

## Test plan

- [x] `cargo test -p perl-parser-core` — all new tests pass, no regressions
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p perl-parser-core --lib` — clean