### PR TITLE
fix(perl-lexer): recognize special punctuation variables $~, $^, $=, $%, $,, $", $;, $^W etc.

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1585,8 +1585,22 @@ impl<'a> PerlLexer<'a> {
                             }
                         }
                     }
+                    // Handle $^Letter (e.g. $^W, $^O, $^X) and bare $^ (format_top_name)
+                    // Not inside prototypes where ^ is a literal prototype char
+                    else if sigil == '$' && ch == '^' && !self.in_prototype {
+                        self.advance(); // consume ^
+                        // $^Letter: consume the single uppercase letter
+                        if let Some(letter) = self.current_char()
+                            && letter.is_ascii_uppercase()
+                        {
+                            self.advance();
+                        }
+                        // bare $^ (no uppercase letter follows): format_top_name — stop here
+                    }
                     // Handle special punctuation variables
+                    // Not inside prototypes where ; and , are literal prototype chars
                     else if sigil == '$'
+                        && !self.in_prototype
                         && matches!(
                             ch,
                             '?' | '!'
@@ -1602,6 +1616,13 @@ impl<'a> PerlLexer<'a> {
                                 | '-'
                                 | '['
                                 | ']'
+                                | '$'
+                                | '~'
+                                | '='
+                                | '%'
+                                | ','
+                                | '"'
+                                | ';'
                         )
                     {
                         self.advance(); // consume the special character

--- a/crates/perl-parser-core/tests/special_punct_variables_tests.rs
+++ b/crates/perl-parser-core/tests/special_punct_variables_tests.rs
@@ -1,0 +1,86 @@
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn parse_ok(src: &str) -> String {
+    let mut parser = Parser::new(src);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "parse should succeed without errors for: {src}\ngot: {sexp}");
+    sexp
+}
+
+#[test]
+fn format_name_var_assign() {
+    parse_ok("$~ = 'REPORT';");
+}
+
+#[test]
+fn format_name_var_read() {
+    let sexp = parse_ok("print $~;");
+    assert!(!sexp.contains("binary_^"), "binary_^ in sexp: {sexp}");
+}
+
+#[test]
+fn format_top_var_assign() {
+    parse_ok("$^ = 'REPORT_TOP';");
+}
+
+#[test]
+fn page_length_var_assign() {
+    parse_ok("$= = 60;");
+}
+
+#[test]
+fn page_number_var_assign() {
+    parse_ok("$% = 0;");
+}
+
+#[test]
+fn output_field_sep_assign() {
+    parse_ok(r#"$, = ", ";"#);
+}
+
+#[test]
+fn list_sep_assign() {
+    parse_ok(r#"$" = ":";"#);
+}
+
+#[test]
+fn subscript_sep_assign() {
+    parse_ok(r#"$; = "\034";"#);
+}
+
+#[test]
+fn caret_w_assign() {
+    let sexp = parse_ok("$^W = 1;");
+    assert!(!sexp.contains("binary_^"), "binary_^ in sexp: {sexp}");
+}
+
+#[test]
+fn caret_o_read() {
+    let sexp = parse_ok("my $os = $^O;");
+    assert!(!sexp.contains("binary_^"), "binary_^ in sexp: {sexp}");
+}
+
+#[test]
+fn caret_x_read() {
+    let sexp = parse_ok("my $perl = $^X;");
+    assert!(!sexp.contains("binary_^"), "binary_^ in sexp: {sexp}");
+}
+
+#[test]
+fn mixed_format_vars() {
+    parse_ok(
+        r#"
+$~ = 'REPORT';
+$^ = 'REPORT_TOP';
+$= = 60;
+write;
+"#,
+    );
+}
+
+#[test]
+fn prototype_semicolon_not_confused_with_special_var() {
+    parse_ok("sub foo($;@) {}");
+}


### PR DESCRIPTION
## Summary

- fix lexer support for special punctuation variables such as `$~`, `$^`, `$=`, `$%`, `$,`, `$"`, and `$;`
- correctly consume unbraced control variables in the `$^Letter` form such as `$^W`, `$^O`, and `$^X`
- preserve prototype parsing by keeping the special-variable path guarded by `!self.in_prototype`

## Files changed

- `crates/perl-lexer/src/lib.rs` — extend the special-variable matcher and handle `$^Letter`
- `crates/perl-parser-core/tests/special_punct_variables_tests.rs` — dedicated regression coverage for punctuation and control variables

## Verification

- `cargo test -p perl-parser-core --test special_punct_variables_tests` — 13/13 pass
- `cargo test -p perl-lexer --lib` — 9/9 pass
