### PR TITLE
docs(vscode): fix wrong crate references in INTERNAL_DEPLOYMENT.md

### DIFF
--- a/vscode-extension/INTERNAL_DEPLOYMENT.md
+++ b/vscode-extension/INTERNAL_DEPLOYMENT.md
@@ -19,13 +19,13 @@ The simplest approach for internal deployment.
 1. **Install perl-lsp binary** on each developer machine:
    ```bash
    # Build from source
-   cargo build -p perl-parser --bin perl-lsp --release
-   
+   cargo build -p perl-lsp --release
+
    # Copy to standard location
    sudo cp target/release/perl-lsp /usr/local/bin/
-   
+
    # Or install via Cargo
-   cargo install --path crates/perl-parser --bin perl-lsp
+   cargo install --path crates/perl-lsp
    ```
 
 2. **Configure VS Code** workspace settings (`.vscode/settings.json`):
@@ -115,13 +115,13 @@ Package the binary directly with the extension.
 1. **Build binaries** for target platforms:
    ```bash
    # Linux
-   cargo build -p perl-parser --bin perl-lsp --release --target x86_64-unknown-linux-gnu
-   
-   # macOS  
-   cargo build -p perl-parser --bin perl-lsp --release --target x86_64-apple-darwin
-   
+   cargo build -p perl-lsp --release --target x86_64-unknown-linux-gnu
+
+   # macOS
+   cargo build -p perl-lsp --release --target x86_64-apple-darwin
+
    # Windows
-   cargo build -p perl-parser --bin perl-lsp --release --target x86_64-pc-windows-msvc
+   cargo build -p perl-lsp --release --target x86_64-pc-windows-msvc
    ```
 
 2. **Create binary directory structure**:
@@ -187,15 +187,15 @@ Copy the provided `.vscode/settings.json` to your project root and customize:
 ### Build Commands
 ```bash
 # Quick build for testing
-cargo build -p perl-parser --bin perl-lsp
+cargo build -p perl-lsp
 
 # Optimized release build
-cargo build -p perl-parser --bin perl-lsp --release
+cargo build -p perl-lsp --release
 
 # Cross-platform builds (with targets installed)
-cargo build -p perl-parser --bin perl-lsp --release --target x86_64-unknown-linux-gnu
-cargo build -p perl-parser --bin perl-lsp --release --target x86_64-apple-darwin  
-cargo build -p perl-parser --bin perl-lsp --release --target x86_64-pc-windows-msvc
+cargo build -p perl-lsp --release --target x86_64-unknown-linux-gnu
+cargo build -p perl-lsp --release --target x86_64-apple-darwin
+cargo build -p perl-lsp --release --target x86_64-pc-windows-msvc
 
 # Install targets if needed
 rustup target add x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Fix 8 build/install commands that incorrectly reference `perl-parser` instead of `perl-lsp`
- The LSP binary lives in `crates/perl-lsp/`, not `crates/perl-parser/` (which has no binary)
- Affects all three build sections: quick build, release build, cross-platform builds

## Changes
- `vscode-extension/INTERNAL_DEPLOYMENT.md`: replace `cargo build -p perl-parser --bin perl-lsp` → `cargo build -p perl-lsp` in all locations

## Verification
- Doc-only change, no code affected
- `cargo build -p perl-lsp --release` is the correct command per CLAUDE.md

## Agent
reviewer on fix/internal-deployment-doc, handoff: .ops-perl-lsp/handoffs/fix-internal-deployment-doc.md