### PR TITLE
fix(diagnostics): suppress strict/warnings false positives for OO frameworks

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -16,12 +16,27 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     let mut has_strict = false;
     let mut has_warnings = false;
 
+    // OO frameworks that implicitly provide strict+warnings
+    const IMPLICIT_STRICT_MODULES: &[&str] = &[
+        "Moo",
+        "Moose",
+        "MooseX::StrictConstructor",
+        "Modern::Perl",
+        "Dancer2",
+        "Catalyst",
+        "Mojolicious",
+        "Mojo::Base",
+    ];
+
     // Check if 'use strict' and 'use warnings' are present
     walk_node(node, &mut |n| {
         if let NodeKind::Use { module, .. } = &n.kind {
             if module == "strict" {
                 has_strict = true;
             } else if module == "warnings" {
+                has_warnings = true;
+            } else if IMPLICIT_STRICT_MODULES.contains(&module.as_str()) {
+                has_strict = true;
                 has_warnings = true;
             }
         }

--- a/crates/perl-lsp-diagnostics/tests/unit_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unit_tests.rs
@@ -540,6 +540,70 @@ fn strict_warnings_related_info() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // =========================================================================
+// 8b. strict_warnings — implicit-strict framework suppression
+// =========================================================================
+
+#[test]
+fn strict_warnings_suppressed_for_moo() -> Result<(), Box<dyn std::error::Error>> {
+    let root = program(vec![use_node("Moo", 0, 8)]);
+    let mut diagnostics = Vec::new();
+    perl_lsp_diagnostics::strict_warnings::check_strict_warnings(&root, &mut diagnostics);
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-strict")),
+        "Moo provides implicit strict - should not fire missing-strict"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-warnings")),
+        "Moo provides implicit warnings - should not fire missing-warnings"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_warnings_suppressed_for_moose() -> Result<(), Box<dyn std::error::Error>> {
+    let root = program(vec![use_node("Moose", 0, 10)]);
+    let mut diagnostics = Vec::new();
+    perl_lsp_diagnostics::strict_warnings::check_strict_warnings(&root, &mut diagnostics);
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-strict")),
+        "Moose provides implicit strict - should not fire missing-strict"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-warnings")),
+        "Moose provides implicit warnings - should not fire missing-warnings"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_warnings_suppressed_for_modern_perl() -> Result<(), Box<dyn std::error::Error>> {
+    let root = program(vec![use_node("Modern::Perl", 0, 20)]);
+    let mut diagnostics = Vec::new();
+    perl_lsp_diagnostics::strict_warnings::check_strict_warnings(&root, &mut diagnostics);
+    assert!(
+        diagnostics.is_empty(),
+        "Modern::Perl replaces strict+warnings - should emit no missing-pragma diagnostics"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_warnings_suppressed_for_mojo_base() -> Result<(), Box<dyn std::error::Error>> {
+    let root = program(vec![use_node("Mojo::Base", 0, 15)]);
+    let mut diagnostics = Vec::new();
+    perl_lsp_diagnostics::strict_warnings::check_strict_warnings(&root, &mut diagnostics);
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-strict")),
+        "Mojo::Base provides implicit strict - should not fire missing-strict"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code.as_deref() != Some("missing-warnings")),
+        "Mojo::Base provides implicit warnings - should not fire missing-warnings"
+    );
+    Ok(())
+}
+
+// =========================================================================
 // 9. lints::common_mistakes — check_common_mistakes
 // =========================================================================
 
@@ -905,7 +969,7 @@ fn undeclared_variable_related_info_explains_strict() -> Result<(), Box<dyn std:
     // Directly test scope_issues_to_diagnostics with a synthetic undeclared variable issue
     use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeIssue};
 
-    let issue = ScopeIssue {
+    let _issue = ScopeIssue {
         kind: IssueKind::UndeclaredVariable,
         variable_name: "$foo".to_string(),
         line: 1,


### PR DESCRIPTION
## Summary
- `check_strict_warnings()` was firing `missing-strict` and `missing-warnings` diagnostics for files that use OO frameworks (Moo, Moose, Modern::Perl, etc.) which implicitly re-export `use strict` and `use warnings`
- Adds `IMPLICIT_STRICT_MODULES` detection: if any of these frameworks are `use`d, both `has_strict` and `has_warnings` are set to `true`
- Also fixes pre-existing unused variable clippy warning (`let issue` → `let _issue`)

## Changes
- `crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs` — adds `IMPLICIT_STRICT_MODULES` const and detection logic in `walk_node` closure
- `crates/perl-lsp-diagnostics/tests/unit_tests.rs` — 4 new tests (Moo, Moose, Modern::Perl, Mojo::Base); fixes pre-existing `_issue` clippy warning

## Verification
- `cargo fmt -p perl-lsp-diagnostics` — clean
- `cargo clippy -p perl-lsp-diagnostics --tests -- -D warnings` — clean
- `cargo test -p perl-lsp-diagnostics` — 58 tests pass (4 new: strict_warnings_suppressed_for_moo, moose, modern_perl, mojo_base)

## Agent
reviewer on fix/strict-warnings-module-false-positive, handoff: .ops-perl-lsp/handoffs/fix-strict-warnings-module-false-positive.md