### PR TITLE
feat: implement four-lane operating model (scout/preplan/build/control)

### DIFF
--- a/.ops-perl-lsp/ready/README.md
+++ b/.ops-perl-lsp/ready/README.md
@@ -1,0 +1,11 @@
+# Ready-to-Build Queue
+
+Work packets that have been scouted and preplanned, ready for a builder to claim when CI capacity is available.
+
+## Format
+Each file: `<branch-name>.md` containing:
+- Problem statement
+- Target files
+- Verification command
+- Suggested PR title
+- CI cost class: none | low | normal | heavy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,37 @@ cargo build -p perl-lsp --release
 cargo test --workspace --lib
 ```
 
+## Default Operating Mode
+
+The lead orchestrates. It does not do substantive implementation inline.
+
+Every task is classified before action:
+- **Scout**: read-only research, triage, issue analysis, docs — fan out aggressively
+- **Preplan**: branch-ready work packets — fan out aggressively
+- **Build**: code changes, commits, PR creation — gated by CI capacity
+- **Control**: CI monitoring, merge routing, green-master repair — narrow
+
+Scout and preplan agents may fan out widely — they cost context, not CI.
+Build agents are gated by active CI capacity, not by open PR count.
+If default branch is red, build capacity goes first to restoring green master.
+
+### Agent Spawn Patterns
+| Task | Lane | Pattern |
+|------|------|---------|
+| Research/explore | Scout | `Agent(subagent_type: "Explore", prompt: "...")` |
+| Plan implementation | Preplan | `Agent(subagent_type: "Plan", prompt: "...")` |
+| Code change | Build | `Agent(isolation: "worktree", prompt: "Goal/Crate/Files/Verify/Commit")` |
+| Parser fix | Build | `/parser-fix` skill |
+| CI monitoring | Control | `Bash(command: "gh run watch <id> --exit-status", run_in_background: true)` |
+| Full campaign | All | `/swarm all` |
+| Corpus check | Control | `/corpus-ratchet` |
+
+### CI Budget Rules
+- Throttle on active CI-producing actions (pushes), not open PR count
+- Use `gh run watch` in background instead of polling `gh pr checks`
+- When CI queue > 10: shift all capacity to scout/preplan
+- Keep a ready-to-build queue so CI slack gets consumed immediately
+
 ## Crate Structure
 
 The workspace contains **116 workspace members** across **121 crate directories** (see `Cargo.toml`), organized in dependency tiers. Key crates:


### PR DESCRIPTION
## Summary

- Adds `## Default Operating Mode` section to `CLAUDE.md` immediately after Quick Reference, encoding the four-lane model (Scout / Preplan / Build / Control) from cycle 1 feedback
- Provides agent spawn patterns table and CI budget rules so the orchestrator routes work by lane constraints, not a single global PR-count throttle
- Creates `.ops-perl-lsp/ready/README.md` to establish the preplan ready-to-build queue format (branch-name files with problem statement, target files, verification command, PR title, CI cost class)

## Motivation

Cycle 1 conflated context/model budget with CI/merge budget, causing artificial throttling. Scout and preplan agents cost context only; build agents are the only ones that consume CI runner capacity. Separating these budgets allows continuous read-only scouting while gating code-writing agents on actual CI saturation.

## Test plan

- [ ] Review `CLAUDE.md` diff — Default Operating Mode section appears between Quick Reference and Crate Structure
- [ ] Confirm `.ops-perl-lsp/ready/README.md` is present with correct format description
- [ ] No code changes — no compilation or test run needed