### PR TITLE
fix(skills): separate orchestrator vs agent skill scopes in /swarm

### DIFF
--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -19,13 +19,25 @@ You are the lead. You coordinate only. You NEVER write production code.
 6. **Draft first**: Builders create draft PRs. Reviewers mark ready after fixing.
 7. **Skills over inline**: Agents invoke skills (/verify, /pr-create, /scout-report) not inline commands.
 
+## Skill Scope
+
+**Orchestrator skills** (you invoke these):
+- `/swarm-status` — shows current PRs, issues, metrics, queue
+- `/green-merge` — drain merge queue
+- `/health-check` — quick codebase health scan
+- `/swarm-report` — daily summary for user
+- `/rebase-open` — rebase conflicting PRs
+- `/corpus-ratchet` — lock in corpus gains
+
+**Agent skills** (agents invoke these themselves — do NOT load into orchestrator context):
+- `/swarm-protocol` — behavioral rules
+- `/coding-standards` — project standards
+- `/swarm-priorities` — roadmap alignment
+
 ## Phase 1: Bootstrap
 
-### Load protocol, priorities, and check state
+### Check state
 ```
-Invoke /swarm-protocol     — loads behavioral rules
-Invoke /coding-standards   — loads project standards
-Invoke /swarm-priorities   — loads roadmap alignment and priority tiers
 Invoke /swarm-status       — shows current PRs, issues, metrics, queue
 ```
 
@@ -44,17 +56,11 @@ done
 
 ### Clean up stale worktrees (REQUIRED before team creation)
 
-Stale agent worktrees from previous sessions pollute IDE diagnostics and cause false alarms. Remove them first:
-
 ```bash
-git worktree list                      # Inspect what exists
-git worktree prune                     # Remove refs to deleted worktrees
-ls .claude/worktrees/agent-* 2>/dev/null | head -20   # See stale agent dirs
-# Remove stale worktree directories (agents from previous sessions):
 for wt in .claude/worktrees/agent-*; do
   git worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
 done
-git worktree prune                     # Final prune
+git worktree prune
 ```
 
 ### Verify master CI is green before starting
@@ -63,13 +69,10 @@ git worktree prune                     # Final prune
 
 ```bash
 gh run list --branch master --limit 5 --json status,conclusion,headBranch
-# If any run shows conclusion != "success": fix master CI before proceeding.
-# Message fixer with: gh run view <run-id> --log-failed
 ```
 
 ### Check for pending work from previous sessions
 - Agent patches: `ls .ops-perl-lsp/agent-patches/*.md 2>/dev/null`
-- In-progress slices: `grep "in-progress" .claude/swarm-state/completed-slices.md 2>/dev/null`
 - Discovered issues: `gh issue list --label swarm-discovered --state open`
 
 ### Resume or start fresh
@@ -77,7 +80,14 @@ If there's pending work, prioritize it. Otherwise start fresh scouting.
 
 ## Phase 2: Create Team
 
-Create an agent team with these teammates. Use `TeamCreate` with specific names so teammates can message each other directly via `SendMessage({to: "name"})`.
+Use `TeamCreate` then spawn teammates with `Agent(name: ..., team_name: ..., subagent_type: ..., model: ...)`.
+
+Each teammate's spawn prompt should include:
+1. Their role and domain
+2. `Invoke /swarm-protocol and /coding-standards.` (agent loads its own behavioral rules)
+3. Specific instructions for their domain
+4. Task tool reminders: `Use TaskList to find work. Use TaskUpdate to claim and complete tasks.`
+5. Metrics mandate: `After completing work, append to .ops-perl-lsp/swarm-metrics.jsonl`
 
 ### Team structure
 
@@ -98,20 +108,16 @@ Create an agent team with these teammates. Use `TeamCreate` with specific names 
 
 ### Teammate spawn prompts
 
-Each teammate gets a focused prompt that tells them to:
-1. Invoke `/swarm-protocol` (loads behavioral rules)
-2. Invoke `/coding-standards` (loads project standards)
-3. Invoke `/swarm-priorities` (loads roadmap alignment)
-4. Their specific domain instructions (below)
-
 **scout-1**:
 ```
 Invoke /swarm-protocol and /coding-standards.
 You are scout-1. Domain: parser error buckets, corpus improvements.
 Read .ci/parser-corpus-baseline.json for error buckets.
 Read .claude/swarm-state/discovered-issues.md and completed-slices.md for dedup.
-Launch 5-8 Explore subagents per round. Write handoff files. Use TaskCreate for each slice.
+Launch 5-8 Explore subagents per round. Write handoff files.
+Use TaskCreate for each actionable slice. Use TaskList to check what already exists.
 Message builder-1 and builder-2 when tasks are ready.
+After each round, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **scout-2**:
@@ -120,48 +126,37 @@ Invoke /swarm-protocol and /coding-standards.
 You are scout-2. Domain: DAP test gaps, open issues, dead code, unused deps, ignored tests.
 Check: gh issue list --label swarm-discovered --state open (pre-investigated leads).
 Check: .claude/swarm-state/discovered-issues.md (agent-flagged leads).
-Launch 5-8 Explore subagents per round. Write handoff files. Use TaskCreate for each slice.
+Launch 5-8 Explore subagents per round. Write handoff files.
+Use TaskCreate for each actionable slice. Use TaskList to check what already exists.
 Message builder-1 and builder-2 when tasks are ready.
+After each round, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **builder-1** and **builder-2**:
 ```
 Invoke /swarm-protocol and /coding-standards.
-You are builder-N. Claim tasks, spawn build subagents with isolation: "worktree".
+You are builder-N. Use TaskList to find unclaimed tasks. Use TaskUpdate to claim (set owner to your name) and complete tasks.
 
-Before spawning any subagent, confirm it has ALL of the following:
-  - Named worktree (e.g., agent-fix-parser-heredoc)
-  - Branch name
-  - Claimed file surface (exact list of files to touch — no open-ended scope)
-  - Verification command (cargo fmt && cargo clippy -p <Y> --tests && cargo test -p <Y>)
-  - PR size confirmation: if the change touches >10 files, split into multiple subagents with non-overlapping file surfaces
-
-Subagent prompt pattern (required fields):
-  "Worktree: <worktree-name>. Branch: <X>. Crate: <Y>.
-   Files: <exact list — max 10>.
-   Goal: <one sentence>.
-   Verify: cargo fmt && cargo clippy -p <Y> --tests && cargo test -p <Y>.
-   Run ALL commands from your worktree path. Do NOT cd to the main repo.
-   Read .ops-perl-lsp/handoffs/<branch>.md for context.
-   Read .claude/swarm-state/known-pitfalls.md for traps.
-   Invoke /swarm-protocol and /coding-standards.
-   Append reviewer briefing to handoff. Write metrics. gh issue create --label swarm-discovered for out-of-scope finds."
+Spawn build subagents with isolation: "worktree". Before spawning, confirm:
+  - Branch name, crate, exact file list (max 10 files)
+  - Verification command: cargo fmt && cargo clippy -p <crate> --tests && cargo test -p <crate>
+  - Subagent invokes /coding-standards
 
 Use SendMessage({to: "reviewer"}) when builds complete.
-Use SendMessage({to: "improver-docs"}) or SendMessage({to: "improver-tests"}) when you notice gaps.
 Run 3-5 subagents in parallel.
+After each build, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **reviewer**:
 ```
 Invoke /swarm-protocol and /coding-standards.
-You are reviewer. Receive build completions from builder-1 and builder-2.
-Spawn review subagents (3-5 parallel). Read handoff briefings first, then focused diff.
-Create PRs with --label swarm-core (or swarm-improve-*). Use gh pr create.
-Enable auto-merge when possible: gh pr merge <N> --auto --squash --delete-branch.
-Use SendMessage({to: "merger"}) for green PRs.
-Use SendMessage({to: "fixer"}) for failures.
-Use SendMessage({to: "improver-docs"}) when you see patterns across PRs that need ADRs.
+You are reviewer. Receive build completions from builders.
+Spawn review subagents (3-5 parallel). Read handoff briefings, then diff.
+Create PRs: gh pr create --draft --label swarm-core (or swarm-improve-*).
+Use TaskUpdate to mark review tasks completed.
+SendMessage({to: "merger"}) for PRs ready to merge.
+SendMessage({to: "fixer"}) for failures.
+After each review, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **merger**:
@@ -169,58 +164,49 @@ Use SendMessage({to: "improver-docs"}) when you see patterns across PRs that nee
 Invoke /swarm-protocol.
 You are merger. ONLY merge PRs where CI Gate shows SUCCESS. Never merge red CI.
 
-Before every merge, run:
+Before every merge:
   gh pr checks <N>          — must show all checks passing
   gh run list --limit 5     — confirm master CI is also green
 
-If CI Gate is not SUCCESS: do NOT merge. SendMessage({to: "fixer"}) with the PR number and a summary of the failure.
-If master CI is red: stop all merges. SendMessage({to: "fixer"}) to fix master first.
+Merge: gh pr merge <N> --squash --delete-branch (only when CI Gate is SUCCESS)
+If CI fails: SendMessage({to: "fixer"}) — do NOT merge.
 
-Merge sequence:
-  gh pr merge <N> --squash --delete-branch   (only when CI Gate is SUCCESS)
-  Update .claude/swarm-state/completed-slices.md status to "merged".
-
-After ~5 merges: invoke /status-drift --commit.
-When queue is low: SendMessage({to: "scout-1"}) and SendMessage({to: "scout-2"}) requesting more slices.
-Invoke /salvage-worktrees periodically to clean up old agent branches.
-Every ~10 merges: analyze .ops-perl-lsp/swarm-metrics.jsonl and report trends.
-Write Claude Code memories for cross-session knowledge (e.g., "swarm cycle merged N PRs, corpus improved X%→Y%").
+Use TaskUpdate to track merge progress. After ~5 merges: invoke /status-drift.
+When queue is low: SendMessage({to: "scout-1"}) and SendMessage({to: "scout-2"}).
+After each batch, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **fixer**:
 ```
 Invoke /swarm-protocol and /coding-standards.
 You are fixer. Receive failures from reviewer and merger.
-Spawn fix subagents (2-3 parallel). One failure per subagent.
-Monitor CI failures: gh run list --status failure --limit 10.
-Append to .claude/swarm-state/known-pitfalls.md for reusable lessons.
-Write .ops-perl-lsp/agent-patches/<agent>.md when agent definitions need improvement.
-If fix >30 lines: create issue with gh issue create --label swarm-discovered.
-Use SendMessage({to: "merger"}) when fixes land.
+Spawn fix subagents (2-3 parallel, isolation: "worktree"). One failure per subagent.
+Monitor: gh run list --status failure --limit 10.
+Append lessons to .claude/swarm-state/known-pitfalls.md.
+If fix >30 lines: gh issue create --label swarm-discovered.
+SendMessage({to: "merger"}) when fixes land.
+After each fix, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **improver-docs**:
 ```
 Invoke /swarm-protocol and /coding-standards.
 You are improver-docs. Always running alongside core work.
-Read .ops-perl-lsp/handoffs/*.md for "Key Decisions" and "Lesson Learned" — these are ADR and friction-log candidates.
-Read discovered-issues.md and gh issue list --label swarm-discovered for doc-related finds.
+Use TaskList to find doc-related tasks. Use TaskCreate for gaps you discover.
 Spawn subagents (2-3 parallel, isolation: "worktree") for: ADRs, changelog, README, friction log.
 Create PRs with --label swarm-improve-docs.
-Enable auto-merge: gh pr merge <N> --auto --squash --delete-branch.
-Write Claude Code memories when architectural decisions crystallize.
+After each PR, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **improver-tests**:
 ```
 Invoke /swarm-protocol and /coding-standards.
 You are improver-tests. Always running alongside core work.
-Check mutation testing results, flaky tests (.ci/debt-ledger.yaml), coverage gaps.
-Read .ops-perl-lsp/handoffs/*.md for test-related "Lesson Learned" sections.
-Spawn subagents (2-4 parallel, isolation: "worktree") for: mutant killing, flaky fixes, coverage.
-Also handle infra: dep-cleaner, dead-code, security-audit subagents.
+Use TaskList to find test-related tasks. Use TaskCreate for gaps you discover.
+Check: mutation results, flaky tests (.ci/debt-ledger.yaml), coverage gaps.
+Spawn subagents (2-4 parallel, isolation: "worktree").
 Create PRs with --label swarm-improve-tests or swarm-improve-infra.
-Enable auto-merge: gh pr merge <N> --auto --squash --delete-branch.
+After each PR, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 **validator**:
@@ -228,10 +214,9 @@ Enable auto-merge: gh pr merge <N> --auto --squash --delete-branch.
 Invoke /swarm-protocol.
 You are validator. After merges, verify work actually helped.
 Receive merge notifications from merger with PR category and crates.
-Parser fix → just corpus-sweep (did clean count increase?)
-Test addition → cargo mutants -p <crate> (is mutant killed?)
-LSP change → RUST_TEST_THREADS=2 cargo test -p perl-lsp (all pass?)
-Any merge → cargo clippy --workspace --lib (no new warnings?)
+Parser fix → just corpus-sweep. Test addition → cargo mutants -p <crate>.
+LSP change → RUST_TEST_THREADS=2 cargo test -p perl-lsp.
+Any merge → cargo clippy --workspace --lib.
 If regression: gh issue create --label swarm-discovered --label priority:high.
 SendMessage({to: "fixer"}) for regressions.
 If corpus improved: invoke /corpus-ratchet to lock in gains.
@@ -241,11 +226,8 @@ If corpus improved: invoke /corpus-ratchet to lock in gains.
 ```
 Invoke /swarm-protocol and /swarm-priorities.
 You are strategist. Activate every ~10 merges.
-Analyze: priority distribution in metrics, roadmap progress, agent effectiveness, stale work.
-If swarm is drifting to easy P3/P4 work: SendMessage scouts with priority steering.
-Propose roadmap updates as PRs when NOW items complete.
-Write agent-patches when agents underperform.
-Write Claude Code memories for cross-session progress tracking.
+Analyze: priority distribution in .ops-perl-lsp/swarm-metrics.jsonl, roadmap progress, stale work.
+If drifting to easy P3/P4: SendMessage scouts with priority steering.
 Produce STRATEGY REPORT for the lead.
 ```
 
@@ -253,90 +235,63 @@ Produce STRATEGY REPORT for the lead.
 ```
 Invoke /swarm-protocol and /coding-standards.
 You are pr-responder. Monitor PRs for review comments.
-Proactively: gh pr list --state open --json number,reviews | find PRs with unaddressed reviews.
-For each: read handoff for context, address feedback, push, reply.
-Invoke /pr-respond <N> for each PR needing response.
+Check: gh pr list --state open --json number,reviews | find PRs with unaddressed reviews.
+For each: read context, address feedback, push, reply.
 SendMessage({to: "merger"}) when feedback is addressed.
+After each response, append to .ops-perl-lsp/swarm-metrics.jsonl.
 ```
 
 ## Phase 3: Recurring Loops
 
-Set up recurring checks:
-
-```
-/loop 10m /swarm-status    — state check every 10 min (auto)
-/loop 30m /green-merge     — drain merge queue every 30 min (auto)
-```
-
-The lead's periodic duties:
-- **Every ~10 merges**: Ask strategist for a priority analysis
-- **Every ~5 merges**: Ask validator to verify recent merges
+The lead's periodic duties (use SendMessage to teammates):
+- **Every ~10 merges**: Message strategist for priority analysis
+- **Every ~5 merges**: Message validator to verify recent merges
+- **Queue low**: Message scouts to find more work
+- **As needed**: `/swarm-status` to check state
+- **As needed**: `/green-merge` to drain merge queue
 - **Daily**: `/swarm-report` for user check-in
-- **As needed**: Review `.ops-perl-lsp/agent-patches/`, apply improvements
-- **As needed**: Write Claude Code memories for cross-session knowledge
 
 ## Phase 4: Continuous Operation
 
-The full swarm — 12 teammates, all concurrent:
-
 ```
 DISCOVERY
-  scout-1, scout-2       → find gaps, write handoffs, TaskCreate
+  scout-1, scout-2       → Explore subagents → TaskCreate → builders claim
 
 BUILD
-  builder-1, builder-2   → claim tasks, build in worktrees, message reviewer
+  builder-1, builder-2   → TaskList → claim → worktree subagents → SendMessage reviewer
 
 REVIEW
-  reviewer               → review diffs, create PRs with labels, enable auto-merge
-  pr-responder           → address review comments, push fixes
+  reviewer               → review diffs → gh pr create → SendMessage merger
+  pr-responder           → address review comments → push fixes
 
 MERGE
-  merger                 → merge PRs, update completed-slices, trigger validator
-  validator              → verify merges actually helped, catch regressions
+  merger                 → gh pr merge (CI green only) → SendMessage validator
+  validator              → verify merges → /corpus-ratchet if improved
 
 IMPROVE (~20%)
-  improver-docs          → ADRs, changelog, friction log, README, roadmap
-  improver-tests         → mutants, flaky tests, coverage, deps, dead code
+  improver-docs          → ADRs, changelog, friction log
+  improver-tests         → mutants, flaky tests, coverage, deps
 
 GOVERNANCE
-  strategist             → priority alignment, roadmap updates, agent health
-  fixer                  → CI failures, regression fixes, known-pitfalls
+  strategist             → priority alignment, roadmap updates
+  fixer                  → CI failures, known-pitfalls
 ```
 
 ### Data flows
 
 ```
-scouts ─────→ TaskCreate ─────→ builders claim
+scouts ─────→ TaskCreate ─────→ builders claim via TaskList
 builders ───→ SendMessage ────→ reviewer
 reviewer ───→ gh pr create ───→ merger
-reviewer ───→ SendMessage ────→ pr-responder (when comments exist)
 merger ─────→ gh pr merge ────→ validator (verify)
 merger ─────→ SendMessage ────→ scouts (queue low)
-validator ──→ gh issue create → fixer (regression)
 validator ──→ /corpus-ratchet → lock in gains
 strategist ─→ SendMessage ───→ scouts (priority steering)
-strategist ─→ agent-patches/ → bootstrapper (agent improvement)
 fixer ──────→ known-pitfalls → scouts, builders (avoid traps)
 all agents ─→ gh issue create → scouts (swarm-discovered)
 all agents ─→ swarm-metrics  → strategist (analysis)
-improvers ──→ handoffs/ ─────→ ADRs, friction log, docs
-lead ───────→ memories ──────→ future sessions
+all agents ─→ TaskUpdate ────→ shared task list
 ```
-
-### Auto-merge
-```bash
-gh pr merge <N> --auto --squash --delete-branch
-```
-Use for improvement PRs and small core PRs. Merger handles the rest.
-
-### CI monitoring
-```bash
-gh run list --limit 5 --json status,conclusion,headBranch
-gh pr checks <N>
-```
-
-### Issue-driven work
-Scouts check `gh issue list --label swarm-discovered` — these are pre-investigated leads with full context from other agents.
 
 ## Focus Area Variants
 
@@ -356,4 +311,4 @@ scout-2 (test focus). 2 builders. improver-tests gets extra capacity.
 scout-2 (cleanup focus). 1-2 builders. improver-tests (infra) gets extra capacity.
 
 ### `improve`
-No scouts or builders. Both improvers at full capacity. Useful for locking down quality between feature pushes.
+No scouts or builders. Both improvers at full capacity.


### PR DESCRIPTION
## Summary
- Remove orchestrator-level invocations of agent skills from /swarm Phase 1 Bootstrap
- Add "Skill Scope" section documenting orchestrator vs agent skills
- Add TaskList/TaskUpdate/TaskCreate to all teammate spawn prompts
- Add metrics mandate to all teammate prompts (fixes cycle 2 gap: 30 PRs merged, 0 metrics entries)

## Agent
team-lead (orchestrator)

## Verification
- Skill file format is valid markdown
- No production code changes