### PR TITLE
docs: add subtree CLAUDE.md for parser-core, perl-lsp, perl-lexer

### DIFF
--- a/crates/perl-lexer/CLAUDE.md
+++ b/crates/perl-lexer/CLAUDE.md
@@ -1,114 +1,15 @@
-# CLAUDE.md
+# perl-lexer
 
-This file provides guidance to Claude Code when working with code in this repository.
+Context-aware tokenizer. Handles Perl's complex lexical grammar.
 
-## Crate Overview
+## Key Challenges
+- Context-sensitive tokenization (/ is divide or regex depending on context)
+- Special variables ($_, $!, $$, $^W, etc.)
+- Quote-like operators (q//, qq//, qw//, etc.)
 
-`perl-lexer` is a **Tier 1 leaf crate** providing context-aware tokenization for Perl source code.
-
-**Purpose**: Mode-based Perl lexer that disambiguates context-sensitive tokens (division vs regex, modulo vs hash sigil, heredocs, quote-like operators) and supports checkpointing for incremental parsing.
-
-**Version**: 0.10.0
-
-## Commands
-
+## Verify
 ```bash
-cargo build -p perl-lexer            # Build this crate
-cargo test -p perl-lexer             # Run tests
-cargo clippy -p perl-lexer           # Lint
-cargo doc -p perl-lexer --open       # View documentation
-cargo bench -p perl-lexer            # Run lexer benchmarks
-cargo test -p perl-lexer --features slow_tests  # Include slow stress tests
+cargo fmt --all
+cargo clippy -p perl-lexer --tests
+cargo test -p perl-lexer
 ```
-
-## Architecture
-
-### Dependencies
-
-- `perl-position-tracking` (workspace) - Line/column position tracking
-- `unicode-ident` - Unicode XID identifier validation
-- `memchr` - Fast byte scanning for delimiters
-- `thiserror` - Error type definitions
-
-### Key Types (public API)
-
-| Type | Module | Purpose |
-|------|--------|---------|
-| `PerlLexer<'a>` | `lib.rs` | Main lexer struct; call `next_token()` to iterate |
-| `Token` | `token.rs` | Token with `token_type`, `text`, `start`, `end` |
-| `TokenType` | `token.rs` | Enum of all token kinds (operators, keywords, literals, etc.) |
-| `StringPart` | `token.rs` | Parts of interpolated strings (Literal, Variable, Expression) |
-| `LexerMode` | `mode.rs` | ExpectTerm, ExpectOperator, ExpectDelimiter, InFormatBody, InDataSection |
-| `LexerConfig` | `lib.rs` | Configuration: `parse_interpolation`, `track_positions`, `max_lookahead` |
-| `LexerCheckpoint` | `checkpoint.rs` | Saved lexer state for backtracking |
-| `CheckpointCache` | `checkpoint.rs` | Cache of checkpoints for incremental parsing |
-| `Checkpointable` | `checkpoint.rs` | Trait: `checkpoint()`, `restore()`, `can_restore()` |
-| `LexerError` | `error.rs` | Error variants (UnterminatedString, UnterminatedRegex, etc.) |
-
-### Modules
-
-| File | Purpose |
-|------|---------|
-| `lib.rs` (~3K lines) | Main lexer: `PerlLexer`, mode transitions, all token-parsing methods |
-| `token.rs` | `Token`, `TokenType`, `StringPart` definitions |
-| `mode.rs` | `LexerMode` enum and context-sensitivity documentation |
-| `checkpoint.rs` | `LexerCheckpoint`, `CheckpointCache`, `Checkpointable` trait |
-| `quote_handler.rs` | Quote-operator helpers (delimiter pairing, modifier specs) |
-| `unicode.rs` | Unicode identifier classification (`is_perl_identifier_start/continue`) |
-| `error.rs` | `LexerError` enum and `Result` alias |
-
-### Budget Limits
-
-Guards against pathological input; emits `UnknownRest` token on overflow:
-
-- `MAX_REGEX_BYTES`: 64 KB
-- `MAX_HEREDOC_BYTES`: 256 KB
-- `MAX_DELIM_NEST`: 128 levels
-- `MAX_HEREDOC_DEPTH`: 100 levels
-- `HEREDOC_TIMEOUT_MS`: 5 seconds
-
-## Usage Examples
-
-### Basic tokenization
-
-```rust
-use perl_lexer::{PerlLexer, TokenType};
-
-let mut lexer = PerlLexer::new("my $x = 42;");
-while let Some(token) = lexer.next_token() {
-    if matches!(token.token_type, TokenType::EOF) { break; }
-    println!("{:?}: {}", token.token_type, token.text);
-}
-```
-
-### Custom configuration
-
-```rust
-use perl_lexer::{PerlLexer, LexerConfig};
-
-let config = LexerConfig {
-    parse_interpolation: true,
-    track_positions: true,
-    max_lookahead: 1024,
-};
-let mut lexer = PerlLexer::with_config("my $x = 1;", config);
-```
-
-### Checkpointing
-
-```rust
-use perl_lexer::{PerlLexer, Checkpointable};
-
-let mut lexer = PerlLexer::new("my $x = 1;");
-let cp = lexer.checkpoint();
-let _ = lexer.next_token();
-lexer.restore(&cp); // backtrack
-```
-
-## Important Notes
-
-- This crate is the foundation for `perl-parser` and the LSP stack; changes are high-impact
-- `lib.rs` is intentionally large (~3K lines) to keep hot paths in a single compilation unit
-- `quote_handler.rs` is `pub(crate)` only; modifier validation lives in the parser layer
-- Test thoroughly when modifying quote, heredoc, or mode-transition logic
-- The `simd` feature flag is defined but currently a no-op placeholder

--- a/crates/perl-lsp/CLAUDE.md
+++ b/crates/perl-lsp/CLAUDE.md
@@ -1,106 +1,20 @@
-# CLAUDE.md
+# perl-lsp
 
-## Crate Overview
+LSP server binary and integration tests.
 
-- **Name**: `perl-lsp`
-- **Version**: 0.10.0
-- **Tier**: 6 (executable / application crate)
-- **Purpose**: Standalone LSP server binary and library for Perl. Provides the `perl-lsp` binary (stdio and TCP modes) and a public library API (`LspServer`, `run_stdio()`, JSON-RPC types). Delegates parsing to `perl-parser` and dispatches LSP features through dedicated provider crates.
-
-## Commands
-
+## Test Threading
+ALWAYS use threading constraints:
 ```bash
-cargo build -p perl-lsp                   # Build (debug)
-cargo build -p perl-lsp --release         # Build (release)
-cargo install --path crates/perl-lsp      # Install binary
-cargo test -p perl-lsp                    # Run tests
-RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2  # Tests with threading limits
-cargo clippy -p perl-lsp                  # Lint
-cargo doc -p perl-lsp --open              # View docs
-
-# Run the server
-./target/release/perl-lsp --stdio         # stdio mode (editor integration)
-./target/release/perl-lsp --socket --port 9257  # TCP mode
-./target/release/perl-lsp --health        # Health check
-./target/release/perl-lsp --version       # Version info
-./target/release/perl-lsp --features-json # Feature catalog as JSON
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 ```
 
-## Architecture
+## After Async Migration
+- LspServer no longer needs &mut self — use `let server` not `let mut server`
+- Test harness uses interior mutability (Arc<Mutex>)
 
-### Dependencies
-
-**Workspace crates** (core):
-- `perl-parser` (with `test-performance` feature) -- parsing engine
-- `perl-lsp-providers` (with `lsp-compat`) -- provider aggregation
-- `perl-lsp-protocol` -- JSON-RPC / LSP message types
-- `perl-lsp-transport` -- message framing (stdio, TCP)
-- `perl-lsp-formatting` -- perltidy integration
-- `perl-lsp-tooling` -- external tool support
-
-**Workspace crates** (feature providers):
-- `perl-lsp-completion`, `perl-lsp-navigation`, `perl-lsp-diagnostics`
-- `perl-lsp-code-actions`, `perl-lsp-rename`, `perl-lsp-semantic-tokens`, `perl-lsp-inlay-hints`
-
-**External**: `lsp-types`, `serde`, `serde_json`, `tokio`, `ropey`, `parking_lot`, `anyhow`, `walkdir`, `regex`, `url`, `md5`, `once_cell`
-
-### Key Types and Modules
-
-| Module | Purpose |
-|--------|---------|
-| `main.rs` | Binary entry point: arg parsing, stdio/TCP dispatch |
-| `lib.rs` | Library root: public re-exports (`LspServer`, `run_stdio`, JSON-RPC types), crate-internal compatibility re-exports |
-| `server.rs` | Re-exports `LspServer` from `runtime` |
-| `runtime/` | Server lifecycle, message routing (`routing.rs`), text sync (`text_sync.rs`), diagnostics, file discovery, window messages |
-| `state/` | Server state: `config.rs` (settings), `document.rs` (open documents), `limits.rs` (resource budgets) |
-| `dispatch.rs` | Request/notification routing to handlers |
-| `handlers/` | Request and notification handler implementations |
-| `features/` | All LSP capability implementations: completion, diagnostics, hover, references, rename, formatting, semantic tokens, code actions, code lens, inlay hints, folding, selection range, signature help, type hierarchy, document links, linked editing |
-| `protocol/` | JSON-RPC message types (`JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`) |
-| `transport/` | Transport layer integration |
-| `convert/` | Conversions between `perl_parser` types and `lsp_types` |
-| `util/uri.rs` | URI conversion (contains the sole `#[allow(clippy::expect_used)]`) |
-| `fallback/` | Text-based fallback when parsing fails |
-| `cancellation.rs` | Request cancellation infrastructure |
-| `security/` | Sandbox and input validation |
-| `diagnostics_catalog.rs` | Stable diagnostic codes |
-| `execute_command.rs` | LSP command execution |
-| `call_hierarchy_provider.rs` | Call hierarchy support |
-
-### Features (Cargo)
-
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `workspace` | yes | Workspace-wide indexing for cross-file features |
-| `incremental` | no | Incremental parsing (`perl-parser/incremental`) |
-| `dap-phase1` | no | Debug Adapter Protocol bridge (`perl-dap`) |
-| `lsp-ga-lock` | no | Lock to conservative GA capability set |
-| `experimental-features` | no | Experimental LSP features |
-
-## Usage Examples
-
-```rust
-// Library: run LSP server on stdio
-perl_lsp::run_stdio().unwrap();
-
-// Library: create server with custom output
-use perl_lsp::LspServer;
-let mut server = LspServer::new();
-server.run().unwrap();
-```
-
+## Verify
 ```bash
-# Binary: editor integration
-perl-lsp --stdio
-
-# Binary: TCP for remote debugging
-perl-lsp --socket --port 9257
+cargo fmt --all
+cargo clippy -p perl-lsp --tests
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 ```
-
-## Important Notes
-
-- This is the user-facing binary -- stability is critical.
-- `util/uri.rs` has the single allowed `#[allow(clippy::expect_used)]` for `lsp_types::Uri` fallback.
-- Tests should use threading constraints (`RUST_TEST_THREADS=2`) to avoid resource exhaustion.
-- The `features.toml` in the workspace root is the canonical source for LSP capability definitions.
-- The crate re-exports many `perl_parser` modules internally (`pub(crate)`) for migration compatibility; these are not part of the public API.

--- a/crates/perl-parser-core/CLAUDE.md
+++ b/crates/perl-parser-core/CLAUDE.md
@@ -1,72 +1,33 @@
-# CLAUDE.md
+# perl-parser-core
 
-## Crate Overview
+Recursive descent parser engine. Most parser fixes happen here.
 
-- **Name**: `perl-parser-core`
-- **Version**: 0.10.0
-- **Tier**: 2 (aggregates Tier 1 leaf crates into the core parsing engine)
-- **Purpose**: Recursive descent parser with IDE-friendly error recovery, AST construction, token stream utilities, and UTF-8/UTF-16 position mapping. Used by `perl-parser` and higher-level analysis/LSP crates.
+## Test Pattern
+- Add tests in a NEW file under `tests/` (e.g., `tests/fix_undef_list.rs`), not in cpan_pattern_tests.rs
+- This prevents merge conflicts when multiple agents add tests simultaneously
+- Test template:
+  ```rust
+  use perl_parser_core::parse;
 
-## Commands
+  #[test]
+  fn test_<description>() -> Result<(), Box<dyn std::error::Error>> {
+      let source = r#"<perl code>"#;
+      let result = parse(source);
+      assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+      Ok(())
+  }
+  ```
 
+## Verify
 ```bash
-cargo build -p perl-parser-core            # Build
-cargo test -p perl-parser-core             # Run tests
-cargo clippy -p perl-parser-core           # Lint
-cargo doc -p perl-parser-core --open       # View docs
+cargo fmt --all
+cargo clippy -p perl-parser-core --tests
+cargo test -p perl-parser-core
 ```
 
-## Architecture
-
-### Dependencies (all workspace Tier 1 crates)
-
-`perl-lexer`, `perl-token`, `perl-ast`, `perl-error`, `perl-position-tracking`, `perl-quote`, `perl-pragma`, `perl-edit`, `perl-builtins`, `perl-regex`, `perl-heredoc`, `perl-tokenizer`
-
-### Key Types and Modules
-
-| Type / Module | Location | Purpose |
-|---------------|----------|---------|
-| `Parser` | `engine/parser/mod.rs` | Main recursive descent parser with `parse()` and `parse_with_recovery()` |
-| `ParserContext` | `engine/parser_context.rs` | Token-level context with budget-controlled error recovery |
-| `RecoveryParser` | `engine/error/recovery_parser.rs` | Error-tolerant parser producing partial ASTs with error nodes |
-| `Node`, `NodeKind`, `SourceLocation` | `engine/ast.rs` (re-exports `perl-ast`) | AST node types |
-| `TokenStream`, `Token`, `TokenKind` | `tokens/token_stream.rs` (re-exports `perl-tokenizer`) | Buffered token stream with lookahead |
-| `ParseError`, `ParseOutput`, `ParseResult` | `engine/error/mod.rs` (re-exports `perl-error`) | Error types and result wrappers |
-| `PositionMapper`, `LineIndex` | `engine/position/mod.rs` (re-exports `perl-position-tracking`) | UTF-8/UTF-16 position conversion |
-| `Trivia`, `TriviaPreservingParser` | `tokens/mod.rs` (re-exports `perl-tokenizer`) | Whitespace/comment preservation |
-| `BudgetTracker`, `ParseBudget` | via `perl-error` | Resource limits for error recovery |
-
-### Module Layout
-
-- `lib.rs` -- public API surface, re-exports from submodules
-- `engine/` -- parser logic: `parser/` (recursive descent + helpers via `include!`), `error/` (recovery), `ast.rs`, `parser_context.rs`, `position/`
-- `tokens/` -- token stream and trivia facades over `perl-tokenizer`
-
-### Parser Design
-
-The parser in `engine/parser/mod.rs` uses `include!` macros to compose parsing logic from separate files: `helpers.rs`, `heredoc.rs`, `statements.rs`, `variables.rs`, `control_flow.rs`, `declarations.rs`, and `expressions/*.rs`. All included files are compiled as part of the `Parser` impl block.
-
-Error recovery returns `Ok(ast)` with ERROR nodes for most failures; `Err` is reserved for catastrophic conditions (recursion limit). This enables IDE features on incomplete code.
-
-## Usage Examples
-
-```rust
-use perl_parser_core::Parser;
-
-// Basic parse
-let mut parser = Parser::new("my $x = 42;");
-let ast = parser.parse()?;
-
-// Parse with recovery (preferred for LSP)
-let mut parser = Parser::new("my $x = ;");
-let output = parser.parse_with_recovery();
-// output.ast always available; output.diagnostics contains errors
-```
-
-## Important Notes
-
-- Prefer `perl-parser` for end-user usage; this crate is the internal engine
-- `Parser` struct has a recursion depth limit of 128 to prevent stack overflow
-- `ParserContext` uses `ParseBudget` to cap errors and nesting depth
-- Changes to this crate affect all higher-level crates in the workspace
-- Doctests are disabled (`doctest = false` in Cargo.toml)
+## Key Files
+- `src/engine/parser/` — main parsing logic
+- `src/engine/parser/expressions.rs` — expression parsing
+- `src/engine/parser/statements.rs` — statement parsing
+- `src/engine/parser/declarations.rs` — use/my/sub declarations
+- `src/engine/parser/control_flow.rs` — if/while/for/etc


### PR DESCRIPTION
## Summary

- Replace verbose architecture docs with agent-focused quick-reference CLAUDE.md files for the three most-edited crate families
- `crates/perl-parser-core/CLAUDE.md`: test pattern guidance (new file per fix, not cpan_pattern_tests.rs), verify commands, key source paths
- `crates/perl-lsp/CLAUDE.md`: threading constraint reminder, async migration note, verify commands
- `crates/perl-lexer/CLAUDE.md`: key challenge callouts (context-sensitive tokenization, quote-like ops), verify commands

## Test plan

- [ ] Verify the three CLAUDE.md files render correctly on GitHub
- [ ] Confirm `cargo test -p perl-parser-core`, `cargo test -p perl-lsp`, `cargo test -p perl-lexer` all pass (no regressions — docs only change)