### PR TITLE
fix(lsp): log serialization errors in outbound writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
  "url",
  "uuid",
  "walkdir",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -69,6 +69,7 @@ walkdir = "2.5.0"
 ropey = { version = "1.6.1" }
 tokio = { version = "1.49.0", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
 once_cell = "1.21.3"
+tracing = "0.1.44"
 
 [build-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-lsp/src/runtime/outbound.rs
+++ b/crates/perl-lsp/src/runtime/outbound.rs
@@ -144,16 +144,26 @@ fn writer_loop_batched_shared(
 }
 
 /// Serialize an `OutboundMessage` to JSON bytes.
+///
+/// Returns an empty `Vec` on serialization failure and logs the error via
+/// `tracing::error!` so callers have diagnostic visibility rather than a
+/// silently-malformed empty frame being delivered to the client.
 fn serialize_message(msg: &OutboundMessage) -> Vec<u8> {
     match msg {
-        OutboundMessage::Response(resp) => serde_json::to_vec(resp).unwrap_or_default(),
+        OutboundMessage::Response(resp) => serde_json::to_vec(resp).unwrap_or_else(|e| {
+            tracing::error!("Failed to serialize outbound response: {e}");
+            Vec::new()
+        }),
         OutboundMessage::Notification { method, params } => {
             let val = json!({
                 "jsonrpc": "2.0",
                 "method": method,
                 "params": params,
             });
-            serde_json::to_vec(&val).unwrap_or_default()
+            serde_json::to_vec(&val).unwrap_or_else(|e| {
+                tracing::error!(method = %method, "Failed to serialize outbound notification: {e}");
+                Vec::new()
+            })
         }
         OutboundMessage::Request { id, method, params } => {
             let val = json!({
@@ -162,7 +172,10 @@ fn serialize_message(msg: &OutboundMessage) -> Vec<u8> {
                 "method": method,
                 "params": params,
             });
-            serde_json::to_vec(&val).unwrap_or_default()
+            serde_json::to_vec(&val).unwrap_or_else(|e| {
+                tracing::error!(id = %id, method = %method, "Failed to serialize outbound request: {e}");
+                Vec::new()
+            })
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `unwrap_or_default()` in all three arms of `serialize_message()` with `unwrap_or_else(|e| { tracing::error!(...); Vec::new() })`
- Serialization failures are now visible in logs instead of silently producing malformed empty frames
- Adds `tracing = "0.1.44"` as a direct dependency of `perl-lsp` (consistent with `perl-lexer`, `perl-dap`)

## Test plan

- [x] `cargo build -p perl-lsp` — clean
- [x] `cargo clippy -p perl-lsp -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Closes #1558