### PR TITLE
fix(perl-lexer): disambiguate $$var scalar deref from $$ PID variable

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1602,10 +1602,17 @@ impl<'a> PerlLexer<'a> {
                                 | '-'
                                 | '['
                                 | ']'
-                                | '$'
                         )
                     {
                         self.advance(); // consume the special character
+                    }
+                    // $$ is the PID special variable, but only when it is not immediately
+                    // followed by an identifier-start character. $$var is scalar dereference
+                    // of $var, so keep the second $ for the next token.
+                    else if sigil == '$' && ch == '$' {
+                        if !self.peek_char(1).is_some_and(is_perl_identifier_start) {
+                            self.advance(); // consume the second $ for bare $$ PID
+                        }
                     }
                     // Handle special array/hash punctuation variables
                     else if (sigil == '@' || sigil == '%') && matches!(ch, '+' | '-') {

--- a/crates/perl-parser-core/tests/cpan_misc_idioms.rs
+++ b/crates/perl-parser-core/tests/cpan_misc_idioms.rs
@@ -315,3 +315,46 @@ mod scalar_builtin_arrow_method {
         assert_clean_parse(code);
     }
 }
+
+mod dollar_dollar_scalar_deref {
+    use super::*;
+
+    fn sexp(source: &str) -> String {
+        parse(source).to_sexp()
+    }
+
+    #[test]
+    fn scalar_deref_keeps_referenced_variable_name() {
+        let sexp = sexp("my $x = $$sv;");
+        assert!(
+            sexp.contains("(variable $ $sv)"),
+            "expected $$sv to survive as a scalar-deref target token, got: {sexp}"
+        );
+        assert!(
+            !sexp.contains("(my_declaration (variable $ x)(variable $ $))"),
+            "expected $$sv not to collapse to the bare $$ PID variable, got: {sexp}"
+        );
+    }
+
+    #[test]
+    fn bare_pid_special_variable_still_parses_as_pid() {
+        let sexp = sexp("my $pid = $$;");
+        assert!(
+            sexp.contains("(variable $ $)"),
+            "expected bare $$ to stay the PID special variable, got: {sexp}"
+        );
+    }
+
+    #[test]
+    fn b_terse_pattern_keeps_both_scalar_deref_uses() {
+        let sexp = sexp(
+            r#"
+my $s = sprintf("%s #%d %s", class($sv), $$sv, $specialsv_name[$$sv]);
+"#,
+        );
+        assert!(
+            sexp.matches("(variable $ $sv)").count() >= 2,
+            "expected both $$sv uses to survive as scalar-deref targets, got: {sexp}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Treat `$$` as the PID special variable only when it is not immediately followed by an identifier-start character
- Leave the second `$` for the next token when lexing `$$var`, so parser consumers see scalar dereference instead of bare PID plus an orphaned identifier
- Add parser-level regression tests that assert the resulting AST shape, not just a clean parse

## Test plan

- [x] `cargo fmt --all`
- [x] `env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/perl-lsp-pr1572-target cargo test -p perl-parser-core dollar_dollar_scalar_deref`
- [x] `env -u RUSTC_WRAPPER CARGO_TARGET_DIR=/tmp/perl-lsp-pr1572-target cargo test -p perl-lexer`