### PR TITLE
test(security): harden path traversal prevention tests

### DIFF
--- a/crates/perl-dap-security/tests/dap_path_traversal_hardened_tests.rs
+++ b/crates/perl-dap-security/tests/dap_path_traversal_hardened_tests.rs
@@ -1,0 +1,713 @@
+//! Hardened security tests for DAP path traversal prevention.
+//!
+//! Exercises DAP-specific security validation against adversarial inputs:
+//! - Path traversal via `validate_path`
+//! - Null byte injection
+//! - Symlink traversal
+//! - Unicode normalization attacks
+//! - Windows-style path separators on Linux
+//! - Expression / condition injection
+//! - Timeout boundary testing
+
+use perl_dap_security::{
+    DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, SecurityError, validate_condition, validate_expression,
+    validate_path, validate_timeout,
+};
+use std::path::{Path, PathBuf};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn workspace() -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let canonical = tmp.path().canonicalize()?;
+    Ok((tmp, canonical))
+}
+
+// ===========================================================================
+// 1. Path traversal -- classic patterns via DAP validate_path
+// ===========================================================================
+
+#[test]
+fn dap_traversal_single_parent() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new(".."), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_traversal_deep_escape() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("../../../etc/passwd"), &ws);
+    assert!(result.is_err());
+    match result {
+        Err(SecurityError::PathTraversalAttempt(_))
+        | Err(SecurityError::PathOutsideWorkspace(_)) => {}
+        Err(e) => return Err(format!("unexpected error: {e:?}").into()),
+        Ok(_) => return Err("expected error".into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_traversal_interleaved() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("a/../b/../../secret"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_traversal_many_parents() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = "../".repeat(50) + "etc/passwd";
+    let result = validate_path(Path::new(&evil), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_traversal_with_dot_padding() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("./././../../../etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_valid_relative_path() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("src/main.pl"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+#[test]
+fn dap_valid_dotfile() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new(".perltidyrc"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+// ===========================================================================
+// 2. Absolute path injection via DAP
+// ===========================================================================
+
+#[test]
+fn dap_absolute_etc_passwd() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("/etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_absolute_proc_self_environ() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("/proc/self/environ"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_absolute_dev_null() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("/dev/null"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_absolute_root() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("/"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_absolute_inside_workspace_is_valid() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+    let file = ws.join("debug_target.pl");
+    std::fs::write(&file, "1;")?;
+
+    let result = validate_path(&file, ws)?;
+    assert!(result.starts_with(ws.canonicalize()?));
+    Ok(())
+}
+
+// ===========================================================================
+// 3. Null byte injection via DAP
+// ===========================================================================
+
+#[test]
+fn dap_null_byte_in_filename() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\0.pl"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_null_byte_after_traversal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("../../\0etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn dap_null_byte_in_extension() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("script.pl\0.txt"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_null_byte_only() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("\0"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_null_byte_multiple() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("a\0b\0c"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+// ===========================================================================
+// 4. Control character injection via DAP
+// ===========================================================================
+
+#[test]
+fn dap_control_newline() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\n.pl"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_control_carriage_return() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\r.pl"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_control_escape_char() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\x1b.pl"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_control_del() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\x7f.pl"), &ws);
+    assert!(matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn dap_tab_is_allowed() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("file\t.pl"), &ws);
+    // Tab is explicitly allowed -- should not produce InvalidPathCharacters
+    assert!(!matches!(result, Err(SecurityError::InvalidPathCharacters)));
+    Ok(())
+}
+
+// ===========================================================================
+// 5. Symlink traversal via DAP (Unix only)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn dap_symlink_escape_to_etc() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    let link = ws.join("escape_link");
+    std::os::unix::fs::symlink(Path::new("/etc"), &link)?;
+
+    let result = validate_path(Path::new("escape_link/passwd"), ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn dap_symlink_relative_escape() -> TestResult {
+    let outer = tempfile::tempdir()?;
+    let ws = outer.path().join("workspace");
+    let secret = outer.path().join("secret");
+    std::fs::create_dir(&ws)?;
+    std::fs::create_dir(&secret)?;
+    std::fs::write(secret.join("key.pem"), "SECRET")?;
+
+    let link = ws.join("escape");
+    std::os::unix::fs::symlink(Path::new("../secret"), &link)?;
+
+    let result = validate_path(Path::new("escape/key.pem"), &ws);
+    assert!(result.is_err(), "Relative symlink escape via DAP must be blocked");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn dap_symlink_chain_escape() -> TestResult {
+    let outer = tempfile::tempdir()?;
+    let ws = outer.path().join("workspace");
+    let secret = outer.path().join("secret");
+    std::fs::create_dir(&ws)?;
+    std::fs::create_dir(&secret)?;
+    std::fs::write(secret.join("data"), "sensitive")?;
+
+    let link2 = ws.join("link2");
+    std::os::unix::fs::symlink(&secret, &link2)?;
+    let link1 = ws.join("link1");
+    std::os::unix::fs::symlink(&link2, &link1)?;
+
+    let result = validate_path(Path::new("link1/data"), &ws);
+    assert!(result.is_err(), "Chained symlink escape via DAP must be blocked");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn dap_symlink_to_proc_rejected() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    let link = ws.join("proc_link");
+    std::os::unix::fs::symlink(Path::new("/proc/self"), &link)?;
+
+    let result = validate_path(Path::new("proc_link/environ"), ws);
+    assert!(result.is_err(), "Symlink to /proc/self must be blocked in DAP");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn dap_symlink_within_workspace_is_valid() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    let target = ws.join("real_dir");
+    std::fs::create_dir(&target)?;
+    std::fs::write(target.join("script.pl"), "1;")?;
+
+    let link = ws.join("alias");
+    std::os::unix::fs::symlink(&target, &link)?;
+
+    let result = validate_path(Path::new("alias/script.pl"), ws)?;
+    assert!(result.starts_with(ws.canonicalize()?));
+    Ok(())
+}
+
+// ===========================================================================
+// 6. Unicode normalization attacks via DAP
+// ===========================================================================
+
+#[test]
+fn dap_unicode_two_dot_leader_u2025() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+2025 TWO DOT LEADER is NOT ".." -- on Linux it is a literal filename character.
+    // The path resolves inside workspace as literal subdirectories.
+    // Security invariant: the resolved path MUST be within the workspace.
+    let evil = "\u{2025}/\u{2025}/etc/passwd";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws), "Path must stay within workspace");
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_unicode_fullwidth_period_u_ff0e() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = "\u{FF0E}\u{FF0E}/etc/passwd";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_unicode_fullwidth_solidus_u_ff0f() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = "..\u{FF0F}..\u{FF0F}etc\u{FF0F}passwd";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_unicode_one_dot_leader_u2024() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = "\u{2024}\u{2024}/\u{2024}\u{2024}/etc/passwd";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_unicode_rlo_bidi_override() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Right-to-left override can be used to disguise filenames
+    let evil = "\u{202E}fdssap/cte/../../../";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_unicode_zero_width_space_in_dotdot() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = ".\u{200B}./etc/passwd";
+    let result = validate_path(Path::new(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 7. Windows-style path separators via DAP
+// ===========================================================================
+
+#[test]
+fn dap_windows_backslash_traversal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("..\\..\\etc\\passwd"), &ws);
+    // On Linux, backslash is a literal char -- must not resolve to /etc/passwd
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_windows_drive_letter() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("C:\\Windows\\System32"), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_windows_unc_path() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("\\\\server\\share\\file"), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 8. Expression validation -- protocol injection
+// ===========================================================================
+
+#[test]
+fn dap_expression_valid_simple() -> TestResult {
+    validate_expression("$x + 1")?;
+    validate_expression("my_func()")?;
+    validate_expression("$hash{key}")?;
+    validate_expression("scalar @array")?;
+    validate_expression("defined($var) && $var > 0")?;
+    Ok(())
+}
+
+#[test]
+fn dap_expression_empty_is_valid() -> TestResult {
+    validate_expression("")?;
+    Ok(())
+}
+
+#[test]
+fn dap_expression_rejects_newline() -> TestResult {
+    let result = validate_expression("1\nprint 'injected'");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+#[test]
+fn dap_expression_rejects_carriage_return() -> TestResult {
+    let result = validate_expression("1\rprint 'injected'");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+#[test]
+fn dap_expression_rejects_crlf() -> TestResult {
+    let result = validate_expression("1\r\nprint 'injected'");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+#[test]
+fn dap_expression_allows_tabs_and_spaces() -> TestResult {
+    validate_expression("$x\t+ 1")?;
+    validate_expression("  $x  ")?;
+    Ok(())
+}
+
+#[test]
+fn dap_expression_with_multiline_perl_attack() -> TestResult {
+    let result = validate_expression("system('rm -rf /')\nprint 'done'");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+// ===========================================================================
+// 9. Condition validation -- protocol injection
+// ===========================================================================
+
+#[test]
+fn dap_condition_valid() -> TestResult {
+    validate_condition("$x > 10")?;
+    validate_condition("defined($var)")?;
+    validate_condition("$i == 42 && $j < 100")?;
+    Ok(())
+}
+
+#[test]
+fn dap_condition_rejects_newline() -> TestResult {
+    let result = validate_condition("$x > 10\nsystem('id')");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+#[test]
+fn dap_condition_rejects_cr() -> TestResult {
+    let result = validate_condition("$x > 10\rsystem('id')");
+    assert!(matches!(result, Err(SecurityError::InvalidExpression)));
+    Ok(())
+}
+
+// ===========================================================================
+// 10. Timeout validation -- boundary testing
+// ===========================================================================
+
+#[test]
+fn dap_timeout_zero_capped_to_one() {
+    assert_eq!(validate_timeout(0), 1);
+}
+
+#[test]
+fn dap_timeout_one_is_minimum() {
+    assert_eq!(validate_timeout(1), 1);
+}
+
+#[test]
+fn dap_timeout_default_unchanged() {
+    assert_eq!(validate_timeout(DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+}
+
+#[test]
+fn dap_timeout_max_unchanged() {
+    assert_eq!(validate_timeout(MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
+}
+
+#[test]
+fn dap_timeout_over_max_capped() {
+    assert_eq!(validate_timeout(MAX_TIMEOUT_MS + 1), MAX_TIMEOUT_MS);
+    assert_eq!(validate_timeout(u32::MAX), MAX_TIMEOUT_MS);
+}
+
+#[test]
+fn dap_timeout_normal_values_unchanged() {
+    assert_eq!(validate_timeout(1000), 1000);
+    assert_eq!(validate_timeout(5000), 5000);
+    assert_eq!(validate_timeout(60_000), 60_000);
+    assert_eq!(validate_timeout(100_000), 100_000);
+}
+
+// ===========================================================================
+// 11. SecurityError -- from WorkspacePathError conversion
+// ===========================================================================
+
+#[test]
+fn dap_error_from_traversal() -> TestResult {
+    let ws_err =
+        perl_path_security::WorkspacePathError::PathTraversalAttempt("test path".to_string());
+    let sec_err: SecurityError = ws_err.into();
+    match sec_err {
+        SecurityError::PathTraversalAttempt(msg) => assert!(msg.contains("test path")),
+        other => return Err(format!("Expected PathTraversalAttempt, got: {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_error_from_outside_workspace() -> TestResult {
+    let ws_err =
+        perl_path_security::WorkspacePathError::PathOutsideWorkspace("outside path".to_string());
+    let sec_err: SecurityError = ws_err.into();
+    match sec_err {
+        SecurityError::PathOutsideWorkspace(msg) => assert!(msg.contains("outside path")),
+        other => return Err(format!("Expected PathOutsideWorkspace, got: {other:?}").into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn dap_error_from_invalid_chars() {
+    let ws_err = perl_path_security::WorkspacePathError::InvalidPathCharacters;
+    let sec_err: SecurityError = ws_err.into();
+    assert!(matches!(sec_err, SecurityError::InvalidPathCharacters));
+}
+
+// ===========================================================================
+// 12. SecurityError -- Display messages
+// ===========================================================================
+
+#[test]
+fn dap_error_display_traversal() {
+    let err = SecurityError::PathTraversalAttempt("../../../etc".to_string());
+    let msg = format!("{err}");
+    assert!(msg.contains("Path traversal attempt detected"));
+    assert!(msg.contains("../../../etc"));
+}
+
+#[test]
+fn dap_error_display_outside() {
+    let err = SecurityError::PathOutsideWorkspace("/tmp/evil".to_string());
+    let msg = format!("{err}");
+    assert!(msg.contains("Path outside workspace"));
+    assert!(msg.contains("/tmp/evil"));
+}
+
+#[test]
+fn dap_error_display_symlink() {
+    let err = SecurityError::SymlinkOutsideWorkspace("/etc".to_string());
+    let msg = format!("{err}");
+    assert!(msg.contains("Symlink resolves outside workspace"));
+    assert!(msg.contains("/etc"));
+}
+
+#[test]
+fn dap_error_display_invalid_chars() {
+    let err = SecurityError::InvalidPathCharacters;
+    let msg = format!("{err}");
+    assert!(msg.contains("Invalid path characters detected"));
+}
+
+#[test]
+fn dap_error_display_invalid_expression() {
+    let err = SecurityError::InvalidExpression;
+    let msg = format!("{err}");
+    assert!(msg.contains("Expression cannot contain newlines"));
+}
+
+#[test]
+fn dap_error_display_excessive_timeout() {
+    let err = SecurityError::ExcessiveTimeout(999_999);
+    let msg = format!("{err}");
+    assert!(msg.contains("999999ms"));
+}
+
+// ===========================================================================
+// 13. Double-encoding bypass attempts via DAP
+// ===========================================================================
+
+#[test]
+fn dap_double_encoded_dotdot() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // %252e%252e is double-URL-encoded ".." -- OS treats as literal
+    let result = validate_path(Path::new("%252e%252e/%252e%252e/etc/passwd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+#[test]
+fn dap_percent_encoded_dotdot() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("%2e%2e/%2e%2e/etc/passwd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+#[test]
+fn dap_percent_encoded_slash() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_path(Path::new("..%2f..%2fetc%2fpasswd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+// ===========================================================================
+// 14. Concurrent access safety
+// ===========================================================================
+
+#[test]
+fn dap_concurrent_validations() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path().to_path_buf();
+
+    let handles: Vec<_> = (0..20)
+        .map(|i| {
+            let ws_clone = ws.clone();
+            std::thread::spawn(move || {
+                let path = if i % 3 == 0 {
+                    PathBuf::from(format!("valid_{i}.pl"))
+                } else if i % 3 == 1 {
+                    PathBuf::from("../../../etc/passwd")
+                } else {
+                    PathBuf::from("file\0evil.pl")
+                };
+                (i, validate_path(&path, &ws_clone))
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        if let Ok((i, result)) = handle.join() {
+            match i % 3 {
+                0 => assert!(result.is_ok(), "Expected OK for valid path at index {i}"),
+                1 => assert!(result.is_err(), "Expected error for traversal at index {i}"),
+                _ => assert!(result.is_err(), "Expected error for null byte at index {i}"),
+            }
+        }
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 15. Constants are sane
+// ===========================================================================
+
+#[test]
+fn dap_constants_are_reasonable() {
+    assert_eq!(MAX_TIMEOUT_MS, 300_000, "Max timeout should be 5 minutes");
+    assert_eq!(DEFAULT_TIMEOUT_MS, 5_000, "Default timeout should be 5 seconds");
+    // Compile-time assertions for constant relationships
+    const {
+        assert!(DEFAULT_TIMEOUT_MS < MAX_TIMEOUT_MS);
+        assert!(DEFAULT_TIMEOUT_MS > 0);
+    }
+}

--- a/crates/perl-path-security/tests/path_traversal_hardened_tests.rs
+++ b/crates/perl-path-security/tests/path_traversal_hardened_tests.rs
@@ -1,0 +1,796 @@
+//! Hardened security tests for path traversal prevention in `perl-path-security`.
+//!
+//! Focuses on adversarial attack vectors not covered by existing test suites:
+//! - Unicode normalization attacks (U+2025 two-dot leader, U+2024 one-dot leader, etc.)
+//! - Null byte injection in varied positions
+//! - Symlink traversal with deeply nested chains
+//! - Windows-style path separators on Linux
+//! - Double-encoding / multi-layer encoding bypasses
+//! - `sanitize_completion_path_input` hardening
+//! - `is_safe_completion_filename` edge cases
+
+use perl_path_security::{
+    WorkspacePathError, build_completion_path, is_hidden_or_forbidden_entry_name,
+    is_safe_completion_filename, resolve_completion_base_directory, sanitize_completion_path_input,
+    split_completion_path_components, validate_workspace_path,
+};
+use std::path::PathBuf;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn workspace() -> Result<(tempfile::TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let canonical = tmp.path().canonicalize()?;
+    Ok((tmp, canonical))
+}
+
+// ===========================================================================
+// 1. Unicode normalization attacks -- U+2025 TWO DOT LEADER
+// ===========================================================================
+
+#[test]
+fn unicode_two_dot_leader_u2025_not_treated_as_dotdot() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+2025 TWO DOT LEADER looks like ".." but must not be treated as parent traversal.
+    // On Linux, U+2025 is a literal filename character -- the path stays within workspace
+    // as a subdirectory tree like: <workspace>/\u{2025}/\u{2025}/etc/passwd
+    // The security invariant: the resolved path MUST be within the workspace.
+    let evil = "\u{2025}/\u{2025}/etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws), "Path must stay within workspace");
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_two_dot_leader_in_subdir() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Attempt: sub/<TWO DOT LEADER>/<TWO DOT LEADER>/../../etc/passwd
+    let evil = "sub/\u{2025}/\u{2025}/../../etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_two_dot_leader_mixed_with_real_dotdot() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Mix real ".." with U+2025 to confuse parsers
+    let evil = "sub/../\u{2025}/../secret";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    // The real ".." is the traversal vector; U+2025 is a literal dir name
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 2. Unicode normalization -- additional confusable characters
+// ===========================================================================
+
+#[test]
+fn unicode_small_full_stop_u_fe52() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+FE52 SMALL FULL STOP -- visually similar to "."
+    let evil = "\u{FE52}\u{FE52}/etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_ideographic_full_stop_u_3002() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+3002 IDEOGRAPHIC FULL STOP -- CJK period
+    let evil = "\u{3002}\u{3002}/etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_fullwidth_solidus_u_ff0f_as_separator() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+FF0F FULLWIDTH SOLIDUS -- looks like "/" but must not be treated as path separator
+    let evil = "..\u{FF0F}..\u{FF0F}etc\u{FF0F}passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_division_slash_u_2215_as_separator() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+2215 DIVISION SLASH
+    let evil = "..\u{2215}..\u{2215}etc\u{2215}passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_reverse_solidus_operator_u_29f5() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+29F5 REVERSE SOLIDUS OPERATOR -- backslash lookalike
+    let evil = "..\u{29F5}..\u{29F5}etc\u{29F5}passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_set_minus_u_2216_as_backslash() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+2216 SET MINUS -- visually similar to backslash
+    let evil = "..\u{2216}..\u{2216}etc\u{2216}passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn unicode_combining_long_solidus_overlay() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // U+0338 COMBINING LONG SOLIDUS OVERLAY added to "."
+    let evil = ".\u{0338}.\u{0338}/etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(evil), &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 3. Null byte injection -- additional adversarial positions
+// ===========================================================================
+
+#[test]
+fn null_byte_after_traversal_sequence() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("../../\0etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn null_byte_within_extension() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("script.pl\0.txt"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn null_byte_before_slash() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("lib\0/Module.pm"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn null_byte_multiple_scattered() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("a\0/b\0/c\0"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn null_byte_with_unicode_payload() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let path = "\u{2025}\0../../etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(path), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+// ===========================================================================
+// 4. Windows-style path separators on Linux
+// ===========================================================================
+
+#[test]
+fn windows_backslash_simple_traversal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let path = PathBuf::from("..\\etc\\passwd");
+    let result = validate_workspace_path(&path, &ws);
+    // On Linux, backslash is a literal character in filenames.
+    // Must never resolve to /etc/passwd.
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+        assert!(
+            !resolved.ends_with("etc/passwd"),
+            "Backslash traversal must not resolve to /etc/passwd on Linux"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn windows_drive_letter_path() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // C:\Windows\System32 -- on Linux this is a relative literal path
+    let path = PathBuf::from("C:\\Windows\\System32");
+    let result = validate_workspace_path(&path, &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn windows_unc_path() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // UNC path \\server\share -- on Linux treated as literal
+    let path = PathBuf::from("\\\\server\\share\\file.pl");
+    let result = validate_workspace_path(&path, &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn mixed_forward_and_back_slash_traversal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let path = PathBuf::from("sub/..\\..\\etc/passwd");
+    let result = validate_workspace_path(&path, &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+#[test]
+fn windows_dot_backslash_prefix() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let path = PathBuf::from(".\\..\\..\\etc\\passwd");
+    let result = validate_workspace_path(&path, &ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(&ws));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// 5. Symlink traversal -- advanced scenarios (Unix only)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn symlink_circular_does_not_escape() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    // Create circular symlinks: a -> b, b -> a
+    let link_a = ws.join("link_a");
+    let link_b = ws.join("link_b");
+    std::os::unix::fs::symlink(&link_b, &link_a)?;
+    std::os::unix::fs::symlink(&link_a, &link_b)?;
+
+    // Attempting to resolve should fail (circular) -- the important thing is
+    // it does not somehow escape the workspace
+    let result = validate_workspace_path(&PathBuf::from("link_a/file.pl"), ws);
+    if let Ok(ref resolved) = result {
+        assert!(resolved.starts_with(ws.canonicalize()?));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_deep_chain_three_levels_escape() -> TestResult {
+    let outer = tempfile::tempdir()?;
+    let ws = outer.path().join("workspace");
+    let secret = outer.path().join("secret");
+    std::fs::create_dir(&ws)?;
+    std::fs::create_dir(&secret)?;
+    std::fs::write(secret.join("key.pem"), "SECRET KEY")?;
+
+    // link3 -> secret, link2 -> link3, link1 -> link2
+    let link3 = ws.join("link3");
+    std::os::unix::fs::symlink(&secret, &link3)?;
+    let link2 = ws.join("link2");
+    std::os::unix::fs::symlink(&link3, &link2)?;
+    let link1 = ws.join("link1");
+    std::os::unix::fs::symlink(&link2, &link1)?;
+
+    let result = validate_workspace_path(&PathBuf::from("link1/key.pem"), &ws);
+    assert!(result.is_err(), "Three-level symlink chain escaping workspace must be blocked");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_relative_escape_via_dotdot() -> TestResult {
+    let outer = tempfile::tempdir()?;
+    let ws = outer.path().join("workspace");
+    let secret = outer.path().join("secret");
+    std::fs::create_dir(&ws)?;
+    std::fs::create_dir(&secret)?;
+    std::fs::write(secret.join("data.txt"), "sensitive")?;
+
+    // Create a symlink that uses relative ".." to escape
+    // ws/escape -> ../secret
+    let link = ws.join("escape");
+    std::os::unix::fs::symlink(std::path::Path::new("../secret"), &link)?;
+
+    let result = validate_workspace_path(&PathBuf::from("escape/data.txt"), &ws);
+    assert!(result.is_err(), "Relative symlink escaping workspace must be blocked");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_to_proc_self() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    let link = ws.join("proc_link");
+    std::os::unix::fs::symlink(std::path::Path::new("/proc/self"), &link)?;
+
+    let result = validate_workspace_path(&PathBuf::from("proc_link/environ"), ws);
+    assert!(result.is_err(), "Symlink to /proc/self must be blocked");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_to_workspace_subdirectory_is_valid() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+
+    std::fs::create_dir_all(ws.join("src/deep"))?;
+    std::fs::write(ws.join("src/deep/mod.pl"), "1;")?;
+
+    // Create a shortcut link within workspace
+    let link = ws.join("shortcut");
+    std::os::unix::fs::symlink(ws.join("src/deep"), &link)?;
+
+    let result = validate_workspace_path(&PathBuf::from("shortcut/mod.pl"), ws)?;
+    assert!(result.starts_with(ws.canonicalize()?));
+    Ok(())
+}
+
+// ===========================================================================
+// 6. sanitize_completion_path_input -- hardened tests
+// ===========================================================================
+
+#[test]
+fn sanitize_completion_rejects_null_byte() {
+    assert!(sanitize_completion_path_input("lib/Foo\0.pm").is_none());
+}
+
+#[test]
+fn sanitize_completion_rejects_parent_traversal() {
+    assert!(sanitize_completion_path_input("../etc/passwd").is_none());
+    assert!(sanitize_completion_path_input("sub/../../etc").is_none());
+    assert!(sanitize_completion_path_input("..").is_none());
+}
+
+#[test]
+fn sanitize_completion_rejects_absolute_path() {
+    assert!(sanitize_completion_path_input("/etc/passwd").is_none());
+    assert!(sanitize_completion_path_input("/usr/bin/perl").is_none());
+}
+
+#[test]
+fn sanitize_completion_rejects_backslash_traversal() {
+    assert!(sanitize_completion_path_input("..\\etc\\passwd").is_none());
+    assert!(sanitize_completion_path_input("sub\\..\\..\\etc").is_none());
+}
+
+#[test]
+fn sanitize_completion_normalizes_backslash_to_forward_slash() {
+    // Valid path with backslashes should be normalized
+    let result = sanitize_completion_path_input("lib\\Foo.pm");
+    assert_eq!(result, Some("lib/Foo.pm".to_string()));
+}
+
+#[test]
+fn sanitize_completion_allows_root_slash() {
+    // Special case: "/" alone is allowed
+    assert_eq!(sanitize_completion_path_input("/"), Some("/".to_string()));
+}
+
+#[test]
+fn sanitize_completion_allows_valid_relative() {
+    assert_eq!(
+        sanitize_completion_path_input("lib/My/Module.pm"),
+        Some("lib/My/Module.pm".to_string())
+    );
+}
+
+#[test]
+fn sanitize_completion_allows_simple_filename() {
+    assert_eq!(sanitize_completion_path_input("Foo.pm"), Some("Foo.pm".to_string()));
+}
+
+#[test]
+fn sanitize_completion_allows_current_dir_prefix() {
+    // Current directory prefix should be allowed since it does not escape
+    let result = sanitize_completion_path_input("./lib");
+    // Component::CurDir is not blocked by the function
+    assert!(result.is_some());
+}
+
+#[test]
+fn sanitize_completion_unicode_two_dot_leader() {
+    // U+2025 TWO DOT LEADER should pass sanitization (it's not "..")
+    let result = sanitize_completion_path_input("\u{2025}/etc");
+    assert!(result.is_some());
+}
+
+#[test]
+fn sanitize_completion_windows_drive_letter() {
+    // Windows drive prefix should be rejected
+    if cfg!(windows) {
+        assert!(sanitize_completion_path_input("C:\\Windows\\System32").is_none());
+    }
+}
+
+// ===========================================================================
+// 7. is_safe_completion_filename -- edge cases
+// ===========================================================================
+
+#[test]
+fn safe_filename_rejects_empty() {
+    assert!(!is_safe_completion_filename(""));
+}
+
+#[test]
+fn safe_filename_rejects_too_long() {
+    let long_name = "a".repeat(256);
+    assert!(!is_safe_completion_filename(&long_name));
+}
+
+#[test]
+fn safe_filename_accepts_max_length() {
+    let max_name = "a".repeat(255);
+    assert!(is_safe_completion_filename(&max_name));
+}
+
+#[test]
+fn safe_filename_rejects_null_byte() {
+    assert!(!is_safe_completion_filename("foo\0bar"));
+}
+
+#[test]
+fn safe_filename_rejects_control_chars() {
+    assert!(!is_safe_completion_filename("foo\x01bar"));
+    assert!(!is_safe_completion_filename("foo\x1fbar"));
+    assert!(!is_safe_completion_filename("foo\x7fbar")); // DEL
+}
+
+#[test]
+fn safe_filename_rejects_windows_reserved() {
+    assert!(!is_safe_completion_filename("CON"));
+    assert!(!is_safe_completion_filename("PRN"));
+    assert!(!is_safe_completion_filename("AUX"));
+    assert!(!is_safe_completion_filename("NUL"));
+    assert!(!is_safe_completion_filename("COM1"));
+    assert!(!is_safe_completion_filename("LPT1"));
+    assert!(!is_safe_completion_filename("CON.txt"));
+    assert!(!is_safe_completion_filename("nul.pl")); // case insensitive
+}
+
+#[test]
+fn safe_filename_accepts_normal_names() {
+    assert!(is_safe_completion_filename("Module.pm"));
+    assert!(is_safe_completion_filename("script.pl"));
+    assert!(is_safe_completion_filename("test.t"));
+    assert!(is_safe_completion_filename(".gitignore"));
+    assert!(is_safe_completion_filename("Makefile.PL"));
+}
+
+#[test]
+fn safe_filename_accepts_unicode_names() {
+    assert!(is_safe_completion_filename("\u{65E5}\u{672C}\u{8A9E}.pm")); // Japanese
+    assert!(is_safe_completion_filename("\u{0410}\u{0411}\u{0412}.pm")); // Cyrillic
+}
+
+// ===========================================================================
+// 8. is_hidden_or_forbidden_entry_name -- coverage
+// ===========================================================================
+
+#[test]
+fn hidden_entries_detected() {
+    assert!(is_hidden_or_forbidden_entry_name(".git"));
+    assert!(is_hidden_or_forbidden_entry_name(".svn"));
+    assert!(is_hidden_or_forbidden_entry_name(".hg"));
+    assert!(is_hidden_or_forbidden_entry_name(".cargo"));
+    assert!(is_hidden_or_forbidden_entry_name(".rustup"));
+    assert!(is_hidden_or_forbidden_entry_name("node_modules"));
+    assert!(is_hidden_or_forbidden_entry_name("target"));
+    assert!(is_hidden_or_forbidden_entry_name("build"));
+    assert!(is_hidden_or_forbidden_entry_name("__pycache__"));
+    assert!(is_hidden_or_forbidden_entry_name(".pytest_cache"));
+    assert!(is_hidden_or_forbidden_entry_name(".mypy_cache"));
+    assert!(is_hidden_or_forbidden_entry_name("System Volume Information"));
+    assert!(is_hidden_or_forbidden_entry_name("$RECYCLE.BIN"));
+}
+
+#[test]
+fn non_hidden_entries_pass() {
+    assert!(!is_hidden_or_forbidden_entry_name("lib"));
+    assert!(!is_hidden_or_forbidden_entry_name("src"));
+    assert!(!is_hidden_or_forbidden_entry_name("t"));
+    assert!(!is_hidden_or_forbidden_entry_name("blib"));
+    assert!(!is_hidden_or_forbidden_entry_name(".")); // single dot (current dir) has len 1
+}
+
+#[test]
+fn hidden_dotfiles_with_longer_names() {
+    // Any file starting with "." and len > 1 is hidden
+    assert!(is_hidden_or_forbidden_entry_name(".perltidyrc"));
+    assert!(is_hidden_or_forbidden_entry_name(".perlcriticrc"));
+    assert!(is_hidden_or_forbidden_entry_name(".env"));
+}
+
+// ===========================================================================
+// 9. split_completion_path_components -- edge cases
+// ===========================================================================
+
+#[test]
+fn split_path_with_nested_dirs() {
+    assert_eq!(
+        split_completion_path_components("lib/My/Module"),
+        ("lib/My".to_string(), "Module".to_string())
+    );
+}
+
+#[test]
+fn split_path_with_trailing_slash() {
+    assert_eq!(split_completion_path_components("lib/"), ("lib".to_string(), String::new()));
+}
+
+#[test]
+fn split_path_bare_filename() {
+    assert_eq!(split_completion_path_components("Foo.pm"), (".".to_string(), "Foo.pm".to_string()));
+}
+
+#[test]
+fn split_path_empty_string() {
+    assert_eq!(split_completion_path_components(""), (".".to_string(), String::new()));
+}
+
+// ===========================================================================
+// 10. build_completion_path -- edge cases
+// ===========================================================================
+
+#[test]
+fn build_path_dot_dir_file() {
+    assert_eq!(build_completion_path(".", "script.pl", false), "script.pl");
+}
+
+#[test]
+fn build_path_dot_dir_directory() {
+    assert_eq!(build_completion_path(".", "lib", true), "lib/");
+}
+
+#[test]
+fn build_path_nested_dir() {
+    assert_eq!(build_completion_path("lib/My", "Module.pm", false), "lib/My/Module.pm");
+}
+
+#[test]
+fn build_path_trailing_slash_normalized() {
+    assert_eq!(build_completion_path("lib/", "Module.pm", false), "lib/Module.pm");
+}
+
+// ===========================================================================
+// 11. resolve_completion_base_directory -- edge cases
+// ===========================================================================
+
+#[test]
+fn resolve_base_dir_dot() {
+    let result = resolve_completion_base_directory(".");
+    assert!(result.is_some());
+}
+
+#[test]
+fn resolve_base_dir_absolute_non_root_rejected() {
+    assert!(resolve_completion_base_directory("/etc").is_none());
+    assert!(resolve_completion_base_directory("/usr/bin").is_none());
+}
+
+#[test]
+fn resolve_base_dir_root_slash_not_rejected() {
+    // "/" is the only absolute path that is allowed
+    // The function allows it (path.is_absolute() && dir_part != "/")
+    let result = resolve_completion_base_directory("/");
+    // "/" exists on Linux, so it should canonicalize or return Some
+    if std::path::Path::new("/").exists() {
+        assert!(result.is_some());
+    }
+}
+
+// ===========================================================================
+// 12. Multi-encoding / double-encoding bypass attempts
+// ===========================================================================
+
+#[test]
+fn double_encoded_dot_dot_stays_literal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // %252e%252e -> double URL encoding of ".." -- OS treats as literal
+    let result = validate_workspace_path(&PathBuf::from("%252e%252e/%252e%252e/etc/passwd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+#[test]
+fn html_entity_encoded_dot_dot_stays_literal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // &#46;&#46; -> HTML entities for ".." -- OS treats as literal
+    let result = validate_workspace_path(&PathBuf::from("&#46;&#46;/&#46;&#46;/etc/passwd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+#[test]
+fn backslash_u_encoded_dot_dot_stays_literal() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // \u002e\u002e -> unicode escape for ".." -- OS treats as literal string
+    let result =
+        validate_workspace_path(&PathBuf::from("\\u002e\\u002e/\\u002e\\u002e/etc/passwd"), &ws)?;
+    assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+// ===========================================================================
+// 13. Control character injection -- comprehensive
+// ===========================================================================
+
+#[test]
+fn control_char_soh_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x01.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn control_char_stx_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x02.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn control_char_etx_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x03.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn control_char_eot_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x04.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn control_char_nak_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x15.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+#[test]
+fn control_char_sub_rejected() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("file\x1a.pl"), &ws);
+    assert!(matches!(result, Err(WorkspacePathError::InvalidPathCharacters)));
+    Ok(())
+}
+
+// ===========================================================================
+// 14. Adversarial traversal patterns -- real-world attack vectors
+// ===========================================================================
+
+#[test]
+fn traversal_with_current_dir_padding() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Pad with "./" to try to confuse depth counting
+    let result =
+        validate_workspace_path(&PathBuf::from("./sub/./././../././../../../etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn traversal_alternating_down_up() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Pattern: a/../b/../c/../d/../../../etc/passwd
+    // Net: go up 3 from workspace (escape)
+    let result =
+        validate_workspace_path(&PathBuf::from("a/../b/../c/../d/../../../etc/passwd"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn traversal_thousand_parent_dirs() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let evil = "../".repeat(1000) + "etc/passwd";
+    let result = validate_workspace_path(&PathBuf::from(&evil), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn traversal_hidden_in_long_valid_prefix() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    // Long valid prefix followed by escape
+    let prefix = "a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z";
+    let ups = "../".repeat(27); // 26 dirs down + 1 more to escape
+    let evil = format!("{prefix}/{ups}etc/passwd");
+    let result = validate_workspace_path(&PathBuf::from(&evil), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+// ===========================================================================
+// 15. Absolute path injection -- additional patterns
+// ===========================================================================
+
+#[test]
+fn absolute_path_to_etc_hosts() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("/etc/hosts"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn absolute_path_to_root_bashrc() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("/root/.bashrc"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn absolute_path_to_var_log() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let result = validate_workspace_path(&PathBuf::from("/var/log/syslog"), &ws);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn absolute_inside_workspace_is_valid() -> TestResult {
+    let tmp = tempfile::tempdir()?;
+    let ws = tmp.path();
+    let file = ws.join("script.pl");
+    std::fs::write(&file, "1;")?;
+
+    let result = validate_workspace_path(&file, ws)?;
+    assert!(result.starts_with(ws.canonicalize()?));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add 75 hardened security tests to `perl-path-security` covering adversarial path traversal attack vectors
- Add 66 hardened security tests to `perl-dap-security` exercising DAP-specific path validation, expression injection, and timeout boundaries
- Total: **141 new tests**, all passing, clippy-clean, no `unwrap()`/`expect()`/`panic!()`

## Attack vectors covered

| Category | Tests | Details |
|----------|-------|---------|
| Unicode normalization | ~20 | U+2025 two-dot leader, U+2024, U+FF0E fullwidth period, U+FF0F fullwidth solidus, U+2215 division slash, U+29F5, U+3002, U+FE52, U+0338, U+2216 |
| Null byte injection | ~10 | Within extensions, before slashes, combined with Unicode, scattered positions |
| Symlink traversal | ~8 | Circular chains, 3-level chains, relative `..` escape, `/proc/self`, valid intra-workspace |
| Windows-style separators | ~8 | Backslash traversal, drive letters, UNC paths, mixed separators |
| Double/multi-encoding | ~6 | Double URL encoding, HTML entities, `\u` escapes |
| Completion path sanitization | ~12 | `sanitize_completion_path_input`, `is_safe_completion_filename`, `split_completion_path_components`, `build_completion_path`, `resolve_completion_base_directory` |
| DAP expression injection | ~10 | Newline, CR, CRLF, multiline Perl attacks |
| Control characters | ~12 | SOH through DEL, comprehensive coverage |
| Adversarial traversal patterns | ~8 | Thousand-level `../`, long valid prefix then escape, alternating down/up |
| Error variant coverage | ~8 | `From` conversion, `Display` messages for all variants |
| Concurrent validation | ~2 | Thread safety with mixed valid/adversarial inputs |
| Timeout boundaries | ~6 | Zero, min, default, max, over-max, u32::MAX |

## Test plan

- [x] `cargo test -p perl-path-security --test path_traversal_hardened_tests` -- 75 passed
- [x] `cargo test -p perl-dap-security --test dap_path_traversal_hardened_tests` -- 66 passed
- [x] `cargo test -p perl-path-security` -- all existing tests still pass (9 unit + 59 comprehensive + 83 extended + 75 hardened = 226 total)
- [x] `cargo test -p perl-dap-security` -- all existing tests still pass (18 unit + 66 hardened = 84 total)
- [x] `cargo clippy -p perl-path-security -p perl-dap-security --tests` -- clean
- [x] No `unwrap()`, `expect()`, `panic!()`, `todo!()` in test code