### PR TITLE
chore(tree-sitter-perl-c): remove 4 unused dependencies

### DIFF
--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -15,11 +15,6 @@ categories = ["parsing", "text-processing"]
 
 [dependencies]
 tree-sitter = "0.26.6"
-serde = { version = "1.0.228", features = ["derive"] }
-# bincode removed - (bincode is deprecated)
-proptest = "1.9.0"
-walkdir = "2.5.0"
-thiserror = "2.0.17"
 
 [dev-dependencies]
 criterion = "0.8.1"


### PR DESCRIPTION
## Summary

- Remove 4 unused dependencies from `tree-sitter-perl-c`: `proptest`, `serde`, `thiserror`, `walkdir`
- Detected by `cargo-machete`; confirmed none are referenced in `lib.rs` or `bin/*.rs`
- This crate is excluded from the default workspace (requires libclang/bindgen), so verification was done via source inspection

## Test plan

- [ ] `cargo-machete` no longer reports these deps for `tree-sitter-perl-c`
- [ ] Crate still builds when libclang is available (bindgen requirement unchanged)