### PR TITLE
feat(scouts): wire scout-writes-issue pattern into all scout definitions

### DIFF
--- a/.claude/agents/swarm-scout.md
+++ b/.claude/agents/swarm-scout.md
@@ -1,0 +1,46 @@
+---
+name: swarm-scout
+description: Scout agent. Explores a single focus area, finds ONE actionable improvement, and writes a GitHub issue as its deliverable. Ephemeral — all value must be captured in the issue.
+model: sonnet
+color: yellow
+---
+
+You are a swarm scout. Your job is to explore a focused area of the codebase, find ONE actionable improvement, and write a GitHub issue documenting it.
+
+## Process
+
+1. **Load protocol** — Invoke `/swarm-protocol` for behavioral rules.
+2. **Dedup** — Check completed-slices, known-pitfalls, discovered-issues, open GitHub issues and PRs. If already covered, pick a different angle or report "no new findings" and exit.
+3. **Explore** — Stay in ONE sector (parser, LSP, DAP, tests, dead-code, etc.). Do not cross sector boundaries. If you discover something in a different sector, note it in your issue but do not investigate it.
+4. **Analyze** — Find ONE concrete, actionable improvement. Gather evidence: file paths with line numbers, error messages, metric values, test output.
+5. **Write GitHub issue** — MUST invoke `/scout-report` to write findings as a GitHub issue before exiting. The issue is your deliverable. Everything else is ephemeral.
+
+## Rules
+
+- **Stay in one sector per scout.** Spawn a fresh agent for a different context group.
+- **Agent output is ephemeral. The GitHub issue is your deliverable.** If you exit without writing an issue, your work is lost.
+- **ONE improvement per scout.** Deep and specific beats broad and shallow.
+- **Evidence over opinion.** Include file:line references, error output, metric values.
+- **MUST invoke `/scout-report` to write findings as GitHub issue before exiting.** This is a hard requirement, not a suggestion.
+
+## Output Format (for coordinator context, NOT the deliverable)
+
+```
+SCOUT COMPLETE
+sector: <focus area>
+issue: <GitHub issue URL>
+summary: <one-line description>
+END_SCOUT
+```
+
+## Spawn Pattern
+
+```
+Agent(
+  subagent_type: "swarm-scout",
+  prompt: "Focus area: <specific target>. Find ONE actionable improvement. Write findings as GitHub issue via /scout-report.",
+  model: "sonnet",
+  run_in_background: true,
+  name: "scout-<focus>-<N>"
+)
+```

--- a/.claude/commands/queue-scout.md
+++ b/.claude/commands/queue-scout.md
@@ -9,7 +9,7 @@ Launch swarm-scout agents to find improvement slices. Focus: **$ARGUMENTS**
 
 ## Focus Areas
 
-### `all` (default) — launch 10-15 scouts across everything:
+### `all` (default) - launch 10-15 scouts across everything:
 
 | Count | Focus | Target |
 |-------|-------|--------|
@@ -20,34 +20,36 @@ Launch swarm-scout agents to find improvement slices. Focus: **$ARGUMENTS**
 | 1-2 | LSP feature polish | `features.toml` gaps, test coverage in `perl-lsp-*` |
 | 1 | Ignored tests | `#[ignore]` tests whose blockers may be resolved |
 
-### Specific focus — launch 3-5 scouts in that area:
-- `parser` — error buckets only
-- `dap` — DAP crate test gaps only
-- `issues` — open GitHub issues only
-- `dead-code` — unused deps, dead code, debt ledger
-- `lsp` — LSP feature polish only
-- `tests` — ignored tests, test coverage gaps
+### Specific focus - launch 3-5 scouts in that area:
+- `parser` - error buckets only
+- `dap` - DAP crate test gaps only
+- `issues` - open GitHub issues only
+- `dead-code` - unused deps, dead code, debt ledger
+- `lsp` - LSP feature polish only
+- `tests` - ignored tests, test coverage gaps
 
 ## Dispatch Pattern
 
 For each scout:
-```
+```text
 Agent(
   subagent_type: "swarm-scout",
-  prompt: "Focus area: <specific target>. Find ONE actionable improvement.",
+  prompt: "Focus area: <specific target>. Find ONE actionable improvement. Write findings as GitHub issue via /scout-report.",
   model: "sonnet",
   run_in_background: true,
   name: "scout-<focus>-<N>"
 )
 ```
 
+Each scout MUST write a GitHub issue via `/scout-report` before exiting. Agent output is ephemeral - the issue is the deliverable.
+
 ## After Scouts Complete
 
-1. Collect all SLICE outputs
-2. Check `files_touched` fields for overlaps
-3. If two slices overlap, keep the higher-impact one, defer the other
-4. Feed non-overlapping slices to swarm-builder agents
-5. Update `.claude/swarm-state/swarm-queue.json` with active slices
+1. Collect GitHub issue numbers from scout output, not SLICE outputs.
+2. Review issues for overlapping file surfaces.
+3. If two issues overlap, keep the higher-impact one and defer the other.
+4. Feed non-overlapping issues to swarm-builder agents.
+5. Update `.claude/swarm-state/swarm-queue.json` with active slices linked to issue numbers.
 
 ## Relationship to /scout
 

--- a/.claude/commands/scout-report.md
+++ b/.claude/commands/scout-report.md
@@ -1,59 +1,68 @@
 ---
-description: Write scout findings as a GitHub issue with structured context
-argument-hint: "<title> <body-summary>"
+description: Write scout findings as a GitHub issue with structured template
+argument-hint: "<one-line title of the finding>"
 ---
 
 # Scout Report
 
-Convert scout findings into a GitHub issue. This is the standard output format for all scout-type skills.
+Write a GitHub issue documenting your scout finding. This is the scout's primary deliverable.
 
-## Required Context
+## Template
 
-The calling scout MUST have gathered:
-1. **Title**: A concise description of the finding
-2. **Category**: One of `bug`, `test-gap`, `dead-code`, `doc-gap`, `perf`, `security`, `devex`, `cleanup`
-3. **Files**: Specific file paths with line numbers
-4. **Impact**: Why this matters (severity, frequency, user-facing?)
-5. **Suggested Approach**: Concrete next steps a builder agent can follow
-
-## Issue Creation
+Create the issue using this exact structure:
 
 ```bash
 gh issue create \
-  --title "<category>: <concise title>" \
+  --title "$ARGUMENTS" \
   --label "swarm-discovered" \
-  --body "$(cat <<'EOF'
-## Discovery
+  --body "$(cat <<'ISSUE_EOF'
+## Problem
 
-<What was found, why it matters>
+_What is wrong or missing? Be specific - include file paths with line numbers, error messages, metric values._
 
-## Category
+<your evidence here>
 
-<bug | test-gap | dead-code | doc-gap | perf | security | devex | cleanup>
+## Options
 
-## Files
+_What are the possible approaches to fix this? List 2-3 with tradeoffs._
 
-<file paths with line numbers>
+1. **Option A** - <description>. Tradeoff: <pro/con>.
+2. **Option B** - <description>. Tradeoff: <pro/con>.
+3. **Option C** - <description>. Tradeoff: <pro/con>.
 
-## Impact
+## Recommendation
 
-<severity: low/medium/high, user-facing: yes/no, frequency: rare/common/always>
+_Which option and why?_
 
-## Suggested Approach
+<your recommendation>
 
-<concrete steps a builder agent can follow without re-investigating>
+## Acceptance Criteria
 
-## Agent
+_How do we know this is done? Be concrete - test commands, metric thresholds, behavior changes._
 
-Discovered by `/scout` exploration.
-EOF
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] <criterion 3>
+
+## Scope
+
+- **Crate(s):** <which crates are affected>
+- **Files:** <key files with paths>
+- **Estimated size:** small / medium / large
+
+---
+_Filed by swarm-scout agent._
+ISSUE_EOF
 )"
 ```
 
 ## Rules
 
 - ONE issue per distinct finding. Do not bundle unrelated findings.
-- If multiple findings in the same category are closely related (same root cause), combine into one issue.
-- Always include enough context that a builder agent can start work without re-investigating.
-- Use `--label swarm-architectural` instead of `--label swarm-discovered` if the finding needs a design decision from the user.
-- Print the issue URL after creation so the caller can reference it.
+- Fill in ALL sections. Do not leave placeholders.
+- **Problem** must have file:line evidence, not just a vague description.
+- **Options** must list at least 2 approaches with real tradeoffs.
+- **Acceptance Criteria** must be verifiable.
+- **Scope** must list affected crates and files so builders know what to claim.
+- Always use label `swarm-discovered`, unless the finding needs a design decision. In that case use `swarm-architectural`.
+- After creating the issue, print the issue URL so the coordinator can collect it.

--- a/.claude/commands/scout.md
+++ b/.claude/commands/scout.md
@@ -1,11 +1,11 @@
 ---
-description: Universal scout launcher — explore any area and produce GitHub issues
+description: Launch a single scout agent for a focus area
 argument-hint: "<focus> e.g. 'parser', 'lsp', 'dap', 'docs', 'tests', 'devex', 'security', 'deps', 'perf'"
 ---
 
-# Scout: Focused Exploration
+# Scout
 
-Launch a focused exploration of: **$ARGUMENTS**
+Launch a focused exploration of **$ARGUMENTS** and produce GitHub issues for concrete findings.
 
 ## Dispatch Table
 
@@ -23,54 +23,44 @@ Launch a focused exploration of: **$ARGUMENTS**
 
 ## Process
 
-1. **Identify focus area** from `$ARGUMENTS` using the dispatch table above. If the argument does not match a known focus, treat it as a crate name and explore `crates/<argument>/`.
+1. Identify the focus area from `$ARGUMENTS` using the dispatch table above. If the argument does not match a known focus, treat it as a crate name and explore `crates/<argument>/`.
 
-2. **Spawn an Explore agent** for the focus area:
+2. Spawn one `swarm-scout` agent for the focus area:
 
-```
+```text
 Agent(
-  subagent_type: "Explore",
+  subagent_type: "swarm-scout",
   prompt: "
     Focus: <focus area>
     Paths: <paths from dispatch table>
 
-    Explore these paths looking for improvement opportunities:
-    - Read source files and tests
-    - Look for TODO/FIXME/HACK comments
-    - Check error handling patterns (unwrap, expect, panic)
-    - Identify missing test coverage
-    - Note any code quality issues
-    - Check for dead code or unused imports
-
-    For each finding, note:
-    1. File path and line number
-    2. What the issue is
-    3. Why it matters (impact)
-    4. Suggested fix approach
-
-    After exploration, invoke /scout-report to create a GitHub issue for each distinct finding.
+    Load /swarm-protocol for behavioral rules.
+    Dedup-check completed slices, open issues, and open PRs.
+    Find ONE actionable improvement with concrete file:line evidence.
+    Write the finding as a GitHub issue via /scout-report.
   ",
+  model: "sonnet",
   run_in_background: true,
   name: "scout-<focus>"
 )
 ```
 
-3. **Collect results** when the agent completes.
+3. Collect the issue URL when the agent completes.
 
 ## Examples
 
-```
-/scout parser       # Explore parser crates for bugs and gaps
-/scout dap          # Audit DAP protocol compliance
-/scout lsp          # Check LSP feature completeness
-/scout security     # Security-focused scan
-/scout perl-refactoring  # Scout a specific crate by name
+```bash
+/scout parser           # Explore parser crates for bugs and gaps
+/scout dap              # Audit DAP protocol compliance
+/scout lsp              # Check LSP feature completeness
+/scout security         # Security-focused scan
+/scout perl-refactoring # Scout a specific crate by name
 ```
 
 ## After Scouting
 
 - Each finding becomes a GitHub issue via `/scout-report`
-- Issues are labeled `swarm-discovered` (or `swarm-architectural` for design decisions)
+- Issues are labeled `swarm-discovered` or `swarm-architectural` for design decisions
 - Builder agents can pick up issues directly
 - Use `/queue-scout` for broad multi-area scouting instead of single-focus
 


### PR DESCRIPTION
## Summary

- Every scout agent now MUST write a GitHub issue via `/scout-report` before exiting, ensuring findings are persisted as structured GitHub issues rather than ephemeral agent output
- New `/scout` skill dispatches a single scout for a focus area with issue-writing wired into the prompt
- New `/scout-report` skill provides a structured issue template (Problem/Options/Recommendation/Acceptance Criteria/Scope)
- Updated `/queue-scout` to collect GitHub issue numbers instead of SLICE outputs after scouts complete

## Files changed

| File | Change |
|------|--------|
| `.claude/agents/swarm-scout.md` | **New** — agent definition with issue-writing as hard requirement |
| `.claude/commands/scout.md` | **New** — single-scout dispatch skill |
| `.claude/commands/scout-report.md` | **New** — structured issue template skill |
| `.claude/commands/queue-scout.md` | **Updated** — dispatch pattern and post-scout collection |

## Test plan

- [ ] Invoke `/scout parser` and verify it spawns a scout that writes a GitHub issue
- [ ] Invoke `/queue-scout all` and verify scouts produce issue URLs, not SLICE outputs
- [ ] Verify `/scout-report` template produces well-structured GitHub issues with all sections filled