### PR TITLE
fix(parser): allow bare return in ternary branches

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
@@ -330,7 +330,6 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    #[ignore = "feature: parser does not yet handle bare return as ternary operand"]
     fn test_return_in_ternary_in_do_block() {
         // my $x = do { $cond ? return : $val }
         let input = "my $x = do { $cond ? return : $val };";
@@ -349,7 +348,6 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    #[ignore = "feature: parser does not yet handle bare return as ternary operand"]
     fn test_bare_return_in_ternary_then() {
         // $cond ? return : $y
         let input = "$cond ? return : $y;";

--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -178,7 +178,7 @@ impl<'a> Parser<'a> {
         if self.peek_kind() == Some(TokenKind::Return)
             && !self.is_keyword_before_fat_arrow()
         {
-            return self.parse_return();
+            return self.parse_return_expr();
         }
 
         let mut expr = self.parse_ternary()?;

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 2097 lib tests (discovered), 4 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2097 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -83,7 +83,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 2097 lib tests (Tier A), 4 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2097 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
## Summary
- parse expression-context `return` via the boundary-aware return parser
- unignore the two ternary bare-return control-flow parser tests that now pass
- refresh `CURRENT_STATUS.md` to reflect the lower tracked ignore count

## Testing
- cargo test -p perl-parser-core --lib
- cargo test -p perl-parser-core --lib engine::parser::control_flow_expr_tests::tests::test_bare_return_in_ternary_then -- --ignored --exact --nocapture
- cargo test -p perl-parser-core --lib engine::parser::control_flow_expr_tests::tests::test_return_in_ternary_in_do_block -- --ignored --exact --nocapture
- python3 scripts/update-current-status.py --check
- git diff --check