### PR TITLE
fix(perl-parser-core): allow undef as placeholder in my list destructuring

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -13,7 +13,17 @@ impl<'a> Parser<'a> {
 
             // Parse comma-separated list of variables with their individual attributes
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                let var = self.parse_variable()?;
+                // `undef` is valid as a placeholder in list destructuring:
+                //   my ($self, undef, $src) = @_;
+                let var = if self.peek_kind() == Some(TokenKind::Undef) {
+                    let undef_token = self.consume_token()?;
+                    Node::new(
+                        NodeKind::Undef,
+                        SourceLocation { start: undef_token.start, end: undef_token.end },
+                    )
+                } else {
+                    self.parse_variable()?
+                };
 
                 // Parse optional attributes for this specific variable
                 let mut var_attributes = Vec::new();

--- a/crates/perl-parser-core/tests/cpan_pattern_tests.rs
+++ b/crates/perl-parser-core/tests/cpan_pattern_tests.rs
@@ -1640,3 +1640,55 @@ if ($start) { init(); run(); }
         assert_clean_parse(code);
     }
 }
+
+mod undef_in_list_assignment {
+    use super::*;
+
+    #[test]
+    fn undef_middle_of_my_list() {
+        let code = "my ($a, undef, $b) = @_;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn undef_first_in_my_list() {
+        let code = "my (undef, $x, $y) = @_;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn undef_last_in_my_list() {
+        let code = "my ($a, $b, undef) = @_;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn multiple_undef_in_my_list() {
+        let code = "my ($a, undef, undef, $b) = @_;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn undef_in_method_signature() {
+        let code = r#"
+sub cat_decode {
+    my ( $obj, undef, $src, $pos ) = @_;
+    return $src;
+}
+"#;
+        assert_clean_parse(code);
+    }
+
+    /// Full OO pattern from Encode::CN::HZ — the original failing file.
+    #[test]
+    fn encode_module_pattern() {
+        let code = r#"
+sub cat_decode {
+    my ( $obj, undef, $src, $pos, $trm, $chk ) = @_;
+    my ( $rdst, $rsrc, $rpos ) = \@_[ 1 .. 3 ];
+    return $rdst;
+}
+"#;
+        assert_clean_parse(code);
+    }
+}


### PR DESCRIPTION
## Summary

- `my ($a, undef, $b) = @_` is valid Perl for discarding positional arguments in list destructuring
- The list parser in `parse_variable_declaration()` unconditionally called `parse_variable()`, which expected a sigil and rejected `undef`
- Added `TokenKind::Undef` check before `parse_variable()` so `undef` elements create `NodeKind::Undef` placeholder nodes

## Test plan

- [ ] 6 new tests in `undef_in_list_assignment` module: undef in middle/first/last position, multiple undefs, method signature pattern, full Encode::CN::HZ pattern
- [ ] 300 existing tests pass (1 pre-existing failure unrelated to this change)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy -p perl-parser-core -- -D warnings` clean

## Impact

~164 CPAN files affected (expected_variable error bucket). Heavy use in Encode:: modules and OO code discarding invocant/position args.