### PR TITLE
fix(perl-parser-core): extend parse_postfix dispatch to scalar/ref/defined

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -181,13 +181,17 @@ impl<'a> Parser<'a> {
         // We're consuming the function name, no longer at statement start
         self.mark_not_stmt_start();
 
-        // `delete` and `exists` take a full postfix expression as their argument
-        // so that arrow-dereference chains are included:
-        //   delete $self->{key}   — $self->{key} is one postfix expr
-        //   exists $ref->[0]      — $ref->[0] is one postfix expr
+        // Some builtins take a full postfix expression as their argument so that
+        // arrow-dereference chains are included in the operand:
+        //   delete $self->{key}    — $self->{key} is one postfix expr
+        //   exists $ref->[0]       — $ref->[0] is one postfix expr
+        //   scalar $dh->read       — $dh->read is one postfix expr
         // Other indirect-call builtins (print, say, etc.) only consume
         // the object/filehandle here; remaining args are parsed in the loop below.
-        let object = if method == "delete" || method == "exists" {
+        let object = if matches!(
+            method.as_str(),
+            "delete" | "exists" | "scalar" | "ref" | "defined"
+        ) {
             self.parse_postfix()?
         } else {
             self.parse_primary()?

--- a/crates/perl-parser-core/tests/cpan_misc_idioms.rs
+++ b/crates/perl-parser-core/tests/cpan_misc_idioms.rs
@@ -262,3 +262,56 @@ fn print_block_with_multiple_args() {
     let code = r#"print { $fh } "key=", $value, "\n";"#;
     assert_clean_parse(code);
 }
+
+mod scalar_builtin_arrow_method {
+    use super::*;
+
+    /// scalar $dh->read — builtin followed by arrow-method call chain
+    #[test]
+    fn scalar_arrow_method() {
+        let code = "my $n = scalar $dh->read;";
+        assert_clean_parse(code);
+    }
+
+    /// ref $obj->method — ref followed by arrow call
+    #[test]
+    fn ref_arrow_method() {
+        let code = r#"if (ref $obj->type eq "ARRAY") { 1; }"#;
+        assert_clean_parse(code);
+    }
+
+    /// defined $self->{key} — defined with hash deref
+    #[test]
+    fn defined_hash_deref() {
+        let code = "return unless defined $self->{value};";
+        assert_clean_parse(code);
+    }
+
+    /// defined $ref->[0] — defined with array deref
+    #[test]
+    fn defined_array_deref() {
+        let code = "my $ok = defined $ref->[0];";
+        assert_clean_parse(code);
+    }
+
+    /// scalar @{$ref} context — indirect scalar on array deref
+    #[test]
+    fn scalar_deref_array() {
+        let code = "my $count = scalar @{$aref};";
+        assert_clean_parse(code);
+    }
+
+    /// Chained arrow on defined — common OO check
+    #[test]
+    fn defined_arrow_chain() {
+        let code = "if (defined $self->{config}->{key}) { do_thing(); }";
+        assert_clean_parse(code);
+    }
+
+    /// scalar in boolean context with arrow method
+    #[test]
+    fn scalar_arrow_method_bool() {
+        let code = "if (scalar $dh->read) { process(); }";
+        assert_clean_parse(code);
+    }
+}


### PR DESCRIPTION
## Summary

- `scalar $dh->read`, `ref $obj->type`, `defined $self->{key}` all failed to parse because `parse_indirect_call()` used `parse_primary()` for the operand, stopping before `->` chains
- Extended the existing `parse_postfix()` dispatch (previously only for `delete`/`exists`) to also cover `scalar`, `ref`, and `defined`
- The operand now includes the full arrow-dereference chain as intended

## Test plan

- [ ] 7 new tests in `scalar_builtin_arrow_method` module: `scalar->method`, `ref->method`, `defined` with hash/array/chained derefs
- [ ] 300 existing tests pass (1 pre-existing failure unrelated to this change)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy -p perl-parser-core -- -D warnings` clean

## Impact

~230 CPAN files affected (unexpected_arrow_expr error bucket).