### PR TITLE
feat(skills): default to draft PRs, add /pr-ready skill

### DIFF
--- a/.claude/commands/bulk-pr.md
+++ b/.claude/commands/bulk-pr.md
@@ -32,7 +32,7 @@ Launch a parallel Agent (with `run_in_background: true`) for each worktree that:
 5. Runs appropriate `cargo test` for changed crates
 6. Creates a descriptive feature branch
 7. Commits with conventional commit message
-8. Pushes and creates PR via `gh pr create`
+8. Pushes and creates draft PR via `gh pr create --draft`
 9. Returns the PR URL
 
 ### 3. Report

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -108,13 +108,15 @@ If not green, fix or document what remains.
 git push -u origin HEAD
 ```
 
-Then create PR:
+Then create PR (always as draft):
 ```bash
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
 <body content>
 EOF
 )"
 ```
+
+> **Note**: PRs open as draft. After review agent fixes issues, mark ready with `/pr-ready`.
 
 If gh unavailable, output the title and body for manual creation.
 

--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -1,0 +1,41 @@
+---
+description: Mark a reviewed draft PR as ready for CI
+argument-hint: "<PR number>"
+---
+
+# Mark PR Ready
+
+Mark a reviewed draft PR as ready for merge. This triggers CI. Context: **$ARGUMENTS**
+
+## Steps
+
+### 1. Parse PR number
+
+Extract the PR number from $ARGUMENTS. If not provided, list open draft PRs:
+```bash
+gh pr list --state open --draft --json number,title,headRefName --template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}{{end}}'
+```
+
+### 2. Verify PR exists and is a draft
+
+```bash
+gh pr view $NUMBER --json isDraft,title,state
+```
+
+If the PR is not a draft, report: "PR #N is already marked ready" and stop.
+If the PR is not open, report the current state and stop.
+
+### 3. Mark ready
+
+```bash
+gh pr ready $NUMBER
+```
+
+### 4. Report
+
+Output: "PR #$NUMBER marked ready -- CI will trigger."
+
+Include the PR URL for convenience:
+```bash
+gh pr view $NUMBER --json url --template '{{.url}}'
+```

--- a/.claude/commands/worktree-pr.md
+++ b/.claude/commands/worktree-pr.md
@@ -63,10 +63,10 @@ EOF
 )"
 ```
 
-7. **Push and PR**:
+6. **Push and PR** (always as draft):
 ```bash
 git push -u origin <branch-name>
-gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+gh pr create --draft --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
 ## Summary
 <what and why>
 
@@ -78,4 +78,6 @@ EOF
 )"
 ```
 
-8. **Return the PR URL**.
+> **Note**: PRs open as draft. After review agent fixes issues, mark ready with `/pr-ready`.
+
+7. **Return the PR URL**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,15 +387,18 @@ This project uses continuous agent swarms with agent teams for parallel codebase
 
 | Skill | Purpose |
 |-------|---------|
-| `/pr-create` | Create a PR from current branch |
+| `/pr-create` | Create a draft PR from current branch |
 | `/pr-cleanup` | Clean up branch for review |
-| `/worktree-pr` | PR a worktree's changes |
-| `/bulk-pr` | PR all worktrees with changes |
+| `/pr-ready` | Mark a reviewed draft PR as ready for CI |
+| `/worktree-pr` | PR a worktree's changes (as draft) |
+| `/bulk-pr` | PR all worktrees with changes (as draft) |
 | `/salvage-worktrees` | Save dirty worktrees before cleanup |
 | `/parser-fix` | TDD parser fix |
 | `/wave` | Launch parallel agent wave |
 | `/corpus-ratchet` | Corpus sweep and baseline update |
 | `/scout-report` | Write scout findings as GitHub issues (used by all scout skills) |
+
+> **PR lifecycle**: Builder creates draft PR --> Review agent fixes issues --> `/pr-ready` marks ready --> CI triggers --> Merge
 
 ### Architecture
 


### PR DESCRIPTION
## Summary

- PR creation skills (`/pr-create`, `/worktree-pr`, `/bulk-pr`) now always use `gh pr create --draft`, preventing CI from triggering on unreviewed PRs
- New `/pr-ready` skill marks a reviewed draft PR as ready for merge, triggering CI at the right time
- CLAUDE.md updated with the new skill and documented PR lifecycle: Builder -> Draft PR -> Review -> `/pr-ready` -> CI -> Merge

## What changed

| File | Change |
|------|--------|
| `.claude/commands/pr-create.md` | Added `--draft` flag, note about `/pr-ready` |
| `.claude/commands/worktree-pr.md` | Added `--draft` flag, note about `/pr-ready` |
| `.claude/commands/bulk-pr.md` | Added `--draft` to step 8 |
| `.claude/commands/pr-ready.md` | **New** -- skill to mark draft PRs ready |
| `CLAUDE.md` | Added `/pr-ready` to skills table, updated descriptions, added lifecycle note |

## Test plan

- [ ] Verify `/pr-create` includes `--draft` flag in `gh pr create` command
- [ ] Verify `/worktree-pr` includes `--draft` flag in `gh pr create` command
- [ ] Verify `/bulk-pr` references `--draft` in bulk creation step
- [ ] Verify `/pr-ready` skill exists with correct frontmatter and steps
- [ ] Verify CLAUDE.md PR/Worktree Skills table includes `/pr-ready`
- [ ] Verify CLAUDE.md includes PR lifecycle note