### PR TITLE
feat(completion): show isa type for Moo/Moose accessor completions

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -1040,6 +1040,81 @@ sub greet {
     }
 
     #[test]
+    fn test_moo_accessor_completion_shows_isa_type() {
+        let code = r#"
+package Example::User;
+use Moo;
+
+has 'name' => (is => 'ro', isa => 'Str');
+has 'age'  => (is => 'rw', isa => 'Int');
+
+sub greet {
+    my $self = shift;
+    $self->
+}
+"#;
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+
+        let pos = must_some(code.find("$self->")) + "$self->".len();
+        let completions = provider.get_completions(code, pos);
+
+        // name accessor should appear with isa type in documentation
+        let name_item = must_some(completions.iter().find(|c| c.label == "name"));
+        let name_doc = must_some(name_item.documentation.as_deref());
+        assert!(
+            name_doc.contains("Str"),
+            "expected `Str` type in name accessor documentation, got: {name_doc:?}"
+        );
+
+        // age accessor should appear with isa type in documentation
+        let age_item = must_some(completions.iter().find(|c| c.label == "age"));
+        let age_doc = must_some(age_item.documentation.as_deref());
+        assert!(
+            age_doc.contains("Int"),
+            "expected `Int` type in age accessor documentation, got: {age_doc:?}"
+        );
+
+        // detail should indicate it's a Moo/Moose accessor, not just "method"
+        let name_detail = must_some(name_item.detail.as_deref());
+        assert!(
+            name_detail.contains("accessor"),
+            "expected 'accessor' in detail for Moo attribute, got: {name_detail:?}"
+        );
+    }
+
+    #[test]
+    fn test_moose_accessor_completion_shows_isa_type() {
+        let code = r#"
+package Example::Animal;
+use Moose;
+
+has 'species' => (is => 'ro', isa => 'Str', required => 1);
+
+sub describe {
+    my $self = shift;
+    $self->
+}
+"#;
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+
+        let pos = must_some(code.find("$self->")) + "$self->".len();
+        let completions = provider.get_completions(code, pos);
+
+        let species_item = must_some(completions.iter().find(|c| c.label == "species"));
+        let species_doc = must_some(species_item.documentation.as_deref());
+        assert!(
+            species_doc.contains("Str"),
+            "expected `Str` type in species accessor documentation, got: {species_doc:?}"
+        );
+    }
+
+    #[test]
     fn test_moo_has_option_key_completion() {
         let code = r#"
 use Moo;

--- a/crates/perl-lsp-completion/src/completion/methods.rs
+++ b/crates/perl-lsp-completion/src/completion/methods.rs
@@ -76,6 +76,48 @@ pub fn infer_receiver_type(context: &CompletionContext, source: &str) -> Option<
     None
 }
 
+/// Build rich documentation for a Moo/Moose accessor from its symbol attributes.
+///
+/// Attributes are stored as `key=value` strings (e.g. `"is=ro"`, `"isa=Str"`).
+/// This function formats them into a human-readable documentation string that
+/// surfaces the type constraint and access mode prominently.
+fn moo_accessor_documentation(name: &str, attributes: &[String]) -> String {
+    let mut isa_value: Option<&str> = None;
+    let mut is_value: Option<&str> = None;
+    let mut extra_parts: Vec<&str> = Vec::new();
+
+    for attr in attributes {
+        if let Some((key, value)) = attr.split_once('=') {
+            match key {
+                "isa" => isa_value = Some(value),
+                "is" => is_value = Some(value),
+                _ => extra_parts.push(attr),
+            }
+        }
+    }
+
+    let mut doc = format!("Moo/Moose accessor `{name}`");
+
+    if let Some(isa) = isa_value {
+        doc.push_str(&format!("\n\n**Type**: `{isa}`"));
+    }
+    if let Some(is) = is_value {
+        let mode = match is {
+            "ro" => "read-only",
+            "rw" => "read-write",
+            "rwp" => "read-write private",
+            "lazy" => "lazy",
+            other => other,
+        };
+        doc.push_str(&format!("\n\n**Access**: {mode}"));
+    }
+    if !extra_parts.is_empty() {
+        doc.push_str(&format!("\n\n**Options**: {}", extra_parts.join(", ")));
+    }
+
+    doc
+}
+
 /// Add method completions
 pub fn add_method_completions(
     completions: &mut Vec<CompletionItem>,
@@ -99,12 +141,27 @@ pub fn add_method_completions(
             continue;
         }
 
-        let documentation = symbols.iter().find_map(|symbol| symbol.documentation.clone());
+        // Check if this is a synthesized Moo/Moose accessor (declaration == "has")
+        let callable_symbol = symbols
+            .iter()
+            .find(|symbol| matches!(symbol.kind, SymbolKind::Subroutine | SymbolKind::Method));
+
+        let is_moo_accessor =
+            callable_symbol.and_then(|s| s.declaration.as_deref()).is_some_and(|d| d == "has");
+
+        let (detail, documentation) = if is_moo_accessor {
+            let attrs = callable_symbol.map(|s| s.attributes.as_slice()).unwrap_or(&[]);
+            ("Moo/Moose accessor".to_string(), Some(moo_accessor_documentation(name, attrs)))
+        } else {
+            let doc = symbols.iter().find_map(|symbol| symbol.documentation.clone());
+            ("method".to_string(), doc)
+        };
+
         if seen.insert(name.clone()) {
             completions.push(CompletionItem {
                 label: name.clone(),
                 kind: crate::completion::items::CompletionItemKind::Function,
-                detail: Some("method".to_string()),
+                detail: Some(detail),
                 documentation,
                 insert_text: Some(format!("{}()", name)),
                 sort_text: Some(format!("1_{}", name)),

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -1214,6 +1214,9 @@ impl SymbolExtractor {
             });
         }
 
+        // Build accessor documentation that includes the isa type when available.
+        let accessor_doc = Self::moo_accessor_doc(&option_map);
+
         for method_name in generated_methods {
             self.table.add_symbol(Symbol {
                 name: method_name.clone(),
@@ -1222,7 +1225,7 @@ impl SymbolExtractor {
                 location: has_location,
                 scope_id,
                 declaration: Some("has".to_string()),
-                documentation: Some("Generated accessor from Moo/Moose `has`".to_string()),
+                documentation: Some(accessor_doc.clone()),
                 attributes: metadata.clone(),
             });
         }
@@ -1367,6 +1370,31 @@ impl SymbolExtractor {
             }
         }
         metadata
+    }
+
+    /// Build a documentation string for a generated Moo/Moose accessor method.
+    ///
+    /// Includes the `isa` type constraint and access mode when present in the
+    /// option map, producing hover-friendly documentation such as:
+    ///
+    /// ```text
+    /// Moo/Moose accessor (isa: Str, ro)
+    /// ```
+    fn moo_accessor_doc(option_map: &HashMap<String, String>) -> String {
+        let mut parts = Vec::new();
+
+        if let Some(isa) = option_map.get("isa") {
+            parts.push(format!("isa: {isa}"));
+        }
+        if let Some(is) = option_map.get("is") {
+            parts.push(is.clone());
+        }
+
+        if parts.is_empty() {
+            "Generated accessor from Moo/Moose `has`".to_string()
+        } else {
+            format!("Moo/Moose accessor ({})", parts.join(", "))
+        }
     }
 
     /// Compute accessor method names for a Moo/Moose `has` declaration.


### PR DESCRIPTION
## Summary

- Enrich `$self->` method completion for Moo/Moose `has`-declared accessors: the completion detail now says **"Moo/Moose accessor"** (instead of generic "method") and the documentation renders the `isa` type constraint, access mode (`ro`/`rw`/`rwp`), and any extra options in structured format.
- Improve the symbol-level documentation stored by the semantic analyzer for synthesized accessor methods so **hover** on `$self->attr` also surfaces the `isa` type (e.g. `Moo/Moose accessor (isa: Str, ro)`).
- Add two new failing-first tests (`test_moo_accessor_completion_shows_isa_type`, `test_moose_accessor_completion_shows_isa_type`) that verify type information appears in completion docs for both Moo and Moose.

## Test plan

- [x] `cargo test -p perl-lsp-completion` -- all 103 tests pass
- [x] `cargo test -p perl-semantic-analyzer` -- all 72 tests pass
- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy --workspace --lib` -- clean