### PR TITLE
fix(parser): handle operator strings in use overload

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -569,6 +569,22 @@ impl<'a> Parser<'a> {
                 match self.peek_kind() {
                     Some(TokenKind::String) => {
                         args.push(self.consume_token()?.text.to_string());
+
+                        // Handle fat arrow after string key (e.g. use overload '""' => \&stringify)
+                        match self.peek_kind() {
+                            Some(TokenKind::Comma) => {
+                                self.consume_token()?; // consume comma
+                                // Continue to parse next argument
+                            }
+                            Some(TokenKind::FatArrow) => {
+                                self.consume_token()?; // consume =>
+                                // Consume the value after =>
+                                self.consume_use_import_value(&mut args)?;
+                            }
+                            _ => {
+                                // No separator, just continue
+                            }
+                        }
                     }
                     Some(TokenKind::QuoteWords) => {
                         // Handle qw(...) in use statements
@@ -623,33 +639,8 @@ impl<'a> Parser<'a> {
                             }
                             Some(TokenKind::FatArrow) => {
                                 self.consume_token()?; // consume =>
-                                // Parse the value as a simple expression
-                                // But check if an identifier is followed by => (making it a key, not a value)
-                                match self.peek_kind() {
-                                    Some(TokenKind::Number | TokenKind::String) => {
-                                        args.push(self.consume_token()?.text.to_string());
-                                    }
-                                    Some(TokenKind::Identifier) => {
-                                        // Peek ahead to see if this identifier is followed by =>
-                                        // If so, it's actually a key for the next pair, not a value
-                                        if self.tokens.peek_second().map(|t| t.kind)
-                                            == Ok(TokenKind::FatArrow)
-                                        {
-                                            // Don't consume - let the outer loop handle it as a key
-                                        } else {
-                                            args.push(self.consume_token()?.text.to_string());
-                                        }
-                                    }
-                                    _ => {
-                                        // For more complex expressions, just consume tokens until semicolon
-                                        while !Self::is_statement_terminator(self.peek_kind())
-                                            && self.peek_kind() != Some(TokenKind::Comma)
-                                            && self.peek_kind() != Some(TokenKind::FatArrow)
-                                        {
-                                            args.push(self.consume_token()?.text.to_string());
-                                        }
-                                    }
-                                }
+                                // Consume the value after =>
+                                self.consume_use_import_value(&mut args)?;
                             }
                             _ => {
                                 // No separator, just continue
@@ -907,4 +898,63 @@ impl<'a> Parser<'a> {
         Ok(Node::new(NodeKind::No { module, args, has_filter_risk }, SourceLocation { start, end }))
     }
 
+    /// Consume a value expression on the right-hand side of `=>` inside a `use`
+    /// import list.  The value may be a simple literal, a code reference
+    /// (`\&name`), an anonymous sub (`sub { ... }`), or a more complex
+    /// expression which is consumed token-by-token until a comma or statement
+    /// terminator is reached.
+    fn consume_use_import_value(&mut self, args: &mut Vec<String>) -> ParseResult<()> {
+        match self.peek_kind() {
+            Some(TokenKind::Number | TokenKind::String) => {
+                args.push(self.consume_token()?.text.to_string());
+            }
+            Some(TokenKind::Identifier) => {
+                // Peek ahead to see if this identifier is followed by =>
+                // If so, it is actually a key for the next pair, not a value.
+                if self.tokens.peek_second().map(|t| t.kind) == Ok(TokenKind::FatArrow) {
+                    // Don't consume - let the outer loop handle it as a key
+                } else {
+                    args.push(self.consume_token()?.text.to_string());
+                }
+            }
+            Some(TokenKind::Sub) => {
+                // Anonymous sub value: sub { ... }
+                // Consume tokens including the entire block
+                args.push(self.consume_token()?.text.to_string()); // 'sub'
+                if self.peek_kind() == Some(TokenKind::LeftBrace) {
+                    let mut depth: usize = 0;
+                    loop {
+                        match self.peek_kind() {
+                            Some(TokenKind::LeftBrace) => {
+                                depth += 1;
+                                args.push(self.consume_token()?.text.to_string());
+                            }
+                            Some(TokenKind::RightBrace) => {
+                                args.push(self.consume_token()?.text.to_string());
+                                depth = depth.saturating_sub(1);
+                                if depth == 0 {
+                                    break;
+                                }
+                            }
+                            None => break,
+                            _ if self.tokens.is_eof() => break,
+                            _ => {
+                                args.push(self.consume_token()?.text.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                // For complex expressions (e.g. \&name), consume tokens until ',' or ';'
+                while !Self::is_statement_terminator(self.peek_kind())
+                    && self.peek_kind() != Some(TokenKind::Comma)
+                    && self.peek_kind() != Some(TokenKind::FatArrow)
+                {
+                    args.push(self.consume_token()?.text.to_string());
+                }
+            }
+        }
+        Ok(())
+    }
 }

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -454,4 +454,6 @@ mod tests;
 #[cfg(test)]
 mod tie_tests;
 #[cfg(test)]
+mod use_overload_tests;
+#[cfg(test)]
 mod x_repetition_tests;

--- a/crates/perl-parser-core/src/engine/parser/use_overload_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/use_overload_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+use perl_tdd_support::must;
+
+/// Helper: parse code and assert no ERROR nodes appear in the s-expression.
+fn parse_ok(code: &str) -> String {
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(
+        !sexp.contains("ERROR"),
+        "Parse produced ERROR node for: {}\n  sexp: {}\n  errors: {:?}",
+        code,
+        sexp,
+        parser.errors(),
+    );
+    sexp
+}
+
+// ── stringify operator ───────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_stringify_operator() {
+    let sexp = parse_ok(r#"use overload '""' => \&stringify;"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── arithmetic operators ─────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_arithmetic_operators() {
+    let sexp = parse_ok(r#"use overload '+' => \&add, '-' => \&sub;"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── comparison operators ─────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_comparison_operators() {
+    let sexp = parse_ok(r#"use overload '<=>' => \&compare, 'cmp' => \&str_compare;"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── conversion operators ─────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_conversion_operators() {
+    let sexp = parse_ok(r#"use overload '0+' => \&numify, 'bool' => \&boolify;"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── diamond operator plus bare key ───────────────────────────────────
+
+#[test]
+fn test_use_overload_diamond_and_fallback() {
+    let sexp = parse_ok(r#"use overload '<>' => \&iterate, fallback => 1;"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── method name values (strings, not code refs) ──────────────────────
+
+#[test]
+fn test_use_overload_method_name_string_value() {
+    let sexp = parse_ok(r#"use overload '+' => 'add';"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── multiple method overloads ────────────────────────────────────────
+
+#[test]
+fn test_use_overload_multiple_method_overloads() {
+    let sexp = parse_ok(r#"use overload '-' => 'subtract', '*' => 'multiply';"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── inline sub values ────────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_inline_sub() {
+    let sexp = parse_ok(r#"use overload '+' => sub { $_[0]{val} + $_[1] };"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── complex multi-line overload declaration ──────────────────────────
+
+#[test]
+fn test_use_overload_complex_multi_operator() {
+    let code = r#"use overload
+    '+' => sub { $_[0]{val} + $_[1] },
+    '-' => sub { $_[0]{val} - $_[1] },
+    '""' => sub { $_[0]{str} },
+    fallback => 1;"#;
+    let sexp = parse_ok(code);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── deref overloading ────────────────────────────────────────────────
+
+#[test]
+fn test_use_overload_deref_operators() {
+    let sexp = parse_ok(r#"use overload '@{}' => sub { $_[0]{array} };"#);
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}
+
+// ── numeric (0+) plus bool ───────────────────────────────────────────
+
+#[test]
+fn test_use_overload_numify_and_bool() {
+    let sexp = parse_ok(
+        r#"use overload '0+' => sub { $_[0]->to_number }, 'bool' => sub { $_[0]->is_true };"#,
+    );
+    assert!(sexp.contains("(use overload"), "Expected use overload node, got: {}", sexp);
+}


### PR DESCRIPTION
## Summary
- The use-statement import parser only handled fat-arrow (`=>`) after bare-identifier keys, not after string-literal keys. This caused `use overload '""' => \&stringify` and similar patterns to produce incorrect ASTs or errors.
- Extracted a reusable `consume_use_import_value` helper that handles numbers, strings, identifiers, anonymous subs, and complex expressions (like code references) after `=>`.
- Wired the helper into both the string-key and identifier-key branches of the import argument parser.

## Test plan
- [x] Added `use_overload_tests.rs` with 10 test cases covering stringify, arithmetic, comparison, conversion, deref, diamond, method-name, inline sub, and multi-operator overload declarations
- [x] All 275 perl-parser-core tests pass (1 pre-existing failure on master unrelated to this change)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p perl-parser-core --lib` passes with no warnings