### PR TITLE
docs(swarm): clarify skill vs command surfaces

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -39,13 +39,16 @@ See [agents/README.md](./agents/README.md) for the roster contract.
 
 - worktree = write boundary
 - worker = context boundary
-- skills and commands = reusable procedure
+- skills = reusable procedure and durable instruction
+- commands = thin operator entrypoints and compatibility shims
 - hooks and settings = deterministic enforcement
 - handoffs, receipts, worktrees, and PRs = volatile execution state
 
-Every agent should keep a local todo list and name the command or skill for
+Every agent should keep a local todo list and name the slash entrypoint for
 each todo item. That keeps procedure attached to the current slice instead of
-floating in remembered context.
+floating in remembered context. In the live repo today, `/swarm` is the main
+skill-backed control-plane entrypoint; many other reusable procedures are still
+command-backed while they remain lightweight.
 
 ## Compatibility Note
 

--- a/.claude/commands/coding-standards.md
+++ b/.claude/commands/coding-standards.md
@@ -6,7 +6,8 @@ user-invocable: false
 
 # Coding Standards (perl-lsp)
 
-Invoke this skill to load project coding standards into your context.
+Invoke this slash entrypoint to load project coding standards into your
+context.
 
 ## Banned in Production Code (tests exempt)
 - `unwrap()`, `expect()` → use `?`, `.ok_or_else()`, or pattern matching

--- a/.claude/commands/swarm-priorities.md
+++ b/.claude/commands/swarm-priorities.md
@@ -68,7 +68,7 @@ Scouts should weight slices in this order:
 ## How Scouts Use This
 
 When creating slices, scouts should:
-1. Read this skill to understand current priorities
+1. Read this slash entrypoint to understand current priorities
 2. Tag each SLICE with a priority tier: `priority: P0 | P1 | P2 | P3 | P4`
 3. Builders should claim higher-priority tasks first
 4. If the queue is mostly P3/P4, scouts should dig harder for P1/P2 work

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -20,11 +20,18 @@ improvement. Disposable workers in isolated worktrees do all code mutation.
 4. **Reviewers**: One PR per reviewer. Fresh context for clean review.
 5. **Ops**: One PR at a time for merges. Verify CI between each.
 6. **Draft first**: Builders create draft PRs. Reviewer marks ready after checking.
-7. **Skills over inline**: Agents invoke skills (/verify-build, /pr-create, /plan-fix, /scout-report) instead of repeating long inline workflows.
+7. **Slash entrypoints over inline**: Agents invoke reusable slash procedures
+   (/verify-build, /pr-create, /plan-fix, /scout-report) instead of repeating
+   long inline workflows.
 
-## Skill Scope
+## Slash Entry Point Scope
 
-**Orchestrator skills** (you invoke these):
+`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
+this repo. Most other procedures listed below are still command-backed slash
+entrypoints under `.claude/commands/`; keep them thin and accurate until they
+earn a full skill migration.
+
+**Orchestrator slash entrypoints** (you invoke these):
 - `/swarm-status` — shows current PRs, issues, metrics, queue
 - `/green-merge` — drain merge queue
 - `/health-check` — quick codebase health scan
@@ -32,7 +39,7 @@ improvement. Disposable workers in isolated worktrees do all code mutation.
 - `/rebase-open` — rebase conflicting PRs
 - `/corpus-ratchet` — lock in corpus gains
 
-**Agent skills** (agents invoke these themselves — do NOT load into orchestrator context):
+**Worker slash entrypoints** (workers invoke these themselves — do NOT load into orchestrator context):
 - `/swarm-protocol` — behavioral rules
 - `/coding-standards` — project standards
 - `/swarm-priorities` — roadmap alignment
@@ -49,7 +56,7 @@ Treat each layer as a different boundary:
 
 1. **Worktree = write boundary**: every PR-shaped code change happens in its own worktree.
 2. **Worker = context boundary**: spawn a fresh worker when objective, file surface, tool profile, permissions, verification loop, or branch changes materially.
-3. **Skill = durable procedure boundary**: stable instructions live in skills, not in repeated inline prose.
+3. **Skill = durable procedure boundary**: stable instructions live in skills and other reusable slash entrypoints, not in repeated inline prose.
 4. **Hook = deterministic control boundary**: anything that must always happen belongs in hooks, not in agent memory.
 
 If a coding task crosses into a different crate, file surface, or verification loop, do not stretch the current worker. Write or update the handoff and spawn a fresh worker in a fresh worktree.

--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -14,11 +14,16 @@ You are the lead. You coordinate only. You NEVER write production code.
 Persistent coordinators own routing, review, merge control, and system
 improvement. Disposable workers in isolated worktrees do all code mutation.
 
-## Skill Scope
+## Slash Entry Point Scope
+
+`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
+this repo. Most other procedures listed below are still command-backed slash
+entrypoints under `.claude/commands/`; keep them thin and accurate until they
+earn a full skill migration.
 
 The scope split is summarized here. See `reference/team-structure.md` for the concrete coordinator handoffs and data flow.
 
-**Orchestrator skills** (you invoke these):
+**Orchestrator slash entrypoints** (you invoke these):
 - `/swarm-status` — shows current PRs, issues, metrics, queue
 - `/green-merge` — drain merge queue
 - `/health-check` — quick codebase health scan
@@ -26,7 +31,7 @@ The scope split is summarized here. See `reference/team-structure.md` for the co
 - `/rebase-open` — rebase conflicting PRs
 - `/corpus-ratchet` — lock in corpus gains
 
-**Agent skills** (agents invoke these themselves — do NOT load into orchestrator context):
+**Worker slash entrypoints** (workers invoke these themselves — do NOT load into orchestrator context):
 - `/swarm-protocol` — behavioral rules
 - `/coding-standards` — project standards
 - `/swarm-priorities` — roadmap alignment
@@ -41,7 +46,7 @@ Treat each layer as a different boundary:
 
 1. **Worktree = write boundary**: every PR-shaped code change happens in its own worktree.
 2. **Worker = context boundary**: spawn a fresh worker when objective, file surface, tool profile, permissions, verification loop, or branch changes materially.
-3. **Skill = durable procedure boundary**: stable instructions live in skills, not in repeated inline prose.
+3. **Skill = durable procedure boundary**: stable instructions live in skills and other reusable slash entrypoints, not in repeated inline prose.
 4. **Hook = deterministic control boundary**: anything that must always happen belongs in hooks, not in agent memory.
 
 If a coding task crosses into a different crate, file surface, or verification loop, do not stretch the current worker. Write or update the handoff and spawn a fresh worker in a fresh worktree.

--- a/docs/handoff/SWARM_DESIGN.md
+++ b/docs/handoff/SWARM_DESIGN.md
@@ -118,11 +118,15 @@ Key frontmatter fields:
 - `user-invocable: false` — hidden from user's skill list (internal use only)
 - `disable-model-invocation: true` — pure instruction, no model call
 
-### Skill Scoping
+### Slash Entry Point Scoping
 
-Skills have scopes. Loading an agent skill into orchestrator context wastes context and causes the orchestrator to do agent work directly.
+Slash entrypoints have scopes. Loading a worker procedure into orchestrator
+context wastes context and causes the orchestrator to do worker work directly.
+`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
+this repo; most procedures below are still command-backed slash entrypoints
+today.
 
-**Orchestrator skills** (lead invokes these):
+**Orchestrator slash entrypoints** (lead invokes these):
 - `/swarm-status` — shows current PRs, issues, metrics, queue
 - `/green-merge` — drain merge queue
 - `/health-check` — quick codebase scan
@@ -130,7 +134,7 @@ Skills have scopes. Loading an agent skill into orchestrator context wastes cont
 - `/rebase-open` — rebase conflicting PRs
 - `/corpus-ratchet` — lock in corpus gains
 
-**Agent skills** (agents invoke these — do NOT load into orchestrator context):
+**Worker slash entrypoints** (workers invoke these — do NOT load into orchestrator context):
 - `/swarm-protocol` — behavioral rules
 - `/coding-standards` — project standards
 - `/swarm-priorities` — roadmap alignment
@@ -139,7 +143,7 @@ Skills have scopes. Loading an agent skill into orchestrator context wastes cont
 - `/plan-fix` — write implementation plans
 - `/scout-report` — create GitHub issues
 
-**Dual-use skills** (either context):
+**Dual-use slash entrypoints** (either context):
 - `/scout`, `/queue-scout`, `/audit`
 
 ## Hooks Architecture
@@ -258,9 +262,16 @@ Each handoff file (`.ops-perl-lsp/handoffs/<branch>.md`) contains:
 - **Known pitfalls** (relevant entries from failure knowledge base)
 - **Builder briefing** (appended after build: what changed, key decisions, what to watch for)
 
-### Skills Over File Reads
+### Slash Entry Points Over File Reads
 
-Protocol, standards, and priorities are **skills** (`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`), not files. Agents invoke them directly into their context instead of spending a `Read` tool call. Subagent prompts are 7 lines pointing to handoff + skills, not 100 lines of inline instructions.
+Protocol, standards, and priorities are reusable slash entrypoints
+(`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`), not
+ad-hoc file reads. Agents invoke them directly into their context instead of
+spending a `Read` tool call. In the live repo today, `/swarm` is the main
+skill-backed entrypoint and most of the procedures named here are
+command-backed; agents still invoke them the same way. Subagent prompts are 7
+lines pointing to handoff + slash entrypoints, not 100 lines of inline
+instructions.
 
 ### Minimal Subagent Prompts
 
@@ -272,7 +283,8 @@ Builder coordinators compose prompts like:
  Commit and push."
 ```
 
-7 lines. The handoff file has all the context. The skill invocations load the rules. No context wasted.
+7 lines. The handoff file has all the context. The slash entrypoints load the
+rules. No context wasted.
 
 ### Context Shift = New Worker
 
@@ -289,7 +301,8 @@ Worker reuse is the exception. Handoffs are the continuity mechanism.
 
 ### Priority Weighting
 
-The `/swarm-priorities` skill loads the roadmap (NOW/NEXT/LATER), open milestones, and high-priority issues. It defines P0-P4 tiers:
+The `/swarm-priorities` slash entrypoint loads the roadmap (NOW/NEXT/LATER),
+open milestones, and high-priority issues. It defines P0-P4 tiers:
 
 | Tier | What |
 |------|------|

--- a/docs/reference/SKILL_AND_AGENT_DESIGN.md
+++ b/docs/reference/SKILL_AND_AGENT_DESIGN.md
@@ -117,11 +117,17 @@ Use a skill when:
 - multiple workers need the same procedure
 - supporting files or templates help keep the hot prompt small
 
+In this repo today, `/swarm` is the main shipped project skill under
+`.claude/skills/`. Many other reusable slash procedures are still
+command-backed entrypoints under `.claude/commands/`. The design direction is
+skill-first, but the runtime docs should describe the current surface
+accurately.
+
 Subagents do not inherit the caller's loaded skills automatically. If a worker
 needs repo procedure or domain knowledge, name the required skills in the
 worker prompt or encode the task itself as a `context: fork` skill.
 
-Typical examples:
+Typical slash entrypoints in this repo today:
 - `/coding-standards`
 - `/swarm-protocol`
 - `/swarm-priorities`
@@ -237,7 +243,7 @@ Crate: perl-parser
 Files: crates/perl-parser/src/heredoc.rs crates/perl-parser/tests/heredoc.rs
 Goal: fix queued heredoc replay after nested interpolation
 Verify: cargo fmt --all && cargo clippy -p perl-parser --tests && cargo test -p perl-parser
-Read .ops-perl-lsp/handoffs/fix-heredoc-queue.md, then invoke /coding-standards and /parser-fix
+Read .ops-perl-lsp/handoffs/fix-heredoc-queue.md, then invoke the slash entrypoints /coding-standards and /parser-fix
 ```
 
 ### Bad Spawn Prompt


### PR DESCRIPTION
## Summary
- clarify that the live repo treats skills as the richer procedural surface while most current slash procedures still ship as command-backed entrypoints
- update the canonical swarm docs to describe `/swarm` as the main skill-backed control-plane entrypoint and command-backed procedures as thin shims/entrypoints
- fix command text that still called command-backed slash surfaces "skills"

## Verification
- git diff --check
