### PR TITLE
feat(swarm): add subagent lifecycle tracking and PR throttling

### DIFF
--- a/.claude/commands/swarm-protocol.md
+++ b/.claude/commands/swarm-protocol.md
@@ -257,6 +257,42 @@ Don't write memories for ephemeral state (which PRs are open, which slices are i
 
 The system gets better with each cycle AND each session.
 
+## 11. CI Budget and Agent Lanes
+
+Agents fall into two lanes with different constraints:
+
+### CI-bound agents (code writers)
+These create PRs and trigger CI runs. Throttle by merge pipeline throughput.
+- Builders (worktree subagents that edit code)
+- Fixers (when they push fixes)
+- Improver-tests (when adding tests)
+
+Rules:
+- Monitor merge pipeline: only create PRs as fast as they can be reviewed and merged
+- When CI queue > 10 runs, pause new PR creation and shift to planning/research
+- Each PR triggers a CI run (~5-8 min). Budget accordingly.
+
+### Non-CI-bound agents (read-only)
+These never trigger CI. Run them freely — they cost context, not CI budget.
+- Scouts (explore, analyze, create handoffs and tasks)
+- Researchers (web search, docs lookup, verification)
+- Planners (implementation design, architecture)
+- Doc drafters (write drafts in handoffs, not PRs)
+- Triage agents (issue investigation, error analysis)
+- Strategists (priority analysis, metrics)
+
+Rules:
+- No throttle needed — run as many as useful
+- Use read-only agents to pre-plan work so code writers are maximally efficient
+- When CI is congested, shift ALL capacity to read-only work
+- Read-only agents prepare handoffs that code writers consume in focused bursts
+
+### The optimal pattern
+1. Continuous read-only agents: scouts, researchers, planners always active
+2. Burst code-writing agents: spawn when CI has capacity, ship PRs, stop
+3. When CI is saturated: shift to planning, research, doc drafting, triage
+4. Pre-planning reduces code-writing agent time → fewer CI-minutes per feature
+
 ## 10. CI Gate Discipline
 
 **NEVER merge a PR with failing CI Gate. If CI fails, message the fixer. Do not merge red.**

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -277,33 +277,31 @@ The lead's periodic duties:
 - **Daily**: `/swarm-report` for user check-in
 - **As needed**: Review `.ops-perl-lsp/agent-patches/`, apply improvements
 - **As needed**: Write Claude Code memories for cross-session knowledge
+- **When CI queue > 10**: Message all code-writing agents (builder-1, builder-2, reviewer, fixer, improver-tests) to pause PR creation and shift to planning
 
 ## Phase 4: Continuous Operation
 
 The full swarm — 12 teammates, all concurrent:
 
 ```
-DISCOVERY
-  scout-1, scout-2       → find gaps, write handoffs, TaskCreate
+DISCOVERY + PLANNING (no CI cost, run freely)
+  scout-1, scout-2    → find gaps, write handoffs, create tasks
+  strategist           → priority alignment, roadmap
+  researchers          → look up docs, verify approaches
 
-BUILD
-  builder-1, builder-2   → claim tasks, build in worktrees, message reviewer
+CODE + CI (throttled by merge pipeline)
+  builder-1, builder-2 → claim tasks, build in worktrees, create PRs
+  reviewer             → review diffs, create PRs with labels, enable auto-merge
+  pr-responder         → address review comments, push fixes
+  fixer                → fix CI failures
+  improver-tests       → add tests (creates PRs)
 
-REVIEW
-  reviewer               → review diffs, create PRs with labels, enable auto-merge
-  pr-responder           → address review comments, push fixes
+MERGE (sequential, no parallel)
+  merger               → merge green PRs one at a time
+  validator            → verify merges helped
 
-MERGE
-  merger                 → merge PRs, update completed-slices, trigger validator
-  validator              → verify merges actually helped, catch regressions
-
-IMPROVE (~20%)
-  improver-docs          → ADRs, changelog, friction log, README, roadmap
-  improver-tests         → mutants, flaky tests, coverage, deps, dead code
-
-GOVERNANCE
-  strategist             → priority alignment, roadmap updates, agent health
-  fixer                  → CI failures, regression fixes, known-pitfalls
+DOCS (low CI cost — doc-only PRs pass CI fast)
+  improver-docs        → ADRs, changelog, friction log
 ```
 
 ### Data flows


### PR DESCRIPTION
## Summary

- Add **Builder Shutdown Protocol** to `swarm-protocol.md` (section 7b): builders must track spawned subagent IDs and report them on shutdown so the lead can monitor orphaned subagents that continue creating PRs after their parent exits.
- Add **PR Creation Throttle** to `swarm-protocol.md` (section 7b): all agents check `gh pr list --state open --json number --jq length` before creating a PR; if > 5 open, they message the lead instead.
- Add **CI queue depth check** to `swarm.md` Phase 1 Bootstrap: lead checks in-progress run count with `gh run list --json status --jq '[.[] | select(.status == "in_progress")] | length'` before launching builders; if > 5, waits.
- Update **builder-1/builder-2 spawn prompt** in `swarm.md` to include subagent ID tracking and PR throttle reminders inline.

## Test plan

- [ ] Read `swarm-protocol.md` section 7b and verify the Builder Shutdown Protocol and PR Creation Throttle subsections are present and well-formed.
- [ ] Read `swarm.md` Phase 1 Bootstrap and verify the CI queue depth check block is present.
- [ ] Read `swarm.md` builder prompt block and verify the two new lines (subagent tracking, PR throttle) are present.
- [ ] Confirm no broken markdown: headers, code fences, and bullet nesting look correct.