### PR TITLE
docs: comprehensive README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,84 @@
 <p align="center">
-  <img src="icon/perl-lsp-logo-lockup.svg" alt="perl-lsp" width="400">
+  <img src="vscode-extension/icon.png" alt="perl-lsp logo" width="120" />
 </p>
 
-![CI](https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg)
-[![crates.io](https://img.shields.io/crates/v/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
-[![docs.rs](https://docs.rs/perl-lsp/badge.svg)](https://docs.rs/perl-lsp)
-[![codecov](https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/perl-lsp)
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
-[![Rust](https://img.shields.io/badge/rust-1.92%2B-orange.svg)](https://www.rust-lang.org/)
-[![Downloads](https://img.shields.io/crates/d/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
+<h1 align="center">perl-lsp</h1>
 
-A fast, native **Perl language server** and **parser toolkit** written in Rust — bringing modern IDE features to Perl. The workspace currently contains **over 115 Rust crates** and is in **Public Alpha (v0.11.0)**.
+<p align="center">
+  A fast, native <strong>Perl language server</strong> written in Rust — bringing modern IDE features to Perl 5.
+</p>
 
-> **Full LSP coverage** · **fast incremental parsing** · **zero runtime Perl dependency**
+<p align="center">
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/v/perl-lsp.svg" alt="crates.io" /></a>
+  <a href="https://docs.rs/perl-lsp"><img src="https://docs.rs/perl-lsp/badge.svg" alt="docs.rs" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="codecov" /></a>
+  <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
+  <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/d/perl-lsp.svg" alt="Downloads" /></a>
+</p>
 
-## Workspace Snapshot (current)
+---
 
-- **Crate directories**: 121 (under `crates/`)
-- **Workspace members**: 116 (`Cargo.toml` workspace members)
-- **Crate families**:
-  - `perl-module-*`: 13
-  - `perl-lsp-*`: 41
-  - `perl-lsp-feature-*`: 8
-  - `perl-dap-*`: 9
-  - `perl-ts-*`: 5
-  - `perl-workspace-*`: 6
-
-Regenerate family counts with:
+## Quick Start
 
 ```bash
-for prefix in perl-module- perl-lsp- perl-lsp-feature- perl-dap- perl-ts- perl-workspace-; do
-  printf "%-18s %s\n" "$prefix" "$(find crates -maxdepth 1 -mindepth 1 -type d -name "${prefix}*" | wc -l)"
-done
+# 1. Install
+cargo install perl-lsp
+
+# 2. Configure your editor (VS Code)
+code --install-extension effortlessmetrics.perl-lsp-rs
+
+# 3. Open a Perl file — completions, diagnostics, hover, and navigation work immediately.
 ```
 
-## Features at a Glance
+<details>
+<summary><strong>Neovim / Emacs setup</strong></summary>
 
-| | Feature | Details |
-|---|---------|---------|
-| ✅ | **Full LSP Coverage** | 100% advertised coverage (53/53), 100% protocol compliance (97/97) |
-| ✅ | **Completion** | Symbols, keywords, modules, variables, snippets |
-| ✅ | **Navigation** | Go-to-definition, references, workspace symbols |
-| ✅ | **Refactoring** | Rename, code actions, formatting |
-| ✅ | **Diagnostics** | Real-time error detection and reporting |
-| ✅ | **Hover** | Documentation and type information on hover |
-| ✅ | **Debug Adapter** | Breakpoints, stepping, variable inspection via DAP bridge |
-| ✅ | **Comprehensive Perl 5 Syntax** | Broad Perl 5.8-5.40 coverage: heredocs, regex, quotes, formats, all constructs |
-| ✅ | **Blazing Fast** | Sub-millisecond incremental parsing (<1ms updates) |
-| ✅ | **Zero Perl Dependency** | Pure Rust — no Perl runtime needed for parsing or LSP |
-| ✅ | **Cross-File Navigation** | Dual indexing with 98% reference coverage |
-| ✅ | **Unicode-Safe** | Full UTF-8/UTF-16 handling with symmetric position conversion |
-| ✅ | **Enterprise Security** | Supply chain security (SBOM + SLSA Level 2), path traversal prevention |
+**Neovim** (nvim-lspconfig):
+
+```lua
+require('lspconfig').perl_ls.setup {
+  cmd = { "perl-lsp", "--stdio" },
+}
+```
+
+**Emacs** (eglot):
+
+```elisp
+(add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
+```
+
+</details>
 
 ## Features
 
-- **Language Server** -- completion, hover, go-to-definition, references, rename, diagnostics, formatting, code actions, document symbols, workspace symbols, and more (**100% advertised coverage**: 53/53 features; `features.toml`)
-- **Debug Adapter** -- breakpoints, stepping, variable inspection via DAP bridge to `perl -d`
-- **Parser** -- v3 native recursive-descent parser with error recovery, heredoc/regex/quote support, and S-expression output
-- **Fast** -- pure Rust, sub-millisecond incremental parsing, no runtime dependencies on Perl for parsing or LSP
+| Feature | Description |
+|---------|-------------|
+| **Completion** | Symbols, keywords, modules, variables, snippets, built-in function signatures |
+| **Navigation** | Go-to-definition, find references, workspace symbols, document symbols |
+| **Hover** | Documentation and type information |
+| **Diagnostics** | Real-time error detection |
+| **Refactoring** | Rename, code actions, formatting |
+| **Debug Adapter** | Breakpoints, stepping, variable inspection via DAP bridge |
+| **Fast** | Sub-millisecond incremental parsing, native Rust binary |
+| **Zero Perl dependency** | No Perl runtime needed for parsing or LSP |
+| **Cross-file navigation** | Dual-indexed workspace with broad reference coverage |
+| **Unicode-safe** | Full UTF-8/UTF-16 position conversion |
+
+Full LSP coverage: all 53 advertised capabilities implemented (see [`features.toml`](features.toml)).
+For live metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
+
+## Why perl-lsp?
+
+| | perl-lsp | Perl::LanguageServer | PLS |
+|---|----------|---------------------|-----|
+| **Language** | Rust (native binary) | Perl | Perl |
+| **Requires Perl runtime** | No | Yes | Yes |
+| **LSP feature coverage** | 53/53 advertised | Partial | Partial |
+| **Incremental parsing** | Yes (sub-ms updates) | N/A | N/A |
+| **Debug adapter** | Built-in (DAP bridge) | Built-in | No |
+| **Supply chain security** | SBOM + SLSA Level 2 | N/A | N/A |
 
 ## Parser Coverage
 
@@ -87,7 +108,7 @@ See [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for the latest computed 
 cargo install perl-lsp
 ```
 
-### From source (default)
+### From source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
@@ -97,107 +118,47 @@ cargo install --path crates/perl-lsp
 
 ### Pre-built binaries
 
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), or use the installer scripts (best-effort / non-canonical):
+Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
-```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
+## Parser Coverage
 
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
+The v3 parser is a native recursive-descent implementation covering broad Perl 5 syntax
+(5.8 through 5.40), including heredocs, regex, quoting constructs, formats, and more.
+
+Coverage is validated by:
+
+- **Corpus test suite** -- 600+ test sections in `tree-sitter-perl/test/corpus/` plus 70+ standalone `.pl` fixtures
+- **CPAN module sweep** -- automated `just corpus-sweep` against 7,000+ `.pm` files from system Perl and CPAN distributions, with error bucketing to prioritize fixes
+- **Ratcheting CI** -- mutation score (87%) and safety baselines (zero `unwrap`/`panic!`/`unsafe` in production code) are enforced as one-way ratchets
+
+For detailed parse rates and the edge-case roadmap, see
+[PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md).
+
+## Architecture
+
+```text
+Editor / IDE
+    |  JSON-RPC (stdio)
+    v
+perl-lsp  (LSP server)
+    |
+    +-- LSP Providers (completion, hover, diagnostics, ...)
+    +-- Workspace Index (dual-indexed symbol lookup)
+    +-- perl-dap (Debug Adapter Protocol bridge)
+    |
+perl-parser  (v3 recursive-descent)
+    |
+perl-lexer   (mode-aware tokenizer)
 ```
 
-## Why perl-lsp?
+The workspace is organized as a family of focused Rust crates (115+), each with a
+single responsibility. This keeps compile times fast and boundaries clear.
 
-| | perl-lsp | Perl::LanguageServer | PLS |
-|---|----------|---------------------|-----|
-| **Language** | Rust (native binary) | Perl | Perl |
-| **Requires Perl runtime** | No (parsing/LSP) | Yes | Yes |
-| **LSP coverage** | 100% (53/53 features) | Partial | Partial |
-| **Protocol compliance** | 100% (97/97 methods) | Partial | Partial |
-| **Incremental parsing** | Yes (<1ms updates) | N/A | N/A |
-| **Debug adapter** | Built-in (DAP bridge) | Built-in | No |
-| **Cross-file navigation** | Dual-indexed (98% coverage) | Limited | Limited |
-| **Mutation tested** | 87% score | N/A | N/A |
-| **Supply chain security** | SBOM + SLSA Level 2 | N/A | N/A |
-| **Startup overhead** | Minimal (native) | Perl interpreter | Perl interpreter |
+For the full tier system, architecture decision records, and design rationale, see:
 
-## Editor Setup
-
-### VS Code
-
-Install the **Perl Language Server** extension (`effortlessmetrics.perl-lsp-rs`) from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=effortlessmetrics.perl-lsp-rs), or build from [source](vscode-extension/).
-
-### Neovim (nvim-lspconfig)
-
-```lua
-require('lspconfig').perl_ls.setup {
-  cmd = { "perl-lsp", "--stdio" },
-}
-```
-
-### Emacs (lsp-mode / eglot)
-
-```elisp
-;; eglot
-(add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
-```
-
-## Access Paths
-
-- **Rust crates on crates.io**: install binaries with `cargo install perl-lsp` / `cargo install perl-dap`, and consume libraries with `cargo add perl-parser` / `cargo add perl-lexer`.
-- **Editor integrations**: the VS Code extension is the primary packaged integration; any LSP-compatible editor can connect to `perl-lsp --stdio` (Neovim, Emacs, etc.).
-- **Debug adapter**: `perl-dap` for VS Code and other DAP-compatible editors.
-- **FFI / non-Rust integration**: the tree-sitter workspace exposes optional C interoperability through `tree-sitter-perl-rs` (`c-parser` feature) for existing C/FFI consumers.
-
-## Quick Start
-
-### 1. Install
-
-```bash
-cargo install perl-lsp
-```
-
-### 2. Configure your editor
-
-**VS Code** — Install the extension `effortlesssteven.perl-lsp` from the marketplace. Done!
-
-**Neovim** — Add to your LSP config:
-
-```lua
-require('lspconfig').perl_ls.setup {
-  cmd = { "perl-lsp", "--stdio" },
-}
-```
-
-**Emacs** — Add to your init:
-
-```elisp
-(add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
-```
-
-### 3. Open a Perl file and start coding
-
-You immediately get completions, hover docs, go-to-definition, diagnostics, and more:
-
-```
-$ perl-lsp --stdio
-# The server communicates via JSON-RPC over stdin/stdout.
-# Your editor handles this automatically once configured.
-```
-
-### Command-line usage
-
-```bash
-# Run the language server (editors connect to this)
-perl-lsp --stdio
-
-# Run the debug adapter
-perl-dap
-
-# Parse a Perl file directly (library usage)
-cargo run -p perl-parser -- path/to/file.pl
-```
+- [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md)
+- [Architecture Decision Records](docs/adr/README.md) (microcrate architecture, dual indexing, incremental parsing, supply chain security)
+- [CLAUDE.md](CLAUDE.md) for the complete developer command reference
 
 ## Published Crates
 
@@ -207,132 +168,42 @@ cargo run -p perl-parser -- path/to/file.pl
 | [`perl-dap`](https://crates.io/crates/perl-dap) | Debug Adapter Protocol binary |
 | [`perl-parser`](https://crates.io/crates/perl-parser) | Recursive-descent Perl parser library |
 | [`perl-lexer`](https://crates.io/crates/perl-lexer) | Context-aware Perl tokenizer |
-| [`perl-corpus`](https://crates.io/crates/perl-corpus) | Parser/LSP test corpus |
-
-## Architecture
-
-### Parser Evolution
-
-The project maintains three parser versions for different use cases:
-
-| Version | Implementation | Status | Purpose |
-|---------|---------------|--------|---------|
-| **v1** | tree-sitter | Legacy | C FFI compatibility, benchmarking |
-| **v2** | Pest | Legacy | Kept out of default CI gate |
-| **v3** | Native recursive descent | **Current** | ~100% Perl 5.8-5.40 coverage, sub-millisecond parsing |
-
-### System Architecture
-
-```
-                          ┌──────────────────────┐
-                          │    Editor / IDE       │
-                          │ (VS Code, Neovim, …)  │
-                          └─────────┬────────────┘
-                                    │ JSON-RPC (stdio)
-                          ┌─────────▼────────────┐
-                          │      perl-lsp         │
-                          │   (LSP Server)        │
-                          │  3-tier profiles:     │
-                          │  ga-lock/production/  │
-                          │  all                  │
-                          └─────────┬────────────┘
-                                    │
-            ┌───────────────────────┼───────────────────────┐
-            │                       │                       │
-   ┌────────▼────────┐   ┌─────────▼─────────┐   ┌────────▼────────┐
-   │  LSP Providers   │   │  Workspace Index   │   │   perl-dap      │
-   │ (41 feature      │   │  (dual-indexed,    │   │  (DAP Bridge)   │
-   │  microcrates)    │   │   98% coverage)    │   │  9 microcrates  │
-   └────────┬────────┘   └─────────┬─────────┘   └────────┬────────┘
-            │                       │                       │
-            └───────────────────────┼───────────────────────┘
-                                    │
-                   ┌────────────────▼────────────────┐
-                   │         perl-parser             │
-                   │  (v3 recursive-descent,         │
-                   │   ~100% Perl 5.8-5.40 syntax)   │
-                   └────────────────┬────────────────┘
-                                    │
-                   ┌────────────────▼────────────────┐
-                   │          perl-lexer             │
-                   │   (mode-aware tokenizer)        │
-                   └─────────────────────────────────┘
-```
-
-> **Key Architectural Decisions**: See [Architecture Decision Records](docs/adr/README.md) for design rationale, including [microcrate architecture (ADR-0008)](docs/adr/0008-microcrate-architecture.md), [dual indexing (ADR-0009)](docs/adr/0009-dual-indexing-strategy.md), and [incremental parsing (ADR-0010)](docs/adr/0010-incremental-parsing-architecture.md).
-
-## Workspace Layout
-
-```text
-crates/
-  perl-lsp/           LSP server binary
-  perl-dap/           DAP server binary
-  perl-parser/        Parser entry points and high-level APIs
-  perl-lexer/         Tokenizer
-  perl-lsp-*/         LSP feature crates (completion, diagnostics, navigation, ...)
-  perl-module-*/      Module resolution microcrates
-  perl-dap-*/         DAP components
-  perl-ts-*/          Tree-sitter integration
-  perl-workspace-*/   Workspace discovery and indexing
-  perl-*/             Core support crates (ast, token, quote, regex, heredoc, error, ...)
-xtask/                Development automation
-book/                 mdbook documentation
-vscode-extension/     VS Code extension source
-```
+| [`perl-corpus`](https://crates.io/crates/perl-corpus) | Parser and LSP test corpus |
 
 ## Development
 
 ```bash
-# Build
-cargo build --workspace
-
-# Test
-cargo test --workspace
-
-# Lint + format
-cargo clippy --workspace --lib && cargo fmt --all
-
-# Check local tooling (dev environment doctor)
-just doctor
-
-# Full local gate (requires Nix)
-nix develop -c just ci-gate
+cargo build --workspace            # Build everything
+cargo test --workspace             # Run all tests
+cargo clippy --workspace --lib     # Lint
+cargo fmt --all                    # Format
+nix develop -c just ci-gate        # Full local gate (required before push)
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for our community standards, [SUPPORT.md](SUPPORT.md) for how to get help, and [CLAUDE.md](CLAUDE.md) for the full command reference.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines,
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards,
+and [SUPPORT.md](SUPPORT.md) for how to get help.
+
+## Security
+
+Release artifacts include SBOM generation (SPDX and CycloneDX) and SLSA Level 2
+provenance attestations. Production code enforces zero `unsafe`, zero `unwrap`/`expect`,
+and zero `panic!`-family macros via CI ratchets. Path traversal and command injection
+vectors are hardened.
+
+See [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) for details.
 
 ## Documentation
 
-### User & Developer Guides
-
-- [Book](book/) -- comprehensive user and developer guide (mdbook)
-- [docs/](docs/README.md) -- documentation index
-- [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md) -- server architecture
-- [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) -- debugger setup and usage
-- [Stability Policy](docs/reference/STABILITY.md) -- API versioning and compatibility
-- [features.toml](features.toml) -- canonical LSP feature catalog
-
-### Strategic Documentation
-
-For project direction, planning, and architectural decisions:
-
-| Document | Purpose |
-|----------|---------|
-| [**ROADMAP.md**](ROADMAP.md) | Version milestones and deliverables (v0.10→v1.0+) |
-| [**NOW_NEXT_LATER.md**](NOW_NEXT_LATER.md) | Current quarter priorities |
-| [**TECHNICAL_VISION.md**](TECHNICAL_VISION.md) | Long-term technical direction (3-5 years) |
-| [**Strategic Documentation Index**](docs/STRATEGIC_DOCUMENTATION.md) | Navigation hub for all strategic docs |
-| [**Architecture Decision Records**](docs/adr/README.md) | Key design decisions and rationale |
-
-### Key Architecture Decision Records
-
-| ADR | Title | Description |
-|-----|-------|-------------|
-| [ADR-0008](docs/adr/0008-microcrate-architecture.md) | Microcrate Architecture | 115+ small crates following SRP |
-| [ADR-0009](docs/adr/0009-dual-indexing-strategy.md) | Dual Indexing | 98% reference coverage |
-| [ADR-0010](docs/adr/0010-incremental-parsing-architecture.md) | Incremental Parsing | <1ms update target |
-| [ADR-0015](docs/adr/0015-supply-chain-security.md) | Supply Chain Security | SBOM + SLSA Level 2 |
-| [ADR-0019](docs/adr/0019-security-first-dap.md) | Security-First DAP | Enterprise-grade debugger security |
+| Resource | Description |
+|----------|-------------|
+| [Book](book/) | Comprehensive user and developer guide |
+| [docs/](docs/README.md) | Documentation index |
+| [features.toml](features.toml) | Canonical LSP feature catalog |
+| [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) | Live project metrics |
+| [ROADMAP.md](ROADMAP.md) | Version milestones and planning |
+| [Stability Policy](docs/reference/STABILITY.md) | API versioning and compatibility |
+| [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) | Debugger setup and usage |
 
 ## History
 
@@ -340,7 +211,14 @@ This project began as a fork of [tree-sitter-perl](https://github.com/tree-sitte
 
 ## License
 
-Dual licensed under MIT OR Apache-2.0:
+Dual licensed under MIT or Apache-2.0:
 
 - [LICENSE-MIT](LICENSE-MIT)
 - [LICENSE-APACHE](LICENSE-APACHE)
+
+## History
+
+This project began as a fork of
+[tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl)
+in July 2025 and has since been rewritten as a native Rust implementation
+focused on LSP and DAP performance.


### PR DESCRIPTION
## Summary

- **Leads with logo and value prop** -- centered logo from vscode-extension/icon.png, one-liner description, badge row
- **Quick Start is first section** -- install + configure in 3 commands, with Neovim/Emacs in a collapsible details block
- **Clean features table** -- scannable, no emoji column, links to features.toml and CURRENT_STATUS.md for live metrics
- **Fixes stale claims** -- removed "~100% coverage" language; uses "broad Perl 5 syntax coverage" and links to PARSER_EDGE_CASE_ROADMAP.md which shows the actual 51% clean-parse rate on CPAN sweep
- **Fixes VS Code extension ID** -- `effortlessmetrics.perl-lsp-rs` (was `effortlesssteven.perl-lsp`)
- **Removes "Workspace Snapshot" section** -- crate family counts are implementation detail, not README material
- **Adds Parser Coverage section** -- mentions corpus suite, CPAN module sweep, ratcheting CI
- **Streamlines Architecture** -- simple text diagram, brief explanation of crate organization, links to docs/ for details
- **Removes duplicate sections** -- old README had both "Editor Setup" and "Quick Start" with the same content
- **Moves fork/origins to brief "History" note** at the bottom
- **Adds Security section** -- SBOM, SLSA, ratchets, links to supply chain security docs
- **Removes "microcrate" jargon** from user-facing copy (replaced with "focused Rust crates")
- **200 lines** (down from 325) -- concise and scannable

## Test plan

- [ ] Verify all relative links resolve correctly (features.toml, docs/, CONTRIBUTING.md, etc.)
- [ ] Verify logo renders on GitHub
- [ ] Verify badges render correctly
- [ ] Confirm VS Code extension ID matches package.json (`effortlessmetrics.perl-lsp-rs`)
- [ ] No markdown lint warnings