### PR TITLE
fix(parser): map/grep/sort BLOCK LIST without trailing semicolon

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -575,12 +575,12 @@ impl<'a> Parser<'a> {
                             }
 
                             // Parse remaining arguments
-                            // For map/grep/sort/first/any/etc., parse list args without requiring commas
+                            // For block-list builtins, parse list arguments without requiring
+                            // commas. Use is_at_statement_end() so `map { ... } @arr` is
+                            // accepted as the last statement before a block close even without
+                            // a trailing semicolon.
                             if Self::is_block_list_func(func_name.as_ref()) {
-                                // Parse list arguments until statement boundary
-                                while !Self::is_statement_terminator(self.peek_kind())
-                                    && !self.is_statement_modifier_keyword()
-                                {
+                                while !self.is_at_statement_end() {
                                     // Skip optional comma or fat arrow
                                     if matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
                                         self.consume_token()?;

--- a/crates/perl-parser-core/tests/map_grep_sort_no_semicolon_tests.rs
+++ b/crates/perl-parser-core/tests/map_grep_sort_no_semicolon_tests.rs
@@ -1,0 +1,53 @@
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn parse_ok(src: &str) {
+    let mut parser = Parser::new(src);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "parse should succeed without errors for: {src}\ngot: {sexp}");
+}
+
+#[test]
+fn map_block_no_semicolon_in_if() {
+    parse_ok("if (1) { map { $_ * 2 } @arr }");
+}
+
+#[test]
+fn sort_block_no_semicolon_in_if() {
+    parse_ok("if (1) { sort { $a cmp $b } @arr }");
+}
+
+#[test]
+fn grep_block_no_semicolon_in_if() {
+    parse_ok(r#"if (1) { grep { /\d/ } @arr }"#);
+}
+
+#[test]
+fn map_block_no_semicolon_with_else() {
+    parse_ok(
+        r#"
+if (@_) {
+    map { $args{$_} = 1 } @_
+}
+else {
+    %args = ();
+}
+"#,
+    );
+}
+
+#[test]
+fn map_block_with_semicolon_regression() {
+    parse_ok("if (1) { map { $_ * 2 } @arr; }");
+}
+
+#[test]
+fn map_block_no_semicolon_in_sub() {
+    parse_ok("sub foo { map { uc $_ } @list }");
+}
+
+#[test]
+fn sort_block_no_semicolon_in_begin() {
+    parse_ok("BEGIN { sort { $a <=> $b } @nums }");
+}


### PR DESCRIPTION
## Summary

- allow `map { ... } @arr`, `grep { ... } @arr`, and `sort { ... } @arr` to end a block without a trailing semicolon
- stop the builtin-block-list argument loop at `is_at_statement_end()` so `}` and other statement boundaries terminate correctly
- preserve the existing semicolon-terminated forms as a regression case

## Files changed

- `crates/perl-parser-core/src/engine/parser/statements.rs` — use `is_at_statement_end()` in the builtin block-list path
- `crates/perl-parser-core/tests/map_grep_sort_no_semicolon_tests.rs` — dedicated regression coverage for block-ending forms

## Verification

- `cargo test -p perl-parser-core --test map_grep_sort_no_semicolon_tests` — 7/7 pass
- `cargo test -p perl-parser-core --lib` — 389 pass, 0 fail, 3 ignored
