### PR TITLE
fix(parser): while/if/for conditions treating builtins as indirect calls

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -16,6 +16,7 @@ impl<'a> Parser<'a> {
         ) {
             self.parse_variable_declaration()?
         } else {
+            self.mark_not_stmt_start();
             self.parse_expression()?
         };
 
@@ -41,6 +42,7 @@ impl<'a> Parser<'a> {
             ) {
                 self.parse_variable_declaration()?
             } else {
+                self.mark_not_stmt_start();
                 self.parse_expression()?
             };
 
@@ -73,6 +75,7 @@ impl<'a> Parser<'a> {
         self.tokens.next()?; // consume 'unless'
 
         self.expect(TokenKind::LeftParen)?;
+        self.mark_not_stmt_start();
         let condition = self.parse_expression()?;
         self.expect(TokenKind::RightParen)?;
 
@@ -113,6 +116,7 @@ impl<'a> Parser<'a> {
         ) {
             self.parse_variable_declaration()?
         } else {
+            self.mark_not_stmt_start();
             self.parse_expression()?
         };
 
@@ -145,6 +149,7 @@ impl<'a> Parser<'a> {
         self.tokens.next()?; // consume 'until'
 
         self.expect(TokenKind::LeftParen)?;
+        self.mark_not_stmt_start();
         let condition = self.parse_expression()?;
         self.expect(TokenKind::RightParen)?;
 
@@ -200,6 +205,7 @@ impl<'a> Parser<'a> {
             Some(Box::new(decl))
         } else {
             // Parse expression
+            self.mark_not_stmt_start();
             let expr = self.parse_expression()?;
 
             // If followed by ), it's a foreach loop
@@ -234,6 +240,7 @@ impl<'a> Parser<'a> {
         let condition = if self.peek_kind() == Some(TokenKind::Semicolon) {
             None
         } else {
+            self.mark_not_stmt_start();
             Some(Box::new(self.parse_expression()?))
         };
         self.expect(TokenKind::Semicolon)?;
@@ -242,6 +249,7 @@ impl<'a> Parser<'a> {
         let update = if self.peek_kind() == Some(TokenKind::RightParen) {
             None
         } else {
+            self.mark_not_stmt_start();
             Some(Box::new(self.parse_expression()?))
         };
 
@@ -278,6 +286,7 @@ impl<'a> Parser<'a> {
         self.in_for_loop_init = false;
 
         self.expect(TokenKind::LeftParen)?;
+        self.mark_not_stmt_start();
         let list = self.parse_expression()?;
         self.expect(TokenKind::RightParen)?;
 
@@ -315,6 +324,7 @@ impl<'a> Parser<'a> {
         self.in_for_loop_init = false;
 
         self.expect(TokenKind::LeftParen)?;
+        self.mark_not_stmt_start();
         let list = self.parse_expression()?;
         self.expect(TokenKind::RightParen)?;
 

--- a/crates/perl-parser-core/tests/cpan_compound_stmt_modifier.rs
+++ b/crates/perl-parser-core/tests/cpan_compound_stmt_modifier.rs
@@ -84,3 +84,84 @@ if ($start) { init(); run(); }
 "#;
     assert_clean_parse(code);
 }
+
+mod while_condition_indirect_call {
+    use super::*;
+
+    #[test]
+    fn while_shift_array() {
+        // File::Spec::Unix pattern — while( shift @chunks )
+        let code = "while (shift @arr) { last; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn while_pop_array() {
+        let code = "while (pop @arr) { last; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn while_assign_shift() {
+        // Common idiom: while (my $x = shift @args) { ... }
+        let code = "while (my $x = shift @args) { print $x; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn while_defined_my_shift() {
+        // File::Spec::Unix line pattern
+        let code = "while (defined(my $dir = shift @basechunks)) { push @chunks, $dir; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn if_shift_array() {
+        let code = "if (shift @arr) { return 1; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn if_pop_array() {
+        let code = "if (pop @arr) { return 1; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn elsif_shift_array() {
+        let code = "if (1) { } elsif (shift @arr) { return 1; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn unless_shift_array() {
+        let code = "unless (shift @arr) { return 1; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn until_shift_array() {
+        let code = "until (shift @arr) { last; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn for_condition_shift() {
+        let code = "for (my $i = 0; shift @arr; $i++) { }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_list_shift() {
+        // foreach with a complex list expression
+        let code = "foreach my $x (@arr) { print $x; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn while_scalar_shift() {
+        // scalar context shift is common
+        let code = "while (my $item = shift @items) { process($item); }";
+        assert_clean_parse(code);
+    }
+}


### PR DESCRIPTION
## Problem

`while(shift @arr)`, `if(shift @arr)`, `until(pop @arr)` and similar patterns
were misparse because `at_stmt_start` was `true` when entering `parse_expression()`
inside condition parentheses. `is_indirect_call_pattern()` then fired on
`shift`/`pop` followed by an array variable, treating the array as an indirect
object rather than the builtin's argument — causing cascading parse errors.

Real-world example from `File::Spec::Unix`:
```perl
while( defined(my $dir= shift @basechunks) ) { ... }
```

## Root Cause

`at_stmt_start` is set to `true` at statement boundaries and never cleared
before `parse_expression()` calls inside `(...)` condition/list contexts in
`control_flow.rs`. `is_indirect_call_pattern()` guards on `at_stmt_start`,
so builtins like `shift @arr` inside conditions were misidentified as
indirect method calls.

## Fix

Add `self.mark_not_stmt_start()` immediately before `parse_expression()` in
all condition/list contexts in `control_flow.rs`:
- `parse_if_statement()` — condition and all elsif conditions
- `parse_unless_statement()` — condition
- `parse_while_statement()` — condition
- `parse_until_statement()` — condition
- `parse_for_statement()` — init, condition, and update expressions
- `parse_foreach_statement()` — list expression
- `parse_foreach_style_for()` — list expression

## Impact

Fixes ~120 files in the `unclosed_paren` corpus error bucket.

## Tests

12 new tests in `while_condition_indirect_call` module covering:
- `while(shift @arr)`, `while(pop @arr)`
- `while(my $x = shift @args)`
- `while(defined(my $dir = shift @basechunks))` (File::Spec::Unix pattern)
- `if(shift)`, `if(pop)`, `elsif(shift)`, `unless(shift)`, `until(shift)`
- `for(; shift @arr; )` — C-style for loop condition
- `foreach my $x (@arr)` — list context

## Test Results

- `cargo test -p perl-parser-core` — 300 pass, 1 pre-existing failure
- `cargo fmt --all` — clean
- No new clippy warnings in changed files