### PR TITLE
feat(workspace-symbols): improve ranking with 4-tier system

### DIFF
--- a/crates/perl-lsp-symbol-query/src/lib.rs
+++ b/crates/perl-lsp-symbol-query/src/lib.rs
@@ -44,29 +44,52 @@ pub fn matches_query(name: &str, query: &str) -> bool {
 
 /// Compares two symbol names by query relevance.
 ///
-/// Ordering:
-/// 1. Exact match first
-/// 2. Prefix match second
-/// 3. Lexicographic name order
+/// Ordering (highest to lowest relevance):
+/// 1. Exact match (case-insensitive)
+/// 2. Prefix match
+/// 3. Contains (substring) match
+/// 4. Fuzzy/subsequence match
+///
+/// Within the same tier, shorter names rank higher (closer to the query
+/// length), with lexicographic order as the final tiebreaker.
 #[must_use]
 pub fn compare_names_by_query(a: &str, b: &str, query: &str) -> Ordering {
     let query_lower = query.to_lowercase();
     let a_lower = a.to_lowercase();
     let b_lower = b.to_lowercase();
 
-    let a_exact = a_lower == query_lower;
-    let b_exact = b_lower == query_lower;
-    let a_prefix = a_lower.starts_with(&query_lower);
-    let b_prefix = b_lower.starts_with(&query_lower);
+    let a_tier = match_tier(&a_lower, &query_lower);
+    let b_tier = match_tier(&b_lower, &query_lower);
 
-    match (a_exact, b_exact) {
-        (true, false) => Ordering::Less,
-        (false, true) => Ordering::Greater,
-        _ => match (a_prefix, b_prefix) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
-            _ => a.cmp(b),
-        },
+    // Lower tier number = better match
+    match a_tier.cmp(&b_tier) {
+        Ordering::Equal => {
+            // Within the same tier, prefer shorter names (closer to the query)
+            match a.len().cmp(&b.len()) {
+                Ordering::Equal => a.cmp(b),
+                len_ord => len_ord,
+            }
+        }
+        tier_ord => tier_ord,
+    }
+}
+
+/// Assigns a numeric tier to a symbol name based on how well it matches the query.
+///
+/// Lower tier = better match:
+/// - 0: exact match
+/// - 1: prefix match
+/// - 2: contains (substring) match
+/// - 3: fuzzy/subsequence or no match (fallback)
+fn match_tier(name_lower: &str, query_lower: &str) -> u8 {
+    if name_lower == query_lower {
+        0
+    } else if name_lower.starts_with(query_lower) {
+        1
+    } else if name_lower.contains(query_lower) {
+        2
+    } else {
+        3
     }
 }
 
@@ -111,5 +134,46 @@ mod tests {
         names.sort_by(|a, b| compare_names_by_query(a, b, "foo"));
 
         assert_eq!(names, ["foo", "foobar", "alpha", "foxtrot"]);
+    }
+
+    #[test]
+    fn contains_matches_rank_above_fuzzy_matches() {
+        // "get_bar" contains "bar" (tier 2)
+        // "baz_art" has "bar" as subsequence b-a-z-a-r-t: b..a..r (tier 3)
+        let mut names = ["baz_art", "get_bar"];
+        names.sort_by(|a, b| compare_names_by_query(a, b, "bar"));
+
+        assert_eq!(names[0], "get_bar", "substring match should rank above fuzzy");
+    }
+
+    #[test]
+    fn exact_match_beats_everything() {
+        let mut names = ["get_log", "getLogger", "log", "logging"];
+        names.sort_by(|a, b| compare_names_by_query(a, b, "log"));
+
+        assert_eq!(names[0], "log", "exact match should be first");
+    }
+
+    #[test]
+    fn shorter_names_preferred_within_same_tier() {
+        // Both are prefix matches (tier 1), shorter should come first
+        let mut names = ["foobarqux", "foobar"];
+        names.sort_by(|a, b| compare_names_by_query(a, b, "foo"));
+
+        assert_eq!(names[0], "foobar");
+        assert_eq!(names[1], "foobarqux");
+    }
+
+    #[test]
+    fn four_tier_ranking_order() {
+        // exact=0, prefix=1, contains=2, fuzzy=3
+        // "lxoxg" is a fuzzy match for "log" (l..o..g subsequence)
+        let mut names = ["get_log", "lxoxg", "log", "logger"];
+        names.sort_by(|a, b| compare_names_by_query(a, b, "log"));
+
+        assert_eq!(names[0], "log", "tier 0: exact");
+        assert_eq!(names[1], "logger", "tier 1: prefix");
+        assert_eq!(names[2], "get_log", "tier 2: contains");
+        assert_eq!(names[3], "lxoxg", "tier 3: fuzzy");
     }
 }

--- a/crates/perl-lsp-workspace-symbols/src/lib.rs
+++ b/crates/perl-lsp-workspace-symbols/src/lib.rs
@@ -555,6 +555,219 @@ my $top_level_var = 42;
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Cross-file search: function names across multiple files
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn search_function_name_across_multiple_files() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source_a = "package FileA;\nsub process_data { 1 }\nsub helper { 2 }\n";
+        let source_b = "package FileB;\nsub process_data { 3 }\nsub render { 4 }\n";
+        let source_c = "package FileC;\nsub unrelated { 5 }\n";
+
+        for (uri, src) in
+            [("file:///a.pm", source_a), ("file:///b.pm", source_b), ("file:///c.pm", source_c)]
+        {
+            source_map.insert(uri.to_string(), src.to_string());
+            let mut parser = Parser::new(src);
+            let ast = must(parser.parse());
+            provider.index_document(uri, &ast, src);
+        }
+
+        let results = provider.search("process_data", &source_map);
+        assert_eq!(results.len(), 2, "process_data should appear in two files");
+
+        let uris: Vec<&str> = results.iter().map(|r| r.location.uri.as_str()).collect();
+        assert!(uris.contains(&"file:///a.pm"), "should find in file A");
+        assert!(uris.contains(&"file:///b.pm"), "should find in file B");
+    }
+
+    // -----------------------------------------------------------------------
+    // Package name search
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn search_package_name_returns_package_definition() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = "package My::Web::Controller;\nsub index { 1 }\n";
+        source_map.insert("file:///controller.pm".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///controller.pm", &ast, source);
+
+        let results = provider.search("Controller", &source_map);
+        let pkg = results
+            .iter()
+            .find(|s| s.name.contains("Controller") && s.kind == 2) // 2 = Module/Package
+            .expect("should find Controller package symbol");
+
+        assert_eq!(pkg.kind, 2, "Package should have Module kind (2)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Fuzzy / subsequence matching
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fuzzy_match_camel_case_subsequence() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = "sub getLogger { 1 }\nsub go_live { 2 }\nsub unrelated { 3 }\n";
+        source_map.insert("file:///log.pl".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///log.pl", &ast, source);
+
+        // "gL" should fuzzy-match "getLogger" (g..e..t..L) and "go_live" (g..o.._..l)
+        // but NOT "unrelated"
+        let results = provider.search("gL", &source_map);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(names.contains(&"getLogger"), "gL should fuzzy-match getLogger, got: {names:?}");
+        assert!(!names.contains(&"unrelated"), "gL should not match unrelated");
+    }
+
+    // -----------------------------------------------------------------------
+    // Symbol kinds are correctly set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn symbol_kinds_are_correct() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = r#"
+package Animal;
+sub new { bless {}, shift }
+sub speak { print "generic\n" }
+use constant MAX_AGE => 100;
+my $count = 0;
+"#;
+        source_map.insert("file:///animal.pm".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///animal.pm", &ast, source);
+
+        let all = provider.search("", &source_map); // empty query => all symbols
+
+        // Package "Animal" should be Module kind (2)
+        if let Some(pkg) = all.iter().find(|s| s.name == "Animal") {
+            assert_eq!(pkg.kind, 2, "Package should be Module kind (2)");
+        }
+
+        // Subroutines should be Function kind (12)
+        for name in ["new", "speak"] {
+            if let Some(sub) = all.iter().find(|s| s.name == name) {
+                assert_eq!(sub.kind, 12, "{name} should be Function kind (12)");
+            }
+        }
+
+        // Constants should be Constant kind (14)
+        if let Some(constant) = all.iter().find(|s| s.name == "MAX_AGE") {
+            assert_eq!(constant.kind, 14, "Constant should be Constant kind (14)");
+        }
+
+        // Variables should be Variable kind (13)
+        if let Some(var) = all.iter().find(|s| s.name.contains("count")) {
+            assert_eq!(var.kind, 13, "Variable should be Variable kind (13)");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Ranking: exact matches above substrings above fuzzy
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn exact_match_ranks_above_substring_and_fuzzy() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = r#"
+sub log { 1 }
+sub logger { 2 }
+sub get_log { 3 }
+"#;
+        source_map.insert("file:///rank.pl".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///rank.pl", &ast, source);
+
+        let results = provider.search("log", &source_map);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(names.len() >= 3, "should match log, logger, get_log");
+
+        // Exact match "log" must be first
+        assert_eq!(names[0], "log", "exact match should be first");
+
+        // Prefix match "logger" should come before substring "get_log"
+        let logger_pos = names.iter().position(|n| *n == "logger");
+        let get_log_pos = names.iter().position(|n| *n == "get_log");
+        if let (Some(lp), Some(gp)) = (logger_pos, get_log_pos) {
+            assert!(lp < gp, "prefix match 'logger' should rank above substring 'get_log'");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Remove document removes symbols from results
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_document_clears_its_symbols() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = "sub ephemeral { 1 }\n";
+        source_map.insert("file:///tmp.pl".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///tmp.pl", &ast, source);
+
+        assert!(!provider.search("ephemeral", &source_map).is_empty());
+
+        provider.remove_document("file:///tmp.pl");
+        assert!(
+            provider.search("ephemeral", &source_map).is_empty(),
+            "symbols should be gone after remove_document"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // search_with_candidates filters to candidate set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn search_with_candidates_filters_results() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = "sub alpha { 1 }\nsub apex { 2 }\nsub beta { 3 }\n";
+        source_map.insert("file:///cand.pl".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///cand.pl", &ast, source);
+
+        // Only include "alpha" in candidates - "apex" should be excluded
+        let candidates = vec!["alpha".to_string()];
+        let results = provider.search_with_candidates("a", &source_map, &candidates);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert!(names.contains(&"alpha"), "alpha is a candidate match");
+        assert!(!names.contains(&"apex"), "apex is not in candidate set");
+    }
+
     #[test]
     fn test_ambiguous_symbol_resolution() {
         let mut provider = WorkspaceSymbolsProvider::new();


### PR DESCRIPTION
## Summary

- **Improved ranking** in `compare_names_by_query` (`perl-lsp-symbol-query`): introduces a 4-tier relevance system (exact > prefix > contains/substring > fuzzy/subsequence). Previously, substring and fuzzy matches were ranked equally, falling through to alphabetical order.
- **Within-tier tiebreaking**: shorter names now rank higher within the same tier, so more specific matches surface first.
- **7 new tests** in `perl-lsp-workspace-symbols` covering cross-file search, package name search, fuzzy matching (e.g. `"gL"` matches `"getLogger"`), symbol kind correctness, ranking order, document removal, and candidate-filtered search.
- **4 new tests** in `perl-lsp-symbol-query` for the ranking tiers.

## Test plan

- [x] `cargo test -p perl-lsp-symbol-query` -- 7 tests pass (4 new)
- [x] `cargo test -p perl-lsp-workspace-symbols` -- 15 tests pass (7 new)
- [x] `cargo clippy -p perl-lsp-symbol-query -p perl-lsp-workspace-symbols -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [x] No `unwrap()`, `expect()`, `panic!()`, or `todo!()` in production code