### PR TITLE
fix(perl-parser-core): consume full expression in use constant NAME => expr

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -919,7 +919,39 @@ impl<'a> Parser<'a> {
                 if self.tokens.peek_second().map(|t| t.kind) == Ok(TokenKind::FatArrow) {
                     // Don't consume - let the outer loop handle it as a key
                 } else {
+                    // Consume the identifier first.
                     args.push(self.consume_token()?.text.to_string());
+                    // If an operator follows (e.g. `$] < 5.016`), the value is a
+                    // full expression. Consume the operator and everything until the
+                    // next value boundary so the stray `<` is not left over for the
+                    // outer parser to misread as a glob/readline construct.
+                    if matches!(
+                        self.peek_kind(),
+                        Some(
+                            TokenKind::Less
+                                | TokenKind::Greater
+                                | TokenKind::LessEqual
+                                | TokenKind::GreaterEqual
+                                | TokenKind::Equal
+                                | TokenKind::NotEqual
+                                | TokenKind::And
+                                | TokenKind::Or
+                                | TokenKind::Plus
+                                | TokenKind::Minus
+                                | TokenKind::Star
+                                | TokenKind::Slash
+                                | TokenKind::Dot
+                                | TokenKind::WordAnd
+                                | TokenKind::WordOr
+                        )
+                    ) {
+                        while !Self::is_statement_terminator(self.peek_kind())
+                            && self.peek_kind() != Some(TokenKind::Comma)
+                            && self.peek_kind() != Some(TokenKind::FatArrow)
+                        {
+                            args.push(self.consume_token()?.text.to_string());
+                        }
+                    }
                 }
             }
             Some(TokenKind::Sub) => {

--- a/crates/perl-parser-core/tests/cpan_module_patterns.rs
+++ b/crates/perl-parser-core/tests/cpan_module_patterns.rs
@@ -145,3 +145,63 @@ fn use_parent_regression() {
     let code = "use parent qw(Base::Class Other::Base);";
     assert_clean_parse(code);
 }
+
+mod use_constant_angle_bracket {
+    use super::*;
+
+    /// Data::Dumper pattern — the original failing file.
+    #[test]
+    fn data_dumper_is_pre_516_perl() {
+        let code = "use constant IS_PRE_516_PERL => $] < 5.016;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn use_constant_less_equal() {
+        let code = "use constant IS_OLD => $] <= 5.020;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn use_constant_greater_than() {
+        let code = "use constant IS_MODERN => $] > 5.020;";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn use_constant_greater_equal() {
+        let code = "use constant SUPPORTS_BOOLS => $] >= 5.036;";
+        assert_clean_parse(code);
+    }
+
+    /// Simple scalar constant still works.
+    #[test]
+    fn use_constant_simple_value() {
+        let code = "use constant MAX => 42;";
+        assert_clean_parse(code);
+    }
+
+    /// String constant still works.
+    #[test]
+    fn use_constant_string_value() {
+        let code = r#"use constant NAME => "Perl";"#;
+        assert_clean_parse(code);
+    }
+
+    /// Angle bracket readline must still work.
+    #[test]
+    fn angle_bracket_readline_still_works() {
+        let code = "my $line = <STDIN>;";
+        assert_clean_parse(code);
+    }
+
+    /// Full Data::Dumper preamble pattern.
+    #[test]
+    fn data_dumper_preamble() {
+        let code = r#"
+use constant IS_PRE_516_PERL => $] < 5.016;
+use constant SUPPORTS_CORE_BOOLS => defined &builtin::is_bool;
+"#;
+        assert_clean_parse(code);
+    }
+}


### PR DESCRIPTION
## Summary

- `use constant IS_PRE_516_PERL => $] < 5.016` failed because `consume_use_import_value()` consumed only `$]` and returned, leaving `< 5.016` unconsumed
- The outer parser then encountered `<` at statement start and misidentified it as a glob/readline `<pattern>` construct
- Fix: when the token after a consumed identifier is a comparison or arithmetic operator, continue consuming until the next value boundary (`,` or `;`)

## Test plan

- [ ] 8 new tests in `use_constant_angle_bracket` module: `<`, `<=`, `>`, `>=`, simple value, string, readline still works, full Data::Dumper preamble
- [ ] 300 existing tests pass (1 pre-existing failure)
- [ ] `cargo fmt --all` clean
- [ ] `cargo clippy -p perl-parser-core -- -D warnings` clean

## Impact

~492 files in `unexpected_token_in_expr` error bucket (partially). Data::Dumper uses this pattern — one of the most-used Perl core modules.