### PR TITLE
feat(swarm): add core worker skills

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -5,8 +5,8 @@ This repo runs one swarm, not multiple parallel pack stories.
 The canonical runtime surfaces are:
 
 - `.claude/agents/` — who owns each lane
-- `.claude/skills/swarm/` — canonical swarm control-plane skill
-- `.claude/commands/` — compatibility slash-command layer and operator entrypoints
+- `.claude/skills/` — canonical skill layer for swarm control and core worker procedures
+- `.claude/commands/` — slash entrypoints that currently live as command files
 - `.claude/settings.json` — shared permissions and hook enforcement
 - `.claude/swarm-state/` — durable queue and dedup state
 
@@ -42,16 +42,18 @@ quality, review, research, and domain-specific execution. See
 
 - worktree = write boundary
 - worker = context boundary
-- skills = reusable procedure and durable instruction
-- commands = thin operator entrypoints and compatibility shims
+- skills and commands = interchangeable slash entrypoints unless frontmatter says otherwise
 - hooks and settings = deterministic enforcement
 - handoffs, receipts, worktrees, and PRs = volatile execution state
 
 Every agent should use the local todo or task tool and name the slash
 entrypoint for each item. That keeps procedure attached to the current slice
-instead of floating in remembered context. In the live repo today, `/swarm` is
-the main skill-backed control-plane entrypoint; many other reusable procedures
-are still command-backed while they remain lightweight.
+instead of floating in remembered context. In the live repo today, `/swarm`,
+`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`, `/plan-fix`,
+`/parser-fix`, and `/verify-build` ship from `.claude/skills/`. Other
+operator procedures currently live under `.claude/commands/`. Agents invoke
+both the same way unless frontmatter intentionally changes who can call them or
+how they run.
 
 The canonical roster mapping lives in
 [agents/AGENT_CATALOG.md](./agents/AGENT_CATALOG.md). It records who usually

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -10,9 +10,11 @@ The live split is:
 - specialist workers: tracked domain, review, docs, quality, and infrastructure
   agents cataloged in `AGENT_CATALOG.md`
 
-These files define who owns each lane. Procedures live in skills and commands.
-Deterministic enforcement lives in hooks and settings. Task-specific context
-lives in handoffs, worktrees, receipts, PRs, and queue files.
+These files define who owns each lane. Procedures live in skills and commands;
+the slash-entrypoint surface is interchangeable unless frontmatter or bundled
+resources make a specific skill-only behavior necessary. Deterministic
+enforcement lives in hooks and settings. Task-specific context lives in
+handoffs, worktrees, receipts, PRs, and queue files.
 
 If a file lives in `.claude/agents/`, it is part of the active tracked swarm
 surface. The canonical active inventory is `AGENT_CATALOG.md`.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -26,10 +26,12 @@ improvement. Disposable workers in isolated worktrees do all code mutation.
 
 ## Slash Entry Point Scope
 
-`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
-this repo. Most other procedures listed below are still command-backed slash
-entrypoints under `.claude/commands/`; keep them thin and accurate until they
-earn a full skill migration.
+`/swarm` is the main control-plane entrypoint. The core worker procedures
+listed below now also ship from `.claude/skills/`:
+`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`, `/plan-fix`,
+`/parser-fix`, and `/verify-build`. Broader operator procedures currently live
+under `.claude/commands/`. Agents invoke both skills and commands the same way
+unless frontmatter intentionally changes who can call them or how they run.
 
 **Orchestrator slash entrypoints** (you invoke these):
 - `/swarm-status` — shows current PRs, issues, metrics, queue

--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: coding-standards
+description: Load perl-lsp coding standards for code-writing or code-review work in this repo. Use when implementing, fixing, reviewing, or validating code.
+user-invocable: false
+---
+
+# Coding Standards
+
+Load these standards before writing or reviewing code in `perl-lsp`.
+
+## Banned In Production Code
+
+- no `unwrap()`, `expect()`, `panic!()`, `todo!()`, or `unimplemented!()`
+- no `dbg!()`
+- no `std::process::abort()`
+- no `std::process::exit()` outside `bin/` and `lifecycle.rs`
+- one allowed exception: `#[allow(clippy::expect_used)]` in `crates/perl-lsp/src/util/uri.rs`
+
+Prefer `?`, `.ok_or_else()`, or explicit pattern matching.
+
+## Common Patterns
+
+- use `Option<Regex>` with `.ok()` for graceful regex init
+- use fixed-size arrays for compile-time non-empty guarantees
+- prefer `.first()` over `.get(0)`
+- prefer `.push(char)` over `.push_str("x")` for a single character
+- prefer `or_default()` over `or_insert_with(Vec::new)`
+- avoid unnecessary `.clone()` on `Copy` types
+
+## Test Standards
+
+- prefer `Result<()>` return types in tests, or `perl_tdd_support::must` / `must_some`
+- use descriptive names like `test_<what>_<scenario>_<expected>`
+- for `perl-lsp` tests use `RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2`
+
+## Commit Format
+
+- use conventional commits: `type(scope): description`
+- types: `fix`, `feat`, `test`, `docs`, `chore`, `perf`, `refactor`
+- scope should usually be the crate or subsystem
+
+## Default Verification
+
+```bash
+cargo fmt --all
+cargo clippy -p <crate> --tests -- -D warnings
+cargo test -p <crate>
+```
+
+Escalate to `nix develop -c just ci-gate` for broader multi-crate changes.
+
+## Git Hygiene
+
+- stage only files you intentionally changed
+- never use `git add -A` or `git add .`
+- normally exclude `Cargo.lock`, `.claude/` control-plane files, `docs/project/CURRENT_STATUS.md`, and `scripts/.ignored-baseline` unless they are the direct task
+- check the staged set with `git diff --cached --name-only`
+
+## Dual Indexing Reminder
+
+Workspace symbol work should preserve both bare and qualified indexing:
+
+```rust
+file_index.references.entry(bare_name.to_string()).or_default().push(symbol_ref.clone());
+file_index.references.entry(qualified).or_default().push(symbol_ref);
+```

--- a/.claude/skills/parser-fix/SKILL.md
+++ b/.claude/skills/parser-fix/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: parser-fix
+description: Run a TDD parser-fix workflow for perl-parser-core or related parser crates. Use when a parser bug has a concrete failing construct and needs tests, a minimal fix, and verification.
+argument-hint: "<bug description>"
+---
+
+# Parser Fix
+
+Fix a parser bug with a failing test first. Bug: **$ARGUMENTS**
+
+## Workflow
+
+1. Find the relevant parser code under `crates/perl-parser-core/src/engine/parser/`
+2. Add failing tests first in the right parser test file
+3. Implement the smallest fix that makes the new tests pass
+4. Verify the parser crates cleanly
+5. Return a concise receipt for the handoff or PR
+
+## Root-Cause Search
+
+Start with the file surface most likely to own the construct:
+
+- `variables.rs`
+- `statements.rs`
+- `expressions/postfix.rs`
+- `expressions/precedence.rs`
+- `declarations.rs`
+
+Understand why the construct fails before editing.
+
+## Test-First Rule
+
+Add tests before the fix. Prefer crate-local parser tests that parse a Perl
+snippet and assert success or the intended AST shape.
+
+## Verification
+
+```bash
+cargo fmt --all
+cargo clippy -p perl-parser-core --lib
+cargo test -p perl-parser-core
+cargo test -p perl-parser
+```
+
+Keep the fix narrow. If the failure turns out to be primarily lexer or corpus
+work, route it into the right worker instead of silently widening the slice.

--- a/.claude/skills/plan-fix/SKILL.md
+++ b/.claude/skills/plan-fix/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: plan-fix
+description: Turn a discovery into a builder-ready handoff packet. Use when a scout or coordinator has identified a concrete slice and needs exact scope, verification, and routing rather than code changes.
+argument-hint: "<slice summary>"
+---
+
+# Plan Fix
+
+Convert a finding into a builder-ready handoff. Context: **$ARGUMENTS**
+
+## Goal
+
+Produce or refresh one handoff packet that a fresh worktree worker can execute
+without rediscovering the problem.
+
+## Before Writing The Handoff
+
+1. Confirm the slice is not already covered by an open PR, issue, or tracked task
+2. Keep the slice to one dominant crate and one verification loop
+3. Split the work if it touches multiple unrelated file surfaces or would exceed
+   a small PR-sized change
+
+## Handoff Must Include
+
+- one-sentence goal
+- why the slice matters now
+- exact file surface
+- one verification command
+- suggested worker or entrypoints to invoke first
+- out-of-scope notes and split criteria
+- receipt expectations for review
+
+## Suggested Handoff Shape
+
+```markdown
+# <slug>
+
+## Goal
+<one sentence>
+
+## Why Now
+<priority, regression, or trust reason>
+
+## File Surface
+- path/to/file.rs
+
+## Verification
+`<single command>`
+
+## Entry Points
+- /coding-standards
+- /parser-fix
+
+## Out Of Scope
+- <explicit non-goals>
+
+## Receipt Requirements
+- <what the worker must report back>
+```
+
+## Task Routing
+
+If task tools are active:
+
+- create or update one task for the slice
+- mark the owner lane
+- route it to the next coordinator explicitly
+
+Do not write production code in this skill. Stop once the handoff packet is
+builder-ready.

--- a/.claude/skills/swarm-priorities/SKILL.md
+++ b/.claude/skills/swarm-priorities/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: swarm-priorities
+description: Load roadmap weighting for scouts and coordinators so slices are ranked by actual repo priorities instead of convenience.
+user-invocable: false
+---
+
+# Swarm Priorities
+
+Load the repo's current priority weighting before scouting or reprioritizing the
+queue.
+
+## Priority Sources
+
+Read what is available and current:
+
+```bash
+cat NOW_NEXT_LATER.md 2>/dev/null || cat ROADMAP.md 2>/dev/null
+cat docs/project/ROADMAP.md 2>/dev/null
+cat docs/project/CURRENT_STATUS.md 2>/dev/null
+gh api repos/:owner/:repo/milestones --jq '.[] | "\\(.title): \\(.open_issues) open, \\(.description)"' 2>/dev/null
+gh issue list --state open --label "priority:high" --limit 20 2>/dev/null
+gh issue list --state open --label "bug" --limit 20 2>/dev/null
+cat features.toml 2>/dev/null | head -50
+```
+
+## Priority Tiers
+
+- `P0`: security, broken CI, merge regressions, urgent bugs
+- `P1`: roadmap-aligned parser, LSP, milestone, or capability work
+- `P2`: test infrastructure, flaky tests, mutation survivors, coverage gaps
+- `P3`: codebase health, DAP quality, debt, dead code, stale docs
+- `P4`: polish and low-leverage cleanup
+
+## How To Use It
+
+- scouts should tag slices with a priority tier
+- builders should prefer higher-priority queued work first
+- leads should check for drift when merges skew toward low-leverage cleanup
+
+If the queue is dominated by `P3` or `P4`, scout harder for `P1` or `P2`
+work instead of just consuming the easy backlog.

--- a/.claude/skills/swarm-protocol/SKILL.md
+++ b/.claude/skills/swarm-protocol/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: swarm-protocol
+description: Load shared swarm behavioral rules for coordinators and workers. Use for task routing, receipts, direct messaging, dedup, worktree boundaries, and lifecycle discipline.
+user-invocable: false
+---
+
+# Swarm Protocol
+
+Shared behavioral rules for swarm coordinators and workers.
+
+## Autonomy
+
+Fix adjacent same-slice issues in the current worktree when they are clearly part
+of the task. For anything outside the slice, create a GitHub issue or handoff
+instead of stretching the worker.
+
+Use `swarm-discovered` for discovered issues and `swarm-architectural` when the
+repo needs a deliberate architecture decision.
+
+## Direct Communication
+
+Message the teammate who should act next. Do not bounce everything through the
+lead.
+
+- builder -> reviewer when a branch is review-ready
+- reviewer -> builder when feedback needs a fresh implementation worker
+- ops -> fixer or validator when CI or trust checks fail
+- any lane -> improver when repeated docs/tests/devex friction appears
+
+## GitHub-Native State
+
+Use GitHub and tracked swarm state as the durable ledger:
+
+- open PRs and issues
+- `.claude/swarm-state/`
+- handoffs and receipts
+- merge and review state
+
+Do not treat transcript memory as proof.
+
+## Metrics And Receipts
+
+After each task, leave a durable receipt:
+
+- what changed
+- what verification ran
+- what passed or failed
+- what remains open
+
+When the lane uses `.ops-perl-lsp/swarm-metrics.jsonl`, append an entry instead
+of rewriting history.
+
+## Dedup Before Starting
+
+Check the queue and state before creating new work:
+
+1. open PRs
+2. open issues
+3. `.claude/swarm-state/`
+4. existing handoffs and receipts
+
+If the slice already exists, update or route it instead of duplicating it.
+
+## Worktree And Worker Boundaries
+
+- code mutation implies an isolated worktree
+- one worker owns one PR-shaped unit of change
+- retire and respawn when the crate, file surface, verification loop,
+  permissions, or branch target changes materially
+- keep review one-PR-at-a-time
+
+## Agent Lifecycle
+
+- shut workers down when no concrete next action exists
+- keep warm contexts only when the same lane and same near-term slice benefit
+  from reuse
+- do not treat `Stop` as proof of completion
+- small, green receipts beat long ambient context
+
+## Review Discipline
+
+- one review context per PR
+- read the handoff and receipt before the diff
+- send materially different fixes back to builder instead of mutating the scope
+  inside review
+
+## Research Discipline
+
+When facts matter, look them up or spawn the right research worker. Do not
+guess at language rules, protocol details, or dependency behavior.

--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -16,10 +16,12 @@ improvement. Disposable workers in isolated worktrees do all code mutation.
 
 ## Slash Entry Point Scope
 
-`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
-this repo. Most other procedures listed below are still command-backed slash
-entrypoints under `.claude/commands/`; keep them thin and accurate until they
-earn a full skill migration.
+`/swarm` is the main control-plane entrypoint. The core worker procedures
+listed below now also ship from `.claude/skills/`:
+`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`, `/plan-fix`,
+`/parser-fix`, and `/verify-build`. Broader operator procedures currently live
+under `.claude/commands/`. Agents invoke both skills and commands the same way
+unless frontmatter intentionally changes who can call them or how they run.
 
 The scope split is summarized here. See `reference/team-structure.md` for the concrete coordinator handoffs and data flow.
 

--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: verify-build
+description: Run the standard per-crate verification pipeline and report a receipt. Use when a worker needs fmt, clippy, and test results for a specific crate before handoff, review, or PR creation.
+argument-hint: "<crate-name> [--skip-fmt] [--skip-clippy] [--skip-test]"
+---
+
+# Verify Build
+
+Run the standard verification pipeline for one crate. Context: **$ARGUMENTS**
+
+## Steps
+
+1. Parse the crate name from the first positional argument
+2. Confirm the crate exists with `cargo metadata`
+3. Run formatting unless `--skip-fmt` is present
+4. Run clippy unless `--skip-clippy` is present
+5. Run tests unless `--skip-test` is present
+6. Report a receipt with pass/fail status for each step
+
+## Commands
+
+Check the crate exists:
+
+```bash
+cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' | grep -qx "<crate>"
+```
+
+Formatting:
+
+```bash
+cargo fmt -p <crate> -- --check
+```
+
+If formatting fails, fix it with:
+
+```bash
+cargo fmt -p <crate>
+```
+
+Clippy:
+
+```bash
+cargo clippy -p <crate> --tests -- -D warnings
+```
+
+Tests:
+
+```bash
+cargo test -p <crate>
+```
+
+For `perl-lsp`, use:
+
+```bash
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
+```
+
+## Receipt Format
+
+Report:
+
+- crate name
+- fmt result
+- clippy result
+- test result
+- overall pass/fail
+- first failure details if anything failed
+
+Use that receipt in the handoff, reviewer briefing, or PR body.

--- a/docs/handoff/SWARM_DESIGN.md
+++ b/docs/handoff/SWARM_DESIGN.md
@@ -122,9 +122,12 @@ Key frontmatter fields:
 
 Slash entrypoints have scopes. Loading a worker procedure into orchestrator
 context wastes context and causes the orchestrator to do worker work directly.
-`/swarm` is the main skill-backed control-plane entrypoint currently shipped in
-this repo; most procedures below are still command-backed slash entrypoints
-today.
+`/swarm` is the main control-plane entrypoint. The core worker entrypoints
+below also ship from `.claude/skills/` today:
+`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`, `/plan-fix`,
+`/parser-fix`, and `/verify-build`. Other slash entrypoints currently live
+under `.claude/commands/`. Agents invoke both the same way unless frontmatter
+intentionally changes who can call them or how they run.
 
 **Orchestrator slash entrypoints** (lead invokes these):
 - `/swarm-status` — shows current PRs, issues, metrics, queue
@@ -267,10 +270,10 @@ Each handoff file (`.ops-perl-lsp/handoffs/<branch>.md`) contains:
 Protocol, standards, and priorities are reusable slash entrypoints
 (`/swarm-protocol`, `/coding-standards`, `/swarm-priorities`), not
 ad-hoc file reads. Agents invoke them directly into their context instead of
-spending a `Read` tool call. In the live repo today, `/swarm` is the main
-skill-backed entrypoint and most of the procedures named here are
-command-backed; agents still invoke them the same way. Subagent prompts are 7
-lines pointing to handoff + slash entrypoints, not 100 lines of inline
+spending a `Read` tool call. In the live repo today, `/swarm` and the core
+worker procedures named here ship from `.claude/skills/`, while broader
+operator flows currently live under `.claude/commands/`. Subagent prompts are
+7 lines pointing to handoff + slash entrypoints, not 100 lines of inline
 instructions.
 
 ### Minimal Subagent Prompts

--- a/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
+++ b/docs/reference/CRATE_ARCHITECTURE_GUIDE.md
@@ -584,8 +584,8 @@ The current swarm runtime is defined by:
 - `.claude/agents/` — canonical tracked agent surface, with the active roster
   and any compatibility material explicitly marked in
   `AGENT_CATALOG.md`
-- `.claude/skills/swarm/` — main skill-backed swarm entrypoint
-- `.claude/commands/` — thin operator entrypoints and compatibility shims
+- `.claude/skills/` — main skill layer for swarm control and core worker procedures
+- `.claude/commands/` — slash entrypoints that currently live as command files
 - `.claude/settings.json` — shared permissions and hook enforcement
 - `.claude/swarm-state/` — tracked queue, dedup, and overlap state
 

--- a/docs/reference/SKILL_AND_AGENT_DESIGN.md
+++ b/docs/reference/SKILL_AND_AGENT_DESIGN.md
@@ -121,11 +121,12 @@ Use a skill when:
 - multiple workers need the same procedure
 - supporting files or templates help keep the hot prompt small
 
-In this repo today, `/swarm` is the main shipped project skill under
-`.claude/skills/`. Many other reusable slash procedures are still
-command-backed entrypoints under `.claude/commands/`. The design direction is
-skill-first, but the runtime docs should describe the current surface
-accurately.
+In this repo today, `/swarm`, `/swarm-protocol`, `/coding-standards`,
+`/swarm-priorities`, `/plan-fix`, `/parser-fix`, and `/verify-build` ship from
+`.claude/skills/`. Other slash entrypoints currently live under
+`.claude/commands/`. They are interchangeable at the call site unless
+frontmatter or bundled resources intentionally change the behavior. The runtime
+docs should describe that surface accurately.
 
 Subagents do not inherit the caller's loaded skills automatically. If a worker
 needs repo procedure or domain knowledge, name the required skills in the


### PR DESCRIPTION
## Summary
Add the core worker slash entrypoints as project skills under .claude/skills/ and align the live repo docs with the actual slash-entrypoint surface.

## What changed
- add project skills for /swarm-protocol, /coding-standards, /swarm-priorities, /plan-fix, /parser-fix, and /verify-build
- keep the existing command files, but document skills and commands as interchangeable entrypoints unless frontmatter intentionally changes behavior
- fix the live repo mismatch where /verify-build and /plan-fix were documented as worker entrypoints without corresponding project skills

## Why
The active agent roster and swarm docs already route work through these entrypoints. Tracking them as real project skills makes the roster contract honest and gives the next frontmatter-hardening pass something real to preload.

## Verification
- git diff --check
- verified the new project skill tree under .claude/skills/

## Stack
Follow-up to #1736. Base branch is now master after restacking.