### PR TITLE
test(parser): enable return-inside-do-block regression

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow_expr_tests.rs
@@ -306,12 +306,7 @@ mod tests {
     // return in do block
     // ---------------------------------------------------------------
 
-    // Pre-existing parser limitation: `return $x if $cond` inside a
-    // do-block triggers an error because the `if` keyword is consumed
-    // as an if-statement rather than a statement modifier. Tracked
-    // separately from the expression-context fix.
     #[test]
-    #[ignore = "feature: statement modifier after return inside do-block"]
     fn test_return_inside_do_block() {
         // do { return $x if $cond; $y }
         let input = "do { return $x if $cond; $y };";

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 2097 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2097 lib tests (discovered), 1 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -83,7 +83,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 2097 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2097 lib tests (Tier A), 1 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
## Summary
- re-enable the `return $x if $cond` inside `do { ... }` parser regression now that it passes on current `master`
- remove the stale limitation comment and ignored marker from `control_flow_expr_tests`
- refresh `docs/project/CURRENT_STATUS.md` so the tracked ignore count drops from 2 to 1

## Verification
- cargo test -p perl-parser-core --lib engine::parser::control_flow_expr_tests::tests::test_return_inside_do_block -- --exact --nocapture
- cargo test -p perl-parser-core --lib
- python3 scripts/update-current-status.py --check
- bash scripts/ignored-test-count.sh
- git diff --check
