### PR TITLE
docs(swarm): align hook docs with live settings

### DIFF
--- a/docs/adr/0033-worktree-first-disposable-workers.md
+++ b/docs/adr/0033-worktree-first-disposable-workers.md
@@ -117,10 +117,17 @@ attempt to enforce invariants such as:
 - mandatory logging
 - state refresh after compaction
 
-In swarm mode, the lifecycle hooks that operationalize this model are
-`SubagentStart`, `SubagentStop`, `WorktreeCreate`, `WorktreeRemove`, and
-`TaskCompleted`. Those are the mechanical boundaries for provisioning, cleanup,
-queue bookkeeping, metrics, and completion gates.
+In the live repo control plane, the primary lifecycle hooks that operationalize
+this model are `SessionStart`, `SubagentStart`, `SubagentStop`,
+`TeammateIdle`, and `TaskCompleted`. Those are the mechanical boundaries for
+state refresh, provisioning, cleanup, queue bookkeeping, metrics, and
+completion gates.
+
+`WorktreeCreate` and `WorktreeRemove` remain available hook boundaries, but
+they are intentionally not registered in the shared project settings because
+they replace Claude Code's default worktree provisioning and teardown behavior.
+Treat them as reserved hooks to adopt only when the repo explicitly wants to
+own that lifecycle itself.
 
 ### 6. Handoffs are the continuity mechanism
 

--- a/docs/reference/SKILL_AND_AGENT_DESIGN.md
+++ b/docs/reference/SKILL_AND_AGENT_DESIGN.md
@@ -266,13 +266,17 @@ The repo still contains historical agent generations and experiments
 donor material, but they are not the architectural center of gravity anymore.
 
 The current control plane is defined by:
+- [`.claude/README.md`](../../.claude/README.md)
 - [`.claude/agents/README.md`](../../.claude/agents/README.md)
 - [`.claude/commands/swarm.md`](../../.claude/commands/swarm.md)
 - [`.claude/skills/swarm/SKILL.md`](../../.claude/skills/swarm/SKILL.md)
 - [`.claude/skills/swarm/reference/team-structure.md`](../../.claude/skills/swarm/reference/team-structure.md)
 - [`.claude/skills/swarm/templates/teammate-prompt-template.md`](../../.claude/skills/swarm/templates/teammate-prompt-template.md)
+- [`.claude/settings.json`](../../.claude/settings.json)
 - [`docs/handoff/SWARM_DESIGN.md`](../handoff/SWARM_DESIGN.md)
-- [`docs/project/AGENT_SWARM_WORKFLOW.md`](../project/AGENT_SWARM_WORKFLOW.md)
 
 The pack under `docs/handoff/swarm-pack/` is a derived export for adoption in
 other repos. It should mirror the live control plane, not compete with it.
+
+[`docs/project/AGENT_SWARM_WORKFLOW.md`](../project/AGENT_SWARM_WORKFLOW.md) is
+historical/operator reference material, not the live runtime contract.


### PR DESCRIPTION
## Summary
- align ADR-0033 with the hooks actually registered in project settings
- treat WorktreeCreate/WorktreeRemove as reserved hooks rather than live runtime hooks
- update the skill/agent design reference so the canonical control plane points at live .claude surfaces and not the older workflow doc

## Testing
- git diff --check
