### PR TITLE
fix(parser): nullary builtins (shift/pop) consume array arg inside paren expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -443,6 +443,28 @@ impl<'a> Parser<'a> {
                         } else if self.peek_kind() == Some(TokenKind::FatArrow) {
                             // Identifier before => is a hash key — do NOT treat as
                             // a builtin function call.  Fall through to break.
+                        } else if Self::is_nullary_builtin(name) {
+                            // Nullary builtins (shift, pop, caller, wantarray, etc.) can also
+                            // take an explicit sigil-starting argument, e.g. `shift @arr`.
+                            let next_is_sigil_arg = self.tokens.peek().ok().is_some_and(|t| {
+                                t.text.starts_with('@')
+                                    || t.text.starts_with('$')
+                                    || t.text.starts_with('%')
+                            });
+                            let args = if next_is_sigil_arg && !self.is_at_statement_end() {
+                                vec![self.parse_ternary()?]
+                            } else {
+                                vec![]
+                            };
+                            let start = expr.location.start;
+                            let end = args
+                                .last()
+                                .map(|arg: &Node| arg.location.end)
+                                .unwrap_or(expr.location.end);
+                            expr = Node::new(
+                                NodeKind::FunctionCall { name: name.clone(), args },
+                                SourceLocation { start, end },
+                            );
                         } else if Self::is_builtin_function(name) {
                             // In call argument lists, `builtin => value` should keep the lhs as a
                             // bareword key so parse_args can auto-quote it for fat-comma pairs.

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -490,6 +490,11 @@ impl<'a> Parser<'a> {
                 let start_token = self.tokens.next()?; // consume (
                 let start = start_token.start;
 
+                // Inside parentheses we are no longer at statement start.
+                // This prevents the indirect-call heuristic from firing on
+                // builtins like `shift`/`pop` inside `(shift @arr)->method()`.
+                self.mark_not_stmt_start();
+
                 // Check for empty list
                 if self.peek_kind() == Some(TokenKind::RightParen) {
                     let end_token = self.tokens.next()?;

--- a/crates/perl-parser-core/tests/paren_expr_stmt_start_tests.rs
+++ b/crates/perl-parser-core/tests/paren_expr_stmt_start_tests.rs
@@ -1,0 +1,50 @@
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn parse_ok(src: &str) -> String {
+    let mut parser = Parser::new(src);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "parse should succeed without errors for: {src}\ngot: {sexp}");
+    sexp
+}
+
+#[test]
+fn shift_in_parens_hash_deref() {
+    parse_ok("my $x = (shift @arr)->{'key'};");
+}
+
+#[test]
+fn shift_in_parens_method_call() {
+    parse_ok("my $x = (shift @arr)->method();");
+}
+
+#[test]
+fn pop_in_parens_deref() {
+    parse_ok("my $x = (pop @stack)->{'field'};");
+}
+
+#[test]
+fn assignment_shift_in_parens_deref() {
+    parse_ok("my $x = ($obj = shift @to_do)->{'_tag'};");
+}
+
+#[test]
+fn nested_paren_assignment_deref() {
+    parse_ok("if (($ptag = ($this = shift @to_do)->{'_tag'}) eq 'pre') { 1; }");
+}
+
+#[test]
+fn simple_paren_expr() {
+    parse_ok("my $x = ($a + $b);");
+}
+
+#[test]
+fn paren_list() {
+    parse_ok("my @x = (1, 2, 3);");
+}
+
+#[test]
+fn paren_with_shift_no_deref() {
+    parse_ok("my $x = shift @arr;");
+}


### PR DESCRIPTION
## Summary

- fix `(shift @arr)->...` and `(pop @stack)->...` inside parenthesized expressions
- clear statement-start context after `(` so indirect-call heuristics do not fire inside parenthesized expressions
- teach the postfix parser to consume one explicit sigil argument for nullary builtins before the deref chain continues

## Files changed

- `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` — mark parenthesized expressions as non-statement-start context
- `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` — consume one explicit sigil argument for nullary builtins in expression context
- `crates/perl-parser-core/tests/paren_expr_stmt_start_tests.rs` — dedicated regression coverage for the parenthesized forms

## Verification

- `cargo test -p perl-parser-core --test paren_expr_stmt_start_tests` — 8/8 pass
- `cargo test -p perl-parser-core --lib` — 389 pass, 0 fail, 3 ignored
