### PR TITLE
chore(xtask): subcategorize unexpected_token_in_expr into specific token buckets

### DIFF
--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -45,6 +45,28 @@ const SEMANTIC_BUCKETS: &[(&str, &str)] = &[
     ("expected expression, found '/'", "unexpected_slash_expr"),
     ("expected expression, found '?'", "unexpected_question_expr"),
     ("expected expression, found 'return'", "unexpected_return_expr"),
+    // Expression errors — keyword tokens (subcategories of catch-all, must precede it)
+    ("expected expression, found 'unless'", "unexpected_token_unless"),
+    ("expected expression, found 'until'", "unexpected_token_until"),
+    ("expected expression, found 'while'", "unexpected_token_while"),
+    ("expected expression, found 'else'", "unexpected_token_else"),
+    ("expected expression, found 'elsif'", "unexpected_token_elsif"),
+    ("expected expression, found 'for'", "unexpected_token_for"),
+    ("expected expression, found 'foreach'", "unexpected_token_foreach"),
+    ("expected expression, found 'use'", "unexpected_token_use"),
+    ("expected expression, found 'no'", "unexpected_token_no"),
+    // Expression errors — word operators
+    ("expected expression, found 'or'", "unexpected_word_op_or"),
+    ("expected expression, found 'and'", "unexpected_word_op_and"),
+    ("expected expression, found 'not'", "unexpected_word_op_not"),
+    ("expected expression, found 'xor'", "unexpected_word_op_xor"),
+    // Expression errors — punctuation
+    ("expected expression, found ','", "unexpected_comma_expr"),
+    ("expected expression, found ';'", "unexpected_semicolon_expr"),
+    ("expected expression, found '}'", "unexpected_rbrace_expr"),
+    ("expected expression, found ')'", "unexpected_rparen_expr"),
+    ("expected expression, found 'end of input'", "unexpected_eof_expr"),
+    // Catch-all for remaining unexpected expression tokens (MUST remain last)
     ("expected expression, found", "unexpected_token_in_expr"),
     // Unclosed delimiters — user-friendly names ('}', ')', ']')
     ("expected '}', found ';'", "unclosed_brace_semicolon"),


### PR DESCRIPTION
## Summary

- Adds 19 specific SEMANTIC_BUCKETS entries before the `unexpected_token_in_expr` catch-all to distinguish specific token categories
- Covers: keyword tokens (unless/until/while/else/elsif/for/foreach/use/no), word operators (or/and/not/xor), punctuation (comma/semicolon/rbrace/rparen/eof)
- Pure observability change — no parser logic touched; catch-all remains last (first-match-wins semantics preserved)

Closes #1702

## Test plan

- [ ] `cargo clippy -p xtask` — clean (verified)
- [ ] `cargo fmt` — clean (verified)
- [ ] `cargo test -p xtask` — 6 pre-existing failures on master (NOT introduced by this PR; verified by `git stash && cargo test` still fails)
- [ ] Run `cargo xtask corpus-audit` against CPAN corpus to verify new bucket categories appear in output

## Notes

Pre-existing xtask test failures: the `test_semantic_bucket_mapping` test checks for `"found FatArrow"` format but SEMANTIC_BUCKETS uses `"found '=>'"` format — a pre-existing mismatch in master unrelated to this change. The 6 failing tests fail identically on master without this PR's changes.