### PR TITLE
feat(skills): add /cycle-transition and /agent-dashboard skills

### DIFF
--- a/.claude/commands/agent-dashboard.md
+++ b/.claude/commands/agent-dashboard.md
@@ -9,40 +9,20 @@ Scan for running agent output and display a progress summary. Context: **$ARGUME
 
 ## Steps
 
-### 1. Locate agent task output files
+### 1. Scan active worktrees as agent proxies
 
-Claude Code stores agent output in the task output directory. Scan for active agent files:
-
-```bash
-echo "=== Scanning for agent output files ==="
-
-# Primary location: Claude task output directory
-TASK_DIR="${CLAUDE_TASK_OUTPUT_DIR:-/tmp/claude-task-output}"
-
-# Also check common agent output locations
-LOCATIONS=(
-    "$TASK_DIR"
-    "/tmp/claude-agent-*"
-    ".claude/worktrees/agent-*/output*"
-)
-
-for loc in "${LOCATIONS[@]}"; do
-    if ls $loc 2>/dev/null | head -1 > /dev/null 2>&1; then
-        echo "Found outputs in: $loc"
-    fi
-done
-```
-
-### 2. Scan active worktrees as agent proxies
-
-Each worktree represents an agent. Check their activity:
+Each agent worktree under `.claude/worktrees/` represents an active or recently-active agent.
+Check their git state to infer progress:
 
 ```bash
 echo "=== Active Agent Worktrees ==="
 git worktree list | grep '.claude/worktrees/' | while read -r line; do
     WT_PATH=$(echo "$line" | awk '{print $1}')
-    WT_BRANCH=$(echo "$line" | awk '{print $3}' | tr -d '[]')
-    WT_COMMIT=$(echo "$line" | awk '{print $2}')
+    # Extract branch name — handle both "[branch]" and "(detached)" formats
+    WT_REF=$(echo "$line" | sed -n 's/.*\[\(.*\)\]/\1/p')
+    if [[ -z "$WT_REF" ]]; then
+        WT_REF=$(echo "$line" | awk '{print $2}')  # fallback to commit hash
+    fi
 
     # Get last commit time in this worktree
     LAST_COMMIT_TIME=$(git -C "$WT_PATH" log -1 --format='%cr' 2>/dev/null || echo "unknown")
@@ -54,20 +34,20 @@ git worktree list | grep '.claude/worktrees/' | while read -r line; do
     # Count commits ahead of master
     AHEAD=$(git -C "$WT_PATH" rev-list origin/master..HEAD --count 2>/dev/null || echo "?")
 
-    echo "AGENT|$WT_BRANCH|$AHEAD commits|$DIRTY dirty|$LAST_COMMIT_TIME|$LAST_COMMIT_MSG"
+    echo "AGENT|$WT_REF|$AHEAD commits|$DIRTY dirty|$LAST_COMMIT_TIME|$LAST_COMMIT_MSG"
 done
 ```
 
-### 3. Check for associated PRs
+### 2. Check for associated PRs
 
 ```bash
 echo "=== Agent PRs ==="
 gh pr list --state open --json number,title,headRefName,statusCheckRollup --limit 50 2>/dev/null | \
-    jq -r '.[] | "\(.number)|\(.headRefName)|\(.title)|\(.statusCheckRollup[0].conclusion // "pending")"' 2>/dev/null || \
+    jq -r '.[] | "\(.number)|\(.headRefName)|\(.title)|\((.statusCheckRollup // [])[0].conclusion // "pending")"' 2>/dev/null || \
     echo "Could not fetch PR data"
 ```
 
-### 4. Format dashboard
+### 3. Format dashboard
 
 Combine all data into a readable table:
 
@@ -93,7 +73,7 @@ Combine all data into a readable table:
 - Total commits ahead of master: N
 ```
 
-### 5. Verbose mode (`--verbose`)
+### 4. Verbose mode (`--verbose`)
 
 If `--verbose` is passed, also show:
 

--- a/.claude/commands/cycle-transition.md
+++ b/.claude/commands/cycle-transition.md
@@ -33,67 +33,42 @@ Worktrees may hold locks on branches that prevent switching to master. Remove al
 
 ```bash
 echo "=== Removing agent worktrees ==="
-WORKTREE_COUNT=0
-git worktree list | grep '.claude/worktrees/' | awk '{print $1}' | while read -r wt; do
-    echo "Removing: $wt"
-    git worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
-    WORKTREE_COUNT=$((WORKTREE_COUNT + 1))
-done
-git worktree prune
-echo "Removed agent worktrees"
-```
-
-If `scripts/cleanup-worktrees.sh` exists, run it as a fallback to catch anything missed:
-
-```bash
+# Use cleanup-worktrees.sh which already handles this correctly
 if [[ -f scripts/cleanup-worktrees.sh ]]; then
     bash scripts/cleanup-worktrees.sh
+else
+    # Fallback: manual cleanup
+    git worktree list | grep '.claude/worktrees/' | awk '{print $1}' | while read -r wt; do
+        echo "Removing: $wt"
+        git worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+    done
+    git worktree prune
 fi
+echo "Worktree cleanup complete"
 ```
 
 ### 3. Switch to master
 
 ```bash
-git checkout master
-```
-
-If checkout fails due to unmerged paths or other issues, report the error and continue with best effort:
-
-```bash
 git checkout master 2>&1 || {
-    echo "WARNING: checkout master failed, attempting reset"
+    echo "WARNING: checkout master failed, attempting force checkout"
     git checkout -f master
 }
 ```
 
 ### 4. Pull latest master
 
-Handle untracked file conflicts by removing conflicting untracked files, then retry.
+Use the safe-pull script which handles untracked file conflicts and stale tracking refs:
 
 ```bash
 echo "=== Pulling latest master ==="
-PULL_OUTPUT=$(git pull origin master 2>&1)
-PULL_EXIT=$?
-
-if [[ $PULL_EXIT -ne 0 ]]; then
-    echo "Pull failed, checking for untracked file conflicts..."
-    # Extract conflicting filenames from error output
-    CONFLICTING=$(echo "$PULL_OUTPUT" | grep -oP "(?<=Untracked working tree file ').*(?=' would be overwritten)" || true)
-    if [[ -n "$CONFLICTING" ]]; then
-        echo "Removing conflicting untracked files:"
-        echo "$CONFLICTING" | while read -r f; do
-            echo "  rm: $f"
-            rm -f "$f"
-        done
-        # Retry pull
-        git pull origin master
-    else
-        echo "WARNING: pull failed for unknown reason:"
-        echo "$PULL_OUTPUT"
-        echo "Continuing anyway..."
-    fi
+if [[ -f scripts/safe-pull.sh ]]; then
+    bash scripts/safe-pull.sh master
 else
-    echo "Pull succeeded"
+    # Fallback if safe-pull.sh not yet available
+    git pull origin master 2>&1 || {
+        echo "WARNING: pull failed, continuing anyway..."
+    }
 fi
 ```
 


### PR DESCRIPTION
## Summary

- Adds `/cycle-transition` skill that automates the end-of-cycle / start-of-cycle boundary — the #1 friction point that previously required 10+ minutes of manual orchestration
- Adds `/agent-dashboard` skill that scans active agent worktrees and associated PRs to display a progress summary table

## `/cycle-transition` handles

1. Stash uncommitted changes on current branch
2. Remove agent worktrees blocking master checkout
3. Switch to master (with force-checkout fallback)
4. Pull latest master (handles untracked file conflicts by removing conflicting files and retrying)
5. Final worktree cleanup pass via `scripts/cleanup-worktrees.sh`
6. Prune merged local branches and stale remote tracking refs
7. Verify master CI is green (warns if red/pending)
8. Report: worktree count, branch count, open PRs, CI status

Each step is defensive — failures are reported and execution continues to the next step.

## `/agent-dashboard` shows

- Active worktrees with commits ahead, dirty file count, last activity time
- Associated open PRs with CI status
- Summary counts (active agents, PRs, dirty work, total commits ahead)
- Verbose mode for full git logs per worktree

## Test plan

- [ ] Run `/cycle-transition` at end of a swarm cycle — verify it cleans up worktrees, switches to master, pulls, and reports
- [ ] Run `/cycle-transition --dry-run` to verify it reports without making changes
- [ ] Run `/agent-dashboard` during active swarm — verify worktree table populates
- [ ] Run `/agent-dashboard --verbose` to verify expanded output