### PR TITLE
feat(green-merge): add batch pacing to prevent CI cancellation cascades

### DIFF
--- a/.claude/commands/green-merge.md
+++ b/.claude/commands/green-merge.md
@@ -49,8 +49,9 @@ If the merge **fails due to a Cargo.lock conflict**, attempt auto-resolution:
    gh pr checkout <number>
    git fetch origin master
    git rebase origin/master
-   # If rebase conflicts on Cargo.lock, accept master's version and regenerate
-   git checkout --theirs Cargo.lock
+   # If rebase conflicts on Cargo.lock, accept master's version and regenerate.
+   # During rebase, --ours refers to the upstream (master) side.
+   git checkout --ours Cargo.lock
    cargo generate-lockfile
    git add Cargo.lock
    git rebase --continue


### PR DESCRIPTION
## Summary

- Add batch pacing to `/green-merge` skill: after every N merges (default 3, configurable via `--batch-size`), stop and wait for master CI to complete before continuing. This prevents the merge → cancel → merge → cancel cascade where rapid merges cause each CI run to cancel the previous one.
- Add Cargo.lock conflict auto-resolution: if a merge fails due to Cargo.lock conflict, checkout theirs, regenerate with `cargo update --workspace`, and retry the merge.
- Enhance reporting with batch number tracking and CI status summary.

## Problem

When green-merge merges 5+ PRs rapidly, each merge triggers a new CI run on master that cancels the in-progress run from the previous merge. This makes it impossible to verify that master is actually green, since no CI run ever completes.

## Solution

Batch pacing with CI verification:
1. Merge up to `batch-size` PRs (default 3)
2. Wait for master CI to complete (poll every 30s, up to 10 retries)
3. If CI passes, continue with next batch
4. If CI fails, stop all merging and report which batch caused the failure

## Test plan

- [ ] Run `/green-merge --dry-run` to verify argument parsing works
- [ ] Run `/green-merge --batch-size 2` with 4+ green PRs to verify pacing behavior
- [ ] Verify CI wait loop triggers after batch-size merges
- [ ] Test Cargo.lock conflict path by creating a PR with a stale Cargo.lock