### PR TITLE
feat(semantic-tokens): improve coverage with comprehensive AST walker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -73,15 +73,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -259,9 +259,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -461,13 +461,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -1090,7 +1089,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1431,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2170,7 +2169,6 @@ version = "0.11.0"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
- "perl-semantic-analyzer",
  "perl-tdd-support",
  "rustc-hash",
 ]
@@ -3705,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3852,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3870,9 +3868,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f456d2108c3fef07342ba4689a8503ec1fb5beed245e2b9be93096ef394848"
+checksum = "e7a6592b1aec0109df37b6bafea77eb4e61466e37b0a5a98bef4f89bfb81b7a2"
 dependencies = [
  "cc",
  "regex",
@@ -4546,7 +4544,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
- "console 0.16.2",
+ "console 0.16.3",
  "duct",
  "indicatif",
  "notify",

--- a/crates/perl-lsp-semantic-tokens/Cargo.toml
+++ b/crates/perl-lsp-semantic-tokens/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-lexer = { workspace = true }
-perl-semantic-analyzer = { workspace = true }
 rustc-hash = "2.1.1"
 
 [dev-dependencies]

--- a/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
+++ b/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
@@ -241,7 +241,9 @@ pub fn collect_semantic_tokens(
                     "my" | "our" | "local" | "state" | "sub" | "package" | "use" | "require"
                     | "if" | "else" | "elsif" | "for" | "foreach" | "while" | "until" | "do"
                     | "return" | "next" | "last" | "redo" | "goto" | "eval" | "given" | "when"
-                    | "default" | "break" | "continue" | "unless" => "keyword",
+                    | "default" | "break" | "continue" | "unless" | "no" | "BEGIN" | "END"
+                    | "CHECK" | "INIT" | "UNITCHECK" | "class" | "method" | "try" | "catch"
+                    | "finally" => "keyword",
                     _ => continue,
                 }
             }
@@ -250,6 +252,9 @@ pub fn collect_semantic_tokens(
             | TokenType::QuoteSingle
             | TokenType::QuoteDouble
             | TokenType::QuoteWords
+            | TokenType::QuoteCommand
+            | TokenType::HeredocStart
+            | TokenType::HeredocBody(_)
             | TokenType::InterpolatedString(_) => "string",
 
             TokenType::Number(_) => "number",
@@ -265,6 +270,9 @@ pub fn collect_semantic_tokens(
             | TokenType::FatComma => "operator",
 
             TokenType::Comment(_) => "comment",
+
+            // POD documentation blocks
+            TokenType::Pod => "comment",
             _ => continue,
         };
 
@@ -273,19 +281,132 @@ pub fn collect_semantic_tokens(
         }
     }
 
-    // 2) AST overlays: package/sub/variable (prefer identifier spans if you track them)
-    walk_ast(ast, &mut |node| {
+    // 2a) Collect variable declaration spans for modifier tagging
+    let mut decl_spans: Vec<(usize, usize, bool)> = Vec::new(); // (start, end, is_our)
+    walk_ast_full(ast, &mut |node| {
+        if let NodeKind::VariableDeclaration { declarator, variable, .. } = &node.kind {
+            let is_our = declarator == "our";
+            decl_spans.push((variable.location.start, variable.location.end, is_our));
+        }
+        if let NodeKind::VariableListDeclaration { declarator, variables, .. } = &node.kind {
+            let is_our = declarator == "our";
+            for v in variables {
+                decl_spans.push((v.location.start, v.location.end, is_our));
+            }
+        }
+        true
+    });
+
+    // 2b) AST overlays: package/sub/variable with precise spans where available
+    walk_ast_full(ast, &mut |node| {
+        // For nodes with name_span, use the precise span for better highlighting
+        match &node.kind {
+            NodeKind::Package { name_span, .. } => {
+                let (sl, sc) = to_pos16(name_span.start);
+                let (el, ec) = to_pos16(name_span.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((
+                        sl,
+                        sc,
+                        len,
+                        kind_idx(&leg, "namespace"),
+                        1, /*declaration*/
+                    ));
+                }
+                return true;
+            }
+            NodeKind::Subroutine { name: Some(_), name_span: Some(span), .. } => {
+                let (sl, sc) = to_pos16(span.start);
+                let (el, ec) = to_pos16(span.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((
+                        sl,
+                        sc,
+                        len,
+                        kind_idx(&leg, "function"),
+                        1 | 2, /*declaration|definition*/
+                    ));
+                }
+                return true;
+            }
+            NodeKind::Subroutine { name: Some(_), .. } => {
+                let (sl, sc) = to_pos16(node.location.start);
+                let (el, ec) = to_pos16(node.location.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((
+                        sl,
+                        sc,
+                        len,
+                        kind_idx(&leg, "function"),
+                        1, /*declaration*/
+                    ));
+                }
+                return true;
+            }
+            NodeKind::Method { .. } => {
+                let (sl, sc) = to_pos16(node.location.start);
+                let (el, ec) = to_pos16(node.location.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((
+                        sl,
+                        sc,
+                        len,
+                        kind_idx(&leg, "method"),
+                        1 | 2, /*declaration|definition*/
+                    ));
+                }
+                return true;
+            }
+            NodeKind::Class { .. } => {
+                let (sl, sc) = to_pos16(node.location.start);
+                let (el, ec) = to_pos16(node.location.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((sl, sc, len, kind_idx(&leg, "class"), 1 /*declaration*/));
+                }
+                return true;
+            }
+            NodeKind::PhaseBlock { phase_span: Some(span), .. } => {
+                let (sl, sc) = to_pos16(span.start);
+                let (el, ec) = to_pos16(span.end);
+                let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+                if len > 0 {
+                    raw_tokens.push((sl, sc, len, kind_idx(&leg, "macro"), 0));
+                }
+                return true;
+            }
+            _ => {}
+        }
+
         let (s, e) = (node.location.start, node.location.end);
         let (sl, sc) = to_pos16(s);
         let (el, ec) = to_pos16(e);
         let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
 
         let (kind, mods): (&str, u32) = match &node.kind {
-            NodeKind::Package { .. } => ("namespace", 0),
-            NodeKind::Subroutine { name: Some(_), .. } => ("function", 1 /*declaration*/),
-            NodeKind::FunctionCall { .. } => ("function", 0),
+            NodeKind::FunctionCall { name, .. } => {
+                // Skip builtins that should remain as keywords from the lexer pass
+                match name.as_str() {
+                    "eval" | "do" | "use" | "no" | "return" | "my" | "our" | "local" | "state"
+                    | "next" | "last" | "redo" | "goto" => return true,
+                    _ => ("function", 0),
+                }
+            }
             NodeKind::MethodCall { .. } => ("method", 0),
-            NodeKind::Variable { .. } => ("variable", 0),
+            NodeKind::Variable { .. } => {
+                let (vs, ve) = (node.location.start, node.location.end);
+                let decl_info = decl_spans.iter().find(|(ds, de, _)| *ds <= vs && ve <= *de);
+                let mods = match decl_info {
+                    Some((_, _, true)) => 1 | 4, // declaration | readonly (our)
+                    Some((_, _, false)) => 1,    // declaration (my/local/state)
+                    None => 0,
+                };
+                ("variable", mods)
+            }
             _ => return true,
         };
 
@@ -366,7 +487,8 @@ fn encode_raw_tokens_to_deltas(
     out
 }
 
-fn walk_ast<F>(node: &Node, visitor: &mut F) -> bool
+/// Comprehensive AST walker for semantic token extraction.
+fn walk_ast_full<F>(node: &Node, visitor: &mut F) -> bool
 where
     F: FnMut(&Node) -> bool,
 {
@@ -374,8 +496,181 @@ where
         return false;
     }
 
-    for child in perl_semantic_analyzer::analysis::declaration::get_node_children(node) {
-        if !walk_ast(child, visitor) {
+    let children: Vec<&Node> = match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            statements.iter().collect()
+        }
+        NodeKind::ExpressionStatement { expression } => vec![expression.as_ref()],
+        NodeKind::VariableDeclaration { variable, initializer, .. } => {
+            let mut c = vec![variable.as_ref()];
+            if let Some(init) = initializer {
+                c.push(init.as_ref());
+            }
+            c
+        }
+        NodeKind::VariableListDeclaration { variables, initializer, .. } => {
+            let mut c: Vec<&Node> = variables.iter().collect();
+            if let Some(init) = initializer {
+                c.push(init.as_ref());
+            }
+            c
+        }
+        NodeKind::Assignment { lhs, rhs, .. } => vec![lhs.as_ref(), rhs.as_ref()],
+        NodeKind::Binary { left, right, .. } => vec![left.as_ref(), right.as_ref()],
+        NodeKind::Ternary { condition, then_expr, else_expr } => {
+            vec![condition.as_ref(), then_expr.as_ref(), else_expr.as_ref()]
+        }
+        NodeKind::Unary { operand, .. } => vec![operand.as_ref()],
+        NodeKind::FunctionCall { args, .. } => args.iter().collect(),
+        NodeKind::MethodCall { object, args, .. } => {
+            let mut c = vec![object.as_ref()];
+            c.extend(args.iter());
+            c
+        }
+        NodeKind::IndirectCall { object, args, .. } => {
+            let mut c = vec![object.as_ref()];
+            c.extend(args.iter());
+            c
+        }
+        NodeKind::Subroutine { prototype, signature, body, .. } => {
+            let mut c = Vec::new();
+            if let Some(proto) = prototype {
+                c.push(proto.as_ref());
+            }
+            if let Some(sig) = signature {
+                c.push(sig.as_ref());
+            }
+            c.push(body.as_ref());
+            c
+        }
+        NodeKind::Method { signature, body, .. } => {
+            let mut c = Vec::new();
+            if let Some(sig) = signature {
+                c.push(sig.as_ref());
+            }
+            c.push(body.as_ref());
+            c
+        }
+        NodeKind::Signature { parameters } => parameters.iter().collect(),
+        NodeKind::MandatoryParameter { variable }
+        | NodeKind::SlurpyParameter { variable }
+        | NodeKind::NamedParameter { variable } => {
+            vec![variable.as_ref()]
+        }
+        NodeKind::OptionalParameter { variable, default_value } => {
+            vec![variable.as_ref(), default_value.as_ref()]
+        }
+        NodeKind::If { condition, then_branch, elsif_branches, else_branch } => {
+            let mut c = vec![condition.as_ref(), then_branch.as_ref()];
+            for (cond, body) in elsif_branches {
+                c.push(cond.as_ref());
+                c.push(body.as_ref());
+            }
+            if let Some(eb) = else_branch {
+                c.push(eb.as_ref());
+            }
+            c
+        }
+        NodeKind::While { condition, body, continue_block } => {
+            let mut c = vec![condition.as_ref(), body.as_ref()];
+            if let Some(cb) = continue_block {
+                c.push(cb.as_ref());
+            }
+            c
+        }
+        NodeKind::For { init, condition, update, body, continue_block } => {
+            let mut c = Vec::new();
+            if let Some(i) = init {
+                c.push(i.as_ref());
+            }
+            if let Some(cond) = condition {
+                c.push(cond.as_ref());
+            }
+            if let Some(upd) = update {
+                c.push(upd.as_ref());
+            }
+            c.push(body.as_ref());
+            if let Some(cb) = continue_block {
+                c.push(cb.as_ref());
+            }
+            c
+        }
+        NodeKind::Foreach { variable, list, body, continue_block } => {
+            let mut c = vec![variable.as_ref(), list.as_ref(), body.as_ref()];
+            if let Some(cb) = continue_block {
+                c.push(cb.as_ref());
+            }
+            c
+        }
+        NodeKind::Package { block, .. } => {
+            let mut c = Vec::new();
+            if let Some(b) = block {
+                c.push(b.as_ref());
+            }
+            c
+        }
+        NodeKind::Class { body, .. } => vec![body.as_ref()],
+        NodeKind::Eval { block } | NodeKind::Do { block } => vec![block.as_ref()],
+        NodeKind::Try { body, catch_blocks, finally_block } => {
+            let mut c = vec![body.as_ref()];
+            for (_var, handler) in catch_blocks {
+                c.push(handler.as_ref());
+            }
+            if let Some(fb) = finally_block {
+                c.push(fb.as_ref());
+            }
+            c
+        }
+        NodeKind::StatementModifier { statement, condition, .. } => {
+            vec![statement.as_ref(), condition.as_ref()]
+        }
+        NodeKind::Return { value } => {
+            let mut c = Vec::new();
+            if let Some(v) = value {
+                c.push(v.as_ref());
+            }
+            c
+        }
+        NodeKind::ArrayLiteral { elements } => elements.iter().collect(),
+        NodeKind::HashLiteral { pairs } => {
+            let mut c = Vec::new();
+            for (k, v) in pairs {
+                c.push(k);
+                c.push(v);
+            }
+            c
+        }
+        NodeKind::LabeledStatement { statement, .. } => vec![statement.as_ref()],
+        NodeKind::Given { expr, body } | NodeKind::When { condition: expr, body } => {
+            vec![expr.as_ref(), body.as_ref()]
+        }
+        NodeKind::Default { body } => vec![body.as_ref()],
+        NodeKind::PhaseBlock { block, .. } => vec![block.as_ref()],
+        NodeKind::VariableWithAttributes { variable, .. } => vec![variable.as_ref()],
+        NodeKind::Match { expr, .. }
+        | NodeKind::Substitution { expr, .. }
+        | NodeKind::Transliteration { expr, .. } => {
+            vec![expr.as_ref()]
+        }
+        NodeKind::Tie { variable, package, args } => {
+            let mut c = vec![variable.as_ref(), package.as_ref()];
+            c.extend(args.iter());
+            c
+        }
+        NodeKind::Untie { variable } => vec![variable.as_ref()],
+        NodeKind::Error { partial, .. } => {
+            let mut c = Vec::new();
+            if let Some(p) = partial {
+                c.push(p.as_ref());
+            }
+            c
+        }
+        // Leaf nodes with no children
+        _ => vec![],
+    };
+
+    for child in children {
+        if !walk_ast_full(child, visitor) {
             return false;
         }
     }

--- a/crates/perl-lsp-semantic-tokens/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-semantic-tokens/tests/comprehensive_unit_tests.rs
@@ -885,3 +885,439 @@ fn given_when_default_keywords_classified() {
         assert!(has_kw, "'{kw}' should be classified as keyword");
     }
 }
+
+// ===========================================================================
+// Improved semantic token coverage tests
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Subroutine names get `function` token type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn subroutine_name_gets_function_type_with_definition_modifier() {
+    let tokens = tokens_for("sub greet { }");
+    let leg = legend();
+    let fn_idx = must_some(leg.map.get("function"));
+    let fn_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *fn_idx).collect();
+    assert!(!fn_tokens.is_empty(), "sub declaration should produce function token");
+    // Should have declaration modifier (bit 0)
+    let has_decl = fn_tokens.iter().any(|t| t[4] & 1 != 0);
+    assert!(has_decl, "named sub should have declaration modifier");
+}
+
+#[test]
+fn multiline_sub_name_still_gets_function_token() {
+    let code = "sub process_data {\n    my $x = 1;\n    return $x;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let fn_idx = must_some(leg.map.get("function"));
+    let has_fn = tokens.iter().any(|t| t[3] == *fn_idx);
+    assert!(has_fn, "multi-line sub should still produce function token for name");
+}
+
+#[test]
+fn function_call_gets_function_type_without_declaration() {
+    let tokens = tokens_for("foo();");
+    let leg = legend();
+    let fn_idx = must_some(leg.map.get("function"));
+    let fn_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *fn_idx).collect();
+    assert!(!fn_tokens.is_empty(), "function call should produce function token");
+    for t in &fn_tokens {
+        assert_eq!(t[4] & 1, 0, "function call should NOT have declaration modifier");
+    }
+}
+
+#[test]
+fn nested_function_calls_produce_function_tokens() {
+    let code = "foo(bar(baz()));";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let fn_idx = must_some(leg.map.get("function"));
+    let fn_count = tokens.iter().filter(|t| t[3] == *fn_idx).count();
+    // Overlap resolution may merge nested calls on the same line
+    assert!(
+        fn_count >= 1,
+        "nested calls should produce at least one function token, got {fn_count}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Package names get `namespace` token type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn package_name_gets_namespace_type() {
+    let tokens = tokens_for("package MyModule;");
+    let leg = legend();
+    let ns_idx = must_some(leg.map.get("namespace"));
+    let has_ns = tokens.iter().any(|t| t[3] == *ns_idx);
+    assert!(has_ns, "package declaration should produce namespace token");
+}
+
+#[test]
+fn nested_package_name_gets_namespace_type() {
+    let tokens = tokens_for("package My::Nested::Module;");
+    let leg = legend();
+    let ns_idx = must_some(leg.map.get("namespace"));
+    let has_ns = tokens.iter().any(|t| t[3] == *ns_idx);
+    assert!(has_ns, "nested package name should produce namespace token");
+}
+
+#[test]
+fn package_declaration_has_declaration_modifier() {
+    let tokens = tokens_for("package Foo;");
+    let leg = legend();
+    let ns_idx = must_some(leg.map.get("namespace"));
+    let ns_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *ns_idx).collect();
+    assert!(!ns_tokens.is_empty(), "should have namespace token");
+    let has_decl = ns_tokens.iter().any(|t| t[4] & 1 != 0);
+    assert!(has_decl, "package should have declaration modifier");
+}
+
+#[test]
+fn package_block_form_gets_namespace_type() {
+    let code = "package Foo {\n    sub bar { }\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let ns_idx = must_some(leg.map.get("namespace"));
+    let has_ns = tokens.iter().any(|t| t[3] == *ns_idx);
+    assert!(has_ns, "package block form should produce namespace token");
+}
+
+// ---------------------------------------------------------------------------
+// Variables get `variable` token type with correct modifiers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scalar_variable_gets_variable_type() {
+    let tokens = tokens_for("$x;");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let has_var = tokens.iter().any(|t| t[3] == *var_idx);
+    assert!(has_var, "scalar variable should produce variable token");
+}
+
+#[test]
+fn array_variable_gets_variable_type() {
+    let tokens = tokens_for("my @arr;");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let has_var = tokens.iter().any(|t| t[3] == *var_idx);
+    assert!(has_var, "array variable should produce variable token");
+}
+
+#[test]
+fn hash_variable_gets_variable_type() {
+    let tokens = tokens_for("my %hash;");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let has_var = tokens.iter().any(|t| t[3] == *var_idx);
+    assert!(has_var, "hash variable should produce variable token");
+}
+
+#[test]
+fn my_declaration_variable_has_declaration_modifier() {
+    let tokens = tokens_for("my $x = 1;");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *var_idx).collect();
+    assert!(!var_tokens.is_empty(), "should have variable token");
+    let has_decl = var_tokens.iter().any(|t| t[4] & 1 != 0);
+    assert!(has_decl, "my-declared variable should have declaration modifier");
+}
+
+#[test]
+fn our_declaration_variable_has_readonly_modifier() {
+    let tokens = tokens_for("our $VERSION = '1.0';");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *var_idx).collect();
+    assert!(!var_tokens.is_empty(), "should have variable token");
+    // our variables should have declaration (bit 0) and readonly (bit 2) modifiers
+    let has_our_mods = var_tokens.iter().any(|t| t[4] & 1 != 0 && t[4] & 4 != 0);
+    assert!(has_our_mods, "our-declared variable should have declaration+readonly modifiers");
+}
+
+#[test]
+fn local_declaration_variable_has_declaration_modifier() {
+    let tokens = tokens_for("local $/ = undef;");
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *var_idx).collect();
+    assert!(!var_tokens.is_empty(), "should have variable token");
+    let has_decl = var_tokens.iter().any(|t| t[4] & 1 != 0);
+    assert!(has_decl, "local-declared variable should have declaration modifier");
+}
+
+#[test]
+fn state_declaration_variable_has_declaration_modifier() {
+    let code = "sub counter {\n    state $count = 0;\n    return $count;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *var_idx).collect();
+    let has_decl = var_tokens.iter().any(|t| t[4] & 1 != 0);
+    assert!(has_decl, "state-declared variable should have declaration modifier");
+}
+
+#[test]
+fn undeclared_variable_has_no_declaration_modifier() {
+    let code = "sub f { return $x; }";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    // The $x variable is used but not declared with my/our/local/state
+    let var_tokens: Vec<_> = tokens.iter().filter(|t| t[3] == *var_idx).collect();
+    if !var_tokens.is_empty() {
+        // At least one variable token should NOT have declaration modifier
+        let has_non_decl = var_tokens.iter().any(|t| t[4] & 1 == 0);
+        assert!(has_non_decl, "undeclared variable should not have declaration modifier");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Regex patterns get `regexp` token type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn regex_match_gets_regexp_type() {
+    let tokens = tokens_for("$x =~ /pattern/;");
+    let leg = legend();
+    let re_idx = must_some(leg.map.get("regexp"));
+    let has_re = tokens.iter().any(|t| t[3] == *re_idx);
+    assert!(has_re, "regex match should produce regexp token");
+}
+
+#[test]
+fn regex_substitution_gets_regexp_type() {
+    let tokens = tokens_for("$x =~ s/foo/bar/g;");
+    let leg = legend();
+    let re_idx = must_some(leg.map.get("regexp"));
+    let has_re = tokens.iter().any(|t| t[3] == *re_idx);
+    assert!(has_re, "substitution should produce regexp token");
+}
+
+#[test]
+fn regex_transliteration_gets_regexp_type() {
+    let tokens = tokens_for("$x =~ tr/a-z/A-Z/;");
+    let leg = legend();
+    let re_idx = must_some(leg.map.get("regexp"));
+    let has_re = tokens.iter().any(|t| t[3] == *re_idx);
+    assert!(has_re, "transliteration should produce regexp token");
+}
+
+#[test]
+fn qr_regex_gets_regexp_type() {
+    let tokens = tokens_for("my $re = qr/pattern/i;");
+    let leg = legend();
+    let re_idx = must_some(leg.map.get("regexp"));
+    let has_re = tokens.iter().any(|t| t[3] == *re_idx);
+    assert!(has_re, "qr// should produce regexp token");
+}
+
+// ---------------------------------------------------------------------------
+// POD documentation gets `comment` token type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pod_single_line_gets_comment_type() {
+    // Single-line POD won't have len > 0 since it spans multiple lines
+    // But we should at least not crash
+    let code = "=pod\n\nSome documentation\n\n=cut\nmy $x = 1;";
+    let tokens = tokens_for(code);
+    // Should still produce tokens for the Perl code after =cut
+    let leg = legend();
+    let kw_idx = must_some(leg.map.get("keyword"));
+    let has_keyword = tokens.iter().any(|t| t[3] == *kw_idx);
+    assert!(has_keyword, "code after POD should still be tokenized");
+}
+
+// ---------------------------------------------------------------------------
+// Variables inside control structures (deep walker test)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variables_inside_if_get_variable_type() {
+    let code = "if (1) {\n    my $x = 42;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let has_var = tokens.iter().any(|t| t[3] == *var_idx);
+    assert!(has_var, "variable inside if block should produce variable token");
+}
+
+#[test]
+fn variables_inside_while_get_variable_type() {
+    let code = "while (1) {\n    my $x = 42;\n    last;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let has_var = tokens.iter().any(|t| t[3] == *var_idx);
+    assert!(has_var, "variable inside while block should produce variable token");
+}
+
+#[test]
+fn variables_inside_for_get_variable_type() {
+    let code = "for my $i (1..10) {\n    my $x = $i * 2;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(var_count >= 2, "should find multiple variables in for loop, got {var_count}");
+}
+
+#[test]
+fn function_call_inside_if_gets_function_type() {
+    let code = "if (1) {\n    print('hello');\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let fn_idx = must_some(leg.map.get("function"));
+    let has_fn = tokens.iter().any(|t| t[3] == *fn_idx);
+    assert!(has_fn, "function call inside if should produce function token");
+}
+
+#[test]
+fn deeply_nested_variable_produces_token() {
+    let code = "if (1) {\n    while (1) {\n        for my $i (1..3) {\n            my $x = $i;\n        }\n    }\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(var_count >= 2, "deeply nested variables should produce tokens, got {var_count}");
+}
+
+// ---------------------------------------------------------------------------
+// New keyword coverage tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_statement_does_not_crash() {
+    // "no strict;" may not produce keyword tokens if the lexer doesn't
+    // classify "no" as a keyword, but should not crash
+    let _tokens = tokens_for("no strict;");
+}
+
+// ---------------------------------------------------------------------------
+// Method call coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn method_call_on_variable_produces_method_token() {
+    let tokens = tokens_for("$obj->method();");
+    let leg = legend();
+    let meth_idx = must_some(leg.map.get("method"));
+    let has_method = tokens.iter().any(|t| t[3] == *meth_idx);
+    assert!(has_method, "$obj->method() should produce method token");
+}
+
+#[test]
+fn chained_method_calls_produce_method_tokens() {
+    let tokens = tokens_for("$obj->foo()->bar();");
+    let leg = legend();
+    let meth_idx = must_some(leg.map.get("method"));
+    let method_count = tokens.iter().filter(|t| t[3] == *meth_idx).count();
+    assert!(
+        method_count >= 1,
+        "chained method calls should produce method tokens, got {method_count}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// String token type coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backtick_command_classified_as_string() {
+    let tokens = tokens_for("my $out = `ls -la`;");
+    let leg = legend();
+    let str_idx = must_some(leg.map.get("string"));
+    let has_string = tokens.iter().any(|t| t[3] == *str_idx);
+    assert!(has_string, "backtick command should be classified as string");
+}
+
+// ---------------------------------------------------------------------------
+// Statement modifier coverage (deep walk)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variable_in_statement_modifier_gets_token() {
+    let code = "print $x if $condition;";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(
+        var_count >= 1,
+        "variables in statement modifier should produce tokens, got {var_count}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ternary expression coverage (deep walk)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variable_in_ternary_gets_token() {
+    let code = "my $y = $x ? 1 : 0;";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(var_count >= 1, "variables in ternary should produce tokens, got {var_count}");
+}
+
+// ---------------------------------------------------------------------------
+// Return value coverage (deep walk)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variable_in_return_gets_token() {
+    let code = "sub f {\n    my $x = 1;\n    return $x;\n}";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(var_count >= 2, "variable in return should produce token, got {var_count}");
+}
+
+// ---------------------------------------------------------------------------
+// Array/hash literal coverage (deep walk)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variables_in_array_literal_get_tokens() {
+    let code = "my @arr = ($x, $y, $z);";
+    let tokens = tokens_for(code);
+    let leg = legend();
+    let var_idx = must_some(leg.map.get("variable"));
+    let var_count = tokens.iter().filter(|t| t[3] == *var_idx).count();
+    assert!(var_count >= 2, "variables in array literal should produce tokens, got {var_count}");
+}
+
+// ---------------------------------------------------------------------------
+// Token type diversity in complex code
+// ---------------------------------------------------------------------------
+
+#[test]
+fn complex_code_produces_many_token_types() {
+    let code = "package Foo;\nuse strict;\nmy $x = 42;\nsub bar {\n    my $y = 'hello';\n    $x =~ /pattern/;\n    return $y;\n}\n";
+    let tokens = tokens_for(code);
+    let leg = legend();
+
+    let types_present: std::collections::HashSet<u32> = tokens.iter().map(|t| t[3]).collect();
+
+    let kw_idx = must_some(leg.map.get("keyword"));
+    let str_idx = must_some(leg.map.get("string"));
+    let num_idx = must_some(leg.map.get("number"));
+    let ns_idx = must_some(leg.map.get("namespace"));
+    let var_idx = must_some(leg.map.get("variable"));
+    let re_idx = must_some(leg.map.get("regexp"));
+
+    assert!(types_present.contains(kw_idx), "should have keyword tokens");
+    assert!(types_present.contains(str_idx), "should have string tokens");
+    assert!(types_present.contains(num_idx), "should have number tokens");
+    assert!(types_present.contains(ns_idx), "should have namespace tokens");
+    assert!(types_present.contains(var_idx), "should have variable tokens");
+    assert!(types_present.contains(re_idx), "should have regexp tokens");
+}


### PR DESCRIPTION
## Summary

- Replace limited `get_node_children`-based AST walker with comprehensive `walk_ast_full` that traverses all 40+ AST node kinds, enabling semantic tokens for deeply nested constructs (variables/functions inside if/while/for/foreach/eval/try/etc.)
- Add POD documentation, heredoc, backtick command, and 11 additional keyword tokens to the lexer pass
- Use precise `name_span` fields for package and subroutine names, and add declaration/definition/readonly modifiers for variables and declarations
- Remove `perl-semantic-analyzer` dependency -- the crate is now self-contained with its own walker

## Test plan

- [x] All 27 existing unit tests pass
- [x] All 66 existing integration tests pass
- [x] 35 new integration tests added covering:
  - Subroutine names get `function` token type (with declaration modifier)
  - Package names get `namespace` token type (with declaration modifier)
  - Variables get `variable` token type with correct modifiers (declaration, readonly for `our`)
  - Regex patterns get `regexp` token type (match, substitution, transliteration, qr//)
  - POD documentation handled without crashes
  - Deep nesting: variables/functions inside if/while/for/foreach produce tokens
  - Statement modifiers, ternary expressions, return values traversed
  - Method calls, chained calls, backtick commands covered
- [x] `cargo clippy -p perl-lsp-semantic-tokens` clean
- [x] `cargo fmt` applied