### PR TITLE
chore(swarm): preload core agent skills

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -24,6 +24,8 @@ Agent design rules:
 - use the local todo or task tool for the current lane or slice
 - start with 3-5 live items and keep them current
 - name the command or skill for each todo item
+- preload stable startup skills in frontmatter when the lane uses them on
+  every run
 - retire workers when crate, file surface, branch, or verification loop changes
 - keep coordinators thin and push code mutation into disposable workers
 - treat receipts and handoffs as durable output; agent transcript is not proof

--- a/.claude/agents/bootstrapper.md
+++ b/.claude/agents/bootstrapper.md
@@ -3,6 +3,8 @@ name: bootstrapper
 description: Repo bootstrap worker for swarm setup. Discovers package layout, control-plane gaps, and reusable worker patterns, then writes or refreshes agent catalog material.
 model: sonnet
 color: green
+skills:
+  - swarm-protocol
 ---
 
 Use the local todo or task tool and attach the command or skill for each step.

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -3,6 +3,10 @@ name: builder
 description: Build coordinator for the swarm. Claims implementation slices, spawns disposable worktree workers, and hands reviewed diffs to the reviewer lane.
 model: sonnet
 color: blue
+skills:
+  - swarm-protocol
+  - coding-standards
+  - swarm-priorities
 ---
 
 Use the local todo or task tool for the active build slice. Start with 3-5 live

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -3,6 +3,9 @@ name: fixer
 description: Surgical failure-repair worker for the swarm. Reproduces one failing branch or CI incident, applies the smallest valid fix, and records a receipt.
 model: sonnet
 color: red
+skills:
+  - swarm-protocol
+  - coding-standards
 ---
 
 Use the local todo or task tool for the active failure mode. Start with 3-5

--- a/.claude/agents/improver.md
+++ b/.claude/agents/improver.md
@@ -3,6 +3,10 @@ name: improver
 description: Continuous improvement coordinator for the swarm. Keeps bounded pressure on docs, tests, devex, and infra without bloating the core delivery lanes.
 model: sonnet
 color: cyan
+skills:
+  - swarm-protocol
+  - coding-standards
+  - swarm-priorities
 ---
 
 Use the local todo or task tool for the active improvement slice. Start with

--- a/.claude/agents/ops.md
+++ b/.claude/agents/ops.md
@@ -3,6 +3,8 @@ name: ops
 description: Merge and queue-health coordinator for the swarm. Owns trusted change flow: merge gating, CI repair routing, post-merge validation, and queue pressure.
 model: sonnet
 color: purple
+skills:
+  - swarm-protocol
 ---
 
 Use the local todo or task tool for the current merge batch. Start with 3-5

--- a/.claude/agents/pr-responder.md
+++ b/.claude/agents/pr-responder.md
@@ -3,6 +3,9 @@ name: pr-responder
 description: PR feedback worker for the swarm. Reads review comments, checks the handoff, applies narrowly scoped follow-up fixes, and records what changed.
 model: sonnet
 color: yellow
+skills:
+  - swarm-protocol
+  - coding-standards
 ---
 
 Use the local todo or task tool for the active PR. Start with 3-5 live items,

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -3,6 +3,9 @@ name: reviewer
 description: Review coordinator for the swarm. Reviews one PR at a time, checks receipts before diff detail, opens or promotes PRs, and routes feedback cleanly.
 model: sonnet
 color: yellow
+skills:
+  - swarm-protocol
+  - coding-standards
 ---
 
 Use the local todo or task tool for the active PR. Start with 3-5 live items,

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -3,6 +3,10 @@ name: scout
 description: Discovery coordinator for the swarm. Finds one actionable slice at a time, writes handoffs and issues, and routes non-overlapping work to builders.
 model: sonnet
 color: yellow
+skills:
+  - swarm-protocol
+  - coding-standards
+  - swarm-priorities
 ---
 
 Use the local todo or task tool for the current scouting round. Start with 3-5

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -3,6 +3,8 @@ name: validator
 description: Post-merge validator for the swarm. Checks that claimed improvements actually landed and raises regressions with receipts and exact commands.
 model: sonnet
 color: purple
+skills:
+  - swarm-protocol
 ---
 
 Use the local todo or task tool for the merge or claim you are validating.

--- a/docs/reference/SKILL_AND_AGENT_DESIGN.md
+++ b/docs/reference/SKILL_AND_AGENT_DESIGN.md
@@ -131,6 +131,8 @@ docs should describe that surface accurately.
 Subagents do not inherit the caller's loaded skills automatically. If a worker
 needs repo procedure or domain knowledge, name the required skills in the
 worker prompt or encode the task itself as a `context: fork` skill.
+For stable startup procedure, prefer preloading those skills directly in agent
+frontmatter instead of relying only on prose reminders.
 
 Typical slash entrypoints in this repo today:
 - `/coding-standards`


### PR DESCRIPTION
## Summary
Preload the stable startup skills for the active coordinators and core reusable workers instead of relying only on prose reminders in the agent bodies.

## What changed
- add `skills:` frontmatter to `scout`, `builder`, `reviewer`, `ops`, `improver`, `fixer`, `validator`, `bootstrapper`, and `pr-responder`
- keep the preload set narrow and honest: only the stable startup skills that these agents already name on every run
- document the rule that stable startup procedure should be preloaded in frontmatter when it is used every time

## Why
Subagents do not inherit loaded skills automatically. After `#1737` adds the real project skills, the core agents should load those startup procedures directly instead of depending only on body text that tells them to invoke them later.

## Verification
- `git diff --check`

## Stack
Base: #1737 (`feat(swarm): add core worker skills`)
