### PR TITLE
refactor(perl-lsp): migrate test harness to interior mutability (&mut LspServer → &LspServer)

### DIFF
--- a/crates/perl-lsp/tests/binary_version_test.rs
+++ b/crates/perl-lsp/tests/binary_version_test.rs
@@ -23,11 +23,11 @@ const EXPECTED_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[test]
 fn lsp_server_version_matches_crate_version() {
     // Start the server using the same resolution logic as other tests
-    let mut server = common::start_lsp_server();
+    let server = common::start_lsp_server();
 
     // Send initialize request
     let response = common::send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -73,7 +73,7 @@ fn lsp_server_version_matches_crate_version() {
     );
 
     // Clean shutdown
-    common::shutdown_and_exit(&mut server);
+    common::shutdown_and_exit(&server);
 
     eprintln!("✓ Server version {} matches expected {}", server_version, EXPECTED_VERSION);
 }
@@ -81,11 +81,11 @@ fn lsp_server_version_matches_crate_version() {
 #[test]
 fn lsp_server_identifier_is_perl_lsp() {
     // Start the server
-    let mut server = common::start_lsp_server();
+    let server = common::start_lsp_server();
 
     // Send initialize request
     let response = common::send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -112,5 +112,5 @@ fn lsp_server_identifier_is_perl_lsp() {
     );
 
     // Clean shutdown
-    common::shutdown_and_exit(&mut server);
+    common::shutdown_and_exit(&server);
 }

--- a/crates/perl-lsp/tests/common/mod.rs
+++ b/crates/perl-lsp/tests/common/mod.rs
@@ -76,29 +76,29 @@ pub fn completion_items(resp: &serde_json::Value) -> &Vec<serde_json::Value> {
 }
 
 pub struct LspServer {
-    pub process: Child,
-    writer: BufWriter<ChildStdin>, // keep stdin pinned and flushed
-    rx: Receiver<Value>,
+    pub process: Mutex<Child>,
+    writer: Mutex<BufWriter<ChildStdin>>, // keep stdin pinned and flushed
+    rx: Mutex<Receiver<Value>>,
     // Keep threads alive for the lifetime of the server
     _stdout_thread: std::thread::JoinHandle<()>,
     _stderr_thread: std::thread::JoinHandle<()>,
-    pending: VecDeque<Value>,
+    pending: Mutex<VecDeque<Value>>,
     /// Flag to track if shutdown has been initiated (prevents double-shutdown)
     shutdown_initiated: std::sync::atomic::AtomicBool,
 }
 
 impl LspServer {
     /// Check if the server process is still running
-    pub fn is_alive(&mut self) -> bool {
-        match self.process.try_wait() {
+    pub fn is_alive(&self) -> bool {
+        match self.process.lock().unwrap_or_else(|e| e.into_inner()).try_wait() {
             Ok(status) => status.is_none(),
             Err(_) => false, // If we can't check status, assume not alive
         }
     }
 
     /// Get mutable access to the stdin writer
-    pub fn stdin_writer(&mut self) -> &mut BufWriter<ChildStdin> {
-        &mut self.writer
+    pub fn stdin_writer(&self) -> std::sync::MutexGuard<'_, BufWriter<ChildStdin>> {
+        self.writer.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 
@@ -380,12 +380,12 @@ pub fn start_lsp_server() -> LspServer {
         };
 
     let server = LspServer {
-        process,
-        writer: BufWriter::new(stdin),
-        rx,
+        process: Mutex::new(process),
+        writer: Mutex::new(BufWriter::new(stdin)),
+        rx: Mutex::new(rx),
         _stdout_thread,
         _stderr_thread,
-        pending: VecDeque::new(),
+        pending: Mutex::new(VecDeque::new()),
         shutdown_initiated: std::sync::atomic::AtomicBool::new(false),
     };
 
@@ -395,7 +395,7 @@ pub fn start_lsp_server() -> LspServer {
     server
 }
 
-pub fn send_request(server: &mut LspServer, mut request: Value) -> Value {
+pub fn send_request(server: &LspServer, mut request: Value) -> Value {
     // IMPORTANT: Extract/assign ID FIRST, before any early returns.
     // This ensures error responses can include the proper request ID.
     let id = match request.get("id") {
@@ -408,7 +408,9 @@ pub fn send_request(server: &mut LspServer, mut request: Value) -> Value {
     };
 
     let body = request.to_string();
-    if let Err(e) = send_message_inner(&mut server.writer, &body) {
+    if let Err(e) =
+        send_message_inner(&mut *server.writer.lock().unwrap_or_else(|e| e.into_inner()), &body)
+    {
         // Handle write errors gracefully with proper JSON-RPC envelope
         // BrokenPipe during teardown is expected; other errors are transport failures
         return map_send_error(Some(id), e, "send_request");
@@ -454,10 +456,11 @@ fn map_send_error(id: Option<Value>, e: io::Error, context: &str) -> Value {
     }
 }
 
-pub fn send_notification(server: &mut LspServer, notification: Value) {
+pub fn send_notification(server: &LspServer, notification: Value) {
     let body = notification.to_string();
     // Ignore write errors during notification sends - BrokenPipe during teardown is expected
-    let _ = send_message_inner(&mut server.writer, &body);
+    let _ =
+        send_message_inner(&mut *server.writer.lock().unwrap_or_else(|e| e.into_inner()), &body);
 }
 
 fn default_timeout() -> Duration {
@@ -584,20 +587,20 @@ fn internal_transport_error(msg: &str) -> Value {
 }
 
 /// Blocking receive with a sane default timeout to avoid hangs.
-pub fn read_response(server: &mut LspServer) -> Value {
+pub fn read_response(server: &LspServer) -> Value {
     read_response_timeout(server, default_timeout()).unwrap_or_else(
         || json!({"error":{"code":ERR_TEST_TIMEOUT,"message":"test harness timeout"}}),
     )
 }
 
 /// Try to receive a response within `dur`. Returns None on timeout.
-pub fn read_response_timeout(server: &mut LspServer, dur: Duration) -> Option<Value> {
-    server.rx.recv_timeout(dur).ok()
+pub fn read_response_timeout(server: &LspServer, dur: Duration) -> Option<Value> {
+    server.rx.lock().unwrap_or_else(|e| e.into_inner()).recv_timeout(dur).ok()
 }
 
 /// Try to receive a notification (message without id) within `dur`. Returns None on timeout or if a response is received.
-pub fn read_notification_timeout(server: &mut LspServer, dur: Duration) -> Option<Value> {
-    match server.rx.recv_timeout(dur) {
+pub fn read_notification_timeout(server: &LspServer, dur: Duration) -> Option<Value> {
+    match server.rx.lock().unwrap_or_else(|e| e.into_inner()).recv_timeout(dur) {
         Ok(val) if val.get("id").is_none() => Some(val),
         Ok(_) => None,  // Got a response, not a notification
         Err(_) => None, // Timeout or disconnected
@@ -605,17 +608,21 @@ pub fn read_notification_timeout(server: &mut LspServer, dur: Duration) -> Optio
 }
 
 /// Receive the response matching `id` (number or string), buffering other traffic.
-pub fn read_response_matching(server: &mut LspServer, id: &Value, dur: Duration) -> Option<Value> {
+pub fn read_response_matching(server: &LspServer, id: &Value, dur: Duration) -> Option<Value> {
     // scan buffered
-    for _ in 0..server.pending.len() {
-        if let Some(msg) = server.pending.pop_front() {
-            if msg.get("id") == Some(id) {
-                return Some(msg);
+    {
+        let mut pending = server.pending.lock().unwrap_or_else(|e| e.into_inner());
+        let len = pending.len();
+        for _ in 0..len {
+            if let Some(msg) = pending.pop_front() {
+                if msg.get("id") == Some(id) {
+                    return Some(msg);
+                }
+                if pending.len() >= PENDING_CAP {
+                    pending.pop_front();
+                }
+                pending.push_back(msg);
             }
-            if server.pending.len() >= PENDING_CAP {
-                server.pending.pop_front();
-            }
-            server.pending.push_back(msg);
         }
     }
     // then poll
@@ -625,15 +632,20 @@ pub fn read_response_matching(server: &mut LspServer, id: &Value, dur: Duration)
         if now >= deadline {
             return None;
         }
-        match server.rx.recv_timeout(deadline - now) {
+        let recv_result = {
+            let rx = server.rx.lock().unwrap_or_else(|e| e.into_inner());
+            rx.recv_timeout(deadline - now)
+        };
+        match recv_result {
             Ok(msg) => {
                 if msg.get("id") == Some(id) {
                     return Some(msg);
                 }
-                if server.pending.len() >= PENDING_CAP {
-                    server.pending.pop_front();
+                let mut pending = server.pending.lock().unwrap_or_else(|e| e.into_inner());
+                if pending.len() >= PENDING_CAP {
+                    pending.pop_front();
                 }
-                server.pending.push_back(msg);
+                pending.push_back(msg);
             }
             Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => return None,
         }
@@ -641,46 +653,52 @@ pub fn read_response_matching(server: &mut LspServer, id: &Value, dur: Duration)
 }
 
 /// Convenience for numeric ids.
-pub fn read_response_matching_i64(server: &mut LspServer, id: i64, dur: Duration) -> Option<Value> {
+pub fn read_response_matching_i64(server: &LspServer, id: i64, dur: Duration) -> Option<Value> {
     read_response_matching(server, &json!(id), dur)
 }
 
 /// Write raw bytes (for malformed/binary frame tests).
-pub fn send_raw(server: &mut LspServer, bytes: &[u8]) {
+pub fn send_raw(server: &LspServer, bytes: &[u8]) {
     // Ignore write errors - BrokenPipe during teardown is expected
-    let _ = server.writer.write_all(bytes).and_then(|_| server.writer.flush());
+    let mut writer = server.writer.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = writer.write_all(bytes).and_then(|_| writer.flush());
 }
 
 /// Read a notification matching the given method name
-pub fn read_notification_method(
-    server: &mut LspServer,
-    method: &str,
-    dur: Duration,
-) -> Option<Value> {
+pub fn read_notification_method(server: &LspServer, method: &str, dur: Duration) -> Option<Value> {
     let deadline = Instant::now() + dur;
 
     // scan buffered first
-    for _ in 0..server.pending.len() {
-        if let Some(msg) = server.pending.pop_front() {
-            if msg.get("id").is_none() && msg.get("method") == Some(&json!(method)) {
-                return Some(msg);
+    {
+        let mut pending = server.pending.lock().unwrap_or_else(|e| e.into_inner());
+        let len = pending.len();
+        for _ in 0..len {
+            if let Some(msg) = pending.pop_front() {
+                if msg.get("id").is_none() && msg.get("method") == Some(&json!(method)) {
+                    return Some(msg);
+                }
+                pending.push_back(msg);
             }
-            server.pending.push_back(msg);
         }
     }
 
     // then poll
     while Instant::now() < deadline {
-        match server.rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+        let recv_result = {
+            let rx = server.rx.lock().unwrap_or_else(|e| e.into_inner());
+            rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        };
+        match recv_result {
             Ok(msg) => {
                 let is_match = msg.get("id").is_none() && msg.get("method") == Some(&json!(method));
                 if is_match {
                     return Some(msg);
                 }
-                if server.pending.len() >= PENDING_CAP {
-                    server.pending.pop_front();
+                let mut pending = server.pending.lock().unwrap_or_else(|e| e.into_inner());
+                if pending.len() >= PENDING_CAP {
+                    pending.pop_front();
                 }
-                server.pending.push_back(msg);
+                pending.push_back(msg);
             }
             Err(_) => break,
         }
@@ -689,16 +707,21 @@ pub fn read_notification_method(
 }
 
 /// Drain messages until no traffic for a quiet period (stabilizes CI)
-pub fn drain_until_quiet(server: &mut LspServer, quiet: Duration, ceiling: Duration) {
+pub fn drain_until_quiet(server: &LspServer, quiet: Duration, ceiling: Duration) {
     let start = Instant::now();
     let mut last = Instant::now();
     while start.elapsed() < ceiling {
-        match server.rx.recv_timeout(quiet.saturating_sub(last.elapsed())) {
+        let recv_result = {
+            let rx = server.rx.lock().unwrap_or_else(|e| e.into_inner());
+            rx.recv_timeout(quiet.saturating_sub(last.elapsed()))
+        };
+        match recv_result {
             Ok(msg) => {
-                if server.pending.len() >= PENDING_CAP {
-                    server.pending.pop_front();
+                let mut pending = server.pending.lock().unwrap_or_else(|e| e.into_inner());
+                if pending.len() >= PENDING_CAP {
+                    pending.pop_front();
                 }
-                server.pending.push_back(msg);
+                pending.push_back(msg);
                 last = Instant::now();
             }
             Err(_) => break, // quiet period achieved
@@ -706,7 +729,7 @@ pub fn drain_until_quiet(server: &mut LspServer, quiet: Duration, ceiling: Durat
     }
 }
 
-pub fn initialize_lsp(server: &mut LspServer) -> Value {
+pub fn initialize_lsp(server: &LspServer) -> Value {
     let init = json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -722,7 +745,9 @@ pub fn initialize_lsp(server: &mut LspServer) -> Value {
     // write without reading
     {
         let body = init.to_string();
-        if let Err(e) = send_message_inner(&mut server.writer, &body) {
+        if let Err(e) =
+            send_message_inner(&mut *server.writer.lock().unwrap_or_else(|e| e.into_inner()), &body)
+        {
             // Handle write errors gracefully with proper JSON-RPC envelope (id=1)
             return map_send_error(Some(json!(1)), e, "initialize");
         }
@@ -801,7 +826,7 @@ pub fn initialize_lsp(server: &mut LspServer) -> Value {
 }
 
 /// Wait for the index-ready notification from the server
-pub fn await_index_ready(server: &mut LspServer) {
+pub fn await_index_ready(server: &LspServer) {
     // Wait for perl-lsp/index-ready notification with a reasonable timeout
     if let Some(_notification) =
         read_notification_method(server, "perl-lsp/index-ready", Duration::from_millis(500))
@@ -813,14 +838,22 @@ pub fn await_index_ready(server: &mut LspServer) {
 }
 
 /// Gracefully shut the server down (best-effort) without hanging tests.
-pub fn shutdown_and_exit(server: &mut LspServer) {
+pub fn shutdown_and_exit(server: &LspServer) {
     use std::sync::atomic::Ordering;
 
     // Mark shutdown as initiated to prevent duplicate shutdown in Drop
     if server.shutdown_initiated.swap(true, Ordering::SeqCst) {
         // Already initiated, just wait for exit
         for _ in 0..20 {
-            if server.process.try_wait().ok().flatten().is_some() {
+            if server
+                .process
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .try_wait()
+                .ok()
+                .flatten()
+                .is_some()
+            {
                 return;
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -837,25 +870,35 @@ pub fn shutdown_and_exit(server: &mut LspServer) {
 
     // Give it a moment, then force-kill if needed.
     for _ in 0..20 {
-        if server.process.try_wait().ok().flatten().is_some() {
+        if server
+            .process
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .try_wait()
+            .ok()
+            .flatten()
+            .is_some()
+        {
             return;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
-    let _ = server.process.kill();
+    let _ = server.process.lock().unwrap_or_else(|e| e.into_inner()).kill();
 }
 
 /// Send raw message to server (for testing malformed input)
-pub fn send_raw_message(server: &mut LspServer, content: &str) {
+pub fn send_raw_message(server: &LspServer, content: &str) {
     // Ignore write errors - BrokenPipe during teardown is expected
-    let _ = send_message_inner(&mut server.writer, content);
+    let _ =
+        send_message_inner(&mut *server.writer.lock().unwrap_or_else(|e| e.into_inner()), content);
 }
 
 /// Send request without waiting for response
-pub fn send_request_no_wait(server: &mut LspServer, req: Value) {
+pub fn send_request_no_wait(server: &LspServer, req: Value) {
     let body = req.to_string();
     // Ignore write errors - BrokenPipe during teardown is expected
-    let _ = send_message_inner(&mut server.writer, &body);
+    let _ =
+        send_message_inner(&mut *server.writer.lock().unwrap_or_else(|e| e.into_inner()), &body);
 }
 
 impl Drop for LspServer {
@@ -863,7 +906,15 @@ impl Drop for LspServer {
         use std::sync::atomic::Ordering;
 
         // Check if already exited
-        if self.process.try_wait().ok().flatten().is_some() {
+        if self
+            .process
+            .get_mut()
+            .unwrap_or_else(|e| e.into_inner())
+            .try_wait()
+            .ok()
+            .flatten()
+            .is_some()
+        {
             return;
         }
 
@@ -871,35 +922,57 @@ impl Drop for LspServer {
         if self.shutdown_initiated.swap(true, Ordering::SeqCst) {
             // Already initiated, just wait for exit then force-kill if needed
             for _ in 0..50 {
-                if self.process.try_wait().ok().flatten().is_some() {
+                if self
+                    .process
+                    .get_mut()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .try_wait()
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
                     return;
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
-            let _ = self.process.kill();
-            let _ = self.process.wait();
+            let _ = self.process.get_mut().unwrap_or_else(|e| e.into_inner()).kill();
+            let _ = self.process.get_mut().unwrap_or_else(|e| e.into_inner()).wait();
             return;
         }
 
         // Best-effort graceful shutdown (never panic in Drop)
         // 1. Try to send shutdown request
         let shutdown_body = r#"{"jsonrpc":"2.0","id":999999,"method":"shutdown","params":{}}"#;
-        let _ = send_message_inner(&mut self.writer, shutdown_body);
+        let _ = send_message_inner(
+            &mut *self.writer.get_mut().unwrap_or_else(|e| e.into_inner()),
+            shutdown_body,
+        );
 
         // 2. Try to send exit notification
         let exit_body = r#"{"jsonrpc":"2.0","method":"exit"}"#;
-        let _ = send_message_inner(&mut self.writer, exit_body);
+        let _ = send_message_inner(
+            &mut *self.writer.get_mut().unwrap_or_else(|e| e.into_inner()),
+            exit_body,
+        );
 
         // 3. Wait briefly for graceful exit (max 500ms)
         for _ in 0..50 {
-            if self.process.try_wait().ok().flatten().is_some() {
+            if self
+                .process
+                .get_mut()
+                .unwrap_or_else(|e| e.into_inner())
+                .try_wait()
+                .ok()
+                .flatten()
+                .is_some()
+            {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));
         }
 
         // 4. Fall back to hard kill if graceful shutdown didn't work
-        let _ = self.process.kill();
-        let _ = self.process.wait();
+        let _ = self.process.get_mut().unwrap_or_else(|e| e.into_inner()).kill();
+        let _ = self.process.get_mut().unwrap_or_else(|e| e.into_inner()).wait();
     }
 }

--- a/crates/perl-lsp/tests/common/test_reliability.rs
+++ b/crates/perl-lsp/tests/common/test_reliability.rs
@@ -18,10 +18,10 @@
 //!     let env = TestEnvironment::validate()?;
 //!     eprintln!("Test environment: {}", env.summary());
 //!
-//!     let mut server = start_lsp_server();
+//!     let server = start_lsp_server();
 //!
 //!     // Perform health check
-//!     HealthCheck::new(&mut server).verify()?;
+//!     HealthCheck::new(&server).verify()?;
 //!
 //!     // Run test...
 //!     Ok(())
@@ -152,13 +152,13 @@ fn detect_available_memory() -> Option<u64> {
 
 /// Health check utilities for LSP server
 pub struct HealthCheck<'a> {
-    server: &'a mut crate::common::LspServer,
+    server: &'a crate::common::LspServer,
     timeout: Duration,
 }
 
 impl<'a> HealthCheck<'a> {
     /// Create a new health check for the given server
-    pub fn new(server: &'a mut crate::common::LspServer) -> Self {
+    pub fn new(server: &'a crate::common::LspServer) -> Self {
         Self { server, timeout: Duration::from_secs(5) }
     }
 

--- a/crates/perl-lsp/tests/common/test_utils.rs
+++ b/crates/perl-lsp/tests/common/test_utils.rs
@@ -65,7 +65,7 @@ impl TestServerBuilder {
 
     pub fn build(self) -> TestServer {
         // Use the canonical common harness for server startup
-        let mut server = super::start_lsp_server();
+        let server = super::start_lsp_server();
 
         // Build initialization params
         let mut init_params = self.initialization_params.unwrap_or_else(|| {
@@ -95,7 +95,7 @@ impl TestServerBuilder {
         // Send initialize request via common harness
         let init_id = next_request_id();
         let init_response = super::send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": init_id,
@@ -111,7 +111,7 @@ impl TestServerBuilder {
 
         // Send initialized notification (required by LSP protocol)
         super::send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "initialized",
@@ -122,11 +122,11 @@ impl TestServerBuilder {
         // Wait for index-ready notification to ensure deterministic completion behavior
         // Only wait if workspace folders were specified (semantic tests usually don't need workspace index)
         if !self.workspace_folders.is_empty() {
-            super::await_index_ready(&mut server);
+            super::await_index_ready(&server);
         } else {
             // For non-workspace tests, just do a brief quiet drain
             super::drain_until_quiet(
-                &mut server,
+                &server,
                 std::time::Duration::from_millis(50),
                 std::time::Duration::from_millis(200),
             );
@@ -149,7 +149,7 @@ impl TestServer {
     /// Send a text document did open notification
     pub fn open_document(&mut self, uri: &str, content: &str) {
         super::send_notification(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -170,7 +170,7 @@ impl TestServer {
     /// Send a text document did change notification
     pub fn change_document(&mut self, uri: &str, content: &str, version: i32) {
         super::send_notification(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -190,7 +190,7 @@ impl TestServer {
     /// Request diagnostics for a document
     pub fn get_diagnostics(&mut self, uri: &str) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -205,7 +205,7 @@ impl TestServer {
     /// Request document symbols
     pub fn get_symbols(&mut self, uri: &str) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -220,7 +220,7 @@ impl TestServer {
     /// Request definition at position
     pub fn get_definition(&mut self, uri: &str, line: u32, character: u32) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -242,7 +242,7 @@ impl TestServer {
         include_declaration: bool,
     ) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -259,7 +259,7 @@ impl TestServer {
     /// Request hover information
     pub fn get_hover(&mut self, uri: &str, line: u32, character: u32) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -275,7 +275,7 @@ impl TestServer {
     /// Request completion items at a position
     pub fn get_completion(&mut self, uri: &str, line: u32, character: u32) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -291,7 +291,7 @@ impl TestServer {
     /// Request signature help
     pub fn get_signature_help(&mut self, uri: &str, line: u32, character: u32) -> Value {
         super::send_request(
-            &mut self.server,
+            &self.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": next_request_id(),
@@ -305,8 +305,8 @@ impl TestServer {
     }
 
     /// Shutdown the server gracefully
-    pub fn shutdown(mut self) {
-        super::shutdown_and_exit(&mut self.server);
+    pub fn shutdown(self) {
+        super::shutdown_and_exit(&self.server);
     }
 }
 

--- a/crates/perl-lsp/tests/dap_non_regression_tests.rs
+++ b/crates/perl-lsp/tests/dap_non_regression_tests.rs
@@ -20,13 +20,13 @@ use common::*;
 #[test]
 // AC:17
 fn test_lsp_features_unaffected_by_dap() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     let text = "use strict;\nmy $x = 1;\nprint $x;\n";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -43,12 +43,12 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
 
     // Wait for diagnostics or settle time to ensure file is processed
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     // Verify basic LSP functionality (hover) with DAP feature enabled
     let hover_id = 100;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": hover_id,
@@ -60,7 +60,7 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
         }),
     );
 
-    let response = read_response_matching_i64(&mut server, hover_id, Duration::from_secs(5));
+    let response = read_response_matching_i64(&server, hover_id, Duration::from_secs(5));
     assert!(response.is_some(), "Hover response should be present after didOpen");
 
     Ok(())
@@ -70,13 +70,13 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
 #[test]
 // AC:17
 fn test_lsp_response_time_maintained() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///perf.pl";
     let text = "my $val = 42;\n";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -92,12 +92,12 @@ fn test_lsp_response_time_maintained() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     let start = Instant::now();
     let hover_id = 200;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": hover_id,
@@ -109,7 +109,7 @@ fn test_lsp_response_time_maintained() -> Result<()> {
         }),
     );
 
-    let response = read_response_matching_i64(&mut server, hover_id, Duration::from_secs(5));
+    let response = read_response_matching_i64(&server, hover_id, Duration::from_secs(5));
     let latency = start.elapsed();
 
     assert!(response.is_some(), "Hover response missing in performance test");
@@ -128,13 +128,13 @@ fn test_lsp_response_time_maintained() -> Result<()> {
 #[test]
 // AC:17
 fn test_workspace_navigation_with_dap() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///nav.pl";
     let text = "package NavTest;\nsub target_func { }\n1;\n";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -151,12 +151,12 @@ fn test_workspace_navigation_with_dap() -> Result<()> {
 
     // Wait for indexing
     std::thread::sleep(Duration::from_millis(1000));
-    drain_until_quiet(&mut server, Duration::from_millis(200), Duration::from_millis(2000));
+    drain_until_quiet(&server, Duration::from_millis(200), Duration::from_millis(2000));
 
     // Verify workspace symbol search works
     let search_id = 300;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": search_id,
@@ -165,7 +165,7 @@ fn test_workspace_navigation_with_dap() -> Result<()> {
         }),
     );
 
-    let response = read_response_matching_i64(&mut server, search_id, Duration::from_secs(5));
+    let response = read_response_matching_i64(&server, search_id, Duration::from_secs(5));
     assert!(response.is_some(), "Workspace symbol response should be present");
     let resp_val = response.ok_or_else(|| anyhow::anyhow!("Expected workspace symbol response"))?;
     assert!(
@@ -181,14 +181,14 @@ fn test_workspace_navigation_with_dap() -> Result<()> {
 #[test]
 // AC:17
 fn test_lsp_dap_memory_isolation() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///memory_test.pl";
     let text = "my $data = 1;\n";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -204,13 +204,13 @@ fn test_lsp_dap_memory_isolation() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     // Send multiple LSP requests to test responsiveness under load
     for i in 0..50 {
         let req_id = 400 + i;
         send_request_no_wait(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": req_id,
@@ -222,7 +222,7 @@ fn test_lsp_dap_memory_isolation() -> Result<()> {
             }),
         );
 
-        if read_response_matching_i64(&mut server, req_id, Duration::from_millis(500)).is_some() {
+        if read_response_matching_i64(&server, req_id, Duration::from_millis(500)).is_some() {
             // Response received
         }
     }
@@ -230,7 +230,7 @@ fn test_lsp_dap_memory_isolation() -> Result<()> {
     // Verify server still responsive after load
     let final_id = 500;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": final_id,
@@ -242,7 +242,7 @@ fn test_lsp_dap_memory_isolation() -> Result<()> {
         }),
     );
 
-    let response = read_response_matching_i64(&mut server, final_id, Duration::from_secs(5));
+    let response = read_response_matching_i64(&server, final_id, Duration::from_secs(5));
     assert!(response.is_some(), "Server should remain responsive after load");
 
     Ok(())
@@ -252,14 +252,14 @@ fn test_lsp_dap_memory_isolation() -> Result<()> {
 #[test]
 // AC:17
 fn test_lsp_test_pass_rate_100_percent() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///comprehensive.pl";
     let text = "package TestPkg;\nsub test_sub { my $var = 1; }\n1;\n";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -275,12 +275,12 @@ fn test_lsp_test_pass_rate_100_percent() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     // Test hover
     let hover_id = 600;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": hover_id,
@@ -292,14 +292,14 @@ fn test_lsp_test_pass_rate_100_percent() -> Result<()> {
         }),
     );
     assert!(
-        read_response_matching_i64(&mut server, hover_id, Duration::from_secs(5)).is_some(),
+        read_response_matching_i64(&server, hover_id, Duration::from_secs(5)).is_some(),
         "Hover should work with DAP feature enabled"
     );
 
     // Test completion
     let completion_id = 601;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": completion_id,
@@ -311,7 +311,7 @@ fn test_lsp_test_pass_rate_100_percent() -> Result<()> {
         }),
     );
     assert!(
-        read_response_matching_i64(&mut server, completion_id, Duration::from_secs(5)).is_some(),
+        read_response_matching_i64(&server, completion_id, Duration::from_secs(5)).is_some(),
         "Completion should work with DAP feature enabled"
     );
 
@@ -322,14 +322,14 @@ fn test_lsp_test_pass_rate_100_percent() -> Result<()> {
 #[test]
 // AC:17
 fn test_concurrent_lsp_dap_sessions() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///concurrent.pl";
     let text = "my $value = 42;\nprint $value;\n";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -345,14 +345,14 @@ fn test_concurrent_lsp_dap_sessions() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     // Send concurrent requests
     let hover_id = 700;
     let completion_id = 701;
 
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": hover_id,
@@ -365,7 +365,7 @@ fn test_concurrent_lsp_dap_sessions() -> Result<()> {
     );
 
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": completion_id,
@@ -378,9 +378,9 @@ fn test_concurrent_lsp_dap_sessions() -> Result<()> {
     );
 
     // Both responses should arrive
-    let hover_resp = read_response_matching_i64(&mut server, hover_id, Duration::from_secs(5));
+    let hover_resp = read_response_matching_i64(&server, hover_id, Duration::from_secs(5));
     let completion_resp =
-        read_response_matching_i64(&mut server, completion_id, Duration::from_secs(5));
+        read_response_matching_i64(&server, completion_id, Duration::from_secs(5));
 
     assert!(hover_resp.is_some(), "Hover response should arrive in concurrent scenario");
     assert!(completion_resp.is_some(), "Completion response should arrive in concurrent scenario");
@@ -392,14 +392,14 @@ fn test_concurrent_lsp_dap_sessions() -> Result<()> {
 #[test]
 // AC:17
 fn test_incremental_parsing_during_debugging() -> Result<()> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///incremental.pl";
     let text = "my $original = 1;\n";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -415,12 +415,12 @@ fn test_incremental_parsing_during_debugging() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(500));
-    drain_until_quiet(&mut server, Duration::from_millis(100), Duration::from_millis(1000));
+    drain_until_quiet(&server, Duration::from_millis(100), Duration::from_millis(1000));
 
     // Apply incremental edit
     let start_time = Instant::now();
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -434,13 +434,13 @@ fn test_incremental_parsing_during_debugging() -> Result<()> {
     );
 
     std::thread::sleep(Duration::from_millis(100));
-    drain_until_quiet(&mut server, Duration::from_millis(50), Duration::from_millis(500));
+    drain_until_quiet(&server, Duration::from_millis(50), Duration::from_millis(500));
     let parse_time = start_time.elapsed();
 
     // Verify LSP still responsive after edit
     let hover_id = 800;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": hover_id,
@@ -452,7 +452,7 @@ fn test_incremental_parsing_during_debugging() -> Result<()> {
         }),
     );
 
-    let response = read_response_matching_i64(&mut server, hover_id, Duration::from_secs(5));
+    let response = read_response_matching_i64(&server, hover_id, Duration::from_secs(5));
     assert!(response.is_some(), "LSP should remain responsive after incremental edit");
     assert!(parse_time < Duration::from_secs(1), "Incremental parsing too slow: {:?}", parse_time);
 

--- a/crates/perl-lsp/tests/lsp_batteries_e2e_workflow_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_e2e_workflow_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 
 #[test]
 fn test_complete_workflow_from_messy_to_clean() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Step 1: Initialize the LSP server
     let init_req = JsonRpcRequest {
@@ -170,7 +170,7 @@ print encode_json({result => $result});
 
 #[test]
 fn test_batteries_included_features_summary() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_batteries_included_test.rs
+++ b/crates/perl-lsp/tests/lsp_batteries_included_test.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 /// Test that formatting is properly advertised in server capabilities
 #[test]
 fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -54,7 +54,7 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
 /// Test that code actions include organize imports
 #[test]
 fn test_organize_imports_code_action_available() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize server
     let init_req = JsonRpcRequest {
@@ -136,7 +136,7 @@ print Dumper($data);
 /// Test that execute commands include perlcritic integration
 #[test]
 fn test_perlcritic_execute_command_available() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -177,7 +177,7 @@ fn test_perlcritic_execute_command_available() -> Result<(), Box<dyn std::error:
 /// Test that basic diagnostics work without external tools
 #[test]
 fn test_builtin_diagnostics_work() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize
     let init_req = JsonRpcRequest {
@@ -255,7 +255,7 @@ fn test_default_configuration_sensible() -> Result<(), Box<dyn std::error::Error
 /// Test that the server provides helpful capabilities information
 #[test]
 fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -296,7 +296,7 @@ fn test_server_capabilities_complete() -> Result<(), Box<dyn std::error::Error>>
 /// Test that formatting gracefully handles missing perltidy
 #[test]
 fn test_formatting_graceful_degradation() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize
     let init_req = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_builtins_test.rs
+++ b/crates/perl-lsp/tests/lsp_builtins_test.rs
@@ -9,7 +9,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 /// Helper to create and initialize a test server
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Send initialize request
     let init_request = JsonRpcRequest {
@@ -37,7 +37,7 @@ fn setup_server() -> LspServer {
 }
 
 /// Helper to open a document
-fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
+fn open_doc(server: &LspServer, uri: &str, text: &str) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -55,12 +55,7 @@ fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
 }
 
 /// Helper to get signature help
-fn get_signature_help(
-    server: &mut LspServer,
-    uri: &str,
-    line: u32,
-    character: u32,
-) -> Option<Value> {
+fn get_signature_help(server: &LspServer, uri: &str, line: u32, character: u32) -> Option<Value> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -76,12 +71,12 @@ fn get_signature_help(
 
 #[test]
 fn test_file_operation_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test seek signature - cursor inside parentheses after FILE,
     let code = "seek(FILE, 0, 0);";
-    open_doc(&mut server, "file:///test.pl", code);
-    let result = get_signature_help(&mut server, "file:///test.pl", 0, 11);
+    open_doc(&server, "file:///test.pl", code);
+    let result = get_signature_help(&server, "file:///test.pl", 0, 11);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -97,8 +92,8 @@ fn test_file_operation_signatures() -> TestResult {
 
     // Test chmod signature - cursor after first comma
     let code = "chmod(0755, $file);";
-    open_doc(&mut server, "file:///test2.pl", code);
-    let result = get_signature_help(&mut server, "file:///test2.pl", 0, 12);
+    open_doc(&server, "file:///test2.pl", code);
+    let result = get_signature_help(&server, "file:///test2.pl", 0, 12);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -114,8 +109,8 @@ fn test_file_operation_signatures() -> TestResult {
 
     // Test stat signature - cursor just inside parentheses
     let code = "stat($file);";
-    open_doc(&mut server, "file:///test3.pl", code);
-    let result = get_signature_help(&mut server, "file:///test3.pl", 0, 5);
+    open_doc(&server, "file:///test3.pl", code);
+    let result = get_signature_help(&server, "file:///test3.pl", 0, 5);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -128,12 +123,12 @@ fn test_file_operation_signatures() -> TestResult {
 
 #[test]
 fn test_string_data_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test pack signature
     let code = r#"pack("C*", @bytes);"#;
-    open_doc(&mut server, "file:///pack.pl", code);
-    let result = get_signature_help(&mut server, "file:///pack.pl", 0, 11);
+    open_doc(&server, "file:///pack.pl", code);
+    let result = get_signature_help(&server, "file:///pack.pl", 0, 11);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -149,8 +144,8 @@ fn test_string_data_signatures() -> TestResult {
 
     // Test unpack signature
     let code = "unpack($template, $data);";
-    open_doc(&mut server, "file:///unpack.pl", code);
-    let result = get_signature_help(&mut server, "file:///unpack.pl", 0, 18);
+    open_doc(&server, "file:///unpack.pl", code);
+    let result = get_signature_help(&server, "file:///unpack.pl", 0, 18);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -160,8 +155,8 @@ fn test_string_data_signatures() -> TestResult {
 
     // Test hex signature
     let code = "hex($str);";
-    open_doc(&mut server, "file:///hex.pl", code);
-    let result = get_signature_help(&mut server, "file:///hex.pl", 0, 4);
+    open_doc(&server, "file:///hex.pl", code);
+    let result = get_signature_help(&server, "file:///hex.pl", 0, 4);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -172,7 +167,7 @@ fn test_string_data_signatures() -> TestResult {
 
 #[test]
 fn test_math_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let math_functions = [
         ("abs($x);", "abs", "VALUE", 4),
@@ -185,8 +180,8 @@ fn test_math_signatures() -> TestResult {
 
     for (i, (code, func_name, expected_params, cursor_pos)) in math_functions.iter().enumerate() {
         let uri = format!("file:///math{}.pl", i);
-        open_doc(&mut server, &uri, code);
-        let result = get_signature_help(&mut server, &uri, 0, *cursor_pos);
+        open_doc(&server, &uri, code);
+        let result = get_signature_help(&server, &uri, 0, *cursor_pos);
 
         assert!(result.is_some(), "Failed for function: {}", func_name);
         let sig = result.ok_or("Expected signature result")?;
@@ -205,12 +200,12 @@ fn test_math_signatures() -> TestResult {
 
 #[test]
 fn test_system_process_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test fork (no parameters)
     let code = "fork();";
-    open_doc(&mut server, "file:///fork.pl", code);
-    let result = get_signature_help(&mut server, "file:///fork.pl", 0, 5);
+    open_doc(&server, "file:///fork.pl", code);
+    let result = get_signature_help(&server, "file:///fork.pl", 0, 5);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -220,8 +215,8 @@ fn test_system_process_signatures() -> TestResult {
 
     // Test kill signature
     let code = "kill(9, @pids);";
-    open_doc(&mut server, "file:///kill.pl", code);
-    let result = get_signature_help(&mut server, "file:///kill.pl", 0, 8);
+    open_doc(&server, "file:///kill.pl", code);
+    let result = get_signature_help(&server, "file:///kill.pl", 0, 8);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -237,8 +232,8 @@ fn test_system_process_signatures() -> TestResult {
 
     // Test system signature
     let code = "system($cmd);";
-    open_doc(&mut server, "file:///system.pl", code);
-    let result = get_signature_help(&mut server, "file:///system.pl", 0, 7);
+    open_doc(&server, "file:///system.pl", code);
+    let result = get_signature_help(&server, "file:///system.pl", 0, 7);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -251,12 +246,12 @@ fn test_system_process_signatures() -> TestResult {
 
 #[test]
 fn test_network_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test socket signature
     let code = "socket(SOCK, AF_INET, SOCK_STREAM, 0);";
-    open_doc(&mut server, "file:///socket.pl", code);
-    let result = get_signature_help(&mut server, "file:///socket.pl", 0, 13);
+    open_doc(&server, "file:///socket.pl", code);
+    let result = get_signature_help(&server, "file:///socket.pl", 0, 13);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -272,8 +267,8 @@ fn test_network_signatures() -> TestResult {
 
     // Test bind signature
     let code = "bind(SOCK, $addr);";
-    open_doc(&mut server, "file:///bind.pl", code);
-    let result = get_signature_help(&mut server, "file:///bind.pl", 0, 11);
+    open_doc(&server, "file:///bind.pl", code);
+    let result = get_signature_help(&server, "file:///bind.pl", 0, 11);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -292,12 +287,12 @@ fn test_network_signatures() -> TestResult {
 
 #[test]
 fn test_control_flow_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test eval signature
     let code = "eval($code);";
-    open_doc(&mut server, "file:///eval.pl", code);
-    let result = get_signature_help(&mut server, "file:///eval.pl", 0, 5);
+    open_doc(&server, "file:///eval.pl", code);
+    let result = get_signature_help(&server, "file:///eval.pl", 0, 5);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -307,8 +302,8 @@ fn test_control_flow_signatures() -> TestResult {
 
     // Test require signature
     let code = "require($module);";
-    open_doc(&mut server, "file:///require.pl", code);
-    let result = get_signature_help(&mut server, "file:///require.pl", 0, 8);
+    open_doc(&server, "file:///require.pl", code);
+    let result = get_signature_help(&server, "file:///require.pl", 0, 8);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -321,12 +316,12 @@ fn test_control_flow_signatures() -> TestResult {
 
 #[test]
 fn test_misc_signatures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test tie signature
     let code = "tie(%hash, 'DB_File');";
-    open_doc(&mut server, "file:///tie.pl", code);
-    let result = get_signature_help(&mut server, "file:///tie.pl", 0, 11);
+    open_doc(&server, "file:///tie.pl", code);
+    let result = get_signature_help(&server, "file:///tie.pl", 0, 11);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -340,8 +335,8 @@ fn test_misc_signatures() -> TestResult {
 
     // Test select signature
     let code = "select(STDOUT);";
-    open_doc(&mut server, "file:///select.pl", code);
-    let result = get_signature_help(&mut server, "file:///select.pl", 0, 7);
+    open_doc(&server, "file:///select.pl", code);
+    let result = get_signature_help(&server, "file:///select.pl", 0, 7);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -354,12 +349,12 @@ fn test_misc_signatures() -> TestResult {
 
 #[test]
 fn test_active_parameter_tracking() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test with multiple parameters
     let code = "atan2(1.5, 2.0);";
-    open_doc(&mut server, "file:///atan2.pl", code);
-    let result = get_signature_help(&mut server, "file:///atan2.pl", 0, 11);
+    open_doc(&server, "file:///atan2.pl", code);
+    let result = get_signature_help(&server, "file:///atan2.pl", 0, 11);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -367,8 +362,8 @@ fn test_active_parameter_tracking() -> TestResult {
 
     // Test with three parameters
     let code = "substr($text, 5, 10);";
-    open_doc(&mut server, "file:///substr.pl", code);
-    let result = get_signature_help(&mut server, "file:///substr.pl", 0, 17);
+    open_doc(&server, "file:///substr.pl", code);
+    let result = get_signature_help(&server, "file:///substr.pl", 0, 17);
 
     assert!(result.is_some());
     let sig = result.ok_or("Expected signature result")?;
@@ -379,7 +374,7 @@ fn test_active_parameter_tracking() -> TestResult {
 
 #[test]
 fn test_all_114_builtins_are_recognized() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // List of all 114 built-in functions we support
     let all_builtins = [
@@ -534,10 +529,10 @@ fn test_all_114_builtins_are_recognized() -> TestResult {
     for func in all_builtins {
         let code = format!("{}($x);", func); // Complete statement with argument
         let uri = format!("file:///{}.pl", func);
-        open_doc(&mut server, &uri, &code);
+        open_doc(&server, &uri, &code);
         // Position cursor just after opening paren
         let cursor_pos = func.len() as u32 + 1;
-        let result = get_signature_help(&mut server, &uri, 0, cursor_pos);
+        let result = get_signature_help(&server, &uri, 0, cursor_pos);
 
         assert!(result.is_some(), "No signature found for function: {}", func);
         let sig = result.ok_or("Expected signature result")?;

--- a/crates/perl-lsp/tests/lsp_cancel_test.rs
+++ b/crates/perl-lsp/tests/lsp_cancel_test.rs
@@ -34,12 +34,12 @@ fn test_cancel_request_handling() {
     // Quick LSP availability check - skip if LSP fails to initialize within reasonable time
     // This prevents false failures in environments with slow LSP startup
     {
-        let mut test_server = start_lsp_server();
+        let test_server = start_lsp_server();
         let init_start = std::time::Instant::now();
 
         // Try a quick initialization with shorter timeout
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            initialize_lsp(&mut test_server)
+            initialize_lsp(&test_server)
         })) {
             Ok(_) => {
                 // LSP started successfully, continue with test
@@ -56,13 +56,13 @@ fn test_cancel_request_handling() {
         }
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // First, test if the slow operation endpoint exists
     let test_id = 8888;
     send_request_no_wait(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": test_id,
@@ -71,8 +71,7 @@ fn test_cancel_request_handling() {
         }),
     );
 
-    let test_response =
-        read_response_matching_i64(&mut server, test_id, Duration::from_millis(600));
+    let test_response = read_response_matching_i64(&server, test_id, Duration::from_millis(600));
     let has_test_endpoint = test_response.is_some_and(|resp| {
         resp.get("error").is_none_or(|e| {
             e["code"].as_i64() != Some(-32601) // -32601 = Method not found
@@ -85,7 +84,7 @@ fn test_cancel_request_handling() {
     if has_test_endpoint {
         // Use the slow operation for reliable cancellation
         send_request_no_wait(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": request_id,
@@ -101,7 +100,7 @@ fn test_cancel_request_handling() {
         // Fall back to hover which may or may not be cancelled in time
         let uri = "file:///test.pl";
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -117,7 +116,7 @@ fn test_cancel_request_handling() {
         );
 
         send_request_no_wait(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": request_id,
@@ -132,7 +131,7 @@ fn test_cancel_request_handling() {
 
     // Send cancellation
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -143,7 +142,7 @@ fn test_cancel_request_handling() {
     );
 
     // Read the response
-    let response = read_response_matching_i64(&mut server, request_id, Duration::from_secs(2));
+    let response = read_response_matching_i64(&server, request_id, Duration::from_secs(2));
 
     if let Some(resp) = response {
         if let Some(error) = resp.get("error") {
@@ -184,12 +183,12 @@ fn test_cancel_request_no_response() {
         return;
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send a didOpen to keep server active
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -205,14 +204,14 @@ fn test_cancel_request_no_response() {
     );
 
     // Drain any diagnostics or other notifications from didOpen (reduced timeout for performance)
-    drain_until_quiet(&mut server, Duration::from_millis(50), Duration::from_millis(200));
+    drain_until_quiet(&server, Duration::from_millis(50), Duration::from_millis(200));
 
     // Check server is still alive before sending cancel
     assert!(server.is_alive(), "server exited before cancel test started");
 
     // Send a cancel request for a non-existent ID
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -223,7 +222,7 @@ fn test_cancel_request_no_response() {
     );
 
     // Use bounded read to check for no response
-    let response = read_response_timeout(&mut server, Duration::from_millis(200));
+    let response = read_response_timeout(&server, Duration::from_millis(200));
 
     // $/cancelRequest is a notification and should not produce any response
     assert!(response.is_none(), "$/cancelRequest produced an unexpected response");
@@ -294,12 +293,12 @@ fn test_cancel_multiple_requests() {
         return;
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -319,7 +318,7 @@ fn test_cancel_multiple_requests() {
 
     for &id in &ids {
         send_request_no_wait(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -334,7 +333,7 @@ fn test_cancel_multiple_requests() {
 
     // Cancel the middle request
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -346,7 +345,7 @@ fn test_cancel_multiple_requests() {
 
     // Check responses
     for &id in &ids {
-        let response = read_response_matching_i64(&mut server, id, Duration::from_secs(2));
+        let response = read_response_matching_i64(&server, id, Duration::from_secs(2));
         if let Some(resp) = response {
             if id == 8002 {
                 // This one might be cancelled (or might complete if fast enough)

--- a/crates/perl-lsp/tests/lsp_cancellation_comprehensive_e2e_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_comprehensive_e2e_tests.rs
@@ -35,8 +35,8 @@ struct E2ETestFixture {
 
 impl E2ETestFixture {
     fn new() -> Self {
-        let mut server = start_lsp_server();
-        initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        initialize_lsp(&server);
 
         // Create comprehensive test workspace for E2E testing
         let test_workspace = E2ETestWorkspace::new();
@@ -44,7 +44,7 @@ impl E2ETestFixture {
         let performance_monitor = E2EPerformanceMonitor::new();
 
         // Setup comprehensive test environment
-        setup_e2e_test_workspace(&mut server);
+        setup_e2e_test_workspace(&server);
 
         // Wait for complete system initialization with adaptive timeout
         let adaptive_initialization_timeout = match max_concurrent_threads() {
@@ -53,18 +53,14 @@ impl E2ETestFixture {
             5..=8 => Duration::from_secs(30), // Lightly constrained environment
             _ => Duration::from_secs(20),     // Unconstrained environment
         };
-        drain_until_quiet(
-            &mut server,
-            Duration::from_millis(2000),
-            adaptive_initialization_timeout,
-        );
+        drain_until_quiet(&server, Duration::from_millis(2000), adaptive_initialization_timeout);
 
         Self { server, test_workspace, scenario_runner, performance_monitor }
     }
 }
 
 /// Setup comprehensive E2E test workspace
-fn setup_e2e_test_workspace(server: &mut LspServer) {
+fn setup_e2e_test_workspace(server: &LspServer) {
     // Create real-world Perl project structure for E2E testing
     let e2e_test_files = create_comprehensive_test_project();
 
@@ -250,11 +246,7 @@ impl E2EScenarioRunner {
         Self { active_scenarios: HashMap::new(), scenario_metrics: HashMap::new() }
     }
 
-    fn run_scenario(
-        &mut self,
-        scenario: &E2ETestScenario,
-        _server: &mut LspServer,
-    ) -> ScenarioResult {
+    fn run_scenario(&mut self, scenario: &E2ETestScenario, _server: &LspServer) -> ScenarioResult {
         let scenario_start = Instant::now();
 
         // Placeholder scenario execution
@@ -502,7 +494,7 @@ fn test_comprehensive_cancellation_workflow_e2e() {
     for scenario in &fixture.test_workspace.scenarios.clone() {
         println!("Executing E2E scenario: {}", scenario.name);
 
-        let scenario_result = fixture.scenario_runner.run_scenario(scenario, &mut fixture.server);
+        let scenario_result = fixture.scenario_runner.run_scenario(scenario, &fixture.server);
 
         // Validate scenario results
         assert!(scenario_result.success, "E2E scenario '{}' should succeed", scenario.name);
@@ -605,7 +597,7 @@ fn test_high_load_cancellation_behavior_e2e() {
     // Validate system remains responsive after high load
     let health_check_start = Instant::now();
     let health_response = send_request(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -723,7 +715,7 @@ impl Drop for E2ETestFixture {
         }
 
         // Graceful server shutdown
-        shutdown_and_exit(&mut self.server);
+        shutdown_and_exit(&self.server);
 
         println!("E2E test fixture cleaned up successfully");
     }

--- a/crates/perl-lsp/tests/lsp_cancellation_infrastructure_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_infrastructure_tests.rs
@@ -39,8 +39,8 @@ struct InfrastructureTestFixture {
 
 impl InfrastructureTestFixture {
     fn new() -> Self {
-        let mut server = start_lsp_server();
-        initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        initialize_lsp(&server);
 
         // Initialize monitoring infrastructure
         let resource_monitor = ResourceMonitor::new();
@@ -48,18 +48,18 @@ impl InfrastructureTestFixture {
         let integration_validator = IntegrationValidator::new();
 
         // Setup test environment for infrastructure quality testing
-        setup_infrastructure_test_environment(&mut server);
+        setup_infrastructure_test_environment(&server);
 
         // Wait for infrastructure to stabilize with adaptive timeout
         let adaptive_timeout = adaptive_timeout();
-        drain_until_quiet(&mut server, Duration::from_millis(800), adaptive_timeout);
+        drain_until_quiet(&server, Duration::from_millis(800), adaptive_timeout);
 
         Self { server, resource_monitor, thread_safety_monitor, integration_validator }
     }
 }
 
 /// Setup test environment for infrastructure quality testing
-fn setup_infrastructure_test_environment(server: &mut LspServer) {
+fn setup_infrastructure_test_environment(server: &LspServer) {
     // Create test files for infrastructure testing
     let test_files = vec![
         (
@@ -441,7 +441,7 @@ impl IntegrationValidator {
         }
     }
 
-    fn validate_integration(&self, server: &mut LspServer) -> IntegrationValidationResult {
+    fn validate_integration(&self, server: &LspServer) -> IntegrationValidationResult {
         let mut test_results = Vec::new();
 
         // Run LSP compatibility tests
@@ -465,7 +465,7 @@ impl IntegrationValidator {
 
     fn run_compatibility_test(
         &self,
-        server: &mut LspServer,
+        server: &LspServer,
         test: &LspCompatibilityTest,
     ) -> CompatibilityTestResult {
         let test_start = Instant::now();
@@ -533,7 +533,7 @@ impl PerformanceRegressionDetector {
         Self { baseline_measurements: HashMap::new() }
     }
 
-    fn check_for_regressions(&self, server: &mut LspServer) -> PerformanceRegressionResult {
+    fn check_for_regressions(&self, server: &LspServer) -> PerformanceRegressionResult {
         let mut regressions = Vec::new();
 
         // Test basic LSP operations for performance regressions
@@ -1626,11 +1626,10 @@ fn test_lsp_infrastructure_integration_ac11() {
         return;
     }
 
-    let mut fixture = InfrastructureTestFixture::new();
+    let fixture = InfrastructureTestFixture::new();
 
     // Run comprehensive integration validation
-    let integration_result =
-        fixture.integration_validator.validate_integration(&mut fixture.server);
+    let integration_result = fixture.integration_validator.validate_integration(&fixture.server);
 
     println!("LSP Infrastructure Integration Test Results:");
 
@@ -1701,16 +1700,16 @@ fn test_lsp_infrastructure_integration_ac11() {
     );
 
     // Test integration with existing LSP behavioral patterns
-    test_existing_lsp_behavioral_integration(&mut fixture.server);
+    test_existing_lsp_behavioral_integration(&fixture.server);
 
     // Test integration with existing LSP test utilities
-    test_existing_lsp_utilities_integration(&mut fixture.server);
+    test_existing_lsp_utilities_integration(&fixture.server);
 
     println!("LSP infrastructure integration validation completed successfully");
 }
 
 /// Test integration with existing LSP behavioral patterns
-fn test_existing_lsp_behavioral_integration(server: &mut LspServer) {
+fn test_existing_lsp_behavioral_integration(server: &LspServer) {
     println!("Testing integration with existing LSP behavioral patterns:");
 
     // Test that existing LSP behavioral tests still pass with cancellation infrastructure
@@ -1774,7 +1773,7 @@ fn test_existing_lsp_behavioral_integration(server: &mut LspServer) {
 }
 
 /// Test integration with existing LSP test utilities
-fn test_existing_lsp_utilities_integration(server: &mut LspServer) {
+fn test_existing_lsp_utilities_integration(server: &LspServer) {
     println!("Testing integration with existing LSP test utilities:");
 
     // Test that existing utility functions work correctly
@@ -1862,7 +1861,7 @@ fn test_lsp_regression_prevention_ac11() {
         return;
     }
 
-    let mut fixture = InfrastructureTestFixture::new();
+    let fixture = InfrastructureTestFixture::new();
 
     // Test that existing LSP functionality remains unaffected by cancellation infrastructure
     // Note: Skip initialize test since the server was already initialized in fixture creation
@@ -1907,7 +1906,7 @@ fn test_lsp_regression_prevention_ac11() {
         let test_start = Instant::now();
 
         let response = send_request(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": test_case.method,
@@ -2017,7 +2016,7 @@ impl Drop for InfrastructureTestFixture {
         );
 
         // Graceful server shutdown
-        shutdown_and_exit(&mut self.server);
+        shutdown_and_exit(&self.server);
 
         println!("Infrastructure quality test fixture cleaned up successfully");
     }

--- a/crates/perl-lsp/tests/lsp_cancellation_parser_integration_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_parser_integration_tests.rs
@@ -37,10 +37,10 @@ struct ParserIntegrationFixture {
 
 impl ParserIntegrationFixture {
     fn new() -> Self {
-        let mut server = start_lsp_server();
+        let server = start_lsp_server();
         // Note: Use a fresh server instance for each fixture to avoid initialization conflicts
         // Each test gets its own independent LSP server instance
-        initialize_lsp(&mut server);
+        initialize_lsp(&server);
 
         // Create comprehensive test workspace for parser integration testing
         let test_workspace = TestWorkspace::new();
@@ -48,7 +48,7 @@ impl ParserIntegrationFixture {
 
         // Setup test files
         for (uri, content) in &parser_test_files {
-            setup_test_file(&mut server, uri, content);
+            setup_test_file(&server, uri, content);
         }
 
         // Wait for initial parsing and indexing to complete with adaptive timeout
@@ -58,7 +58,7 @@ impl ParserIntegrationFixture {
             5..=8 => Duration::from_secs(15), // Lightly constrained environment
             _ => Duration::from_secs(10),     // Unconstrained environment
         };
-        drain_until_quiet(&mut server, Duration::from_millis(1500), adaptive_timeout);
+        drain_until_quiet(&server, Duration::from_millis(1500), adaptive_timeout);
 
         Self { server, test_workspace, parser_test_files }
     }
@@ -305,7 +305,7 @@ sub cross_ref_function_{} {{
 }
 
 /// Setup test file helper
-fn setup_test_file(server: &mut LspServer, uri: &str, content: &str) {
+fn setup_test_file(server: &LspServer, uri: &str, content: &str) {
     send_notification(
         server,
         json!({
@@ -1603,7 +1603,7 @@ impl Drop for ParserIntegrationFixture {
         println!("  Total test content: {} KB", total_content_size / 1024);
 
         // Graceful server shutdown
-        shutdown_and_exit(&mut self.server);
+        shutdown_and_exit(&self.server);
     }
 }
 

--- a/crates/perl-lsp/tests/lsp_cancellation_performance_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_performance_tests.rs
@@ -39,25 +39,25 @@ struct PerformanceTestFixture {
 
 impl PerformanceTestFixture {
     fn new() -> Self {
-        let mut server = start_lsp_server();
-        initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        initialize_lsp(&server);
 
         // Setup test workspace for performance validation
-        setup_performance_test_workspace(&mut server);
+        setup_performance_test_workspace(&server);
 
         // Wait for initial indexing to stabilize with adaptive timeout
         let adaptive_timeout = adaptive_timeout();
-        drain_until_quiet(&mut server, Duration::from_millis(800), adaptive_timeout);
+        drain_until_quiet(&server, Duration::from_millis(800), adaptive_timeout);
 
         // Collect baseline measurements
-        let baseline_measurements = collect_baseline_measurements(&mut server);
+        let baseline_measurements = collect_baseline_measurements(&server);
 
         Self { server, metrics_collector: MetricsCollector::new(), baseline_measurements }
     }
 }
 
 /// Setup performance test workspace with various complexity levels
-fn setup_performance_test_workspace(server: &mut LspServer) {
+fn setup_performance_test_workspace(server: &LspServer) {
     // Small test file for quick operations
     setup_test_file(
         server,
@@ -140,7 +140,7 @@ sub cross_reference_function {
 }
 
 /// Setup test file helper
-fn setup_test_file(server: &mut LspServer, uri: &str, content: &str) {
+fn setup_test_file(server: &LspServer, uri: &str, content: &str) {
     send_notification(
         server,
         json!({
@@ -313,7 +313,7 @@ struct BaselineMeasurements {
 }
 
 /// Collect baseline measurements without cancellation
-fn collect_baseline_measurements(server: &mut LspServer) -> BaselineMeasurements {
+fn collect_baseline_measurements(server: &LspServer) -> BaselineMeasurements {
     // Measure hover latency
     let hover_start = Instant::now();
     let _ = send_request(
@@ -599,7 +599,7 @@ impl ThreadingScenario {
 /// AC:12 - End-to-end cancellation response time validation across all LSP providers
 #[test]
 fn test_end_to_end_cancellation_response_time_ac12() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = PerformanceTestFixture::new();
+    let fixture = PerformanceTestFixture::new();
 
     let provider_scenarios = vec![
         (
@@ -656,7 +656,7 @@ fn test_end_to_end_cancellation_response_time_ac12() -> Result<(), Box<dyn std::
 
             // Send request
             send_request_no_wait(
-                &mut fixture.server,
+                &fixture.server,
                 json!({
                     "jsonrpc": "2.0",
                     "id": request_id,
@@ -667,7 +667,7 @@ fn test_end_to_end_cancellation_response_time_ac12() -> Result<(), Box<dyn std::
 
             // Immediate cancellation to test response time
             send_notification(
-                &mut fixture.server,
+                &fixture.server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "$/cancelRequest",
@@ -683,11 +683,8 @@ fn test_end_to_end_cancellation_response_time_ac12() -> Result<(), Box<dyn std::
             );
 
             // Measure response time
-            let response = read_response_matching_i64(
-                &mut fixture.server,
-                request_id,
-                Duration::from_millis(200),
-            );
+            let response =
+                read_response_matching_i64(&fixture.server, request_id, Duration::from_millis(200));
 
             let end_to_end_time = start_time.elapsed();
 
@@ -1155,6 +1152,6 @@ impl Drop for PerformanceTestFixture {
         }
 
         // Graceful server shutdown
-        shutdown_and_exit(&mut self.server);
+        shutdown_and_exit(&self.server);
     }
 }

--- a/crates/perl-lsp/tests/lsp_cancellation_protocol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_protocol_tests.rs
@@ -35,8 +35,8 @@ struct CancellationTestFixture {
 
 impl CancellationTestFixture {
     fn new() -> Self {
-        let mut server = start_lsp_server();
-        initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        initialize_lsp(&server);
 
         let mut test_workspace_files = HashMap::new();
 
@@ -85,7 +85,7 @@ print "Results: $result, $other, $complex\n";
 
         // Setup test files
         for (uri, content) in &test_workspace_files {
-            setup_test_file(&mut server, uri, content);
+            setup_test_file(&server, uri, content);
         }
 
         // Wait for indexing to complete with adaptive timeout
@@ -94,18 +94,18 @@ print "Results: $result, $other, $complex\n";
             3..=4 => Duration::from_secs(4), // Moderate: reduced timeout
             _ => Duration::from_secs(3),     // Unconstrained: shorter timeout
         };
-        drain_until_quiet(&mut server, Duration::from_millis(200), indexing_timeout);
+        drain_until_quiet(&server, Duration::from_millis(200), indexing_timeout);
 
         Self { server }
     }
 
     fn setup_test_file(&mut self, uri: &str, content: &str) {
-        setup_test_file(&mut self.server, uri, content);
+        setup_test_file(&self.server, uri, content);
     }
 }
 
 /// Setup test file helper
-fn setup_test_file(server: &mut LspServer, uri: &str, content: &str) {
+fn setup_test_file(server: &LspServer, uri: &str, content: &str) {
     send_notification(
         server,
         json!({
@@ -132,12 +132,12 @@ fn setup_test_file(server: &mut LspServer, uri: &str, content: &str) {
 #[test]
 fn test_enhanced_cancel_request_with_provider_context_ac1() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Test completion provider cancellation with enhanced context
     let completion_id = 1001;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": completion_id,
@@ -152,7 +152,7 @@ fn test_enhanced_cancel_request_with_provider_context_ac1() -> Result<(), Box<dy
     // Send enhanced cancellation with provider context
     // This should fail initially as enhanced cancellation infrastructure doesn't exist
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -170,7 +170,7 @@ fn test_enhanced_cancel_request_with_provider_context_ac1() -> Result<(), Box<dy
 
     // Validate enhanced cancellation response
     let response =
-        read_response_matching_i64(&mut fixture.server, completion_id, Duration::from_millis(500));
+        read_response_matching_i64(&fixture.server, completion_id, Duration::from_millis(500));
 
     if let Some(resp) = response {
         if let Some(error) = resp.get("error") {
@@ -209,7 +209,7 @@ fn test_enhanced_cancel_request_with_provider_context_ac1() -> Result<(), Box<dy
 #[test]
 fn test_multiple_provider_cancellation_with_context_ac1() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     let provider_scenarios = vec![
         (
@@ -253,7 +253,7 @@ fn test_multiple_provider_cancellation_with_context_ac1() -> Result<(), Box<dyn 
     // Send all provider requests concurrently
     for (id, method, params, _provider_type) in &provider_scenarios {
         send_request_no_wait(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -266,7 +266,7 @@ fn test_multiple_provider_cancellation_with_context_ac1() -> Result<(), Box<dyn 
     // Cancel all requests with provider-specific context
     for (id, method, _params, provider_type) in &provider_scenarios {
         send_notification(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "$/cancelRequest",
@@ -288,7 +288,7 @@ fn test_multiple_provider_cancellation_with_context_ac1() -> Result<(), Box<dyn 
     // Validate all cancellations with enhanced error context
     for (id, method, _params, _provider_type) in &provider_scenarios {
         let response =
-            read_response_matching_i64(&mut fixture.server, *id, Duration::from_millis(1000));
+            read_response_matching_i64(&fixture.server, *id, Duration::from_millis(1000));
 
         if let Some(resp) = response {
             if let Some(error) = resp.get("error") {
@@ -324,11 +324,11 @@ fn test_multiple_provider_cancellation_with_context_ac1() -> Result<(), Box<dyn 
 /// AC:1 - JSON-RPC 2.0 protocol compliance validation
 #[test]
 fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Test 1: Invalid cancellation request handling
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -340,7 +340,7 @@ fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Err
     );
 
     // Verify server remains stable and doesn't crash
-    let health_check = read_response_timeout(&mut fixture.server, Duration::from_millis(200));
+    let health_check = read_response_timeout(&fixture.server, Duration::from_millis(200));
     assert!(health_check.is_none(), "$/cancelRequest notification should not produce response");
     assert!(
         fixture.server.is_alive(),
@@ -349,7 +349,7 @@ fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Err
 
     // Test 2: Cancellation of non-existent request
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -358,13 +358,13 @@ fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Err
     );
 
     // Should handle gracefully without response
-    let response = read_response_timeout(&mut fixture.server, Duration::from_millis(200));
+    let response = read_response_timeout(&fixture.server, Duration::from_millis(200));
     assert!(response.is_none(), "Non-existent request cancellation should not produce response");
 
     // Test 3: JSON-RPC structure validation
     let test_id = 3001;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": test_id,
@@ -377,7 +377,7 @@ fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Err
     );
 
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -386,7 +386,7 @@ fn test_json_rpc_protocol_compliance_ac1() -> Result<(), Box<dyn std::error::Err
     );
 
     if let Some(resp) =
-        read_response_matching_i64(&mut fixture.server, test_id, Duration::from_millis(500))
+        read_response_matching_i64(&fixture.server, test_id, Duration::from_millis(500))
     {
         // Validate JSON-RPC 2.0 structure
         assert_eq!(resp.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
@@ -697,7 +697,7 @@ fn test_provider_cleanup_thread_safety_ac2() -> Result<(), Box<dyn std::error::E
 /// AC:3 - Dual indexing cancellation with consistency preservation
 #[test]
 fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Wait for initial indexing to complete with adaptive timeout
     let initial_indexing_timeout = match max_concurrent_threads() {
@@ -705,12 +705,12 @@ fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::
         3..=4 => Duration::from_secs(6),  // Moderate: reduced timeout
         _ => Duration::from_secs(4),      // Unconstrained: shorter timeout
     };
-    drain_until_quiet(&mut fixture.server, Duration::from_millis(500), initial_indexing_timeout);
+    drain_until_quiet(&fixture.server, Duration::from_millis(500), initial_indexing_timeout);
 
     // Verify baseline dual pattern functionality before cancellation testing
     let baseline_qualified =
-        request_workspace_symbols(&mut fixture.server, "TestModule::test_function");
-    let baseline_bare = request_workspace_symbols(&mut fixture.server, "test_function");
+        request_workspace_symbols(&fixture.server, "TestModule::test_function");
+    let baseline_bare = request_workspace_symbols(&fixture.server, "test_function");
 
     // Baseline assertions - these should work with current implementation
     assert!(
@@ -721,7 +721,7 @@ fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::
     // Test cancellation during workspace symbol search (re-indexing simulation)
     let reindex_id = 3001;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": reindex_id,
@@ -732,7 +732,7 @@ fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::
 
     // Cancel during indexing operation to test consistency preservation
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -748,8 +748,8 @@ fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::
 
     // Verify dual pattern functionality is preserved after cancellation
     let post_cancel_qualified =
-        request_workspace_symbols(&mut fixture.server, "TestModule::test_function");
-    let post_cancel_bare = request_workspace_symbols(&mut fixture.server, "test_function");
+        request_workspace_symbols(&fixture.server, "TestModule::test_function");
+    let post_cancel_bare = request_workspace_symbols(&fixture.server, "test_function");
 
     // Index consistency validation - enhanced implementation will ensure
     // atomic operations preserve dual indexing integrity
@@ -774,7 +774,7 @@ fn test_dual_indexing_cancellation_consistency_ac3() -> Result<(), Box<dyn std::
 }
 
 /// Helper function to request workspace symbols
-fn request_workspace_symbols(server: &mut LspServer, query: &str) -> Vec<Value> {
+fn request_workspace_symbols(server: &LspServer, query: &str) -> Vec<Value> {
     let response = send_request(
         server,
         json!({
@@ -791,7 +791,7 @@ fn request_workspace_symbols(server: &mut LspServer, query: &str) -> Vec<Value> 
 /// AC:3 - Cross-file navigation cancellation with multi-tier fallback preservation
 #[test]
 fn test_cross_file_navigation_cancellation_ac3() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Wait for cross-file indexing to stabilize with adaptive timeout
     let cross_file_timeout = match max_concurrent_threads() {
@@ -799,12 +799,12 @@ fn test_cross_file_navigation_cancellation_ac3() -> Result<(), Box<dyn std::erro
         3..=4 => Duration::from_secs(8),  // Moderate: reduced timeout
         _ => Duration::from_secs(5),      // Unconstrained: shorter timeout
     };
-    drain_until_quiet(&mut fixture.server, Duration::from_millis(1000), cross_file_timeout);
+    drain_until_quiet(&fixture.server, Duration::from_millis(1000), cross_file_timeout);
 
     // Test definition resolution cancellation across files
     let definition_id = 4001;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": definition_id,
@@ -818,7 +818,7 @@ fn test_cross_file_navigation_cancellation_ac3() -> Result<(), Box<dyn std::erro
 
     // Cancel definition resolution to test multi-tier fallback preservation
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -835,12 +835,12 @@ fn test_cross_file_navigation_cancellation_ac3() -> Result<(), Box<dyn std::erro
 
     // Validate cancellation response or completion
     let response =
-        read_response_matching_i64(&mut fixture.server, definition_id, Duration::from_secs(2));
+        read_response_matching_i64(&fixture.server, definition_id, Duration::from_secs(2));
     validate_cancellation_or_completion(response, "cross-file definition resolution");
 
     // Verify workspace navigation remains functional after cancellation
     let verification_response = send_request(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/definition",
@@ -907,12 +907,12 @@ fn test_workspace_symbol_dual_pattern_cancellation_ac3() -> Result<(), Box<dyn s
         3..=4 => Duration::from_secs(12), // Moderate: reduced timeout
         _ => Duration::from_secs(8),      // Unconstrained: shorter timeout
     };
-    drain_until_quiet(&mut fixture.server, Duration::from_millis(1000), large_file_timeout);
+    drain_until_quiet(&fixture.server, Duration::from_millis(1000), large_file_timeout);
 
     // Test qualified pattern search with cancellation
     let qualified_search_id = 5001;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": qualified_search_id,
@@ -924,7 +924,7 @@ fn test_workspace_symbol_dual_pattern_cancellation_ac3() -> Result<(), Box<dyn s
     // Cancel after brief delay to test cancellation during search
     thread::sleep(Duration::from_millis(50));
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -941,7 +941,7 @@ fn test_workspace_symbol_dual_pattern_cancellation_ac3() -> Result<(), Box<dyn s
     // Test bare pattern search with cancellation
     let bare_search_id = 5002;
     send_request_no_wait(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "id": bare_search_id,
@@ -952,7 +952,7 @@ fn test_workspace_symbol_dual_pattern_cancellation_ac3() -> Result<(), Box<dyn s
 
     thread::sleep(Duration::from_millis(50));
     send_notification(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -967,13 +967,10 @@ fn test_workspace_symbol_dual_pattern_cancellation_ac3() -> Result<(), Box<dyn s
     );
 
     // Validate both search cancellations
-    let qualified_response = read_response_matching_i64(
-        &mut fixture.server,
-        qualified_search_id,
-        Duration::from_secs(3),
-    );
+    let qualified_response =
+        read_response_matching_i64(&fixture.server, qualified_search_id, Duration::from_secs(3));
     let bare_response =
-        read_response_matching_i64(&mut fixture.server, bare_search_id, Duration::from_secs(3));
+        read_response_matching_i64(&fixture.server, bare_search_id, Duration::from_secs(3));
 
     validate_cancellation_or_completion(qualified_response, "qualified pattern search");
     validate_cancellation_or_completion(bare_response, "bare pattern search");
@@ -1007,7 +1004,7 @@ fn generate_large_perl_content(function_count: usize) -> String {
 /// AC:4 - Enhanced -32800 error code responses with context and performance tracking
 #[test]
 fn test_enhanced_error_response_handling_ac4() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     let test_scenarios = vec![
         (
@@ -1045,7 +1042,7 @@ fn test_enhanced_error_response_handling_ac4() -> Result<(), Box<dyn std::error:
 
         // Send request
         send_request_no_wait(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": request_id,
@@ -1056,7 +1053,7 @@ fn test_enhanced_error_response_handling_ac4() -> Result<(), Box<dyn std::error:
 
         // Cancel with enhanced context
         send_notification(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "$/cancelRequest",
@@ -1080,7 +1077,7 @@ fn test_enhanced_error_response_handling_ac4() -> Result<(), Box<dyn std::error:
 
         // Validate enhanced error response
         if let Some(response) =
-            read_response_matching_i64(&mut fixture.server, request_id, Duration::from_secs(1))
+            read_response_matching_i64(&fixture.server, request_id, Duration::from_secs(1))
         {
             if let Some(error) = response.get("error") {
                 // Validate standard error code
@@ -1147,14 +1144,14 @@ fn test_enhanced_error_response_handling_ac4() -> Result<(), Box<dyn std::error:
 /// AC:4 - Graceful error handling under various cancellation scenarios
 #[test]
 fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Test 1: Rapid successive cancellations
     let rapid_ids = vec![7001, 7002, 7003, 7004, 7005];
 
     for &id in &rapid_ids {
         send_request_no_wait(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -1168,7 +1165,7 @@ fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error
 
         // Immediate cancellation
         send_notification(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "$/cancelRequest",
@@ -1181,7 +1178,7 @@ fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error
     let mut responses = Vec::new();
     for &id in &rapid_ids {
         if let Some(resp) =
-            read_response_matching_i64(&mut fixture.server, id, Duration::from_millis(500))
+            read_response_matching_i64(&fixture.server, id, Duration::from_millis(500))
         {
             responses.push((id, resp));
         }
@@ -1229,7 +1226,7 @@ fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error
     ];
 
     for malformed_request in malformed_scenarios {
-        send_notification(&mut fixture.server, malformed_request);
+        send_notification(&fixture.server, malformed_request);
 
         // Brief pause to process
         thread::sleep(adaptive_sleep_ms(50));
@@ -1243,7 +1240,7 @@ fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error
 
     // Final stability check
     let health_response = send_request(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -1271,7 +1268,7 @@ fn test_graceful_error_degradation_ac4() -> Result<(), Box<dyn std::error::Error
 /// AC:5 - Multiple concurrent cancellation handling without interference
 #[test]
 fn test_concurrent_cancellation_coordination_ac5() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Create concurrent requests across different providers
     let concurrent_requests = vec![
@@ -1321,7 +1318,7 @@ fn test_concurrent_cancellation_coordination_ac5() -> Result<(), Box<dyn std::er
     let start_time = Instant::now();
     for (id, method, params) in &concurrent_requests {
         send_request_no_wait(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -1346,7 +1343,7 @@ fn test_concurrent_cancellation_coordination_ac5() -> Result<(), Box<dyn std::er
     for (id, delay) in cancellation_patterns {
         thread::sleep(delay);
         send_notification(
-            &mut fixture.server,
+            &fixture.server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "$/cancelRequest",
@@ -1365,7 +1362,7 @@ fn test_concurrent_cancellation_coordination_ac5() -> Result<(), Box<dyn std::er
     let mut results = HashMap::new();
     for (id, method, _) in &concurrent_requests {
         if let Some(response) =
-            read_response_matching_i64(&mut fixture.server, *id, Duration::from_secs(2))
+            read_response_matching_i64(&fixture.server, *id, Duration::from_secs(2))
         {
             results.insert(*id, ((*method).to_string(), response));
         }
@@ -1429,7 +1426,7 @@ fn test_concurrent_cancellation_coordination_ac5() -> Result<(), Box<dyn std::er
 /// AC:5 - Resource cleanup during concurrent cancellation without memory leaks
 #[test]
 fn test_concurrent_resource_cleanup_ac5() -> Result<(), Box<dyn std::error::Error>> {
-    let mut fixture = CancellationTestFixture::new();
+    let fixture = CancellationTestFixture::new();
 
     // Memory measurement before concurrent operations
     let baseline_memory = estimate_memory_usage();
@@ -1446,7 +1443,7 @@ fn test_concurrent_resource_cleanup_ac5() -> Result<(), Box<dyn std::error::Erro
             let id = (wave * 1000) + req_in_wave + 9000;
 
             send_request_no_wait(
-                &mut fixture.server,
+                &fixture.server,
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
@@ -1466,7 +1463,7 @@ fn test_concurrent_resource_cleanup_ac5() -> Result<(), Box<dyn std::error::Erro
             if idx % 3 != 0 {
                 // Cancel ~67% of requests
                 send_notification(
-                    &mut fixture.server,
+                    &fixture.server,
                     json!({
                         "jsonrpc": "2.0",
                         "method": "$/cancelRequest",
@@ -1487,7 +1484,7 @@ fn test_concurrent_resource_cleanup_ac5() -> Result<(), Box<dyn std::error::Erro
     }
 
     // Wait for all operations to settle
-    drain_until_quiet(&mut fixture.server, Duration::from_millis(500), Duration::from_secs(10));
+    drain_until_quiet(&fixture.server, Duration::from_millis(500), Duration::from_secs(10));
 
     // Memory measurement after concurrent operations
     let final_memory = estimate_memory_usage();
@@ -1509,7 +1506,7 @@ fn test_concurrent_resource_cleanup_ac5() -> Result<(), Box<dyn std::error::Erro
 
     // Final system health check
     let health_response = send_request(
-        &mut fixture.server,
+        &fixture.server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -1547,7 +1544,7 @@ fn estimate_memory_usage() -> usize {
 impl Drop for CancellationTestFixture {
     fn drop(&mut self) {
         // Graceful cleanup
-        shutdown_and_exit(&mut self.server);
+        shutdown_and_exit(&self.server);
     }
 }
 

--- a/crates/perl-lsp/tests/lsp_capabilities_contract.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_contract.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 /// PHASE 1 RE-ENABLED: Pure API contract test, no I/O, safe for CI
 #[test]
 fn test_ga_capabilities_contract() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Send initialize request through public API
     let request = JsonRpcRequest {
@@ -121,7 +121,7 @@ fn test_ga_capabilities_contract() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 
 fn test_unsupported_methods_return_error() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize first through public API
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_capabilities_contract_full.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_contract_full.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 #[test]
 #[cfg(not(feature = "lsp-ga-lock"))]
 fn full_capabilities_match_contract() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_code_actions_tests.rs
+++ b/crates/perl-lsp/tests/lsp_code_actions_tests.rs
@@ -9,12 +9,12 @@ use common::{
 /// Test extract variable refactoring
 #[test]
 fn test_extract_variable() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -35,7 +35,7 @@ print $result;
 
     // Request code actions for the expression "length($str)"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -58,19 +58,19 @@ print $result;
         let title = a["title"].as_str().unwrap_or("");
         title.contains("Extract") && title.contains("variable")
     }));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test adding error checking to file operations
 #[test]
 fn test_add_error_checking() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -91,7 +91,7 @@ close($fh);
 
     // Request code actions for the open statement
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -111,19 +111,19 @@ close($fh);
 
     let actions = response["result"].as_array().ok_or("Expected result to be an array")?;
     assert!(actions.iter().any(|a| a["title"].as_str().unwrap_or("").contains("error checking")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test converting old-style for loops to foreach
 #[test]
 fn test_convert_loop_style() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -144,7 +144,7 @@ for (my $i = 0; $i < @array; $i++) {
 
     // Request code actions for the for loop
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 3,
@@ -168,19 +168,19 @@ for (my $i = 0; $i < @array; $i++) {
         "Expected 'foreach loop' conversion action but got: {:?}",
         actions.iter().map(|a| a["title"].as_str()).collect::<Vec<_>>()
     );
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test converting to postfix form
 #[test]
 fn test_convert_to_postfix() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -201,7 +201,7 @@ if ($debug) {
 
     // Request code actions for the if statement
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 4,
@@ -221,19 +221,19 @@ if ($debug) {
 
     let actions = response["result"].as_array().ok_or("Expected result to be an array")?;
     assert!(actions.iter().any(|a| a["title"].as_str().unwrap_or("").contains("postfix")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test adding missing pragmas
 #[test]
 fn test_add_missing_pragmas() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -255,7 +255,7 @@ print $x;
 
     // Request code actions for the entire document
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 5,
@@ -275,19 +275,19 @@ print $x;
 
     let actions = response["result"].as_array().ok_or("Expected result to be an array")?;
     assert!(actions.iter().any(|a| a["title"].as_str().unwrap_or("").contains("pragma")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test quick fix for undefined variable
 #[test]
 fn test_fix_undefined_variable() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -309,7 +309,7 @@ print $undefined_var;
 
     // First get diagnostics
     let diag_response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 6,
@@ -322,7 +322,7 @@ print $undefined_var;
 
     // Request code actions with diagnostics
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 7,
@@ -345,19 +345,19 @@ print $undefined_var;
         let title = a["title"].as_str().unwrap_or("");
         title.contains("Declare") && title.contains("my")
     }));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test extract subroutine refactoring
 #[test]
 fn test_extract_subroutine() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -383,7 +383,7 @@ my $y = 20;
 
     // Request code actions for the block
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 8,
@@ -403,19 +403,19 @@ my $y = 20;
 
     let actions = response["result"].as_array().ok_or("Expected result to be an array")?;
     assert!(actions.iter().any(|a| a["title"].as_str().unwrap_or("").contains("subroutine")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test organize imports refactoring
 #[test]
 fn test_organize_imports() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -442,7 +442,7 @@ print "test\n";
 
     // Request code actions for the import section
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 9,
@@ -462,19 +462,19 @@ print "test\n";
 
     let actions = response["result"].as_array().ok_or("Expected result to be an array")?;
     assert!(actions.iter().any(|a| a["title"].as_str().unwrap_or("").contains("Organize imports")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Test multiple refactorings available
 #[test]
 fn test_multiple_refactorings() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -497,7 +497,7 @@ if ($processed > 100) {
 
     // Request code actions for the complex expression
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 10,
@@ -521,6 +521,6 @@ if ($processed > 100) {
     // Should have multiple refactoring options
     assert!(!actions.is_empty(), "Expected code actions but got none");
     assert!(actions.iter().any(|a| a["kind"].as_str() == Some("refactor.extract")));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_code_lens_reference_test.rs
+++ b/crates/perl-lsp/tests/lsp_code_lens_reference_test.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -37,7 +37,7 @@ fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
 
 #[test]
 fn test_code_lens_reference_counting() -> TestResult {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
 
     // Open a document with a subroutine that's called multiple times
     let code = r#"
@@ -165,7 +165,7 @@ sub unused_function {
 
 #[test]
 fn test_code_lens_package_references() -> TestResult {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
 
     // Open a document with a package that's used
     let code = r#"

--- a/crates/perl-lsp/tests/lsp_color_tests.rs
+++ b/crates/perl-lsp/tests/lsp_color_tests.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 /// Helper to send a request and get result
-fn send_request(server: &mut LspServer, method: &str, params: Value) -> Result<Value, String> {
+fn send_request(server: &LspServer, method: &str, params: Value) -> Result<Value, String> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -31,11 +31,11 @@ fn send_request(server: &mut LspServer, method: &str, params: Value) -> Result<V
 /// Create a test server with a document containing color codes
 fn setup_color_server() -> LspServer {
     let output = Arc::new(Mutex::new(Box::new(Vec::new()) as Box<dyn std::io::Write + Send>));
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Initialize the server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         json!({
             "capabilities": {},
@@ -84,10 +84,10 @@ fn setup_color_server() -> LspServer {
 
 #[test]
 fn lsp_color_detect_hex_colors() -> TestResult {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentColor",
         json!({
             "textDocument": {
@@ -125,10 +125,10 @@ fn lsp_color_detect_hex_colors() -> TestResult {
 
 #[test]
 fn lsp_color_detect_ansi_colors() -> TestResult {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentColor",
         json!({
             "textDocument": {
@@ -156,11 +156,11 @@ fn lsp_color_detect_ansi_colors() -> TestResult {
 
 #[test]
 fn lsp_color_presentation_hex() -> TestResult {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     // Test color presentation for pure red
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/colorPresentation",
         json!({
             "textDocument": {
@@ -197,11 +197,11 @@ fn lsp_color_presentation_hex() -> TestResult {
 
 #[test]
 fn lsp_color_presentation_with_alpha() -> TestResult {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     // Test color presentation with alpha channel
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/colorPresentation",
         json!({
             "textDocument": {
@@ -237,11 +237,11 @@ fn lsp_color_presentation_with_alpha() -> TestResult {
 #[test]
 fn lsp_color_empty_document() -> TestResult {
     let output = Arc::new(Mutex::new(Box::new(Vec::new()) as Box<dyn std::io::Write + Send>));
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Initialize
     send_request(
-        &mut server,
+        &server,
         "initialize",
         json!({
             "capabilities": {},
@@ -277,7 +277,7 @@ fn lsp_color_empty_document() -> TestResult {
     server.handle_request(did_open);
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentColor",
         json!({
             "textDocument": {
@@ -294,15 +294,15 @@ fn lsp_color_empty_document() -> TestResult {
 
 #[test]
 fn lsp_color_invalid_params() {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     // Missing textDocument field
-    let result = send_request(&mut server, "textDocument/documentColor", json!({}));
+    let result = send_request(&server, "textDocument/documentColor", json!({}));
     assert!(result.is_err(), "Should return error for missing textDocument");
 
     // Missing color field in presentation
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/colorPresentation",
         json!({
             "textDocument": {"uri": "file:///test/colors.pl"}
@@ -313,11 +313,11 @@ fn lsp_color_invalid_params() {
 
 #[test]
 fn lsp_color_round_trip() -> TestResult {
-    let mut server = setup_color_server();
+    let server = setup_color_server();
 
     // Get colors from document
     let detected = send_request(
-        &mut server,
+        &server,
         "textDocument/documentColor",
         json!({
             "textDocument": {
@@ -331,7 +331,7 @@ fn lsp_color_round_trip() -> TestResult {
     if let Some(first_color) = colors.first() {
         // Use detected color to get presentations
         let presentations = send_request(
-            &mut server,
+            &server,
             "textDocument/colorPresentation",
             json!({
                 "textDocument": {
@@ -357,11 +357,11 @@ fn lsp_color_round_trip() -> TestResult {
 #[test]
 fn lsp_color_utf16_position_with_non_ascii_prefix() -> TestResult {
     let output = Arc::new(Mutex::new(Box::new(Vec::new()) as Box<dyn std::io::Write + Send>));
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Initialize
     send_request(
-        &mut server,
+        &server,
         "initialize",
         json!({
             "capabilities": {},
@@ -402,7 +402,7 @@ fn lsp_color_utf16_position_with_non_ascii_prefix() -> TestResult {
     server.handle_request(did_open);
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentColor",
         json!({
             "textDocument": {

--- a/crates/perl-lsp/tests/lsp_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_completion_tests.rs
@@ -7,13 +7,13 @@ use common::{completion_items, initialize_lsp, send_notification, send_request, 
 /// Test basic variable completion
 #[test]
 fn test_scalar_variable_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open a document with scalar variables
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -36,7 +36,7 @@ $cou
 
     // Request completion at position after "$cou"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -65,12 +65,12 @@ $cou
 /// Test array variable completion
 #[test]
 fn test_array_variable_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -92,7 +92,7 @@ my @data = qw(a b c);
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -119,12 +119,12 @@ my @data = qw(a b c);
 /// Test hash variable completion
 #[test]
 fn test_hash_variable_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -146,7 +146,7 @@ my %settings = ();
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -174,12 +174,12 @@ my %settings = ();
 /// Test function completion
 #[test]
 fn test_function_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -207,7 +207,7 @@ proc
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -235,12 +235,12 @@ proc
 /// Test built-in function completion
 #[test]
 fn test_builtin_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -256,7 +256,7 @@ fn test_builtin_completion() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -284,12 +284,12 @@ fn test_builtin_completion() -> Result<(), Box<dyn std::error::Error>> {
 /// Test keyword completion
 #[test]
 fn test_keyword_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -305,7 +305,7 @@ fn test_keyword_completion() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -340,12 +340,12 @@ fn test_keyword_completion() -> Result<(), Box<dyn std::error::Error>> {
 /// Test special variable completion
 #[test]
 fn test_special_variable_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -361,7 +361,7 @@ fn test_special_variable_completion() -> Result<(), Box<dyn std::error::Error>> 
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -402,12 +402,12 @@ fn test_special_variable_completion() -> Result<(), Box<dyn std::error::Error>> 
 /// Test method completion after ->
 #[test]
 fn test_method_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -423,7 +423,7 @@ fn test_method_completion() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -458,12 +458,12 @@ fn test_method_completion() -> Result<(), Box<dyn std::error::Error>> {
 /// Test completion in mixed context
 #[test]
 fn test_mixed_context_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -489,7 +489,7 @@ va
 
     // Request completion at position after "va"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -519,12 +519,12 @@ va
 /// Test completion details and documentation
 #[test]
 fn test_completion_details() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -540,7 +540,7 @@ fn test_completion_details() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -575,12 +575,12 @@ fn test_completion_details() -> Result<(), Box<dyn std::error::Error>> {
 /// Test completion with empty prefix (should show all relevant items)
 #[test]
 fn test_empty_prefix_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -596,7 +596,7 @@ fn test_empty_prefix_completion() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -627,12 +627,12 @@ fn test_empty_prefix_completion() -> Result<(), Box<dyn std::error::Error>> {
 /// Test that completion doesn't trigger in comments
 #[test]
 fn test_no_completion_in_comments() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -648,7 +648,7 @@ fn test_no_completion_in_comments() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -668,12 +668,12 @@ fn test_no_completion_in_comments() -> Result<(), Box<dyn std::error::Error>> {
 /// Test completion with package context
 #[test]
 fn test_package_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -697,7 +697,7 @@ MyModule::"#
 
     // Test package member completion (qualified name after ::)
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -730,12 +730,12 @@ MyModule::"#
 /// Test package completion for known core modules outside the workspace index
 #[test]
 fn test_core_module_package_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -753,7 +753,7 @@ List::Util::"#
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -792,12 +792,12 @@ List::Util::"#
 #[test]
 fn test_core_module_package_completion_additional_module() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -815,7 +815,7 @@ Cwd::"#
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -836,12 +836,12 @@ Cwd::"#
 /// Test snippet expansion in completions
 #[test]
 fn test_snippet_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -857,7 +857,7 @@ fn test_snippet_completion() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -915,12 +915,12 @@ fn test_snippet_completion() -> Result<(), Box<dyn std::error::Error>> {
 /// Test array and hash element access completion
 #[test]
 fn test_element_access_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -940,7 +940,7 @@ $arr"#
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -968,12 +968,12 @@ $arr"#
 /// Test completion filtering and ranking
 #[test]
 fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -989,7 +989,7 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -1018,14 +1018,14 @@ fn test_completion_ranking() -> Result<(), Box<dyn std::error::Error>> {
 /// Test completion with incremental typing
 #[test]
 fn test_incremental_completion() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
 
     // Initial document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -1047,7 +1047,7 @@ $p"#
 
     // First completion request with "$p"
     let response1 = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -1064,7 +1064,7 @@ $p"#
 
     // Update document to narrow down
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -1087,7 +1087,7 @@ $pre"#
 
     // Second completion request with "$pre"
     let response2 = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -1104,7 +1104,7 @@ $pre"#
 
     // Update to be more specific
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -1127,7 +1127,7 @@ $prefi"#
 
     // Third completion request with "$prefi"
     let response3 = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",

--- a/crates/perl-lsp/tests/lsp_concurrency.rs
+++ b/crates/perl-lsp/tests/lsp_concurrency.rs
@@ -12,14 +12,14 @@ use common::{
 
 #[test]
 fn test_concurrent_document_modifications() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///concurrent.pl";
 
     // Open initial document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -53,7 +53,7 @@ fn test_concurrent_document_modifications() -> Result<(), Box<dyn std::error::Er
     for handle in handles {
         let (version, text) = handle.join().map_err(|_| "Thread join failed")?;
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -75,7 +75,7 @@ fn test_concurrent_document_modifications() -> Result<(), Box<dyn std::error::Er
 
     // Final request should see consistent state
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -93,12 +93,12 @@ fn test_concurrent_document_modifications() -> Result<(), Box<dyn std::error::Er
 
 #[test]
 fn test_concurrent_requests() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open test document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -134,7 +134,7 @@ fn test_concurrent_requests() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -154,8 +154,8 @@ fn test_concurrent_requests() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Rapidly open and close documents (adaptive count)
     let document_count = (max_concurrent_threads()).clamp(2, 10);
@@ -164,7 +164,7 @@ fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
 
         // Open document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -181,7 +181,7 @@ fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
 
         // Immediately try to use it
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i * 2 + 1,
@@ -195,7 +195,7 @@ fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
 
         // Close document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didClose",
@@ -212,7 +212,7 @@ fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
 
         // Try to use after close (should fail gracefully)
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i * 2 + 2,
@@ -230,14 +230,14 @@ fn test_race_condition_open_close() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_workspace_symbol_during_changes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open multiple documents (adaptive count)
     let document_count = (max_concurrent_threads() / 2).clamp(2, 5);
     for i in 0..document_count {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -255,7 +255,7 @@ fn test_workspace_symbol_during_changes() -> Result<(), Box<dyn std::error::Erro
 
     // Start workspace symbol search
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 100,
@@ -269,7 +269,7 @@ fn test_workspace_symbol_during_changes() -> Result<(), Box<dyn std::error::Erro
     // Modify documents during search (adaptive count)
     for i in 0..document_count {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -288,7 +288,7 @@ fn test_workspace_symbol_during_changes() -> Result<(), Box<dyn std::error::Erro
 
     // Another workspace search
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 101,
@@ -304,12 +304,12 @@ fn test_workspace_symbol_during_changes() -> Result<(), Box<dyn std::error::Erro
 
 #[test]
 fn test_reference_search_during_edits() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open document with variable
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -326,7 +326,7 @@ fn test_reference_search_during_edits() -> Result<(), Box<dyn std::error::Error>
 
     // Start reference search
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -341,7 +341,7 @@ fn test_reference_search_during_edits() -> Result<(), Box<dyn std::error::Error>
 
     // Modify document while search might be in progress
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -359,7 +359,7 @@ fn test_reference_search_during_edits() -> Result<(), Box<dyn std::error::Error>
 
     // Another reference search
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -377,14 +377,14 @@ fn test_reference_search_during_edits() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_completion_cache_invalidation() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///completion.pl";
 
     // Open document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -401,7 +401,7 @@ fn test_completion_cache_invalidation() -> Result<(), Box<dyn std::error::Error>
 
     // Request completion
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -415,7 +415,7 @@ fn test_completion_cache_invalidation() -> Result<(), Box<dyn std::error::Error>
 
     // Change document (should invalidate completion cache)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -433,7 +433,7 @@ fn test_completion_cache_invalidation() -> Result<(), Box<dyn std::error::Error>
 
     // Request completion again (should reflect new state)
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -450,8 +450,8 @@ fn test_completion_cache_invalidation() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_diagnostic_publishing_race() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///diagnostic.pl";
 
@@ -466,7 +466,7 @@ fn test_diagnostic_publishing_race() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": if version == 1 { "textDocument/didOpen" } else { "textDocument/didChange" },
@@ -495,7 +495,7 @@ fn test_diagnostic_publishing_race() -> Result<(), Box<dyn std::error::Error>> {
 
     // Final state should be consistent
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -511,14 +511,14 @@ fn test_diagnostic_publishing_race() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_multi_file_rename_race() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create multiple files with shared variable (adaptive count)
     let file_count = (max_concurrent_threads() / 2).clamp(1, 3);
     for i in 0..file_count {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -536,7 +536,7 @@ fn test_multi_file_rename_race() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start rename operation
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -552,7 +552,7 @@ fn test_multi_file_rename_race() -> Result<(), Box<dyn std::error::Error>> {
     // Modify files during rename (adaptive count)
     for i in 0..file_count {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -574,12 +574,12 @@ fn test_multi_file_rename_race() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_call_hierarchy_during_refactoring() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create call hierarchy
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -613,7 +613,7 @@ sub baz {
 
     // Prepare call hierarchy
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -627,7 +627,7 @@ sub baz {
 
     // Modify document during hierarchy traversal
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -670,14 +670,14 @@ sub qux {
 
 #[test]
 fn test_semantic_tokens_consistency() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///semantic.pl";
 
     // Open document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -696,7 +696,7 @@ fn test_semantic_tokens_consistency() -> Result<(), Box<dyn std::error::Error>> 
     let request_count = max_concurrent_threads().clamp(2, 5);
     for id in 1..request_count {
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -710,7 +710,7 @@ fn test_semantic_tokens_consistency() -> Result<(), Box<dyn std::error::Error>> 
         // Interleave with edits
         if id % 2 == 0 {
             send_notification(
-                &mut server,
+                &server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "textDocument/didChange",

--- a/crates/perl-lsp/tests/lsp_concurrent_request_management_tests_simple.rs
+++ b/crates/perl-lsp/tests/lsp_concurrent_request_management_tests_simple.rs
@@ -15,8 +15,8 @@ use common::{initialize_lsp, send_notification, send_request, start_lsp_server};
 fn test_concurrent_request_processing_ac3() {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#enhanced-concurrent-request-management
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send multiple concurrent requests
     let concurrent_requests = 5;
@@ -27,7 +27,7 @@ fn test_concurrent_request_processing_ac3() {
 
         // Send different types of requests
         let response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -53,8 +53,8 @@ fn test_concurrent_request_processing_ac3() {
 fn test_lsp_workflow_stage_tracking_ac4() {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#enhanced-concurrent-request-management
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Test different LSP workflow stages
     let workflow_tests = vec![
@@ -68,7 +68,7 @@ fn test_lsp_workflow_stage_tracking_ac4() {
         let start_time = Instant::now();
 
         let response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": method,
@@ -98,8 +98,8 @@ fn test_lsp_workflow_stage_tracking_ac4() {
 fn test_request_timeout_cancellation_integration_ac3_ac4() {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#enhanced-concurrent-request-management
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send request that might take time
     let request_id = json!("cancellable_test");
@@ -108,7 +108,7 @@ fn test_request_timeout_cancellation_integration_ac3_ac4() {
 
     // Send long-running request
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": request_id,
@@ -126,7 +126,7 @@ fn test_request_timeout_cancellation_integration_ac3_ac4() {
 
     // Test cancellation (send cancellation notification)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -138,7 +138,7 @@ fn test_request_timeout_cancellation_integration_ac3_ac4() {
 
     // Verify server remains responsive after cancellation
     let health_response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": "health_check",
@@ -157,8 +157,8 @@ fn test_request_timeout_cancellation_integration_ac3_ac4() {
 fn test_performance_metrics_collection_ac3() {
     // Tests feature spec: SPEC_144_IGNORED_TESTS_ARCHITECTURAL_BLUEPRINT.md#enhanced-concurrent-request-management
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Test different types of requests to collect varied metrics
     let request_types = [
@@ -175,7 +175,7 @@ fn test_performance_metrics_collection_ac3() {
         let request_start = Instant::now();
 
         let response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": format!("metrics_{}", i),

--- a/crates/perl-lsp/tests/lsp_content_length_framing_integration.rs
+++ b/crates/perl-lsp/tests/lsp_content_length_framing_integration.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 #[test]
 fn handles_back_to_back_frames_in_single_write() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     let first = json!({
         "jsonrpc": "2.0",
@@ -33,9 +33,9 @@ fn handles_back_to_back_frames_in_single_write() -> Result<(), Box<dyn std::erro
 
     let timeout = Duration::from_secs(2);
     let first_response =
-        read_response_matching_i64(&mut server, 901, timeout).ok_or("missing response 901")?;
+        read_response_matching_i64(&server, 901, timeout).ok_or("missing response 901")?;
     let second_response =
-        read_response_matching_i64(&mut server, 902, timeout).ok_or("missing response 902")?;
+        read_response_matching_i64(&server, 902, timeout).ok_or("missing response 902")?;
 
     assert_eq!(first_response.get("id"), Some(&json!(901)));
     assert_eq!(second_response.get("id"), Some(&json!(902)));

--- a/crates/perl-lsp/tests/lsp_cross_file_nav.rs
+++ b/crates/perl-lsp/tests/lsp_cross_file_nav.rs
@@ -2,7 +2,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::json;
 
 fn init_server() -> LspServer {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -21,7 +21,7 @@ fn init_server() -> LspServer {
     srv
 }
 
-fn open(server: &mut LspServer, uri: &str, text: &str) {
+fn open(server: &LspServer, uri: &str, text: &str) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -42,11 +42,11 @@ fn open(server: &mut LspServer, uri: &str, text: &str) {
 
 #[test]
 fn test_cross_file_definition() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = init_server();
+    let srv = init_server();
 
     // File 1: defines Foo::bar
     open(
-        &mut srv,
+        &srv,
         "file:///lib/Foo.pm",
         r#"package Foo;
 use strict;
@@ -62,7 +62,7 @@ sub bar {
 
     // File 2: calls Foo::bar
     open(
-        &mut srv,
+        &srv,
         "file:///app.pl",
         r#"#!/usr/bin/perl
 use strict;
@@ -115,11 +115,11 @@ print "Result: $result\n";
 
 #[test]
 fn test_cross_file_references() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = init_server();
+    let srv = init_server();
 
     // File 1: defines and uses a function
     open(
-        &mut srv,
+        &srv,
         "file:///lib/Utils.pm",
         r#"package Utils;
 use strict;
@@ -140,7 +140,7 @@ sub test_self {
 
     // File 2: uses Utils::process_data
     open(
-        &mut srv,
+        &srv,
         "file:///script1.pl",
         r#"#!/usr/bin/perl
 use strict;
@@ -153,7 +153,7 @@ my $result = Utils::process_data(5);
 
     // File 3: also uses Utils::process_data
     open(
-        &mut srv,
+        &srv,
         "file:///script2.pl",
         r#"#!/usr/bin/perl
 use strict;
@@ -207,11 +207,11 @@ for (1..10) {
 
 #[test]
 fn test_workspace_symbols_after_indexing() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = init_server();
+    let srv = init_server();
 
     // Index multiple files
     open(
-        &mut srv,
+        &srv,
         "file:///lib/Math.pm",
         r#"package Math;
 sub add { $_[0] + $_[1] }
@@ -222,7 +222,7 @@ sub multiply { $_[0] * $_[1] }
     );
 
     open(
-        &mut srv,
+        &srv,
         "file:///lib/String.pm",
         r#"package String;
 sub concat { $_[0] . $_[1] }

--- a/crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs
+++ b/crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs
@@ -11,7 +11,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 /// Test that documentLink/resolve returns target for deferred module links
 #[test]
 fn test_document_link_resolve_module() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -76,7 +76,7 @@ fn test_document_link_resolve_module() -> TestResult {
 /// Test that documentLink/resolve handles file path links
 #[test]
 fn test_document_link_resolve_file() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -139,7 +139,7 @@ fn test_document_link_resolve_file() -> TestResult {
 /// Test that already-resolved links pass through unchanged
 #[test]
 fn test_document_link_resolve_already_resolved() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -193,7 +193,7 @@ fn test_document_link_resolve_already_resolved() -> TestResult {
 /// Test error handling for invalid link data
 #[test]
 fn test_document_link_resolve_invalid_data() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -247,7 +247,7 @@ fn test_document_link_resolve_invalid_data() -> TestResult {
 /// Test error handling for missing parameters
 #[test]
 fn test_document_link_resolve_missing_params() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -290,7 +290,7 @@ fn test_document_link_resolve_missing_params() -> TestResult {
 /// Test that data field is preserved in resolved link
 #[test]
 fn test_document_link_resolve_preserves_data() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -352,7 +352,7 @@ fn test_document_link_resolve_preserves_data() -> TestResult {
 /// Test URL type links (already resolved)
 #[test]
 fn test_document_link_resolve_url_type() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({
@@ -408,7 +408,7 @@ fn test_document_link_resolve_url_type() -> TestResult {
 /// Integration test: documentLink returns deferred links, resolve fills them in
 #[test]
 fn test_document_link_integration() -> TestResult {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_params = json!({

--- a/crates/perl-lsp/tests/lsp_document_symbols_test.rs
+++ b/crates/perl-lsp/tests/lsp_document_symbols_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -41,7 +41,7 @@ fn setup_server() -> LspServer {
     server
 }
 
-fn open_document(server: &mut LspServer, uri: &str, content: &str) {
+fn open_document(server: &LspServer, uri: &str, content: &str) {
     let notification = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         method: "textDocument/didOpen".to_string(),
@@ -61,7 +61,7 @@ fn open_document(server: &mut LspServer, uri: &str, content: &str) {
 
 #[test]
 fn test_document_symbols_basic() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 package MyModule;
@@ -85,7 +85,7 @@ sub calculate {
 1;
 "#;
 
-    open_document(&mut server, "file:///test.pl", content);
+    open_document(&server, "file:///test.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -141,7 +141,7 @@ sub calculate {
 
 #[test]
 fn test_document_symbols_nested() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 package Outer;
@@ -161,7 +161,7 @@ sub another_sub {
 1;
 "#;
 
-    open_document(&mut server, "file:///nested.pl", content);
+    open_document(&server, "file:///nested.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -201,9 +201,9 @@ sub another_sub {
 
 #[test]
 fn test_document_symbols_empty_document() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
-    open_document(&mut server, "file:///empty.pl", "");
+    open_document(&server, "file:///empty.pl", "");
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -229,7 +229,7 @@ fn test_document_symbols_empty_document() -> TestResult {
 
 #[test]
 fn test_document_symbols_with_constants() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 use constant PI => 3.14159;
@@ -244,7 +244,7 @@ sub area {
 }
 "#;
 
-    open_document(&mut server, "file:///constants.pl", content);
+    open_document(&server, "file:///constants.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -273,7 +273,7 @@ sub area {
 
 #[test]
 fn test_document_symbols_with_labels() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 for my $i (1..10) {
@@ -290,7 +290,7 @@ sub process {
 }
 "#;
 
-    open_document(&mut server, "file:///labels.pl", content);
+    open_document(&server, "file:///labels.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -317,7 +317,7 @@ sub process {
 
 #[test]
 fn test_document_symbols_all_variable_types() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 my $scalar = 42;
@@ -332,7 +332,7 @@ local $/ = "\n";
 state $persistent = 0;
 "#;
 
-    open_document(&mut server, "file:///variables.pl", content);
+    open_document(&server, "file:///variables.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -383,7 +383,7 @@ state $persistent = 0;
 
 #[test]
 fn test_document_symbols_hierarchical_structure() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 package Parent;
@@ -405,7 +405,7 @@ sub child_method {
 }
 "#;
 
-    open_document(&mut server, "file:///hierarchy.pl", content);
+    open_document(&server, "file:///hierarchy.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_e2e_user_stories.rs
+++ b/crates/perl-lsp/tests/lsp_e2e_user_stories.rs
@@ -23,13 +23,13 @@ fn create_test_server() -> LspServer {
 }
 
 /// Helper to send a request and get response with timeout
-fn send_request(server: &mut LspServer, method: &str, params: Option<Value>) -> Option<Value> {
+fn send_request(server: &LspServer, method: &str, params: Option<Value>) -> Option<Value> {
     send_request_with_timeout(server, method, params, Duration::from_secs(5))
 }
 
 /// Helper to send a request with explicit timeout to prevent hanging tests
 fn send_request_with_timeout(
-    server: &mut LspServer,
+    server: &LspServer,
     method: &str,
     params: Option<Value>,
     _timeout: Duration,
@@ -67,7 +67,7 @@ fn send_request_with_timeout(
 }
 
 /// Initialize the LSP server
-fn initialize_server(server: &mut LspServer) {
+fn initialize_server(server: &LspServer) {
     send_request(
         server,
         "initialize",
@@ -81,7 +81,7 @@ fn initialize_server(server: &mut LspServer) {
 }
 
 /// Open a document in the server
-fn open_document(server: &mut LspServer, uri: &str, text: &str) {
+fn open_document(server: &LspServer, uri: &str, text: &str) {
     send_request(
         server,
         "textDocument/didOpen",
@@ -97,7 +97,7 @@ fn open_document(server: &mut LspServer, uri: &str, text: &str) {
 }
 
 /// Update a document in the server
-fn update_document(server: &mut LspServer, uri: &str, version: i32, text: &str) {
+fn update_document(server: &LspServer, uri: &str, version: i32, text: &str) {
     send_request(
         server,
         "textDocument/didChange",
@@ -119,8 +119,8 @@ fn update_document(server: &mut LspServer, uri: &str, version: i32, text: &str) 
 
 #[test]
 fn test_user_story_real_time_diagnostics() {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Scenario 1: Developer opens a file with syntax error
     let code_with_error = r#"
@@ -132,7 +132,7 @@ sub process_data {
 }
 "#;
 
-    open_document(&mut server, "file:///test/syntax_error.pl", code_with_error);
+    open_document(&server, "file:///test/syntax_error.pl", code_with_error);
 
     // The server should have published diagnostics
     // In a real implementation, we'd check the diagnostics notification
@@ -155,7 +155,7 @@ sub process_data {
 }
 "#;
 
-    update_document(&mut server, "file:///test/syntax_error.pl", 2, fixed_code);
+    update_document(&server, "file:///test/syntax_error.pl", 2, fixed_code);
 
     // Wait a moment for diagnostics to be updated
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -171,7 +171,7 @@ sub calculate {
 }
 "#;
 
-    open_document(&mut server, "file:///test/undefined_var.pl", code_with_warning);
+    open_document(&server, "file:///test/undefined_var.pl", code_with_warning);
     // In a full implementation, the diagnostics provider would detect undefined $y
 }
 
@@ -181,8 +181,8 @@ sub calculate {
 
 #[test]
 fn test_user_story_code_completion() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Scenario 1: Developer types '$' and wants to see available variables
     let code = r#"
@@ -194,10 +194,10 @@ my @user_roles = ("admin", "editor");
 $
 "#;
 
-    open_document(&mut server, "file:///test/completion.pl", code);
+    open_document(&server, "file:///test/completion.pl", code);
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/completion",
         Some(json!({
             "textDocument": {
@@ -223,10 +223,10 @@ $
 pri  # Developer is typing 'print'
 "#;
 
-    open_document(&mut server, "file:///test/builtin.pl", code2);
+    open_document(&server, "file:///test/builtin.pl", code2);
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/completion",
         Some(json!({
             "textDocument": {
@@ -253,8 +253,8 @@ pri  # Developer is typing 'print'
 
 #[test]
 fn test_user_story_go_to_definition() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 package UserManager;
@@ -276,11 +276,11 @@ sub generate_id {
 my $user = create_user("Bob", "bob@example.com");
 "#;
 
-    open_document(&mut server, "file:///test/definitions.pl", code);
+    open_document(&server, "file:///test/definitions.pl", code);
 
     // Developer ctrl+clicks on 'create_user' on line 17
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/definition",
         Some(json!({
             "textDocument": {
@@ -316,8 +316,8 @@ my $user = create_user("Bob", "bob@example.com");
 
 #[test]
 fn test_user_story_find_references() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 my $config_file = "/etc/app.conf";
@@ -335,11 +335,11 @@ sub backup_config {
 print "Using config: $config_file\n";
 "#;
 
-    open_document(&mut server, "file:///test/references.pl", code);
+    open_document(&server, "file:///test/references.pl", code);
 
     // Developer wants to find all references to $config_file
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/references",
         Some(json!({
             "textDocument": {
@@ -384,8 +384,8 @@ print "Using config: $config_file\n";
 
 #[test]
 fn test_user_story_hover_information() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 use List::Util qw(max min sum);
@@ -394,11 +394,11 @@ my @numbers = (5, 2, 8, 1, 9);
 my $total = sum(@numbers);  # Developer hovers over 'sum'
 "#;
 
-    open_document(&mut server, "file:///test/hover.pl", code);
+    open_document(&server, "file:///test/hover.pl", code);
 
     // Developer hovers over 'sum'
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/hover",
         Some(json!({
             "textDocument": {
@@ -424,8 +424,8 @@ my $total = sum(@numbers);  # Developer hovers over 'sum'
 
 #[test]
 fn test_user_story_document_symbols() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 package MyApp::Controller;
@@ -453,11 +453,11 @@ sub render_response {
 1;
 "#;
 
-    open_document(&mut server, "file:///test/outline.pl", code);
+    open_document(&server, "file:///test/outline.pl", code);
 
     // Developer opens the outline view (using document symbols for document-specific outline)
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -504,8 +504,8 @@ sub render_response {
 
 #[test]
 fn test_user_story_signature_help() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Test with a built-in function first
     let code = r#"
@@ -513,11 +513,11 @@ my $text = "Hello World";
 my $result = substr($text, 6, );  # <- cursor is here after comma
 "#;
 
-    open_document(&mut server, "file:///test/signature.pl", code);
+    open_document(&server, "file:///test/signature.pl", code);
 
     // Developer just typed the comma after "6"
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/signatureHelp",
         Some(json!({
             "textDocument": {
@@ -557,8 +557,8 @@ my $result = substr($text, 6, );  # <- cursor is here after comma
 
 #[test]
 fn test_user_story_rename_symbol() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 sub calculate_total {
@@ -579,11 +579,11 @@ my $sum = calculate_total($items);
 print "Total: $sum\n";
 "#;
 
-    open_document(&mut server, "file:///test/rename.pl", code);
+    open_document(&server, "file:///test/rename.pl", code);
 
     // Developer wants to rename 'calculate_total' to 'compute_sum'
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/rename",
         Some(json!({
             "textDocument": {
@@ -620,8 +620,8 @@ print "Total: $sum\n";
 
 #[test]
 fn test_user_story_code_actions() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code = r#"
 use strict;
@@ -635,11 +635,11 @@ sub process {
 }
 "#;
 
-    open_document(&mut server, "file:///test/actions.pl", code);
+    open_document(&server, "file:///test/actions.pl", code);
 
     // Developer sees a warning and requests code actions
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/codeAction",
         Some(json!({
             "textDocument": {
@@ -681,8 +681,8 @@ sub process {
 
 #[test]
 fn test_user_story_incremental_parsing() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Large file with many functions
     let mut large_code = String::from("package LargeModule;\n\n");
@@ -690,17 +690,17 @@ fn test_user_story_incremental_parsing() -> TestResult {
         large_code.push_str(&format!("sub function_{} {{\n    return {};\n}}\n\n", i, i));
     }
 
-    open_document(&mut server, "file:///test/large.pl", &large_code);
+    open_document(&server, "file:///test/large.pl", &large_code);
 
     // Developer makes a small edit in the middle
     let edited_code = large_code.replace("function_50", "function_fifty");
 
     // The edit is incremental - only one function name changed
-    update_document(&mut server, "file:///test/large.pl", 2, &edited_code);
+    update_document(&server, "file:///test/large.pl", 2, &edited_code);
 
     // Request document symbols to verify parsing still works after incremental edit
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -749,8 +749,8 @@ fn test_user_story_incremental_parsing() -> TestResult {
 
 #[test]
 fn test_complete_development_workflow() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Step 1: Developer creates a new Perl module
     let initial_code = r#"
@@ -767,7 +767,7 @@ sub add {
 1;
 "#;
 
-    open_document(&mut server, "file:///test/Calculator.pm", initial_code);
+    open_document(&server, "file:///test/Calculator.pm", initial_code);
 
     // Step 2: Developer creates a script that uses the module
     let script_code = r#"
@@ -778,11 +778,11 @@ my $result = Calculator::add(5, 3);
 print "Result: $result\n";
 "#;
 
-    open_document(&mut server, "file:///test/script.pl", script_code);
+    open_document(&server, "file:///test/script.pl", script_code);
 
     // Step 3: Developer wants to see all available functions in Calculator
     let symbols_result = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "add"
@@ -822,11 +822,11 @@ sub multiply {
 1;
 "#;
 
-    update_document(&mut server, "file:///test/Calculator.pm", 2, updated_calculator);
+    update_document(&server, "file:///test/Calculator.pm", 2, updated_calculator);
 
     // Step 6: Developer gets completion for the new function
     let completion_result = send_request(
-        &mut server,
+        &server,
         "textDocument/completion",
         Some(json!({
             "textDocument": {
@@ -852,8 +852,8 @@ sub multiply {
 
 #[test]
 fn test_user_story_debugging_workflow() {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Developer is debugging a complex data processing script
     let debug_code = r#"
@@ -901,11 +901,11 @@ my $results = process_records($data);
 print Dumper($results);
 "#;
 
-    open_document(&mut server, "file:///test/debug.pl", debug_code);
+    open_document(&server, "file:///test/debug.pl", debug_code);
 
     // Scenario 1: Developer hovers over transform_record to understand what it does
     let hover_result = send_request(
-        &mut server,
+        &server,
         "textDocument/hover",
         Some(json!({
             "textDocument": {
@@ -922,7 +922,7 @@ print Dumper($results);
 
     // Scenario 2: Developer finds all references to see where function is called
     let refs = send_request(
-        &mut server,
+        &server,
         "textDocument/references",
         Some(json!({
             "textDocument": {
@@ -942,7 +942,7 @@ print Dumper($results);
 
     // Scenario 3: Developer uses call hierarchy to understand call flow
     let call_hierarchy = send_request(
-        &mut server,
+        &server,
         "textDocument/prepareCallHierarchy",
         Some(json!({
             "textDocument": {
@@ -964,8 +964,8 @@ print Dumper($results);
 
 #[test]
 fn test_user_story_module_navigation() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Scenario: Developer working with custom modules
     let main_script = r#"
@@ -997,7 +997,7 @@ sub process_user {
 }
 "#;
 
-    open_document(&mut server, "file:///test/main.pl", main_script);
+    open_document(&server, "file:///test/main.pl", main_script);
 
     // Module file
     let module_code = r#"
@@ -1019,11 +1019,11 @@ sub fetch_all {
 1;
 "#;
 
-    open_document(&mut server, "file:///test/lib/MyApp/Database.pm", module_code);
+    open_document(&server, "file:///test/lib/MyApp/Database.pm", module_code);
 
     // Developer wants to navigate to Database module definition
     let definition = send_request(
-        &mut server,
+        &server,
         "textDocument/definition",
         Some(json!({
             "textDocument": {
@@ -1043,7 +1043,7 @@ sub fetch_all {
 
     // Developer wants to find all uses of the Database module
     let workspace_symbols = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "Database"
@@ -1071,8 +1071,8 @@ sub fetch_all {
 #[cfg(feature = "lsp-extras")]
 #[test]
 fn test_user_story_code_review_workflow() {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     // Code being reviewed with potential issues
     let review_code = r#"
@@ -1152,11 +1152,11 @@ sub save_users {
 }
 "#;
 
-    open_document(&mut server, "file:///test/auth.pl", review_code);
+    open_document(&server, "file:///test/auth.pl", review_code);
 
     // Reviewer uses document symbols to understand structure
     let symbols = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -1169,7 +1169,7 @@ sub save_users {
 
     // Reviewer checks for code issues
     let code_actions = send_request(
-        &mut server,
+        &server,
         "textDocument/codeAction",
         Some(json!({
             "textDocument": {
@@ -1192,7 +1192,7 @@ sub save_users {
 
     // Reviewer uses call hierarchy to understand impact
     let prepare_call = send_request(
-        &mut server,
+        &server,
         "textDocument/prepareCallHierarchy",
         Some(json!({
             "textDocument": {
@@ -1214,8 +1214,8 @@ sub save_users {
 
 #[test]
 fn test_user_story_api_documentation() {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let code_with_builtins = r#"
 use strict;
@@ -1245,11 +1245,11 @@ sub process_data {
 }
 "#;
 
-    open_document(&mut server, "file:///test/builtins.pl", code_with_builtins);
+    open_document(&server, "file:///test/builtins.pl", code_with_builtins);
 
     // Scenario 1: Hover over 'map' for documentation
     let map_hover = send_request(
-        &mut server,
+        &server,
         "textDocument/hover",
         Some(json!({
             "textDocument": {
@@ -1266,7 +1266,7 @@ sub process_data {
 
     // Scenario 2: Signature help for sprintf
     let sprintf_sig = send_request(
-        &mut server,
+        &server,
         "textDocument/signatureHelp",
         Some(json!({
             "textDocument": {
@@ -1283,7 +1283,7 @@ sub process_data {
 
     // Scenario 3: Completion for List::Util functions
     let completion = send_request(
-        &mut server,
+        &server,
         "textDocument/completion",
         Some(json!({
             "textDocument": {
@@ -1305,8 +1305,8 @@ sub process_data {
 
 #[test]
 fn test_user_story_performance_optimization() -> TestResult {
-    let mut server = create_test_server();
-    initialize_server(&mut server);
+    let server = create_test_server();
+    initialize_server(&server);
 
     let performance_code = r#"
 use strict;
@@ -1368,11 +1368,11 @@ sub transform_a { return $_[0] }
 sub transform_b { return $_[0] }
 "#;
 
-    open_document(&mut server, "file:///test/performance.pl", performance_code);
+    open_document(&server, "file:///test/performance.pl", performance_code);
 
     // Developer uses code lens to see complexity/usage hints
     let code_lens = send_request(
-        &mut server,
+        &server,
         "textDocument/codeLens",
         Some(json!({
             "textDocument": {
@@ -1391,7 +1391,7 @@ sub transform_b { return $_[0] }
 
     // Developer gets suggestions for optimization
     let actions = send_request(
-        &mut server,
+        &server,
         "textDocument/codeAction",
         Some(json!({
             "textDocument": {

--- a/crates/perl-lsp/tests/lsp_edge_cases_test.rs
+++ b/crates/perl-lsp/tests/lsp_edge_cases_test.rs
@@ -6,7 +6,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::{Value, json};
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -21,7 +21,7 @@ fn setup_server() -> LspServer {
     server
 }
 
-fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
+fn open_doc(server: &LspServer, uri: &str, text: &str) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -39,7 +39,7 @@ fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
 }
 
 #[allow(dead_code)]
-fn get_diagnostics(server: &mut LspServer, uri: &str) -> Option<Value> {
+fn get_diagnostics(server: &LspServer, uri: &str) -> Option<Value> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -55,10 +55,10 @@ fn get_diagnostics(server: &mut LspServer, uri: &str) -> Option<Value> {
 #[test]
 
 fn test_empty_file_handling() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test completely empty file
-    open_doc(&mut server, "file:///empty.pl", "");
+    open_doc(&server, "file:///empty.pl", "");
 
     // Should not crash and should handle gracefully
     let request = JsonRpcRequest {
@@ -77,7 +77,7 @@ fn test_empty_file_handling() {
 #[test]
 
 fn test_malformed_perl_recovery() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test file with severe syntax errors
     let malformed = r#"
@@ -91,7 +91,7 @@ my $var = ;  # Missing value
 for (;;  # Incomplete for loop
 "#;
 
-    open_doc(&mut server, "file:///malformed.pl", malformed);
+    open_doc(&server, "file:///malformed.pl", malformed);
 
     // Server should not crash and should provide some diagnostics
     // Even if parsing fails, it should handle gracefully
@@ -100,7 +100,7 @@ for (;;  # Incomplete for loop
 #[test]
 
 fn test_unicode_edge_cases() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test various Unicode scenarios
     let unicode_code = r#"
@@ -112,7 +112,7 @@ sub Σ { return sum(@_); }
 my $emoji = "🦀";
 "#;
 
-    open_doc(&mut server, "file:///unicode.pl", unicode_code);
+    open_doc(&server, "file:///unicode.pl", unicode_code);
 
     // Test that Unicode symbols work in navigation
     let request = JsonRpcRequest {
@@ -131,12 +131,12 @@ my $emoji = "🦀";
 #[test]
 
 fn test_large_line_handling() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Create a file with an extremely long line
     let long_line = "my $var = \"".to_string() + &"x".repeat(10000) + "\";";
 
-    open_doc(&mut server, "file:///longline.pl", &long_line);
+    open_doc(&server, "file:///longline.pl", &long_line);
 
     // Should handle without stack overflow or excessive memory
 }
@@ -144,11 +144,11 @@ fn test_large_line_handling() {
 #[test]
 
 fn test_rapid_edits() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Simulate rapid typing
     let uri = "file:///rapid.pl";
-    open_doc(&mut server, uri, "");
+    open_doc(&server, uri, "");
 
     // Send many rapid updates
     for i in 0..100 {
@@ -176,7 +176,7 @@ fn test_rapid_edits() {
 #[test]
 
 fn test_circular_references() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test code with potential circular references
     let circular = r#"
@@ -189,7 +189,7 @@ use A;
 sub bar { A::foo(); }
 "#;
 
-    open_doc(&mut server, "file:///circular.pl", circular);
+    open_doc(&server, "file:///circular.pl", circular);
 
     // Find references should not infinite loop
     let request = JsonRpcRequest {
@@ -210,7 +210,7 @@ sub bar { A::foo(); }
 #[test]
 
 fn test_special_variable_handling() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test Perl's special variables
     let special_vars = r#"
@@ -234,7 +234,7 @@ $| = 0;
 $. = 0;
 "#;
 
-    open_doc(&mut server, "file:///special.pl", special_vars);
+    open_doc(&server, "file:///special.pl", special_vars);
 
     // These should be recognized but not cause issues
     let request = JsonRpcRequest {
@@ -253,7 +253,7 @@ $. = 0;
 #[test]
 
 fn test_heredoc_edge_cases() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test complex heredoc scenarios
     let heredocs = r#"
@@ -279,7 +279,7 @@ Second heredoc
 SECOND
 "#;
 
-    open_doc(&mut server, "file:///heredoc.pl", heredocs);
+    open_doc(&server, "file:///heredoc.pl", heredocs);
 
     // Should parse heredocs correctly
 }
@@ -287,7 +287,7 @@ SECOND
 #[test]
 
 fn test_regex_with_special_delimiters() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test regex with various delimiters
     let regex_code = r#"
@@ -301,7 +301,7 @@ $text =~ tr/a-z/A-Z/;
 $text =~ y/a-z/A-Z/;
 "#;
 
-    open_doc(&mut server, "file:///regex.pl", regex_code);
+    open_doc(&server, "file:///regex.pl", regex_code);
 
     // Should handle all regex delimiters
 }
@@ -309,7 +309,7 @@ $text =~ y/a-z/A-Z/;
 #[test]
 
 fn test_incomplete_statements() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test code with incomplete statements (common while typing)
     let incomplete = r#"
@@ -321,7 +321,7 @@ sub foo {
     for my $i (
 "#;
 
-    open_doc(&mut server, "file:///incomplete.pl", incomplete);
+    open_doc(&server, "file:///incomplete.pl", incomplete);
 
     // Should not crash on incomplete code
 }
@@ -329,7 +329,7 @@ sub foo {
 #[test]
 
 fn test_mixed_encodings() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test file with mixed content
     let mixed = r#"
@@ -340,7 +340,7 @@ my $latin1 = "café";
 my $emoji = "🎉";
 "#;
 
-    open_doc(&mut server, "file:///mixed.pl", mixed);
+    open_doc(&server, "file:///mixed.pl", mixed);
 
     // Should handle different encodings
 }
@@ -348,10 +348,10 @@ my $emoji = "🎉";
 #[test]
 
 fn test_boundary_positions() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let code = "my $x = 1;";
-    open_doc(&mut server, "file:///boundary.pl", code);
+    open_doc(&server, "file:///boundary.pl", code);
 
     // Test position at start of file
     let request = JsonRpcRequest {
@@ -405,13 +405,13 @@ fn test_boundary_positions() {
 #[test]
 
 fn test_concurrent_file_operations() {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Open multiple files
     for i in 0..10 {
         let uri = format!("file:///file{}.pl", i);
         let code = format!("my $var{} = {};", i, i);
-        open_doc(&mut server, &uri, &code);
+        open_doc(&server, &uri, &code);
     }
 
     // Perform operations on different files

--- a/crates/perl-lsp/tests/lsp_encoding_edge_cases.rs
+++ b/crates/perl-lsp/tests/lsp_encoding_edge_cases.rs
@@ -50,8 +50,8 @@ fn analyze_unicode_complexity(text: &str) -> (usize, usize, usize) {
 
 #[test]
 fn test_utf8_bom() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // UTF-8 with BOM
     let content = String::from("\u{FEFF}#!/usr/bin/perl\nprint 'BOM test';\n");
@@ -59,7 +59,7 @@ fn test_utf8_bom() -> Result<(), Box<dyn std::error::Error>> {
     let uri = "file:///bom_test.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -76,7 +76,7 @@ fn test_utf8_bom() -> Result<(), Box<dyn std::error::Error>> {
 
     // Should handle BOM correctly
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -87,15 +87,15 @@ fn test_utf8_bom() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_mixed_line_endings() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Mix of LF, CRLF, and CR
     let content = "#!/usr/bin/perl\nprint 'line1';\r\nprint 'line2';\rprint 'line3';\n";
@@ -103,7 +103,7 @@ fn test_mixed_line_endings() -> Result<(), Box<dyn std::error::Error>> {
     let uri = "file:///mixed_endings.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -120,7 +120,7 @@ fn test_mixed_line_endings() -> Result<(), Box<dyn std::error::Error>> {
 
     // Line positions should be calculated correctly
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -132,15 +132,15 @@ fn test_mixed_line_endings() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_unicode_normalization() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Different Unicode normalizations of é
     // NFC: é (single character U+00E9)
@@ -153,7 +153,7 @@ fn test_unicode_normalization() -> Result<(), Box<dyn std::error::Error>> {
 
     // Open NFC version
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -170,7 +170,7 @@ fn test_unicode_normalization() -> Result<(), Box<dyn std::error::Error>> {
 
     // Open NFD version
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -187,7 +187,7 @@ fn test_unicode_normalization() -> Result<(), Box<dyn std::error::Error>> {
 
     // Both should work
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -198,7 +198,7 @@ fn test_unicode_normalization() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
@@ -209,7 +209,7 @@ fn test_emoji_and_special_unicode() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::{Duration, Instant};
 
     let start_time = Instant::now();
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Adaptive timeout based on thread constraints (Issue #200)
     let unicode_timeout = compute_adaptive_timeout();
@@ -228,7 +228,7 @@ fn test_emoji_and_special_unicode() -> Result<(), Box<dyn std::error::Error>> {
         }
     );
 
-    let init_result = initialize_lsp(&mut server);
+    let init_result = initialize_lsp(&server);
 
     // Validate initialization succeeded before proceeding
     assert!(
@@ -266,7 +266,7 @@ my $test = 'hello';
 
     let doc_open_start = Instant::now();
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -289,7 +289,7 @@ my $test = 'hello';
     eprintln!("Testing server responsiveness with hover request...");
     let hover_start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 100,
@@ -301,7 +301,7 @@ my $test = 'hello';
         }),
     );
 
-    let hover_response = read_response_timeout(&mut server, Duration::from_secs(10));
+    let hover_response = read_response_timeout(&server, Duration::from_secs(10));
     let hover_time = hover_start.elapsed();
     eprintln!("Hover request completed in {:?}: {:?}", hover_time, hover_response.is_some());
 
@@ -309,7 +309,7 @@ my $test = 'hello';
     eprintln!("Testing document symbols request...");
     let symbol_request_start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -321,7 +321,7 @@ my $test = 'hello';
     );
 
     // Use explicit timeout and validate response structure
-    let response = read_response_timeout(&mut server, unicode_timeout);
+    let response = read_response_timeout(&server, unicode_timeout);
 
     if response.is_none() {
         eprintln!("Document symbols request timed out after {:?}", unicode_timeout);
@@ -329,7 +329,7 @@ my $test = 'hello';
 
         // Try a simpler request to see if server is still alive
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 999,
@@ -341,7 +341,7 @@ my $test = 'hello';
             }),
         );
 
-        let fallback = read_response_timeout(&mut server, Duration::from_secs(5));
+        let fallback = read_response_timeout(&server, Duration::from_secs(5));
         eprintln!("Fallback request succeeded: {}", fallback.is_some());
 
         // Mark this as an expected performance limitation rather than a hard failure
@@ -433,8 +433,8 @@ my $test = 'hello';
 
 #[test]
 fn test_surrogate_pairs() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Emojis that use surrogate pairs in UTF-16
     let content = r#"
@@ -446,7 +446,7 @@ my $emoji3 = '👨‍👩‍👧‍👦'; # Family with ZWJ sequences
     let uri = "file:///surrogates.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -463,7 +463,7 @@ my $emoji3 = '👨‍👩‍👧‍👦'; # Family with ZWJ sequences
 
     // Position calculation with surrogate pairs
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -475,15 +475,15 @@ my $emoji3 = '👨‍👩‍👧‍👦'; # Family with ZWJ sequences
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_invalid_utf8_sequences() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Valid UTF-8 with comments about invalid sequences
     let content = r#"
@@ -499,7 +499,7 @@ my $text = "valid utf-8 only";
     let uri = "file:///invalid_utf8.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -516,7 +516,7 @@ my $text = "valid utf-8 only";
 
     // Should handle gracefully
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -527,15 +527,15 @@ my $text = "valid utf-8 only";
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_encoding_pragma() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Perl encoding pragmas
     let content = r#"
@@ -550,7 +550,7 @@ my $latin = 'café';
     let uri = "file:///encoding_pragma.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -567,7 +567,7 @@ my $latin = 'café';
 
     // Should recognize encoding pragmas
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -578,15 +578,15 @@ my $latin = 'café';
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_grapheme_clusters() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Complex grapheme clusters
     let content = r#"
@@ -603,7 +603,7 @@ my $combined = 'e̊⃝'; # Multiple combining marks
     let uri = "file:///graphemes.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -620,7 +620,7 @@ my $combined = 'e̊⃝'; # Multiple combining marks
 
     // Character positions with grapheme clusters
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -632,15 +632,15 @@ my $combined = 'e̊⃝'; # Multiple combining marks
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_zero_width_characters() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Zero-width characters that can cause issues
     let content = format!(
@@ -653,7 +653,7 @@ fn test_zero_width_characters() -> Result<(), Box<dyn std::error::Error>> {
     let uri = "file:///zero_width.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -670,7 +670,7 @@ fn test_zero_width_characters() -> Result<(), Box<dyn std::error::Error>> {
 
     // Should handle zero-width characters
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -681,15 +681,15 @@ fn test_zero_width_characters() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_bidi_text() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Bidirectional text
     let content = r#"
@@ -705,7 +705,7 @@ my $embed = '\u{202A}LTR embed\u{202A}';
     let uri = "file:///bidi.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -722,7 +722,7 @@ my $embed = '\u{202A}LTR embed\u{202A}';
 
     // Should handle bidi text
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -734,15 +734,15 @@ my $embed = '\u{202A}LTR embed\u{202A}';
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_confusable_characters() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Visually similar but different characters
     let content = r#"
@@ -763,7 +763,7 @@ my $backticks = '`test`';
     let uri = "file:///confusable.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -780,7 +780,7 @@ my $backticks = '`test`';
 
     // Should distinguish confusable characters
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -791,15 +791,15 @@ my $backticks = '`test`';
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_private_use_area() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Private Use Area characters
     let content = r#"
@@ -814,7 +814,7 @@ my $spua = '󰀀';  # U+F0000
     let uri = "file:///pua.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -831,7 +831,7 @@ my $spua = '󰀀';  # U+F0000
 
     // Should handle PUA characters
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -842,15 +842,15 @@ my $spua = '󰀀';  # U+F0000
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_long_unicode_identifiers() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Very long Unicode identifiers
     let content = r#"
@@ -867,7 +867,7 @@ my $mixed_中文_english_العربية_русский = 5;
     let uri = "file:///long_unicode.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -884,7 +884,7 @@ my $mixed_中文_english_العربية_русский = 5;
 
     // Should handle long Unicode identifiers
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -895,15 +895,15 @@ my $mixed_中文_english_العربية_русский = 5;
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }
 
 #[test]
 fn test_unicode_in_regex() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Unicode in regular expressions
     let content = r#"
@@ -924,7 +924,7 @@ if ($text =~ /café/i) { } # Case insensitive with accents
     let uri = "file:///unicode_regex.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -941,7 +941,7 @@ if ($text =~ /café/i) { } # Case insensitive with accents
 
     // Should handle Unicode in regex
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -952,7 +952,7 @@ if ($text =~ /café/i) { } # Case insensitive with accents
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_error_recovery.rs
+++ b/crates/perl-lsp/tests/lsp_error_recovery.rs
@@ -12,14 +12,14 @@ use common::{
 
 #[test]
 fn test_recover_from_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///recovery.pl";
 
     // Start with invalid syntax
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -39,7 +39,7 @@ fn test_recover_from_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
 
     // Fix the syntax error
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -56,11 +56,11 @@ fn test_recover_from_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Wait for diagnostics to clear after fix
-    common::drain_until_quiet(&mut server, common::short_timeout(), Duration::from_secs(2));
+    common::drain_until_quiet(&server, common::short_timeout(), Duration::from_secs(2));
 
     // Should now work correctly
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/documentSymbol",
@@ -74,14 +74,14 @@ fn test_recover_from_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
     assert!(response["result"].is_array(), "Response was not an array: {}", response);
     let symbols = response["result"].as_array().ok_or("Expected 'result' to be an array")?;
     assert!(!symbols.is_empty());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_partial_document_parsing() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with mixed valid and invalid sections
     let content = r#"
@@ -104,7 +104,7 @@ sub another_valid {
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -121,7 +121,7 @@ sub another_valid {
 
     // Should still find valid symbols
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/documentSymbol",
@@ -141,20 +141,20 @@ sub another_valid {
 
     assert!(function_names.contains(&"valid_function".to_string()));
     assert!(function_names.contains(&"another_valid".to_string()));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_incremental_edit_recovery() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///incremental.pl";
 
     // Start with valid document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -171,7 +171,7 @@ fn test_incremental_edit_recovery() -> Result<(), Box<dyn std::error::Error>> {
 
     // Make edit that breaks syntax temporarily
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -193,7 +193,7 @@ fn test_incremental_edit_recovery() -> Result<(), Box<dyn std::error::Error>> {
 
     // Complete the edit to fix syntax
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -215,7 +215,7 @@ fn test_incremental_edit_recovery() -> Result<(), Box<dyn std::error::Error>> {
 
     // Should work correctly after recovery
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -231,18 +231,18 @@ fn test_incremental_edit_recovery() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
     assert!(response["result"].is_object() || response["result"].is_null());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_workspace_recovery_after_error() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open multiple files, one with error
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -258,7 +258,7 @@ fn test_workspace_recovery_after_error() -> Result<(), Box<dyn std::error::Error
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -274,7 +274,7 @@ fn test_workspace_recovery_after_error() -> Result<(), Box<dyn std::error::Error
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -294,7 +294,7 @@ fn test_workspace_recovery_after_error() -> Result<(), Box<dyn std::error::Error
 
     // Workspace symbols should still work
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "workspace/symbol",
@@ -310,14 +310,14 @@ fn test_workspace_recovery_after_error() -> Result<(), Box<dyn std::error::Error
     if !symbols.is_empty() {
         assert!(symbols.iter().any(|s| s["name"] == "foo"), "Workspace symbols: {:?}", symbols);
     }
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_reference_search_with_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with partial errors
     let content = r#"
@@ -335,7 +335,7 @@ print $var;  # Another valid reference
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -352,7 +352,7 @@ print $var;  # Another valid reference
 
     // Find references should work despite errors
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/references",
@@ -375,14 +375,14 @@ print $var;  # Another valid reference
     // When there are syntax errors, references might not be found
     // The important thing is that the server doesn't crash and returns a valid response
     eprintln!("Found {} references (may be 0 due to parse errors): {:?}", refs.len(), refs);
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_completion_in_broken_context() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with syntax error before completion point
     let content = r#"
@@ -395,7 +395,7 @@ sub broken {
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -412,7 +412,7 @@ sub broken {
 
     // Completion should still work
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -432,14 +432,14 @@ sub broken {
 
     // Should suggest "print" despite earlier error
     assert!(items.iter().any(|item| item["label"] == "print"));
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_rename_with_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let content = r#"
 my $old_name = 42;
@@ -456,7 +456,7 @@ $old_name++;
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -473,7 +473,7 @@ $old_name++;
 
     // Prepare rename should work
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/prepareRename",
@@ -491,7 +491,7 @@ $old_name++;
     if response["result"].is_object() {
         // Perform rename
         let response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/rename",
@@ -509,14 +509,14 @@ $old_name++;
         );
         assert!(response["result"]["changes"].is_object());
     }
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_formatting_with_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with formatting issues and syntax error
     let content = r#"my$x=1;my$y=2;
@@ -525,7 +525,7 @@ sub bar{print$y;;}  # Syntax error
 my   $z   =   3;"#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -542,7 +542,7 @@ my   $z   =   3;"#;
 
     // Format document request
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/formatting",
@@ -559,20 +559,20 @@ my   $z   =   3;"#;
     );
     // Should either format what it can or return error gracefully
     assert!(response["result"].is_array() || response["error"].is_object());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///diagnostic.pl";
 
     // Start with multiple errors
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -591,7 +591,7 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
 
     // Fix one error at a time
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -612,13 +612,13 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Wait for change to be processed
-    common::drain_until_quiet(&mut server, common::short_timeout(), Duration::from_secs(2));
+    common::drain_until_quiet(&server, common::short_timeout(), Duration::from_secs(2));
 
     std::thread::sleep(Duration::from_millis(100));
 
     // Fix second error
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -639,13 +639,13 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Wait for change to be processed
-    common::drain_until_quiet(&mut server, common::short_timeout(), Duration::from_secs(2));
+    common::drain_until_quiet(&server, common::short_timeout(), Duration::from_secs(2));
 
     std::thread::sleep(Duration::from_millis(100));
 
     // Fix last error
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -666,14 +666,14 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Wait for all changes to be processed
-    common::drain_until_quiet(&mut server, common::short_timeout(), Duration::from_secs(2));
+    common::drain_until_quiet(&server, common::short_timeout(), Duration::from_secs(2));
 
     // Extra settle time for the server to complete async processing
     std::thread::sleep(Duration::from_millis(200));
 
     // Document should be fully functional now
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/documentSymbol",
@@ -712,10 +712,10 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
 
         // Wait for server to process buffered notifications
         std::thread::sleep(Duration::from_millis(200 * attempt as u64));
-        common::drain_until_quiet(&mut server, common::short_timeout(), Duration::from_secs(2));
+        common::drain_until_quiet(&server, common::short_timeout(), Duration::from_secs(2));
 
         let retry_response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/documentSymbol",
@@ -739,14 +739,14 @@ fn test_diagnostic_recovery() -> Result<(), Box<dyn std::error::Error>> {
         max_attempts, final_count, last_summaries
     );
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_goto_definition_with_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let content = r#"
 sub my_func {
@@ -757,7 +757,7 @@ my $result = my_func();  # Should still find definition
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -774,7 +774,7 @@ my $result = my_func();  # Should still find definition
 
     // Go to definition should work despite error in target
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/definition",
@@ -790,14 +790,14 @@ my $result = my_func();  # Should still find definition
         }),
     );
     assert!(response["result"].is_array() || response["result"].is_object());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_hover_in_error_context() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let content = r#"
 use strict;
@@ -812,7 +812,7 @@ sub broken {
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -829,7 +829,7 @@ sub broken {
 
     // Hover should work on valid variable despite nearby error
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -845,6 +845,6 @@ sub broken {
         }),
     );
     assert!(response["result"].is_object() || response["result"].is_null());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_error_suggestions_test.rs
+++ b/crates/perl-lsp/tests/lsp_error_suggestions_test.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 
 /// Helper function to initialize LSP server
 fn init_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -34,7 +34,7 @@ fn init_server() -> Result<LspServer, Box<dyn std::error::Error>> {
 
 /// Helper to open document and get diagnostics
 fn get_diagnostics_for_code(code: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let mut server = init_server()?;
+    let server = init_server()?;
     let uri = "file:///test.pl";
 
     let did_open_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp/tests/lsp_execute_command_tests.rs
@@ -5,7 +5,7 @@ use std::fs;
 use tempfile::TempDir;
 
 fn setup_server(root_path: Option<String>) -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -37,7 +37,7 @@ fn setup_server(root_path: Option<String>) -> LspServer {
 fn test_execute_command_run_file() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root_path = temp_dir.path().to_string_lossy().to_string();
-    let mut server = setup_server(Some(root_path.clone()));
+    let server = setup_server(Some(root_path.clone()));
 
     // Create a test file
     let test_content = r#"#!/usr/bin/perl
@@ -97,7 +97,7 @@ print "Hello, World!\n";
 fn test_execute_command_run_tests() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root_path = temp_dir.path().to_string_lossy().to_string();
-    let mut server = setup_server(Some(root_path.clone()));
+    let server = setup_server(Some(root_path.clone()));
 
     // Create a test file with Test::More
     let test_content = r#"#!/usr/bin/perl
@@ -167,7 +167,7 @@ is(1 + 1, 2, "Math works");
 
 #[test]
 fn test_execute_command_unknown() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server(None);
+    let server = setup_server(None);
 
     // Try an unknown command
     let execute_request = JsonRpcRequest {
@@ -192,7 +192,7 @@ fn test_execute_command_unknown() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_execute_command_capabilities() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize and check capabilities
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_feature_coverage_audit.rs
+++ b/crates/perl-lsp/tests/lsp_feature_coverage_audit.rs
@@ -21,7 +21,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 // ---------------------------------------------------------------------------
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -45,7 +45,7 @@ fn setup_server() -> LspServer {
     server
 }
 
-fn open_document(server: &mut LspServer, uri: &str, content: &str) {
+fn open_document(server: &LspServer, uri: &str, content: &str) {
     let notification = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         method: "textDocument/didOpen".to_string(),
@@ -64,7 +64,7 @@ fn open_document(server: &mut LspServer, uri: &str, content: &str) {
 
 /// Send a request and return the result field, or an error.
 fn send_request(
-    server: &mut LspServer,
+    server: &LspServer,
     id: i64,
     method: &str,
     params: serde_json::Value,
@@ -85,11 +85,11 @@ fn send_request(
 
 #[test]
 fn semantic_tokens_empty_document() -> TestResult {
-    let mut server = setup_server();
-    open_document(&mut server, "file:///empty.pl", "");
+    let server = setup_server();
+    open_document(&server, "file:///empty.pl", "");
 
     let result = send_request(
-        &mut server,
+        &server,
         10,
         "textDocument/semanticTokens/full",
         json!({"textDocument": {"uri": "file:///empty.pl"}}),
@@ -107,17 +107,17 @@ fn semantic_tokens_empty_document() -> TestResult {
 
 #[test]
 fn semantic_tokens_multiline_subroutine() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"sub greet {
     my ($name) = @_;
     print "Hello, $name!\n";
     return 1;
 }
 "#;
-    open_document(&mut server, "file:///multi.pl", content);
+    open_document(&server, "file:///multi.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         10,
         "textDocument/semanticTokens/full",
         json!({"textDocument": {"uri": "file:///multi.pl"}}),
@@ -139,7 +139,7 @@ fn semantic_tokens_multiline_subroutine() -> TestResult {
 
 #[test]
 fn semantic_tokens_moose_class() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package Animal;
 use Moose;
 
@@ -155,10 +155,10 @@ no Moose;
 __PACKAGE__->meta->make_immutable;
 1;
 "#;
-    open_document(&mut server, "file:///moose.pm", content);
+    open_document(&server, "file:///moose.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         10,
         "textDocument/semanticTokens/full",
         json!({"textDocument": {"uri": "file:///moose.pm"}}),
@@ -179,13 +179,13 @@ __PACKAGE__->meta->make_immutable;
 
 #[test]
 fn semantic_tokens_invalid_perl_does_not_crash() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     // Deliberately malformed Perl
     let content = "sub { { { my $x = ; } } }\n@#$%^&\n";
-    open_document(&mut server, "file:///bad.pl", content);
+    open_document(&server, "file:///bad.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         10,
         "textDocument/semanticTokens/full",
         json!({"textDocument": {"uri": "file:///bad.pl"}}),
@@ -207,11 +207,11 @@ fn semantic_tokens_invalid_perl_does_not_crash() -> TestResult {
 
 #[test]
 fn inlay_hints_empty_document() -> TestResult {
-    let mut server = setup_server();
-    open_document(&mut server, "file:///empty_hints.pl", "");
+    let server = setup_server();
+    open_document(&server, "file:///empty_hints.pl", "");
 
     let result = send_request(
-        &mut server,
+        &server,
         20,
         "textDocument/inlayHint",
         json!({
@@ -231,17 +231,17 @@ fn inlay_hints_empty_document() -> TestResult {
 
 #[test]
 fn inlay_hints_multiple_builtins() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"my @data = (3, 1, 4, 1, 5);
 push(@data, 9, 2, 6);
 my $joined = join(",", @data);
 my $sub = substr("hello world", 0, 5);
 splice(@data, 1, 2, 99);
 "#;
-    open_document(&mut server, "file:///builtins.pl", content);
+    open_document(&server, "file:///builtins.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         20,
         "textDocument/inlayHint",
         json!({
@@ -269,12 +269,12 @@ splice(@data, 1, 2, 99);
 
 #[test]
 fn inlay_hints_invalid_perl_does_not_crash() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = "sub broken {{ my $x = ;\n@! invalid perl }}\n";
-    open_document(&mut server, "file:///bad_hints.pl", content);
+    open_document(&server, "file:///bad_hints.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         20,
         "textDocument/inlayHint",
         json!({
@@ -298,17 +298,17 @@ fn inlay_hints_invalid_perl_does_not_crash() -> TestResult {
 
 #[test]
 fn document_links_use_statements() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"use strict;
 use warnings;
 use File::Path qw(make_path);
 use Data::Dumper;
 require JSON::XS;
 "#;
-    open_document(&mut server, "file:///links.pl", content);
+    open_document(&server, "file:///links.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         30,
         "textDocument/documentLink",
         json!({"textDocument": {"uri": "file:///links.pl"}}),
@@ -330,11 +330,11 @@ require JSON::XS;
 
 #[test]
 fn document_links_empty_document() -> TestResult {
-    let mut server = setup_server();
-    open_document(&mut server, "file:///empty_links.pl", "");
+    let server = setup_server();
+    open_document(&server, "file:///empty_links.pl", "");
 
     let result = send_request(
-        &mut server,
+        &server,
         30,
         "textDocument/documentLink",
         json!({"textDocument": {"uri": "file:///empty_links.pl"}}),
@@ -348,7 +348,7 @@ fn document_links_empty_document() -> TestResult {
 
 #[test]
 fn document_links_multiple_module_forms() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"use parent 'Exporter';
 use base qw(Class::Accessor);
 use Moose;
@@ -356,10 +356,10 @@ use Moo;
 require Carp;
 use Scalar::Util 'blessed';
 "#;
-    open_document(&mut server, "file:///modules.pl", content);
+    open_document(&server, "file:///modules.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         30,
         "textDocument/documentLink",
         json!({"textDocument": {"uri": "file:///modules.pl"}}),
@@ -383,7 +383,7 @@ use Scalar::Util 'blessed';
 
 #[test]
 fn selection_range_nested_scopes() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package MyApp;
 
 sub process {
@@ -396,10 +396,10 @@ sub process {
     return 1;
 }
 "#;
-    open_document(&mut server, "file:///scopes.pl", content);
+    open_document(&server, "file:///scopes.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         40,
         "textDocument/selectionRange",
         json!({
@@ -442,16 +442,16 @@ sub process {
 
 #[test]
 fn selection_range_multiple_positions() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"my $x = 1;
 my $y = 2;
 sub add { return $_[0] + $_[1] }
 my $sum = add($x, $y);
 "#;
-    open_document(&mut server, "file:///multi_sel.pl", content);
+    open_document(&server, "file:///multi_sel.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         40,
         "textDocument/selectionRange",
         json!({
@@ -483,11 +483,11 @@ my $sum = add($x, $y);
 
 #[test]
 fn selection_range_empty_document() -> TestResult {
-    let mut server = setup_server();
-    open_document(&mut server, "file:///empty_sel.pl", "");
+    let server = setup_server();
+    open_document(&server, "file:///empty_sel.pl", "");
 
     let result = send_request(
-        &mut server,
+        &server,
         40,
         "textDocument/selectionRange",
         json!({
@@ -516,7 +516,7 @@ fn selection_range_empty_document() -> TestResult {
 
 #[test]
 fn folding_ranges_heredoc() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"my $text = <<'END_TEXT';
 This is a heredoc
 that spans multiple
@@ -531,10 +531,10 @@ my $html = <<"HTML";
 </html>
 HTML
 "#;
-    open_document(&mut server, "file:///heredoc.pl", content);
+    open_document(&server, "file:///heredoc.pl", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         50,
         "textDocument/foldingRange",
         json!({"textDocument": {"uri": "file:///heredoc.pl"}}),
@@ -555,7 +555,7 @@ HTML
 
 #[test]
 fn folding_ranges_pod_comments() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"=head1 NAME
 
 MyModule - A test module
@@ -577,10 +577,10 @@ sub new {
     return bless {}, $class;
 }
 "#;
-    open_document(&mut server, "file:///pod.pm", content);
+    open_document(&server, "file:///pod.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         50,
         "textDocument/foldingRange",
         json!({"textDocument": {"uri": "file:///pod.pm"}}),
@@ -609,7 +609,7 @@ sub new {
 
 #[test]
 fn moose_class_document_symbols() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package Animal;
 use Moose;
 
@@ -630,10 +630,10 @@ no Moose;
 __PACKAGE__->meta->make_immutable;
 1;
 "#;
-    open_document(&mut server, "file:///animal.pm", content);
+    open_document(&server, "file:///animal.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         60,
         "textDocument/documentSymbol",
         json!({"textDocument": {"uri": "file:///animal.pm"}}),
@@ -666,7 +666,7 @@ __PACKAGE__->meta->make_immutable;
 
 #[test]
 fn dbi_usage_completion() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"use DBI;
 
 my $dbh = DBI->connect("dbi:SQLite:dbname=test.db", "", "");
@@ -689,11 +689,11 @@ sub get_user {
 
 get_
 "#;
-    open_document(&mut server, "file:///dbi.pl", content);
+    open_document(&server, "file:///dbi.pl", content);
 
     // Request completion for the partial function name "get_"
     let result = send_request(
-        &mut server,
+        &server,
         60,
         "textDocument/completion",
         json!({
@@ -722,7 +722,7 @@ get_
 
 #[test]
 fn dbi_usage_document_symbols() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package MyApp::DB;
 
 use DBI;
@@ -748,10 +748,10 @@ sub query {
 
 1;
 "#;
-    open_document(&mut server, "file:///db.pm", content);
+    open_document(&server, "file:///db.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         60,
         "textDocument/documentSymbol",
         json!({"textDocument": {"uri": "file:///db.pm"}}),
@@ -777,7 +777,7 @@ sub query {
 
 #[test]
 fn moose_class_folding_ranges() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package Animal;
 use Moose;
 
@@ -802,10 +802,10 @@ no Moose;
 __PACKAGE__->meta->make_immutable;
 1;
 "#;
-    open_document(&mut server, "file:///moose_fold.pm", content);
+    open_document(&server, "file:///moose_fold.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         50,
         "textDocument/foldingRange",
         json!({"textDocument": {"uri": "file:///moose_fold.pm"}}),
@@ -829,14 +829,14 @@ __PACKAGE__->meta->make_immutable;
 
 #[test]
 fn diagnostics_strict_undeclared_variable() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"use strict;
 use warnings;
 
 my $declared = 42;
 print $undeclared;
 "#;
-    open_document(&mut server, "file:///strict.pl", content);
+    open_document(&server, "file:///strict.pl", content);
 
     // Diagnostics are typically published as notifications, but we can also
     // test via the pull diagnostics endpoint if available, or verify the
@@ -845,7 +845,7 @@ print $undeclared;
 
     // Verify server is still responsive after opening a file with issues
     let result = send_request(
-        &mut server,
+        &server,
         70,
         "textDocument/documentSymbol",
         json!({"textDocument": {"uri": "file:///strict.pl"}}),
@@ -862,18 +862,18 @@ print $undeclared;
 
 #[test]
 fn diagnostics_syntax_error_does_not_crash_server() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"sub broken {
     my $x = ;
     if ( {
     }
 }
 "#;
-    open_document(&mut server, "file:///broken.pl", content);
+    open_document(&server, "file:///broken.pl", content);
 
     // Server must remain responsive after opening a file with syntax errors
     let result = send_request(
-        &mut server,
+        &server,
         70,
         "textDocument/foldingRange",
         json!({"textDocument": {"uri": "file:///broken.pl"}}),
@@ -907,7 +907,7 @@ fn diagnostics_syntax_error_does_not_crash_server() -> TestResult {
 
 #[test]
 fn hover_on_package_name() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package MyApp::Controller;
 
 sub new {
@@ -917,7 +917,7 @@ sub new {
 
 1;
 "#;
-    open_document(&mut server, "file:///pkg_hover.pm", content);
+    open_document(&server, "file:///pkg_hover.pm", content);
 
     let req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -937,9 +937,9 @@ sub new {
 
 #[test]
 fn hover_on_use_statement_module() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = "use List::Util qw(sum max min);\nmy $total = sum(1, 2, 3);\n";
-    open_document(&mut server, "file:///use_hover.pl", content);
+    open_document(&server, "file:///use_hover.pl", content);
 
     let req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -962,9 +962,9 @@ fn hover_on_use_statement_module() -> TestResult {
 
 #[test]
 fn code_actions_empty_range() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = "my $x = 42;\nprint $x;\n";
-    open_document(&mut server, "file:///actions.pl", content);
+    open_document(&server, "file:///actions.pl", content);
 
     let req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -997,11 +997,11 @@ fn code_actions_empty_range() -> TestResult {
 
 #[test]
 fn document_symbols_empty_file() -> TestResult {
-    let mut server = setup_server();
-    open_document(&mut server, "file:///empty_sym.pl", "");
+    let server = setup_server();
+    open_document(&server, "file:///empty_sym.pl", "");
 
     let result = send_request(
-        &mut server,
+        &server,
         100,
         "textDocument/documentSymbol",
         json!({"textDocument": {"uri": "file:///empty_sym.pl"}}),
@@ -1015,7 +1015,7 @@ fn document_symbols_empty_file() -> TestResult {
 
 #[test]
 fn document_symbols_multiple_packages() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
     let content = r#"package Foo;
 
 sub foo_method { return 1 }
@@ -1030,10 +1030,10 @@ sub baz_method { return 3 }
 
 1;
 "#;
-    open_document(&mut server, "file:///multi_pkg.pm", content);
+    open_document(&server, "file:///multi_pkg.pm", content);
 
     let result = send_request(
-        &mut server,
+        &server,
         100,
         "textDocument/documentSymbol",
         json!({"textDocument": {"uri": "file:///multi_pkg.pm"}}),

--- a/crates/perl-lsp/tests/lsp_filesystem_failures.rs
+++ b/crates/perl-lsp/tests/lsp_filesystem_failures.rs
@@ -20,8 +20,8 @@ use common::{initialize_lsp, read_response, send_notification, send_request, sta
 
 #[test]
 fn test_read_only_file() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create a read-only file
     let temp_dir = std::env::temp_dir();
@@ -37,7 +37,7 @@ fn test_read_only_file() -> TestResult {
 
     // Open read-only file (should work)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -54,7 +54,7 @@ fn test_read_only_file() -> TestResult {
 
     // Try to save changes (should fail gracefully)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didSave",
@@ -82,8 +82,8 @@ fn test_read_only_file() -> TestResult {
 
 #[test]
 fn test_directory_as_file() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let dir_path = temp_dir.join(format!("dir_{}", std::process::id()));
@@ -93,7 +93,7 @@ fn test_directory_as_file() -> TestResult {
 
     // Try to open a directory as a file
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -110,7 +110,7 @@ fn test_directory_as_file() -> TestResult {
 
     // Should handle gracefully
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -122,7 +122,7 @@ fn test_directory_as_file() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Cleanup
@@ -133,14 +133,14 @@ fn test_directory_as_file() -> TestResult {
 
 #[test]
 fn test_non_existent_file() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///completely/non/existent/path/file.pl";
 
     // Try to open non-existent file
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -157,7 +157,7 @@ fn test_non_existent_file() -> TestResult {
 
     // Should work with in-memory content
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -168,7 +168,7 @@ fn test_non_existent_file() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array() || response["result"].is_null());
 
     Ok(())
@@ -184,8 +184,8 @@ fn test_permission_denied_directory() -> TestResult {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     // Use unique directory name to avoid conflicts
@@ -208,7 +208,7 @@ fn test_permission_denied_directory() -> TestResult {
 
     // Try to access file in restricted directory
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -224,7 +224,7 @@ fn test_permission_denied_directory() -> TestResult {
     perms.set_mode(0o755);
     fs::set_permissions(restricted_dir, perms)?;
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Clean up directory
@@ -243,8 +243,8 @@ fn test_permission_denied_directory() {
 #[test]
 #[cfg(unix)]
 fn test_symlink_loop() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     // Use unique names to avoid conflicts
@@ -266,7 +266,7 @@ fn test_symlink_loop() -> TestResult {
 
     // Try to open symlink loop
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -283,7 +283,7 @@ fn test_symlink_loop() -> TestResult {
 
     // Should handle without infinite loop
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -294,7 +294,7 @@ fn test_symlink_loop() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Clean up symlinks
@@ -313,8 +313,8 @@ fn test_symlink_loop() {
 
 #[test]
 fn test_broken_symlink() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let target = &temp_dir.join("target.pl");
@@ -336,7 +336,7 @@ fn test_broken_symlink() -> TestResult {
 
     // Try to open broken symlink
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -353,7 +353,7 @@ fn test_broken_symlink() -> TestResult {
 
     // Should handle gracefully
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -365,7 +365,7 @@ fn test_broken_symlink() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     Ok(())
@@ -373,8 +373,8 @@ fn test_broken_symlink() -> TestResult {
 
 #[test]
 fn test_very_long_path() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create extremely long path (may exceed PATH_MAX on some systems)
     let mut long_path = String::from("file:///");
@@ -385,7 +385,7 @@ fn test_very_long_path() -> TestResult {
 
     // Try to open file with very long path
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -402,7 +402,7 @@ fn test_very_long_path() -> TestResult {
 
     // Should handle gracefully
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -413,7 +413,7 @@ fn test_very_long_path() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     Ok(())
@@ -421,8 +421,8 @@ fn test_very_long_path() -> TestResult {
 
 #[test]
 fn test_special_filename_characters() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
 
@@ -472,7 +472,7 @@ fn test_special_filename_characters() -> TestResult {
         if fs::write(file_path, "print 'special';").is_ok() {
             if let Ok(uri) = path_to_uri(file_path) {
                 send_notification(
-                    &mut server,
+                    &server,
                     json!({
                         "jsonrpc": "2.0",
                         "method": "textDocument/didOpen",
@@ -495,8 +495,8 @@ fn test_special_filename_characters() -> TestResult {
 
 #[test]
 fn test_case_sensitive_filesystem() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let file_lower = &temp_dir.join("test.pl");
@@ -516,7 +516,7 @@ fn test_case_sensitive_filesystem() -> TestResult {
     let uri_upper = path_to_uri(file_upper)?;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -532,7 +532,7 @@ fn test_case_sensitive_filesystem() -> TestResult {
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -549,7 +549,7 @@ fn test_case_sensitive_filesystem() -> TestResult {
 
     // Should handle both files correctly
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -560,7 +560,7 @@ fn test_case_sensitive_filesystem() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     Ok(())
@@ -568,8 +568,8 @@ fn test_case_sensitive_filesystem() -> TestResult {
 
 #[test]
 fn test_file_deleted_while_open() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let file_path = &temp_dir.join("delete_me.pl");
@@ -579,7 +579,7 @@ fn test_file_deleted_while_open() -> TestResult {
 
     // Open file
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -599,7 +599,7 @@ fn test_file_deleted_while_open() -> TestResult {
 
     // Try to perform operations on deleted file
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -611,12 +611,12 @@ fn test_file_deleted_while_open() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Try to save
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didSave",
@@ -632,8 +632,8 @@ fn test_file_deleted_while_open() -> TestResult {
 
 #[test]
 fn test_file_modified_externally() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let file_path = &temp_dir.join("external.pl");
@@ -643,7 +643,7 @@ fn test_file_modified_externally() -> TestResult {
 
     // Open file
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -663,7 +663,7 @@ fn test_file_modified_externally() -> TestResult {
 
     // Server state may be out of sync
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -674,12 +674,12 @@ fn test_file_modified_externally() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Notify of external change
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -700,7 +700,7 @@ fn test_file_modified_externally() -> TestResult {
 
 #[test]
 fn test_workspace_folder_deleted() -> TestResult {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     let temp_dir = std::env::temp_dir();
     let workspace_path = &temp_dir.to_path_buf();
@@ -708,7 +708,7 @@ fn test_workspace_folder_deleted() -> TestResult {
 
     // Initialize with workspace folder
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -729,7 +729,7 @@ fn test_workspace_folder_deleted() -> TestResult {
     assert!(response["result"].is_object());
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "initialized",
@@ -741,7 +741,7 @@ fn test_workspace_folder_deleted() -> TestResult {
     // Note: We can't actually delete temp_dir while we're using it
     // Instead, simulate by removing workspace folder via LSP
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "workspace/didChangeWorkspaceFolders",
@@ -759,7 +759,7 @@ fn test_workspace_folder_deleted() -> TestResult {
 
     // Try to perform workspace operations
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -770,7 +770,7 @@ fn test_workspace_folder_deleted() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should return an array (possibly empty) or null
     assert!(response.is_object());
     assert!(response["result"].is_array() || response["result"].is_null());
@@ -780,8 +780,8 @@ fn test_workspace_folder_deleted() -> TestResult {
 
 #[test]
 fn test_hidden_files() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let hidden_file = &temp_dir.join(".hidden.pl");
@@ -791,7 +791,7 @@ fn test_hidden_files() -> TestResult {
 
     // Open hidden file
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -808,7 +808,7 @@ fn test_hidden_files() -> TestResult {
 
     // Should work normally
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -819,7 +819,7 @@ fn test_hidden_files() -> TestResult {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array() || response["result"].is_null());
 
     Ok(())
@@ -827,8 +827,8 @@ fn test_hidden_files() -> TestResult {
 
 #[test]
 fn test_device_files() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to open device files (Linux specific)
     let device_files = vec!["/dev/null", "/dev/zero", "/dev/random", "/dev/urandom"];
@@ -838,7 +838,7 @@ fn test_device_files() -> TestResult {
         if device_path.exists() {
             if let Ok(uri) = path_to_uri(&device_path) {
                 send_notification(
-                    &mut server,
+                    &server,
                     json!({
                         "jsonrpc": "2.0",
                         "method": "textDocument/didOpen",
@@ -861,8 +861,8 @@ fn test_device_files() -> TestResult {
 
 #[test]
 fn test_fifo_pipe() -> TestResult {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let temp_dir = std::env::temp_dir();
     let fifo_path = &temp_dir.join("pipe.pl");
@@ -875,7 +875,7 @@ fn test_fifo_pipe() -> TestResult {
 
         // Try to open FIFO
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -892,7 +892,7 @@ fn test_fifo_pipe() -> TestResult {
 
         // Should handle special file type
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -904,7 +904,7 @@ fn test_fifo_pipe() -> TestResult {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 

--- a/crates/perl-lsp/tests/lsp_folding_ranges_test.rs
+++ b/crates/perl-lsp/tests/lsp_folding_ranges_test.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -32,7 +32,7 @@ fn setup_server() -> LspServer {
     server
 }
 
-fn open_document(server: &mut LspServer, uri: &str, content: &str) {
+fn open_document(server: &LspServer, uri: &str, content: &str) {
     let notification = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         method: "textDocument/didOpen".to_string(),
@@ -51,7 +51,7 @@ fn open_document(server: &mut LspServer, uri: &str, content: &str) {
 
 #[test]
 fn test_folding_ranges_subroutines() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 sub hello {
@@ -73,7 +73,7 @@ sub nested {
 }
 "#;
 
-    open_document(&mut server, "file:///test.pl", content);
+    open_document(&server, "file:///test.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -110,7 +110,7 @@ sub nested {
 #[cfg(feature = "lsp-extras")]
 #[test]
 fn test_folding_ranges_blocks() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 if ($condition) {
@@ -133,7 +133,7 @@ foreach my $item (@items) {
 };
 "#;
 
-    open_document(&mut server, "file:///blocks.pl", content);
+    open_document(&server, "file:///blocks.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -161,7 +161,7 @@ foreach my $item (@items) {
 
 #[test]
 fn test_folding_ranges_packages() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 package MyModule {
@@ -183,7 +183,7 @@ package AnotherModule {
 }
 "#;
 
-    open_document(&mut server, "file:///packages.pl", content);
+    open_document(&server, "file:///packages.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -211,7 +211,7 @@ package AnotherModule {
 
 #[test]
 fn test_folding_ranges_try_catch() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 try {
@@ -225,7 +225,7 @@ try {
 }
 "#;
 
-    open_document(&mut server, "file:///try.pl", content);
+    open_document(&server, "file:///try.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -253,7 +253,7 @@ try {
 
 #[test]
 fn test_folding_ranges_data_structures() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 my @array = (
@@ -272,7 +272,7 @@ my %hash = (
 );
 "#;
 
-    open_document(&mut server, "file:///data.pl", content);
+    open_document(&server, "file:///data.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -300,7 +300,7 @@ my %hash = (
 
 #[test]
 fn test_folding_ranges_imports() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let content = r#"
 use strict;
@@ -315,7 +315,7 @@ sub main {
 }
 "#;
 
-    open_document(&mut server, "file:///imports.pl", content);
+    open_document(&server, "file:///imports.pl", content);
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -345,9 +345,9 @@ sub main {
 
 #[test]
 fn test_folding_ranges_empty_document() -> TestResult {
-    let mut server = setup_server();
+    let server = setup_server();
 
-    open_document(&mut server, "file:///empty.pl", "");
+    open_document(&server, "file:///empty.pl", "");
 
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 /// Test that inlayHint/resolve adds tooltip when requested
 #[test]
 fn lsp_inlay_hint_resolve_adds_tooltip() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -69,7 +69,7 @@ fn lsp_inlay_hint_resolve_adds_tooltip() -> Result<(), Box<dyn std::error::Error
 /// Test that resolve preserves data field
 #[test]
 fn lsp_inlay_hint_resolve_preserves_data() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -119,7 +119,7 @@ fn lsp_inlay_hint_resolve_preserves_data() -> Result<(), Box<dyn std::error::Err
 /// Test that resolve returns same hint if already has tooltip
 #[test]
 fn lsp_inlay_hint_resolve_no_op_when_complete() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -167,7 +167,7 @@ fn lsp_inlay_hint_resolve_no_op_when_complete() -> Result<(), Box<dyn std::error
 /// Test that resolve handles missing params gracefully
 #[test]
 fn lsp_inlay_hint_resolve_handles_invalid_params() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_inlay_hints.rs
+++ b/crates/perl-lsp/tests/lsp_inlay_hints.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn inlay_hints_for_substr_and_types() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
@@ -4,7 +4,7 @@ use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::json;
 
 fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize the server
     let init_request = JsonRpcRequest {
@@ -31,7 +31,7 @@ fn setup_server() -> Result<LspServer, Box<dyn std::error::Error>> {
     Ok(server)
 }
 
-fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
+fn open_doc(server: &LspServer, uri: &str, text: &str) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: None,
@@ -49,7 +49,7 @@ fn open_doc(server: &mut LspServer, uri: &str, text: &str) {
 }
 
 fn inline_completion(
-    server: &mut LspServer,
+    server: &LspServer,
     uri: &str,
     line: u32,
     character: u32,
@@ -69,10 +69,10 @@ fn inline_completion(
 
 #[test]
 fn test_inline_completion_after_arrow() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
     let uri = "file:///test.pl";
-    open_doc(&mut server, uri, "my $obj = Package->");
-    let result = inline_completion(&mut server, uri, 0, 19)?;
+    open_doc(&server, uri, "my $obj = Package->");
+    let result = inline_completion(&server, uri, 0, 19)?;
     let items = result["items"].as_array().ok_or("items array")?;
     assert!(!items.is_empty());
     assert_eq!(items[0]["insertText"].as_str().ok_or("insertText not a string")?, "new()");
@@ -81,10 +81,10 @@ fn test_inline_completion_after_arrow() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_inline_completion_after_use() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
     let uri = "file:///test.pl";
-    open_doc(&mut server, uri, "use ");
-    let result = inline_completion(&mut server, uri, 0, 4)?;
+    open_doc(&server, uri, "use ");
+    let result = inline_completion(&server, uri, 0, 4)?;
     let items = result["items"].as_array().ok_or("items array")?;
     assert!(!items.is_empty());
     let mut suggestions = Vec::new();
@@ -99,10 +99,10 @@ fn test_inline_completion_after_use() -> Result<(), Box<dyn std::error::Error>> 
 
 #[test]
 fn test_inline_completion_shebang() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
     let uri = "file:///test.pl";
-    open_doc(&mut server, uri, "#!");
-    let result = inline_completion(&mut server, uri, 0, 2)?;
+    open_doc(&server, uri, "#!");
+    let result = inline_completion(&server, uri, 0, 2)?;
     let items = result["items"].as_array().ok_or("items array")?;
     assert!(!items.is_empty());
     assert_eq!(
@@ -114,10 +114,10 @@ fn test_inline_completion_shebang() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_inline_completion_sub_body() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
     let uri = "file:///test.pl";
-    open_doc(&mut server, uri, "sub test ");
-    let result = inline_completion(&mut server, uri, 0, 9)?;
+    open_doc(&server, uri, "sub test ");
+    let result = inline_completion(&server, uri, 0, 9)?;
     let items = result["items"].as_array().ok_or("items array")?;
     assert!(!items.is_empty());
     assert!(items[0]["insertText"].as_str().ok_or("insertText not a string")?.contains("{"));
@@ -126,10 +126,10 @@ fn test_inline_completion_sub_body() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_inline_completion_no_suggestions() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server()?;
+    let server = setup_server()?;
     let uri = "file:///test.pl";
-    open_doc(&mut server, uri, "my $x = 42;");
-    let result = inline_completion(&mut server, uri, 0, 10)?;
+    open_doc(&server, uri, "my $x = 42;");
+    let result = inline_completion(&server, uri, 0, 10)?;
     let items = result["items"].as_array().ok_or("items array")?;
     assert!(items.is_empty());
     Ok(())

--- a/crates/perl-lsp/tests/lsp_integration_tests.rs
+++ b/crates/perl-lsp/tests/lsp_integration_tests.rs
@@ -15,7 +15,7 @@ fn create_test_server() -> LspServer {
 }
 
 /// Helper to send a request and get response
-fn send_request(server: &mut LspServer, method: &str, params: Option<Value>) -> Option<Value> {
+fn send_request(server: &LspServer, method: &str, params: Option<Value>) -> Option<Value> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -27,7 +27,7 @@ fn send_request(server: &mut LspServer, method: &str, params: Option<Value>) -> 
 }
 
 /// Helper to send the initialized notification (required after initialize request)
-fn send_initialized(server: &mut LspServer) {
+fn send_initialized(server: &LspServer) {
     let initialized_notification = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -39,7 +39,7 @@ fn send_initialized(server: &mut LspServer) {
 
 #[test]
 fn test_lsp_initialization() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     let params = json!({
         "processId": null,
@@ -47,7 +47,7 @@ fn test_lsp_initialization() -> TestResult {
         "rootUri": "file:///test"
     });
 
-    let result = send_request(&mut server, "initialize", Some(params));
+    let result = send_request(&server, "initialize", Some(params));
     assert!(result.is_some());
 
     let capabilities = result.ok_or("Failed to get initialization response")?;
@@ -75,11 +75,11 @@ fn test_lsp_initialization() -> TestResult {
 
 #[test]
 fn test_workspace_symbols_integration() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -87,7 +87,7 @@ fn test_workspace_symbols_integration() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     // Open a document with symbols
     let test_code = r#"
@@ -106,7 +106,7 @@ my $local_var = 456;
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -120,7 +120,7 @@ my $local_var = 456;
 
     // Search for symbols
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "func"
@@ -147,11 +147,11 @@ my $local_var = 456;
 
 #[test]
 fn test_code_lens_integration() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -159,7 +159,7 @@ fn test_code_lens_integration() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     // Open a test file
     let test_code = r#"#!/usr/bin/perl
@@ -180,7 +180,7 @@ sub TestPackage::test_method {
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -194,7 +194,7 @@ sub TestPackage::test_method {
 
     // Get code lenses
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/codeLens",
         Some(json!({
             "textDocument": {
@@ -229,11 +229,11 @@ sub TestPackage::test_method {
 
 #[test]
 fn test_code_lens_resolve() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -241,7 +241,7 @@ fn test_code_lens_resolve() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     // Test resolving a code lens
     let unresolved_lens = json!({
@@ -254,7 +254,7 @@ fn test_code_lens_resolve() -> TestResult {
         }
     });
 
-    let result = send_request(&mut server, "codeLens/resolve", Some(unresolved_lens));
+    let result = send_request(&server, "codeLens/resolve", Some(unresolved_lens));
     assert!(result.is_some());
 
     let resolved = result.ok_or("Failed to resolve code lens")?;
@@ -266,11 +266,11 @@ fn test_code_lens_resolve() -> TestResult {
 
 #[test]
 fn test_multiple_documents() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -278,7 +278,7 @@ fn test_multiple_documents() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     // Open multiple documents
     let doc1 = r#"
@@ -292,7 +292,7 @@ sub function2 { }
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -305,7 +305,7 @@ sub function2 { }
     );
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -319,7 +319,7 @@ sub function2 { }
 
     // Search across all documents
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "Module"
@@ -347,11 +347,11 @@ sub function2 { }
 
 #[test]
 fn test_document_updates() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -359,11 +359,11 @@ fn test_document_updates() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -377,7 +377,7 @@ fn test_document_updates() -> TestResult {
 
     // Update the document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didChange",
         Some(json!({
             "textDocument": {
@@ -392,7 +392,7 @@ fn test_document_updates() -> TestResult {
 
     // Search for new symbols
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "new"
@@ -414,7 +414,7 @@ fn test_document_updates() -> TestResult {
 
     // Ensure stale symbols from old content are no longer discoverable
     let stale_result = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "old_function"
@@ -431,10 +431,10 @@ fn test_document_updates() -> TestResult {
 
 #[test]
 fn test_incremental_change_replaces_symbol_set() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -442,10 +442,10 @@ fn test_incremental_change_replaces_symbol_set() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -458,7 +458,7 @@ fn test_incremental_change_replaces_symbol_set() -> TestResult {
     );
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didChange",
         Some(json!({
             "textDocument": {
@@ -472,7 +472,7 @@ fn test_incremental_change_replaces_symbol_set() -> TestResult {
     );
 
     let new_symbols = send_request(
-        &mut server,
+        &server,
         "workspace/symbol",
         Some(json!({
             "query": "symbol"
@@ -548,16 +548,16 @@ package MyPkg;
 
 #[test]
 fn test_error_handling() {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Try to use server before initialization
-    let _result = send_request(&mut server, "textDocument/completion", Some(json!({})));
+    let _result = send_request(&server, "textDocument/completion", Some(json!({})));
     // Server may return an error or empty result - either is fine
     // Just ensure it doesn't panic
 
     // Initialize
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -567,17 +567,17 @@ fn test_error_handling() {
     );
 
     // Send invalid request
-    let result = send_request(&mut server, "invalid/method", Some(json!({})));
+    let result = send_request(&server, "invalid/method", Some(json!({})));
     assert!(result.is_none());
 }
 
 #[test]
 fn test_semantic_tokens_full() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -585,11 +585,11 @@ fn test_semantic_tokens_full() -> TestResult {
             "capabilities": {}
         })),
     );
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -616,7 +616,7 @@ process_data($obj, $global);
 
     // Request semantic tokens
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/semanticTokens/full",
         Some(json!({
             "textDocument": {
@@ -640,11 +640,11 @@ process_data($obj, $global);
 
 #[test]
 fn test_semantic_tokens_range() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -652,11 +652,11 @@ fn test_semantic_tokens_range() -> TestResult {
             "capabilities": {}
         })),
     );
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -676,7 +676,7 @@ print $var3;
 
     // Request semantic tokens for a range (lines 1-3)
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/semanticTokens/range",
         Some(json!({
             "textDocument": {
@@ -706,11 +706,11 @@ print $var3;
 
 #[test]
 fn test_call_hierarchy_prepare() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     let init_result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -727,11 +727,11 @@ fn test_call_hierarchy_prepare() -> TestResult {
         eprintln!("call hierarchy not advertised; skipping test");
         return Ok(());
     }
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -759,7 +759,7 @@ sub process_data {
 
     // Prepare call hierarchy at "main" function
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/prepareCallHierarchy",
         Some(json!({
             "textDocument": {
@@ -788,11 +788,11 @@ sub process_data {
 
 #[test]
 fn test_call_hierarchy_incoming() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     let init_result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -809,11 +809,11 @@ fn test_call_hierarchy_incoming() -> TestResult {
         eprintln!("call hierarchy not advertised; skipping test");
         return Ok(());
     }
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -840,7 +840,7 @@ sub target_func {
 
     // First prepare call hierarchy for target_func
     let prepare_result = send_request(
-        &mut server,
+        &server,
         "textDocument/prepareCallHierarchy",
         Some(json!({
             "textDocument": {
@@ -859,7 +859,7 @@ sub target_func {
 
     // Get incoming calls
     let incoming_result = send_request(
-        &mut server,
+        &server,
         "callHierarchy/incomingCalls",
         Some(json!({
             "item": target_item
@@ -886,11 +886,11 @@ sub target_func {
 
 #[test]
 fn test_call_hierarchy_outgoing() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     let init_result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -907,11 +907,11 @@ fn test_call_hierarchy_outgoing() -> TestResult {
         eprintln!("call hierarchy not advertised; skipping test");
         return Ok(());
     }
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -935,7 +935,7 @@ sub helper {
 
     // First prepare call hierarchy for main
     let prepare_result = send_request(
-        &mut server,
+        &server,
         "textDocument/prepareCallHierarchy",
         Some(json!({
             "textDocument": {
@@ -954,7 +954,7 @@ sub helper {
 
     // Get outgoing calls
     let outgoing_result = send_request(
-        &mut server,
+        &server,
         "callHierarchy/outgoingCalls",
         Some(json!({
             "item": main_item
@@ -982,11 +982,11 @@ sub helper {
 
 #[test]
 fn test_inlay_hints() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -994,11 +994,11 @@ fn test_inlay_hints() -> TestResult {
             "capabilities": {}
         })),
     );
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document with function calls
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1019,7 +1019,7 @@ my $hash = { key => "value" };
 
     // Request inlay hints
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/inlayHint",
         Some(json!({
             "textDocument": {
@@ -1060,11 +1060,11 @@ my $hash = { key => "value" };
 
 #[test]
 fn test_inlay_hints_range() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1072,11 +1072,11 @@ fn test_inlay_hints_range() -> TestResult {
             "capabilities": {}
         })),
     );
-    send_request(&mut server, "initialized", None);
+    send_request(&server, "initialized", None);
 
     // Open a document
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1095,7 +1095,7 @@ push(@array4, "value4");  # Line 4
 
     // Request inlay hints for lines 2-3 only
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/inlayHint",
         Some(json!({
             "textDocument": {
@@ -1129,10 +1129,10 @@ push(@array4, "value4");  # Line 4
 
 #[test]
 fn test_glob_expression_document_symbols() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1140,7 +1140,7 @@ fn test_glob_expression_document_symbols() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = r#"
 my @files = glob "*.pl";
@@ -1149,7 +1149,7 @@ my @all = glob "**/*.pm";
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1162,7 +1162,7 @@ my @all = glob "**/*.pm";
     );
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -1183,10 +1183,10 @@ my @all = glob "**/*.pm";
 
 #[test]
 fn test_glob_expression_hover() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1194,12 +1194,12 @@ fn test_glob_expression_hover() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = "my @files = glob '*.pl';\n";
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1213,7 +1213,7 @@ fn test_glob_expression_hover() -> TestResult {
 
     let glob_position = test_code.find("glob").ok_or("Could not find 'glob'")?;
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/hover",
         Some(json!({
             "textDocument": {
@@ -1239,10 +1239,10 @@ fn test_glob_expression_hover() -> TestResult {
 
 #[test]
 fn test_glob_expression_completion() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1250,12 +1250,12 @@ fn test_glob_expression_completion() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = "my @files = glob '*.pl';\nmy $file = ";
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1268,7 +1268,7 @@ fn test_glob_expression_completion() -> TestResult {
     );
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/completion",
         Some(json!({
             "textDocument": {
@@ -1288,10 +1288,10 @@ fn test_glob_expression_completion() -> TestResult {
 
 #[test]
 fn test_glob_angle_bracket_syntax() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1299,7 +1299,7 @@ fn test_glob_angle_bracket_syntax() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = r#"
 my @files = <*.pl>;
@@ -1307,7 +1307,7 @@ my @modules = <lib/**/*.pm>;
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1320,7 +1320,7 @@ my @modules = <lib/**/*.pm>;
     );
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -1341,10 +1341,10 @@ my @modules = <lib/**/*.pm>;
 
 #[test]
 fn test_glob_vs_readline_distinction() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1352,7 +1352,7 @@ fn test_glob_vs_readline_distinction() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = r#"
 my @files = <*.pl>;
@@ -1363,7 +1363,7 @@ my $content = <$fh>;
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1376,7 +1376,7 @@ my $content = <$fh>;
     );
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {
@@ -1397,10 +1397,10 @@ my $content = <$fh>;
 
 #[test]
 fn test_glob_complex_patterns() -> TestResult {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!({
             "processId": null,
@@ -1408,7 +1408,7 @@ fn test_glob_complex_patterns() -> TestResult {
             "rootUri": "file:///test"
         })),
     );
-    send_initialized(&mut server);
+    send_initialized(&server);
 
     let test_code = r#"
 my @recursive = glob "**/*.pm";
@@ -1420,7 +1420,7 @@ my @mixed = glob "/tmp/[abc]*{.txt,.log}";
 "#;
 
     send_request(
-        &mut server,
+        &server,
         "textDocument/didOpen",
         Some(json!({
             "textDocument": {
@@ -1433,7 +1433,7 @@ my @mixed = glob "/tmp/[abc]*{.txt,.log}";
     );
 
     let result = send_request(
-        &mut server,
+        &server,
         "textDocument/documentSymbol",
         Some(json!({
             "textDocument": {

--- a/crates/perl-lsp/tests/lsp_invariants_test.rs
+++ b/crates/perl-lsp/tests/lsp_invariants_test.rs
@@ -14,12 +14,12 @@ use serde_json::json;
 /// Verify all responses have proper JSON-RPC structure
 #[test]
 fn test_response_structure_invariants() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Test successful response
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/documentSymbol",
@@ -41,19 +41,19 @@ fn test_response_structure_invariants() -> Result<(), Box<dyn std::error::Error>
 
     // Must have matching ID
     assert!(response.get("id").is_some(), "Response must have an id field");
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify error responses have proper structure
 #[test]
 fn test_error_response_structure() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send unknown method to trigger error
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/unknownMethod",
@@ -79,19 +79,19 @@ fn test_error_response_structure() -> Result<(), Box<dyn std::error::Error>> {
         || code < -32000, // Server-defined errors
         "Error code must be standard JSON-RPC or server-defined"
     );
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify ID matching between request and response
 #[test]
 fn test_id_matching_invariants() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Test with number ID
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 42,
@@ -107,7 +107,7 @@ fn test_id_matching_invariants() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test with string ID
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": "test-id",
@@ -120,19 +120,19 @@ fn test_id_matching_invariants() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
     assert_eq!(response["id"], "test-id", "Response ID must match string request ID");
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify diagnostics always include version and errors are cleared when fixed
 #[test]
 fn test_diagnostics_version_invariant() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open document with a parse error (undefined variable usage)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -149,7 +149,7 @@ fn test_diagnostics_version_invariant() -> Result<(), Box<dyn std::error::Error>
 
     // Wait for diagnostics
     if let Some(diag) = common::read_notification_method(
-        &mut server,
+        &server,
         "textDocument/publishDiagnostics",
         common::short_timeout(),
     ) {
@@ -159,7 +159,7 @@ fn test_diagnostics_version_invariant() -> Result<(), Box<dyn std::error::Error>
 
     // Fix the error by using all variables (avoids unused variable warnings)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -177,7 +177,7 @@ fn test_diagnostics_version_invariant() -> Result<(), Box<dyn std::error::Error>
 
     // Wait for updated diagnostics
     if let Some(diag) = common::read_notification_method(
-        &mut server,
+        &server,
         "textDocument/publishDiagnostics",
         common::short_timeout(),
     ) {
@@ -189,25 +189,25 @@ fn test_diagnostics_version_invariant() -> Result<(), Box<dyn std::error::Error>
         let errors: Vec<_> = diags.iter().filter(|d| d["severity"] == 1).collect();
         assert!(errors.is_empty(), "Fixed code should have no error-level diagnostics");
     }
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify server doesn't crash on malformed JSON
 #[test]
 fn test_no_crash_on_malformed_json() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send various malformed inputs
-    common::send_raw_message(&mut server, "{invalid json");
-    common::send_raw_message(&mut server, "null");
-    common::send_raw_message(&mut server, "[]");
-    common::send_raw_message(&mut server, "42");
+    common::send_raw_message(&server, "{invalid json");
+    common::send_raw_message(&server, "null");
+    common::send_raw_message(&server, "[]");
+    common::send_raw_message(&server, "42");
 
     // Server should still be responsive
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/documentSymbol",
@@ -219,19 +219,19 @@ fn test_no_crash_on_malformed_json() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
     assert!(response["result"].is_array() || response["error"].is_object());
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify proper error for invalid method
 #[test]
 fn test_invalid_request_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Unknown method should return -32601
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "unknownMethod",
@@ -241,19 +241,19 @@ fn test_invalid_request_errors() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(response["error"].is_object());
     assert_eq!(response["error"]["code"], -32601); // Method not found
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify notifications don't produce responses
 #[test]
 fn test_notifications_no_response() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send notification (no ID field)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -269,7 +269,7 @@ fn test_notifications_no_response() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Should not get a response for notification
-    let resp = common::read_response_timeout(&mut server, common::short_timeout());
+    let resp = common::read_response_timeout(&server, common::short_timeout());
 
     // We might get a diagnostics notification, but not a response
     if let Some(r) = resp {
@@ -280,20 +280,20 @@ fn test_notifications_no_response() -> Result<(), Box<dyn std::error::Error>> {
             Some("textDocument/publishDiagnostics")
         );
     }
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 /// Verify server handles concurrent requests properly
 #[test]
 fn test_concurrent_request_handling() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send multiple requests with different IDs
     for i in 200..205 {
         common::send_request_no_wait(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -311,7 +311,7 @@ fn test_concurrent_request_handling() -> Result<(), Box<dyn std::error::Error>> 
     let mut received_ids = Vec::new();
     for _ in 0..5 {
         if let Some(resp) =
-            common::read_response_timeout(&mut server, std::time::Duration::from_secs(5))
+            common::read_response_timeout(&server, std::time::Duration::from_secs(5))
         {
             if let Some(id) = resp["id"].as_i64() {
                 received_ids.push(id);
@@ -322,6 +322,6 @@ fn test_concurrent_request_handling() -> Result<(), Box<dyn std::error::Error>> 
     // Should receive all IDs (order may vary)
     received_ids.sort();
     assert_eq!(received_ids, vec![200, 201, 202, 203, 204]);
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_lifecycle_events_test.rs
+++ b/crates/perl-lsp/tests/lsp_lifecycle_events_test.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 /// Helper to set up an initialized LSP server with a document
 fn setup_server_with_document() -> (LspServer, String) {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // 1. Send initialize request with JsonRpcRequest
     let init_request = JsonRpcRequest {
@@ -58,7 +58,7 @@ fn get_result(response: Option<JsonRpcResponse>) -> Option<Value> {
 
 #[test]
 fn test_did_save_notification() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification
     let request = JsonRpcRequest {
@@ -80,7 +80,7 @@ fn test_did_save_notification() {
 
 #[test]
 fn test_did_save_with_text() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification with text
     let request = JsonRpcRequest {
@@ -102,7 +102,7 @@ fn test_did_save_with_text() {
 
 #[test]
 fn test_will_save_notification() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send willSave notification - Manual save (reason = 1)
     let request = JsonRpcRequest {
@@ -152,7 +152,7 @@ fn test_will_save_notification() {
 
 #[test]
 fn test_will_save_wait_until_returns_valid_edits() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send willSaveWaitUntil request (this is a request, not notification)
     let request = JsonRpcRequest {
@@ -194,7 +194,7 @@ fn test_will_save_wait_until_returns_valid_edits() -> Result<(), Box<dyn std::er
 
 #[test]
 fn test_will_save_wait_until_with_formatting() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Update document with poorly formatted code
     let change_notification = JsonRpcRequest {
@@ -253,7 +253,7 @@ fn test_will_save_wait_until_with_formatting() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn test_did_close_after_save() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Send didSave notification
     let save_notification = JsonRpcRequest {
@@ -287,7 +287,7 @@ fn test_did_close_after_save() {
 
 #[test]
 fn test_save_events_sequence() {
-    let (mut server, uri) = setup_server_with_document();
+    let (server, uri) = setup_server_with_document();
 
     // Simulate typical save sequence: willSave -> willSaveWaitUntil -> didSave
 
@@ -335,7 +335,7 @@ fn test_save_events_sequence() {
 
 #[test]
 fn test_save_with_invalid_uri() {
-    let (mut server, _uri) = setup_server_with_document();
+    let (server, _uri) = setup_server_with_document();
 
     // Try to save a document that was never opened
     let request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_links_and_selection.rs
+++ b/crates/perl-lsp/tests/lsp_links_and_selection.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 #[test]
 fn document_links_and_selection() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_malformed_frames_test.rs
+++ b/crates/perl-lsp/tests/lsp_malformed_frames_test.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 fn test_malformed_headers_handling() -> Result<(), Box<dyn std::error::Error>> {
     // Validates PR #173's enhanced malformed frame recovery implementation
     // Tests that the server gracefully handles malformed headers with enhanced error recovery
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send header with extra spaces - this should be handled gracefully
     let body = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).to_string();
@@ -27,7 +27,7 @@ fn test_malformed_headers_handling() -> Result<(), Box<dyn std::error::Error>> {
 
     // PR #173: Enhanced malformed frame recovery should handle this gracefully
     // Server should continue processing or send an appropriate response
-    let _response = common::read_response_timeout(&mut server, Duration::from_millis(1000));
+    let _response = common::read_response_timeout(&server, Duration::from_millis(1000));
 
     // Verify server didn't crash and either processed request or handled error gracefully
     // The enhanced error handling should maintain session continuity
@@ -36,7 +36,7 @@ fn test_malformed_headers_handling() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test that server is still responsive after malformed header
     let test_response = common::send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "shutdown"
@@ -50,7 +50,7 @@ fn test_malformed_headers_handling() -> Result<(), Box<dyn std::error::Error>> {
 fn test_edge_case_malformed_frame_recovery() -> Result<(), Box<dyn std::error::Error>> {
     // Validates PR #173's enhanced malformed frame recovery for edge cases
     // Tests header-only with missing body scenario - server should recover gracefully
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send header without body - this is a malformed frame that should be handled
     let header = "Content-Length: 50\r\n\r\n";
@@ -68,12 +68,12 @@ fn test_edge_case_malformed_frame_recovery() -> Result<(), Box<dyn std::error::E
     // The server may terminate the connection but should not panic or crash
     // Try to initialize - this may fail if connection was terminated
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        initialize_lsp(&mut server);
+        initialize_lsp(&server);
     })) {
         Ok(()) => {
             // If initialization succeeded, verify server is responsive
             let response = common::send_request(
-                &mut server,
+                &server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "shutdown"
@@ -95,21 +95,21 @@ fn test_edge_case_malformed_frame_recovery() -> Result<(), Box<dyn std::error::E
 
 #[test]
 fn test_invalid_json_body() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send invalid JSON
-    send_raw_message(&mut server, "{this is not: valid json}}");
+    send_raw_message(&server, "{this is not: valid json}}");
 
     // Server should either send error response or ignore
-    let _response = common::read_response_timeout(&mut server, Duration::from_millis(500));
+    let _response = common::read_response_timeout(&server, Duration::from_millis(500));
     // We don't assert on the response - server may ignore or error
 
     // Test that server can handle subsequent requests after invalid JSON
     // Server may terminate connection, which is acceptable recovery behavior
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         common::send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/documentSymbol",
@@ -139,7 +139,7 @@ fn test_invalid_json_body() -> Result<(), Box<dyn std::error::Error>> {
 fn test_server_specific_header_parsing() -> Result<(), Box<dyn std::error::Error>> {
     // Validates PR #173's enhanced header parsing implementation
     // Tests how our server handles duplicate Content-Length headers specifically
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send duplicate Content-Length headers
     let body = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).to_string();
@@ -154,7 +154,7 @@ fn test_server_specific_header_parsing() -> Result<(), Box<dyn std::error::Error
 
     // PR #173: Our server should handle duplicate headers gracefully
     // Enhanced frame parsing should either process the request or handle error appropriately
-    let response = common::read_response_timeout(&mut server, Duration::from_millis(1000));
+    let response = common::read_response_timeout(&server, Duration::from_millis(1000));
 
     // Verify our specific implementation handles duplicate headers
     // Server should either parse successfully or provide enhanced error response
@@ -168,7 +168,7 @@ fn test_server_specific_header_parsing() -> Result<(), Box<dyn std::error::Error
         None => {
             // If response is None, verify server is still responsive (enhanced recovery)
             let test_response = common::send_request(
-                &mut server,
+                &server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "shutdown"
@@ -187,8 +187,8 @@ fn test_server_specific_header_parsing() -> Result<(), Box<dyn std::error::Error
 fn test_wrong_content_length_recovery() -> Result<(), Box<dyn std::error::Error>> {
     // Validates PR #173's enhanced recovery from wrong Content-Length headers
     // Tests that server gracefully handles mismatched content length and recovers
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send body with wrong Content-Length
     let body = json!({"jsonrpc": "2.0", "id": 100, "method": "shutdown"}).to_string();
@@ -209,7 +209,7 @@ fn test_wrong_content_length_recovery() -> Result<(), Box<dyn std::error::Error>
     // Connection may be terminated, which is acceptable recovery
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         common::send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/documentSymbol",
@@ -230,7 +230,7 @@ fn test_wrong_content_length_recovery() -> Result<(), Box<dyn std::error::Error>
             // If first request succeeded, test shutdown too
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 common::send_request(
-                    &mut server,
+                    &server,
                     json!({
                         "jsonrpc": "2.0",
                         "method": "shutdown"
@@ -260,12 +260,12 @@ fn test_wrong_content_length_recovery() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_unknown_method() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send request with unknown method
     let response = common::send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/unknownMethod",
@@ -287,7 +287,7 @@ fn test_unknown_method() -> Result<(), Box<dyn std::error::Error>> {
 fn test_header_case_sensitivity() -> Result<(), Box<dyn std::error::Error>> {
     // Validates PR #173's header case sensitivity handling implementation
     // Tests that our server properly handles case-insensitive headers per HTTP/LSP standards
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Try different header casings - HTTP headers should be case-insensitive
     let body = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).to_string();
@@ -301,7 +301,7 @@ fn test_header_case_sensitivity() -> Result<(), Box<dyn std::error::Error>> {
 
     // PR #173: Enhanced header parsing should handle case-insensitive headers correctly
     // Our implementation should follow HTTP/LSP standards for case-insensitive headers
-    let response = common::read_response_timeout(&mut server, Duration::from_millis(1000));
+    let response = common::read_response_timeout(&server, Duration::from_millis(1000));
 
     match response {
         Some(resp) => {
@@ -313,7 +313,7 @@ fn test_header_case_sensitivity() -> Result<(), Box<dyn std::error::Error>> {
         None => {
             // If parsing fails due to case sensitivity, verify enhanced recovery works
             let test_response = common::send_request(
-                &mut server,
+                &server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "shutdown"
@@ -338,6 +338,6 @@ fn test_header_case_sensitivity() -> Result<(), Box<dyn std::error::Error>> {
     let _ = server.stdin_writer().flush(); // Ignore flush errors
 
     // Server should handle mixed case headers consistently
-    let _final_response = common::read_response_timeout(&mut server, Duration::from_millis(500));
+    let _final_response = common::read_response_timeout(&server, Duration::from_millis(500));
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_master_integration_test.rs
+++ b/crates/perl-lsp/tests/lsp_master_integration_test.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 #[test]
 fn test_complete_lsp_integration() {
     // Initialize server
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Step 1: Initialize
     let init_request = JsonRpcRequest {
@@ -200,7 +200,7 @@ fn test_all_test_suites_pass() {
 fn test_complete_workflow_performance() {
     use std::time::Instant;
 
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_memory_pressure.rs
+++ b/crates/perl-lsp/tests/lsp_memory_pressure.rs
@@ -20,8 +20,8 @@ fn memory_scale() -> usize {
 
 #[test]
 fn test_extremely_large_document() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create a 10MB document
     let mut large_content = String::with_capacity(10 * 1024 * 1024);
@@ -34,7 +34,7 @@ fn test_extremely_large_document() {
 
     // Open extremely large document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -52,7 +52,7 @@ fn test_extremely_large_document() {
     // Try to get symbols for large document
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -63,7 +63,7 @@ fn test_extremely_large_document() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     let elapsed = start.elapsed();
 
     // Should complete within reasonable time
@@ -73,8 +73,8 @@ fn test_extremely_large_document() {
 
 #[test]
 fn test_many_small_documents() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open 1000 small documents
     for i in 0..1000 {
@@ -82,7 +82,7 @@ fn test_many_small_documents() {
         let content = format!("#!/usr/bin/perl\nmy $var{} = {};\nprint $var{};\n", i, i, i);
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -105,7 +105,7 @@ fn test_many_small_documents() {
 
     // Server should still be responsive
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -116,14 +116,14 @@ fn test_many_small_documents() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_deep_ast_nesting() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create deeply nested expression (may cause stack overflow)
     let mut nested = String::from("1");
@@ -135,7 +135,7 @@ fn test_deep_ast_nesting() {
     let uri = "file:///deep_nesting.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -152,7 +152,7 @@ fn test_deep_ast_nesting() {
 
     // Should handle without stack overflow
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -163,14 +163,14 @@ fn test_deep_ast_nesting() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_wide_ast_tree() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create document with many top-level symbols
     let mut content = String::new();
@@ -181,7 +181,7 @@ fn test_wide_ast_tree() {
     let uri = "file:///wide_tree.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -198,7 +198,7 @@ fn test_wide_ast_tree() {
 
     // Request symbols (should handle many symbols)
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -209,14 +209,14 @@ fn test_wide_ast_tree() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array() || response["error"].is_object());
 }
 
 #[test]
 fn test_memory_leak_detection() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///leak_test.pl";
 
@@ -224,7 +224,7 @@ fn test_memory_leak_detection() {
     for i in 0..100 {
         // Open document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -241,7 +241,7 @@ fn test_memory_leak_detection() {
 
         // Perform operations
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -252,11 +252,11 @@ fn test_memory_leak_detection() {
             }),
         );
 
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
 
         // Close document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didClose",
@@ -273,8 +273,8 @@ fn test_memory_leak_detection() {
 
 #[test]
 fn test_infinite_loop_in_content() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document that might trigger infinite parsing
     let content = r#"
@@ -295,7 +295,7 @@ This heredoc never ends...
     let uri = "file:///infinite.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -313,7 +313,7 @@ This heredoc never ends...
     // Should parse without hanging
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -324,7 +324,7 @@ This heredoc never ends...
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     let elapsed = start.elapsed();
 
     assert!(elapsed < Duration::from_secs(5));
@@ -333,8 +333,8 @@ This heredoc never ends...
 
 #[test]
 fn test_exponential_backtracking() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Pattern that could cause exponential backtracking
     let mut content = String::from("my $x = '");
@@ -344,7 +344,7 @@ fn test_exponential_backtracking() {
     let uri = "file:///backtrack.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -362,7 +362,7 @@ fn test_exponential_backtracking() {
     // Should handle without exponential time
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -373,7 +373,7 @@ fn test_exponential_backtracking() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     let elapsed = start.elapsed();
 
     assert!(elapsed < Duration::from_secs(2));
@@ -382,8 +382,8 @@ fn test_exponential_backtracking() {
 
 #[test]
 fn test_recursive_macro_expansion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with recursive-like patterns
     let content = r#"
@@ -401,7 +401,7 @@ BEGIN {
     let uri = "file:///recursive.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -418,7 +418,7 @@ BEGIN {
 
     // Should handle recursive patterns
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -430,14 +430,14 @@ BEGIN {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_cache_exhaustion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create many unique documents to exhaust any caches
     for i in 0..1000 {
@@ -448,7 +448,7 @@ fn test_cache_exhaustion() {
             format!("package Package{};\nsub unique_func_{} {{ return {}; }}\n1;", i, i, i);
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -465,7 +465,7 @@ fn test_cache_exhaustion() {
 
         // Request hover to trigger caching
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -477,12 +477,12 @@ fn test_cache_exhaustion() {
             }),
         );
 
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
     }
 
     // Cache should handle eviction properly
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 9999,
@@ -494,14 +494,14 @@ fn test_cache_exhaustion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_string_explosion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create document with many string concatenations
     let mut content = String::from("my $str = ");
@@ -513,7 +513,7 @@ fn test_string_explosion() {
     let uri = "file:///string_explosion.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -530,7 +530,7 @@ fn test_string_explosion() {
 
     // Should handle many string operations
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -541,14 +541,14 @@ fn test_string_explosion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_symbol_table_explosion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create document with many symbols
     let mut content = String::new();
@@ -571,7 +571,7 @@ fn test_symbol_table_explosion() {
     let uri = "file:///symbol_explosion.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -588,7 +588,7 @@ fn test_symbol_table_explosion() {
 
     // Request all symbols
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -599,12 +599,12 @@ fn test_symbol_table_explosion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Search in large symbol table
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -615,14 +615,14 @@ fn test_symbol_table_explosion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_diagnostic_explosion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create document with many syntax errors
     let mut content = String::new();
@@ -637,7 +637,7 @@ fn test_diagnostic_explosion() {
     let uri = "file:///many_errors.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -657,7 +657,7 @@ fn test_diagnostic_explosion() {
 
     // Request code actions for error
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -675,14 +675,14 @@ fn test_diagnostic_explosion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_reference_chain() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create long chain of references
     let mut content = String::new();
@@ -694,7 +694,7 @@ fn test_reference_chain() {
     let uri = "file:///ref_chain.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -711,7 +711,7 @@ fn test_reference_chain() {
 
     // Find references to first variable (should find many)
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -726,21 +726,21 @@ fn test_reference_chain() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_incremental_parsing_stress() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///incremental.pl";
     let initial = "print 'hello';\n".repeat(100);
 
     // Open document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -758,7 +758,7 @@ fn test_incremental_parsing_stress() {
     // Send many rapid incremental changes
     for i in 2..1002 {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -781,7 +781,7 @@ fn test_incremental_parsing_stress() {
 
     // Server should handle rapid changes
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -792,6 +792,6 @@ fn test_incremental_parsing_stress() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }

--- a/crates/perl-lsp/tests/lsp_multi_error_diagnostics_test.rs
+++ b/crates/perl-lsp/tests/lsp_multi_error_diagnostics_test.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 #[test]
 fn test_451_lsp_reports_multiple_parse_errors() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - Integration test for multiple error collection
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server with diagnostic support
     let init_request = JsonRpcRequest {
@@ -114,7 +114,7 @@ my $c = ;       # Error 3: missing expression
 #[test]
 fn test_451_lsp_reports_errors_in_nested_blocks() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - Nested block error collection
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -198,7 +198,7 @@ while (1) {
 #[test]
 fn test_451_lsp_respects_error_limit() -> Result<(), Box<dyn std::error::Error>> {
     // AC:451 - AC5: Error limit enforcement
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),

--- a/crates/perl-lsp/tests/lsp_new_features_tests.rs
+++ b/crates/perl-lsp/tests/lsp_new_features_tests.rs
@@ -6,10 +6,7 @@ mod common;
 use common::{initialize_lsp, send_notification, send_request, start_lsp_server};
 
 #[cfg(feature = "lsp-extras")]
-fn resolve_link(
-    server: &mut common::LspServer,
-    link: &serde_json::Value,
-) -> Option<serde_json::Value> {
+fn resolve_link(server: &common::LspServer, link: &serde_json::Value) -> Option<serde_json::Value> {
     let response = send_request(
         server,
         json!({
@@ -26,12 +23,12 @@ fn resolve_link(
 #[cfg(feature = "lsp-extras")]
 #[test]
 fn test_document_links_metacpan() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -51,7 +48,7 @@ require Module::Load;
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -66,7 +63,7 @@ require Module::Load;
     assert!(links.len() >= 3, "Should have links for Data::Dumper, File::Path, and Module::Load");
 
     let resolved_links: Vec<_> =
-        links.iter().filter_map(|link| resolve_link(&mut server, link)).collect();
+        links.iter().filter_map(|link| resolve_link(&server, link)).collect();
 
     // Check Data::Dumper link
     let dumper_link = resolved_links
@@ -83,12 +80,12 @@ require Module::Load;
 #[cfg(feature = "lsp-extras")]
 #[test]
 fn test_document_links_local_files() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///workspace/src/main.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -107,7 +104,7 @@ do "config/settings.pl";
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -124,7 +121,7 @@ do "config/settings.pl";
     }
 
     let resolved_links: Vec<_> =
-        links.iter().filter_map(|link| resolve_link(&mut server, link)).collect();
+        links.iter().filter_map(|link| resolve_link(&server, link)).collect();
     if resolved_links.is_empty() {
         return Ok(());
     }
@@ -140,12 +137,12 @@ do "config/settings.pl";
 /// Test selection ranges
 #[test]
 fn test_selection_ranges() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -169,7 +166,7 @@ sub process_data {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 3,
@@ -203,12 +200,12 @@ sub process_data {
 /// Test on-type formatting for braces
 #[test]
 fn test_on_type_formatting_brace() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -224,7 +221,7 @@ fn test_on_type_formatting_brace() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 4,
@@ -255,12 +252,12 @@ fn test_on_type_formatting_brace() -> Result<(), Box<dyn std::error::Error>> {
 /// Test on-type formatting for newline
 #[test]
 fn test_on_type_formatting_newline() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -276,7 +273,7 @@ fn test_on_type_formatting_newline() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 5,
@@ -314,11 +311,11 @@ fn test_on_type_formatting_newline() -> Result<(), Box<dyn std::error::Error>> {
 /// Test workspace/didChangeWatchedFiles registration
 #[test]
 fn test_file_watcher_registration() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Initialize with dynamic registration support
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -341,7 +338,7 @@ fn test_file_watcher_registration() -> Result<(), Box<dyn std::error::Error>> {
 
     // Send initialized notification - this should trigger file watcher registration
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "initialized",
@@ -358,12 +355,12 @@ fn test_file_watcher_registration() -> Result<(), Box<dyn std::error::Error>> {
 /// Test that selection ranges handle edge cases
 #[test]
 fn test_selection_ranges_edge_cases() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -380,7 +377,7 @@ fn test_selection_ranges_edge_cases() -> Result<(), Box<dyn std::error::Error>> 
 
     // Test at the start of the identifier
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 6,
@@ -403,12 +400,12 @@ fn test_selection_ranges_edge_cases() -> Result<(), Box<dyn std::error::Error>> 
 /// Test on-type formatting with tabs
 #[test]
 fn test_on_type_formatting_tabs() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///test.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -424,7 +421,7 @@ fn test_on_type_formatting_tabs() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 7,
@@ -457,8 +454,8 @@ fn test_on_type_formatting_tabs() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(windows)]
 #[test]
 fn test_document_links_windows_path_with_space() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Simulate a file living in a folder with a space; we don't need the file to exist.
     let uri = "file:///C:/Temp/Perl%20LSP%20Demo/main.pl";
@@ -466,7 +463,7 @@ fn test_document_links_windows_path_with_space() -> Result<(), Box<dyn std::erro
 
     // Open doc
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -483,7 +480,7 @@ fn test_document_links_windows_path_with_space() -> Result<(), Box<dyn std::erro
 
     // Request document links
     let resp = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc":"2.0",
             "id": 99001,

--- a/crates/perl-lsp/tests/lsp_on_type_formatting.rs
+++ b/crates/perl-lsp/tests/lsp_on_type_formatting.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn on_type_braces_indent() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),
@@ -69,7 +69,7 @@ fn on_type_braces_indent() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 
 fn on_type_closing_brace_dedent() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_performance_benchmarks.rs
+++ b/crates/perl-lsp/tests/lsp_performance_benchmarks.rs
@@ -22,8 +22,8 @@ const MAX_HOVER_TIME: Duration = Duration::from_millis(20);
 #[test]
 fn benchmark_initialization() {
     let start = Instant::now();
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
     let duration = start.elapsed();
 
     println!("Initialization time: {:?}", duration);
@@ -37,8 +37,8 @@ fn benchmark_initialization() {
 
 #[test]
 fn benchmark_parsing_simple_file() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let simple_code = r#"
 #!/usr/bin/perl
@@ -53,7 +53,7 @@ print "Hello, World!\n";
     let start = Instant::now();
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -70,7 +70,7 @@ print "Hello, World!\n";
 
     // Request diagnostics to ensure parsing is complete
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -81,7 +81,7 @@ print "Hello, World!\n";
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     let size_kb = simple_code.len() as f64 / 1024.0;
@@ -93,8 +93,8 @@ print "Hello, World!\n";
 
 #[test]
 fn benchmark_parsing_large_file() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Generate a 100KB file
     let large_code = generators::generate_large_file(2500);
@@ -103,7 +103,7 @@ fn benchmark_parsing_large_file() {
     let start = Instant::now();
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -120,7 +120,7 @@ fn benchmark_parsing_large_file() {
 
     // Request diagnostics
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -131,7 +131,7 @@ fn benchmark_parsing_large_file() {
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     let size_kb = large_code.len() as f64 / 1024.0;
@@ -148,15 +148,15 @@ fn benchmark_parsing_large_file() {
 
 #[test]
 fn benchmark_incremental_parsing() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let initial_code = "my $x = 1;\n".repeat(100);
     let uri = "file:///incremental.pl";
 
     // Open initial document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -180,7 +180,7 @@ fn benchmark_incremental_parsing() {
         let start = Instant::now();
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -206,8 +206,8 @@ fn benchmark_incremental_parsing() {
 
 #[test]
 fn benchmark_diagnostics() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code_with_errors = r#"
 my $x = ;  # Missing value
@@ -219,7 +219,7 @@ for my $i (@) { }  # Missing array
     let uri = "file:///errors.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -237,7 +237,7 @@ for my $i (@) { }  # Missing array
     let start = Instant::now();
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -248,7 +248,7 @@ for my $i (@) { }  # Missing array
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Diagnostic time: {:?}", duration);
@@ -262,14 +262,14 @@ for my $i (@) { }  # Missing array
 
 #[test]
 fn benchmark_document_symbols() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = generators::generate_symbols(50);
     let uri = "file:///symbols.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -287,7 +287,7 @@ fn benchmark_document_symbols() {
     let start = Instant::now();
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -298,7 +298,7 @@ fn benchmark_document_symbols() {
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Symbol extraction time: {:?}", duration);
@@ -312,8 +312,8 @@ fn benchmark_document_symbols() {
 
 #[test]
 fn benchmark_goto_definition() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = r#"
 my $var = 42;
@@ -328,7 +328,7 @@ function();
     let uri = "file:///definition.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -346,7 +346,7 @@ function();
     let start = Instant::now();
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -358,7 +358,7 @@ function();
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Go to definition time: {:?}", duration);
@@ -372,8 +372,8 @@ function();
 
 #[test]
 fn benchmark_find_references() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = r#"
 my $shared = 42;
@@ -386,7 +386,7 @@ for (1..10) { $shared++; }
     let uri = "file:///references.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -404,7 +404,7 @@ for (1..10) { $shared++; }
     let start = Instant::now();
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -417,7 +417,7 @@ for (1..10) { $shared++; }
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Find references time: {:?}", duration);
@@ -431,8 +431,8 @@ for (1..10) { $shared++; }
 
 #[test]
 fn benchmark_hover() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = r#"
 use strict;
@@ -444,7 +444,7 @@ open(my $fh, '<', 'file.txt');
     let uri = "file:///hover.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -462,7 +462,7 @@ open(my $fh, '<', 'file.txt');
     let start = Instant::now();
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -474,7 +474,7 @@ open(my $fh, '<', 'file.txt');
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Hover time: {:?}", duration);
@@ -488,8 +488,8 @@ open(my $fh, '<', 'file.txt');
 
 #[test]
 fn benchmark_concurrent_requests() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open multiple documents
     for i in 0..10 {
@@ -497,7 +497,7 @@ fn benchmark_concurrent_requests() {
         let uri = format!("file:///concurrent_{}.pl", i);
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -521,7 +521,7 @@ fn benchmark_concurrent_requests() {
 
         // Interleave different request types
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i * 3,
@@ -533,7 +533,7 @@ fn benchmark_concurrent_requests() {
         );
 
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i * 3 + 1,
@@ -545,7 +545,7 @@ fn benchmark_concurrent_requests() {
         );
 
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i * 3 + 2,
@@ -560,7 +560,7 @@ fn benchmark_concurrent_requests() {
 
     // Read all responses
     for _ in 0..30 {
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
     }
 
     let duration = start.elapsed();
@@ -574,8 +574,8 @@ fn benchmark_concurrent_requests() {
 
 #[test]
 fn benchmark_memory_usage() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open many large documents to test memory usage
     for i in 0..50 {
@@ -583,7 +583,7 @@ fn benchmark_memory_usage() {
         let uri = format!("file:///memory_{}.pl", i);
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -606,7 +606,7 @@ fn benchmark_memory_usage() {
         let uri = format!("file:///memory_{}.pl", i);
 
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -617,7 +617,7 @@ fn benchmark_memory_usage() {
             }),
         );
 
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
     }
 
     let duration = start.elapsed();
@@ -628,8 +628,8 @@ fn benchmark_memory_usage() {
 
 #[test]
 fn benchmark_deep_nesting() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let deep_code = generators::generate_nested_code(50);
     let uri = "file:///deep.pl";
@@ -637,7 +637,7 @@ fn benchmark_deep_nesting() {
     let start = Instant::now();
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -653,7 +653,7 @@ fn benchmark_deep_nesting() {
     );
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -664,7 +664,7 @@ fn benchmark_deep_nesting() {
         }),
     );
 
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let duration = start.elapsed();
 
     println!("Deep nesting parse time: {:?}", duration);
@@ -700,21 +700,21 @@ fn benchmark_summary() {
 // Helper functions for summary benchmark
 fn benchmark_initialization_time() -> Duration {
     let start = Instant::now();
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
     start.elapsed()
 }
 
 fn benchmark_simple_file_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "my $x = 42;\n";
     let uri = "file:///bench.pl";
 
     let start = Instant::now();
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -732,15 +732,15 @@ fn benchmark_simple_file_time() -> Duration {
 }
 
 fn benchmark_large_file_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = generators::generate_large_file(1000);
     let uri = "file:///large.pl";
 
     let start = Instant::now();
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -758,14 +758,14 @@ fn benchmark_large_file_time() -> Duration {
 }
 
 fn benchmark_incremental_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "my $x = 1;\n";
     let uri = "file:///inc.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -783,7 +783,7 @@ fn benchmark_incremental_time() -> Duration {
     let start = Instant::now();
     for i in 0..10 {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -803,14 +803,14 @@ fn benchmark_incremental_time() -> Duration {
 }
 
 fn benchmark_diagnostics_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "my $x = ;\n";
     let uri = "file:///diag.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -827,7 +827,7 @@ fn benchmark_diagnostics_time() -> Duration {
 
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -837,19 +837,19 @@ fn benchmark_diagnostics_time() -> Duration {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     start.elapsed()
 }
 
 fn benchmark_symbols_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = generators::generate_symbols(20);
     let uri = "file:///sym.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -866,7 +866,7 @@ fn benchmark_symbols_time() -> Duration {
 
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -876,19 +876,19 @@ fn benchmark_symbols_time() -> Duration {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     start.elapsed()
 }
 
 fn benchmark_definition_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "my $x = 42;\nprint $x;\n";
     let uri = "file:///def.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -905,7 +905,7 @@ fn benchmark_definition_time() -> Duration {
 
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -916,19 +916,19 @@ fn benchmark_definition_time() -> Duration {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     start.elapsed()
 }
 
 fn benchmark_references_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "my $x = 42;\n$x++;\nprint $x;\n";
     let uri = "file:///ref.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -945,7 +945,7 @@ fn benchmark_references_time() -> Duration {
 
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -957,19 +957,19 @@ fn benchmark_references_time() -> Duration {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     start.elapsed()
 }
 
 fn benchmark_hover_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let code = "print 'test';\n";
     let uri = "file:///hover.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -986,7 +986,7 @@ fn benchmark_hover_time() -> Duration {
 
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -997,20 +997,20 @@ fn benchmark_hover_time() -> Duration {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     start.elapsed()
 }
 
 fn benchmark_concurrent_time() -> Duration {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open a document
     let code = "my $x = 42;\n";
     let uri = "file:///concurrent.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -1030,7 +1030,7 @@ fn benchmark_concurrent_time() -> Duration {
     // Send 10 requests
     for i in 0..10 {
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i,
@@ -1045,7 +1045,7 @@ fn benchmark_concurrent_time() -> Duration {
 
     // Read all responses
     for _ in 0..10 {
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
     }
 
     start.elapsed() / 10

--- a/crates/perl-lsp/tests/lsp_perltidy_test.rs
+++ b/crates/perl-lsp/tests/lsp_perltidy_test.rs
@@ -86,7 +86,7 @@ fn test_pragma_code_actions() -> Result<(), Box<dyn std::error::Error>> {
 fn test_formatting_provider_capability() -> Result<(), Box<dyn std::error::Error>> {
     let has_perltidy = perl_lsp::execute_command::command_exists("perltidy");
 
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),

--- a/crates/perl-lsp/tests/lsp_protocol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_protocol_tests.rs
@@ -77,10 +77,10 @@ fn test_diagnostics_clear_protocol_framing() -> Result<(), Box<dyn std::error::E
     let writer = CapturingWriter::new(buffer.clone());
     let output: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(Box::new(writer)));
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Helper to send requests/notifications
-    let mut send = |method: &str, id: Option<Value>, params: Value| {
+    let send = |method: &str, id: Option<Value>, params: Value| {
         let req = JsonRpcRequest {
             _jsonrpc: "2.0".into(),
             id,

--- a/crates/perl-lsp/tests/lsp_protocol_violations.rs
+++ b/crates/perl-lsp/tests/lsp_protocol_violations.rs
@@ -15,11 +15,11 @@ use common::{
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_missing_jsonrpc_version() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send request without jsonrpc field
     send_request(
-        &mut server,
+        &server,
         json!({
             "id": 1,
             "method": "initialize",
@@ -27,18 +27,18 @@ fn test_missing_jsonrpc_version() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
     assert_eq!(response["error"]["code"], -32600); // Invalid Request
 }
 
 #[test]
 fn test_wrong_jsonrpc_version() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send request with wrong version
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "1.0",
             "id": 1,
@@ -47,18 +47,18 @@ fn test_wrong_jsonrpc_version() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_notification_with_id() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Notifications should not have an id field
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,  // Invalid for notification
@@ -73,11 +73,11 @@ fn test_notification_with_id() {
 
 #[test]
 fn test_request_without_id() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Requests must have an id field
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -95,12 +95,12 @@ fn test_request_without_id() {
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_duplicate_request_ids() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send two requests with same ID
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 100,
@@ -113,7 +113,7 @@ fn test_duplicate_request_ids() {
     );
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 100,  // Duplicate ID
@@ -126,15 +126,15 @@ fn test_duplicate_request_ids() {
     );
 
     // Should handle both, but may cause confusion
-    let response1 = read_response(&mut server);
-    let response2 = read_response(&mut server);
+    let response1 = read_response(&server);
+    let response2 = read_response(&server);
     assert_eq!(response1["id"], 100);
     assert_eq!(response2["id"], 100);
 }
 
 #[test]
 fn test_invalid_content_length_header() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send malformed content-length
     server
@@ -149,7 +149,7 @@ fn test_invalid_content_length_header() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_mismatched_content_length() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Content-Length doesn't match actual content
     let content = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
@@ -167,7 +167,7 @@ fn test_mismatched_content_length() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_missing_content_length_header() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send without Content-Length
     server
@@ -182,7 +182,7 @@ fn test_missing_content_length_header() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_additional_headers() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send with additional headers
     let content = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
@@ -196,15 +196,15 @@ fn test_additional_headers() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     server.stdin_writer().flush()?;
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["id"].is_number());
     Ok(())
 }
 
 #[test]
 fn test_invalid_utf8_in_message() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to send invalid UTF-8
     let mut invalid_content = Vec::from(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:///test.pl\",\"languageId\":\"perl\",\"version\":1,\"text\":\"");
@@ -226,11 +226,11 @@ fn test_invalid_utf8_in_message() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_request_before_initialization() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Try to use server before initialization
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -242,21 +242,21 @@ fn test_request_before_initialization() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
     assert_eq!(response["error"]["code"], -32002); // Server not initialized
 }
 
 #[test]
 fn test_double_initialization() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Initialize once
-    initialize_lsp(&mut server);
+    initialize_lsp(&server);
 
     // Try to initialize again
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -269,14 +269,14 @@ fn test_double_initialization() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_invalid_method_name_format() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Test various invalid method names
     let invalid_methods = [
@@ -294,7 +294,7 @@ fn test_invalid_method_name_format() {
     for (i, method) in invalid_methods.iter().enumerate() {
         // Fix: capture the response returned by send_request
         let response = send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i + 100,
@@ -315,12 +315,12 @@ fn test_invalid_method_name_format() {
 
 #[test]
 fn test_params_type_violations() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Params should be object or array, not scalar
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -329,12 +329,12 @@ fn test_params_type_violations() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 
     // Number params
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -343,14 +343,14 @@ fn test_params_type_violations() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_circular_json_reference() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create a JSON string that would cause circular reference if parsed incorrectly
     let circular_json = r#"{
@@ -367,7 +367,7 @@ fn test_circular_json_reference() -> Result<(), Box<dyn std::error::Error>> {
         }
     }"#;
 
-    send_request(&mut server, serde_json::from_str(circular_json)?);
+    send_request(&server, serde_json::from_str(circular_json)?);
 
     // Should handle without stack overflow
     std::thread::sleep(Duration::from_millis(100));
@@ -376,8 +376,8 @@ fn test_circular_json_reference() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_extremely_nested_json() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create deeply nested structure
     let mut nested = json!(null);
@@ -386,7 +386,7 @@ fn test_extremely_nested_json() {
     }
 
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -399,18 +399,18 @@ fn test_extremely_nested_json() {
     );
 
     // Should handle without stack overflow
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object() || response["result"].is_object());
 }
 
 #[test]
 fn test_null_values_in_required_fields() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send nulls where objects are expected
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -422,18 +422,18 @@ fn test_null_values_in_required_fields() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_wrong_type_for_position() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Position with wrong types
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -448,17 +448,17 @@ fn test_wrong_type_for_position() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_negative_positions() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -475,7 +475,7 @@ fn test_negative_positions() {
 
     // Negative line and character
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -487,19 +487,19 @@ fn test_negative_positions() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should handle gracefully
     assert!(response.is_object());
 }
 
 #[test]
 fn test_float_positions() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Positions with floating point numbers
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -511,15 +511,15 @@ fn test_float_positions() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should truncate or error
     assert!(response.is_object());
 }
 
 #[test]
 fn test_invalid_uri_schemes() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let invalid_uris = vec![
         "not-a-uri",
@@ -534,7 +534,7 @@ fn test_invalid_uri_schemes() {
 
     for uri in invalid_uris {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -556,12 +556,12 @@ fn test_invalid_uri_schemes() {
 
 #[test]
 fn test_response_without_request() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send a response without a corresponding request
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 999,
@@ -576,7 +576,7 @@ fn test_response_without_request() {
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_batch_request_violations() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Empty batch
     server.stdin_writer().write_all(b"Content-Length: 2\r\n\r\n[]")?;
@@ -604,7 +604,7 @@ fn test_batch_request_violations() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_incomplete_message() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Send partial message
     let content = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}"#; // Missing closing brace
@@ -621,14 +621,14 @@ fn test_incomplete_message() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_mixed_protocol_versions() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Initialize with 2.0
-    initialize_lsp(&mut server);
+    initialize_lsp(&server);
 
     // Then send 1.0 style request
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "1.0",
             "id": 2,
@@ -637,17 +637,17 @@ fn test_mixed_protocol_versions() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
 }
 
 #[test]
 fn test_method_result_and_error() {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Response with both result and error (invalid)
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,

--- a/crates/perl-lsp/tests/lsp_pull_diagnostics_test.rs
+++ b/crates/perl-lsp/tests/lsp_pull_diagnostics_test.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 /// Test Pull Diagnostics support (LSP 3.17)
 #[test]
 fn test_document_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -84,7 +84,7 @@ print $y;  # Undefined variable
 
 #[test]
 fn test_document_diagnostic_unchanged() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -168,7 +168,7 @@ print "Hello, World!\n";
 
 #[test]
 fn test_workspace_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -265,7 +265,7 @@ print "OK\n";
 
 #[test]
 fn test_diagnostic_provider_capability() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -295,7 +295,7 @@ fn test_diagnostic_provider_capability() -> Result<(), Box<dyn std::error::Error
 
 #[test]
 fn test_workspace_diagnostic_with_previous_ids() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_real_world_integration.rs
+++ b/crates/perl-lsp/tests/lsp_real_world_integration.rs
@@ -14,8 +14,8 @@ fn test_cpan_module_structure() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Typical CPAN module structure
     let module_code = r#"
@@ -80,7 +80,7 @@ This is a sample CPAN-style module for testing.
     let uri = "file:///Module.pm";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -97,7 +97,7 @@ This is a sample CPAN-style module for testing.
 
     // Request document symbols
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -132,8 +132,8 @@ fn test_mojolicious_app() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let mojo_app = r#"
 #!/usr/bin/env perl
@@ -200,7 +200,7 @@ __DATA__
     let uri = "file:///app.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -217,7 +217,7 @@ __DATA__
 
     // Test diagnostics - should have no errors
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -244,8 +244,8 @@ fn test_dbi_database_code() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let dbi_code = r#"
 #!/usr/bin/perl
@@ -340,7 +340,7 @@ END {
     let uri = "file:///database.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -357,7 +357,7 @@ END {
 
     // Request symbols
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -391,8 +391,8 @@ fn test_perl_test_file() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let test_code = r#"
 #!/usr/bin/perl
@@ -464,7 +464,7 @@ done_testing();
     let uri = "file:///test.t";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -481,7 +481,7 @@ done_testing();
 
     // Verify parsing succeeds
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -506,8 +506,8 @@ fn test_catalyst_controller() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let catalyst_code = r#"
 package MyApp::Controller::API;
@@ -637,7 +637,7 @@ __PACKAGE__->meta->make_immutable;
     let uri = "file:///Controller.pm";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -654,7 +654,7 @@ __PACKAGE__->meta->make_immutable;
 
     // Request symbols - should find all REST methods
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -687,8 +687,8 @@ fn test_complex_regex_patterns() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let regex_code = r#"
 #!/usr/bin/perl
@@ -798,7 +798,7 @@ sub normalize_text {
     let uri = "file:///regex.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -815,7 +815,7 @@ sub normalize_text {
 
     // Should parse complex regex patterns without errors
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -840,8 +840,8 @@ fn test_modern_perl_features() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let modern_perl = r#"
 #!/usr/bin/perl
@@ -937,7 +937,7 @@ sub array_operations {
     let uri = "file:///modern.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -954,7 +954,7 @@ sub array_operations {
 
     // Request symbols to verify modern constructs are recognized
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -985,8 +985,8 @@ fn test_multi_file_project() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Main script
     let main_script = r#"
@@ -1058,7 +1058,7 @@ sub get {
     let config_uri = "file:///lib/MyApp/Config.pm";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -1074,7 +1074,7 @@ sub get {
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -1093,7 +1093,7 @@ sub get {
     // For now, just verify both files parse correctly
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -1107,7 +1107,7 @@ sub get {
     assert_eq!(items.len(), 0, "Main script should parse without errors");
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,

--- a/crates/perl-lsp/tests/lsp_security_edge_cases.rs
+++ b/crates/perl-lsp/tests/lsp_security_edge_cases.rs
@@ -17,8 +17,8 @@ use common::{initialize_lsp, read_response, send_notification, send_request, sta
 
 #[test]
 fn test_path_traversal_prevention() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try various path traversal attempts
     let malicious_uris = vec![
@@ -30,7 +30,7 @@ fn test_path_traversal_prevention() {
 
     for uri in malicious_uris {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -47,7 +47,7 @@ fn test_path_traversal_prevention() {
 
         // Should handle safely
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -60,15 +60,15 @@ fn test_path_traversal_prevention() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_code_injection_prevention() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to inject malicious code patterns
     let malicious_content = [
@@ -81,7 +81,7 @@ fn test_code_injection_prevention() {
 
     for (i, content) in malicious_content.iter().enumerate() {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -98,7 +98,7 @@ fn test_code_injection_prevention() {
 
         // Should parse without executing
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i + 1,
@@ -111,21 +111,21 @@ fn test_code_injection_prevention() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_null_byte_injection() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try null byte injection
     let content_with_null = "print 'before';\0print 'after';";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -142,7 +142,7 @@ fn test_null_byte_injection() {
 
     // Should handle null bytes safely
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -155,14 +155,14 @@ fn test_null_byte_injection() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_format_string_vulnerability() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try format string attacks
     let format_attacks = [
@@ -173,7 +173,7 @@ fn test_format_string_vulnerability() {
 
     for (i, content) in format_attacks.iter().enumerate() {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -190,7 +190,7 @@ fn test_format_string_vulnerability() {
 
         // Should parse safely
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i + 1,
@@ -207,19 +207,19 @@ fn test_format_string_vulnerability() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_integer_overflow_prevention() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to cause integer overflow
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -236,7 +236,7 @@ fn test_integer_overflow_prevention() {
 
     // Request with extreme positions
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -253,15 +253,15 @@ fn test_integer_overflow_prevention() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should handle gracefully without panic
     assert!(response.is_object());
 }
 
 #[test]
 fn test_special_file_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to open special file URIs
     let special_uris = vec![
@@ -275,7 +275,7 @@ fn test_special_file_handling() {
 
     for uri in special_uris {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -292,7 +292,7 @@ fn test_special_file_handling() {
 
         // Should handle special files safely
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -305,19 +305,19 @@ fn test_special_file_handling() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_protocol_confusion() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Mix different protocol versions
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "1.0",  // Wrong version
             "id": 1,
@@ -326,12 +326,12 @@ fn test_protocol_confusion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 
     // Send without jsonrpc field
     send_request(
-        &mut server,
+        &server,
         json!({
             "id": 2,
             "method": "textDocument/hover",
@@ -339,14 +339,14 @@ fn test_protocol_confusion() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_resource_uri_validation() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Various malformed URIs
     let bad_uris = vec![
@@ -361,7 +361,7 @@ fn test_resource_uri_validation() {
 
     for uri in bad_uris {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -378,7 +378,7 @@ fn test_resource_uri_validation() {
 
         // Should validate URI properly
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -391,15 +391,15 @@ fn test_resource_uri_validation() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_encoding_edge_cases() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Various encoding edge cases
     let encodings = [
@@ -417,7 +417,7 @@ fn test_encoding_edge_cases() {
 
     for (i, content) in encodings.iter().enumerate() {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -434,7 +434,7 @@ fn test_encoding_edge_cases() {
 
         // Should handle various encodings
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": i + 1,
@@ -447,22 +447,22 @@ fn test_encoding_edge_cases() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_symlink_and_hardlink_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open same content via different "paths"
     let content = "sub shared_function { return 42; }";
 
     // Simulate opening via symlink
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -479,7 +479,7 @@ fn test_symlink_and_hardlink_handling() {
 
     // Open "same" file via different path
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -496,7 +496,7 @@ fn test_symlink_and_hardlink_handling() {
 
     // Both should work independently
     let response1 = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -510,7 +510,7 @@ fn test_symlink_and_hardlink_handling() {
     );
 
     let response2 = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -530,8 +530,8 @@ fn test_symlink_and_hardlink_handling() {
 
 #[test]
 fn test_permission_denied_simulation() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Simulate files that might have permission issues
     let restricted_paths = vec![
@@ -542,7 +542,7 @@ fn test_permission_denied_simulation() {
 
     for path in restricted_paths {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -559,7 +559,7 @@ fn test_permission_denied_simulation() {
 
         // Should handle even if path suggests restricted access
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -572,15 +572,15 @@ fn test_permission_denied_simulation() {
             }),
         );
 
-        let response = read_response(&mut server);
+        let response = read_response(&server);
         assert!(response.is_object());
     }
 }
 
 #[test]
 fn test_time_based_attacks() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to detect timing differences (shouldn't exist)
     let valid_var = "my $valid = 42;";
@@ -588,7 +588,7 @@ fn test_time_based_attacks() {
 
     // Open both documents
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -604,7 +604,7 @@ fn test_time_based_attacks() {
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -622,7 +622,7 @@ fn test_time_based_attacks() {
     // Measure timing for both
     let start_valid = std::time::Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -634,12 +634,12 @@ fn test_time_based_attacks() {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let time_valid = start_valid.elapsed();
 
     let start_invalid = std::time::Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -651,7 +651,7 @@ fn test_time_based_attacks() {
             }
         }),
     );
-    let _ = read_response(&mut server);
+    let _ = read_response(&server);
     let time_invalid = start_invalid.elapsed();
 
     // Times should be similar (no timing leak)

--- a/crates/perl-lsp/tests/lsp_semantic_tokens.rs
+++ b/crates/perl-lsp/tests/lsp_semantic_tokens.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 #[test]
 
 fn semantic_tokens_emit_data() -> Result<(), Box<dyn std::error::Error>> {
-    let mut srv = LspServer::new();
+    let srv = LspServer::new();
     let init = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
         id: Some(json!(1)),

--- a/crates/perl-lsp/tests/lsp_smoke.rs
+++ b/crates/perl-lsp/tests/lsp_smoke.rs
@@ -115,7 +115,7 @@ fn create_server() -> LspServer {
 /// NOTE: Does NOT send `initialized` notification to avoid triggering
 /// workspace indexing and stdout notifications that interfere with test output.
 /// For tests that need full initialization, use `initialize_server_full()`.
-fn initialize_server(server: &mut LspServer) -> Result<Value, Box<dyn std::error::Error>> {
+fn initialize_server(server: &LspServer) -> Result<Value, Box<dyn std::error::Error>> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(1)),
@@ -146,7 +146,7 @@ fn initialize_server(server: &mut LspServer) -> Result<Value, Box<dyn std::error
 
 /// Send initialize request AND initialized notification
 /// Use when you need full server functionality including workspace indexing
-fn initialize_server_full(server: &mut LspServer) -> Result<Value, Box<dyn std::error::Error>> {
+fn initialize_server_full(server: &LspServer) -> Result<Value, Box<dyn std::error::Error>> {
     let result = initialize_server(server)?;
 
     // Send initialized notification
@@ -162,7 +162,7 @@ fn initialize_server_full(server: &mut LspServer) -> Result<Value, Box<dyn std::
 }
 
 /// Open a document in the server
-fn open_document(server: &mut LspServer, uri: &str, content: &str) {
+fn open_document(server: &LspServer, uri: &str, content: &str) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -180,7 +180,7 @@ fn open_document(server: &mut LspServer, uri: &str, content: &str) {
 }
 
 /// Send a request and get the result
-fn send_request(server: &mut LspServer, id: i32, method: &str, params: Value) -> Option<Value> {
+fn send_request(server: &LspServer, id: i32, method: &str, params: Value) -> Option<Value> {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(id)),
@@ -196,7 +196,7 @@ fn send_request(server: &mut LspServer, id: i32, method: &str, params: Value) ->
 }
 
 /// Shutdown the server gracefully
-fn shutdown_server(server: &mut LspServer) {
+fn shutdown_server(server: &LspServer) {
     let request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: Some(json!(999)),
@@ -226,8 +226,8 @@ fn shutdown_server(server: &mut LspServer) {
 /// - Core providers are advertised (hover, completion, definition)
 #[test]
 fn smoke_server_initialization_and_capabilities() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let init_result = initialize_server(&mut server)?;
+    let server = create_server();
+    let init_result = initialize_server(&server)?;
 
     // Verify response structure
     let caps = &init_result["capabilities"];
@@ -254,15 +254,15 @@ fn smoke_server_initialization_and_capabilities() -> Result<(), Box<dyn std::err
         "documentSymbolProvider must be advertised"
     );
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
 /// Smoke test: Server rejects double initialization
 #[test]
 fn smoke_double_initialization_rejected() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
     // Try to initialize again
     let request = JsonRpcRequest {
@@ -279,7 +279,7 @@ fn smoke_double_initialization_rejected() -> Result<(), Box<dyn std::error::Erro
     let response = server.handle_request(request).ok_or("Should return response")?;
     assert!(response.error.is_some(), "Second initialize should return error");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -290,14 +290,14 @@ fn smoke_double_initialization_rejected() -> Result<(), Box<dyn std::error::Erro
 /// Smoke test: Document open is accepted
 #[test]
 fn smoke_document_open() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     // Verify document is tracked by requesting hover (should not fail)
     let result = send_request(
-        &mut server,
+        &server,
         10,
         "textDocument/hover",
         json!({
@@ -309,17 +309,17 @@ fn smoke_document_open() -> Result<(), Box<dyn std::error::Error>> {
     // Result can be null but should not error
     assert!(result.is_some(), "Hover should return a response (even if null)");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
 /// Smoke test: Document change is accepted
 #[test]
 fn smoke_document_change() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     // Change the document
     let change_request = JsonRpcRequest {
@@ -340,7 +340,7 @@ fn smoke_document_change() -> Result<(), Box<dyn std::error::Error>> {
 
     // Verify server still responds
     let result = send_request(
-        &mut server,
+        &server,
         11,
         "textDocument/hover",
         json!({
@@ -351,7 +351,7 @@ fn smoke_document_change() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(result.is_some(), "Server should still respond after document change");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -362,12 +362,12 @@ fn smoke_document_change() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Hover returns valid response
 #[test]
 fn smoke_hover_response_structure() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         20,
         "textDocument/hover",
         json!({
@@ -388,19 +388,19 @@ fn smoke_hover_response_structure() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
 /// Smoke test: Hover on subroutine name
 #[test]
 fn smoke_hover_on_subroutine() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         21,
         "textDocument/hover",
         json!({
@@ -411,7 +411,7 @@ fn smoke_hover_on_subroutine() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(result.is_some(), "Hover on subroutine should return response");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -422,12 +422,12 @@ fn smoke_hover_on_subroutine() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Completion returns items
 #[test]
 fn smoke_completion_returns_items() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         30,
         "textDocument/completion",
         json!({
@@ -454,21 +454,21 @@ fn smoke_completion_returns_items() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
 /// Smoke test: Completion for builtins
 #[test]
 fn smoke_completion_builtins() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
     // Open a file with partial builtin
-    open_document(&mut server, "file:///builtin.pl", "pri");
+    open_document(&server, "file:///builtin.pl", "pri");
 
     let result = send_request(
-        &mut server,
+        &server,
         31,
         "textDocument/completion",
         json!({
@@ -494,7 +494,7 @@ fn smoke_completion_builtins() -> Result<(), Box<dyn std::error::Error>> {
         assert!(has_print, "Completion should include 'print' for 'pri' prefix");
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -505,13 +505,13 @@ fn smoke_completion_builtins() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Definition returns locations
 #[test]
 fn smoke_definition_returns_locations() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     // Request definition for say_hello call
     let result = send_request(
-        &mut server,
+        &server,
         40,
         "textDocument/definition",
         json!({
@@ -536,7 +536,7 @@ fn smoke_definition_returns_locations() -> Result<(), Box<dyn std::error::Error>
         }
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -547,12 +547,12 @@ fn smoke_definition_returns_locations() -> Result<(), Box<dyn std::error::Error>
 /// Smoke test: Document symbols returns symbols
 #[test]
 fn smoke_document_symbols() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         50,
         "textDocument/documentSymbol",
         json!({
@@ -587,7 +587,7 @@ fn smoke_document_symbols() -> Result<(), Box<dyn std::error::Error>> {
         names
     );
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -598,12 +598,12 @@ fn smoke_document_symbols() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: References returns locations
 #[test]
 fn smoke_find_references() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         60,
         "textDocument/references",
         json!({
@@ -624,7 +624,7 @@ fn smoke_find_references() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -635,12 +635,12 @@ fn smoke_find_references() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Folding ranges returns ranges
 #[test]
 fn smoke_folding_ranges() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     let result = send_request(
-        &mut server,
+        &server,
         70,
         "textDocument/foldingRange",
         json!({
@@ -658,7 +658,7 @@ fn smoke_folding_ranges() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -669,13 +669,13 @@ fn smoke_folding_ranges() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Workspace symbol search
 #[test]
 fn smoke_workspace_symbols() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
-    open_document(&mut server, "file:///module.pm", FIXTURE_MODULE);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    open_document(&server, "file:///module.pm", FIXTURE_MODULE);
 
     let result = send_request(
-        &mut server,
+        &server,
         80,
         "workspace/symbol",
         json!({
@@ -694,7 +694,7 @@ fn smoke_workspace_symbols() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -705,11 +705,11 @@ fn smoke_workspace_symbols() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Server handles unknown method gracefully
 #[test]
 fn smoke_unknown_method_error() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
     let result = send_request(
-        &mut server,
+        &server,
         90,
         "textDocument/unknownMethod",
         json!({
@@ -722,7 +722,7 @@ fn smoke_unknown_method_error() -> Result<(), Box<dyn std::error::Error>> {
 
     // Server should still be responsive
     let hover_result = send_request(
-        &mut server,
+        &server,
         91,
         "textDocument/hover",
         json!({
@@ -732,19 +732,19 @@ fn smoke_unknown_method_error() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert!(hover_result.is_some(), "Server should still respond after error");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
 /// Smoke test: Server handles request for non-existent document
 #[test]
 fn smoke_nonexistent_document() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
 
     // Don't open any document, just request hover
     let result = send_request(
-        &mut server,
+        &server,
         92,
         "textDocument/hover",
         json!({
@@ -756,7 +756,7 @@ fn smoke_nonexistent_document() -> Result<(), Box<dyn std::error::Error>> {
     // Should return something (null is acceptable)
     assert!(result.is_some(), "Should return response for non-existent document");
 
-    shutdown_server(&mut server);
+    shutdown_server(&server);
     Ok(())
 }
 
@@ -767,13 +767,13 @@ fn smoke_nonexistent_document() -> Result<(), Box<dyn std::error::Error>> {
 /// Smoke test: Graceful shutdown
 #[test]
 fn smoke_graceful_shutdown() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_server();
-    let _ = initialize_server_full(&mut server)?;
-    open_document(&mut server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
+    let server = create_server();
+    let _ = initialize_server_full(&server)?;
+    open_document(&server, "file:///test.pl", FIXTURE_SIMPLE_SUB);
 
     // Make some requests
     let _ = send_request(
-        &mut server,
+        &server,
         100,
         "textDocument/hover",
         json!({

--- a/crates/perl-lsp/tests/lsp_smoke_e2e.rs
+++ b/crates/perl-lsp/tests/lsp_smoke_e2e.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::time::{Duration, Instant};
 
 fn send_request_with_timeout(
-    server: &mut common::LspServer,
+    server: &common::LspServer,
     id: i64,
     method: &str,
     params: Value,
@@ -41,7 +41,7 @@ fn line_col(source: &str, target_line: usize, needle: &str) -> Result<(u32, u32)
 
 #[test]
 fn lsp_smoke_e2e_stdio_flow() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = common::start_lsp_server();
+    let server = common::start_lsp_server();
     let timeout = Duration::from_secs(2);
     let init_timeout = common::timeout_scaler::TimeoutProfile::Initialization.timeout();
 
@@ -56,7 +56,7 @@ my $value = gre
 "#;
 
     let init_response = send_request_with_timeout(
-        &mut server,
+        &server,
         1,
         "initialize",
         json!({
@@ -80,7 +80,7 @@ my $value = gre
     assert!(init_response.get("error").is_none(), "initialize returned error: {init_response:#}");
 
     common::send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "initialized",
@@ -89,7 +89,7 @@ my $value = gre
     );
 
     common::send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -116,7 +116,7 @@ my $value = gre
         .ok_or("completion token missing in fixture")?;
 
     let completion_response = send_request_with_timeout(
-        &mut server,
+        &server,
         2,
         "textDocument/completion",
         json!({
@@ -137,7 +137,7 @@ my $value = gre
 
     let (hover_line, hover_col) = line_col(fixture, 4, "$greeting")?;
     let hover_response = send_request_with_timeout(
-        &mut server,
+        &server,
         3,
         "textDocument/hover",
         json!({
@@ -154,7 +154,7 @@ my $value = gre
 
     let (def_line, def_col) = line_col(fixture, 5, "greet()")?;
     let definition_response = send_request_with_timeout(
-        &mut server,
+        &server,
         4,
         "textDocument/definition",
         json!({
@@ -184,7 +184,7 @@ my $result = greet();
 my $value = gre
 "#;
     common::send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -209,7 +209,7 @@ my $value = gre
         .ok_or("v2 completion token missing")?;
 
     let v2_completion_response = send_request_with_timeout(
-        &mut server,
+        &server,
         5,
         "textDocument/completion",
         json!({
@@ -231,7 +231,7 @@ my $value = gre
     // ── Step 6: textDocument/references ─────────────────────────────────
     let (ref_line, ref_col) = line_col(fixture_v2, 4, "$greeting")?;
     let references_response = send_request_with_timeout(
-        &mut server,
+        &server,
         6,
         "textDocument/references",
         json!({
@@ -253,7 +253,7 @@ my $value = gre
 
     // ── Step 7: textDocument/documentSymbol ─────────────────────────────
     let doc_symbol_response = send_request_with_timeout(
-        &mut server,
+        &server,
         7,
         "textDocument/documentSymbol",
         json!({
@@ -275,7 +275,7 @@ my $value = gre
 
     // ── Step 8: workspace/symbol ────────────────────────────────────────
     let ws_symbol_response = send_request_with_timeout(
-        &mut server,
+        &server,
         8,
         "workspace/symbol",
         json!({
@@ -297,7 +297,7 @@ my $value = gre
     // ── Step 9: $/cancelRequest for bogus ID, then valid request ────────
     // Send cancel for a request ID that was never issued (should not crash)
     common::send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -309,7 +309,7 @@ my $value = gre
 
     // Now send a valid request to confirm the server is still healthy
     let post_cancel_response = send_request_with_timeout(
-        &mut server,
+        &server,
         9,
         "textDocument/hover",
         json!({
@@ -325,13 +325,13 @@ my $value = gre
 
     // ── Shutdown ────────────────────────────────────────────────────────
     let shutdown_response =
-        send_request_with_timeout(&mut server, 10, "shutdown", json!(null), timeout)?;
+        send_request_with_timeout(&server, 10, "shutdown", json!(null), timeout)?;
     assert!(
         shutdown_response.get("error").is_none(),
         "shutdown returned error: {shutdown_response:#}"
     );
     common::send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "exit",
@@ -341,13 +341,13 @@ my $value = gre
 
     let wait_deadline = Instant::now() + Duration::from_secs(2);
     loop {
-        if let Some(status) = server.process.try_wait()? {
+        if let Some(status) = server.process.lock().unwrap_or_else(|e| e.into_inner()).try_wait()? {
             assert!(status.success(), "perl-lsp process exited with non-zero status: {status}");
             break;
         }
 
         if Instant::now() >= wait_deadline {
-            let _ = server.process.kill();
+            let _ = server.process.lock().unwrap_or_else(|e| e.into_inner()).kill();
             return Err("perl-lsp did not exit cleanly within timeout".into());
         }
 

--- a/crates/perl-lsp/tests/lsp_stress_tests.rs
+++ b/crates/perl-lsp/tests/lsp_stress_tests.rs
@@ -20,8 +20,8 @@ fn stress_iterations() -> usize {
 
 #[test]
 fn test_large_file_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create a very large file (1MB+)
     let mut content = String::new();
@@ -35,7 +35,7 @@ fn test_large_file_handling() {
     let start = Instant::now();
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -55,7 +55,7 @@ fn test_large_file_handling() {
 
     // Should still be able to process requests
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -68,14 +68,14 @@ fn test_large_file_handling() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
 }
 
 #[test]
 fn test_many_open_documents() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open many documents (configurable via env)
     let iterations = stress_iterations();
@@ -84,7 +84,7 @@ fn test_many_open_documents() {
             format!("package Module{};\nmy $var = {};\nsub func {{ return $var; }}\n1;", i, i);
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -102,7 +102,7 @@ fn test_many_open_documents() {
 
     // Server should still respond
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -113,18 +113,18 @@ fn test_many_open_documents() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
 }
 
 #[test]
 fn test_rapid_fire_requests() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open a test document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -143,7 +143,7 @@ fn test_rapid_fire_requests() {
     let start = Instant::now();
     for id in 1..=1000 {
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -162,7 +162,7 @@ fn test_rapid_fire_requests() {
 
         // Read response to avoid buffer overflow
         if id % 100 == 0 {
-            let _ = read_response(&mut server);
+            let _ = read_response(&server);
         }
     }
 
@@ -172,8 +172,8 @@ fn test_rapid_fire_requests() {
 
 #[test]
 fn test_deeply_nested_ast() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create extremely deep nesting (1000 levels)
     let mut content = String::new();
@@ -186,7 +186,7 @@ fn test_deeply_nested_ast() {
     }
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -203,7 +203,7 @@ fn test_deeply_nested_ast() {
 
     // Should handle without stack overflow
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -216,14 +216,14 @@ fn test_deeply_nested_ast() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_massive_symbol_count() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create file with 10,000 symbols
     let mut content = String::new();
@@ -232,7 +232,7 @@ fn test_massive_symbol_count() {
     }
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -250,7 +250,7 @@ fn test_massive_symbol_count() {
     // Request all symbols
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -263,7 +263,7 @@ fn test_massive_symbol_count() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
 
     // Should complete in reasonable time
@@ -272,8 +272,8 @@ fn test_massive_symbol_count() {
 
 #[test]
 fn test_complex_regex_patterns() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create file with complex regex patterns
     let content = r#"
@@ -292,7 +292,7 @@ if ($text =~ /[^\x00-\x1F\x7F-\x9F\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/) { }
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -310,7 +310,7 @@ if ($text =~ /[^\x00-\x1F\x7F-\x9F\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/) { }
     // Should handle complex patterns without hanging
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -323,15 +323,15 @@ if ($text =~ /[^\x00-\x1F\x7F-\x9F\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/) { }
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
     assert!(start.elapsed() < Duration::from_secs(2));
 }
 
 #[test]
 fn test_infinite_loop_prevention() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create potentially infinite recursive structure
     let content = r#"
@@ -355,7 +355,7 @@ use base 'C';
 "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -372,7 +372,7 @@ use base 'C';
 
     // Should handle circular dependencies
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -392,14 +392,14 @@ use base 'C';
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response.is_object());
 }
 
 #[test]
 fn test_memory_leak_prevention() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Repeatedly open and close large documents
     for iteration in 0..100 {
@@ -413,7 +413,7 @@ fn test_memory_leak_prevention() {
 
         // Open document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -430,7 +430,7 @@ fn test_memory_leak_prevention() {
 
         // Perform operations
         send_request(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "id": iteration + 1,
@@ -443,11 +443,11 @@ fn test_memory_leak_prevention() {
             }),
         );
 
-        let _ = read_response(&mut server);
+        let _ = read_response(&server);
 
         // Close document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didClose",
@@ -462,7 +462,7 @@ fn test_memory_leak_prevention() {
 
     // Server should still be responsive
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 999,
@@ -471,14 +471,14 @@ fn test_memory_leak_prevention() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert_eq!(response["result"], json!(null));
 }
 
 #[test]
 fn test_workspace_search_performance() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create many files with many symbols
     for file_idx in 0..100 {
@@ -491,7 +491,7 @@ fn test_workspace_search_performance() {
         }
 
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -510,7 +510,7 @@ fn test_workspace_search_performance() {
     // Search across all 10,000 symbols
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -521,7 +521,7 @@ fn test_workspace_search_performance() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
 
     // Should complete search in reasonable time
@@ -530,8 +530,8 @@ fn test_workspace_search_performance() {
 
 #[test]
 fn test_completion_with_huge_scope() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create file with thousands of variables in scope
     let mut content = String::new();
@@ -541,7 +541,7 @@ fn test_completion_with_huge_scope() {
     content.push_str("\n# Type here for completion\n$vari");
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -559,7 +559,7 @@ fn test_completion_with_huge_scope() {
     // Request completion with huge scope
     let start = Instant::now();
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -576,7 +576,7 @@ fn test_completion_with_huge_scope() {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"]["items"].is_array());
 
     // Should complete in reasonable time despite large scope

--- a/crates/perl-lsp/tests/lsp_test_infrastructure_validation.rs
+++ b/crates/perl-lsp/tests/lsp_test_infrastructure_validation.rs
@@ -42,21 +42,21 @@ fn test_health_check_server_responsiveness() -> Result<(), String> {
     let _env = TestEnvironment::validate()?;
     let _monitor = ResourceMonitor::start("health_check_test");
 
-    let mut server = start_lsp_server();
-    let _init_response = initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    let _init_response = initialize_lsp(&server);
 
     // Give server time to fully initialize
     drain_until_quiet(
-        &mut server,
+        &server,
         std::time::Duration::from_millis(100),
         std::time::Duration::from_secs(1),
     );
 
     // Perform health check
     let health_result =
-        HealthCheck::new(&mut server).with_timeout(TimeoutProfile::Standard.timeout()).verify();
+        HealthCheck::new(&server).with_timeout(TimeoutProfile::Standard.timeout()).verify();
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
 
     match health_result {
         Ok(()) => Ok(()),
@@ -208,7 +208,7 @@ fn test_lsp_lifecycle_with_infrastructure_support() -> Result<(), String> {
     let _monitor = ResourceMonitor::start("lsp_lifecycle_test");
 
     // Start server with graceful degradation
-    let mut server = {
+    let server = {
         let mut degradation = GracefulDegradation::new(2);
         degradation.attempt(|| Ok::<_, String>(start_lsp_server()))?
     };
@@ -217,26 +217,25 @@ fn test_lsp_lifecycle_with_infrastructure_support() -> Result<(), String> {
     let init_timeout = TimeoutProfile::Initialization.timeout();
     eprintln!("Using initialization timeout: {:?}", init_timeout);
 
-    let _init_response = initialize_lsp(&mut server);
+    let _init_response = initialize_lsp(&server);
 
     // Wait for server to settle
     drain_until_quiet(
-        &mut server,
+        &server,
         std::time::Duration::from_millis(100),
         std::time::Duration::from_secs(1),
     );
 
     // Perform health check
-    HealthCheck::new(&mut server)
-        .with_timeout(TimeoutProfile::Standard.timeout())
-        .verify()
-        .map_err(|e| {
+    HealthCheck::new(&server).with_timeout(TimeoutProfile::Standard.timeout()).verify().map_err(
+        |e| {
             let error = TestError::new("LSP lifecycle health check", e);
             eprintln!("{}", error);
             "Health check failed".to_string()
-        })?;
+        },
+    )?;
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
 
     Ok(())
 }
@@ -251,11 +250,11 @@ fn test_server_startup_reliability() -> Result<(), String> {
     for i in 0..3 {
         eprintln!("Server startup attempt {}/3", i + 1);
 
-        let mut server = start_lsp_server();
-        let _init_response = initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        let _init_response = initialize_lsp(&server);
 
         // Verify server is responsive
-        HealthCheck::new(&mut server)
+        HealthCheck::new(&server)
             .with_timeout(TimeoutProfile::Standard.timeout())
             .verify()
             .map_err(|e| {
@@ -264,7 +263,7 @@ fn test_server_startup_reliability() -> Result<(), String> {
                 format!("Server startup {} failed", i + 1)
             })?;
 
-        shutdown_and_exit(&mut server);
+        shutdown_and_exit(&server);
 
         // Brief delay between iterations in constrained environments
         if env.is_constrained() {

--- a/crates/perl-lsp/tests/lsp_testability_generic_io.rs
+++ b/crates/perl-lsp/tests/lsp_testability_generic_io.rs
@@ -215,7 +215,7 @@ fn lsp_testability_message_handling_integration() {
     let input = Cursor::new(init_msg);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Attempt to handle the message
     let mut input = std::io::BufReader::new(input);
@@ -235,7 +235,7 @@ fn lsp_protocol_edge_case_malformed_message() {
     let input = Cursor::new(malformed);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Server should handle the malformed message gracefully
     let mut input = std::io::BufReader::new(input);
@@ -254,7 +254,7 @@ fn lsp_protocol_edge_case_missing_header() {
     let input = Cursor::new(invalid_msg);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Server should handle missing header gracefully
     let mut input = std::io::BufReader::new(input);
@@ -294,7 +294,7 @@ fn lsp_protocol_edge_case_rapid_messages() {
     let input = Cursor::new(messages);
     let output = make_shared_output();
 
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Process all messages
     let mut input = std::io::BufReader::new(input);

--- a/crates/perl-lsp/tests/lsp_type_hierarchy_test.rs
+++ b/crates/perl-lsp/tests/lsp_type_hierarchy_test.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 #[test]
 
 fn test_type_hierarchy_prepare() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -91,7 +91,7 @@ sub new {
 #[test]
 
 fn test_type_hierarchy_supertypes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -199,7 +199,7 @@ package Parent2;
 #[test]
 
 fn test_type_hierarchy_subtypes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -308,7 +308,7 @@ our @ISA = ('Base');
 #[test]
 
 fn test_type_hierarchy_capability_advertised() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -339,7 +339,7 @@ fn test_type_hierarchy_capability_advertised() -> Result<(), Box<dyn std::error:
 #[test]
 
 fn test_type_hierarchy_with_namespace_packages() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_unhappy_paths.rs
+++ b/crates/perl-lsp/tests/lsp_unhappy_paths.rs
@@ -18,31 +18,34 @@ use common::read_response;
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_malformed_json_request() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Malformed frame; don't append extra newline
-    send_raw(&mut server, b"Content-Length: 5\r\n\r\n{{{{{");
+    send_raw(&server, b"Content-Length: 5\r\n\r\n{{{{{");
 
     // Do NOT block: accept None as compliant behavior
     // Server may ignore malformed JSON, send notifications, or send an error
-    let _maybe = read_response_timeout(&mut server, short_timeout());
+    let _maybe = read_response_timeout(&server, short_timeout());
     // Any behavior is acceptable - we just verify the server doesn't crash
 
     // Server must remain alive
-    assert!(server.process.try_wait()?.is_none(), "server crashed");
-    shutdown_and_exit(&mut server);
+    assert!(
+        server.process.lock().unwrap_or_else(|e| e.into_inner()).try_wait()?.is_none(),
+        "server crashed"
+    );
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_invalid_method() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Call non-existent method
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 4242,
@@ -54,18 +57,18 @@ fn test_invalid_method() -> Result<(), Box<dyn std::error::Error>> {
     // Check for error response
     assert!(response.get("error").is_some(), "expected error for invalid method");
     assert_eq!(response["error"]["code"], -32601); // Method not found
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_missing_required_params() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send completion request without required params
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -101,18 +104,18 @@ fn test_missing_required_params() -> Result<(), Box<dyn std::error::Error>> {
             response
         )));
     }
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_invalid_uri_format() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send document with invalid URI
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -129,7 +132,7 @@ fn test_invalid_uri_format() -> Result<(), Box<dyn std::error::Error>> {
 
     // Try to get diagnostics - should handle gracefully with enhanced error handling
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -174,18 +177,18 @@ fn test_invalid_uri_format() -> Result<(), Box<dyn std::error::Error>> {
         ));
     }
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_document_not_found() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Request operations on non-existent document - should handle gracefully
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -230,18 +233,18 @@ fn test_document_not_found() -> Result<(), Box<dyn std::error::Error>> {
         ));
     }
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_out_of_bounds_position() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open a small document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -258,7 +261,7 @@ fn test_out_of_bounds_position() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request completion at out-of-bounds position - should handle gracefully
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -304,21 +307,21 @@ fn test_out_of_bounds_position() -> Result<(), Box<dyn std::error::Error>> {
         ));
     }
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_concurrent_document_edits() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///concurrent.pl";
 
     // Open document
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -336,7 +339,7 @@ fn test_concurrent_document_edits() -> Result<(), Box<dyn std::error::Error>> {
     // Send multiple rapid edits
     for i in 2..10 {
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didChange",
@@ -355,7 +358,7 @@ fn test_concurrent_document_edits() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request symbols - should use latest version
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -368,7 +371,7 @@ fn test_concurrent_document_edits() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
     Ok(())
 }
@@ -376,14 +379,14 @@ fn test_concurrent_document_edits() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_version_mismatch() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     let uri = "file:///version.pl";
 
     // Open with version 1
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -400,7 +403,7 @@ fn test_version_mismatch() -> Result<(), Box<dyn std::error::Error>> {
 
     // Send change with wrong version (skip version 2)
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didChange",
@@ -418,7 +421,7 @@ fn test_version_mismatch() -> Result<(), Box<dyn std::error::Error>> {
 
     // Server should handle version mismatch gracefully
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -431,7 +434,7 @@ fn test_version_mismatch() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array() || response["error"].is_object());
     Ok(())
 }
@@ -439,12 +442,12 @@ fn test_version_mismatch() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_invalid_regex_pattern() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open document with invalid regex
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -464,7 +467,7 @@ fn test_invalid_regex_pattern() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request hover on invalid regex
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -481,7 +484,7 @@ fn test_invalid_regex_pattern() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should handle parse error gracefully
     assert!(response.is_object());
     Ok(())
@@ -490,12 +493,12 @@ fn test_invalid_regex_pattern() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_circular_module_dependency() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create circular dependency
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -511,7 +514,7 @@ fn test_circular_module_dependency() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -528,7 +531,7 @@ fn test_circular_module_dependency() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request references - should handle circular deps
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -548,7 +551,7 @@ fn test_circular_module_dependency() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
     Ok(())
 }
@@ -556,15 +559,15 @@ fn test_circular_module_dependency() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_extremely_long_line() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create document with extremely long line
     let long_string = "x".repeat(100000);
     let content = format!("my $x = '{}';\nprint $x;", long_string);
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -581,7 +584,7 @@ fn test_extremely_long_line() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request completion in long line
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -598,7 +601,7 @@ fn test_extremely_long_line() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should handle without crashing
     assert!(response.is_object());
     Ok(())
@@ -607,8 +610,8 @@ fn test_extremely_long_line() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_deeply_nested_structure() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Create deeply nested structure
     let mut nested = String::from("sub test {\n");
@@ -622,7 +625,7 @@ fn test_deeply_nested_structure() -> Result<(), Box<dyn std::error::Error>> {
     nested.push_str("}\n");
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -639,7 +642,7 @@ fn test_deeply_nested_structure() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request symbols - should handle deep nesting
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -652,21 +655,21 @@ fn test_deeply_nested_structure() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
     Ok(())
 }
 
 #[test]
 fn test_binary_content() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Try to open binary content
     let binary_content = "#!/usr/bin/perl\n\0\x7F\x7E\x00binary data here\n";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -683,7 +686,7 @@ fn test_binary_content() -> Result<(), Box<dyn std::error::Error>> {
 
     // Should handle binary data gracefully - request document symbols
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -703,21 +706,21 @@ fn test_binary_content() -> Result<(), Box<dyn std::error::Error>> {
         response.get("result").is_some() || response.get("error").is_some(),
         "Expected either result or error for binary content"
     );
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_binary_frame() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send actual binary junk as a frame body; behavior is implementation-defined
-    send_raw(&mut server, b"Content-Length: 8\r\n\r\n\x00\x01\x02\x03\x04\x05\x06\x07");
+    send_raw(&server, b"Content-Length: 8\r\n\r\n\x00\x01\x02\x03\x04\x05\x06\x07");
 
     // Enhanced timeout for binary frame handling with adaptive scaling
     let binary_timeout = std::cmp::max(short_timeout(), Duration::from_millis(200));
-    let _maybe = read_response_timeout(&mut server, binary_timeout);
+    let _maybe = read_response_timeout(&server, binary_timeout);
     // Any behavior is acceptable - ignore, error, or notification
 
     // Allow brief recovery time for server to process malformed input
@@ -725,7 +728,9 @@ fn test_binary_frame() -> Result<(), Box<dyn std::error::Error>> {
 
     // Enhanced error handling: server may crash on malformed binary frames
     // This is acceptable behavior for LSP servers when receiving non-UTF8 content
-    if let Ok(Some(_exit_status)) = server.process.try_wait() {
+    if let Ok(Some(_exit_status)) =
+        server.process.lock().unwrap_or_else(|e| e.into_inner()).try_wait()
+    {
         // Server crashed - this is acceptable for binary frame input
         eprintln!("Server crashed on binary frame (acceptable behavior)");
         return Ok(());
@@ -733,7 +738,7 @@ fn test_binary_frame() -> Result<(), Box<dyn std::error::Error>> {
 
     // If server survived, verify it's still responsive
     let ping_response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 9999,
@@ -746,18 +751,18 @@ fn test_binary_frame() -> Result<(), Box<dyn std::error::Error>> {
 
     // Accept any valid response format
     assert!(ping_response.is_object(), "Server should respond to requests after binary frame");
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[test]
 fn test_cancel_request() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open a document first to make the completion request valid
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -789,13 +794,13 @@ fn test_cancel_request() -> Result<(), Box<dyn std::error::Error>> {
     });
     let request_str = serde_json::to_string(&request_json)?;
     send_raw(
-        &mut server,
+        &server,
         format!("Content-Length: {}\r\n\r\n{}", request_str.len(), request_str).as_bytes(),
     );
 
     // Immediately send cancellation request
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "$/cancelRequest",
@@ -813,7 +818,7 @@ fn test_cancel_request() -> Result<(), Box<dyn std::error::Error>> {
     while attempts < 3 && !got_completion_response {
         // Enhanced timeout for cancellation protocol with adaptive scaling
         let cancel_timeout = std::cmp::max(Duration::from_millis(500), adaptive_timeout() / 4);
-        let response = read_response_timeout(&mut server, cancel_timeout);
+        let response = read_response_timeout(&server, cancel_timeout);
 
         if let Some(resp) = response {
             // Check if this is a notification (has method, no id)
@@ -861,19 +866,19 @@ fn test_cancel_request() -> Result<(), Box<dyn std::error::Error>> {
     // If we didn't get a completion response after notifications, that's also valid
     // The cancellation might have prevented the response entirely
 
-    shutdown_and_exit(&mut server);
+    shutdown_and_exit(&server);
     Ok(())
 }
 
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_shutdown_without_exit() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Send shutdown request
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -882,12 +887,12 @@ fn test_shutdown_without_exit() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert_eq!(response["result"], json!(null));
 
     // Try to send another request after shutdown
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -905,7 +910,7 @@ fn test_shutdown_without_exit() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Should get error - server is shut down
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["error"].is_object());
     Ok(())
 }
@@ -913,11 +918,11 @@ fn test_shutdown_without_exit() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "strict-jsonrpc")]
 #[test]
 fn test_invalid_capability_request() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
+    let server = start_lsp_server();
 
     // Initialize without certain capabilities
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -936,11 +941,11 @@ fn test_invalid_capability_request() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let _response = read_response(&mut server);
+    let _response = read_response(&server);
 
     // Try to use disabled capability
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 2,
@@ -957,7 +962,7 @@ fn test_invalid_capability_request() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     // Should handle gracefully
     assert!(response.is_object());
     Ok(())
@@ -966,8 +971,8 @@ fn test_invalid_capability_request() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_unicode_unhappy_paths() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Document with various Unicode edge cases
     let content = r#"
@@ -979,7 +984,7 @@ fn test_unicode_unhappy_paths() -> Result<(), Box<dyn std::error::Error>> {
     "#;
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -996,7 +1001,7 @@ fn test_unicode_unhappy_paths() -> Result<(), Box<dyn std::error::Error>> {
 
     // Request symbols - should handle Unicode
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -1009,7 +1014,7 @@ fn test_unicode_unhappy_paths() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
     Ok(())
 }
@@ -1017,14 +1022,14 @@ fn test_unicode_unhappy_paths() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "stress-tests")]
 #[test]
 fn test_memory_stress() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Open many documents
     for i in 0..100 {
         let content = format!("my $var{} = {};\n", i, i).repeat(100);
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -1042,7 +1047,7 @@ fn test_memory_stress() -> Result<(), Box<dyn std::error::Error>> {
 
     // Server should still respond
     send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -1055,7 +1060,7 @@ fn test_memory_stress() -> Result<(), Box<dyn std::error::Error>> {
         }),
     );
 
-    let response = read_response(&mut server);
+    let response = read_response(&server);
     assert!(response["result"].is_array());
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_unicode_props.rs
+++ b/crates/perl-lsp/tests/lsp_unicode_props.rs
@@ -19,15 +19,15 @@ fn test_utf16_position_roundtrip() {
         "mixed\n\r\nlines", // Mixed line endings
     ];
 
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     for text in test_strings {
         let uri = "file:///test.pl";
 
         // Open document with the test string
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -45,7 +45,7 @@ fn test_utf16_position_roundtrip() {
         // Test hover at various positions to exercise UTF-16 conversion
         for i in 0..text.len().min(10) {
             let _response = send_request(
-                &mut server,
+                &server,
                 json!({
                     "jsonrpc": "2.0",
                     "method": "textDocument/hover",
@@ -82,14 +82,14 @@ fn test_utf16_handles_various_strings() {
     for text in test_cases {
         let formatted = format!("{}\n🦀{}\n", text, text);
 
-        let mut server = start_lsp_server();
-        initialize_lsp(&mut server);
+        let server = start_lsp_server();
+        initialize_lsp(&server);
 
         let uri = "file:///test.pl";
 
         // Open document
         send_notification(
-            &mut server,
+            &server,
             json!({
                 "jsonrpc": "2.0",
                 "method": "textDocument/didOpen",
@@ -108,7 +108,7 @@ fn test_utf16_handles_various_strings() {
         for line in 0..3 {
             for character in [0, 1, 5, 10] {
                 let _response = send_request(
-                    &mut server,
+                    &server,
                     json!({
                         "jsonrpc": "2.0",
                         "method": "textDocument/hover",

--- a/crates/perl-lsp/tests/lsp_virtual_content_tests.rs
+++ b/crates/perl-lsp/tests/lsp_virtual_content_tests.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 /// Helper to send a request and get result
 fn send_request(
-    server: &mut LspServer,
+    server: &LspServer,
     method: &str,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
@@ -32,11 +32,11 @@ fn send_request(
 /// Create a test server
 fn setup_server() -> LspServer {
     let output = Arc::new(Mutex::new(Box::new(Vec::new()) as Box<dyn std::io::Write + Send>));
-    let mut server = LspServer::with_output(output);
+    let server = LspServer::with_output(output);
 
     // Initialize the server
     send_request(
-        &mut server,
+        &server,
         "initialize",
         json!({
             "capabilities": {},
@@ -60,10 +60,10 @@ fn setup_server() -> LspServer {
 
 #[test]
 fn lsp_virtual_perldoc_strict() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/textDocumentContent",
         json!({
             "uri": "perldoc://strict"
@@ -95,10 +95,10 @@ fn lsp_virtual_perldoc_strict() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn lsp_virtual_perldoc_invalid_module() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/textDocumentContent",
         json!({
             "uri": "perldoc://ThisModuleDefinitelyDoesNotExist12345"
@@ -112,10 +112,10 @@ fn lsp_virtual_perldoc_invalid_module() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn lsp_virtual_unsupported_scheme() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/textDocumentContent",
         json!({
             "uri": "unsupported://some/path"
@@ -134,24 +134,24 @@ fn lsp_virtual_unsupported_scheme() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn lsp_virtual_missing_params() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Empty params
-    let result = send_request(&mut server, "workspace/textDocumentContent", json!({}));
+    let result = send_request(&server, "workspace/textDocumentContent", json!({}));
     assert!(result.is_err(), "Should return error for missing URI");
     Ok(())
 }
 
 #[test]
 fn lsp_virtual_perldoc_common_modules() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Test common modules that should be available on most systems
     let modules = vec!["warnings", "vars"];
 
     for module in modules {
         let result = send_request(
-            &mut server,
+            &server,
             "workspace/textDocumentContent",
             json!({
                 "uri": format!("perldoc://{}", module)
@@ -178,10 +178,10 @@ fn lsp_virtual_perldoc_common_modules() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn lsp_virtual_empty_module_name() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/textDocumentContent",
         json!({
             "uri": "perldoc://"

--- a/crates/perl-lsp/tests/lsp_window_tests.rs
+++ b/crates/perl-lsp/tests/lsp_window_tests.rs
@@ -67,7 +67,7 @@ impl Clone for OutputCapture {
 fn lsp_window_show_message_request_format() -> Result<(), Box<dyn std::error::Error>> {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize server to enable capabilities
     let init_params = json!({
@@ -140,7 +140,7 @@ fn lsp_window_show_document_requires_capability() -> Result<(), Box<dyn std::err
 fn lsp_window_show_document_with_capability() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with showDocument capability
     let init_params = json!({
@@ -189,7 +189,7 @@ fn lsp_window_show_document_with_capability() {
 fn lsp_window_progress_lifecycle() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -262,7 +262,7 @@ fn lsp_window_progress_lifecycle() {
 fn lsp_window_progress_duplicate_token_fails() -> Result<(), Box<dyn std::error::Error>> {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -298,7 +298,7 @@ fn lsp_window_progress_duplicate_token_fails() -> Result<(), Box<dyn std::error:
 fn lsp_window_progress_cancel_handler() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with workDoneProgress capability
     let init_params = json!({
@@ -345,7 +345,7 @@ fn lsp_window_progress_cancel_handler() {
 fn lsp_window_telemetry_respects_config() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize server first
     let _ = server.handle_request(perl_lsp::JsonRpcRequest {
@@ -453,7 +453,7 @@ fn lsp_window_progress_without_capability() -> Result<(), Box<dyn std::error::Er
 fn lsp_window_show_document_external_flag() {
     let output = OutputCapture::new();
     let output_box: Box<dyn Write + Send> = Box::new(output.clone());
-    let mut server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
 
     // Initialize with showDocument capability
     let init_params = json!({

--- a/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
@@ -13,13 +13,13 @@ use common::{completion_items, initialize_lsp, send_notification, send_request, 
 /// functions from other files in the workspace that have been indexed.
 #[test]
 fn test_completion_cross_file_function() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Index a module file with a function
     let module_uri = "file:///workspace/EmailUtils.pm";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -51,7 +51,7 @@ sub parse_email_header {
     // Now open a different file and request completion
     let script_uri = "file:///workspace/script.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -73,7 +73,7 @@ vali
 
     // Request completion at position after "vali"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -101,13 +101,13 @@ vali
 /// Test cross-file package member completion with qualified names
 #[test]
 fn test_completion_cross_file_qualified() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Index a module file
     let module_uri = "file:///workspace/DataProcessor.pm";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -139,7 +139,7 @@ sub transform_data {
     // Open a file requesting qualified completion
     let script_uri = "file:///workspace/main.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -160,7 +160,7 @@ my $result = DataProcessor::
 
     // Request completion after "DataProcessor::"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -206,13 +206,13 @@ my $result = DataProcessor::
 #[test]
 #[ignore = "feature: cross-file variable completion not yet wired to workspace index"]
 fn test_completion_cross_file_variable() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Index a module with exported variables
     let module_uri = "file:///workspace/Config.pm";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -237,7 +237,7 @@ our $DEBUG_MODE = 1;
     // Open a file requesting variable completion
     let script_uri = "file:///workspace/app.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -258,7 +258,7 @@ print $Config::CONF
 
     // Request completion after "$Config::CONF"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",
@@ -286,13 +286,13 @@ print $Config::CONF
 /// Test that workspace completions are provided even for unqualified calls
 #[test]
 fn test_completion_bare_function_from_workspace() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Index a module with exported functions
     let module_uri = "file:///workspace/StringUtils.pm";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -328,7 +328,7 @@ sub uppercase {
     // Open a file that imports the module
     let script_uri = "file:///workspace/text_processor.pl";
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -350,7 +350,7 @@ tri
 
     // Request completion after "tri"
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/completion",

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -13,7 +13,7 @@ fn create_test_server() -> LspServer {
 
 /// Helper to make a request to the server
 fn make_request(
-    server: &mut LspServer,
+    server: &LspServer,
     method: &str,
     params: Option<Value>,
 ) -> Result<Option<Value>, String> {
@@ -37,7 +37,7 @@ fn make_request(
 }
 
 /// Helper to send the initialized notification (required after initialize request)
-fn send_initialized(server: &mut LspServer) {
+fn send_initialized(server: &LspServer) {
     let initialized_notification = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
         id: None,
@@ -49,7 +49,7 @@ fn send_initialized(server: &mut LspServer) {
 
 #[test]
 fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server first
     let init_params = json!({
@@ -57,8 +57,8 @@ fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Err
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Send a file created notification
     let params = json!({
@@ -70,7 +70,7 @@ fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Err
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didChangeWatchedFiles", Some(params));
+    let result = make_request(&server, "workspace/didChangeWatchedFiles", Some(params));
 
     // This is a notification, should return None
     assert!(result.is_ok());
@@ -80,7 +80,7 @@ fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 fn test_did_change_watched_files_changed() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -88,8 +88,8 @@ fn test_did_change_watched_files_changed() -> Result<(), Box<dyn std::error::Err
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // First open a document
     let open_params = json!({
@@ -100,7 +100,7 @@ fn test_did_change_watched_files_changed() -> Result<(), Box<dyn std::error::Err
             "text": "use strict;\nprint 'Hello';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Send a file changed notification
     let params = json!({
@@ -112,7 +112,7 @@ fn test_did_change_watched_files_changed() -> Result<(), Box<dyn std::error::Err
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didChangeWatchedFiles", Some(params));
+    let result = make_request(&server, "workspace/didChangeWatchedFiles", Some(params));
 
     // This is a notification, should return None
     assert!(result.is_ok());
@@ -122,7 +122,7 @@ fn test_did_change_watched_files_changed() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 fn test_did_change_watched_files_deleted() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -130,8 +130,8 @@ fn test_did_change_watched_files_deleted() -> Result<(), Box<dyn std::error::Err
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // First open a document
     let open_params = json!({
@@ -142,7 +142,7 @@ fn test_did_change_watched_files_deleted() -> Result<(), Box<dyn std::error::Err
             "text": "use strict;\nprint 'Hello';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Send a file deleted notification
     let params = json!({
@@ -154,7 +154,7 @@ fn test_did_change_watched_files_deleted() -> Result<(), Box<dyn std::error::Err
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didChangeWatchedFiles", Some(params));
+    let result = make_request(&server, "workspace/didChangeWatchedFiles", Some(params));
 
     // This is a notification, should return None
     assert!(result.is_ok());
@@ -164,7 +164,7 @@ fn test_did_change_watched_files_deleted() -> Result<(), Box<dyn std::error::Err
 
 #[test]
 fn test_did_change_watched_files_invalid_uri() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -172,8 +172,8 @@ fn test_did_change_watched_files_invalid_uri() -> Result<(), Box<dyn std::error:
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Send notification with invalid URI (missing uri field)
     let params = json!({
@@ -184,7 +184,7 @@ fn test_did_change_watched_files_invalid_uri() -> Result<(), Box<dyn std::error:
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didChangeWatchedFiles", Some(params));
+    let result = make_request(&server, "workspace/didChangeWatchedFiles", Some(params));
 
     // Should handle gracefully
     assert!(result.is_ok());
@@ -194,7 +194,7 @@ fn test_did_change_watched_files_invalid_uri() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn test_will_rename_files() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -202,8 +202,8 @@ fn test_will_rename_files() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Open a document that uses a module
     let open_params = json!({
@@ -214,7 +214,7 @@ fn test_will_rename_files() -> Result<(), Box<dyn std::error::Error>> {
             "text": "use lib 'lib';\nuse MyModule;\nuse parent 'MyModule';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Request to rename a module file
     let params = json!({
@@ -226,7 +226,7 @@ fn test_will_rename_files() -> Result<(), Box<dyn std::error::Error>> {
         ]
     });
 
-    let result = make_request(&mut server, "workspace/willRenameFiles", Some(params));
+    let result = make_request(&server, "workspace/willRenameFiles", Some(params));
 
     // Should return a workspace edit (potentially empty if no references found)
     let edit = result?.ok_or("expected workspace edit response")?;
@@ -237,7 +237,7 @@ fn test_will_rename_files() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -245,8 +245,8 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Open the renamed module and a dependent file that imports it.
     let module_open = json!({
@@ -257,7 +257,7 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
             "text": "package MyModule;\n1;\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(module_open));
+    let _ = make_request(&server, "textDocument/didOpen", Some(module_open));
 
     let dependent_open = json!({
         "textDocument": {
@@ -267,7 +267,7 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
             "text": "use MyModule;\nuse parent 'MyModule';\nrequire MyModule;\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(dependent_open));
+    let _ = make_request(&server, "textDocument/didOpen", Some(dependent_open));
 
     // Request rename edits for module file rename.
     let params = json!({
@@ -279,7 +279,7 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
         ]
     });
 
-    let edit = make_request(&mut server, "workspace/willRenameFiles", Some(params))?
+    let edit = make_request(&server, "workspace/willRenameFiles", Some(params))?
         .ok_or("expected workspace edit response")?;
     let changes =
         edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
@@ -311,7 +311,7 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
 
 #[test]
 fn test_will_rename_files_missing_uri() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -319,8 +319,8 @@ fn test_will_rename_files_missing_uri() -> Result<(), Box<dyn std::error::Error>
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Request with missing URIs
     let params = json!({
@@ -331,7 +331,7 @@ fn test_will_rename_files_missing_uri() -> Result<(), Box<dyn std::error::Error>
         ]
     });
 
-    let result = make_request(&mut server, "workspace/willRenameFiles", Some(params));
+    let result = make_request(&server, "workspace/willRenameFiles", Some(params));
 
     // Should handle gracefully and return empty edit
     let edit = result?.ok_or("expected workspace edit response")?;
@@ -342,7 +342,7 @@ fn test_will_rename_files_missing_uri() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn test_did_delete_files() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -350,8 +350,8 @@ fn test_did_delete_files() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Open a document
     let open_params = json!({
@@ -362,7 +362,7 @@ fn test_did_delete_files() -> Result<(), Box<dyn std::error::Error>> {
             "text": "use strict;\nprint 'Hello';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Send delete notification
     let params = json!({
@@ -373,7 +373,7 @@ fn test_did_delete_files() -> Result<(), Box<dyn std::error::Error>> {
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didDeleteFiles", Some(params));
+    let result = make_request(&server, "workspace/didDeleteFiles", Some(params));
 
     // This is a notification, should return None
     assert!(result.is_ok());
@@ -383,7 +383,7 @@ fn test_did_delete_files() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_did_delete_files_invalid_uri() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -391,8 +391,8 @@ fn test_did_delete_files_invalid_uri() -> Result<(), Box<dyn std::error::Error>>
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Send delete notification with missing URI
     let params = json!({
@@ -403,7 +403,7 @@ fn test_did_delete_files_invalid_uri() -> Result<(), Box<dyn std::error::Error>>
         ]
     });
 
-    let result = make_request(&mut server, "workspace/didDeleteFiles", Some(params));
+    let result = make_request(&server, "workspace/didDeleteFiles", Some(params));
 
     // Should handle gracefully
     assert!(result.is_ok());
@@ -413,7 +413,7 @@ fn test_did_delete_files_invalid_uri() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -421,8 +421,8 @@ fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Open a document
     let open_params = json!({
@@ -433,7 +433,7 @@ fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
             "text": "print 'Hello';\nprint 'World';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Apply an edit
     let params = json!({
@@ -452,7 +452,7 @@ fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let result = make_request(&mut server, "workspace/applyEdit", Some(params));
+    let result = make_request(&server, "workspace/applyEdit", Some(params));
 
     // Should return success
     let response = result?.ok_or("expected applyEdit response")?;
@@ -462,7 +462,7 @@ fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_apply_edit_multi_line() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -470,8 +470,8 @@ fn test_apply_edit_multi_line() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Open a document
     let open_params = json!({
@@ -482,7 +482,7 @@ fn test_apply_edit_multi_line() -> Result<(), Box<dyn std::error::Error>> {
             "text": "print 'Hello';\nprint 'World';\nprint 'End';\n"
         }
     });
-    let _ = make_request(&mut server, "textDocument/didOpen", Some(open_params));
+    let _ = make_request(&server, "textDocument/didOpen", Some(open_params));
 
     // Apply a multi-line edit
     let params = json!({
@@ -501,7 +501,7 @@ fn test_apply_edit_multi_line() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let result = make_request(&mut server, "workspace/applyEdit", Some(params));
+    let result = make_request(&server, "workspace/applyEdit", Some(params));
 
     // Should return success
     let response = result?.ok_or("expected applyEdit response")?;
@@ -511,7 +511,7 @@ fn test_apply_edit_multi_line() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_apply_edit_no_document() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -519,8 +519,8 @@ fn test_apply_edit_no_document() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Try to apply edit to non-existent document
     let params = json!({
@@ -539,7 +539,7 @@ fn test_apply_edit_no_document() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let result = make_request(&mut server, "workspace/applyEdit", Some(params));
+    let result = make_request(&server, "workspace/applyEdit", Some(params));
 
     // Should still return success (edit was "applied" even if document doesn't exist)
     let response = result?.ok_or("expected applyEdit response")?;
@@ -549,7 +549,7 @@ fn test_apply_edit_no_document() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_apply_edit_invalid_params() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -557,13 +557,13 @@ fn test_apply_edit_invalid_params() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Send invalid params (no edit field)
     let params = json!({});
 
-    let result = make_request(&mut server, "workspace/applyEdit", Some(params));
+    let result = make_request(&server, "workspace/applyEdit", Some(params));
 
     // Should return failure
     let response = result?.ok_or("expected applyEdit response")?;
@@ -575,7 +575,7 @@ fn test_apply_edit_invalid_params() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_path_to_module_name() -> Result<(), Box<dyn std::error::Error>> {
     // Test the path_to_module_name function indirectly through willRenameFiles
-    let mut server = create_test_server();
+    let server = create_test_server();
 
     // Initialize the server
     let init_params = json!({
@@ -583,8 +583,8 @@ fn test_path_to_module_name() -> Result<(), Box<dyn std::error::Error>> {
         "rootUri": "file:///test/workspace",
         "capabilities": {}
     });
-    let _ = make_request(&mut server, "initialize", Some(init_params));
-    send_initialized(&mut server);
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
 
     // Test various path patterns
     let test_cases = vec![
@@ -603,7 +603,7 @@ fn test_path_to_module_name() -> Result<(), Box<dyn std::error::Error>> {
             ]
         });
 
-        let result = make_request(&mut server, "workspace/willRenameFiles", Some(params));
+        let result = make_request(&server, "workspace/willRenameFiles", Some(params));
 
         // Should always succeed and return a workspace edit
         let edit = result?.ok_or("expected workspace edit response")?;

--- a/crates/perl-lsp/tests/lsp_workspace_index_e2e.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_index_e2e.rs
@@ -104,7 +104,7 @@ sub new_name {
 /// Test LSP workspace/symbol request with index
 #[test]
 fn test_lsp_workspace_symbols_with_index() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let init_request = JsonRpcRequest {
@@ -198,7 +198,7 @@ fn test_lsp_workspace_symbols_with_index() -> Result<(), Box<dyn std::error::Err
 /// Test cross-file go-to-definition
 #[test]
 fn test_cross_file_definition() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize
     let init_request = JsonRpcRequest {

--- a/crates/perl-lsp/tests/lsp_workspace_symbol_resolve_test.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_symbol_resolve_test.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 /// Helper to properly initialize a server with the required initialized notification
 fn setup_server() -> LspServer {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize request
     let init_request = JsonRpcRequest {
@@ -33,7 +33,7 @@ fn setup_server() -> LspServer {
 /// Test Workspace Symbol Resolve support (LSP 3.17)
 #[test]
 fn test_workspace_symbol_resolve() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Open a document with symbols
     let uri = "file:///test.pl";
@@ -103,7 +103,7 @@ our $VERSION = '1.0';
 
 #[test]
 fn test_workspace_symbol_resolve_with_container() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Open a document with nested symbols
     let uri = "file:///test.pl";
@@ -176,7 +176,7 @@ sub another_method {
 
 #[test]
 fn test_workspace_symbol_resolve_capability() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     let init_request = JsonRpcRequest {
         _jsonrpc: "2.0".into(),
@@ -205,7 +205,7 @@ fn test_workspace_symbol_resolve_capability() -> Result<(), Box<dyn std::error::
 
 #[test]
 fn test_workspace_symbol_resolve_unknown_symbol() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = setup_server();
+    let server = setup_server();
 
     // Try to resolve a symbol without opening the document
     let unknown_symbol = json!({

--- a/crates/perl-lsp/tests/server_cancellation_test.rs
+++ b/crates/perl-lsp/tests/server_cancellation_test.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 #[test]
 fn server_side_cancellation_emits_err_server_cancelled() -> Result<(), Box<dyn std::error::Error>> {
-    let mut server = LspServer::new();
+    let server = LspServer::new();
 
     // Initialize server
     let _ = server.handle_request(serde_json::from_value::<JsonRpcRequest>(json!({

--- a/crates/perl-lsp/tests/support/lsp_harness.rs
+++ b/crates/perl-lsp/tests/support/lsp_harness.rs
@@ -91,7 +91,7 @@ impl LspHarness {
 
         let (tx, rx) = mpsc::channel::<Vec<u8>>();
         let handle = thread::spawn(move || {
-            let mut server = server;
+            let server = server;
             while let Ok(msg) = rx.recv() {
                 if msg.is_empty() {
                     break;

--- a/crates/perl-lsp/tests/unit_inlay_anchors.rs
+++ b/crates/perl-lsp/tests/unit_inlay_anchors.rs
@@ -21,7 +21,7 @@ mod tests {
 
     /// Drive initialize + didOpen + inlayHint(range) and return the result array (or empty array).
     fn get_hints(
-        server: &mut LspServer,
+        server: &LspServer,
         uri: &str,
         text: &str,
     ) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
@@ -94,7 +94,7 @@ mod tests {
         // Tests anchoring behavior for non-parenthesized function calls.
         // For `open my $fh, ...` we anchor at "my" to precede the variable declaration.
         // For array/hash operations, we anchor at the sigil position.
-        let (mut server, _out) = start_server();
+        let (server, _out) = start_server();
         let uri = "file:///tmp/anchors.pl";
         let text = r#"
 open my $fh, "<", $file;
@@ -102,7 +102,7 @@ push @arr, "x";
 my %h = ();
 my $r = {};
 "#;
-        let hints = get_hints(&mut server, uri, text)?;
+        let hints = get_hints(&server, uri, text)?;
         // Lines are 0-based; first non-empty is line 1.
         // For "open my $fh", the filehandle hint anchors at "my" (column 5)
         assert_unique_label_at(text, &hints, "filehandle:", 1, "my")?;
@@ -116,14 +116,14 @@ my $r = {};
         // Tests anchoring behavior for parenthesized function calls.
         // For `open(FH, ...)` we anchor at '(' to maintain visual alignment.
         // For other args, we anchor at the variable/token position.
-        let (mut server, _out) = start_server();
+        let (server, _out) = start_server();
         let uri = "file:///tmp/paren.pl";
         let text = r#"
 push(@arr, "x");
 substr($s, 0, 5);
 open(FH, "<", "file.txt");
 "#;
-        let hints = get_hints(&mut server, uri, text)?;
+        let hints = get_hints(&server, uri, text)?;
         // For parenthesized calls, the parameter hint anchors at the "(" or first
         // token position depending on how the parser reports the arg location.
         // push(@arr  → array: at "(" (column 4)

--- a/crates/perl-lsp/tests/utf16_regression_tests.rs
+++ b/crates/perl-lsp/tests/utf16_regression_tests.rs
@@ -113,8 +113,8 @@ fn extract_definition_locations(response: &serde_json::Value) -> Vec<(String, u3
 /// - '=' is at position 13
 #[test]
 fn test_utf16_emoji_position_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Code with emoji in variable name
     // Line 0: "my $emoji_🎉 = 1;"
@@ -131,7 +131,7 @@ fn test_utf16_emoji_position_handling() {
     let uri = "file:///test_emoji.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -154,7 +154,7 @@ fn test_utf16_emoji_position_handling() {
 
     // Request hover at $after (line 1, position 3 in UTF-16)
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -219,8 +219,8 @@ fn test_utf16_emoji_position_handling() {
 /// - Positions after "日本語" would be off by +6 (9 bytes - 3 UTF-16 units)
 #[test]
 fn test_utf16_cjk_position_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Code with CJK variable name
     // Line 0: "my $日本語 = 'hello';"
@@ -238,7 +238,7 @@ fn test_utf16_cjk_position_handling() {
     let uri = "file:///test_cjk.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -268,7 +268,7 @@ fn test_utf16_cjk_position_handling() {
     // Request hover at $result (line 1, position 3)
     let expected_result_start = utf16_len("my "); // 3
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -302,7 +302,7 @@ fn test_utf16_cjk_position_handling() {
     let expected_cjk_ref_start = utf16_len(prefix_to_cjk_ref); // 13
 
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/definition",
@@ -355,8 +355,8 @@ fn test_utf16_cjk_position_handling() {
 /// Total: 12 UTF-16 units, 18 bytes
 #[test]
 fn test_utf16_mixed_content_position_handling() {
-    let mut server = start_lsp_server();
-    initialize_lsp(&mut server);
+    let server = start_lsp_server();
+    initialize_lsp(&server);
 
     // Code with mixed Unicode content
     // We'll put a variable AFTER the mixed content string to verify positions
@@ -366,7 +366,7 @@ my $length = length($greeting);
     let uri = "file:///test_mixed.pl";
 
     send_notification(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/didOpen",
@@ -392,7 +392,7 @@ my $length = length($greeting);
     // Request hover at $length on line 1
     let expected_length_start = utf16_len("my "); // 3
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -422,7 +422,7 @@ my $length = length($greeting);
     // Request hover at $greeting on line 0 - this is BEFORE the mixed content in the string
     // Position: "my " = 3, then "$greeting" starts at 3
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",
@@ -452,7 +452,7 @@ my $length = length($greeting);
 
     // Just verify this doesn't panic or return garbage positions
     let response = send_request(
-        &mut server,
+        &server,
         json!({
             "jsonrpc": "2.0",
             "method": "textDocument/hover",

--- a/crates/perl-lsp/tests/workspace_resolution_tests.rs
+++ b/crates/perl-lsp/tests/workspace_resolution_tests.rs
@@ -48,7 +48,7 @@ fn create_test_server() -> (LspServer, Arc<Mutex<Vec<u8>>>) {
 
 /// Helper to send a request to the server
 fn send_request(
-    server: &mut LspServer,
+    server: &LspServer,
     method: &str,
     id: Option<Value>,
     params: Value,
@@ -59,7 +59,7 @@ fn send_request(
 }
 
 /// Helper to initialize and mark server as ready
-fn initialize_server(server: &mut LspServer) {
+fn initialize_server(server: &LspServer) {
     // Initialize
     send_request(
         server,
@@ -148,10 +148,10 @@ fn workspace_config_system_inc_disabled_by_default() {
 
 #[test]
 fn initialize_with_workspace_folders() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!(1)),
         json!({
@@ -171,10 +171,10 @@ fn initialize_with_workspace_folders() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn initialize_with_root_uri_fallback() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     let result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!(1)),
         json!({
@@ -190,11 +190,11 @@ fn initialize_with_root_uri_fallback() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn initialize_with_legacy_root_path_fallback() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Legacy rootPath (deprecated since LSP 3.0 but still used by some clients)
     let result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!(1)),
         json!({
@@ -210,11 +210,11 @@ fn initialize_with_legacy_root_path_fallback() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn initialize_windows_root_path_conversion() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Windows-style rootPath should be handled
     let result = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!(1)),
         json!({
@@ -229,11 +229,11 @@ fn initialize_windows_root_path_conversion() -> Result<(), Box<dyn std::error::E
 
 #[test]
 fn initialize_rejects_double_initialize() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // First initialize should succeed
     let result1 = send_request(
-        &mut server,
+        &server,
         "initialize",
         Some(json!(1)),
         json!({
@@ -277,14 +277,14 @@ fn initialize_rejects_double_initialize() -> Result<(), Box<dyn std::error::Erro
 
 #[test]
 fn configuration_returns_workspace_include_paths() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Initialize and mark ready
-    initialize_server(&mut server);
+    initialize_server(&server);
 
     // Request configuration
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/configuration",
         Some(json!(2)),
         json!({
@@ -308,14 +308,14 @@ fn configuration_returns_workspace_include_paths() -> Result<(), Box<dyn std::er
 
 #[test]
 fn configuration_returns_system_inc_disabled() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Initialize and mark ready
-    initialize_server(&mut server);
+    initialize_server(&server);
 
     // Request configuration
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/configuration",
         Some(json!(2)),
         json!({
@@ -333,14 +333,14 @@ fn configuration_returns_system_inc_disabled() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn configuration_returns_resolution_timeout() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Initialize and mark ready
-    initialize_server(&mut server);
+    initialize_server(&server);
 
     // Request configuration
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/configuration",
         Some(json!(2)),
         json!({
@@ -362,10 +362,10 @@ fn configuration_returns_resolution_timeout() -> Result<(), Box<dyn std::error::
 
 #[test]
 fn did_change_configuration_updates_workspace_settings() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut server, _buffer) = create_test_server();
+    let (server, _buffer) = create_test_server();
 
     // Initialize and mark ready
-    initialize_server(&mut server);
+    initialize_server(&server);
 
     // Send didChangeConfiguration notification
     let req = JsonRpcRequest {
@@ -390,7 +390,7 @@ fn did_change_configuration_updates_workspace_settings() -> Result<(), Box<dyn s
 
     // Verify configuration was updated by requesting it
     let result = send_request(
-        &mut server,
+        &server,
         "workspace/configuration",
         Some(json!(2)),
         json!({


### PR DESCRIPTION
## Summary

- Wraps `LspServer` test harness fields (`process`, `writer`, `rx`, `pending`) in `Mutex<T>` for interior mutability
- Changes all 15 helper function signatures from `&mut LspServer` to `&LspServer`
- Removes ~1800 unnecessary `mut` bindings across 70+ test files, eliminating `unused_mut` warnings from PR #1555

## Motivation

PR #1555 (async runtime migration) changed server-side `LspServer` to use `&self`. This follow-up cleans the test harness to match, removing warning noise throughout the test suite.

## Key Changes

- `common/mod.rs`: `LspServer` struct fields wrapped in `Mutex<T>`; all helper signatures updated to `&LspServer`
- `common/test_reliability.rs`: `HealthCheck::new()` updated to accept `&LspServer`
- `common/test_utils.rs`: `TestServer` call sites updated (`&mut self.server` → `&self.server`)
- All 70+ test files: `let mut server` → `let server`, `&mut server` → `&server`

## Test Results

- `cargo clippy -p perl-lsp --tests -- -D warnings` — clean
- `cargo fmt --all` — clean
- `RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2` — passes (one pre-existing failure: `test_enhanced_cancel_request_with_provider_context_ac1` which also fails on master)

## Agent

builder-2@swarm-0120