### PR TITLE
test(lsp): wait for workspace completion indexing

### DIFF
--- a/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_completion_tests.rs
@@ -338,6 +338,7 @@ sub uppercase {
             }
         }),
     );
+    await_open_processing(&server);
 
     // Open a file that imports the module
     let script_uri = "file:///workspace/text_processor.pl";
@@ -361,6 +362,7 @@ tri
             }
         }),
     );
+    await_open_processing(&server);
 
     // Request completion after "tri"
     let response = send_request(


### PR DESCRIPTION
## Summary
- drain spawned-server traffic after didOpen before asserting workspace completion results
- stabilize the existing cross-file function and qualified completion transport tests
- keep the change scoped to test timing/readiness rather than completion logic

## Verification
- env -u RUSTC_WRAPPER cargo test -p perl-lsp test_completion_cross_file_function --test lsp_workspace_completion_tests -- --exact --nocapture
- env -u RUSTC_WRAPPER cargo test -p perl-lsp test_completion_cross_file_qualified --test lsp_workspace_completion_tests -- --exact --nocapture
- git diff --check