### PR TITLE
fix(parser): fat arrow as list separator in builtins

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -304,9 +304,9 @@ impl<'a> Parser<'a> {
                             if name == "bless" {
                                 args.push(self.parse_hash_or_block()?);
 
-                                // Parse remaining arguments separated by commas
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // Parse remaining arguments separated by commas or fat arrows
+                                while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    self.consume_token()?; // consume comma or fat arrow
                                     if self.is_at_statement_end() {
                                         break;
                                     }
@@ -319,16 +319,16 @@ impl<'a> Parser<'a> {
                                 // Parse trailing list arguments for map/grep/sort.
                                 // In Perl, the block form does not require a comma
                                 // before the list: `grep { ... } @array`
-                                // First consume without a comma if present
+                                // First consume without a comma/fat arrow if present
                                 if !self.is_at_statement_end()
-                                    && self.peek_kind() != Some(TokenKind::Comma)
+                                    && !matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow))
                                 {
                                     args.push(self.parse_ternary()?);
                                 }
 
-                                // Then consume any remaining comma-separated arguments
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // Then consume any remaining comma/fat-arrow-separated arguments
+                                while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    self.consume_token()?; // consume comma or fat arrow
                                     if self.is_at_statement_end() {
                                         break;
                                     }
@@ -338,9 +338,9 @@ impl<'a> Parser<'a> {
                                 // Other builtins - parse {} as first argument
                                 args.push(self.parse_hash_or_block()?);
 
-                                // Parse remaining arguments separated by commas
-                                while self.peek_kind() == Some(TokenKind::Comma) {
-                                    self.consume_token()?; // consume comma
+                                // Parse remaining arguments separated by commas or fat arrows
+                                while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    self.consume_token()?; // consume comma or fat arrow
                                     if self.is_at_statement_end() {
                                         break;
                                     }
@@ -458,11 +458,11 @@ impl<'a> Parser<'a> {
                                     // Parse remaining arguments for map/grep/sort without requiring commas
                                     // But respect statement boundaries including ] and )
                                     while !self.is_at_statement_end() {
-                                        // Skip comma if present
-                                        if self.peek_kind() == Some(TokenKind::Comma) {
+                                        // Skip comma or fat arrow if present
+                                        if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
                                             self.consume_token()?;
                                         }
-                                        // Check again after potential comma
+                                        // Check again after potential comma/fat arrow
                                         if self.is_at_statement_end() {
                                             break;
                                         }
@@ -474,9 +474,9 @@ impl<'a> Parser<'a> {
                                     // Special handling for bless {} - parse it as a hash
                                     args.push(self.parse_hash_or_block()?);
 
-                                    // Parse remaining arguments separated by commas
-                                    while self.peek_kind() == Some(TokenKind::Comma) {
-                                        self.consume_token()?; // consume comma
+                                    // Parse remaining arguments separated by commas or fat arrows
+                                    while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                        self.consume_token()?; // consume comma or fat arrow
                                         if self.is_at_statement_end() {
                                             break;
                                         }
@@ -490,8 +490,8 @@ impl<'a> Parser<'a> {
                                     self.tokens.relex_as_term();
                                     args.push(self.parse_ternary()?);
 
-                                    // Parse remaining arguments separated by commas
-                                    while self.peek_kind() == Some(TokenKind::Comma) {
+                                    // Parse remaining arguments separated by commas or fat arrows
+                                    while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
                                         self.consume_token()?;
                                         if self.is_at_statement_end() {
                                             break;

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3173,6 +3173,122 @@ mod line_index_extended_tests {
         Ok(())
     }
 
+    // ---- Wave 2B-ext: Fat arrow in postfix builtin paths ----
+
+    #[test]
+    fn wave2b_bless_hash_literal_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        // bless {} => $class  —  exercises the bless-with-LeftBrace path in postfix.rs
+        let mut parser = Parser::new("bless {} => $class;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "bless {{}} => $class should parse cleanly, got: {sexp}");
+        assert!(sexp.contains("call bless"), "should be a bless call, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_bless_hash_with_entries_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        // bless { key => 1 } => $class
+        let mut parser = Parser::new("bless { key => 1 } => $class;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "bless {{ key => 1 }} => $class should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_split_regex_fat_arrow() -> Result<(), Box<dyn std::error::Error>> {
+        // split /,/ => @parts  —  exercises the split-with-Slash path in postfix.rs
+        let mut parser = Parser::new("split /,/ => @parts;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "split /,/ => @parts should parse cleanly, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_unshift_fat_arrow_multiple() -> Result<(), Box<dyn std::error::Error>> {
+        // unshift @arr => 1, 2, 3  —  fat arrow then commas
+        let mut parser = Parser::new("unshift @arr => 1, 2, 3;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "unshift @arr => 1, 2, 3 should parse cleanly, got: {sexp}"
+        );
+        assert!(sexp.contains("call unshift"), "should be an unshift call, got: {sexp}");
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_grep_block_fat_arrow_list() -> Result<(), Box<dyn std::error::Error>> {
+        // grep { defined } => @list  —  exercises the sort/map/grep block path in postfix.rs
+        // (when reached via postfix, e.g. inside an expression context)
+        let mut parser = Parser::new("my @r = grep { defined } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "grep {{ defined }} => @list in assignment should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_bless_hash_fat_arrow_in_assignment() -> Result<(), Box<dyn std::error::Error>> {
+        // my $obj = bless {} => $class  —  in assignment, goes through postfix.rs bless path
+        let mut parser = Parser::new("my $obj = bless {} => $class;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "bless {{}} => $class in assignment should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_split_regex_fat_arrow_in_assignment() -> Result<(), Box<dyn std::error::Error>> {
+        // my @parts = split /,/ => $str  —  in assignment, goes through postfix.rs split path
+        let mut parser = Parser::new("my @parts = split /,/ => $str;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "split /,/ => $str in assignment should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_sort_block_fat_arrow_in_assignment() -> Result<(), Box<dyn std::error::Error>> {
+        // my @s = sort { $a <=> $b } => @list  —  in assignment, goes through postfix.rs
+        let mut parser = Parser::new("my @s = sort { $a <=> $b } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "sort {{ $a <=> $b }} => @list in assignment should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn wave2b_map_block_fat_arrow_in_assignment() -> Result<(), Box<dyn std::error::Error>> {
+        // my @r = map { $_ * 2 } => @list
+        let mut parser = Parser::new("my @r = map { $_ * 2 } => @list;");
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+        assert!(
+            !sexp.contains("ERROR"),
+            "map {{ $_ * 2 }} => @list in assignment should parse cleanly, got: {sexp}"
+        );
+        Ok(())
+    }
+
     // ---- Wave 2C: split /regex/ ----
 
     #[test]


### PR DESCRIPTION
## Summary

- Accept `=>` (fat arrow) alongside `,` in all builtin argument parsing paths in `postfix.rs`
- Previously, specialized code paths for `bless {}`, `sort/map/grep { BLOCK }`, `split /regex/`, and other builtins with `{}` first argument only checked for `Comma`, causing parse errors when fat arrow was used as separator in expression contexts (e.g., `my $obj = bless {} => $class`)
- The generic builtin path in `statements.rs` already handled this correctly; this PR fixes the 6 remaining code paths in `postfix.rs` for consistency

## Test plan

- [x] Added 9 new tests covering fat arrow in postfix builtin paths (`bless {} =>`, `grep { } =>`, `map { } =>`, `sort { } =>`, `split // =>`, `unshift => multiple args`)
- [x] All 21 wave2b tests pass (12 existing + 9 new)
- [x] All 368 lib tests pass, 291 integration tests pass
- [x] `cargo clippy --workspace --lib` clean
- [x] `cargo fmt -p perl-parser-core --check` clean