### PR TITLE
fix(parser): foreach/for with implicit $_ topic variable and bare scalar

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -272,7 +272,14 @@ impl<'a> Parser<'a> {
         self.in_for_loop_init = true;
         let variable = if self.peek_kind() == Some(TokenKind::My) {
             self.parse_variable_declaration()?
+        } else if self.peek_kind() == Some(TokenKind::LeftParen) {
+            // foreach (LIST) — implicit $_ topic variable
+            Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "_".to_string() },
+                SourceLocation { start, end: start },
+            )
         } else {
+            // foreach $var (LIST) — bare scalar without my
             self.parse_variable()?
         };
         self.in_for_loop_init = false;
@@ -310,6 +317,7 @@ impl<'a> Parser<'a> {
         let variable = if self.peek_kind() == Some(TokenKind::My) {
             self.parse_variable_declaration()?
         } else {
+            // for $var (LIST) — bare scalar without my
             self.parse_variable()?
         };
         self.in_for_loop_init = false;

--- a/crates/perl-parser-core/tests/fix_foreach_bare_variable.rs
+++ b/crates/perl-parser-core/tests/fix_foreach_bare_variable.rs
@@ -1,0 +1,51 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// foreach (LIST) — implicit $_ topic variable
+#[test]
+fn foreach_implicit_topic_no_variable() {
+    assert_clean_parse("foreach (@INC) { print; }");
+}
+
+#[test]
+fn foreach_implicit_topic_keys() {
+    assert_clean_parse("foreach (keys %ENV) { print \"$_\\n\"; }");
+}
+
+#[test]
+fn foreach_implicit_topic_array_ref() {
+    assert_clean_parse("foreach (@{$list}) { process($_); }");
+}
+
+// foreach $var (LIST) — bare scalar without my
+#[test]
+fn foreach_bare_scalar_no_my() {
+    assert_clean_parse("foreach $mod (@ISA) { eval \"require $mod\"; }");
+}
+
+#[test]
+fn foreach_bare_scalar_dirs() {
+    assert_clean_parse("foreach $dir (@dirs) { push @found, $dir if -d $dir; }");
+}
+
+#[test]
+fn for_bare_scalar_no_my() {
+    assert_clean_parse("for $mod (@ISA) { print $mod; }");
+}
+
+// Regression: existing working cases still work
+#[test]
+fn foreach_with_my_still_works() {
+    assert_clean_parse("foreach my $item (@list) { print $item; }");
+}
+
+#[test]
+fn for_with_my_still_works() {
+    assert_clean_parse("for my $i (1..10) { print $i; }");
+}
+
+// Labeled foreach with implicit $_
+#[test]
+fn labeled_foreach_implicit_topic() {
+    assert_clean_parse("LOOP: foreach (@args) { next LOOP if $_ eq 'skip'; }");
+}


### PR DESCRIPTION
## Summary
- `foreach (@INC) { ... }` — implicit `$_` topic variable — was failing with `expected_variable`
- `for $mod (@ISA) { ... }` — bare scalar without `my` — same error
- Added `LeftParen` check in `parse_foreach_statement` to synthesize implicit `$_` node (same pattern already used in the `for` keyword path)
- Estimated impact: **182 files** in the `expected_variable` error bucket. Issue #1700.

## Agent
builder-1 (cycle3 team)

## Handoff
No separate handoff file — direct build from issue #1700.

## Verification
- `cargo test -p perl-parser-core --test fix_foreach_bare_variable` — 9 passed
- `cargo test -p perl-parser-core` — 389 passed (all suites), 0 failed
- `cargo clippy -p perl-parser-core --lib` — clean
- `cargo fmt --all` — clean

## What to Watch For
- The `parse_foreach_style_for` function is only called from the `for` path when `My` or a sigil is detected (line 185), so no change was needed there
- Regression: `foreach my $item (@list)` and `for my $i (1..10)` both still work (covered by tests)