### PR TITLE
feat(swarm): add direct-action agent pattern as preferred build approach

### DIFF
--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -86,6 +86,71 @@ Create an agent team with these teammates. Use `TeamCreate` with specific names 
 | `strategist` | Priority alignment | swarm-strategist | sonnet |
 | `pr-responder` | Review comment handler | swarm-pr-responder | sonnet |
 
+## Direct-Action Subagent Pattern
+
+This is the **preferred pattern** for all build subagents. Learned from cycle 1: heavyweight coordinator builders that spawn further subagents produced zero PRs. Small, scoped direct-action agents shipped quickly.
+
+### When to use direct-action vs coordinator
+
+| Situation | Pattern |
+|-----------|---------|
+| Specific crate, known files, clear fix | **Direct-action** — spawn worktree agent directly |
+| Simple test addition, doc update, cleanup | **Direct-action** — spawn worktree agent directly |
+| Multi-step exploration needed before work can be scoped | **Coordinator** — scout first, then direct-action once scoped |
+| Unknown file surface, requires investigation | **Coordinator** — explore first, claim files, then direct-action |
+
+Rule: if you know the files, use direct-action. If you don't, scout first, then use direct-action.
+
+### The template
+
+```
+Agent(
+  isolation: "worktree",
+  prompt: "
+    Goal: <one sentence>
+    Crate: <crate name>
+    Files: <exact files to edit — max 10>
+    Branch: <branch name>
+    Steps:
+    1. <specific step>
+    2. <specific step>
+    3. Verify: <cargo command>
+    4. Commit: <message>
+    5. Push and create PR
+    Optional: invoke /<skill> if branching needed
+  "
+)
+```
+
+### Guardrails
+
+- **Max 10 files per agent.** If a task touches more than 10 files, split into multiple agents with non-overlapping file surfaces.
+- **Each agent = one PR.** No agent produces multiple PRs or skips the PR step.
+- **No active agent without:** named worktree, branch, claimed file surface, verification command.
+- **Skills extend, not replace:** the final optional step may invoke a skill, but only after the task is already tightly scoped.
+
+### Example (builder-1 spawning a direct-action agent)
+
+```
+Agent(
+  isolation: "worktree",
+  prompt: "
+    Goal: Fix statement modifier parsing after complex expressions in perl-parser
+    Crate: perl-parser
+    Files: crates/perl-parser/src/statement.rs, crates/perl-parser/tests/statement_modifier.rs
+    Branch: fix-stmt-modifier-complex-expr
+    Steps:
+    1. Read the handoff at .ops-perl-lsp/handoffs/fix-stmt-modifier-complex-expr.md
+    2. Add a failing test reproducing the issue in tests/statement_modifier.rs
+    3. Fix the parsing logic in src/statement.rs
+    4. Verify: cargo fmt && cargo clippy -p perl-parser --tests && cargo test -p perl-parser
+    5. Commit: fix(parser): statement modifiers after complex expressions
+    6. Push and create PR with --label swarm-core
+    Optional: invoke /coding-standards if unsure about style
+  "
+)
+```
+
 ### Teammate spawn prompts
 
 Each teammate gets a focused prompt that tells them to:

--- a/.claude/commands/wave.md
+++ b/.claude/commands/wave.md
@@ -7,14 +7,58 @@ argument-hint: "<category> e.g. 'parser-fixes', 'test-coverage', 'doc-updates', 
 
 Launch a wave of agents for: **$ARGUMENTS**
 
+## Direct-Action Agent Template
+
+Every agent spawned by a wave MUST use this template. No coordinator layers. No speculative spawning. The lead spawns worktree agents directly:
+
+```
+Agent(
+  isolation: "worktree",
+  prompt: "
+    Goal: <one sentence>
+    Crate: <crate name>
+    Files: <exact files to edit — max 10>
+    Branch: <branch name>
+    Steps:
+    1. <specific step>
+    2. <specific step>
+    3. Verify: <cargo command>
+    4. Commit: <message>
+    5. Push and create PR
+    Optional: invoke /<skill> if branching needed
+  "
+)
+```
+
+**Rules:**
+- Max 10 files per agent. If a task touches more, split into multiple agents with non-overlapping file surfaces.
+- Each agent produces exactly one PR.
+- No agent is active without: named worktree, branch, claimed file surface, verification command.
+- Skills extend good execution trees — they do not replace task scoping. Invoke them only as a final optional step.
+
 ## Categories
 
 ### `parser-fixes`
 For each known parser bug from `.ci/parser-corpus-baseline.json` error buckets:
-- Launch an agent per fix using `/parser-fix` pattern
+- Launch an agent per fix using the direct-action template above
 - Each in its own worktree (`isolation: "worktree"`)
 - TDD: failing test → fix → verify
 - Reference `docs/project/PARSER_EDGE_CASE_ROADMAP.md` for known issues
+
+Example agent prompt:
+```
+Goal: Fix heredoc indentation parsing in perl-parser
+Crate: perl-parser
+Files: crates/perl-parser/src/heredoc.rs, crates/perl-parser/tests/heredoc.rs
+Branch: fix-heredoc-indent
+Steps:
+1. Read the failing corpus test in crates/perl-parser/tests/
+2. Add a regression test that reproduces the failure
+3. Fix the parsing logic in crates/perl-parser/src/heredoc.rs
+4. Verify: cargo fmt && cargo clippy -p perl-parser --tests && cargo test -p perl-parser
+5. Commit: fix(parser): heredoc indentation edge case
+6. Push and create PR with --label swarm-core
+```
 
 ### `test-coverage`
 Launch agents to improve test coverage across crates:
@@ -25,6 +69,20 @@ Launch agents to improve test coverage across crates:
 - `perl-lsp` — LSP feature integration tests
 - `perl-refactoring` — rename/extract tests
 - `perl-dap` — DAP protocol tests
+
+Example agent prompt:
+```
+Goal: Add Moose pattern tests to perl-parser-core
+Crate: perl-parser-core
+Files: crates/perl-parser-core/tests/moose_patterns.rs
+Branch: test-parser-core-moose
+Steps:
+1. Read crates/perl-parser-core/src/ to understand current coverage
+2. Add 5-10 tests covering Moose has/with/extends patterns
+3. Verify: cargo fmt && cargo clippy -p perl-parser-core --tests && cargo test -p perl-parser-core
+4. Commit: test(parser-core): add Moose pattern coverage
+5. Push and create PR with --label swarm-improve-tests
+```
 
 ### `doc-updates`
 Launch agents to update documentation:
@@ -42,18 +100,19 @@ Launch agents for codebase hygiene:
 - Obsolete script deletion
 - `.gitignore` updates
 
-## Pattern
+## Spawning the Wave
 
-For each item in the category:
+For each item in the category, spawn using the direct-action template:
 ```
 Agent(
-  prompt: "<specific task>",
-  mode: "auto",
   isolation: "worktree",
+  prompt: "<filled-in template from above>",
   run_in_background: true,
   name: "<descriptive-name>"
 )
 ```
+
+Spawn 3-8 agents in parallel. Do not wait for one to finish before spawning the next.
 
 ## After wave completes
 


### PR DESCRIPTION
## Summary

- Updates `.claude/commands/wave.md` to use the direct-action agent template as the mandatory spawn pattern, replacing the old coordinator-layer approach that produced zero PRs in cycle 1
- Adds a new `## Direct-Action Subagent Pattern` section to `.claude/commands/swarm.md` after the team structure table, documenting when to use direct-action vs coordinator, the full template, max-10-files guardrail, and one-agent-one-PR rule
- Embeds concrete worked examples in `wave.md` (parser-fix and test-coverage categories) so agents have no ambiguity about how to fill in the template

## Motivation

Cycle 1 feedback (`feedback_direct_action_agents.md`, `feedback_small_pr_guardrails.md`): builder coordinators that spawned further subagents idled and shipped nothing. The concrete, scoped work (ADR-0031 #1559, status drift #1560) shipped quickly because those agents had exact file surfaces and verification commands up front.

## Test plan

- [ ] Read `wave.md` — every category now has a direct-action example prompt
- [ ] Read `swarm.md` — `## Direct-Action Subagent Pattern` section appears after the team structure table
- [ ] Verify the template fields match the memory file spec: Goal, Crate, Files, Branch, Steps, Verify, Commit, PR
- [ ] Confirm max-10-files and one-agent-one-PR rules are stated explicitly in both files