### PR TITLE
fix(parser): foreach (LIST) with implicit $_ topic variable

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -268,14 +268,25 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'foreach'
 
-        // Set flag to prevent semicolon consumption in variable declaration
-        self.in_for_loop_init = true;
-        let variable = if self.peek_kind() == Some(TokenKind::My) {
-            self.parse_variable_declaration()?
+        // Check for implicit $_ topic variable: `foreach (LIST) { ... }`
+        // When the next token is '(' there is no explicit iterator variable;
+        // Perl implicitly uses $_ in that case.
+        let variable = if self.peek_kind() == Some(TokenKind::LeftParen) {
+            Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "_".to_string() },
+                SourceLocation { start, end: start },
+            )
         } else {
-            self.parse_variable()?
+            // Set flag to prevent semicolon consumption in variable declaration
+            self.in_for_loop_init = true;
+            let v = if self.peek_kind() == Some(TokenKind::My) {
+                self.parse_variable_declaration()?
+            } else {
+                self.parse_variable()?
+            };
+            self.in_for_loop_init = false;
+            v
         };
-        self.in_for_loop_init = false;
 
         self.expect(TokenKind::LeftParen)?;
         let list = self.parse_expression()?;

--- a/crates/perl-parser-core/tests/cpan_pattern_tests.rs
+++ b/crates/perl-parser-core/tests/cpan_pattern_tests.rs
@@ -1640,3 +1640,83 @@ if ($start) { init(); run(); }
         assert_clean_parse(code);
     }
 }
+
+// ---------------------------------------------------------------------------
+// foreach (LIST) with implicit $_ topic variable (fix/foreach-implicit-topic-variable)
+// ---------------------------------------------------------------------------
+// Root cause: parse_foreach_statement() always tried to parse an iterator
+// variable before the '(' list — failing when the variable was omitted and $_ is
+// used implicitly. Very common Perl idiom: `foreach (@arr) { ... }`.
+// ---------------------------------------------------------------------------
+mod foreach_implicit_topic_variable {
+    use super::*;
+
+    #[test]
+    fn foreach_array_implicit_topic() {
+        // Most common form: foreach (@arr) { ... }
+        let code = "foreach (@arr) { print $_; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_keys_hash_implicit_topic() {
+        // DB_File.pm pattern: foreach (keys %h)
+        let code = "foreach (keys %h) { print $h{$_}; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_range_implicit_topic() {
+        // DB_File.pm pattern: foreach (0 .. $length - 1)
+        let code = "foreach (0 .. $n - 1) { print $_; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_sort_keys_implicit_topic() {
+        // DB_File.pm pattern: foreach (sort keys %h)
+        let code = "foreach (sort keys %h) { print $_; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_regex_match_implicit_topic() {
+        // Text::Glob pattern: for ($glob =~ m/(.)/gs)
+        let code = r#"foreach ($glob =~ m/(.)/gs) { $regex .= $_; }"#;
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_with_explicit_variable_still_works() {
+        // Ensure the existing explicit-variable path is not broken
+        let code = "foreach my $item (@arr) { print $item; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_with_dollar_variable_still_works() {
+        let code = "foreach $item (@arr) { print $item; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_reverse_implicit_topic() {
+        // lib.pm pattern: foreach (reverse @_)
+        let code = "foreach (reverse @_) { unshift @INC, $_; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn foreach_qw_implicit_topic() {
+        // List::Util.pm pattern: foreach (qw( some keys here ))
+        let code = "foreach (qw( a b c )) { print \"$_\\n\"; }";
+        assert_clean_parse(code);
+    }
+
+    #[test]
+    fn for_implicit_topic_unchanged() {
+        // Ensure `for` with implicit $_ still works (pre-existing behavior)
+        let code = "for (1..10) { print $_; }";
+        assert_clean_parse(code);
+    }
+}


### PR DESCRIPTION
## Problem

`foreach (@arr) { ... }`, `foreach (keys %h) { ... }`, and similar forms
without an explicit iterator variable failed to parse with:

```
Invalid syntax: Expected variable, found '('
```

This is one of the most common Perl idioms, found throughout the standard
library (`File::Spec`, `lib.pm`, `DB_File`, `Opcode`, `DynaLoader`,
`List::Util`, `Text::Glob`, and many others).

## Root Cause

`parse_foreach_statement()` unconditionally tried to parse an iterator
variable before the `(` list. When the variable was omitted (Perl then uses
`$_` implicitly), the `(` caused a parse failure.

## Fix

When `peek_kind() == LeftParen` after consuming `foreach`, skip the
variable-parsing path and synthesise an implicit `$_` node at the current
position — identical to the pattern already used in `parse_for_statement()`
for the single-expression foreach-style for loop.

## Impact

Fixes ~36+ files in the local corpus. This is a foundational pattern —
many module files use this form exclusively.

## Tests

10 new tests in `foreach_implicit_topic_variable` module:
- `foreach (@arr)`, `foreach (keys %h)`, `foreach (0 .. $n)`
- `foreach (sort keys %h)`, `foreach (reverse @_)`, `foreach (qw(...))`
- `foreach ($glob =~ m/.../gs)` — Text::Glob pattern
- Explicit-variable regression (`foreach my $x (@arr)`, `foreach $x (@arr)`)
- `for (1..10)` pre-existing implicit-topic behavior unchanged

## Test Results

- `cargo test -p perl-parser-core` — 300 pass, 1 pre-existing failure
- `cargo fmt --all` — clean