### PR TITLE
fix(folding): emit Region kind for heredoc folding ranges

### DIFF
--- a/crates/perl-lsp-folding/src/lib.rs
+++ b/crates/perl-lsp-folding/src/lib.rs
@@ -237,8 +237,8 @@ impl FoldingRangeExtractor {
 
             // POD is typically inside strings or special constructs, not a separate NodeKind
             NodeKind::Heredoc { .. } => {
-                // Heredocs are always foldable
-                self.add_range_from_node(node, None);
+                // Heredocs are always foldable as regions
+                self.add_range_from_node(node, Some(FoldingRangeKind::Region));
             }
 
             NodeKind::StatementModifier { statement, modifier: _, condition } => {

--- a/crates/perl-lsp-folding/tests/heredoc_folding.rs
+++ b/crates/perl-lsp-folding/tests/heredoc_folding.rs
@@ -1,0 +1,109 @@
+//! Tests for heredoc folding range extraction.
+
+use std::sync::Arc;
+
+use perl_lsp_folding::{FoldingRangeExtractor, FoldingRangeKind};
+use perl_parser_core::{ParseError, Parser, ast::Node};
+
+fn parse(source: &str) -> Result<Arc<Node>, ParseError> {
+    let mut parser = Parser::new(source);
+    parser.parse().map(Arc::new)
+}
+
+#[test]
+fn heredoc_produces_region_fold_via_ast() -> Result<(), ParseError> {
+    let code = "my $x = <<END;\nline one\nline two\nEND\n";
+    let ast = parse(code)?;
+    let mut extractor = FoldingRangeExtractor::new();
+    let ranges = extractor.extract(&ast);
+
+    let region_folds: Vec<_> =
+        ranges.iter().filter(|r| matches!(r.kind, Some(FoldingRangeKind::Region))).collect();
+
+    assert!(!region_folds.is_empty(), "heredoc should produce at least one Region fold");
+
+    // The fold should cover a meaningful span
+    for fold in &region_folds {
+        assert!(fold.end_offset > fold.start_offset, "fold range must be non-empty");
+    }
+    Ok(())
+}
+
+#[test]
+fn indented_heredoc_produces_region_fold() -> Result<(), ParseError> {
+    let code = "my $x = <<~END;\n    line one\n    line two\nEND\n";
+    let ast = parse(code)?;
+    let mut extractor = FoldingRangeExtractor::new();
+    let ranges = extractor.extract(&ast);
+
+    let region_folds: Vec<_> =
+        ranges.iter().filter(|r| matches!(r.kind, Some(FoldingRangeKind::Region))).collect();
+
+    assert!(!region_folds.is_empty(), "indented heredoc should produce a Region fold");
+    Ok(())
+}
+
+#[test]
+fn single_quoted_heredoc_produces_region_fold() -> Result<(), ParseError> {
+    let code = "my $x = <<'END';\nno $interpolation\nEND\n";
+    let ast = parse(code)?;
+    let mut extractor = FoldingRangeExtractor::new();
+    let ranges = extractor.extract(&ast);
+
+    let region_folds: Vec<_> =
+        ranges.iter().filter(|r| matches!(r.kind, Some(FoldingRangeKind::Region))).collect();
+
+    assert!(!region_folds.is_empty(), "single-quoted heredoc should produce a Region fold");
+    Ok(())
+}
+
+#[test]
+fn heredoc_fold_has_region_kind_not_none() -> Result<(), ParseError> {
+    let code = "my $msg = <<EOF;\nHello\nWorld\nEOF\n";
+    let ast = parse(code)?;
+    let mut extractor = FoldingRangeExtractor::new();
+    let ranges = extractor.extract(&ast);
+
+    // Every Region fold must actually have kind = Region (not None)
+    let region_folds: Vec<_> =
+        ranges.iter().filter(|r| matches!(r.kind, Some(FoldingRangeKind::Region))).collect();
+
+    assert!(!region_folds.is_empty(), "heredoc should produce at least one Region fold");
+
+    // Verify that no fold has kind = None (the old bug)
+    let none_folds: Vec<_> = ranges.iter().filter(|r| r.kind.is_none()).collect();
+    assert!(
+        none_folds.is_empty(),
+        "heredoc folds should not have kind = None; found {} with None kind",
+        none_folds.len()
+    );
+    Ok(())
+}
+
+#[test]
+fn no_heredoc_no_region_fold() -> Result<(), ParseError> {
+    let code = "my $x = 42;\nprint $x;\n";
+    let ast = parse(code)?;
+    let mut extractor = FoldingRangeExtractor::new();
+    let ranges = extractor.extract(&ast);
+
+    let region_folds: Vec<_> =
+        ranges.iter().filter(|r| matches!(r.kind, Some(FoldingRangeKind::Region))).collect();
+
+    assert!(region_folds.is_empty(), "code without heredocs should not produce Region folds");
+    Ok(())
+}
+
+#[test]
+fn lexer_based_heredoc_ranges_also_region() {
+    let code = "my $x = <<END;\nline1\nline2\nEND\n";
+    let ranges = FoldingRangeExtractor::extract_heredoc_ranges(code);
+
+    for r in &ranges {
+        assert!(r.end_offset > r.start_offset);
+        assert!(
+            matches!(r.kind, Some(FoldingRangeKind::Region)),
+            "lexer-based heredoc fold should be Region"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Heredoc AST nodes were producing folding ranges with `kind = None` instead of `FoldingRangeKind::Region`, causing editors to miss the semantic fold type for multi-line heredoc blocks.
- Changed the `Heredoc` arm in `FoldingRangeExtractor::visit_node` to pass `Some(FoldingRangeKind::Region)` instead of `None`.
- Added six integration tests covering standard `<<END`, indented `<<~END`, single-quoted `<<'END'`, kind correctness, negative case (no heredoc), and the lexer-based extraction path.

## Test plan
- [x] `cargo test -p perl-lsp-folding` — all 6 new tests pass
- [x] `cargo clippy --workspace --lib` — clean
- [x] `cargo fmt --all` — clean