### PR TITLE
chore(status): fix computed metrics drift after recent merges

### DIFF
--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 2032 lib tests (discovered), 4 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2040 lib tests (discovered), 4 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -83,7 +83,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 2032 lib tests (Tier A), 4 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2040 lib tests (Tier A), 4 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
## Summary

- `docs/project/CURRENT_STATUS.md` was stale: Tier A test count read 2032 but actual count is 2040 after recent merged PRs
- This caused `policy_checks` gate failures on all recent PRs (the policy_checks gate runs `update-status --check` and fails when stale)
- Fixed by running `just status-update` (i.e., `cargo run -p xtask -- update-status --write`)

## Agent

fixer

## Verification

- `cargo run -p xtask -- update-status --check` → "All files are up to date."