### PR TITLE
fix(perl-parser-core): bare block before for/foreach loop parsed as postfix modifier

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -256,6 +256,11 @@ impl<'a> Parser<'a> {
     /// In Perl, compound statements (if/while/for/foreach/given/default/try/sub/package)
     /// are terminated by their own closing brace — a modifier keyword that follows is a
     /// new top-level statement, not a modifier on the compound statement.
+    ///
+    /// A bare `Block` is also compound: `{ ... } for @arr` is a syntax error in Perl
+    /// (verified: `perl -c` rejects it). Without this, `{ ... }\nfor my $x (...) { }`
+    /// would be misread as `{ ... } for my` (postfix-for with `my` as the iterator
+    /// expression), causing the `for my $x (LIST) { BLOCK }` form to fail.
     fn is_compound_statement(node: &Node) -> bool {
         matches!(
             node.kind,
@@ -268,6 +273,7 @@ impl<'a> Parser<'a> {
                 | NodeKind::Try { .. }
                 | NodeKind::Subroutine { .. }
                 | NodeKind::Package { .. }
+                | NodeKind::Block { .. }
         )
     }
 

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3842,3 +3842,75 @@ mod wave2a_qualified_subscripts {
         Ok(())
     }
 }
+
+// ---------------------------------------------------------------------------
+// Bare block followed by for-loop (regression tests for is_compound_statement)
+// ---------------------------------------------------------------------------
+//
+// A bare `{ ... }` block is a compound statement in Perl.  When it is followed
+// by `for my $var (LIST) { BODY }` on the next line the parser must NOT
+// interpret the `for` as a postfix statement modifier on the block.  Without
+// the fix, the parser would produce:
+//
+//   (statement_modifier_for (block ...) my) ... ERROR
+//
+// because `is_compound_statement` did not include `Block`, so the postfix-for
+// check fired.
+
+#[cfg(test)]
+mod bare_block_for_regression {
+    use perl_parser_core::Parser;
+
+    fn parse_clean(src: &str) -> Result<(), String> {
+        let mut parser = Parser::new(src);
+        let ast = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+        let sexp = ast.to_sexp();
+        if sexp.contains("ERROR") {
+            return Err(format!("expected clean parse, got ERROR nodes in: {sexp}\nsource: {src}"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn bare_block_then_for_my_var() {
+        parse_clean("{ my $x = 1; }\nfor my $i (1..3) { print $i; }\n").unwrap();
+    }
+
+    #[test]
+    fn bare_block_then_foreach_my_var() {
+        parse_clean("{ my $y = 2; }\nforeach my $item (@arr) { print $item; }\n").unwrap();
+    }
+
+    #[test]
+    fn bare_block_then_for_my_alias() {
+        // Real-world pattern from List::SomeUtils / Module::Implementation
+        parse_clean(
+            r#"
+{
+    my $loader = build_loader_sub(
+        implementations => [ 'XS', 'PP' ],
+        symbols         => \@subs,
+    );
+    $loader->();
+}
+
+for my $alias ( keys %aliases ) {
+    no strict 'refs';
+    *{$alias} = __PACKAGE__->can( $aliases{$alias} );
+}
+"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn if_block_then_for_still_works() {
+        // if/while/etc. blocks were already compound — should be unaffected
+        parse_clean("if (1) { my $x = 1; }\nfor my $i (1..3) { print $i; }\n").unwrap();
+    }
+
+    #[test]
+    fn nested_bare_blocks_then_for() {
+        parse_clean("{ { my $x = 1; } }\nfor my $k (keys %h) { print $k; }\n").unwrap();
+    }
+}


### PR DESCRIPTION
## Problem

When a bare `{ ... }` block appears as a statement followed by a `for`/`foreach`
loop on the next line, the parser misparsed the `for` as a postfix statement
modifier:

```perl
{
    my $loader = build_loader_sub(implementations => ['XS', 'PP']);
    $loader->();
}

for my $alias ( keys %aliases ) {   # ← misparsed as postfix for
    no strict 'refs';
    *{$alias} = __PACKAGE__->can( $aliases{$alias} );
}
```

Produced:
```
(statement_modifier_for (block ...) (identifier my))
(variable $ alias)
(ERROR "expected '}', found identifier at position 183")
```

Root cause: `is_compound_statement()` did not include `NodeKind::Block`, so the
post-statement check saw a bare block as a non-compound statement and consumed
the following `for` keyword as a modifier.

Note: `{ ... } for @arr` is a `perl -c` syntax error — bare blocks can never
take a postfix modifier, so they should always be treated as compound.

## Fix

Add `NodeKind::Block { .. }` to the `matches!` in `is_compound_statement()`.
One-line change in `statements.rs`.

## Tests

5 regression tests in `bare_block_for_regression` module:
- `bare_block_then_for_my_var` — basic case
- `bare_block_then_foreach_my_var` — foreach variant
- `bare_block_then_for_my_alias` — real-world List::SomeUtils pattern
- `if_block_then_for_still_works` — existing compound forms unaffected
- `nested_bare_blocks_then_for` — nested blocks

All 5 pass. 305 total tests pass. One pre-existing failure
(`multiple_keyword_pairs_at_statement_level`) is unrelated and also fails on master.

## Closes

Fixes #1551 (bare block + for loop misparse)