### PR TITLE
feat(parser): support multi-statement blocks in map/grep/sort

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -128,6 +128,15 @@ impl<'a> Parser<'a> {
                         if matches!(third.kind, TokenKind::Comma | TokenKind::FatArrow) {
                             return false;
                         }
+                        // A closing brace/paren/bracket means the call is the
+                        // last expression inside a block or parenthesised list,
+                        // e.g. `grep { defined $v }` — not an indirect call.
+                        if matches!(
+                            third.kind,
+                            TokenKind::RightBrace | TokenKind::RightParen | TokenKind::RightBracket
+                        ) {
+                            return false;
+                        }
                         return true;
                     }
                     return true;

--- a/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
@@ -1,15 +1,23 @@
 impl<'a> Parser<'a> {
     /// Parse block specifically for builtin functions (map, grep, sort)
-    /// These always parse {} as blocks, never as hashes
+    /// These always parse {} as blocks, never as hashes.
+    ///
+    /// The block may contain multiple statements separated by semicolons,
+    /// e.g. `map { my $y = uc $_; $y } @list`.
     fn parse_builtin_block(&mut self) -> ParseResult<Node> {
         self.with_recursion_guard(|s| {
             let start_token = s.tokens.next()?; // consume {
             let start = start_token.start;
 
-            // Parse the expression inside the block (if any)
             let mut statements = Vec::new();
-            if s.peek_kind() != Some(TokenKind::RightBrace) {
-                statements.push(s.parse_expression()?);
+
+            while s.peek_kind() != Some(TokenKind::RightBrace) && !s.tokens.is_eof() {
+                statements.push(s.parse_statement()?);
+
+                // Swallow stray semicolons between statements
+                while s.peek_kind() == Some(TokenKind::Semicolon) {
+                    s.consume_token()?;
+                }
             }
 
             s.expect(TokenKind::RightBrace)?;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -313,26 +313,8 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_comma()?);
                                 }
                             } else if matches!(name.as_str(), "sort" | "map" | "grep") {
-                                // Parse block expression as first argument
-                                let block_start = self.current_position();
-                                self.expect(TokenKind::LeftBrace)?;
-
-                                // Parse the expression inside the block (if any)
-                                let mut statements = Vec::new();
-                                if self.peek_kind() != Some(TokenKind::RightBrace) {
-                                    statements.push(self.parse_expression()?);
-                                }
-
-                                self.expect(TokenKind::RightBrace)?;
-                                let block_end = self.previous_position();
-
-                                // Wrap the expression in a block node
-                                let block = Node::new(
-                                    NodeKind::Block { statements },
-                                    SourceLocation { start: block_start, end: block_end },
-                                );
-
-                                args.push(block);
+                                // Parse block (may contain multiple statements) as first argument
+                                args.push(self.parse_builtin_block()?);
 
                                 // Parse trailing list arguments for map/grep/sort.
                                 // In Perl, the block form does not require a comma
@@ -470,26 +452,8 @@ impl<'a> Parser<'a> {
                                 if matches!(name.as_str(), "sort" | "map" | "grep")
                                     && self.peek_kind() == Some(TokenKind::LeftBrace)
                                 {
-                                    // Parse block expression as first argument
-                                    let block_start = self.current_position();
-                                    self.expect(TokenKind::LeftBrace)?;
-
-                                    // Parse the expression inside the block (if any)
-                                    let mut statements = Vec::new();
-                                    if self.peek_kind() != Some(TokenKind::RightBrace) {
-                                        statements.push(self.parse_expression()?);
-                                    }
-
-                                    self.expect(TokenKind::RightBrace)?;
-                                    let block_end = self.previous_position();
-
-                                    // Wrap the expression in a block node
-                                    let block = Node::new(
-                                        NodeKind::Block { statements },
-                                        SourceLocation { start: block_start, end: block_end },
-                                    );
-
-                                    args.push(block);
+                                    // Parse block (may contain multiple statements) as first argument
+                                    args.push(self.parse_builtin_block()?);
 
                                     // Parse remaining arguments for map/grep/sort without requiring commas
                                     // But respect statement boundaries including ] and )

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -422,6 +422,8 @@ mod coderef_invocation_tests;
 #[cfg(test)]
 mod declaration_in_args_tests;
 #[cfg(test)]
+mod for_builtin_block_tests;
+#[cfg(test)]
 mod format_comprehensive_tests;
 #[cfg(test)]
 mod format_tests;


### PR DESCRIPTION
## Summary

- **Multi-statement builtin blocks**: `parse_builtin_block()` now loops over semicolon-separated statements instead of parsing a single expression, enabling Perl patterns like `map { my $y = uc $_; $y } @list`
- **DRY postfix paths**: Two inline copies of the old single-expression block parser in `postfix.rs` replaced with calls to the shared `parse_builtin_block()`
- **Indirect-call heuristic fix**: Closing delimiters (`}`, `)`, `]`) now suppress the AC1 indirect-call heuristic in `calls.rs`, preventing `defined $v }` from being misclassified as an indirect method call

## Test plan

- [x] All 17 `for_builtin_block_tests` pass (single-expression, multi-statement, standalone, inside for-loops, nested builtins)
- [x] Full `perl-parser-core` lib tests pass (228 pass; 1 pre-existing failure in `keyword_autoquoting_tests::my_and_use_before_fat_arrow`)
- [x] `cargo fmt --all -- --check` clean