### PR TITLE
feat(swarm): wire one-agent-one-context principle into all dispatch points

### DIFF
--- a/.claude/agents5/swarm-builder.md
+++ b/.claude/agents5/swarm-builder.md
@@ -7,6 +7,13 @@ color: blue
 
 You are a builder teammate in the perl-lsp swarm. You continuously claim build tasks and implement them using subagents in worktree isolation.
 
+## One Agent, One Context
+
+- Each subagent handles **ONE crate/file-surface** with `isolation: "worktree"`.
+- Use `/pr-create` (creates draft PR) and `/verify` (runs fmt+clippy+test) instead of inline commands.
+- Only `git add` files you intentionally changed. Never `git add -A` or `git add .`.
+- Builders create **draft PRs**. Reviewers mark ready after inspection.
+
 ## Operating Mode
 
 You are a **persistent teammate**, not a one-shot agent. You:

--- a/.claude/agents5/swarm-reviewer.md
+++ b/.claude/agents5/swarm-reviewer.md
@@ -7,6 +7,12 @@ color: yellow
 
 You are a reviewer teammate in the perl-lsp swarm. You continuously review completed builds, fix small issues, create PRs, and feed results to the merger.
 
+## One Agent, One Context
+
+- Each review subagent handles **ONE PR** with fresh context for a clean review.
+- Reviewers mark draft PRs as ready-for-review after inspection passes.
+- Never review multiple PRs in the same subagent -- spawn a fresh subagent per PR.
+
 ## Operating Mode
 
 You are a **persistent teammate**, not a one-shot agent. You:

--- a/.claude/agents6/swarm-builder.md
+++ b/.claude/agents6/swarm-builder.md
@@ -7,6 +7,13 @@ color: blue
 
 You are a builder teammate in the perl-lsp swarm. You continuously claim build tasks and implement them using subagents in worktree isolation.
 
+## One Agent, One Context
+
+- Each subagent handles **ONE crate/file-surface** with `isolation: "worktree"`.
+- Use `/pr-create` (creates draft PR) and `/verify` (runs fmt+clippy+test) instead of inline commands.
+- Only `git add` files you intentionally changed. Never `git add -A` or `git add .`.
+- Builders create **draft PRs**. Reviewers mark ready after inspection.
+
 ## Protocol
 
 Invoke `/swarm-protocol` for shared rules: autonomy (fix what you see, create side PRs for adjacent issues), direct messaging (message improvers when you find gaps), metrics, discovery log, self-improvement patches.

--- a/.claude/agents6/swarm-reviewer.md
+++ b/.claude/agents6/swarm-reviewer.md
@@ -7,6 +7,12 @@ color: yellow
 
 You are a reviewer teammate in the perl-lsp swarm. You continuously review completed builds, fix small issues, create PRs, and feed results to the merger.
 
+## One Agent, One Context
+
+- Each review subagent handles **ONE PR** with fresh context for a clean review.
+- Reviewers mark draft PRs as ready-for-review after inspection passes.
+- Never review multiple PRs in the same subagent -- spawn a fresh subagent per PR.
+
 ## Protocol
 
 Invoke `/swarm-protocol` for shared rules: autonomy, direct messaging (message fixers directly, message improver-docs when you see patterns across PRs), metrics, discovery log.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -9,6 +9,16 @@ Start a continuous swarm. Focus: **$ARGUMENTS**
 
 You are the lead. You coordinate only. You NEVER write production code.
 
+## Dispatch Principles
+
+1. **One agent, one context**: Each agent handles ONE PR, ONE crate, ONE issue, ONE sector
+2. **Scouts**: One sector per scout. Fresh agent for different context group.
+3. **Builders**: One crate per builder. Worktree isolated.
+4. **Reviewers**: One PR per reviewer. Fresh context for clean review.
+5. **Mergers**: One PR at a time. Verify CI between each.
+6. **Draft first**: Builders create draft PRs. Reviewers mark ready after fixing.
+7. **Skills over inline**: Agents invoke skills (/verify, /pr-create, /scout-report) not inline commands.
+
 ## Phase 1: Bootstrap
 
 ### Load protocol, priorities, and check state

--- a/.claude/commands/wave.md
+++ b/.claude/commands/wave.md
@@ -7,6 +7,12 @@ argument-hint: "<category> e.g. 'parser-fixes', 'test-coverage', 'doc-updates', 
 
 Launch a wave of agents for: **$ARGUMENTS**
 
+## Dispatch Principles
+
+- **Each wave agent handles one independent task in one worktree.** No agent spans multiple crates or PRs.
+- **PRs created as draft** — review agents mark ready after inspection.
+- Invoke skills (`/verify`, `/pr-create`) rather than inlining commands.
+
 ## Direct-Action Agent Template
 
 Every agent spawned by a wave MUST use this template. No coordinator layers. No speculative spawning. The lead spawns worktree agents directly:


### PR DESCRIPTION
## Summary

- Adds "Dispatch Principles" section to `.claude/commands/swarm.md` (7 numbered rules covering scouts, builders, reviewers, mergers, draft-first, skills-over-inline)
- Adds "Dispatch Principles" section to `.claude/commands/wave.md` (one task per worktree, draft PRs, skill invocation)
- Adds "One Agent, One Context" section to builder agent definitions (`agents5/swarm-builder.md`, `agents6/swarm-builder.md`) -- one crate per subagent, `/pr-create` and `/verify` skills, explicit git-add hygiene, draft-first
- Adds "One Agent, One Context" section to reviewer agent definitions (`agents5/swarm-reviewer.md`, `agents6/swarm-reviewer.md`) -- one PR per subagent, fresh context, mark-ready workflow

## Test plan

- [ ] Verify swarm startup loads the new Dispatch Principles section
- [ ] Verify wave dispatch respects one-task-per-worktree rule
- [ ] Confirm builder subagents create draft PRs (not ready PRs)
- [ ] Confirm reviewer subagents handle one PR each with fresh context