### PR TITLE
feat(hooks): add SubagentStart, Stop, PreToolUse, SessionStart hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,30 +8,30 @@
   "permissions": {
     "defaultMode": "bypassPermissions",
     "allow": [
-      "Bash(gh:*)",
-      "Bash(git:*)",
-      "Bash(cargo:*)",
-      "Bash(just:*)",
-      "Bash(python3:*)",
-      "Bash(bash:*)",
-      "Bash(sed:*)",
-      "Bash(mkdir:*)",
-      "Bash(cp:*)",
-      "Bash(mv:*)",
-      "Bash(rm:*)",
-      "Bash(ls:*)",
-      "Bash(cat:*)",
-      "Bash(wc:*)",
-      "Bash(grep:*)",
-      "Bash(sort:*)",
-      "Bash(head:*)",
-      "Bash(tail:*)",
-      "Bash(echo:*)",
-      "Bash(date:*)",
-      "Bash(chmod:*)",
-      "Bash(diff:*)",
-      "Bash(find:*)",
-      "Bash(for:*)",
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(cargo *)",
+      "Bash(just *)",
+      "Bash(python3 *)",
+      "Bash(bash *)",
+      "Bash(sed *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(rm *)",
+      "Bash(ls *)",
+      "Bash(cat *)",
+      "Bash(wc *)",
+      "Bash(grep *)",
+      "Bash(sort *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(echo *)",
+      "Bash(date *)",
+      "Bash(chmod *)",
+      "Bash(diff *)",
+      "Bash(find *)",
+      "Bash(for *)",
       "WebFetch",
       "WebSearch"
     ]
@@ -68,6 +68,49 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/task-completed.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "swarm-builder|swarm-reviewer|swarm-fixer",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Reminder: Invoke /coding-standards before writing any code. No unwrap(), expect(), panic!(), todo!() in production. Use Result/Option. Run cargo fmt + clippy before committing.'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); STOP_ACTIVE=$(echo \"$INPUT\" | jq -r '.stop_hook_active // false'); if [ \"$STOP_ACTIVE\" = \"true\" ]; then exit 0; fi; echo 'Before stopping: verify all claimed tasks are completed with actual deliverables (branches pushed, PRs created). If not, keep working.' >&2; exit 0"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE 'git push --force|git push -f |git checkout \\.|git reset --hard|rm -rf /|cargo publish|git clean -fd'; then echo \"Blocked: dangerous command '$CMD'. Use safer alternatives.\" >&2; exit 2; fi; exit 0"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Post-compaction context refresh: This project uses agent-based development. The orchestrator routes work to agents, never writes code directly. Key rules: No unwrap/expect/panic in production code. Use TaskList/TaskUpdate for task coordination. Invoke skills (/parser-fix, /verify-build, /scout-report) instead of inline instructions. See CLAUDE.md for full context.'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds 4 new hook events to `.claude/settings.json` for enforcing agent discipline and safety
- **SubagentStart**: injects coding-standards reminder into swarm-builder/reviewer/fixer agents
- **Stop**: reminds agents to verify deliverables (branches pushed, PRs created) before stopping
- **PreToolUse**: blocks dangerous bash commands (`git push --force`, `rm -rf /`, `cargo publish`, etc.)
- **SessionStart**: re-injects critical project context after compaction events
- Fixes permission rule syntax from `Bash(cmd:*)` to `Bash(cmd *)` per official Claude Code docs

## Test plan
- [ ] Verify JSON is valid (`python3 -m json.tool .claude/settings.json`)
- [ ] Verify all existing hooks (PostToolUse, TeammateIdle, TaskCompleted) are preserved
- [ ] Verify new hooks are present: SubagentStart, Stop, PreToolUse, SessionStart
- [ ] Verify permission rules use space syntax: `Bash(gh *)` not `Bash(gh:*)`
- [ ] Manually test PreToolUse by attempting a blocked command like `git push --force`