### PR TITLE
feat(swarm): separate CI-bound and non-CI-bound agent lanes

### DIFF
--- a/.claude/commands/swarm-protocol.md
+++ b/.claude/commands/swarm-protocol.md
@@ -279,3 +279,39 @@ gh pr checks <N>           # Must show all checks passing
 gh run list --limit 5      # Confirm master CI is green
 gh pr merge <N> --squash --delete-branch   # Only if both above are green
 ```
+
+## 11. CI Budget and Agent Lanes
+
+Agents fall into two lanes with different constraints:
+
+### CI-bound agents (code writers)
+These create PRs and trigger CI runs. Throttle by merge pipeline throughput.
+- Builders (worktree subagents that edit code)
+- Fixers (when they push fixes)
+- Improver-tests (when adding tests)
+
+Rules:
+- Monitor merge pipeline: only create PRs as fast as they can be reviewed and merged
+- When CI queue > 10 runs, pause new PR creation and shift to planning/research
+- Each PR triggers a CI run (~5-8 min). Budget accordingly.
+
+### Non-CI-bound agents (read-only)
+These never trigger CI. Run them freely — they cost context, not CI budget.
+- Scouts (explore, analyze, create handoffs and tasks)
+- Researchers (web search, docs lookup, verification)
+- Planners (implementation design, architecture)
+- Doc drafters (write drafts in handoffs, not PRs)
+- Triage agents (issue investigation, error analysis)
+- Strategists (priority analysis, metrics)
+
+Rules:
+- No throttle needed — run as many as useful
+- Use read-only agents to pre-plan work so code writers are maximally efficient
+- When CI is congested, shift ALL capacity to read-only work
+- Read-only agents prepare handoffs that code writers consume in focused bursts
+
+### The optimal pattern
+1. Continuous read-only agents: scouts, researchers, planners always active
+2. Burst code-writing agents: spawn when CI has capacity, ship PRs, stop
+3. When CI is saturated: shift to planning, research, doc drafting, triage
+4. Pre-planning reduces code-writing agent time → fewer CI-minutes per feature

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -277,33 +277,33 @@ The lead's periodic duties:
 - **Daily**: `/swarm-report` for user check-in
 - **As needed**: Review `.ops-perl-lsp/agent-patches/`, apply improvements
 - **As needed**: Write Claude Code memories for cross-session knowledge
+- **When CI queue > 10**: Message all code-writing agents (builder-1, builder-2, reviewer, fixer, improver-tests) to pause PR creation and shift to planning/research
 
 ## Phase 4: Continuous Operation
 
-The full swarm — 12 teammates, all concurrent:
+The full swarm — 12 teammates, two lanes:
 
 ```
-DISCOVERY
-  scout-1, scout-2       → find gaps, write handoffs, TaskCreate
+DISCOVERY + PLANNING (no CI cost, run freely)
+  scout-1, scout-2    → find gaps, write handoffs, create tasks
+  strategist           → priority alignment, roadmap
+  researchers          → look up docs, verify approaches
 
-BUILD
-  builder-1, builder-2   → claim tasks, build in worktrees, message reviewer
+CODE + CI (throttled by merge pipeline)
+  builder-1, builder-2 → claim tasks, build in worktrees, create PRs
+  reviewer             → review diffs, create PRs
+  fixer                → fix CI failures
+  improver-tests       → add tests (creates PRs)
 
-REVIEW
-  reviewer               → review diffs, create PRs with labels, enable auto-merge
+REVIEW COMMENTS (low CI cost)
   pr-responder           → address review comments, push fixes
 
-MERGE
-  merger                 → merge PRs, update completed-slices, trigger validator
-  validator              → verify merges actually helped, catch regressions
+MERGE (sequential, no parallel)
+  merger                 → merge green PRs one at a time
+  validator              → verify merges helped
 
-IMPROVE (~20%)
-  improver-docs          → ADRs, changelog, friction log, README, roadmap
-  improver-tests         → mutants, flaky tests, coverage, deps, dead code
-
-GOVERNANCE
-  strategist             → priority alignment, roadmap updates, agent health
-  fixer                  → CI failures, regression fixes, known-pitfalls
+DOCS (low CI cost — doc-only PRs pass CI fast)
+  improver-docs        → ADRs, changelog, friction log
 ```
 
 ### Data flows


### PR DESCRIPTION
## Summary
- Add swarm-protocol section 11 defining two agent lanes: CI-bound (builders, fixers, improver-tests) throttled by merge pipeline throughput, and non-CI-bound (scouts, researchers, planners, strategists) that run freely with no throttle
- Update swarm.md Phase 4 Continuous Operation to show the two-lane structure with clear groupings (DISCOVERY + PLANNING, CODE + CI, REVIEW COMMENTS, MERGE, DOCS)
- Add Phase 3 rule: when CI queue > 10, message all code-writing agents to pause PR creation and shift to planning/research

## Agent
swarm-improve-infra subagent

## Verification
- No code changes — docs/commands only
- No CI required