### PR TITLE
docs(swarm): mark legacy agent generations historical

### DIFF
--- a/docs/adr/ADR_001_AGENT_ARCHITECTURE.md
+++ b/docs/adr/ADR_001_AGENT_ARCHITECTURE.md
@@ -1,7 +1,18 @@
 # ADR-001: Agent Architecture Specialization
 
 ## Status
-Accepted - **Fully Implemented in PR #153** with 94 specialized agents and comprehensive agent customization framework
+Superseded - historical reference for the `.claude/agents2/` specialization
+phase. The current swarm control plane is defined by
+[ADR-0032](0032-skill-scoping-and-hook-enforcement.md),
+[ADR-0033](0033-worktree-first-disposable-workers.md), and
+[`.claude/README.md`](../../.claude/README.md).
+
+## Historical Note
+
+This ADR captures an intermediate agent-generation model built around
+specialized rosters under `.claude/agents2/`. Keep it for project history and
+operator archaeology, but do not treat it as the live runtime contract for the
+repo.
 
 ## Context
 The tree-sitter-perl project initially used generic Claude Code agents stored in `.claude/agents/` directory. As the project matured with 5 published crates, comprehensive LSP features, and specialized Perl parsing requirements, it became clear that generic agents could not adequately address the domain-specific needs of the Perl parser ecosystem.

--- a/docs/adr/ADR_003_MISSING_DOCUMENTATION_INFRASTRUCTURE.md
+++ b/docs/adr/ADR_003_MISSING_DOCUMENTATION_INFRASTRUCTURE.md
@@ -297,7 +297,7 @@ cargo doc --no-deps --package perl-parser
 
 ## Related Decisions
 
-- **[ADR-001: Agent Architecture](ADR_001_AGENT_ARCHITECTURE.md)** - 97 specialized agents supporting documentation workflow
+- **[ADR-001: Agent Architecture](ADR_001_AGENT_ARCHITECTURE.md)** - historical `.claude/agents2/` specialization phase referenced for context only
 - **[ADR-002: API Documentation Infrastructure](ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md)** - Original infrastructure design and rationale
 - **[API Documentation Standards](../reference/API_DOCUMENTATION_STANDARDS.md)** - Comprehensive quality requirements and templates
 - **[Missing Documentation Guide](../reference/MISSING_DOCUMENTATION_GUIDE.md)** - Systematic 4-phase implementation strategy

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@ This directory contains Architecture Decision Records (ADRs) for significant des
 
 | ADR | Status | Ref/Date | Title | Description |
 |-----|--------|----------|-------|-------------|
-| [ADR-001](ADR_001_AGENT_ARCHITECTURE.md) | Accepted | PR #153 | Agent Architecture | 97 specialized agents for Perl parser ecosystem workflow |
+| [ADR-001](ADR_001_AGENT_ARCHITECTURE.md) | Superseded | PR #153 | Agent Architecture | Historical `.claude/agents2/` specialization phase; see ADR-0032/0033 for the current swarm model |
 | [ADR-002](ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md) | Accepted | PR #160 | API Documentation (SPEC-149) | Documentation enforcement with acceptance criteria and quality gates |
 | [ADR-003](ADR_003_MISSING_DOCUMENTATION_INFRASTRUCTURE.md) | Accepted | PR #159 | Missing Docs Infrastructure | Documentation enforcement validation framework |
 | [ADR-004](ADR_004_EXECUTE_COMMAND_CODE_ACTIONS.md) | Draft | 2025-01-15 | Execute Command & Code Actions | LSP executeCommand integration with perlcritic |

--- a/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
+++ b/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
@@ -570,122 +570,47 @@ pub fn get_code_actions(&self, ast: &Node, range: (usize, usize), diagnostics: &
 - Tree-sitter compatible error nodes and diagnostics
 - Performance optimized (<5% overhead for normal code)
 
-## Agent Ecosystem Integration (PR #153) (*Diataxis: Explanation* - Specialized workflow automation)
+## Repo-Native Swarm Control Plane (*Diataxis: Explanation* - current repo automation)
 
-### 94 Specialized Agents Architecture
+This repository now carries a repo-native Claude swarm control plane alongside
+the Rust workspace. The live control plane is the tracked `.claude/` tree, not
+the older specialized-agent generations under `.claude/agents2/` and related
+directories.
 
-**Workflow Enhancement**: PR #153 introduces a comprehensive agent ecosystem with 94 specialized agents designed specifically for the tree-sitter-perl parsing ecosystem.
+### Canonical Runtime Surfaces (*Diataxis: Reference* - live swarm surfaces)
 
-#### Agent Directory Structure (*Diataxis: Reference* - Agent organization)
+The current swarm runtime is defined by:
 
-```
-.claude/agents2/                          # 94 specialized agents (vs. 53 generic)
-├── review/                               # 26 agents - PR review workflow
-│   ├── review-security-scanner.md       # UTF-16 security validation
-│   ├── review-mutation-tester.md        # 87% quality score validation
-│   ├── review-performance-validator.md  # Performance preservation
-│   └── review-governance-gate.md        # Final quality assurance
-├── integration/                          # 21 agents - CI/CD coordination
-│   ├── integration-test-coordinator.md  # Adaptive threading orchestration
-│   ├── integration-workspace-validator.md # Multi-crate validation
-│   └── integration-performance-monitor.md # LSP performance tracking
-├── generative/                           # 24 agents - Content creation
-│   ├── generative-doc-writer.md         # Parser ecosystem documentation
-│   ├── generative-test-creator.md       # Mutation hardening test generation
-│   └── generative-parser-enhancer.md    # AST and parsing improvements
-├── mantle/                               # 17 agents - Maintenance operations
-│   ├── mantle-dependency-manager.md     # Workspace dependency coordination
-│   ├── mantle-release-coordinator.md    # Multi-crate release orchestration
-│   └── mantle-security-auditor.md       # Enterprise security compliance
-└── other/                                # 6 agents - Cross-cutting concerns
-    ├── agent-customizer.md              # Self-adapting agent framework
-    └── workflow-orchestrator.md         # Agent coordination patterns
-```
+- `.claude/agents/` — canonical coordinator and reusable-worker roster
+- `.claude/skills/swarm/` — main skill-backed swarm entrypoint
+- `.claude/commands/` — thin operator entrypoints and compatibility shims
+- `.claude/settings.json` — shared permissions and hook enforcement
+- `.claude/swarm-state/` — tracked queue, dedup, and overlap state
 
-#### Specialized Agent Capabilities (*Diataxis: Explanation* - Domain expertise integration)
+See [../../.claude/README.md](../../.claude/README.md) for the live control
+plane contract, [SKILL_AND_AGENT_DESIGN.md](SKILL_AND_AGENT_DESIGN.md) for the
+boundary model, and [../adr/0033-worktree-first-disposable-workers.md](../adr/0033-worktree-first-disposable-workers.md)
+for the worktree-first execution doctrine.
 
-**Parser Ecosystem Context Integration:**
-- **Multi-crate Architecture**: Understanding of 5 published crates and their interdependencies
-- **Performance Standards**: Built-in knowledge of performance requirements
-- **Security Requirements**: UTF-16 position conversion security, Unicode safety
-- **Quality Metrics**: Mutation testing (87% score), zero clippy warnings, comprehensive test coverage
+### Current Execution Model (*Diataxis: Explanation* - how the swarm runs)
 
-**Intelligent Workflow Coordination:**
-```rust
-// Example: Security-focused agent routing
-SecurityScanner → MutationTester → PerformanceValidator → GovernanceGate
+The repo now treats:
 
-// Example: Development agent coordination
-CodeEnhancer → TestCreator → DocGenerator → ReviewPrep
-```
+- **worktrees** as the write boundary for PR-shaped changes
+- **disposable workers** as the context boundary for implementation work
+- **skills** as the richer reusable procedure surface
+- **commands** as thin slash entrypoints while procedures remain lightweight
+- **hooks and settings** as the deterministic enforcement layer
 
-#### Agent Customization Framework (*Diataxis: Reference* - Self-adapting architecture)
+The live coordinator model is intentionally small: `scout`, `builder`,
+`reviewer`, `ops`, and `improver` route work, while disposable workers in
+isolated worktrees perform the actual code mutation.
 
-**Contextual Adaptation Engine:**
-```markdown
-# Agent customizes itself based on project context
-- Multi-crate workspace patterns (perl-parser ⭐, perl-lsp ⭐, perl-lexer, perl-corpus)
-- Performance requirements (sub-microsecond parsing, <1ms LSP updates)
-- Enterprise security standards (UTF-16 safety, path traversal prevention)
-- Comprehensive quality validation (87% mutation score, zero clippy warnings)
-```
+### Historical Note (*Diataxis: Explanation* - older generations)
 
-**Self-Documenting Configuration:**
-- **Inline Expertise**: Each agent includes parser ecosystem domain knowledge
-- **Quality Integration**: Built-in understanding of mutation testing and performance benchmarks
-- **Security Awareness**: UTF-16 position conversion security and enterprise patterns
-- **Workflow Intelligence**: Context-aware routing between specialized agents
-
-#### Quality and Security Integration (*Diataxis: Explanation* - Enterprise-grade validation)
-
-**Mutation Testing Coordination:**
-- **Real Bug Discovery**: Agents coordinate mutation testing that discovered UTF-16 security vulnerabilities
-- **Quality Score Achievement**: 87% mutation score through systematic agent-driven testing
-- **Security Validation**: UTF-16 boundary violation detection and remediation
-
-**Performance Preservation:**
-- **Performance Standards**: Agents ensure LSP performance improvements are maintained
-- **Security-Performance Balance**: Enhanced security without performance regression
-- **Adaptive Threading**: CI environment optimization through intelligent agent coordination
-
-#### Integration Points (*Diataxis: Reference* - Agent ecosystem interfaces)
-
-**Crate Integration:**
-- **`/crates/perl-parser/`**: Core parser logic enhanced by generative agents (test creation, performance optimization)
-- **`/crates/perl-lsp/`**: LSP server validated by review agents (security scanning, performance validation)
-- **`/crates/perl-lexer/`**: Tokenizer improvements coordinated by integration agents
-- **`/crates/perl-corpus/`**: Test corpus expansion through generative and integration agents
-
-**Documentation Ecosystem:**
-- **`/docs/`**: Comprehensive documentation maintained by specialized doc-writer agents
-- **ADRs**: Architecture decisions documented and validated by governance agents
-- **Security Guides**: Enterprise security patterns maintained by security-focused agents
-
-#### Workflow Orchestration Patterns (*Diataxis: How-to* - Agent coordination)
-
-**Review Workflow:**
-```bash
-# Agent-coordinated PR review with intelligent routing
-review-security-scanner     # UTF-16 security validation
-  ↓
-review-mutation-tester      # 87% quality score verification
-  ↓
-review-performance-validator # Performance preservation
-  ↓
-review-governance-gate      # Final quality assurance and routing decision
-```
-
-**Development Workflow:**
-```bash
-# Agent-enhanced development cycle
-generative-parser-enhancer  # AST and parsing improvements
-  ↓
-generative-test-creator     # Comprehensive test coverage
-  ↓
-integration-test-coordinator # Multi-crate validation
-  ↓
-generative-doc-writer       # Documentation synchronization
-```
+Older agent generations (`.claude/agents2` through `.claude/agents6`) remain
+useful as donor material and operator history, but they are not the current
+runtime contract for this repository.
 
 ## Development Guidelines
 


### PR DESCRIPTION
## Summary
- mark the old `.claude/agents2` specialization ADR as historical instead of current runtime guidance
- update the ADR index and related docs to point readers to the modern swarm control-plane ADRs
- replace the crate architecture guide's stale 94-agent section with the current repo-native `.claude/` control-plane model

## Verification
- git diff --check
