### PR TITLE
fix(lsp): remove unused mut from test server declarations

### DIFF
--- a/crates/perl-lsp/tests/lsp_batteries_e2e_workflow_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_e2e_workflow_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 
 #[test]
 fn test_complete_workflow_from_messy_to_clean() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Step 1: Initialize the LSP server
     let init_req = JsonRpcRequest {
@@ -170,7 +170,7 @@ print encode_json({result => $result});
 
 #[test]
 fn test_batteries_included_features_summary() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_batteries_included_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_included_test.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 /// Test that formatting is properly advertised in server capabilities
 #[test]
 fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -54,7 +54,7 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
 /// Test that code actions include organize imports
 #[test]
 fn test_organize_imports_code_action_available() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize server
     let init_req = JsonRpcRequest {
@@ -136,7 +136,7 @@ print Dumper($data);
 /// Test that execute commands include perlcritic integration
 #[test]
 fn test_perlcritic_execute_command_available() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -177,7 +177,7 @@ fn test_perlcritic_execute_command_available() -> Result<(), Box<dyn std::error:
 /// Test that basic diagnostics work without external tools
 #[test]
 fn test_builtin_diagnostics_work() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize
     let init_req = JsonRpcRequest {
@@ -255,7 +255,7 @@ fn test_default_configuration_sensible() -> Result<(), Box<dyn std::error::Error
 /// Test that the server provides helpful capabilities information
 #[test]
 fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -296,7 +296,7 @@ fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>>
 /// Test that formatting gracefully handles missing perltidy
 #[test]
 fn test_formatting_graceful_degradation() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize
     let init_req = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_builtins_test.rs
+++ b/crates/perl-lsp/tests/lsp_builtins_test.rs
@@ -9,7 +9,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 /// Helper to create and initialize a test server
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Send initialize request
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_capabilities_contract.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_contract.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 /// PHASE 1 RE-ENABLED: Pure API contract test, no I/O, safe for CI
 #[test]
 fn test_ga_capabilities_contract() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Send initialize request through public API
     let request = JsonRpcRequest {
@@ -121,7 +121,7 @@ fn test_ga_capabilities_contract() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 
 fn test_unsupported_methods_return_error() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize first through public API
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_capabilities_contract_full.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_contract_full.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 #[test]
 #[cfg(not(feature = "lsp-ga-lock"))]
 fn full_capabilities_match_contract() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_capabilities_contract_lock.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_contract_lock.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 
 #[test]
 fn locked_capabilities_are_conservative() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_code_lens_reference_test.rs
+++ b/crates/perl-lsp/tests/lsp_code_lens_reference_test.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -37,7 +37,7 @@ fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
 
 #[test]
 fn test_code_lens_reference_counting() -> TestResult {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
 
     // Open a document with a subroutine that's called multiple times
     let code = r#"
@@ -165,7 +165,7 @@ sub unused_function {
 
 #[test]
 fn test_code_lens_package_references() -> TestResult {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
 
     // Open a document with a package that's used
     let code = r#"

--- a/crates/perl-lsp/tests/lsp_cross_file_nav.rs
+++ b/crates/perl-lsp/tests/lsp_cross_file_nav.rs
@@ -2,7 +2,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::json;
 
 fn init_server() -> LspServer {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs
+++ b/crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs
@@ -11,7 +11,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 /// Test that documentLink/resolve returns target for deferred module links
 #[test]
 fn test_document_link_resolve_module() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -76,7 +76,7 @@ fn test_document_link_resolve_module() -> TestResult {
 /// Test that documentLink/resolve handles file path links
 #[test]
 fn test_document_link_resolve_file() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -139,7 +139,7 @@ fn test_document_link_resolve_file() -> TestResult {
 /// Test that already-resolved links pass through unchanged
 #[test]
 fn test_document_link_resolve_already_resolved() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -193,7 +193,7 @@ fn test_document_link_resolve_already_resolved() -> TestResult {
 /// Test error handling for invalid link data
 #[test]
 fn test_document_link_resolve_invalid_data() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -247,7 +247,7 @@ fn test_document_link_resolve_invalid_data() -> TestResult {
 /// Test error handling for missing parameters
 #[test]
 fn test_document_link_resolve_missing_params() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -290,7 +290,7 @@ fn test_document_link_resolve_missing_params() -> TestResult {
 /// Test that data field is preserved in resolved link
 #[test]
 fn test_document_link_resolve_preserves_data() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -352,7 +352,7 @@ fn test_document_link_resolve_preserves_data() -> TestResult {
 /// Test URL type links (already resolved)
 #[test]
 fn test_document_link_resolve_url_type() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -408,7 +408,7 @@ fn test_document_link_resolve_url_type() -> TestResult {
 /// Integration test: documentLink returns deferred links, resolve fills them in
 #[test]
 fn test_document_link_integration() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({

--- a/crates/perl-lsp/tests/lsp_document_symbols_test.rs
+++ b/crates/perl-lsp/tests/lsp_document_symbols_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_edge_cases_test.rs
+++ b/crates/perl-lsp/tests/lsp_edge_cases_test.rs
@@ -6,7 +6,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::{Value, json};
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_error_suggestions_test.rs
+++ b/crates/perl-lsp/tests/lsp_error_suggestions_test.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 
 /// Helper function to initialize LSP server
 fn init_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -34,7 +34,7 @@ fn init_server() -> Result<LspServer, Box<dyn std::error::Error>> {
 
 /// Helper to open document and get diagnostics
 fn get_diagnostics_for_code(code: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let mut server = init_server()?;
+    let server = init_server()?;
     let uri = "file:///test.pl";
 
     let did_open_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp/tests/lsp_execute_command_tests.rs
@@ -5,7 +5,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn setup_server(root_path: Option<String>) -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -37,7 +37,7 @@ fn setup_server(root_path: Option<String>) -> LspServer {
 fn test_execute_command_run_file() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root_path = temp_dir.path().to_string_lossy().to_string();
-    let mut server = setup_server(Some(root_path.clone()));
+    let server = setup_server(Some(root_path.clone()));
 
     // Create a test file
     let test_content = r#"#!/usr/bin/perl
@@ -97,7 +97,7 @@ print "Hello, World!\n";
 fn test_execute_command_run_tests() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root_path = temp_dir.path().to_string_lossy().to_string();
-    let mut server = setup_server(Some(root_path.clone()));
+    let server = setup_server(Some(root_path.clone()));
 
     // Create a test file with Test::More
     let test_content = r#"#!/usr/bin/perl
@@ -167,7 +167,7 @@ is(1 + 1, 2, "Math works");
 
 #[test]
 fn test_execute_command_unknown() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server(None);
+    let server = setup_server(None);
 
     // Try an unknown command
     let execute_request = JsonRpcRequest {
@@ -192,7 +192,7 @@ fn test_execute_command_unknown() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_execute_command_capabilities() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize and check capabilities
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_feature_coverage_audit.rs
+++ b/crates/perl-lsp/tests/lsp_feature_coverage_audit.rs
@@ -21,7 +21,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 // ---------------------------------------------------------------------------
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_folding_ranges_test.rs
+++ b/crates/perl-lsp/tests/lsp_folding_ranges_test.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 /// Test that inlayHint/resolve adds tooltip when requested
 #[test]
 fn lsp_inlay_hint_resolve_adds_tooltip() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -69,7 +69,7 @@ fn lsp_inlay_hint_resolve_adds_tooltip() -> Result<(), Box<dyn std::error::Error
 /// Test that resolve preserves data field
 #[test]
 fn lsp_inlay_hint_resolve_preserves_data() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -119,7 +119,7 @@ fn lsp_inlay_hint_resolve_preserves_data() -> Result<(), Box<dyn std::error::Err
 /// Test that resolve returns same hint if already has tooltip
 #[test]
 fn lsp_inlay_hint_resolve_no_op_when_complete() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -167,7 +167,7 @@ fn lsp_inlay_hint_resolve_no_op_when_complete() -> Result<(), Box<dyn std::error
 /// Test that resolve handles missing params gracefully
 #[test]
 fn lsp_inlay_hint_resolve_handles_invalid_params() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_inlay_hints.rs
+++ b/crates/perl-lsp/tests/lsp_inlay_hints.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn inlay_hints_for_substr_and_types() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
@@ -4,7 +4,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::json;
 
 fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_lifecycle_events_test.rs
+++ b/crates/perl-lsp/tests/lsp_lifecycle_events_test.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 /// Helper to set up an initialized LSP server with a document
 fn setup_server_with_document() -> (LspServer, String) {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // 1. Send initialize request with JsonRpcRequest
     let init_request = JsonRpcRequest {
@@ -58,7 +58,7 @@ fn get_result(response: Option<JsonRpcResponse>) -> Option<Value> {
 
 #[test]
 fn test_did_save_notification() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification
     let request = JsonRpcRequest {
@@ -80,7 +80,7 @@ fn test_did_save_notification() {
 
 #[test]
 fn test_did_save_with_text() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification with text
     let request = JsonRpcRequest {
@@ -102,7 +102,7 @@ fn test_did_save_with_text() {
 
 #[test]
 fn test_will_save_notification() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send willSave notification - Manual save (reason = 1)
     let request = JsonRpcRequest {
@@ -152,7 +152,7 @@ fn test_will_save_notification() {
 
 #[test]
 fn test_will_save_wait_until_returns_valid_edits() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send willSaveWaitUntil request (this is a request, not notification)
     let request = JsonRpcRequest {
@@ -194,7 +194,7 @@ fn test_will_save_wait_until_returns_valid_edits() -> Result<(), Box<dyn std::er
 
 #[test]
 fn test_will_save_wait_until_with_formatting() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Update document with poorly formatted code
     let change_notification = JsonRpcRequest {
@@ -253,7 +253,7 @@ fn test_will_save_wait_until_with_formatting() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn test_did_close_after_save() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification
     let save_notification = JsonRpcRequest {
@@ -287,7 +287,7 @@ fn test_did_close_after_save() {
 
 #[test]
 fn test_save_events_sequence() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Simulate typical save sequence: willSave -> willSaveWaitUntil -> didSave
 
@@ -335,7 +335,7 @@ fn test_save_events_sequence() {
 
 #[test]
 fn test_save_with_invalid_uri() {
-    let (mut server, _uri) = setup_server_with_document();
+    let (server, _uri) = setup_server_with_document();
 
     // Try to save a document that was never opened
     let request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_links_and_selection.rs
+++ b/crates/perl-lsp/tests/lsp_links_and_selection.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 #[test]
 fn document_links_and_selection() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_master_integration_test.rs
+++ b/crates/perl-lsp/tests/lsp_master_integration_test.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 #[test]
 fn test_complete_lsp_integration() {
     // Initialize server
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Step 1: Initialize
     let init_request = JsonRpcRequest {
@@ -200,7 +200,7 @@ fn test_all_test_suites_pass() {
 fn test_complete_workflow_performance() {
     use std::time::Instant;
 
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_multi_error_diagnostics_test.rs
+++ b/crates/perl-lsp/tests/lsp_multi_error_diagnostics_test.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 #[test]
 fn test_451_lsp_reports_multiple_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - Integration test for multiple error collection
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server with diagnostic support
     let init_request = JsonRpcRequest {
@@ -114,7 +114,7 @@ my $c = ;       # Error 3: missing expression
 #[test]
 fn test_451_lsp_reports_errors_in_nested_blocks() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - Nested block error collection
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -198,7 +198,7 @@ while (1) {
 #[test]
 fn test_451_lsp_respects_error_limit() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - AC5: Error limit enforcement
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),

--- a/crates/perl-lsp/tests/lsp_on_type_formatting.rs
+++ b/crates/perl-lsp/tests/lsp_on_type_formatting.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn on_type_braces_indent() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -69,7 +69,7 @@ fn on_type_braces_indent() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 
 fn on_type_closing_brace_dedent() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_perltidy_test.rs
+++ b/crates/perl-lsp/tests/lsp_perltidy_test.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 #[cfg(feature = "lsp-extras")]
 #[test]
 fn test_pragma_code_actions() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize server
     let init_req = JsonRpcRequest {
@@ -86,7 +86,7 @@ fn test_pragma_code_actions() -> Result<(), Box<dyn std::error::Error>> {
 fn test_formatting_provider_capability() -> Result<(), Box<dyn std::error::Error>> {
     let has_perltidy = perl_lsp::execute_command::command_exists("perltidy");
 
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_protocol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_protocol_tests.rs
@@ -77,7 +77,7 @@ fn test_diagnostics_clear_protocol_framing() -> Result<(), Box<dyn std::error::E
     let writer = CapturingWriter::new(buffer.clone());
     let output: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(Box::new(writer)));
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Helper to send requests/notifications
     let mut send = |method: &str, id: Option<Value>, params: Value| {

--- a/crates/perl-lsp/tests/lsp_pull_diagnostics_test.rs
+++ b/crates/perl-lsp/tests/lsp_pull_diagnostics_test.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 /// Test Pull Diagnostics support (LSP 3.17)
 #[test]
 fn test_document_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -84,7 +84,7 @@ print $y;  # Undefined variable
 
 #[test]
 fn test_document_diagnostic_unchanged() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -168,7 +168,7 @@ print "Hello, World!\n";
 
 #[test]
 fn test_workspace_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -265,7 +265,7 @@ print "OK\n";
 
 #[test]
 fn test_diagnostic_provider_capability() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -295,7 +295,7 @@ fn test_diagnostic_provider_capability() -> Result<(), Box<dyn std::error::Error
 
 #[test]
 fn test_workspace_diagnostic_with_previous_ids() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_semantic_tokens.rs
+++ b/crates/perl-lsp/tests/lsp_semantic_tokens.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn semantic_tokens_emit_data() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_testability_generic_io.rs
+++ b/crates/perl-lsp/tests/lsp_testability_generic_io.rs
@@ -215,7 +215,7 @@ fn lsp_testability_message_handling_integration() {
     let input = Cursor::new(init_msg);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Attempt to handle the message
     let mut input = std::io::BufReader::new(input);
@@ -235,7 +235,7 @@ fn lsp_protocol_edge_case_malformed_message() {
     let input = Cursor::new(malformed);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Server should handle the malformed message gracefully
     let mut input = std::io::BufReader::new(input);
@@ -254,7 +254,7 @@ fn lsp_protocol_edge_case_missing_header() {
     let input = Cursor::new(invalid_msg);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Server should handle missing header gracefully
     let mut input = std::io::BufReader::new(input);
@@ -294,7 +294,7 @@ fn lsp_protocol_edge_case_rapid_messages() {
     let input = Cursor::new(messages);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Process all messages
     let mut input = std::io::BufReader::new(input);

--- a/crates/perl-lsp/tests/lsp_type_hierarchy_test.rs
+++ b/crates/perl-lsp/tests/lsp_type_hierarchy_test.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 #[test]
 
 fn test_type_hierarchy_prepare() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -91,7 +91,7 @@ sub new {
 #[test]
 
 fn test_type_hierarchy_supertypes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -199,7 +199,7 @@ package Parent2;
 #[test]
 
 fn test_type_hierarchy_subtypes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -308,7 +308,7 @@ our @ISA = ('Base');
 #[test]
 
 fn test_type_hierarchy_capability_advertised() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -339,7 +339,7 @@ fn test_type_hierarchy_capability_advertised() -> Result<(), Box<dyn std::error:
 #[test]
 
 fn test_type_hierarchy_with_namespace_packages() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_window_tests.rs
+++ b/crates/perl-lsp/tests/lsp_window_tests.rs
@@ -67,7 +67,7 @@ impl Clone for OutputCapture {
 fn lsp_window_show_message_request_format() -> Result<(), Box<dyn std::error::Error>> {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize server to enable capabilities
     let init_params = json!({
@@ -140,7 +140,7 @@ fn lsp_window_show_document_requires_capability() -> Result<(), Box<dyn std::err
 fn lsp_window_show_document_with_capability() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with showDocument capability
     let init_params = json!({
@@ -189,7 +189,7 @@ fn lsp_window_show_document_with_capability() {
 fn lsp_window_progress_lifecycle() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -262,7 +262,7 @@ fn lsp_window_progress_lifecycle() {
 fn lsp_window_progress_duplicate_token_fails() -> Result<(), Box<dyn std::error::Error>> {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -298,7 +298,7 @@ fn lsp_window_progress_duplicate_token_fails() -> Result<(), Box<dyn std::error:
 fn lsp_window_progress_cancel_handler() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -345,7 +345,7 @@ fn lsp_window_progress_cancel_handler() {
 fn lsp_window_telemetry_respects_config() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize server first
     let _ = server.handle_request(perl_lsp::JsonRpcRequest {
@@ -453,7 +453,7 @@ fn lsp_window_progress_without_capability() -> Result<(), Box<dyn std::error::Er
 fn lsp_window_show_document_external_flag() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with showDocument capability
     let init_params = json!({

--- a/crates/perl-lsp/tests/lsp_workspace_index_e2e.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_index_e2e.rs
@@ -104,7 +104,7 @@ sub new_name {
 /// Test LSP workspace/symbol request with index
 #[test]
 fn test_lsp_workspace_symbols_with_index() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -198,7 +198,7 @@ fn test_lsp_workspace_symbols_with_index() -> Result<(), Box<dyn std::error::Err
 /// Test cross-file go-to-definition
 #[test]
 fn test_cross_file_definition() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_workspace_symbol_resolve_test.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_symbol_resolve_test.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 /// Helper to properly initialize a server with the required initialized notification
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize request
     let init_request = JsonRpcRequest {
@@ -33,7 +33,7 @@ fn setup_server() -> LspServer {
 /// Test Workspace Symbol Resolve support (LSP 3.17)
 #[test]
 fn test_workspace_symbol_resolve() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Open a document with symbols
     let uri = "file:///test.pl";
@@ -103,7 +103,7 @@ our $VERSION = '1.0';
 
 #[test]
 fn test_workspace_symbol_resolve_with_container() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Open a document with nested symbols
     let uri = "file:///test.pl";
@@ -176,7 +176,7 @@ sub another_method {
 
 #[test]
 fn test_workspace_symbol_resolve_capability() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -205,7 +205,7 @@ fn test_workspace_symbol_resolve_capability() -> Result<(), Box<dyn std::error::
 
 #[test]
 fn test_workspace_symbol_resolve_unknown_symbol() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Try to resolve a symbol without opening the document
     let unknown_symbol = json!({

--- a/crates/perl-lsp/tests/server_cancellation_test.rs
+++ b/crates/perl-lsp/tests/server_cancellation_test.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 #[test]
 fn server_side_cancellation_emits_err_server_cancelled() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let _ = server.handle_request(serde_json::from_value::<JsonRpcRequest>(json!({

--- a/crates/perl-lsp/tests/support/lsp_harness.rs
+++ b/crates/perl-lsp/tests/support/lsp_harness.rs
@@ -91,7 +91,7 @@ impl LspHarness {
 
         let (tx, rx) = mpsc::channel::<Vec<u8>>();
         let handle = thread::spawn(move || {
-            let mut server = server;
+            let server = server;
             while let Ok(msg) = rx.recv() {
                 if msg.is_empty() {
                     break;


### PR DESCRIPTION
## Summary
- Remove `mut` from `let mut server`/`let mut srv` in LSP test files
- LspServer methods no longer require `&mut self` after async migration (#1555)
- Retain `mut` where bindings are genuinely used with `&mut server` (process-based helpers, TestServer methods)

## Agent
direct-builder (async cleanup batch)

## Verification
- cargo clippy -p perl-lsp --tests — zero unused_mut warnings for server/srv variables (one pre-existing closure warning in lsp_protocol_tests.rs:83 unrelated to this change)
- cargo test -p perl-lsp — all tests pass except one pre-existing failure in lsp_cancellation_protocol_tests (unimplemented enhanced cancellation feature)
- No E0596 mutability errors introduced