### PR TITLE
test(parser): add statement modifier after complex expression tests

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -678,10 +678,12 @@ impl Node {
                 format!("(regex {:?} {:?} {:?}{})", pattern, replacement, modifiers, risk_marker)
             }
 
-            NodeKind::Match { expr, pattern, modifiers, has_embedded_code } => {
+            NodeKind::Match { expr, pattern, modifiers, has_embedded_code, negated } => {
                 let risk_marker = if *has_embedded_code { " (risk:code)" } else { "" };
+                let op = if *negated { "not_match" } else { "match" };
                 format!(
-                    "(match {} (regex {:?} {:?}{}))",
+                    "({} {} (regex {:?} {:?}{}))",
+                    op,
                     expr.to_sexp(),
                     pattern,
                     modifiers,
@@ -689,25 +691,36 @@ impl Node {
                 )
             }
 
-            NodeKind::Substitution { expr, pattern, replacement, modifiers, has_embedded_code } => {
+            NodeKind::Substitution {
+                expr,
+                pattern,
+                replacement,
+                modifiers,
+                has_embedded_code,
+                negated,
+            } => {
                 let risk_marker = if *has_embedded_code { " (risk:code)" } else { "" };
+                let neg_marker = if *negated { " (negated)" } else { "" };
                 format!(
-                    "(substitution {} {:?} {:?} {:?}{})",
+                    "(substitution {} {:?} {:?} {:?}{}{})",
                     expr.to_sexp(),
                     pattern,
                     replacement,
                     modifiers,
-                    risk_marker
+                    risk_marker,
+                    neg_marker
                 )
             }
 
-            NodeKind::Transliteration { expr, search, replace, modifiers } => {
+            NodeKind::Transliteration { expr, search, replace, modifiers, negated } => {
+                let neg_marker = if *negated { " (negated)" } else { "" };
                 format!(
-                    "(transliteration {} {:?} {:?} {:?})",
+                    "(transliteration {} {:?} {:?} {:?}{})",
                     expr.to_sexp(),
                     search,
                     replace,
-                    modifiers
+                    modifiers,
+                    neg_marker
                 )
             }
 
@@ -1872,7 +1885,7 @@ pub enum NodeKind {
         has_embedded_code: bool,
     },
 
-    /// Match operation: `$str =~ /pattern/modifiers`
+    /// Match operation: `$str =~ /pattern/modifiers` or `$str !~ /pattern/modifiers`
     Match {
         /// Expression to match against
         expr: Box<Node>,
@@ -1882,6 +1895,8 @@ pub enum NodeKind {
         modifiers: String,
         /// Whether the regex contains embedded code `(?{...})`
         has_embedded_code: bool,
+        /// Whether the binding operator was `!~` (negated match)
+        negated: bool,
     },
 
     /// Substitution operation: `$str =~ s/pattern/replacement/modifiers`
@@ -1896,6 +1911,8 @@ pub enum NodeKind {
         modifiers: String,
         /// Whether the regex contains embedded code `(?{...})`
         has_embedded_code: bool,
+        /// Whether the binding operator was `!~` (negated match)
+        negated: bool,
     },
 
     /// Transliteration operation: `$str =~ tr/search/replace/` or `y///`
@@ -1908,6 +1925,8 @@ pub enum NodeKind {
         replace: String,
         /// Transliteration modifiers (c, d, s, r)
         modifiers: String,
+        /// Whether the binding operator was `!~` (negated match)
+        negated: bool,
     },
 
     // Package system
@@ -2529,6 +2548,7 @@ mod tests {
                 pattern: String::new(),
                 modifiers: String::new(),
                 has_embedded_code: false,
+                negated: false,
             },
             NodeKind::Substitution {
                 expr: Box::new(dummy_node()),
@@ -2536,12 +2556,14 @@ mod tests {
                 replacement: String::new(),
                 modifiers: String::new(),
                 has_embedded_code: false,
+                negated: false,
             },
             NodeKind::Transliteration {
                 expr: Box::new(dummy_node()),
                 search: String::new(),
                 replace: String::new(),
                 modifiers: String::new(),
+                negated: false,
             },
             NodeKind::Package { name: String::new(), name_span: loc, block: None },
             NodeKind::Use { module: String::new(), args: vec![], has_filter_risk: false },

--- a/crates/perl-ast/tests/additional_unit_tests.rs
+++ b/crates/perl-ast/tests/additional_unit_tests.rs
@@ -340,6 +340,7 @@ fn for_each_child_mut_visits_match_node() {
             pattern: "foo".to_string(),
             modifiers: "i".to_string(),
             has_embedded_code: false,
+            negated: false,
         },
         loc(0, 10),
     );
@@ -357,6 +358,7 @@ fn for_each_child_mut_visits_substitution_node() {
             replacement: "bar".to_string(),
             modifiers: "g".to_string(),
             has_embedded_code: false,
+            negated: false,
         },
         loc(0, 15),
     );
@@ -373,6 +375,7 @@ fn for_each_child_mut_visits_transliteration_node() {
             search: "a-z".to_string(),
             replace: "A-Z".to_string(),
             modifiers: "".to_string(),
+            negated: false,
         },
         loc(0, 15),
     );

--- a/crates/perl-ast/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-ast/tests/comprehensive_unit_tests.rs
@@ -1053,6 +1053,7 @@ fn sexp_match_and_substitution() -> Result<(), Box<dyn std::error::Error>> {
             pattern: "foo".to_string(),
             modifiers: "i".to_string(),
             has_embedded_code: false,
+            negated: false,
         },
         loc(0, 15),
     );
@@ -1063,6 +1064,7 @@ fn sexp_match_and_substitution() -> Result<(), Box<dyn std::error::Error>> {
             replacement: "new".to_string(),
             modifiers: "g".to_string(),
             has_embedded_code: false,
+            negated: false,
         },
         loc(0, 20),
     );
@@ -1079,6 +1081,7 @@ fn sexp_transliteration() -> Result<(), Box<dyn std::error::Error>> {
             search: "a-z".to_string(),
             replace: "A-Z".to_string(),
             modifiers: "".to_string(),
+            negated: false,
         },
         loc(0, 15),
     );

--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -446,6 +446,7 @@ impl<'a> Parser<'a> {
                         if let NodeKind::Substitution { pattern, replacement, modifiers, has_embedded_code, .. } =
                             &right.kind
                         {
+                            let negated = matches!(op_token.kind, TokenKind::NotMatch);
                             // Update the expression in the substitution
                             expr = Node::new(
                                 NodeKind::Substitution {
@@ -454,6 +455,7 @@ impl<'a> Parser<'a> {
                                     replacement: replacement.clone(),
                                     modifiers: modifiers.clone(),
                                     has_embedded_code: *has_embedded_code,
+                                    negated,
                                 },
                                 SourceLocation { start, end },
                             );
@@ -461,6 +463,7 @@ impl<'a> Parser<'a> {
                             search, replace, modifiers, ..
                         } = &right.kind
                         {
+                            let negated = matches!(op_token.kind, TokenKind::NotMatch);
                             // Update the expression in the transliteration
                             expr = Node::new(
                                 NodeKind::Transliteration {
@@ -468,12 +471,14 @@ impl<'a> Parser<'a> {
                                     search: search.clone(),
                                     replace: replace.clone(),
                                     modifiers: modifiers.clone(),
+                                    negated,
                                 },
                                 SourceLocation { start, end },
                             );
                         } else if let NodeKind::Regex { pattern, replacement, modifiers, has_embedded_code } =
                             &right.kind
                         {
+                            let negated = matches!(op_token.kind, TokenKind::NotMatch);
                             if let Some(replacement) = replacement {
                                 let pat = if pattern.len() >= 2 {
                                     pattern[1..pattern.len() - 1].to_string()
@@ -487,6 +492,7 @@ impl<'a> Parser<'a> {
                                         replacement: replacement.clone(),
                                         modifiers: modifiers.clone(),
                                         has_embedded_code: *has_embedded_code,
+                                        negated,
                                     },
                                     SourceLocation { start, end },
                                 );
@@ -497,6 +503,7 @@ impl<'a> Parser<'a> {
                                         pattern: pattern.clone(),
                                         modifiers: modifiers.clone(),
                                         has_embedded_code: *has_embedded_code,
+                                        negated,
                                     },
                                     SourceLocation { start, end },
                                 );

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -215,6 +215,7 @@ impl<'a> Parser<'a> {
                         replacement,
                         modifiers,
                         has_embedded_code,
+                        negated: false,
                     },
                     SourceLocation { start: token.start, end: token.end },
                 ))
@@ -235,6 +236,7 @@ impl<'a> Parser<'a> {
                         search,
                         replace,
                         modifiers,
+                        negated: false,
                     },
                     SourceLocation { start: token.start, end: token.end },
                 ))

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -465,3 +465,29 @@ fn test_valid_regex_patterns_no_false_positive() {
         );
     }
 }
+
+#[test]
+fn test_debug_paren_regex_binding() {
+    // Quick diagnostic test
+    let test_cases = vec![
+        ("simple =~", "$text =~ s/foo/bar/;"),
+        ("paren assign =~", "(my $x = $y) =~ s/foo/bar/;"),
+        ("paren assign tr", "($str = $input) =~ tr/a-z/A-Z/;"),
+        ("paren assign chomp", "(my $line = <STDIN>) =~ s/\\n$//;"),
+        ("paren with if modifier", "(my $x = $input) =~ s/foo/bar/ if $cond;"),
+        ("paren assign !~", "(my $x = $y) !~ /pattern/;"),
+        ("paren assign regex match", "(my $x = $y) =~ /pattern/;"),
+        ("paren assign regex global", "(my $x = $y) =~ s/foo/bar/g;"),
+        ("nested paren", "((my $x = $y)) =~ s/foo/bar/;"),
+        ("paren list assign split if", "(my @parts = split /,/, $str) if $cond;"),
+    ];
+
+    for (name, code) in test_cases {
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        println!("{}: {}", name, sexp);
+        assert!(!sexp.contains("ERROR"), "{} should not contain ERROR: {}", name, sexp);
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for statement modifier parsing after complex expressions (parenthesized assignments with `=~`, `!~`, regex match, substitution, transliteration)
- Add `negated` field to `Match`, `Substitution`, and `Transliteration` AST nodes to track `!~` vs `=~` binding operators
- Update all construction sites and pattern matches to include the new `negated` field

## Test plan
- [x] `cargo test -p perl-parser-core -- test_debug_paren_regex_binding` passes
- [x] `cargo fmt --all -- --check` passes
- [x] All 10 test cases parse without ERROR nodes