### PR TITLE
docs(changelog+readme): fill unreleased entries, deduplicate sections, add friction log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Async Runtime with Concurrent Dispatch**: LSP server migrated to a two-lane scheduler — exclusive worker for mutations + 4-worker read pool for concurrent hover/goto-def/completion requests. `$/cancelRequest` is now processed inline before enqueuing (#1555).
+- **Continuous Swarm Infrastructure**: 53 agents, 22 skills, 12 named teammates, GitHub-native tracking, handoff protocol, and portable agent pack for other repos (#1553).
+- **Goto AST Node**: Dedicated `Goto` node with full `TokenKind::display_name` support (#1521).
+- **Smarter Selection Range**: Expand/shrink selection chains with semantic awareness (#1545).
+- **Cross-file Go-to-Definition for Methods and Modules**: Improved navigation for method calls and `use parent`/`base` statements (#1542, #1544).
+- **Enhanced Diagnostics**: Added `suggestion` field to diagnostic messages (#1543).
+- **Inlay Hints for Builtins**: Derive parameter names from builtin function signatures (#1541).
+- **Semantic Tokens**: Comprehensive AST walker with new token types for broader coverage (#1540).
+- **DAP Improvements**: POD detection, conditional expression validation in breakpoints (#1536), and improved variable inspection rendering (#1535).
+- **Hover Enhancements**: Improved documentation quality in hover responses (#1537).
+- **Cross-sigil Variable Highlighting**: Highlight `@foo` and `%foo` references when cursor is on `$foo` (#1538).
+- **Extract Variable for Methods**: Code actions handle method calls and hash/array access (#1534).
+- **Workspace Symbols Ranking**: Improved ranking with comprehensive tests (#1529).
+- **Completion for Moo/Moose Accessors**: Show `isa` type in completion for accessor methods (#1525).
+- **Signature Help Builtin Coverage**: Expanded coverage for common Perl builtins (#1532).
+
+### Fixed
+- **Parser**: Statement modifiers after complex expressions (#1550), package-qualified variable subscripts (#1548), fat arrow as list separator in all builtin argument paths (#1549), split regex slash disambiguation in expression contexts (#1547).
+- **Incremental Parsing**: Improved efficiency and fixed position underflow (#1539).
+- **On-Type Formatting**: Heredoc suppression, string/comment-aware brace matching, correct trigger semantics (#1530).
+- **Test Count Sync**: Updated test count to 1953, removed PerlIO from corpus manifest (#1552).
+
+### Changed
+- **bypassPermissions**: Set as default permission mode (#1554).
+- **Native Debt Report**: `xtask` now has a native `debt-report` subcommand (#1528).
+- **Devex Targeted Checks**: Converted from shell script to native Rust xtask subcommand (#1527).
+
 ## [0.11.0] - 2026-03-12
 
 This release finalizes the 0.11.0 distribution pipeline across GitHub releases,

--- a/README.md
+++ b/README.md
@@ -82,12 +82,17 @@ For live metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
 
 ## Parser Coverage
 
-The parser is tested continuously against real-world Perl code to drive coverage improvements:
+The v3 parser is a native recursive-descent implementation covering broad Perl 5 syntax
+(5.8 through 5.40), including heredocs, regex, quoting constructs, formats, and more.
+It is tested continuously against real-world Perl code to drive coverage improvements:
 
-- **System Perl corpus sweep** -- the parser is benchmarked against all `.pm` and `.pl` files found in the system Perl installation. Current parse rates are tracked in [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and the baseline file (`.ci/parser-corpus-baseline.json`).
+- **Corpus test suite** -- 600+ test sections in `tree-sitter-perl/test/corpus/` plus 70+ standalone `.pl` fixtures.
+- **System Perl corpus sweep** -- benchmarked against all `.pm` and `.pl` files found in the system Perl installation. Current parse rates are tracked in [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and the baseline file (`.ci/parser-corpus-baseline.json`).
 - **Common-files gate** -- a curated set of core modules that must parse with zero errors on every PR (`.ci/common-corpus-manifest.txt`).
 - **Ratcheting CI gate** -- the overall parse rate can only go up, never down. Regressions fail the build.
 - **CPAN top 1000 goal** -- the long-term target is for 90%+ of the most-downloaded CPAN distributions to parse cleanly, driving parser improvements toward real-world Perl idioms.
+
+For detailed parse rates and the edge-case roadmap, see [PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md).
 
 ### Corpus Commands
 
@@ -119,20 +124,6 @@ cargo install --path crates/perl-lsp
 ### Pre-built binaries
 
 Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
-
-## Parser Coverage
-
-The v3 parser is a native recursive-descent implementation covering broad Perl 5 syntax
-(5.8 through 5.40), including heredocs, regex, quoting constructs, formats, and more.
-
-Coverage is validated by:
-
-- **Corpus test suite** -- 600+ test sections in `tree-sitter-perl/test/corpus/` plus 70+ standalone `.pl` fixtures
-- **CPAN module sweep** -- automated `just corpus-sweep` against 7,000+ `.pm` files from system Perl and CPAN distributions, with error bucketing to prioritize fixes
-- **Ratcheting CI** -- mutation score (87%) and safety baselines (zero `unwrap`/`panic!`/`unsafe` in production code) are enforced as one-way ratchets
-
-For detailed parse rates and the edge-case roadmap, see
-[PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md).
 
 ## Architecture
 
@@ -216,9 +207,3 @@ Dual licensed under MIT or Apache-2.0:
 - [LICENSE-MIT](LICENSE-MIT)
 - [LICENSE-APACHE](LICENSE-APACHE)
 
-## History
-
-This project began as a fork of
-[tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl)
-in July 2025 and has since been rewritten as a native Rust implementation
-focused on LSP and DAP performance.

--- a/docs/project/FRICTION_LOG.md
+++ b/docs/project/FRICTION_LOG.md
@@ -1,0 +1,57 @@
+# Friction Log
+
+Tracks pain points encountered by agents and developers: confusing errors, hard-to-find code, unclear APIs, missing setup steps. Used to prioritize devex improvements.
+
+Format: date, who hit it, what happened, suggested fix.
+
+---
+
+## 2026-03-15 — improver-docs / readme audit
+
+**Category**: docs
+**Who**: improver-docs agent during README audit
+**What**: README.md contained a duplicate `## Parser Coverage` section (lines 83 and 123) and a duplicate `## History` section (lines 208 and 219). The second Parser Coverage block had different (complementary) content from the first. Both were added during separate PRs without a cross-check.
+**Suggested fix**: The canonical check for README is `grep -n "^## " README.md` — any heading appearing twice is a duplicate. Fixed in PR docs(changelog+readme): deduplicate sections.
+
+---
+
+## 2026-03-15 — improver-docs / changelog audit
+
+**Category**: docs
+**Who**: improver-docs agent during CHANGELOG audit
+**What**: After 20+ PRs merged since 0.11.0 (PRs #1521–#1555), the `[Unreleased]` section in CHANGELOG.md was empty. Users and release tooling (git-cliff) would not surface these changes until a release PR was opened.
+**Suggested fix**: Run `git log --oneline <last-release-tag>..HEAD` after each merge wave and append summaries to `[Unreleased]`. Consider a CI check that fails if `[Unreleased]` is empty and commits have landed since the last release tag.
+
+---
+
+## 2026-03-16 — async migration / PR #1555
+
+**Category**: test-debt
+**Who**: Builder working on async runtime migration (PR #1555)
+**What**: After migrating `LspServer` methods from `&mut self` to `&self`, approximately 150 test call sites still passed `&mut LspServer`. These generate clippy warnings (not errors) and do not break tests but create noise in CI output and mislead contributors about the actual signature.
+**Files**: ~26 test files in `crates/perl-lsp/tests/`
+**Suggested fix**: A single-pass `sed` or automated refactor across the test directory. Tracked as Task #6 (Async test helper cleanup). See ADR-0031 for context.
+
+---
+
+## 2026-03-16 — async migration / PR #1555
+
+**Category**: architecture
+**Who**: Reviewer of PR #1555
+**What**: `unsafe impl Send for LspServer` and `unsafe impl Sync for LspServer` are required because `ParentMap` holds raw pointers into AST nodes. The compiler cannot verify safety. The safety invariant (pointers are only accessed while `Arc<Mutex>` lock is held; pointed-to AST is not dropped while pointers live) is documented in the code but not in any ADR or architecture doc. Future contributors modifying `LspServer` field layout may not discover this constraint.
+**Files**: `crates/perl-lsp/src/server.rs` (approximately)
+**Suggested fix**: ADR-0031 now documents this. Long-term: replace raw pointers with index-based references in `ParentMap` to eliminate the unsafe entirely.
+
+---
+
+## Template
+
+```
+## YYYY-MM-DD — <agent or developer> / <branch or context>
+
+**Category**: docs | test-debt | devex | build | architecture | security
+**Who**: <who encountered it>
+**What**: <what happened — be specific enough that someone else can reproduce>
+**Files**: <relevant paths with line numbers if known>
+**Suggested fix**: <actionable recommendation>
+```


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — fills the empty `[Unreleased]` section with Added/Fixed/Changed entries covering PRs #1521–#1555 (async runtime migration, swarm infrastructure, parser fixes, new LSP features including selection range, navigation, diagnostics, semantic tokens, DAP improvements)
- **README.md** — removes duplicate `## Parser Coverage` section (merged v3 description + corpus test suite detail + commands into one); removes trailing duplicate `## History` section
- **docs/project/FRICTION_LOG.md** — creates the friction log (did not exist) with initial entries: README duplicate detection, changelog gap after merge waves, and async migration test signature debt

## Agent

improver-docs

## Verification

- No code changes, docs only
- README structure verified with `grep -n "^## " README.md` — no duplicate headings remain