### PR TITLE
docs: update version references for 0.12.0 public alpha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code when working with code in this repository.
 
-**Latest Release**: 0.10.0
+**Latest Release**: 0.12.0
 **API Stability**: See [docs/reference/STABILITY.md](docs/reference/STABILITY.md)
 **Metrics**: See [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for computed status
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ---
 
+> **Note**: perl-lsp is in public alpha. Core features work well, but expect some rough edges. [Report issues](https://github.com/EffortlessMetrics/perl-lsp/issues).
+
 ## Quick Start
 
 ```bash
@@ -198,6 +200,7 @@ See [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) for details
 | [features.toml](features.toml) | Canonical LSP feature catalog |
 | [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) | Live project metrics |
 | [ROADMAP.md](ROADMAP.md) | Version milestones and planning |
+| [Getting Started](docs/tutorials/GETTING_STARTED.md) | Installation and first steps |
 | [Stability Policy](docs/reference/STABILITY.md) | API versioning and compatibility |
 | [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) | Debugger setup and usage |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -29,7 +29,7 @@ If you've found a bug or have a feature request, please search the [existing iss
 
 ## Service Level Agreement (SLA)
 
-As a v0.9.x alpha release, we target the following response times for issues:
+As a v0.12.x public alpha release, we target the following response times for issues:
 
 | Priority | Response Time | Fix Time (Target) |
 |----------|---------------|-------------------|
@@ -46,9 +46,9 @@ We only provide active support for the current major version and the immediate p
 
 | Version | Status | Support Level |
 |---------|--------|---------------|
-| **0.9.x** | **Current** | Full Support (Bug fixes + Security) |
-| **0.9.x** | Maintenance | Security Patches Only |
-| **< 0.9** | End of Life | No Support |
+| **0.12.x** | **Current** | Full Support (Bug fixes + Security) |
+| **0.11.x** | Maintenance | Security Patches Only |
+| **< 0.11** | End of Life | No Support |
 
 ## Community
 
@@ -59,4 +59,4 @@ Join our community to stay updated and connect with other users:
 
 ---
 
-**Last Updated**: 2026-02-20
+**Last Updated**: 2026-03-16

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 # Perl LSP Documentation
 
-Documentation for Perl LSP v0.10.0 — a Language Server Protocol implementation for Perl.
+Documentation for Perl LSP v0.12.0 — a Language Server Protocol implementation for Perl.
 
 ## Repository snapshot
 
-- Workspace version: **v0.10.0**
+- Workspace version: **v0.12.0**
 - Workspace members: **112 crates**
 - Family counts (from `crates/`):
   - `perl-module-*`: 13
@@ -132,4 +132,4 @@ nix develop -c just status-check  # Verify metrics haven't drifted
 
 ---
 
-Version: v0.10.0
+Version: v0.12.0

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Canonical**: This is the authoritative roadmap. See `CURRENT_STATUS.md` for computed metrics.
 > **Stale roadmaps**: Archived at `docs/archive/roadmaps/`; retrieve from git history if needed.
 
-> **Status (2026-03-11)**: **Public Alpha (v0.11.0)**. Release preparation (crates.io, VS Code marketplace) and documentation alignment underway.
+> **Status (2026-03-16)**: **Public Alpha (v0.12.0)**. Release preparation (crates.io, VS Code marketplace) and documentation alignment underway.
 >
 > **Canonical receipt**: `nix develop -c just ci-gate` must be green before merging.
 > **CI** is intentionally optional/opt-in; the repo is local-first by design.
@@ -12,11 +12,11 @@
 
 ## Alpha Disclaimer
 
-Perl LSP is currently in **Public Alpha**. Version 0.11.0 represents a substantially complete feature set, but APIs and protocols are still evolving. We value early adopter feedback to refine the project toward the v0.15.0 Stability Contract milestone.
+Perl LSP is currently in **Public Alpha**. Version 0.12.0 represents a substantially complete feature set, but APIs and protocols are still evolving. We value early adopter feedback to refine the project toward the v0.15.0 Stability Contract milestone.
 
 ---
 
-## Current State (v0.11.0)
+## Current State (v0.12.0)
 
 | Component | Release Stance | Evidence | Notes |
 |-----------|----------------|----------|-------|
@@ -42,7 +42,7 @@ Perl LSP is currently in **Public Alpha**. Version 0.11.0 represents a substanti
 - Merge and ratchet parser coverage baseline
 - Keep close-out receipts green (`just ci-gate`)
 
-**Next (v0.11.0)**
+**Next (v0.12.0)**
 - Complete Moo/Moose/Class::Accessor attribute resolution (foundation: `requires` tracking and multi-attribute `has` landed in PR #946)
 - Cross-file type inference via `use parent`/`use base`
 - Native DAP enhancements (variables/evaluate)
@@ -65,12 +65,12 @@ For current metrics (LSP coverage %, corpus counts, test pass rates), see [CURRE
 
 | Crate | Version | Status | Purpose |
 |-------|---------|--------|----------|
-| **perl-parser** | v0.11.0 | Public Alpha | Main parser library |
-| **perl-lsp** | v0.11.0 | Public Alpha | LSP server |
-| **perl-lexer** | v0.11.0 | Public Alpha | Context-aware tokenizer |
-| **perl-corpus** | v0.11.0 | Public Alpha | Test corpus |
-| **perl-dap** | v0.11.0 | Preview (Native + Bridge) | Debug Adapter Protocol |
-| **perl-parser-pest** | v0.11.0 | Legacy | Pest-based parser (maintained) |
+| **perl-parser** | v0.12.0 | Public Alpha | Main parser library |
+| **perl-lsp** | v0.12.0 | Public Alpha | LSP server |
+| **perl-lexer** | v0.12.0 | Public Alpha | Context-aware tokenizer |
+| **perl-corpus** | v0.12.0 | Public Alpha | Test corpus |
+| **perl-dap** | v0.12.0 | Preview (Native + Bridge) | Debug Adapter Protocol |
+| **perl-parser-pest** | v0.12.0 | Legacy | Pest-based parser (maintained) |
 
 ---
 
@@ -137,7 +137,7 @@ See [`CURRENT_STATUS.md`](CURRENT_STATUS.md) for detailed completion history.
 - **[features.toml](../features.toml)** - Canonical capability definitions
 - **[LESSONS.md](LESSONS.md)** - Project learnings
 
-<!-- Last Updated: 2026-03-11 -->
+<!-- Last Updated: 2026-03-16 -->
 
 ## Detailed Forward-Looking Roadmap
 

--- a/docs/project/WORKSPACE_ARCHITECTURE.md
+++ b/docs/project/WORKSPACE_ARCHITECTURE.md
@@ -460,7 +460,7 @@ confirms every crate at the correct version is visible on crates.io.
 The entire publish pipeline has a 120-minute timeout, accounting for
 crates.io index propagation delays across 111 crates.
 
-All crates share a single version (`0.10.0` as of this writing), managed
+All crates share a single version (`0.12.0` as of this writing), managed
 through workspace inheritance. The `workspace.package.version` field in the
 root Cargo.toml is the single source of truth, and `cargo xtask bump-version`
 updates all references in Cargo.toml files, package.json, README, and source

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -41,7 +41,7 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.10.0
+# Should output: ok 0.12.0
 ```
 
 ## Quick Editor Setup


### PR DESCRIPTION
## Summary

- Update stale version references (0.9.x, 0.10.0, 0.11.0) to 0.12.0 across 7 documentation files
- Add public alpha notice to README.md (after badges, before Quick Start)
- Add Getting Started guide link to README.md documentation table
- Update SUPPORT.md supported versions table to reflect 0.12.x as current, 0.11.x as maintenance

### Files changed

| File | Changes |
|------|---------|
| `CLAUDE.md` | Latest Release 0.10.0 -> 0.12.0 |
| `README.md` | Public alpha note + Getting Started link |
| `SUPPORT.md` | 0.9.x -> 0.12.x, version table, date |
| `docs/README.md` | 0.10.0 -> 0.12.0 (3 locations) |
| `docs/tutorials/GETTING_STARTED.md` | Health check example version |
| `docs/project/ROADMAP.md` | Status, disclaimer, component table, dates |
| `docs/project/WORKSPACE_ARCHITECTURE.md` | Prose version reference |

Historical references (ADRs, CODEBASE_CURIOSITIES, GA_RUNBOOK, ROADMAP milestone headings) are intentionally preserved.

## Test plan

- [ ] Verify no stale 0.9.x/0.10.0/0.11.0 version references remain in updated files
- [ ] Confirm historical/milestone references are preserved correctly
- [ ] Verify README public alpha note renders correctly
- [ ] Verify Getting Started link in README documentation table works