### PR TITLE
feat(skills): add scout launcher skills for codebase exploration

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,114 @@
+---
+description: Deep audit of a specific crate — API quality, tests, error handling, docs, panic safety
+argument-hint: "<crate-name> e.g. 'perl-dap', 'perl-parser-core', 'perl-workspace-index'"
+---
+
+# Audit: Deep Crate Review
+
+Perform a thorough audit of: **$ARGUMENTS**
+
+## Process
+
+Resolve the crate path: `crates/$ARGUMENTS/`. If the crate name has no `perl-` prefix, try `crates/perl-$ARGUMENTS/`.
+
+Spawn an Explore agent to perform the audit:
+
+```
+Agent(
+  subagent_type: "Explore",
+  prompt: "
+    Crate: $ARGUMENTS
+    Path: crates/<resolved-crate>/
+
+    Perform a deep audit of this crate across all dimensions below.
+    Read every source file in src/ and every test file in tests/.
+
+    ## 1. API Quality
+    - Are public types and functions well-named?
+    - Are there unnecessary pub items that should be pub(crate)?
+    - Is the API surface minimal and coherent?
+    - Are there builder patterns where constructors have too many args?
+
+    ## 2. Test Coverage
+    - What percentage of public functions have tests?
+    - Are edge cases covered (empty input, max values, Unicode, errors)?
+    - Are there integration tests in addition to unit tests?
+    - List specific untested functions/paths.
+
+    ## 3. Error Handling
+    - Are errors descriptive and actionable?
+    - Any unwrap/expect/panic in non-test code?
+    - Are error types specific (not just String or anyhow)?
+    - Is error propagation clean (using ? operator)?
+
+    ## 4. Documentation
+    - Do all public items have doc comments?
+    - Are there module-level docs explaining purpose?
+    - Are examples provided for non-obvious APIs?
+    - Is there a crate-level README or lib.rs doc?
+
+    ## 5. Panic Safety
+    - Any panic!, todo!, unimplemented!, unreachable! in production code?
+    - Any index operations that could panic (arr[i] vs arr.get(i))?
+    - Any slice operations without bounds checking?
+    - Any integer overflow possibilities?
+
+    ## 6. Performance
+    - Unnecessary allocations (String where &str suffices)?
+    - Redundant clones?
+    - O(n^2) or worse algorithms?
+    - Missing capacity hints for Vec/HashMap?
+    - Hot loops with allocations inside?
+
+    ## 7. Dependencies
+    - Are all dependencies actually used?
+    - Are there lighter alternatives for heavy deps?
+    - Are feature flags used efficiently?
+
+    ## 8. Code Quality
+    - Dead code or unreachable branches?
+    - Overly complex functions (>50 lines)?
+    - Magic numbers without constants?
+    - Duplicated logic that could be extracted?
+
+    For each finding, record:
+    - Dimension (1-8 above)
+    - Severity: critical / warning / info
+    - File:line
+    - Description
+    - Suggested fix
+
+    After the audit, invoke /scout-report to create a single comprehensive GitHub issue titled:
+    'audit(<crate-name>): <N> findings across <M> dimensions'
+
+    The issue body should be a structured report with sections for each dimension,
+    sorted by severity (critical first).
+  ",
+  run_in_background: true,
+  name: "audit-<crate-name>"
+)
+```
+
+## Output
+
+A single GitHub issue with:
+- Title: `audit(<crate>): <N> findings across <M> dimensions`
+- Label: `swarm-discovered`
+- Body: structured findings by dimension, sorted by severity
+- Each finding has file:line, description, and suggested fix
+
+## Examples
+
+```
+/audit perl-dap                # Audit the DAP server
+/audit perl-parser-core        # Audit parser core infrastructure
+/audit perl-workspace-index    # Audit workspace indexing
+/audit perl-lsp-diagnostics    # Audit LSP diagnostics provider
+```
+
+## When to Use
+
+- Before a release: `/audit <crate>` for each crate in the release
+- After major refactoring: verify the refactored crate is clean
+- When picking up an unfamiliar crate: get oriented fast
+- Pre-swarm: audit a crate to generate a queue of improvement slices

--- a/.claude/commands/compare.md
+++ b/.claude/commands/compare.md
@@ -1,0 +1,126 @@
+---
+description: Compare two approaches or implementations and write a trade-off analysis
+argument-hint: "<A> vs <B> e.g. 'workspace index vs flat index' or 'Option A vs Option B from issue #1653'"
+---
+
+# Compare: Trade-Off Analysis
+
+Compare: **$ARGUMENTS**
+
+## Process
+
+1. **Parse the comparison** from `$ARGUMENTS`. Expect one of:
+   - Two approaches: `"<approach A> vs <approach B>"`
+   - An issue reference: `"Option A vs Option B from issue #<N>"`
+   - Two implementations: `"<crate-a>::<fn> vs <crate-b>::<fn>"`
+
+2. **Gather context**:
+
+   If an issue is referenced:
+   ```bash
+   gh issue view <N> --json title,body,comments
+   ```
+
+   If code is referenced, read the relevant source files.
+
+3. **Spawn an Explore agent** to perform the comparison:
+
+```
+Agent(
+  subagent_type: "Explore",
+  prompt: "
+    Compare: $ARGUMENTS
+
+    ## Research Phase
+    - Read all relevant source code for both approaches
+    - Check if benchmarks exist (look in benches/ directories)
+    - Look for prior art in the codebase (similar patterns already chosen)
+    - Check git log for context on why current approach was chosen
+
+    ## Analysis Dimensions
+
+    For each approach, evaluate:
+
+    ### Correctness
+    - Does it handle all edge cases?
+    - Are there known failure modes?
+
+    ### Performance
+    - Time complexity
+    - Space complexity
+    - Benchmark data if available
+
+    ### Maintainability
+    - Code complexity (LOC, cyclomatic complexity)
+    - How many files/crates affected?
+    - How easy to test?
+
+    ### Compatibility
+    - Does it break existing APIs?
+    - SemVer implications?
+    - Migration cost?
+
+    ### Risk
+    - What could go wrong?
+    - How reversible is the choice?
+    - Dependencies introduced or removed?
+
+    ## Output
+
+    Write the comparison as a structured analysis. If an issue was referenced,
+    post the comparison as a comment on that issue:
+    ```bash
+    gh issue comment <N> --body '<comparison>'
+    ```
+
+    If no issue was referenced, invoke /scout-report to create a new issue titled:
+    'compare: <A> vs <B>'
+    with label 'swarm-architectural' (since comparisons usually need a design decision).
+
+    The analysis MUST include:
+    1. Summary table (dimension x approach)
+    2. Recommendation with rationale
+    3. Risks of the recommended approach
+    4. Migration plan if switching from current to recommended
+  ",
+  run_in_background: true,
+  name: "compare-<short-label>"
+)
+```
+
+## Output Format
+
+### Summary Table
+| Dimension | Approach A | Approach B |
+|-----------|-----------|-----------|
+| Correctness | ... | ... |
+| Performance | ... | ... |
+| Maintainability | ... | ... |
+| Compatibility | ... | ... |
+| Risk | ... | ... |
+
+### Recommendation
+One paragraph: which approach and why.
+
+### Risks
+What could go wrong with the recommendation.
+
+### Migration Plan
+Steps to adopt the recommendation (if it differs from current).
+
+## Examples
+
+```
+/compare "workspace index vs flat index"
+/compare "Option A vs Option B from issue #1653"
+/compare "perl-lexer::tokenize vs perl-tokenizer::scan"
+/compare "pest parser vs recursive descent for heredocs"
+/compare "async LSP vs sync LSP with thread pool"
+```
+
+## When to Use
+
+- Design decision needed: two viable approaches, unclear winner
+- Refactoring evaluation: is the new way actually better?
+- Issue triage: someone proposed two options, need analysis
+- Architecture review: compare current design against alternative

--- a/.claude/commands/find-issues.md
+++ b/.claude/commands/find-issues.md
@@ -1,0 +1,104 @@
+---
+description: Open-ended issue discovery — scan for improvement opportunities across the codebase
+argument-hint: "[--limit <N>] [--dry-run]"
+---
+
+# Find Issues: Open-Ended Discovery
+
+Scan the codebase for improvement opportunities without a specific focus. Context: **$ARGUMENTS**
+
+## What It Checks
+
+Run these checks in parallel and collect findings:
+
+### 1. Clippy warnings
+```bash
+cargo clippy --workspace --lib 2>&1 | grep "warning\[" | sort | uniq -c | sort -rn | head -20
+```
+
+### 2. TODO/FIXME/HACK comments
+```bash
+grep -rn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" crates/*/src/ --include="*.rs" | head -50
+```
+
+### 3. Ignored tests
+```bash
+grep -rn "#\[ignore" crates/*/tests/ crates/*/src/ --include="*.rs" | head -30
+```
+
+### 4. Dead code signals
+```bash
+cargo machete 2>&1 | head -30
+```
+
+### 5. Missing documentation
+```bash
+# Public items without doc comments
+cargo doc --workspace --no-deps 2>&1 | grep "warning.*missing" | head -20
+```
+
+### 6. Banned patterns in production code
+```bash
+# Check for unwrap/expect/panic outside tests
+grep -rn "\.unwrap()\|\.expect(\|panic!\|todo!\|unimplemented!\|dbg!" crates/*/src/ --include="*.rs" | grep -v "test" | grep -v "#\[allow" | head -30
+```
+
+### 7. Large files (complexity signal)
+```bash
+find crates/*/src/ -name "*.rs" -exec wc -l {} \; | sort -rn | head -15
+```
+
+### 8. Test coverage gaps
+```bash
+# Crates with src/ but no tests/
+for crate in crates/*/; do
+  if [ -d "$crate/src" ] && [ ! -d "$crate/tests" ]; then
+    echo "NO TESTS: $crate"
+  fi
+done
+```
+
+## Process
+
+1. **Run all checks** above (in parallel where possible).
+
+2. **Group findings by category**:
+   - `clippy` — lint warnings
+   - `todo-fixme` — unfinished work markers
+   - `ignored-tests` — tests that could be un-ignored
+   - `dead-code` — unused dependencies or dead code
+   - `doc-gaps` — missing documentation
+   - `banned-patterns` — coding standard violations
+   - `complexity` — files that may need refactoring
+   - `test-gaps` — crates missing tests
+
+3. **For each non-empty category**, invoke `/scout-report` to create a GitHub issue:
+   - Title: `<category>: <N> findings across <M> crates`
+   - Body: list of specific findings with file paths
+   - Label: `swarm-discovered`
+
+4. **Print summary** to stdout:
+   ```
+   === Find Issues Summary ===
+   clippy:          12 warnings across 5 crates
+   todo-fixme:       8 markers in 4 files
+   ignored-tests:    3 tests may be un-ignorable
+   dead-code:        2 unused deps
+   doc-gaps:         0
+   banned-patterns:  1 unwrap in production code
+   complexity:       3 files >500 lines
+   test-gaps:        4 crates with no tests
+   ---
+   Created 6 GitHub issues.
+   ```
+
+## Options
+
+- `--limit <N>` — Cap findings per category at N (default: 10)
+- `--dry-run` — Print findings but do not create GitHub issues
+
+## When to Use
+
+- "What should we work on next?" — run `/find-issues`
+- Before a swarm cycle — run `/find-issues --dry-run` to preview
+- After a release — run `/find-issues` to find new improvement areas

--- a/.claude/commands/health-check.md
+++ b/.claude/commands/health-check.md
@@ -1,0 +1,120 @@
+---
+description: Quick codebase health scan — CI, PRs, tests, corpus, clippy, worktrees
+argument-hint: ""
+---
+
+# Health Check: Quick Codebase Scan
+
+Fast scan of overall codebase health. Outputs a formatted table to stdout (no GitHub issues).
+
+## Checks
+
+Run all of the following and report results in a summary table:
+
+### 1. CI Status
+```bash
+gh run list --limit 3 --json status,conclusion,name,headBranch,createdAt
+```
+
+### 2. Open PRs
+```bash
+gh pr list --state open --json number,title,labels --limit 30 | jq length
+```
+
+### 3. Open Issues
+```bash
+gh issue list --state open --limit 100 --json number | jq length
+```
+
+### 4. Failing Tests
+```bash
+cargo test --workspace --lib --no-fail-fast 2>&1 | tail -5
+```
+
+### 5. Corpus Baseline
+```bash
+if [ -f .ci/parser-corpus-baseline.json ]; then
+  cat .ci/parser-corpus-baseline.json | jq '.summary // .total // "present"'
+else
+  echo "NOT FOUND"
+fi
+```
+
+### 6. Clippy Warnings
+```bash
+cargo clippy --workspace --lib 2>&1 | grep -c "^warning\[" || echo "0"
+```
+
+### 7. Active Worktrees
+```bash
+git worktree list | wc -l
+```
+
+### 8. Ignored Tests
+```bash
+grep -rc "#\[ignore" crates/*/tests/ crates/*/src/ --include="*.rs" 2>/dev/null | awk -F: '{s+=$2} END {print s+0}'
+```
+
+### 9. Debt Budget
+```bash
+if [ -f .ci/debt-ledger.yaml ]; then
+  echo "present"
+else
+  echo "NOT FOUND"
+fi
+```
+
+### 10. Unused Dependencies
+```bash
+cargo machete 2>&1 | grep -c "unused" || echo "0"
+```
+
+## Output Format
+
+Print a formatted table to stdout:
+
+```
+=== Health Check ===
+
+| Check              | Status | Detail                    |
+|--------------------|--------|---------------------------|
+| CI (latest)        | OK/BAD | last 3 runs summary       |
+| Open PRs           | <N>    | N open pull requests      |
+| Open Issues         | <N>    | N open issues             |
+| Tests              | OK/BAD | N pass, M fail            |
+| Corpus baseline    | OK/BAD | present / not found       |
+| Clippy warnings    | <N>    | N warnings                |
+| Active worktrees   | <N>    | N worktrees               |
+| Ignored tests      | <N>    | N ignored tests           |
+| Debt ledger        | OK/BAD | present / not found       |
+| Unused deps        | <N>    | N unused dependencies     |
+
+Overall: OK / NEEDS ATTENTION (<list of BAD checks>)
+```
+
+## Thresholds
+
+| Check | OK | NEEDS ATTENTION |
+|-------|----|-----------------|
+| CI | All recent runs succeeded | Any failure in last 3 runs |
+| Open PRs | < 15 | >= 15 |
+| Tests | All pass | Any failure |
+| Corpus baseline | File exists | File missing |
+| Clippy warnings | 0 | > 0 |
+| Active worktrees | < 10 | >= 10 (cleanup needed) |
+| Ignored tests | < 20 | >= 20 |
+| Debt ledger | File exists | File missing |
+| Unused deps | 0 | > 0 |
+
+## When to Use
+
+- Start of day: "Is everything OK before I start work?"
+- Before a swarm cycle: "Is the baseline clean?"
+- After a merge burst: "Did anything break?"
+- Quick status check: faster than `/swarm-status` (no GitHub API calls for PRs/issues if offline)
+
+## Notes
+
+- This outputs to stdout only. No GitHub issues are created.
+- For deeper investigation of any failing check, use `/scout <area>` or `/audit <crate>`.
+- For full swarm state including PR details, use `/swarm-status`.

--- a/.claude/commands/queue-scout.md
+++ b/.claude/commands/queue-scout.md
@@ -48,3 +48,10 @@ Agent(
 3. If two slices overlap, keep the higher-impact one, defer the other
 4. Feed non-overlapping slices to swarm-builder agents
 5. Update `.claude/swarm-state/swarm-queue.json` with active slices
+
+## Relationship to /scout
+
+- `/queue-scout` = broad sweep across all areas (10-15 scouts in parallel)
+- `/scout <focus>` = single-area deep dive (1 agent, produces GitHub issues via `/scout-report`)
+
+Use `/scout <area>` when you already know where to look. Use `/queue-scout` when you want to discover what needs attention across the whole codebase.

--- a/.claude/commands/scout-report.md
+++ b/.claude/commands/scout-report.md
@@ -1,0 +1,59 @@
+---
+description: Write scout findings as a GitHub issue with structured context
+argument-hint: "<title> <body-summary>"
+---
+
+# Scout Report
+
+Convert scout findings into a GitHub issue. This is the standard output format for all scout-type skills.
+
+## Required Context
+
+The calling scout MUST have gathered:
+1. **Title**: A concise description of the finding
+2. **Category**: One of `bug`, `test-gap`, `dead-code`, `doc-gap`, `perf`, `security`, `devex`, `cleanup`
+3. **Files**: Specific file paths with line numbers
+4. **Impact**: Why this matters (severity, frequency, user-facing?)
+5. **Suggested Approach**: Concrete next steps a builder agent can follow
+
+## Issue Creation
+
+```bash
+gh issue create \
+  --title "<category>: <concise title>" \
+  --label "swarm-discovered" \
+  --body "$(cat <<'EOF'
+## Discovery
+
+<What was found, why it matters>
+
+## Category
+
+<bug | test-gap | dead-code | doc-gap | perf | security | devex | cleanup>
+
+## Files
+
+<file paths with line numbers>
+
+## Impact
+
+<severity: low/medium/high, user-facing: yes/no, frequency: rare/common/always>
+
+## Suggested Approach
+
+<concrete steps a builder agent can follow without re-investigating>
+
+## Agent
+
+Discovered by `/scout` exploration.
+EOF
+)"
+```
+
+## Rules
+
+- ONE issue per distinct finding. Do not bundle unrelated findings.
+- If multiple findings in the same category are closely related (same root cause), combine into one issue.
+- Always include enough context that a builder agent can start work without re-investigating.
+- Use `--label swarm-architectural` instead of `--label swarm-discovered` if the finding needs a design decision from the user.
+- Print the issue URL after creation so the caller can reference it.

--- a/.claude/commands/scout.md
+++ b/.claude/commands/scout.md
@@ -1,0 +1,82 @@
+---
+description: Universal scout launcher — explore any area and produce GitHub issues
+argument-hint: "<focus> e.g. 'parser', 'lsp', 'dap', 'docs', 'tests', 'devex', 'security', 'deps', 'perf'"
+---
+
+# Scout: Focused Exploration
+
+Launch a focused exploration of: **$ARGUMENTS**
+
+## Dispatch Table
+
+| Focus | Crate paths | Exploration targets |
+|-------|-------------|---------------------|
+| `parser` | `crates/perl-parser/`, `crates/perl-parser-core/`, `crates/perl-lexer/`, `crates/perl-tokenizer/` | Error buckets in `.ci/parser-corpus-baseline.json`, edge cases, TODO comments, missing test coverage |
+| `lsp` | `crates/perl-lsp/`, `crates/perl-lsp-*/` | `features.toml` gaps, provider quality, test coverage, error handling, threading issues |
+| `dap` | `crates/perl-dap/`, `crates/perl-dap-*/` | Protocol compliance, test gaps, error handling, security (command injection, path traversal) |
+| `docs` | `docs/`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `crates/*/README.md` | Stale docs, missing docs, undocumented architecture, broken links, outdated examples |
+| `tests` | `crates/*/tests/` | `#[ignore]` tests whose blockers may be resolved, low-coverage crates, missing edge cases, flaky tests |
+| `devex` | `xtask/`, `scripts/`, `.ci/`, `justfile`, `Cargo.toml` | Build friction, slow commands, confusing errors, missing tooling, DX paper cuts |
+| `security` | `deny.toml`, `crates/perl-dap-security/`, `crates/perl-dap-shell/` | Dependency advisories (`cargo audit`), unsafe code, command injection, path traversal, secrets in code |
+| `deps` | `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.github/dependabot.yml` | Unused deps (`cargo machete`), outdated deps, duplicate versions, license issues |
+| `perf` | `crates/perl-parser/`, `crates/perl-lexer/`, `crates/perl-workspace-index/` | Hot paths, unnecessary allocations, redundant clones, benchmark regressions, O(n^2) patterns |
+
+## Process
+
+1. **Identify focus area** from `$ARGUMENTS` using the dispatch table above. If the argument does not match a known focus, treat it as a crate name and explore `crates/<argument>/`.
+
+2. **Spawn an Explore agent** for the focus area:
+
+```
+Agent(
+  subagent_type: "Explore",
+  prompt: "
+    Focus: <focus area>
+    Paths: <paths from dispatch table>
+
+    Explore these paths looking for improvement opportunities:
+    - Read source files and tests
+    - Look for TODO/FIXME/HACK comments
+    - Check error handling patterns (unwrap, expect, panic)
+    - Identify missing test coverage
+    - Note any code quality issues
+    - Check for dead code or unused imports
+
+    For each finding, note:
+    1. File path and line number
+    2. What the issue is
+    3. Why it matters (impact)
+    4. Suggested fix approach
+
+    After exploration, invoke /scout-report to create a GitHub issue for each distinct finding.
+  ",
+  run_in_background: true,
+  name: "scout-<focus>"
+)
+```
+
+3. **Collect results** when the agent completes.
+
+## Examples
+
+```
+/scout parser       # Explore parser crates for bugs and gaps
+/scout dap          # Audit DAP protocol compliance
+/scout lsp          # Check LSP feature completeness
+/scout security     # Security-focused scan
+/scout perl-refactoring  # Scout a specific crate by name
+```
+
+## After Scouting
+
+- Each finding becomes a GitHub issue via `/scout-report`
+- Issues are labeled `swarm-discovered` (or `swarm-architectural` for design decisions)
+- Builder agents can pick up issues directly
+- Use `/queue-scout` for broad multi-area scouting instead of single-focus
+
+## Relationship to /queue-scout
+
+- `/scout <focus>` = single-area deep dive (3-5 minutes, 1 agent)
+- `/queue-scout` = broad sweep across all areas (10-15 scouts in parallel)
+
+Use `/scout` when you know where to look. Use `/queue-scout` when you want to discover what needs attention.

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ coverage-*.md
 # Docs directory is curated -- never ignore tracked documentation
 !docs/**/*.md
 
+# Slash commands are curated -- never ignore tracked skill definitions
+!.claude/commands/*.md
+
 # Spec manifest files
 SPEC*.manifest.yml
 SPEC-*.manifest.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@ cargo test --workspace --lib
 | Multiple changes | Parallel worktree agents |
 | Swarm cycle | `/swarm all` |
 | Corpus improvement | `/corpus-ratchet` |
+| Focused scouting | `/scout <area>` |
+| Issue discovery | `/find-issues` |
+| Crate audit | `/audit <crate>` |
+| Design comparison | `/compare "A vs B"` |
+| Quick health check | `/health-check` |
 
 ## Crate Structure
 
@@ -367,7 +372,12 @@ This project uses continuous agent swarms with agent teams for parallel codebase
 | `/swarm-status` | Show PRs, issues, metrics, queue depth |
 | `/swarm-report` | Generate daily check-in summary |
 | `/coding-standards` | Load project coding standards |
-| `/queue-scout` | Launch scouts to find work |
+| `/queue-scout` | Launch broad multi-area scouts to find work |
+| `/scout` | Single-area deep dive (parser, lsp, dap, docs, tests, devex, security, deps, perf) |
+| `/find-issues` | Open-ended issue discovery across the codebase |
+| `/audit` | Deep audit of a specific crate |
+| `/compare` | Compare two approaches or implementations |
+| `/health-check` | Quick codebase health scan (stdout, no issues) |
 | `/green-merge` | Merge all passing PRs |
 | `/rebase-open` | Rebase conflicted PRs |
 | `/status-drift` | Fix computed metric drift |
@@ -385,6 +395,7 @@ This project uses continuous agent swarms with agent teams for parallel codebase
 | `/parser-fix` | TDD parser fix |
 | `/wave` | Launch parallel agent wave |
 | `/corpus-ratchet` | Corpus sweep and baseline update |
+| `/scout-report` | Write scout findings as GitHub issues (used by all scout skills) |
 
 ### Architecture
 


### PR DESCRIPTION
## Summary

- Add six new slash commands for focused codebase exploration and issue discovery:
  - `/scout <area>` — universal scout launcher with dispatch table for 9 focus areas (parser, lsp, dap, docs, tests, devex, security, deps, perf)
  - `/find-issues` — open-ended discovery scanning clippy warnings, TODO/FIXME comments, ignored tests, dead code, banned patterns, and test coverage gaps
  - `/audit <crate>` — deep single-crate audit across 8 quality dimensions (API quality, test coverage, error handling, docs, panic safety, performance, dependencies, code quality)
  - `/compare "A vs B"` — trade-off analysis between two approaches with structured comparison table
  - `/health-check` — fast codebase health scan with formatted stdout table (no GitHub issues)
  - `/scout-report` — shared output format for all scout-type skills to create structured GitHub issues
- Update CLAUDE.md skill tables (Core Skills and Agent Patterns) with all new skills
- Update `/queue-scout` with cross-reference to `/scout` as the single-area alternative
- Add `.gitignore` negation for `.claude/commands/*.md` to prevent broad report/status ignore patterns from hiding skill files

## Test plan

- [ ] Verify each new command file has valid frontmatter (description, argument-hint)
- [ ] Verify CLAUDE.md skill tables include all new entries
- [ ] Verify `/queue-scout` references `/scout`
- [ ] Verify `.gitignore` negation allows `scout-report.md` to be tracked