### PR TITLE
chore: set default permission mode to bypassPermissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
     "symlinkDirectories": ["target"]
   },
   "permissions": {
-    "defaultMode": "auto",
+    "defaultMode": "bypassPermissions",
     "allow": [
       "Bash(gh:*)",
       "Bash(git:*)",


### PR DESCRIPTION
## Summary
- Changes `.claude/settings.json` default permission mode from `auto` to `bypassPermissions` for autonomous swarm operation

## Test plan
- [x] Verify settings JSON is valid