### PR TITLE
docs(swarm): mark legacy workflow surfaces as archived

### DIFF
--- a/.claude/commands/bootstrap-agents.md
+++ b/.claude/commands/bootstrap-agents.md
@@ -9,7 +9,8 @@ disable-model-invocation: true
 Discover the codebase structure and generate domain-specific agent definitions. Context: **$ARGUMENTS**
 
 ## When to Use
-- **First time**: after `swarm-pack/setup.sh` installs portable agents — run this to add domain agents
+- **First time in this repo**: when the tracked `.claude/` control plane is present and you want to add repo-specific domain agents
+- **Imported bundle**: after copying the derived `swarm-pack` starter into another repo and you want to specialize it
 - **Refresh**: when the codebase structure changed (new packages, reorganization)
 - **Single domain**: `--domain <name>` to regenerate agents for one domain only
 
@@ -18,7 +19,7 @@ Discover the codebase structure and generate domain-specific agent definitions. 
 1. **Discovers** your repo: packages, tests, errors, standards, CI, docs
 2. **Identifies** natural domains (package families, layers, feature areas)
 3. **Generates** 3-5 agent files per domain: fix, test, scout, explorer
-4. **Customizes** the portable agents with repo-specific details
+4. **Customizes** the repo-local agent roster with codebase-specific details
 5. **Creates** `.claude/agents/AGENT_CATALOG.md` for orchestrator reference
 
 ## Process

--- a/docs/handoff/agent-swarm-workflow/README.md
+++ b/docs/handoff/agent-swarm-workflow/README.md
@@ -1,7 +1,16 @@
 # Agent Swarm Workflow
 
+> Status: archived portable bundle.
+>
+> For `perl-lsp`, the canonical swarm runtime lives in the tracked `.claude/`
+> directory plus [SWARM_DESIGN.md](../../SWARM_DESIGN.md) and
+> [SKILL_AND_AGENT_DESIGN.md](../../../reference/SKILL_AND_AGENT_DESIGN.md).
+> This directory is kept as a historical/exportable bundle for the older
+> wave-based workflow, not as the primary source of truth for the repo.
+
 A portable pattern for orchestrating multiple Claude Code agents in parallel to
-accomplish large-scale codebase changes efficiently and safely.
+accomplish large-scale codebase changes efficiently and safely when you want to
+transplant the older wave workflow into another repository.
 
 ## How it works
 
@@ -85,6 +94,9 @@ Orchestrator (main thread)
 | `slash-commands/quality-ratchet.md` | Baseline ratcheting after improvements |
 
 ## Getting started
+
+For `perl-lsp` itself, do not bootstrap from this bundle; use the tracked repo
+`.claude/` surfaces instead.
 
 1. Run `setup-script.sh` in your repository root
 2. Customize the placeholders (`$TEST_CMD`, `$LINT_CMD`, etc.) in the copied

--- a/docs/handoff/agent-swarm-workflow/setup-script.sh
+++ b/docs/handoff/agent-swarm-workflow/setup-script.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 #
-# Bootstrap script for the agent swarm workflow.
+# Legacy bootstrap script for the archived wave-based agent swarm workflow.
 #
 # Copies portable slash commands into .claude/commands/ and creates a
 # minimal .claude/settings.json with a PostToolUse hook.
+#
+# For perl-lsp itself, the tracked repo `.claude/` configuration is canonical.
+# This script is for exporting the older portable workflow to another repo.
 #
 # Usage:
 #   bash docs/handoff/agent-swarm-workflow/setup-script.sh
@@ -97,6 +100,10 @@ echo ""
 echo "========================================================================"
 echo " Agent Swarm Workflow -- Setup Complete"
 echo "========================================================================"
+echo ""
+echo " NOTE: This bundle is a legacy portable archive."
+echo "       For perl-lsp itself, prefer the tracked .claude/ skills, agents,"
+echo "       hooks, and docs/handoff/SWARM_DESIGN.md."
 echo ""
 echo " Files created in: ${CMD_DIR}/"
 echo ""

--- a/docs/handoff/swarm-pack/commands/bootstrap-agents.md
+++ b/docs/handoff/swarm-pack/commands/bootstrap-agents.md
@@ -8,7 +8,8 @@ argument-hint: "[--dry-run] [--domain <name>] [--refresh]"
 Discover the codebase structure and generate domain-specific agent definitions. Context: **$ARGUMENTS**
 
 ## When to Use
-- **First time**: after `swarm-pack/setup.sh` installs portable agents — run this to add domain agents
+- **First time after import**: once the derived `swarm-pack` starter is copied into a new repo and you want repo-specific domain agents
+- **In perl-lsp itself**: prefer the tracked repo `.claude/` surfaces; this pack is a derived export
 - **Refresh**: when the codebase structure changed (new packages, reorganization)
 - **Single domain**: `--domain <name>` to regenerate agents for one domain only
 
@@ -17,7 +18,7 @@ Discover the codebase structure and generate domain-specific agent definitions. 
 1. **Discovers** your repo: packages, tests, errors, standards, CI, docs
 2. **Identifies** natural domains (package families, layers, feature areas)
 3. **Generates** 3-5 agent files per domain: fix, test, scout, explorer
-4. **Customizes** the portable agents with repo-specific details
+4. **Customizes** the imported starter agents with repo-specific details
 5. **Creates** `.claude/agents/AGENT_CATALOG.md` for orchestrator reference
 
 ## Process
@@ -29,7 +30,7 @@ Agent(
   subagent_type: "bootstrapper",
   prompt: "Discover this codebase and generate domain-specific agents. $ARGUMENTS.
 Write agents to .claude/agents/.
-Update portable agents with repo-specific details.
+Update the repo-local coordinator and worker roster when the pattern is reusable.
 Create .claude/agents/AGENT_CATALOG.md.
 Target ~25-35 domain agents.",
   mode: "auto"

--- a/docs/project/AGENT_SWARM_WORKFLOW.md
+++ b/docs/project/AGENT_SWARM_WORKFLOW.md
@@ -1,11 +1,18 @@
 # Agent Swarm Workflow
 
-A practical reference for the parallel-agent development methodology used in
-perl-lsp. For historical context and analysis, see
+> Status: historical wave-pattern reference. The canonical swarm runtime for
+> `perl-lsp` lives in the tracked `.claude/` surfaces plus
+> [SWARM_DESIGN.md](../handoff/SWARM_DESIGN.md),
+> [SKILL_AND_AGENT_DESIGN.md](../reference/SKILL_AND_AGENT_DESIGN.md), and
+> [ADR-0033](../adr/0033-worktree-first-disposable-workers.md).
+>
+> This document is retained as operator history for the older `/wave` +
+> `/bulk-pr` workflow.
+
+A practical historical reference for the parallel-agent development methodology used in
+perl-lsp. For background analysis, see
 [AGENTIC_SWARM_ERA.md](AGENTIC_SWARM_ERA.md) and
-[AGENTIC_DEVELOPMENT.md](AGENTIC_DEVELOPMENT.md). For the governing execution
-doctrine, see [ADR-0033](../adr/0033-worktree-first-disposable-workers.md) and
-[SKILL_AND_AGENT_DESIGN.md](../reference/SKILL_AND_AGENT_DESIGN.md).
+[AGENTIC_DEVELOPMENT.md](AGENTIC_DEVELOPMENT.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- mark the older `/wave` + `/bulk-pr` workflow docs as archived/reference-only and point readers back to the canonical tracked `.claude/` swarm surfaces
- remove the last pack-first wording from the bootstrap docs so `swarm-pack` reads as a derived export, not the repo's primary install path
- add a legacy warning to the archived portable setup script so operators do not confuse it with the live perl-lsp runtime

## Verification
- `git diff --check`
- `bash -n docs/handoff/agent-swarm-workflow/setup-script.sh`