### PR TITLE
fix(perl-parser-core): push/pop with postfix deref lvalue and ->0* last-index

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -131,8 +131,11 @@ impl<'a> Parser<'a> {
 
         // AC1: General indirect method call heuristic: method $object
         // Lowercase identifier followed by a sigiled variable ($x, @arr, %hash)
-        if name.chars().next().is_some_and(|c| c.is_lowercase()) 
-           && !matches!(name, "tie" | "untie") 
+        //
+        // Array/list manipulation builtins never use indirect object syntax.
+        // `push $aref->@*, $x` has $aref as the first arg, not an indirect object.
+        if name.chars().next().is_some_and(|c| c.is_lowercase())
+            && !matches!(name, "tie" | "untie" | "push" | "pop" | "shift" | "unshift" | "splice")
         {
             if let Ok(next) = self.tokens.peek_second() {
                 let next_text = &next.text;
@@ -156,6 +159,11 @@ impl<'a> Parser<'a> {
                             third.kind,
                             TokenKind::RightBrace | TokenKind::RightParen | TokenKind::RightBracket
                         ) {
+                            return false;
+                        }
+                        // Arrow after $var means method/deref chain: func $obj->method(...)
+                        // That's a regular call with a complex first argument, not indirect object.
+                        if third.kind == TokenKind::Arrow {
                             return false;
                         }
                         return true;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -155,6 +155,26 @@ impl<'a> Parser<'a> {
                         }
 
                         Some(TokenKind::Identifier | TokenKind::Method) => {
+                            // Check for ->$#* (postfix last-index dereference, Perl 5.20+).
+                            // The lexer produces Identifier("$#") for `$#` when no array
+                            // name follows, so we handle it here before the method-call path.
+                            if self.tokens.peek().is_ok_and(|t| t.text.as_ref() == "$#") {
+                                if self.tokens.peek_second().is_ok_and(|t| t.kind == TokenKind::Star) {
+                                    self.tokens.next()?; // consume $#
+                                    self.tokens.next()?; // consume *
+                                    let start = expr.location.start;
+                                    let end = self.previous_position();
+                                    expr = Node::new(
+                                        NodeKind::Unary {
+                                            op: "->$#*".to_string(),
+                                            operand: Box::new(expr),
+                                        },
+                                        SourceLocation { start, end },
+                                    );
+                                    continue;
+                                }
+                            }
+
                             // Method call
                             let method = self.tokens.next()?.text.to_string();
 

--- a/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-parser-core/tests/comprehensive_unit_tests.rs
@@ -3991,3 +3991,78 @@ mod list_util_block_funcs {
         parse_ok("my @r = map { $_ * 2 } @arr;");
     }
 }
+
+// Regression tests for:
+//   1. push/pop/shift/unshift/splice with postfix-deref lvalue (e.g. push $aref->@*, $x)
+//   2. ->$#* (postfix last-index dereference, Perl 5.20+)
+//
+// Root causes fixed:
+//   1. The indirect-call heuristic was firing for push/pop/etc. when followed by $var->@*
+//      because those builtins were not excluded from the heuristic.
+//   2. ->$#* was mishandled: the lexer produces Identifier("$#") + Star, which the
+//      postfix handler was consuming as a method call with name "$#".
+#[cfg(test)]
+mod postfix_deref_regression {
+    use perl_parser_core::Parser;
+
+    fn parse_clean(src: &str) -> Result<(), String> {
+        let mut parser = Parser::new(src);
+        let ast = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+        let sexp = ast.to_sexp();
+        if sexp.contains("ERROR") {
+            return Err(format!("expected clean parse, got ERROR nodes in: {sexp}\nsource: {src}"));
+        }
+        Ok(())
+    }
+
+    // --- push/pop/shift/unshift with postfix deref ---
+
+    #[test]
+    fn push_postfix_array_deref() {
+        parse_clean("push $aref->@*, $x;").unwrap();
+    }
+
+    #[test]
+    fn push_deep_postfix_array_deref() {
+        parse_clean("push $h->{key}->@*, $val;").unwrap();
+    }
+
+    #[test]
+    fn unshift_postfix_array_deref() {
+        parse_clean("unshift $aref->@*, $x;").unwrap();
+    }
+
+    #[test]
+    fn push_normal_array_regression() {
+        // Plain push @array, $val must still work
+        parse_clean("push @array, $val;").unwrap();
+    }
+
+    #[test]
+    fn push_brace_array_regression() {
+        // push @{$ref}, $val must still work
+        parse_clean("push @{$ref}, $val;").unwrap();
+    }
+
+    // --- ->$#* last-index postfix dereference ---
+
+    #[test]
+    fn last_index_postfix_deref_simple() {
+        parse_clean("my $n = $aref->$#*;").unwrap();
+    }
+
+    #[test]
+    fn last_index_postfix_deref_in_for() {
+        parse_clean("for (my $i = 0; $i <= $aref->$#*; $i++) { }").unwrap();
+    }
+
+    #[test]
+    fn last_index_postfix_deref_arithmetic() {
+        parse_clean("my $len = $aref->$#* + 1;").unwrap();
+    }
+
+    #[test]
+    fn last_index_postfix_deref_on_hash_slot() {
+        parse_clean("my $n = $self->{data}->$#*;").unwrap();
+    }
+}


### PR DESCRIPTION
## Problem

Two parser bugs with Perl 5.20+ postfix dereference syntax:

### 1. `push $aref->@*, $x` fails

```perl
push $aref->@*, $item;           # ERROR
push $h->{key}->@*, $val;       # ERROR
unshift $aref->@*, $first;      # ERROR
```

Root cause: the indirect-call heuristic in `is_indirect_call_pattern()` fired
for `push`/`pop`/`shift`/`unshift`/`splice` because these names weren't
excluded. The heuristic consumed `$aref` as an indirect object and then
choked on the `->` that followed.

### 2. `$aref->$#*` fails

```perl
my $n = $aref->$#*;              # ERROR — postfix last-index deref
for (my $i=0; $i<=$aref->$#*; $i++) { }  # ERROR
```

Root cause: `->$#*` (equivalent to `$#{$aref}`) — the lexer produces
`Identifier("$#")` when `$#` has no array name after it. The postfix
Arrow handler matched this as a method name, consuming `$aref->$#` as
a method call, leaving `*;` unparseable.

## Fix

**Fix 1**: Added `push | pop | shift | unshift | splice` to the exclusion list
in `is_indirect_call_pattern()`. These builtins never use indirect object syntax.
Also added `TokenKind::Arrow` to the third-token guard — `func $obj->method()`
is never an indirect-object pattern.

**Fix 2**: Added a check in the `Identifier | Method` branch of the Arrow
postfix handler: if the identifier text is `"$#"` and the next token is `Star`,
emit a `->$#*` unary node instead of treating it as a method call.

## Tests

9 regression tests in `postfix_deref_regression` module:
- `push_postfix_array_deref` — `push $aref->@*, $x`
- `push_deep_postfix_array_deref` — `push $h->{key}->@*, $val`
- `unshift_postfix_array_deref` — `unshift $aref->@*, $x`
- `push_normal_array_regression` — `push @array, $val` (unchanged)
- `push_brace_array_regression` — `push @{$ref}, $val` (unchanged)
- `last_index_postfix_deref_simple` — `$aref->$#*`
- `last_index_postfix_deref_in_for` — C-style for loop with `$aref->$#*`
- `last_index_postfix_deref_arithmetic` — `$aref->$#* + 1`
- `last_index_postfix_deref_on_hash_slot` — `$self->{data}->$#*`

All 9 pass. 309 total tests pass. 1 pre-existing failure unrelated to this change.

## Corpus Impact

Fixes parse errors in ~25 system Perl files using `->$#*` or
`push $ref->@*` patterns (primarily in `Biber::*` namespace).