### PR TITLE
chore(security): tighten cargo-deny policy and suppress known duplicates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,90 +1,37 @@
-# This template contains all of the possible sections and their default values
+# cargo-deny configuration for perl-lsp
+# https://embarkstudios.github.io/cargo-deny/
+#
+# Run: cargo deny check
+# Lint levels: deny | warn | allow
 
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
+# -- Dependency graph ----------------------------------------------------------
 
-# The values provided in this template are the default values that will be used
-# when any section or field is not specified in your own configuration
-
-# Root options
-
-# The graph table configures how the dependency graph is constructed and thus
-# which crates the checks are performed against
 [graph]
-# If 1 or more target triples (and optionally, target_features) are specified,
-# only the specified targets will be checked when running `cargo deny check`.
-# This means, if a particular package is only ever used as a target specific
-# dependency, such as, for example, the `nix` crate only being used via the
-# `target_family = "unix"` configuration, that only having windows targets in
-# this list would mean the nix crate, as well as any of its exclusive
-# dependencies not shared by any other crates, would be ignored, as the target
-# list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
-# When creating the dependency graph used as the source of truth when checks are
-# executed, this field can be used to prune crates from the graph, removing them
-# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
-# is pruned from the graph, all of its dependencies will also be pruned unless
-# they are connected to another crate in the graph that hasn't been pruned,
-# so it should be used with care. The identifiers are [Package ID Specifications]
-# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
-# If true, metadata will be collected with `--all-features`. Note that this can't
-# be toggled off if true, if you want to conditionally enable `--all-features` it
-# is recommended to pass `--all-features` on the cmd line instead
+targets = []
 all-features = false
-# If true, metadata will be collected with `--no-default-features`. The same
-# caveat with `all-features` applies
 no-default-features = false
-# If set, these feature will be enabled when collecting metadata. If `--features`
-# is specified on the cmd line they will take precedence over this option.
-#features = []
 
-# The output table provides options for how/if diagnostics are outputted
 [output]
-# When outputting inclusion graphs in diagnostics that include features, this
-# option can be used to specify the depth at which feature edges will be added.
-# This option is included since the graphs can be quite large and the addition
-# of features from the crate(s) to all of the graph roots can be far too verbose.
-# This option can be overridden via `--feature-depth` on the cmd line
 feature-depth = 1
 
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
+# -- Advisories ----------------------------------------------------------------
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
-[advisories]
-# The path where the advisory databases are cloned/fetched into
-#db-path = "$CARGO_HOME/advisory-dbs"
-# The url(s) of the advisory databases to use
-#db-urls = ["https://github.com/rustsec/advisory-db"]
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
-ignore = [
-    { id = "RUSTSEC-2023-0089", reason = "atomic-polyfill unmaintained (transitive via heapless/postcard in legacy pest/tree-sitter crates). No upgrade path available. Tracking migration to portable-atomic." },
-]
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
-# If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
 
-# This section is considered when running `cargo deny check licenses`
-# More documentation for the licenses section can be found here:
+[advisories]
+ignore = [
+    # atomic-polyfill is unmaintained (RUSTSEC-2023-0089).
+    # Transitive dep chain: postcard -> heapless -> atomic-polyfill.
+    # postcard is used by tree-sitter-perl. No upgrade path exists until
+    # postcard drops heapless or heapless migrates to portable-atomic.
+    # Risk: Low -- atomic-polyfill is a thin polyfill crate with no known
+    # security vulnerability; the advisory is "unmaintained" only.
+    { id = "RUSTSEC-2023-0089", reason = "atomic-polyfill unmaintained (postcard -> heapless -> atomic-polyfill). No upgrade path. Risk: low (unmaintained, not vulnerable)." },
+]
+
+# -- Licenses ------------------------------------------------------------------
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+
 [licenses]
-# List of explicitly allowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "MIT",
     "Apache-2.0",
@@ -96,143 +43,74 @@ allow = [
     "CC0-1.0",
     "Zlib",
 ]
-# The confidence threshold for detecting a license from license text.
-# The higher the value, the more closely the license text must be to the
-# canonical license text of a valid SPDX license file.
-# [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.8
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
-]
-
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-#[[licenses.clarify]]
-# The package spec the clarification applies to
-#crate = "ring"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+exceptions = []
 
 [licenses.private]
-# If true, ignores workspace crates that aren't published, or are only
-# published to private registries.
-# To see how to mark a crate as unpublished (to the official registry),
-# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+# Ignore unpublished workspace crates -- they are internal
 ignore = true
-# One or more private registries that you might publish crates to, if a crate
-# is only published to private registries, and ignore is true, the crate will
-# not have its license(s) checked
-registries = [
-    #"https://sekretz.com/registry
-]
+registries = []
 
-# This section is considered when running `cargo deny check bans`.
-# More documentation about the 'bans' section can be found here:
+# -- Bans ----------------------------------------------------------------------
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+
 [bans]
-# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
-# Lint level for when a crate version requirement is `*`
 wildcards = "allow"
-# The graph highlighting used when creating dotgraphs for crates
-# with multiple versions
-# * lowest-version - The path to the lowest versioned duplicate is highlighted
-# * simplest-path - The path to the version with the fewest edges is highlighted
-# * all - Both lowest-version and simplest-path are used
 highlight = "all"
-# The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overridden by allowing/denying
-# `default` on a crate-by-crate basis if desired.
 workspace-default-features = "allow"
-# The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overridden by allowing/denying `default`
-# on a crate-by-crate basis if desired.
 external-default-features = "allow"
-# List of crates that are allowed. Use with care!
-allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
-]
-# List of crates to deny
-deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
-]
+allow = []
+deny = []
 
-# List of features to allow/deny
-# Each entry the name of a crate and a version range. If version is
-# not specified, all versions will be matched.
-#[[bans.features]]
-#crate = "reqwest"
-# Features to not allow
-#deny = ["json"]
-# Features to allow
-#allow = [
-#    "rustls",
-#    "__rustls",
-#    "__tls",
-#    "hyper-rustls",
-#    "rustls",
-#    "rustls-pemfile",
-#    "rustls-tls-webpki-roots",
-#    "tokio-rustls",
-#    "webpki-roots",
-#]
-# If true, the allowed features must exactly match the enabled feature set. If
-# this is set there is no point setting `deny`
-#exact = true
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
+# Known duplicate crates caused by transitive dependency version splits.
+# These are expected and tracked for eventual deduplication when upstreams unify.
 skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
-]
-# Similarly to `skip` allows you to skip certain crates during duplicate
-# detection. Unlike skip, it also includes the entire tree of transitive
-# dependencies starting at the specified crate, up to a certain depth, which is
-# by default infinite.
-skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+    # bitflags 1.x pulled by fluent-uri (via lsp-types); 2.x used everywhere else
+    { crate = "bitflags@1.3.2", reason = "fluent-uri (lsp-types transitive) pins bitflags 1.x" },
+
+    # windows-sys ecosystem: three-way split across 0.59/0.60/0.61.
+    # 0.59: console, stacker; 0.60: notify, shared_child; 0.61: clap/anstyle.
+    # Platform-specific, only affects Windows. Upstream convergence happens naturally.
+    { crate = "windows-sys@0.59.0", reason = "console/stacker transitives pin 0.59" },
+    { crate = "windows-sys@0.60.2", reason = "notify/shared_child transitives pin 0.60" },
+    { crate = "windows-targets@0.52.6", reason = "older windows-sys 0.59 transitive" },
+
+    # rand ecosystem: 0.9 vs 0.10 split during major version transition
+    { crate = "rand@0.9.2", reason = "transitive dep version split during rand 0.9 -> 0.10 migration" },
+    { crate = "rand_core@0.9.5", reason = "transitive dep version split during rand_core 0.9 -> 0.10 migration" },
+    { crate = "getrandom@0.3.4", reason = "older getrandom pulled by rand 0.9 transitives" },
+
+    # hashbrown: 0.15 vs 0.16 split
+    { crate = "hashbrown@0.15.5", reason = "transitive dep version split during hashbrown 0.15 -> 0.16 migration" },
+
+    # cpufeatures: 0.2 vs 0.3 split
+    { crate = "cpufeatures@0.2.17", reason = "transitive dep version split during cpufeatures 0.2 -> 0.3 migration" },
+
+    # r-efi: 5.x vs 6.x split (platform-specific, UEFI target only)
+    { crate = "r-efi@5.3.0", reason = "transitive dep version split, UEFI platform crate" },
 ]
 
-# This section is considered when running `cargo deny check sources`.
-# More documentation about the 'sources' section can be found here:
+# Windows platform crate duplicates: windows-sys has a 0.59/0.60/0.61 three-way
+# split across transitive deps (console, stacker, notify, shared_child, clap).
+# Skip the older windows-targets tree to suppress all associated windows_*
+# platform crate duplicates (0.52.x).
+skip-tree = [
+    { crate = "windows-targets@0.52.6", reason = "skip all windows_*@0.52.x platform crates under old windows-targets" },
+]
+
+# -- Sources -------------------------------------------------------------------
 # https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+
 [sources]
-# Lint level for what to happen when a crate from a crate registry that is not
-# in the allow list is encountered
-unknown-registry = "warn"
-# Lint level for what to happen when a crate from a git repository that is not
-# in the allow list is encountered
-unknown-git = "warn"
-# List of URLs for allowed crate registries. Defaults to the crates.io index
-# if not specified. If it is specified but empty, no registries are allowed.
+# All dependencies must come from crates.io. Unknown registries or git sources
+# are denied to prevent supply chain attacks via source confusion.
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# List of URLs for allowed Git repositories
 allow-git = []
 
 [sources.allow-org]
-# github.com organizations to allow git sources for
 github = []
-# gitlab.com organizations to allow git sources for
 gitlab = []
-# bitbucket.org organizations to allow git sources for
 bitbucket = []


### PR DESCRIPTION
## Summary

- **Tighten source policy**: Changed `unknown-registry` and `unknown-git` from `warn` to `deny`, preventing supply chain attacks via source confusion (all deps already come from crates.io, so this is a no-op hardening)
- **Suppress 17 known duplicate crate warnings**: Added `skip` entries with documented justifications for transitive version splits (windows-sys 0.59/0.60/0.61, rand 0.9/0.10, bitflags 1/2, hashbrown, cpufeatures, r-efi, getrandom). Uses `skip-tree` for `windows-targets@0.52.6` to handle all `windows_*@0.52.x` platform crates in one entry
- **Clean up boilerplate**: Replaced verbose template comments with concise section headers and doc links, reducing file from 239 lines to 117 while preserving all functional configuration
- **Refine advisory ignore**: Updated RUSTSEC-2023-0089 justification with full dep chain (`postcard -> heapless -> atomic-polyfill`) and risk assessment (unmaintained, not vulnerable)

### Supply Chain Security Posture

| Check | Status | Notes |
|-------|--------|-------|
| Advisories | Pass | 1 ignored (RUSTSEC-2023-0089, unmaintained, not vulnerable) |
| Licenses | Pass | 9 approved SPDX identifiers; private workspace crates excluded |
| Bans | Pass | 0 warnings after skip entries for known transitive duplicates |
| Sources | Pass | All deps from crates.io; unknown registries/git now denied |

## Test plan

- [x] `cargo deny check` passes with zero warnings and zero errors
- [x] Verified RUSTSEC-2023-0089 ignore is still needed (`atomic-polyfill` in Cargo.lock via `postcard -> heapless`)
- [x] Verified removing the ignore causes advisory check failure
- [x] Verified all four check sections pass independently: advisories, licenses, bans, sources