### PR TITLE
docs: add portable agent swarm workflow handoff kit

### DIFF
--- a/docs/handoff/agent-swarm-workflow/README.md
+++ b/docs/handoff/agent-swarm-workflow/README.md
@@ -1,0 +1,105 @@
+# Agent Swarm Workflow
+
+A portable pattern for orchestrating multiple Claude Code agents in parallel to
+accomplish large-scale codebase changes efficiently and safely.
+
+## How it works
+
+### The core idea
+
+Instead of one agent doing everything sequentially, an **orchestrator thread**
+launches **waves of focused agents**, each working in its own git worktree.
+The agents run in parallel, each doing one well-scoped task. When a wave
+completes, a second round of **PR agents** validates, commits, and publishes
+each worktree's changes. The orchestrator tracks completions and launches the
+next wave.
+
+### Architecture
+
+```
+Orchestrator (main thread)
+  |
+  |-- Wave 1: Implementation agents (parallel, each in a worktree)
+  |     |-- agent-fix-parser-bug      (worktree: agent-abc123)
+  |     |-- agent-add-test-coverage   (worktree: agent-def456)
+  |     |-- agent-update-docs         (worktree: agent-ghi789)
+  |     '-- agent-cleanup-dead-code   (worktree: agent-jkl012)
+  |
+  |-- Bulk PR: PR agents validate + publish each worktree
+  |     |-- pr-agent for agent-abc123  -> PR #101
+  |     |-- pr-agent for agent-def456  -> PR #102
+  |     |-- pr-agent for agent-ghi789  -> PR #103
+  |     '-- pr-agent for agent-jkl012  -> PR #104
+  |
+  |-- Merge coordination: merge PRs, resolve conflicts
+  |
+  |-- Wave 2: Next category of work (repeat)
+  |
+  '-- Quality ratchet: update baselines so improvements stick
+```
+
+### Key principles
+
+1. **Worktree isolation** -- Every agent that writes code operates in its own
+   git worktree. This prevents merge conflicts between agents and lets them
+   run truly in parallel.
+
+2. **Orchestrator never writes code** -- The main thread only coordinates:
+   dispatching agents, tracking completions, launching PR waves, and updating
+   baselines.
+
+3. **Focused agents** -- Each agent has a single, well-defined task.
+   A bug fix agent does TDD: write failing test, fix, verify. A docs agent
+   updates documentation. Small scope means higher success rates.
+
+4. **PR pipeline** -- Implementation and PR creation are separate concerns.
+   Implementation agents just write code. PR agents validate, branch, commit,
+   push, and create the pull request.
+
+5. **Wave pattern** -- Work is organized in waves by category (fixes, tests,
+   docs, cleanup). This lets the orchestrator merge one category before
+   starting the next, reducing conflict probability.
+
+6. **Quality ratcheting** -- After merges, baselines are updated so metrics
+   can only improve. Test counts, lint warnings, coverage -- once they get
+   better, they stay better.
+
+## Files in this directory
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This overview |
+| `agent-patterns.md` | Patterns and anti-patterns for agent dispatch |
+| `example-prompts.md` | Copy-paste agent prompts for common tasks |
+| `setup-script.sh` | Bootstrap script for a new repository |
+| `slash-commands/` | Portable slash command templates |
+
+## Slash commands
+
+| Command | Purpose |
+|---------|---------|
+| `slash-commands/worktree-pr.md` | PR a single worktree's changes |
+| `slash-commands/tdd-fix.md` | TDD fix workflow (test-first) |
+| `slash-commands/bulk-pr.md` | PR all worktrees at once |
+| `slash-commands/wave.md` | Launch parallel agent waves |
+| `slash-commands/quality-ratchet.md` | Baseline ratcheting after improvements |
+
+## Getting started
+
+1. Run `setup-script.sh` in your repository root
+2. Customize the placeholders (`$TEST_CMD`, `$LINT_CMD`, etc.) in the copied
+   slash commands
+3. Start Claude Code and use `/wave` to launch your first swarm
+
+## Language support
+
+The templates use placeholder variables and work with any language:
+
+| Variable | Rust example | Python example | TypeScript example | Go example |
+|----------|-------------|----------------|-------------------|------------|
+| `$TEST_CMD` | `cargo test` | `pytest` | `npm test` | `go test ./...` |
+| `$LINT_CMD` | `cargo clippy` | `ruff check .` | `eslint .` | `golangci-lint run` |
+| `$FMT_CMD` | `cargo fmt` | `ruff format .` | `prettier --write .` | `gofmt -w .` |
+| `$BUILD_CMD` | `cargo build` | `python -m build` | `npm run build` | `go build ./...` |
+| `$CHECK_CMD` | `cargo check` | `mypy .` | `tsc --noEmit` | `go vet ./...` |
+| `$GATE_CMD` | `just ci-gate` | `make ci` | `npm run ci` | `make ci` |

--- a/docs/handoff/agent-swarm-workflow/agent-patterns.md
+++ b/docs/handoff/agent-swarm-workflow/agent-patterns.md
@@ -1,0 +1,246 @@
+# Patterns for Effective Agent Dispatch
+
+Hard-won lessons from running agent swarms on real codebases.
+
+## Core patterns
+
+### 1. Worktree isolation
+
+Always use `isolation: "worktree"` for any agent that writes code.
+
+**Why**: Two agents editing the same git index will corrupt each other's work.
+Worktrees give each agent a clean, independent working copy. They share the
+same git object store, so they're cheap to create and fast to set up.
+
+```
+Agent(
+  prompt: "Fix the date parsing bug",
+  mode: "auto",
+  isolation: "worktree",
+  run_in_background: true,
+  name: "fix-date-parsing"
+)
+```
+
+**Anti-pattern**: Running multiple agents in the same checkout with
+`isolation: "none"`. They will overwrite each other's changes.
+
+### 2. Background dispatch for parallelism
+
+Use `run_in_background: true` for agents that should run in parallel.
+
+```
+# Launch 4 agents simultaneously
+Agent(prompt: "Task A", isolation: "worktree", run_in_background: true, name: "task-a")
+Agent(prompt: "Task B", isolation: "worktree", run_in_background: true, name: "task-b")
+Agent(prompt: "Task C", isolation: "worktree", run_in_background: true, name: "task-c")
+Agent(prompt: "Task D", isolation: "worktree", run_in_background: true, name: "task-d")
+```
+
+Wait for all to complete before launching the PR wave. The orchestrator
+receives a notification when each background agent finishes.
+
+### 3. Name agents descriptively
+
+Use the `name` parameter so you can track which agent is doing what.
+
+Good names:
+- `fix-null-pointer-in-tokenizer`
+- `add-tests-for-auth-module`
+- `update-api-docs-v3`
+- `remove-dead-code-utils`
+
+Bad names:
+- `agent-1`
+- `worker`
+- `task`
+
+### 4. PR pipeline: separate implementation from publication
+
+Split the work into two phases:
+
+**Phase 1 -- Implementation agents** write code:
+- TDD fix agents
+- Test coverage agents
+- Documentation agents
+- Cleanup agents
+
+**Phase 2 -- PR agents** publish the results:
+- Validate (fmt, lint, test)
+- Create branch with conventional name
+- Commit with descriptive message
+- Push and create pull request
+
+This separation means implementation agents can focus purely on correctness,
+and PR agents apply a uniform publication process.
+
+### 5. Wave pattern
+
+Organize work in waves by category:
+
+```
+Wave 1: Bug fixes (highest priority, most likely to conflict with each other)
+  -> Bulk PR -> Merge all -> Rebase remaining worktrees
+
+Wave 2: Test coverage (builds on fixes, unlikely to conflict)
+  -> Bulk PR -> Merge all
+
+Wave 3: Documentation (depends on final code shape)
+  -> Bulk PR -> Merge all
+
+Wave 4: Cleanup (safe to do last)
+  -> Bulk PR -> Merge all
+```
+
+**Why waves matter**: Bug fixes often touch the same files. By doing them
+first and merging before the next wave, you avoid conflicts between fix agents
+and test agents.
+
+### 6. Quality ratcheting
+
+After each merge wave, update your baselines:
+
+```bash
+# Example: test count ratchet
+current_tests=$(grep -c "#\[test\]" src/**/*.rs)
+echo "$current_tests" > .ci/test-count-baseline.txt
+git add .ci/test-count-baseline.txt
+git commit -m "ci: ratchet test baseline to $current_tests"
+```
+
+Ratcheting ensures that improvements from the swarm are permanent. The next
+CI run will fail if someone drops below the new baseline.
+
+Things worth ratcheting:
+- Test count
+- Lint warning count (should be zero)
+- Code coverage percentage
+- Clean file count in a corpus sweep
+- Dead code count (should only decrease)
+
+### 7. Orchestrator role
+
+The main thread (orchestrator) should only:
+
+- Decide what work needs doing
+- Dispatch agents with clear, scoped prompts
+- Track completions
+- Launch PR waves
+- Coordinate merges
+- Update baselines
+
+The orchestrator should never:
+
+- Edit code directly
+- Run tests (that's the agents' job)
+- Make implementation decisions (agents decide how to fix)
+
+## Advanced patterns
+
+### Dependency chains
+
+When one agent's output feeds another:
+
+```
+# Phase 1: Generate
+Agent(prompt: "Create the API schema", isolation: "worktree", name: "schema")
+# Wait for completion
+
+# Phase 2: Consume (PR the schema first, then launch consumers)
+Agent(prompt: "PR the schema worktree", name: "pr-schema")
+# Wait, merge
+
+# Phase 3: Parallel consumers on the merged result
+Agent(prompt: "Generate client from schema", isolation: "worktree", run_in_background: true)
+Agent(prompt: "Generate server stubs from schema", isolation: "worktree", run_in_background: true)
+Agent(prompt: "Generate docs from schema", isolation: "worktree", run_in_background: true)
+```
+
+### Conflict resolution
+
+When two agents touched the same file:
+
+1. Merge the first PR
+2. The second worktree needs a rebase:
+   ```bash
+   cd .claude/worktrees/agent-xyz
+   git fetch origin
+   git rebase origin/master
+   ```
+3. If the rebase has conflicts, dispatch a fix-up agent:
+   ```
+   Agent(
+     prompt: "Resolve merge conflicts in this worktree and verify tests pass",
+     isolation: "none",  # work in the existing worktree
+     name: "resolve-conflicts"
+   )
+   ```
+
+### Retry with narrower scope
+
+If an agent fails on a broad task, split it:
+
+```
+# Too broad -- agent gets confused
+Agent(prompt: "Fix all date handling bugs")
+
+# Better -- one bug per agent
+Agent(prompt: "Fix: parse_date returns None for ISO 8601 dates with timezone offset")
+Agent(prompt: "Fix: date_diff panics when crossing DST boundary")
+Agent(prompt: "Fix: format_date drops milliseconds for timestamps before epoch")
+```
+
+### Smoke test before PR wave
+
+Before launching the PR wave, do a quick validation:
+
+```bash
+# Check which worktrees actually have meaningful changes
+for d in .claude/worktrees/agent-*; do
+  changes=$(cd "$d" && git diff --stat HEAD 2>/dev/null | tail -1)
+  if [ -n "$changes" ]; then
+    echo "READY: $(basename $d) | $changes"
+  fi
+done
+```
+
+Skip worktrees that only have debugging artifacts or incomplete work.
+
+## Anti-patterns
+
+### Letting agents coordinate with each other
+
+Agents cannot communicate. Do not prompt one agent to "wait for agent X" or
+"check what agent Y did." All coordination goes through the orchestrator.
+
+### Too many agents at once
+
+Diminishing returns set in around 5-8 parallel agents. Beyond that:
+- System resources become constrained
+- More conflicts to resolve
+- Harder to track what's happening
+
+Start with 3-4 agents per wave and scale up if your system handles it.
+
+### Vague prompts
+
+```
+# Bad: agent has to guess what "improve" means
+Agent(prompt: "Improve the auth module")
+
+# Good: specific, measurable, verifiable
+Agent(prompt: "Add unit tests for the JWT token refresh flow in auth/refresh.rs.
+Cover: expired token, valid refresh, revoked refresh token, malformed token.")
+```
+
+### Mixing concerns in one agent
+
+```
+# Bad: too many concerns
+Agent(prompt: "Fix the parser bug, add tests, update docs, and clean up dead code")
+
+# Good: one concern per agent
+Agent(prompt: "Fix: parser rejects valid heredoc with indented delimiter")
+Agent(prompt: "Add heredoc edge case tests for indented and stripped delimiters")
+Agent(prompt: "Update heredoc section in syntax-reference.md with new examples")
+```

--- a/docs/handoff/agent-swarm-workflow/example-prompts.md
+++ b/docs/handoff/agent-swarm-workflow/example-prompts.md
@@ -1,0 +1,235 @@
+# Example Agent Prompts
+
+Copy-paste templates for common agent tasks. Replace placeholders with your
+project's specifics.
+
+Placeholders used throughout:
+- `$PROJECT_ROOT` -- absolute path to your repository root
+- `$TEST_CMD` -- your test runner (e.g., `cargo test`, `pytest`, `npm test`, `go test ./...`)
+- `$LINT_CMD` -- your linter (e.g., `cargo clippy`, `ruff check .`, `eslint .`, `golangci-lint run`)
+- `$FMT_CMD` -- your formatter (e.g., `cargo fmt`, `ruff format .`, `prettier --write .`, `gofmt -w .`)
+- `$CHECK_CMD` -- fast type/build check (e.g., `cargo check`, `mypy .`, `tsc --noEmit`, `go vet ./...`)
+
+---
+
+## Fix a bug (TDD)
+
+```
+Fix the following bug using test-driven development:
+
+BUG: <describe the bug, including reproduction steps if known>
+
+Steps:
+1. Find the root cause by searching the codebase.
+2. Write a failing test FIRST that demonstrates the bug.
+3. Run $TEST_CMD to confirm the test fails for the right reason.
+4. Implement the minimal fix.
+5. Run $TEST_CMD to confirm the test passes.
+6. Run $FMT_CMD and $LINT_CMD to verify code quality.
+7. Do NOT create a PR -- just leave the changes in the worktree.
+
+Coding standards:
+- No panicking constructs in production code (unwrap, expect, panic, etc.)
+- Use proper error handling (Result, Option, error types)
+- Keep the fix minimal -- change as little as possible
+```
+
+## Add test coverage for a module
+
+```
+Add comprehensive test coverage for the module at: <path/to/module>
+
+Steps:
+1. Read the module and understand its public API and edge cases.
+2. Identify untested or under-tested code paths.
+3. Write tests that cover:
+   - Happy path for each public function/method
+   - Edge cases (empty input, boundary values, nil/null/None)
+   - Error cases (invalid input, missing dependencies)
+4. Run $TEST_CMD to verify all tests pass.
+5. Run $FMT_CMD and $LINT_CMD.
+6. Do NOT create a PR -- just leave the changes in the worktree.
+
+Guidelines:
+- Use the project's existing test patterns and helpers
+- Each test should test ONE thing and have a descriptive name
+- Tests should be deterministic (no randomness, no network, no clock)
+- Prefer table-driven / parameterized tests for similar cases
+```
+
+## Update documentation
+
+```
+Update the documentation for: <feature or component>
+
+Reason: <why it needs updating, e.g., "API changed in PR #123">
+
+Steps:
+1. Find all documentation files related to this feature:
+   - README sections
+   - Doc comments in source code
+   - Dedicated docs/ files
+   - Example code
+2. Read the current implementation to understand the actual behavior.
+3. Update documentation to match reality:
+   - Fix incorrect descriptions
+   - Add missing parameters or options
+   - Update examples to use current API
+   - Remove references to deprecated features
+4. Run $CHECK_CMD to verify any doc-embedded code examples still compile.
+5. Do NOT create a PR -- just leave the changes in the worktree.
+
+Guidelines:
+- Documentation should describe WHAT and WHY, not just HOW
+- Keep examples minimal but complete (they should work if copy-pasted)
+- Use consistent terminology throughout
+```
+
+## Clean up dead code
+
+```
+Find and remove dead code in: <path or module scope>
+
+Steps:
+1. Use your project's dead code detection tooling if available:
+   - Rust: `cargo machete` for unused deps, compiler warnings for unused code
+   - Python: `vulture .` or `ruff check --select F841,F811`
+   - TypeScript: `ts-prune` or compiler `noUnusedLocals`
+   - Go: `staticcheck ./...`
+2. Review each finding manually:
+   - Is it truly unreachable, or called via reflection/macros/dynamic dispatch?
+   - Is it part of a public API that external consumers might use?
+   - Is it intentionally kept for future use (check for TODO/FIXME comments)?
+3. Remove confirmed dead code.
+4. Run $TEST_CMD to verify nothing breaks.
+5. Run $LINT_CMD to confirm cleanliness.
+6. Do NOT create a PR -- just leave the changes in the worktree.
+
+Guidelines:
+- When in doubt, keep the code -- false positives are worse than missed dead code
+- Remove entire files when all their contents are dead
+- Update any documentation that references removed code
+```
+
+## Convert a shell script to native code
+
+```
+Convert the shell script at <path/to/script.sh> to native code in
+the project's primary language.
+
+Steps:
+1. Read the shell script thoroughly. Understand every command, pipe, and
+   conditional.
+2. Identify external tool dependencies (grep, sed, awk, jq, curl, etc.)
+   and find native equivalents.
+3. Write the native implementation:
+   - Preserve the exact same behavior and output format
+   - Handle all error cases that the shell script handles (and more)
+   - Add proper argument parsing if the script takes arguments
+   - Follow the project's coding standards
+4. Write tests that verify the native code matches the shell script's output
+   for representative inputs.
+5. Run $TEST_CMD, $FMT_CMD, $LINT_CMD.
+6. Do NOT create a PR -- just leave the changes in the worktree.
+
+Guidelines:
+- Do not delete the original shell script yet (the PR reviewer will decide)
+- Document any behavioral differences in comments
+- The native version should be faster and more robust, not just a transliteration
+```
+
+## PR a worktree's changes
+
+```
+Create a pull request from the changes in this worktree.
+
+Steps:
+1. Examine the changes: git diff --stat HEAD, git diff HEAD
+2. Validate:
+   - $FMT_CMD -- --check (or equivalent dry-run)
+   - $LINT_CMD
+   - $TEST_CMD (for affected modules at minimum)
+   Fix any issues before proceeding.
+3. Create a branch:
+   - fix/... for bug fixes
+   - feat/... for new features
+   - test/... for test additions
+   - docs/... for documentation
+   - chore/... for cleanup
+4. Stage and commit with a conventional commit message.
+5. Push and create PR with gh pr create.
+6. Return the PR URL.
+```
+
+## Refactor for readability
+
+```
+Refactor the code at <path/to/file> for improved readability.
+
+Constraints:
+- NO behavioral changes -- this is a pure refactoring
+- All existing tests must continue to pass without modification
+- Do not change public API signatures
+
+Steps:
+1. Read the code and identify readability issues:
+   - Long functions that should be extracted
+   - Unclear variable names
+   - Missing or misleading comments
+   - Complex conditionals that could be simplified
+   - Duplicated logic that could be shared
+2. Apply refactorings one at a time, running $TEST_CMD after each.
+3. Run $FMT_CMD and $LINT_CMD.
+4. Do NOT create a PR -- just leave the changes in the worktree.
+```
+
+## Add a new feature
+
+```
+Implement the following feature:
+
+FEATURE: <description>
+ACCEPTANCE CRITERIA:
+- <criterion 1>
+- <criterion 2>
+- <criterion 3>
+
+Steps:
+1. Understand the existing architecture around where this feature fits.
+2. Write failing tests FIRST that encode the acceptance criteria.
+3. Implement the feature to make the tests pass.
+4. Run the full test suite: $TEST_CMD
+5. Run $FMT_CMD and $LINT_CMD.
+6. Do NOT create a PR -- just leave the changes in the worktree.
+
+Coding standards:
+- Follow existing patterns in the codebase
+- No panicking constructs in production code
+- Add doc comments on public items
+- Keep the implementation minimal -- do not gold-plate
+```
+
+## Bulk dispatch template
+
+Use this as the orchestrator prompt to launch a wave:
+
+```
+Launch the following agents in parallel, each in its own worktree:
+
+1. Agent: "fix-<name>"
+   Prompt: "<specific bug fix prompt from above>"
+
+2. Agent: "test-<name>"
+   Prompt: "<specific test coverage prompt from above>"
+
+3. Agent: "docs-<name>"
+   Prompt: "<specific docs prompt from above>"
+
+4. Agent: "cleanup-<name>"
+   Prompt: "<specific cleanup prompt from above>"
+
+Use isolation: "worktree" and run_in_background: true for all of them.
+
+After all agents complete, run /bulk-pr to create PRs for all worktrees
+with changes.
+```

--- a/docs/handoff/agent-swarm-workflow/setup-script.sh
+++ b/docs/handoff/agent-swarm-workflow/setup-script.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Bootstrap script for the agent swarm workflow.
+#
+# Copies portable slash commands into .claude/commands/ and creates a
+# minimal .claude/settings.json with a PostToolUse hook.
+#
+# Usage:
+#   bash docs/handoff/agent-swarm-workflow/setup-script.sh
+#
+# Run from your repository root.
+
+set -euo pipefail
+
+# --- Configuration ---------------------------------------------------------
+# Override these if your project uses different commands.
+
+# The command that runs after every Edit/Write to catch errors early.
+# Examples:
+#   Rust:       "cargo check --quiet --message-format=short 2>&1 | head -20 || true"
+#   Python:     "python -m py_compile \"$FILE\" 2>&1 | head -20 || true"
+#   TypeScript: "npx tsc --noEmit 2>&1 | head -20 || true"
+#   Go:         "go vet ./... 2>&1 | head -20 || true"
+POST_EDIT_CHECK="${POST_EDIT_CHECK:-cargo check --quiet --message-format=short 2>&1 | head -20 || true}"
+
+# --- Resolve paths ---------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SLASH_CMD_SRC="${SCRIPT_DIR}/slash-commands"
+REPO_ROOT="$(pwd)"
+CLAUDE_DIR="${REPO_ROOT}/.claude"
+CMD_DIR="${CLAUDE_DIR}/commands"
+SETTINGS="${CLAUDE_DIR}/settings.json"
+
+# --- Pre-flight checks -----------------------------------------------------
+
+if [ ! -d "${SLASH_CMD_SRC}" ]; then
+    echo "ERROR: Cannot find slash-commands/ directory at ${SLASH_CMD_SRC}"
+    echo "       Run this script from the repository root, or set SCRIPT_DIR."
+    exit 1
+fi
+
+# --- Create directories ----------------------------------------------------
+
+echo "Creating .claude/commands/ ..."
+mkdir -p "${CMD_DIR}"
+
+# --- Copy slash commands ----------------------------------------------------
+
+echo "Copying slash command templates ..."
+
+for src_file in "${SLASH_CMD_SRC}"/*.md; do
+    filename="$(basename "$src_file")"
+    dest="${CMD_DIR}/${filename}"
+
+    if [ -f "$dest" ]; then
+        echo "  SKIP: ${filename} (already exists, not overwriting)"
+    else
+        cp "$src_file" "$dest"
+        echo "  COPY: ${filename}"
+    fi
+done
+
+# --- Create settings.json --------------------------------------------------
+
+if [ -f "$SETTINGS" ]; then
+    echo ""
+    echo "SKIP: .claude/settings.json already exists."
+    echo "      Review it manually and add PostToolUse hooks if needed."
+    echo "      Recommended hook command: ${POST_EDIT_CHECK}"
+else
+    echo ""
+    echo "Creating .claude/settings.json ..."
+    cat > "$SETTINGS" <<SETTINGSEOF
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${POST_EDIT_CHECK}"
+          }
+        ]
+      }
+    ]
+  }
+}
+SETTINGSEOF
+    echo "  Created with PostToolUse hook: ${POST_EDIT_CHECK}"
+fi
+
+# --- Print instructions -----------------------------------------------------
+
+echo ""
+echo "========================================================================"
+echo " Agent Swarm Workflow -- Setup Complete"
+echo "========================================================================"
+echo ""
+echo " Files created in: ${CMD_DIR}/"
+echo ""
+echo " Next steps:"
+echo ""
+echo "   1. Edit the slash commands in .claude/commands/ to replace"
+echo "      placeholder variables with your project's commands:"
+echo ""
+echo "        \$TEST_CMD   -- your test runner       (e.g., cargo test, pytest)"
+echo "        \$LINT_CMD   -- your linter             (e.g., cargo clippy, ruff)"
+echo "        \$FMT_CMD    -- your formatter           (e.g., cargo fmt, prettier)"
+echo "        \$BUILD_CMD  -- your build command       (e.g., cargo build, npm build)"
+echo "        \$CHECK_CMD  -- fast type/compile check  (e.g., cargo check, tsc)"
+echo "        \$GATE_CMD   -- full CI gate command     (e.g., just ci-gate, make ci)"
+echo ""
+echo "   2. Review .claude/settings.json and adjust the PostToolUse hook"
+echo "      command if needed."
+echo ""
+echo "   3. Start Claude Code and try:"
+echo "        /wave test-coverage     -- launch a test coverage wave"
+echo "        /tdd-fix <bug>          -- fix a bug with TDD"
+echo "        /bulk-pr                -- PR all worktrees at once"
+echo ""
+echo "   4. (Optional) Add .claude/ to .gitignore if you do not want"
+echo "      to check in agent configuration, or commit it to share"
+echo "      with your team."
+echo ""
+echo "   5. Read docs/handoff/agent-swarm-workflow/agent-patterns.md"
+echo "      for tips on effective agent dispatch."
+echo ""
+echo "========================================================================"

--- a/docs/handoff/agent-swarm-workflow/slash-commands/bulk-pr.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/bulk-pr.md
@@ -1,0 +1,51 @@
+---
+description: PR all worktrees with uncommitted changes
+argument-hint: "[--dry-run] [--filter <pattern>]"
+---
+
+# Bulk PR Worktrees
+
+Scan all agent worktrees for uncommitted changes and create PRs for each. Context: **$ARGUMENTS**
+
+## Steps
+
+### 1. Scan worktrees
+```bash
+cd $PROJECT_ROOT/.claude/worktrees
+for d in agent-*; do
+  changes=$(cd "$d" && git diff --stat HEAD 2>/dev/null | tail -1)
+  if [ -n "$changes" ]; then
+    files=$(cd "$d" && git diff --name-only HEAD 2>/dev/null | tr '\n' ', ')
+    echo "READY: $d | $changes | $files"
+  fi
+done
+```
+
+### 2. For each worktree with changes
+
+Launch a parallel Agent (with `run_in_background: true`) for each worktree that:
+
+1. cd to the worktree
+2. Examines `git diff HEAD` to understand the changes
+3. Runs `$FMT_CMD -- --check` (fix if needed)
+4. Runs `$LINT_CMD` (fix if needed)
+5. Runs `$TEST_CMD` for changed modules
+6. Creates a descriptive feature branch
+7. Commits with conventional commit message
+8. Pushes and creates PR via `gh pr create`
+9. Returns the PR URL
+
+### 3. Report
+
+Collect all PR URLs and report:
+
+| Worktree | Branch | PR URL | Status |
+|----------|--------|--------|--------|
+| agent-xxx | fix/... | #1234 | Created |
+| ... | | | |
+
+### Tips
+- Group small related changes (e.g., multiple test additions in the same module) if they are logically related
+- Skip worktrees where the diff is just 1-2 lines of uncommitted debugging artifacts
+- Use `--dry-run` to preview without creating PRs
+- If `--filter <pattern>` is provided, only process worktrees whose names match

--- a/docs/handoff/agent-swarm-workflow/slash-commands/quality-ratchet.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/quality-ratchet.md
@@ -1,0 +1,99 @@
+---
+description: Run quality checks, compare against baseline, update if improved
+argument-hint: "[--check | --update] [--metric <name>]"
+---
+
+# Quality Ratchet
+
+Run quality metrics and ratchet the baseline forward. Mode: **$ARGUMENTS**
+
+## Concept
+
+A quality ratchet ensures that metrics can only improve. After agents make
+improvements, you update the baseline. Future runs fail if metrics drop below
+the new floor.
+
+## Metrics to track
+
+Adapt these to your project. Store baselines in `.ci/` or a similar directory.
+
+### Test count
+```bash
+# Measure current test count
+# Rust:
+test_count=$(cargo test --workspace --lib -- --list 2>/dev/null | grep -c "test$" || echo 0)
+# Python:
+test_count=$(pytest --collect-only -q 2>/dev/null | tail -1 | grep -oP '\d+(?= test)')
+# TypeScript:
+test_count=$(npx jest --listTests 2>/dev/null | wc -l)
+# Go:
+test_count=$(go test ./... -list '.*' 2>/dev/null | grep -c '^Test')
+
+echo "Current test count: $test_count"
+```
+
+### Lint warnings
+```bash
+# Should be zero; ratchet prevents regressions
+# Rust:
+warnings=$($LINT_CMD 2>&1 | grep -c "warning\[" || echo 0)
+# Python:
+warnings=$($LINT_CMD 2>&1 | wc -l)
+
+echo "Current warning count: $warnings"
+```
+
+### Build / type-check cleanliness
+```bash
+$CHECK_CMD 2>&1
+echo "Exit code: $?"
+```
+
+## Check against baseline
+
+```bash
+baseline_file=".ci/quality-baseline.json"
+if [ -f "$baseline_file" ]; then
+    echo "Comparing against baseline..."
+    # Read baseline values and compare
+    # Fail if any metric regressed
+else
+    echo "No baseline found. Run with --update to create one."
+fi
+```
+
+## Update baseline after improvements
+
+```bash
+# 1. Run all metrics to see current state
+# 2. If metrics improved, update baseline
+
+cat > .ci/quality-baseline.json <<'BASELINEEOF'
+{
+  "test_count": <current>,
+  "lint_warnings": <current>,
+  "updated_at": "<date>"
+}
+BASELINEEOF
+
+# 3. Verify the ratchet holds
+# (re-run check to make sure baseline matches reality)
+
+# 4. Commit
+git add .ci/quality-baseline.json
+git commit -m "ci: ratchet quality baseline (tests: <N>, warnings: <N>)"
+```
+
+## Integration with agent swarm
+
+Typical flow:
+1. `/wave bug-fixes` -- agents fix bugs
+2. `/bulk-pr` -- create PRs
+3. Merge PRs
+4. `/quality-ratchet --update` -- lock in improvements
+5. `/wave test-coverage` -- agents add tests
+6. `/bulk-pr` -- create PRs
+7. Merge PRs
+8. `/quality-ratchet --update` -- lock in higher test count
+
+The ratchet prevents future work from accidentally undoing improvements.

--- a/docs/handoff/agent-swarm-workflow/slash-commands/tdd-fix.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/tdd-fix.md
@@ -1,0 +1,53 @@
+---
+description: TDD fix workflow (failing test, fix, verify)
+argument-hint: "<bug description> e.g. 'login fails when email contains +'"
+---
+
+# TDD Fix
+
+Fix a bug using test-driven development. Bug: **$ARGUMENTS**
+
+## Launch an agent in a worktree to do this work:
+
+Use the Agent tool with `isolation: "worktree"` and `mode: "auto"` to:
+
+### 1. Find the root cause
+- Search the codebase for the module responsible for the described behavior
+- Read the relevant source code to understand WHY the bug occurs
+- Check for existing tests that should have caught this
+
+### 2. Write failing tests FIRST
+- Add tests in the appropriate test file
+- Each test should exercise the buggy behavior and assert the correct outcome
+- The test MUST fail before your fix (this proves it tests the right thing)
+
+```
+# Run tests to confirm they fail:
+$TEST_CMD
+```
+
+### 3. Implement minimal fix
+- Change as little code as possible
+- Follow the project's coding standards:
+  - No panicking constructs in production code (unwrap, expect, panic, todo, etc.)
+  - Use proper error handling (Result, Option, error types)
+  - Match existing patterns in surrounding code
+
+### 4. Verify
+```bash
+$FMT_CMD
+$LINT_CMD
+$TEST_CMD
+```
+All must pass cleanly.
+
+### 5. Create PR
+- Branch, commit, push, `gh pr create`
+- Title: `fix(<scope>): <description>`
+- Return PR URL
+
+## Coding standards reminder
+- No fatal constructs in production code
+- Use `?`, `.ok_or_else()`, pattern matching for errors
+- In tests: use `Result<()>` return types or equivalent assertion helpers
+- Formatter and linter must be clean

--- a/docs/handoff/agent-swarm-workflow/slash-commands/wave.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/wave.md
@@ -1,0 +1,68 @@
+---
+description: Launch a wave of parallel agents for codebase improvement
+argument-hint: "<category> e.g. 'bug-fixes', 'test-coverage', 'doc-updates', 'cleanup'"
+---
+
+# Wave: Parallel Agent Dispatch
+
+Launch a wave of agents for: **$ARGUMENTS**
+
+## Categories
+
+### `bug-fixes`
+For each known bug or failing test:
+- Launch an agent per fix using `/tdd-fix` pattern
+- Each in its own worktree (`isolation: "worktree"`)
+- TDD: failing test, fix, verify
+
+### `test-coverage`
+Launch agents to improve test coverage across modules:
+- Identify modules with low or missing test coverage
+- One agent per module or logical area
+- Each agent reads the module, writes tests, verifies they pass
+
+### `doc-updates`
+Launch agents to update documentation:
+- README and getting-started guides
+- API reference and doc comments
+- Architecture and design docs
+- Changelog and migration guides
+
+### `cleanup`
+Launch agents for codebase hygiene:
+- Unused dependencies
+- Lint warnings
+- Dead code removal
+- Obsolete file deletion
+- Configuration updates
+
+### `refactoring`
+Launch agents for structural improvements:
+- Extract common patterns into shared utilities
+- Simplify complex functions
+- Improve naming consistency
+- Reduce duplication
+
+## Pattern
+
+For each item in the category:
+```
+Agent(
+  prompt: "<specific task>",
+  mode: "auto",
+  isolation: "worktree",
+  run_in_background: true,
+  name: "<descriptive-name>"
+)
+```
+
+## After wave completes
+
+Run `/bulk-pr` to create PRs for all worktrees with changes.
+
+## Guidelines
+
+- Keep each agent's scope narrow and well-defined
+- 3-8 agents per wave is the sweet spot
+- Bug fixes first, then tests, then docs, then cleanup
+- Merge one wave before starting the next to reduce conflicts

--- a/docs/handoff/agent-swarm-workflow/slash-commands/worktree-pr.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/worktree-pr.md
@@ -1,0 +1,65 @@
+---
+description: PR a worktree's changes (validate, branch, commit, push, PR)
+argument-hint: "<worktree-path> [commit message]"
+---
+
+# Worktree PR
+
+Create a PR from a worktree's uncommitted changes. Context: **$ARGUMENTS**
+
+## Steps
+
+1. **Identify the worktree** -- parse $ARGUMENTS for the worktree path. If not provided, list available worktrees with changes:
+```bash
+cd $PROJECT_ROOT/.claude/worktrees && for d in agent-*; do changes=$(cd "$d" && git diff --stat HEAD 2>/dev/null | tail -1); [ -n "$changes" ] && echo "$d: $changes"; done
+```
+
+2. **Understand the changes** -- cd to the worktree and examine:
+```bash
+git diff --stat HEAD
+git diff HEAD
+```
+
+3. **Validate** -- run checks in the worktree:
+```bash
+$FMT_CMD -- --check    # or equivalent dry-run mode
+$LINT_CMD 2>&1 | tail -5
+$TEST_CMD 2>&1 | tail -10
+```
+Fix any issues before proceeding.
+
+4. **Branch** -- create a descriptive feature branch:
+- `fix/...` for bug fixes
+- `feat/...` for new features
+- `test/...` for test additions
+- `docs/...` for documentation
+- `chore/...` for cleanup
+```bash
+git checkout -b <branch-name>
+```
+
+5. **Commit** -- stage relevant files and commit with conventional commit message:
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <description>
+EOF
+)"
+```
+
+6. **Push and PR**:
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+## Summary
+<what and why>
+
+## Evidence
+- `$TEST_CMD` -- passes
+- `$LINT_CMD` -- clean
+- `$FMT_CMD` -- clean
+EOF
+)"
+```
+
+7. **Return the PR URL**.


### PR DESCRIPTION
## Summary

- Adds `docs/handoff/agent-swarm-workflow/` with 9 files (1,052 lines) for replicating the agent swarm development pattern in any repository
- Includes: setup script, 5 generalized slash commands (`worktree-pr`, `tdd-fix`, `bulk-pr`, `wave`, `quality-ratchet`), agent patterns guide, example prompts, and README
- Contains language-specific placeholders for Rust, Python, TypeScript, and Go

## Test plan

- [ ] Verify all 9 files render correctly on GitHub
- [ ] Review setup script for correctness across target platforms
- [ ] Confirm slash command templates are self-contained and portable