### PR TITLE
chore(lsp): add missing_docs enforcement to LSP provider crates

### DIFF
--- a/crates/perl-lsp-cancellation/src/lib.rs
+++ b/crates/perl-lsp-cancellation/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Enhanced LSP cancellation infrastructure with thread-safe atomic operations
 //!
 //! This module provides comprehensive cancellation support for Perl LSP operations,

--- a/crates/perl-lsp-capability-map/src/lib.rs
+++ b/crates/perl-lsp-capability-map/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! LSP capability/feature translation helpers.
 //!
 //! This microcrate owns one responsibility: map between

--- a/crates/perl-lsp-completion-item/src/lib.rs
+++ b/crates/perl-lsp-completion-item/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Completion item domain types and sorting utilities.
 //!
 //! This microcrate isolates completion payload representation and deterministic

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Configuration models for perl-lsp server runtime state.
 //!
 //! This microcrate isolates configuration parsing and defaults from the main

--- a/crates/perl-lsp-feature-contracts/src/lib.rs
+++ b/crates/perl-lsp-feature-contracts/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Shared feature contracts for profile parsing, BDD-grid rows, and capability mapping.
 //!
 //! This crate defines the canonical [`FeatureProfileKind`] enum and associated
@@ -112,7 +113,8 @@ pub const fn feature_profile_specs() -> &'static [FeatureProfileSpec] {
     FEATURE_PROFILE_SPECS
 }
 
-#[allow(dead_code, clippy::all)]
+/// Auto-generated feature catalog from `features.toml`.
+#[allow(dead_code, clippy::all, missing_docs)]
 pub mod catalog {
     include!(concat!(env!("OUT_DIR"), "/feature_contracts.rs"));
 }
@@ -120,13 +122,21 @@ pub mod catalog {
 /// Human-readable BDD-oriented feature row for automation and reporting.
 #[derive(Debug, Clone, Serialize)]
 pub struct BddFeatureRow {
+    /// Canonical feature identifier (e.g., `lsp.completion`).
     pub id: &'static str,
+    /// LSP specification section this feature implements.
     pub spec: &'static str,
+    /// Feature area grouping (e.g., `text_document`, `workspace`).
     pub area: &'static str,
+    /// Maturity level: `ga`, `beta`, `alpha`, or `planned`.
     pub maturity: &'static str,
+    /// Whether this feature is advertised to clients.
     pub advertised: bool,
+    /// Whether this feature counts toward compliance percentage.
     pub counts_in_coverage: bool,
+    /// Short human-readable description of the feature.
     pub description: &'static str,
+    /// Test identifiers that verify this feature.
     pub tests: &'static [&'static str],
 }
 

--- a/crates/perl-lsp-feature-flags/src/lib.rs
+++ b/crates/perl-lsp-feature-flags/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Shared feature flag types for LSP profile-driven capability selection.
 //!
 //! The `BuildFlags` shape is the single source of truth for runtime-constructed

--- a/crates/perl-lsp-feature-governance/src/lib.rs
+++ b/crates/perl-lsp-feature-governance/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Feature governance façade for Perl LSP.
 //!
 //! This crate consolidates profile policy and BDD-grid reporting APIs into a

--- a/crates/perl-lsp-feature-grid/src/lib.rs
+++ b/crates/perl-lsp-feature-grid/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! BDD grid and feature-profile interoperability primitives.
 //!
 //! This crate intentionally contains only compatibility and reporting logic used by

--- a/crates/perl-lsp-feature-ids/src/lib.rs
+++ b/crates/perl-lsp-feature-ids/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Canonical feature identifiers shared across feature-flagging and BDD-grid layers.
 //!
 //! The constants in this crate are stable across feature-profiles and provide a

--- a/crates/perl-lsp-feature-policy/src/lib.rs
+++ b/crates/perl-lsp-feature-policy/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! LSP feature policy and capability profile helpers.
 //!
 //! This microcrate centralizes capability set selection, turning high-level profile

--- a/crates/perl-lsp-feature-profile-cli/src/lib.rs
+++ b/crates/perl-lsp-feature-profile-cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! CLI profile-token parsing for Perl LSP feature governance.
 //!
 //! This microcrate owns one responsibility: parse user-facing profile tokens

--- a/crates/perl-lsp-feature-profile/src/lib.rs
+++ b/crates/perl-lsp-feature-profile/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Canonical feature profile definitions used by runtime profile selection, CLI parsing,
 //! and downstream reporting tools.
 //!

--- a/crates/perl-lsp-folding/src/lib.rs
+++ b/crates/perl-lsp-folding/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Folding range extraction for LSP textDocument/foldingRange
 //!
 //! This module provides folding range extraction from the Perl AST,

--- a/crates/perl-lsp-import-management/src/lib.rs
+++ b/crates/perl-lsp-import-management/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Perl import-management helpers for LSP code actions.
 //!
 //! This crate intentionally focuses on a single responsibility:

--- a/crates/perl-lsp-input-validation/src/lib.rs
+++ b/crates/perl-lsp-input-validation/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Input validation and sanitization utilities for production hardening.
 
 use anyhow::{Result, anyhow};

--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! CLI and startup configuration primitives for the Perl LSP binary.
 //!
 //! This crate extracts the runtime launch decision surface into a dedicated crate so
@@ -49,6 +50,7 @@ impl TransportArgs {
 #[derive(Parser, Debug, Clone)]
 #[command(name = "perl-lsp", version, about = "Perl Language Server", long_about = None)]
 pub struct LspArgs {
+    /// Transport configuration (stdio or socket).
     #[command(flatten)]
     pub transport: TransportArgs,
 

--- a/crates/perl-lsp-limits/src/lib.rs
+++ b/crates/perl-lsp-limits/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Central configuration for LSP operation limits and bounded behavior
 //!
 //! This module provides a single source of truth for all resource limits,

--- a/crates/perl-lsp-on-type-formatting/src/lib.rs
+++ b/crates/perl-lsp-on-type-formatting/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! On-type formatting provider for Perl LSP.
 //!
 //! Provides automatic indentation and formatting when typing trigger characters

--- a/crates/perl-lsp-performance/src/lib.rs
+++ b/crates/perl-lsp-performance/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Performance optimizations for large projects.
 //!
 //! This module is designed for large workspace scaling, including repositories

--- a/crates/perl-lsp-text-utils/src/lib.rs
+++ b/crates/perl-lsp-text-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Text helpers for code-action style source edits.
 
 /// Helper wrapper for source text and pre-split lines.

--- a/crates/perl-lsp-uri/src/lib.rs
+++ b/crates/perl-lsp-uri/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Typed URI parsing helpers for LSP components.
 
 use lsp_types::Uri;

--- a/crates/perl-lsp-workspace-symbols/src/lib.rs
+++ b/crates/perl-lsp-workspace-symbols/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Workspace symbols provider for LSP with comprehensive Perl symbol support.
 //!
 //! Provides workspace/symbol functionality for searching symbols across all files


### PR DESCRIPTION
## Summary

- Add `#![warn(missing_docs)]` to 22 `perl-lsp-*` crates that lacked it
- Add doc comments to `BddFeatureRow` fields in `perl-lsp-feature-contracts` and `LspArgs.transport` in `perl-lsp-launcher` to satisfy the new lint
- Add `#[allow(missing_docs)]` to the auto-generated `catalog` module in `perl-lsp-feature-contracts` (contents generated from `features.toml`)

This is a quick win for public alpha quality: any future public API additions to these crates will trigger a compiler warning if they lack documentation.

Uses `warn` (not `deny`) so existing CI remains green while incrementally improving doc coverage.

**Crates updated (22):**
`perl-lsp-cancellation`, `perl-lsp-capability-map`, `perl-lsp-completion-item`, `perl-lsp-config`, `perl-lsp-feature-contracts`, `perl-lsp-feature-flags`, `perl-lsp-feature-governance`, `perl-lsp-feature-grid`, `perl-lsp-feature-ids`, `perl-lsp-feature-policy`, `perl-lsp-feature-profile-cli`, `perl-lsp-feature-profile`, `perl-lsp-folding`, `perl-lsp-import-management`, `perl-lsp-input-validation`, `perl-lsp-launcher`, `perl-lsp-limits`, `perl-lsp-on-type-formatting`, `perl-lsp-performance`, `perl-lsp-text-utils`, `perl-lsp-uri`, `perl-lsp-workspace-symbols`

## Test plan

- [x] `cargo clippy` passes on all 22 crates with `--lib` (verified locally)
- [x] No new warnings introduced (all existing public items already had doc comments except the ones fixed here)
- [x] `cargo fmt --all` applied