### PR TITLE
test(feature-governance): add 132 tests across 9 crates

### DIFF
--- a/crates/perl-lsp-capability-map/src/lib.rs
+++ b/crates/perl-lsp-capability-map/src/lib.rs
@@ -311,6 +311,7 @@ pub fn caps_from_feature_ids(features: &[&str]) -> ServerCapabilities {
 mod tests {
     use lsp_types::{ColorProviderCapability, ServerCapabilities};
 
+    use super::*;
     use super::{LSP_COLOR, LSP_DOCUMENT_COLOR, caps_from_feature_ids, feature_ids_from_caps};
 
     #[test]
@@ -333,5 +334,156 @@ mod tests {
     fn caps_from_feature_ids_accepts_canonical_color_id() {
         let caps = caps_from_feature_ids(&[LSP_DOCUMENT_COLOR]);
         assert!(caps.color_provider.is_some());
+    }
+
+    // ── Round-trip tests ────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_single_feature_completion() {
+        let caps = caps_from_feature_ids(&[LSP_COMPLETION]);
+        let ids = feature_ids_from_caps(&caps);
+        assert!(ids.contains(&LSP_COMPLETION));
+    }
+
+    #[test]
+    fn round_trip_single_feature_hover() {
+        let caps = caps_from_feature_ids(&[LSP_HOVER]);
+        let ids = feature_ids_from_caps(&caps);
+        assert!(ids.contains(&LSP_HOVER));
+    }
+
+    #[test]
+    fn round_trip_preserves_all_mappable_features() {
+        // Every feature that caps_from_feature_ids can set should survive a round trip.
+        let all_mappable: &[&str] = &[
+            LSP_COMPLETION,
+            LSP_HOVER,
+            LSP_SIGNATURE_HELP,
+            LSP_DEFINITION,
+            LSP_DECLARATION,
+            LSP_NOTEBOOK_DOCUMENT_SYNC,
+            LSP_TYPE_DEFINITION,
+            LSP_IMPLEMENTATION,
+            LSP_REFERENCES,
+            LSP_DOCUMENT_HIGHLIGHT,
+            LSP_DOCUMENT_SYMBOL,
+            LSP_CODE_ACTION,
+            LSP_CODE_LENS,
+            LSP_DOCUMENT_LINK,
+            LSP_DOCUMENT_COLOR,
+            LSP_FORMATTING,
+            LSP_RANGE_FORMATTING,
+            LSP_ON_TYPE_FORMATTING,
+            LSP_RENAME,
+            LSP_FOLDING_RANGE,
+            LSP_SELECTION_RANGE,
+            LSP_LINKED_EDITING_RANGE,
+            LSP_CALL_HIERARCHY,
+            LSP_SEMANTIC_TOKENS,
+            LSP_MONIKER,
+            LSP_INLINE_VALUE,
+            LSP_INLAY_HINT,
+            LSP_PULL_DIAGNOSTICS,
+            LSP_WORKSPACE_SYMBOL,
+            LSP_EXECUTE_COMMAND,
+        ];
+
+        let caps = caps_from_feature_ids(all_mappable);
+        let extracted = feature_ids_from_caps(&caps);
+
+        for &feature in all_mappable {
+            assert!(extracted.contains(&feature), "round-trip lost feature '{feature}'");
+        }
+    }
+
+    // ── Empty / default cases ───────────────────────────────────────
+
+    #[test]
+    fn empty_caps_yields_no_features() {
+        let caps = ServerCapabilities::default();
+        assert!(feature_ids_from_caps(&caps).is_empty());
+    }
+
+    #[test]
+    fn empty_feature_list_yields_default_caps() {
+        let caps = caps_from_feature_ids(&[]);
+        assert!(caps.completion_provider.is_none());
+        assert!(caps.hover_provider.is_none());
+    }
+
+    #[test]
+    fn unknown_feature_id_is_ignored() {
+        let caps = caps_from_feature_ids(&["lsp.nonexistent_feature"]);
+        // Should produce default (empty) caps without panicking
+        assert!(feature_ids_from_caps(&caps).is_empty());
+    }
+
+    // ── Output is sorted and deduplicated ───────────────────────────
+
+    #[test]
+    fn feature_ids_from_caps_are_sorted() {
+        let caps = caps_from_feature_ids(&[LSP_RENAME, LSP_COMPLETION, LSP_HOVER, LSP_DEFINITION]);
+        let ids = feature_ids_from_caps(&caps);
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "feature_ids_from_caps output must be sorted");
+    }
+
+    #[test]
+    fn duplicate_input_features_produce_no_duplicate_caps() {
+        let caps = caps_from_feature_ids(&[LSP_HOVER, LSP_HOVER, LSP_HOVER]);
+        let ids = feature_ids_from_caps(&caps);
+        assert_eq!(ids.iter().filter(|&&id| id == LSP_HOVER).count(), 1);
+    }
+
+    // ── Individual capability mapping spot checks ───────────────────
+
+    #[test]
+    fn caps_from_completion_has_trigger_characters() {
+        let caps = caps_from_feature_ids(&[LSP_COMPLETION]);
+        let provider = caps.completion_provider.as_ref();
+        assert!(provider.is_some());
+        let triggers = provider.and_then(|p| p.trigger_characters.as_ref());
+        assert!(triggers.is_some());
+        let triggers = triggers.map(|t| t.len()).unwrap_or(0);
+        assert!(triggers > 0, "completion should have trigger characters");
+    }
+
+    #[test]
+    fn caps_from_signature_help_has_trigger_characters() {
+        let caps = caps_from_feature_ids(&[LSP_SIGNATURE_HELP]);
+        assert!(caps.signature_help_provider.is_some());
+    }
+
+    #[test]
+    fn caps_from_semantic_tokens_has_legend() {
+        let caps = caps_from_feature_ids(&[LSP_SEMANTIC_TOKENS]);
+        assert!(caps.semantic_tokens_provider.is_some());
+    }
+
+    #[test]
+    fn caps_from_pull_diagnostics_has_identifier() {
+        let caps = caps_from_feature_ids(&[LSP_PULL_DIAGNOSTICS]);
+        assert!(caps.diagnostic_provider.is_some());
+    }
+
+    #[test]
+    fn caps_from_code_lens_has_resolve_provider() {
+        let caps = caps_from_feature_ids(&[LSP_CODE_LENS]);
+        let lens = caps.code_lens_provider.as_ref();
+        assert!(lens.is_some());
+    }
+
+    #[test]
+    fn caps_from_execute_command_has_commands() {
+        let caps = caps_from_feature_ids(&[LSP_EXECUTE_COMMAND]);
+        let exec = caps.execute_command_provider.as_ref();
+        assert!(exec.is_some());
+    }
+
+    #[test]
+    fn caps_from_notebook_sync_has_selector() {
+        let caps = caps_from_feature_ids(&[LSP_NOTEBOOK_DOCUMENT_SYNC]);
+        assert!(caps.notebook_document_sync.is_some());
     }
 }

--- a/crates/perl-lsp-feature-contracts/src/lib.rs
+++ b/crates/perl-lsp-feature-contracts/src/lib.rs
@@ -186,3 +186,222 @@ pub fn compliance_percent_for_grid() -> f32 {
     let advertised = advertised_trackable_feature_count_for_grid();
     (advertised as f64 / trackable as f64 * 100.0).round() as f32
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── FeatureProfileKind ──────────────────────────────────────────
+
+    #[test]
+    fn from_ga_lock_enabled_true_yields_ga_lock() {
+        assert_eq!(FeatureProfileKind::from_ga_lock_enabled(true), FeatureProfileKind::GaLock);
+    }
+
+    #[test]
+    fn from_ga_lock_enabled_false_yields_production() {
+        assert_eq!(FeatureProfileKind::from_ga_lock_enabled(false), FeatureProfileKind::Production,);
+    }
+
+    #[test]
+    fn all_profiles_returns_three_variants() {
+        let all = FeatureProfileKind::all();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0], FeatureProfileKind::GaLock);
+        assert_eq!(all[1], FeatureProfileKind::Production);
+        assert_eq!(all[2], FeatureProfileKind::All);
+    }
+
+    #[test]
+    fn from_str_name_rejects_unknown_token() {
+        assert!(FeatureProfileKind::from_str_name("bogus").is_none());
+        assert!(FeatureProfileKind::from_str_name("").is_none());
+        assert!(FeatureProfileKind::from_str_name("GA-LOCK").is_none());
+    }
+
+    #[test]
+    fn aliases_are_non_empty_for_every_profile() {
+        for profile in FeatureProfileKind::all() {
+            assert!(
+                !profile.aliases().is_empty(),
+                "aliases for {} should not be empty",
+                profile.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn aliases_contain_canonical_name() {
+        for profile in FeatureProfileKind::all() {
+            let aliases = profile.aliases();
+            assert!(
+                aliases.contains(&profile.as_str()),
+                "aliases for {} should contain canonical name",
+                profile.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn supported_cli_profiles_covers_all_aliases() {
+        let cli_tokens = FeatureProfileKind::supported_cli_profiles();
+        for profile in FeatureProfileKind::all() {
+            for alias in profile.aliases() {
+                assert!(
+                    cli_tokens.contains(alias),
+                    "CLI tokens should include alias '{}' for profile '{}'",
+                    alias,
+                    profile.as_str()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn auto_token_resolves_to_current() {
+        let resolved = FeatureProfileKind::from_str_name("auto");
+        assert_eq!(resolved, Some(FeatureProfileKind::current()));
+    }
+
+    // ── FeatureProfileSpec ──────────────────────────────────────────
+
+    #[test]
+    fn feature_profile_specs_has_three_entries() {
+        let specs = feature_profile_specs();
+        assert_eq!(specs.len(), 3);
+    }
+
+    #[test]
+    fn feature_profile_specs_canonical_names_match_enum() {
+        let specs = feature_profile_specs();
+        let expected_names: Vec<&str> =
+            FeatureProfileKind::all().iter().map(|p| p.as_str()).collect();
+        let spec_names: Vec<&str> = specs.iter().map(|s| s.canonical).collect();
+        assert_eq!(spec_names, expected_names);
+    }
+
+    #[test]
+    fn feature_profile_specs_descriptions_are_non_empty() {
+        for spec in feature_profile_specs() {
+            assert!(
+                !spec.description.is_empty(),
+                "description for '{}' should not be empty",
+                spec.canonical
+            );
+        }
+    }
+
+    // ── Catalog / BDD grid ──────────────────────────────────────────
+
+    #[test]
+    fn all_features_is_non_empty() {
+        assert!(!all_features().is_empty());
+    }
+
+    #[test]
+    fn all_features_have_non_empty_ids() {
+        for feature in all_features() {
+            assert!(!feature.id.is_empty(), "feature id should not be empty");
+        }
+    }
+
+    #[test]
+    fn all_features_have_valid_areas() {
+        let valid_areas = ["text_document", "workspace", "window", "notebook", "debug", "protocol"];
+        for feature in all_features() {
+            assert!(
+                valid_areas.contains(&feature.area),
+                "feature '{}' has unexpected area '{}'",
+                feature.id,
+                feature.area
+            );
+        }
+    }
+
+    #[test]
+    fn all_features_have_valid_maturity() {
+        let valid_maturities = ["ga", "beta", "alpha", "planned"];
+        for feature in all_features() {
+            assert!(
+                valid_maturities.contains(&feature.maturity),
+                "feature '{}' has unexpected maturity '{}'",
+                feature.id,
+                feature.maturity
+            );
+        }
+    }
+
+    #[test]
+    fn feature_ids_are_unique() {
+        let ids: Vec<&str> = all_features().iter().map(|f| f.id).collect();
+        let mut deduped = ids.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(ids.len(), deduped.len(), "feature IDs must be unique");
+    }
+
+    #[test]
+    fn bdd_feature_rows_sorted_by_area_then_id() {
+        let rows = bdd_feature_rows();
+        for window in rows.windows(2) {
+            let ordering = window[0].area.cmp(window[1].area).then(window[0].id.cmp(window[1].id));
+            assert!(
+                ordering.is_le(),
+                "BDD rows not sorted: '{}' in '{}' should come before '{}' in '{}'",
+                window[0].id,
+                window[0].area,
+                window[1].id,
+                window[1].area,
+            );
+        }
+    }
+
+    #[test]
+    fn bdd_feature_rows_count_matches_all_features() {
+        assert_eq!(bdd_feature_rows().len(), all_features().len());
+    }
+
+    #[test]
+    fn trackable_features_are_subset_of_all() {
+        let all_count = all_features().len();
+        let trackable = trackable_feature_count_for_grid();
+        assert!(trackable <= all_count);
+    }
+
+    #[test]
+    fn advertised_trackable_is_subset_of_trackable() {
+        let trackable = trackable_feature_count_for_grid();
+        let advertised = advertised_trackable_feature_count_for_grid();
+        assert!(advertised <= trackable);
+    }
+
+    #[test]
+    fn compliance_percent_is_in_valid_range() {
+        let pct = compliance_percent_for_grid();
+        assert!((0.0..=100.0).contains(&pct), "compliance must be 0-100, got {pct}");
+    }
+
+    #[test]
+    fn has_feature_returns_true_for_known_ids() {
+        assert!(has_feature("lsp.completion"));
+        assert!(has_feature("lsp.hover"));
+        assert!(has_feature("lsp.definition"));
+    }
+
+    #[test]
+    fn has_feature_returns_false_for_unknown_ids() {
+        assert!(!has_feature("lsp.nonexistent"));
+        assert!(!has_feature(""));
+    }
+
+    #[test]
+    fn advertised_features_is_non_empty() {
+        assert!(!advertised_features().is_empty());
+    }
+
+    #[test]
+    fn version_strings_are_non_empty() {
+        assert!(!VERSION.is_empty());
+        assert!(!LSP_VERSION.is_empty());
+    }
+}

--- a/crates/perl-lsp-feature-flags/src/lib.rs
+++ b/crates/perl-lsp-feature-flags/src/lib.rs
@@ -410,7 +410,7 @@ impl BuildFlags {
 
 #[cfg(test)]
 mod tests {
-    use super::BuildFlags;
+    use super::{AdvertisedFeatures, BuildFlags};
     use perl_lsp_feature_contracts::all_features;
     use perl_lsp_feature_ids::LSP_DOCUMENT_COLOR;
 
@@ -490,5 +490,179 @@ mod tests {
                 declaration: true
             }
         );
+    }
+
+    // ── ga_lock profile shape ───────────────────────────────────────
+
+    #[test]
+    fn ga_lock_has_expected_profile_shape() {
+        let ga = BuildFlags::ga_lock();
+        assert!(ga.completion);
+        assert!(ga.hover);
+        assert!(ga.definition);
+        assert!(ga.formatting, "ga-lock should include formatting");
+        assert!(ga.range_formatting, "ga-lock should include range_formatting");
+        assert!(!ga.inline_values, "ga-lock should exclude inline_values");
+    }
+
+    // ── all() profile enables everything ────────────────────────────
+
+    #[test]
+    fn all_profile_enables_every_flag() {
+        let all = BuildFlags::all();
+        assert!(all.completion);
+        assert!(all.hover);
+        assert!(all.definition);
+        assert!(all.type_definition);
+        assert!(all.implementation);
+        assert!(all.references);
+        assert!(all.document_symbol);
+        assert!(all.workspace_symbol);
+        assert!(all.inlay_hints);
+        assert!(all.pull_diagnostics);
+        assert!(all.workspace_symbol_resolve);
+        assert!(all.semantic_tokens);
+        assert!(all.code_actions);
+        assert!(all.execute_command);
+        assert!(all.rename);
+        assert!(all.document_links);
+        assert!(all.selection_ranges);
+        assert!(all.on_type_formatting);
+        assert!(all.code_lens);
+        assert!(all.call_hierarchy);
+        assert!(all.type_hierarchy);
+        assert!(all.linked_editing);
+        assert!(all.inline_completion);
+        assert!(all.inline_values);
+        assert!(all.notebook_document_sync);
+        assert!(all.notebook_cell_execution);
+        assert!(all.moniker);
+        assert!(all.document_color);
+        assert!(all.source_organize_imports);
+        assert!(all.formatting);
+        assert!(all.range_formatting);
+        assert!(all.folding_range);
+        assert!(all.signature_help);
+        assert!(all.document_highlight);
+        assert!(all.declaration);
+    }
+
+    // ── Default is all-false ────────────────────────────────────────
+
+    #[test]
+    fn default_flags_are_all_false() {
+        let default = BuildFlags::default();
+        assert!(default.to_feature_ids().is_empty(), "default flags should yield no features");
+    }
+
+    // ── all() produces strictly more IDs than ga_lock() ─────────────
+
+    #[test]
+    fn all_produces_superset_of_ga_lock_ids() {
+        let all_ids = BuildFlags::all().to_feature_ids();
+        let ga_ids = BuildFlags::ga_lock().to_feature_ids();
+        for id in &ga_ids {
+            assert!(all_ids.contains(id), "'all' profile should contain ga-lock feature '{id}'");
+        }
+        assert!(all_ids.len() >= ga_ids.len());
+    }
+
+    // ── to_advertised_features mapping ──────────────────────────────
+
+    #[test]
+    fn to_advertised_features_maps_completion() {
+        let flags = BuildFlags { completion: true, ..Default::default() };
+        let adv = flags.to_advertised_features();
+        assert!(adv.completion);
+        assert!(!adv.hover);
+    }
+
+    #[test]
+    fn to_advertised_features_maps_code_actions_to_code_action() {
+        let flags = BuildFlags { code_actions: true, ..Default::default() };
+        let adv = flags.to_advertised_features();
+        assert!(
+            adv.code_action,
+            "BuildFlags.code_actions should map to AdvertisedFeatures.code_action"
+        );
+    }
+
+    #[test]
+    fn to_advertised_features_maps_pull_diagnostics_to_diagnostic_provider() {
+        let flags = BuildFlags { pull_diagnostics: true, ..Default::default() };
+        let adv = flags.to_advertised_features();
+        assert!(
+            adv.diagnostic_provider,
+            "BuildFlags.pull_diagnostics should map to AdvertisedFeatures.diagnostic_provider"
+        );
+    }
+
+    #[test]
+    fn to_advertised_features_maps_selection_ranges_to_selection_range() {
+        let flags = BuildFlags { selection_ranges: true, ..Default::default() };
+        let adv = flags.to_advertised_features();
+        assert!(
+            adv.selection_range,
+            "BuildFlags.selection_ranges should map to AdvertisedFeatures.selection_range"
+        );
+    }
+
+    #[test]
+    fn default_advertised_features_are_all_false() {
+        let adv = AdvertisedFeatures::default();
+        assert!(!adv.completion);
+        assert!(!adv.hover);
+        assert!(!adv.definition);
+        assert!(!adv.references);
+        assert!(!adv.document_symbol);
+        assert!(!adv.workspace_symbol);
+        assert!(!adv.code_action);
+        assert!(!adv.code_lens);
+        assert!(!adv.formatting);
+        assert!(!adv.rename);
+    }
+
+    // ── Individual flag toggling produces exactly one feature ID ─────
+
+    #[test]
+    fn single_flag_produces_single_id() {
+        let cases: Vec<(&str, BuildFlags)> = vec![
+            ("completion", BuildFlags { completion: true, ..Default::default() }),
+            ("hover", BuildFlags { hover: true, ..Default::default() }),
+            ("definition", BuildFlags { definition: true, ..Default::default() }),
+            ("references", BuildFlags { references: true, ..Default::default() }),
+            ("rename", BuildFlags { rename: true, ..Default::default() }),
+            ("formatting", BuildFlags { formatting: true, ..Default::default() }),
+            ("signature_help", BuildFlags { signature_help: true, ..Default::default() }),
+            ("declaration", BuildFlags { declaration: true, ..Default::default() }),
+        ];
+        for (label, flags) in cases {
+            let ids = flags.to_feature_ids();
+            assert_eq!(
+                ids.len(),
+                1,
+                "flag '{label}' should produce exactly 1 feature id, got {ids:?}"
+            );
+        }
+    }
+
+    // ── Production vs all diff ──────────────────────────────────────
+
+    #[test]
+    fn production_and_all_differ_on_formatting() {
+        let prod = BuildFlags::production();
+        let all = BuildFlags::all();
+        assert!(!prod.formatting);
+        assert!(all.formatting);
+        assert!(!prod.range_formatting);
+        assert!(all.range_formatting);
+    }
+
+    #[test]
+    fn ga_lock_and_production_differ_on_inline_values() {
+        let ga = BuildFlags::ga_lock();
+        let prod = BuildFlags::production();
+        assert!(!ga.inline_values, "ga-lock excludes inline_values");
+        assert!(prod.inline_values, "production includes inline_values");
     }
 }

--- a/crates/perl-lsp-feature-governance/src/lib.rs
+++ b/crates/perl-lsp-feature-governance/src/lib.rs
@@ -30,3 +30,235 @@ pub use perl_lsp_feature_profile_cli::{
 pub const fn feature_profile_metadata() -> &'static [FeatureProfileSpec] {
     feature_profile_specs()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Facade re-exports are functional ────────────────────────────
+
+    #[test]
+    fn facade_exposes_all_features() {
+        let features = all_features();
+        assert!(!features.is_empty(), "all_features() should return non-empty list");
+    }
+
+    #[test]
+    fn facade_exposes_has_feature() {
+        assert!(has_feature("lsp.completion"));
+        assert!(!has_feature("lsp.nonexistent"));
+    }
+
+    #[test]
+    fn facade_exposes_advertised_features() {
+        let adv = advertised_features();
+        assert!(!adv.is_empty());
+    }
+
+    #[test]
+    fn facade_exposes_bdd_feature_rows() {
+        let rows = bdd_feature_rows();
+        assert!(!rows.is_empty());
+    }
+
+    #[test]
+    fn facade_exposes_compliance_percent() {
+        let pct = compliance_percent();
+        assert!((0.0..=100.0).contains(&pct));
+    }
+
+    #[test]
+    fn facade_exposes_compliance_percent_for_grid() {
+        let pct = compliance_percent_for_grid();
+        assert!((0.0..=100.0).contains(&pct));
+    }
+
+    #[test]
+    fn facade_exposes_trackable_counts() {
+        let trackable = trackable_feature_count_for_grid();
+        let advertised = advertised_trackable_feature_count_for_grid();
+        assert!(trackable > 0);
+        assert!(advertised <= trackable);
+    }
+
+    #[test]
+    fn facade_exposes_version_constants() {
+        assert!(!VERSION.is_empty());
+        assert!(!LSP_VERSION.is_empty());
+    }
+
+    // ── Grid re-exports ─────────────────────────────────────────────
+
+    #[test]
+    fn facade_exposes_feature_grid_columns() {
+        assert!(FEATURE_GRID_COLUMNS.contains(&"id"));
+        assert!(FEATURE_GRID_COLUMNS.contains(&"area"));
+        assert!(FEATURE_GRID_COLUMNS.contains(&"maturity"));
+        assert!(FEATURE_GRID_COLUMNS.contains(&"advertised"));
+    }
+
+    #[test]
+    fn facade_to_json_produces_valid_json() -> Result<(), serde_json::Error> {
+        let json_str = to_json();
+        let value: serde_json::Value = serde_json::from_str(&json_str)?;
+        assert!(value.get("version").is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn facade_to_json_for_profile_includes_profile_key() -> Result<(), serde_json::Error> {
+        let json_str = to_json_for_profile(FeatureProfile::All);
+        let value: serde_json::Value = serde_json::from_str(&json_str)?;
+        assert_eq!(value["profile"].as_str(), Some("all"));
+        Ok(())
+    }
+
+    #[test]
+    fn facade_to_json_for_all_profiles_includes_all_three() -> Result<(), serde_json::Error> {
+        let json_str = to_json_for_all_profiles();
+        let value: serde_json::Value = serde_json::from_str(&json_str)?;
+        let profiles = value["profiles"].as_array();
+        assert!(profiles.is_some());
+        let profiles = profiles.map(|p| p.len()).unwrap_or(0);
+        assert!(profiles >= 3, "should include at least ga-lock, production, all");
+        Ok(())
+    }
+
+    #[test]
+    fn facade_compliance_percent_for_profile_returns_valid_range() {
+        for profile in FeatureProfile::all() {
+            let pct = compliance_percent_for_profile(*profile);
+            assert!(
+                (0.0..=100.0).contains(&pct),
+                "compliance for {} should be 0-100, got {}",
+                profile.as_str(),
+                pct
+            );
+        }
+    }
+
+    // ── Policy re-exports ───────────────────────────────────────────
+
+    #[test]
+    fn facade_flags_for_profile_returns_expected_types() {
+        let flags = flags_for_profile(FeatureProfile::Production);
+        assert!(flags.completion);
+    }
+
+    #[test]
+    fn facade_flags_for_runtime_enables_formatting_with_perltidy() {
+        let flags = flags_for_runtime(FeatureProfile::Production, true);
+        assert!(flags.formatting);
+    }
+
+    #[test]
+    fn facade_feature_ids_from_flags_returns_sorted() {
+        let flags = flags_for_profile(FeatureProfile::All);
+        let ids = feature_ids_from_flags(&flags);
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted);
+    }
+
+    #[test]
+    fn facade_catalog_advertised_feature_ids_non_empty() {
+        let ids = catalog_advertised_feature_ids(FeatureProfile::Production);
+        assert!(!ids.is_empty());
+    }
+
+    // ── Profile re-exports ──────────────────────────────────────────
+
+    #[test]
+    fn facade_parse_profile_name_resolves_known() {
+        assert!(parse_profile_name("all").is_some());
+        assert!(parse_profile_name("bogus").is_none());
+    }
+
+    #[test]
+    fn facade_parse_profile_token_normalizes() {
+        assert!(parse_profile_token("  ALL  ").is_some());
+    }
+
+    #[test]
+    fn facade_supported_cli_profiles_non_empty() {
+        assert!(!supported_cli_profiles().is_empty());
+    }
+
+    #[test]
+    fn facade_feature_profile_kind_variants() {
+        assert_eq!(FeatureProfileKind::GaLock.as_str(), "ga-lock");
+        assert_eq!(FeatureProfileKind::Production.as_str(), "production");
+        assert_eq!(FeatureProfileKind::All.as_str(), "all");
+    }
+
+    // ── Profile CLI re-exports ──────────────────────────────────────
+
+    #[test]
+    fn facade_parse_feature_profile_arg_works() {
+        let result = parse_feature_profile_arg("prod");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn facade_parse_feature_profile_arg_or_current_fallback() {
+        let profile = parse_feature_profile_arg_or_current("nonsense");
+        assert_eq!(profile, FeatureProfile::current());
+    }
+
+    #[test]
+    fn facade_feature_profile_label_is_canonical() {
+        assert_eq!(feature_profile_label(FeatureProfile::GaLock), "ga-lock");
+    }
+
+    #[test]
+    fn facade_feature_profile_supported_tokens_non_empty() {
+        assert!(!feature_profile_supported_tokens().is_empty());
+    }
+
+    // ── feature_profile_metadata ────────────────────────────────────
+
+    #[test]
+    fn feature_profile_metadata_matches_specs() {
+        let metadata = feature_profile_metadata();
+        let specs = feature_profile_specs();
+        assert_eq!(metadata.len(), specs.len());
+        for (m, s) in metadata.iter().zip(specs.iter()) {
+            assert_eq!(m.canonical, s.canonical);
+        }
+    }
+
+    // ── Capability map re-exports ───────────────────────────────────
+
+    #[test]
+    fn facade_caps_from_feature_ids_works() {
+        let caps = caps_from_feature_ids(&["lsp.completion", "lsp.hover"]);
+        let ids = feature_ids_from_caps(&caps);
+        assert!(ids.contains(&"lsp.completion"));
+        assert!(ids.contains(&"lsp.hover"));
+    }
+
+    // ── Feature struct fields ───────────────────────────────────────
+
+    #[test]
+    fn feature_struct_has_expected_fields() {
+        let feature = &all_features()[0];
+        assert!(!feature.id.is_empty());
+        assert!(!feature.spec.is_empty());
+        assert!(!feature.area.is_empty());
+        assert!(!feature.maturity.is_empty());
+        assert!(!feature.description.is_empty());
+    }
+
+    #[test]
+    fn bdd_feature_row_serialization_has_all_column_fields() {
+        let rows = bdd_feature_rows();
+        let first = &rows[0];
+        // Verify all FEATURE_GRID_COLUMNS fields are present in BddFeatureRow
+        assert!(!first.id.is_empty());
+        assert!(!first.spec.is_empty());
+        assert!(!first.area.is_empty());
+        assert!(!first.maturity.is_empty());
+        assert!(!first.description.is_empty());
+        // advertised and counts_in_coverage are bools, always present
+    }
+}

--- a/crates/perl-lsp-feature-grid/src/lib.rs
+++ b/crates/perl-lsp-feature-grid/src/lib.rs
@@ -215,4 +215,113 @@ mod tests {
         assert!(keys.contains(&"production"));
         assert!(keys.contains(&"all"));
     }
+
+    // ── compliance_percent_for_profile ───────────────────────────────
+
+    #[test]
+    fn compliance_percent_is_in_valid_range_for_all_profiles() {
+        for profile in FeatureProfile::all() {
+            let pct = compliance_percent_for_profile(*profile);
+            assert!(
+                (0.0..=100.0).contains(&pct),
+                "compliance for {} should be in [0, 100], got {}",
+                profile.as_str(),
+                pct
+            );
+        }
+    }
+
+    #[test]
+    fn all_profile_compliance_gte_ga_lock_compliance() {
+        let all_pct = compliance_percent_for_profile(FeatureProfile::All);
+        let ga_pct = compliance_percent_for_profile(FeatureProfile::GaLock);
+        assert!(all_pct >= ga_pct, "'all' compliance ({all_pct}) should be >= ga-lock ({ga_pct})");
+    }
+
+    // ── feature_profile_contracts ───────────────────────────────────
+
+    #[test]
+    fn feature_profile_contracts_returns_specs() {
+        let contracts = super::feature_profile_contracts();
+        assert_eq!(contracts.len(), 3);
+        assert_eq!(contracts[0].canonical, "ga-lock");
+        assert_eq!(contracts[1].canonical, "production");
+        assert_eq!(contracts[2].canonical, "all");
+    }
+
+    // ── FEATURE_GRID_COLUMNS ────────────────────────────────────────
+
+    #[test]
+    fn feature_grid_columns_has_expected_entries() {
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"id"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"area"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"spec"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"maturity"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"advertised"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"counts_in_coverage"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"description"));
+        assert!(super::FEATURE_GRID_COLUMNS.contains(&"tests"));
+    }
+
+    // ── to_json_for_profiles ────────────────────────────────────────
+
+    #[test]
+    fn to_json_for_profiles_subset() {
+        let payload = super::to_json_for_profiles(&[FeatureProfile::GaLock]);
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        let profiles = must_some(value.get("profiles").and_then(|v| v.as_array()));
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0]["profile"].as_str(), Some("ga-lock"));
+    }
+
+    // ── Profile summary fields ──────────────────────────────────────
+
+    #[test]
+    fn profile_summary_contains_required_keys() {
+        let payload = to_json_for_all_profiles();
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        let profiles = must_some(value.get("profiles").and_then(|v| v.as_array()));
+        for profile_value in profiles {
+            assert!(profile_value.get("profile").is_some(), "missing 'profile' key");
+            assert!(profile_value.get("advertised").is_some(), "missing 'advertised' key");
+            assert!(
+                profile_value.get("compliance_percent").is_some(),
+                "missing 'compliance_percent'"
+            );
+            assert!(
+                profile_value.get("trackable_feature_count").is_some(),
+                "missing 'trackable_feature_count'"
+            );
+            assert!(
+                profile_value.get("advertised_trackable_feature_count").is_some(),
+                "missing 'advertised_trackable_feature_count'"
+            );
+            assert!(
+                profile_value.get("advertised_feature_count").is_some(),
+                "missing 'advertised_feature_count'"
+            );
+        }
+    }
+
+    // ── Production profile JSON ─────────────────────────────────────
+
+    #[test]
+    fn to_json_for_production_profile() {
+        let payload = to_json_for_profile(FeatureProfile::Production);
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        assert_eq!(value["profile"].as_str(), Some("production"));
+        assert!(value.get("feature_count").is_some());
+    }
+
+    // ── Default to_json has no profile key ───────────────────────────
+
+    #[test]
+    fn default_to_json_omits_profile_key() {
+        let payload = to_json();
+        let value: serde_json::Value = must(serde_json::from_str(&payload));
+        assert!(
+            value.get("profile").is_none(),
+            "default to_json() should not have a 'profile' key"
+        );
+    }
 }

--- a/crates/perl-lsp-feature-ids/src/lib.rs
+++ b/crates/perl-lsp-feature-ids/src/lib.rs
@@ -147,4 +147,181 @@ mod tests {
         assert_eq!(LSP_INLINE_COMPLETION, "lsp.inline_completion");
         assert_eq!(DAP_CORE, "dap.core");
     }
+
+    #[test]
+    fn all_lsp_ids_start_with_lsp_prefix() {
+        let lsp_ids: &[&str] = &[
+            LSP_COMPLETION,
+            LSP_HOVER,
+            LSP_SIGNATURE_HELP,
+            LSP_DEFINITION,
+            LSP_DECLARATION,
+            LSP_EXECUTE_COMMAND,
+            LSP_TYPE_DEFINITION,
+            LSP_IMPLEMENTATION,
+            LSP_REFERENCES,
+            LSP_DOCUMENT_SYMBOL,
+            LSP_WORKSPACE_SYMBOL,
+            LSP_CODE_ACTION,
+            LSP_CODE_LENS,
+            LSP_FORMATTING,
+            LSP_RANGE_FORMATTING,
+            LSP_RANGES_FORMATTING,
+            LSP_ON_TYPE_FORMATTING,
+            LSP_RENAME,
+            LSP_DOCUMENT_LINK,
+            LSP_FOLDING_RANGE,
+            LSP_SELECTION_RANGE,
+            LSP_INLAY_HINT,
+            LSP_SEMANTIC_TOKENS,
+            LSP_TYPE_HIERARCHY,
+            LSP_CALL_HIERARCHY,
+            LSP_PULL_DIAGNOSTICS,
+            LSP_INLINE_COMPLETION,
+            LSP_INLINE_VALUE,
+            LSP_DOCUMENT_COLOR,
+            LSP_COLOR,
+            LSP_LINKED_EDITING_RANGE,
+            LSP_MONIKER,
+            LSP_INLINE_VALUES,
+            LSP_NOTEBOOK_DOCUMENT_SYNC,
+            LSP_NOTEBOOK_CELL_EXECUTION,
+            LSP_PROGRESS,
+            LSP_SHOW_MESSAGE,
+            LSP_LOG_MESSAGE,
+            LSP_WORK_DONE_PROGRESS,
+            LSP_TEXT_DOCUMENT_SYNC,
+            LSP_DID_SAVE,
+            LSP_WILL_SAVE,
+            LSP_WILL_SAVE_WAIT_UNTIL,
+            LSP_DOCUMENT_HIGHLIGHT,
+            LSP_PREPARE_RENAME,
+            LSP_COLOR_PRESENTATION,
+            LSP_COMPLETION_ITEM_RESOLVE,
+            LSP_CODE_ACTION_RESOLVE,
+            LSP_CODE_LENS_RESOLVE,
+            LSP_DOCUMENT_LINK_RESOLVE,
+            LSP_INLAY_HINT_RESOLVE,
+            LSP_WORKSPACE_SYMBOL_RESOLVE,
+            LSP_CODE_LENS_REFRESH,
+            LSP_SEMANTIC_TOKENS_REFRESH,
+            LSP_INLAY_HINT_REFRESH,
+            LSP_INLINE_VALUE_REFRESH,
+            LSP_DIAGNOSTIC_REFRESH,
+            LSP_FOLDING_RANGE_REFRESH,
+        ];
+        for id in lsp_ids {
+            assert!(id.starts_with("lsp."), "LSP feature ID '{id}' should start with 'lsp.'");
+        }
+    }
+
+    #[test]
+    fn all_dap_ids_start_with_dap_prefix() {
+        let dap_ids: &[&str] = &[DAP_CORE, DAP_INLINE_VALUES, DAP_BREAKPOINTS_BASIC];
+        for id in dap_ids {
+            assert!(id.starts_with("dap."), "DAP feature ID '{id}' should start with 'dap.'");
+        }
+    }
+
+    #[test]
+    fn no_duplicate_ids_in_constants() {
+        let all_ids: &[&str] = &[
+            LSP_COMPLETION,
+            LSP_HOVER,
+            LSP_SIGNATURE_HELP,
+            LSP_DEFINITION,
+            LSP_DECLARATION,
+            LSP_EXECUTE_COMMAND,
+            LSP_TYPE_DEFINITION,
+            LSP_IMPLEMENTATION,
+            LSP_REFERENCES,
+            LSP_DOCUMENT_SYMBOL,
+            LSP_WORKSPACE_SYMBOL,
+            LSP_CODE_ACTION,
+            LSP_CODE_LENS,
+            LSP_FORMATTING,
+            LSP_RANGE_FORMATTING,
+            LSP_RANGES_FORMATTING,
+            LSP_ON_TYPE_FORMATTING,
+            LSP_RENAME,
+            LSP_DOCUMENT_LINK,
+            LSP_FOLDING_RANGE,
+            LSP_SELECTION_RANGE,
+            LSP_INLAY_HINT,
+            LSP_SEMANTIC_TOKENS,
+            LSP_TYPE_HIERARCHY,
+            LSP_CALL_HIERARCHY,
+            LSP_PULL_DIAGNOSTICS,
+            LSP_INLINE_COMPLETION,
+            LSP_INLINE_VALUE,
+            LSP_DOCUMENT_COLOR,
+            LSP_COLOR,
+            LSP_LINKED_EDITING_RANGE,
+            LSP_MONIKER,
+            LSP_INLINE_VALUES,
+            LSP_NOTEBOOK_DOCUMENT_SYNC,
+            LSP_NOTEBOOK_CELL_EXECUTION,
+            LSP_PROGRESS,
+            LSP_SHOW_MESSAGE,
+            LSP_LOG_MESSAGE,
+            LSP_WORK_DONE_PROGRESS,
+            LSP_TEXT_DOCUMENT_SYNC,
+            LSP_DID_SAVE,
+            LSP_WILL_SAVE,
+            LSP_WILL_SAVE_WAIT_UNTIL,
+            LSP_DOCUMENT_HIGHLIGHT,
+            LSP_PREPARE_RENAME,
+            LSP_COLOR_PRESENTATION,
+            LSP_COMPLETION_ITEM_RESOLVE,
+            LSP_CODE_ACTION_RESOLVE,
+            LSP_CODE_LENS_RESOLVE,
+            LSP_DOCUMENT_LINK_RESOLVE,
+            LSP_INLAY_HINT_RESOLVE,
+            LSP_WORKSPACE_SYMBOL_RESOLVE,
+            LSP_CODE_LENS_REFRESH,
+            LSP_SEMANTIC_TOKENS_REFRESH,
+            LSP_INLAY_HINT_REFRESH,
+            LSP_INLINE_VALUE_REFRESH,
+            LSP_DIAGNOSTIC_REFRESH,
+            LSP_FOLDING_RANGE_REFRESH,
+            DAP_CORE,
+            DAP_INLINE_VALUES,
+            DAP_BREAKPOINTS_BASIC,
+        ];
+        let mut sorted = all_ids.to_vec();
+        sorted.sort_unstable();
+        for window in sorted.windows(2) {
+            assert_ne!(window[0], window[1], "duplicate feature ID constant: '{}'", window[0]);
+        }
+    }
+
+    #[test]
+    fn resolve_route_ids_follow_naming_convention() {
+        let resolve_ids = &[
+            LSP_COMPLETION_ITEM_RESOLVE,
+            LSP_CODE_ACTION_RESOLVE,
+            LSP_CODE_LENS_RESOLVE,
+            LSP_DOCUMENT_LINK_RESOLVE,
+            LSP_INLAY_HINT_RESOLVE,
+            LSP_WORKSPACE_SYMBOL_RESOLVE,
+        ];
+        for id in resolve_ids {
+            assert!(id.ends_with("_resolve"), "resolve route ID '{id}' should end with '_resolve'");
+        }
+    }
+
+    #[test]
+    fn refresh_route_ids_follow_naming_convention() {
+        let refresh_ids = &[
+            LSP_CODE_LENS_REFRESH,
+            LSP_SEMANTIC_TOKENS_REFRESH,
+            LSP_INLAY_HINT_REFRESH,
+            LSP_INLINE_VALUE_REFRESH,
+            LSP_DIAGNOSTIC_REFRESH,
+            LSP_FOLDING_RANGE_REFRESH,
+        ];
+        for id in refresh_ids {
+            assert!(id.ends_with("_refresh"), "refresh route ID '{id}' should end with '_refresh'");
+        }
+    }
 }

--- a/crates/perl-lsp-feature-policy/src/lib.rs
+++ b/crates/perl-lsp-feature-policy/src/lib.rs
@@ -151,7 +151,7 @@ pub fn catalog_advertised_feature_ids(profile: FeatureProfile) -> Vec<&'static s
 
 #[cfg(test)]
 mod tests {
-    use super::FeatureProfile;
+    use super::*;
 
     #[test]
     fn profile_labels_are_stable() {
@@ -170,5 +170,190 @@ mod tests {
         assert!(supported.contains(&"prod"));
         assert!(supported.contains(&"production"));
         assert!(supported.contains(&"all"));
+    }
+
+    // ── from_kind round-trip ────────────────────────────────────────
+
+    #[test]
+    fn from_kind_preserves_all_variants() {
+        assert_eq!(FeatureProfile::from_kind(FeatureProfileKind::GaLock), FeatureProfile::GaLock,);
+        assert_eq!(
+            FeatureProfile::from_kind(FeatureProfileKind::Production),
+            FeatureProfile::Production,
+        );
+        assert_eq!(FeatureProfile::from_kind(FeatureProfileKind::All), FeatureProfile::All,);
+    }
+
+    // ── from_ga_lock_enabled ────────────────────────────────────────
+
+    #[test]
+    fn from_ga_lock_enabled_true_is_ga_lock() {
+        assert_eq!(FeatureProfile::from_ga_lock_enabled(true), FeatureProfile::GaLock);
+    }
+
+    #[test]
+    fn from_ga_lock_enabled_false_is_production() {
+        assert_eq!(FeatureProfile::from_ga_lock_enabled(false), FeatureProfile::Production);
+    }
+
+    // ── from_cli_argument ───────────────────────────────────────────
+
+    #[test]
+    fn from_cli_argument_resolves_known_tokens() {
+        assert_eq!(FeatureProfile::from_cli_argument("ga-lock"), FeatureProfile::GaLock);
+        assert_eq!(FeatureProfile::from_cli_argument("prod"), FeatureProfile::Production);
+        assert_eq!(FeatureProfile::from_cli_argument("all"), FeatureProfile::All);
+    }
+
+    #[test]
+    fn from_cli_argument_falls_back_for_unknown() {
+        let result = FeatureProfile::from_cli_argument("bogus");
+        assert_eq!(result, FeatureProfile::current());
+    }
+
+    // ── parse_profile ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_profile_returns_none_for_unknown() {
+        assert!(FeatureProfile::parse_profile("nope").is_none());
+    }
+
+    #[test]
+    fn parse_profile_returns_some_for_valid() {
+        assert_eq!(FeatureProfile::parse_profile("all"), Some(FeatureProfile::All));
+    }
+
+    // ── build_flags and profile shapes ──────────────────────────────
+
+    #[test]
+    fn build_flags_returns_ga_lock_for_ga_lock_profile() {
+        let flags = FeatureProfile::GaLock.build_flags();
+        let expected = BuildFlags::ga_lock();
+        assert_eq!(flags, expected);
+    }
+
+    #[test]
+    fn build_flags_returns_production_for_production_profile() {
+        let flags = FeatureProfile::Production.build_flags();
+        let expected = BuildFlags::production();
+        assert_eq!(flags, expected);
+    }
+
+    #[test]
+    fn build_flags_returns_all_for_all_profile() {
+        let flags = FeatureProfile::All.build_flags();
+        let expected = BuildFlags::all();
+        assert_eq!(flags, expected);
+    }
+
+    // ── runtime_flags with perltidy ─────────────────────────────────
+
+    #[test]
+    fn runtime_flags_enables_formatting_when_perltidy_available() {
+        let flags = FeatureProfile::Production.runtime_flags(true);
+        assert!(flags.formatting, "formatting should be enabled with perltidy");
+        assert!(flags.range_formatting, "range_formatting should be enabled with perltidy");
+    }
+
+    #[test]
+    fn runtime_flags_preserves_disabled_formatting_without_perltidy() {
+        let flags = FeatureProfile::Production.runtime_flags(false);
+        assert!(!flags.formatting, "formatting should remain off without perltidy");
+        assert!(!flags.range_formatting, "range_formatting should remain off without perltidy");
+    }
+
+    // ── flags_for_profile / flags_for_runtime ───────────────────────
+
+    #[test]
+    fn flags_for_profile_matches_build_flags() {
+        for profile in FeatureProfile::all() {
+            assert_eq!(
+                flags_for_profile(*profile),
+                profile.build_flags(),
+                "flags_for_profile({}) should match build_flags()",
+                profile.as_str(),
+            );
+        }
+    }
+
+    #[test]
+    fn flags_for_runtime_matches_runtime_flags() {
+        for &has_perltidy in &[true, false] {
+            for profile in FeatureProfile::all() {
+                assert_eq!(
+                    flags_for_runtime(*profile, has_perltidy),
+                    profile.runtime_flags(has_perltidy),
+                );
+            }
+        }
+    }
+
+    // ── advertised_features ─────────────────────────────────────────
+
+    #[test]
+    fn advertised_features_reflects_build_flags() {
+        let adv = FeatureProfile::Production.advertised_features();
+        assert!(adv.completion);
+        assert!(adv.hover);
+        assert!(!adv.formatting, "production does not advertise formatting without perltidy");
+    }
+
+    #[test]
+    fn runtime_advertised_features_with_perltidy() {
+        let adv = FeatureProfile::Production.runtime_advertised_features(true);
+        assert!(adv.formatting, "production should advertise formatting with perltidy");
+    }
+
+    // ── catalog_advertised_feature_ids ──────────────────────────────
+
+    #[test]
+    fn catalog_advertised_ids_are_non_empty_for_all_profiles() {
+        for profile in FeatureProfile::all() {
+            let ids = catalog_advertised_feature_ids(*profile);
+            assert!(
+                !ids.is_empty(),
+                "catalog_advertised_feature_ids({}) should not be empty",
+                profile.as_str(),
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_advertised_ids_all_superset_of_ga_lock() {
+        let all_ids = catalog_advertised_feature_ids(FeatureProfile::All);
+        let ga_ids = catalog_advertised_feature_ids(FeatureProfile::GaLock);
+        for id in &ga_ids {
+            assert!(all_ids.contains(id), "'all' advertised IDs should contain ga-lock ID '{id}'");
+        }
+    }
+
+    #[test]
+    fn catalog_advertised_ids_only_contain_catalog_known_ids() {
+        let catalog_ids = advertised_features();
+        for profile in FeatureProfile::all() {
+            let ids = catalog_advertised_feature_ids(*profile);
+            for id in &ids {
+                assert!(
+                    catalog_ids.contains(id),
+                    "profile '{}' emitted non-catalog ID '{id}'",
+                    profile.as_str(),
+                );
+            }
+        }
+    }
+
+    // ── all() profiles ──────────────────────────────────────────────
+
+    #[test]
+    fn all_profiles_returns_three() {
+        assert_eq!(FeatureProfile::all().len(), 3);
+    }
+
+    // ── feature_ids_from_flags ──────────────────────────────────────
+
+    #[test]
+    fn feature_ids_from_flags_for_default_is_empty() {
+        let ids = feature_ids_from_flags(&BuildFlags::default());
+        assert!(ids.is_empty());
     }
 }

--- a/crates/perl-lsp-feature-profile-cli/src/lib.rs
+++ b/crates/perl-lsp-feature-profile-cli/src/lib.rs
@@ -62,10 +62,11 @@ impl std::error::Error for UnsupportedFeatureProfileError {}
 #[cfg(test)]
 mod tests {
     use super::{
-        FeatureProfile, feature_profile_supported_tokens, parse_feature_profile_arg,
+        FeatureProfile, UnsupportedFeatureProfileError, feature_profile_label,
+        feature_profile_supported_tokens, parse_feature_profile_arg,
         parse_feature_profile_arg_or_current,
     };
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_err};
 
     #[test]
     fn parse_feature_profile_accepts_known_aliases() {
@@ -92,5 +93,67 @@ mod tests {
         assert!(supported.contains(&"ga"));
         assert!(supported.contains(&"prod"));
         assert!(supported.contains(&"all"));
+    }
+
+    // ── Error diagnostics ───────────────────────────────────────────
+
+    #[test]
+    fn parse_feature_profile_arg_returns_error_for_unknown() {
+        let err = must_err(parse_feature_profile_arg("bogus"));
+        assert!(err.raw_profile == "bogus", "error should capture the raw profile token");
+    }
+
+    #[test]
+    fn unsupported_error_message_contains_raw_token() {
+        let err = UnsupportedFeatureProfileError { raw_profile: "xyzzy".to_string() };
+        let msg = err.message();
+        assert!(msg.contains("xyzzy"), "error message should contain the raw token");
+    }
+
+    #[test]
+    fn unsupported_error_message_lists_supported_tokens() {
+        let err = UnsupportedFeatureProfileError { raw_profile: "bad".to_string() };
+        let msg = err.message();
+        assert!(msg.contains("auto"), "error message should list 'auto'");
+        assert!(msg.contains("prod"), "error message should list 'prod'");
+        assert!(msg.contains("all"), "error message should list 'all'");
+    }
+
+    #[test]
+    fn unsupported_error_display_matches_message() {
+        let err = UnsupportedFeatureProfileError { raw_profile: "nope".to_string() };
+        let display = format!("{err}");
+        assert_eq!(display, err.message());
+    }
+
+    #[test]
+    fn unsupported_error_is_std_error() {
+        let err: Box<dyn std::error::Error> =
+            Box::new(UnsupportedFeatureProfileError { raw_profile: "test".to_string() });
+        let msg = format!("{err}");
+        assert!(msg.contains("test"));
+    }
+
+    // ── feature_profile_label ───────────────────────────────────────
+
+    #[test]
+    fn feature_profile_label_returns_canonical_name() {
+        assert_eq!(feature_profile_label(FeatureProfile::GaLock), "ga-lock");
+        assert_eq!(feature_profile_label(FeatureProfile::Production), "production");
+        assert_eq!(feature_profile_label(FeatureProfile::All), "all");
+    }
+
+    // ── parse_feature_profile_arg_or_current with valid input ───────
+
+    #[test]
+    fn parse_feature_profile_arg_or_current_accepts_valid() {
+        let profile = parse_feature_profile_arg_or_current("all");
+        assert_eq!(profile, FeatureProfile::All);
+    }
+
+    #[test]
+    fn parse_feature_profile_arg_or_current_with_whitespace() {
+        let profile = parse_feature_profile_arg_or_current("  ga  ");
+        assert_eq!(profile, FeatureProfile::GaLock);
     }
 }

--- a/crates/perl-lsp-feature-profile/src/lib.rs
+++ b/crates/perl-lsp-feature-profile/src/lib.rs
@@ -64,4 +64,49 @@ mod tests {
     fn normalized_profiles_keep_legacy_underscores() {
         assert_eq!(super::parse_profile_token("ga_lock"), Some(FeatureProfileKind::GaLock));
     }
+
+    // ── parse_profile_token normalization ────────────────────────────
+
+    #[test]
+    fn parse_profile_token_trims_whitespace() {
+        assert_eq!(super::parse_profile_token("  all  "), Some(FeatureProfileKind::All));
+        assert_eq!(super::parse_profile_token("\tprod\n"), Some(FeatureProfileKind::Production));
+    }
+
+    #[test]
+    fn parse_profile_token_lowercases() {
+        assert_eq!(super::parse_profile_token("ALL"), Some(FeatureProfileKind::All));
+        assert_eq!(super::parse_profile_token("Prod"), Some(FeatureProfileKind::Production));
+        assert_eq!(super::parse_profile_token("GA-LOCK"), Some(FeatureProfileKind::GaLock));
+    }
+
+    #[test]
+    fn parse_profile_token_normalizes_underscore_to_hyphen() {
+        assert_eq!(super::parse_profile_token("GA_LOCK"), Some(FeatureProfileKind::GaLock));
+    }
+
+    #[test]
+    fn parse_profile_token_rejects_empty() {
+        assert!(super::parse_profile_token("").is_none());
+    }
+
+    #[test]
+    fn parse_profile_token_rejects_unknown() {
+        assert!(super::parse_profile_token("debug").is_none());
+        assert!(super::parse_profile_token("minimal").is_none());
+    }
+
+    #[test]
+    fn parse_profile_token_resolves_auto() {
+        assert_eq!(super::parse_profile_token("auto"), Some(FeatureProfileKind::current()));
+        assert_eq!(super::parse_profile_token("AUTO"), Some(FeatureProfileKind::current()));
+    }
+
+    // ── from_str_name delegates ─────────────────────────────────────
+
+    #[test]
+    fn from_str_name_delegates_to_profile_kind() {
+        assert_eq!(super::from_str_name("all"), FeatureProfileKind::from_str_name("all"));
+        assert_eq!(super::from_str_name("bogus"), None);
+    }
 }


### PR DESCRIPTION
Comprehensive test coverage for the feature governance subsystem (19 → 151 tests). Covers: feature contracts/catalog integrity, capability map round-trips, feature flags/profiles/policy, governance facade, BDD grid, profile CLI parsing. All 151 tests pass.