### PR TITLE
feat(swarm): add four-lane queue structure (scout/ready/blocked/merged)

### DIFF
--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -70,6 +70,13 @@ gh run list --json status --jq '[.[] | select(.status == "in_progress")] | lengt
 - In-progress slices: `grep "in-progress" .claude/swarm-state/completed-slices.md 2>/dev/null`
 - Discovered issues: `gh issue list --label swarm-discovered --state open`
 
+### Check ready queue
+```bash
+ls .claude/queues/ready/*.md 2>/dev/null | wc -l
+ls .claude/queues/scout/*.md 2>/dev/null | wc -l
+```
+Ready packets are pre-planned work. Builders should claim from ready/ before scouting new work.
+
 ### Resume or start fresh
 If there's pending work, prioritize it. Otherwise start fresh scouting.
 

--- a/.claude/queues/blocked/README.md
+++ b/.claude/queues/blocked/README.md
@@ -1,0 +1,3 @@
+# Blocked Queue
+Work packets that can't proceed due to dependencies, design decisions, or red CI.
+Move back to ready/ when unblocked.

--- a/.claude/queues/merged/README.md
+++ b/.claude/queues/merged/README.md
@@ -1,0 +1,3 @@
+# Merged Queue
+Completed work packets. Keep for dedup and retrospective analysis.
+Periodically archive old entries.

--- a/.claude/queues/ready/README.md
+++ b/.claude/queues/ready/README.md
@@ -1,0 +1,21 @@
+# Ready-to-Build Queue
+
+Branch-ready work packets. Builders pull from here when CI capacity is available.
+
+## Packet Format
+Each file: `<branch-name>.md`
+
+```yaml
+target: <crate or subsystem>
+files:
+  - <path/to/file1.rs>
+  - <path/to/file2.rs>
+verification: cargo fmt && cargo clippy -p <crate> --tests && cargo test -p <crate>
+pr_title: "<conventional commit title>"
+ci_cost: none | low | normal | heavy
+depends_on: []  # other packets or PRs that must land first
+risk: <low | medium | high>
+```
+
+## Body
+Problem statement, approach, test template, known pitfalls.

--- a/.claude/queues/scout/README.md
+++ b/.claude/queues/scout/README.md
@@ -1,0 +1,3 @@
+# Scout Queue
+Raw observations and investigation requests. Scouts pick up items here and produce ready packets.
+Files: `<topic>.md` with observation, source, and suggested investigation path.


### PR DESCRIPTION
## Summary

- Adds `.claude/queues/` with four lane directories: `scout/`, `ready/`, `blocked/`, `merged/`
- Each directory has a `README.md` defining the purpose and packet format for that lane
- Updates `.claude/commands/swarm.md` Phase 1 Bootstrap to check the ready queue depth before starting fresh scouting

## Test plan

- [ ] Verify all four `README.md` files are present under `.claude/queues/`
- [ ] Verify `swarm.md` Phase 1 Bootstrap contains the "Check ready queue" section after "Check for pending work"
- [ ] Confirm packet format in `ready/README.md` matches the specified YAML schema