### PR TITLE
chore(swarm): constrain research workers

### DIFF
--- a/.claude/agents/AGENT_CATALOG.md
+++ b/.claude/agents/AGENT_CATALOG.md
@@ -17,9 +17,9 @@ Every live agent file should encode four things directly in the prompt surface: 
 | `fixer` | `ops or reviewer` | `reviewer or ops` | /swarm-protocol, /coding-standards, /verify-build | `fixer.md` |
 | `validator` | `ops` | `ops or fixer` | /swarm-protocol, validation command | `validator.md` |
 | `pr-responder` | `reviewer or ops` | `reviewer` | /swarm-protocol, /coding-standards, /pr-ready | `pr-responder.md` |
-| `research-web` | `scout or improver` | `scout or builder` | /swarm-protocol, /swarm-priorities | `research-web.md` |
-| `research-docs` | `scout or improver` | `scout or builder` | /swarm-protocol, /swarm-priorities | `research-docs.md` |
-| `research-verify` | `scout or improver` | `scout or builder` | /swarm-protocol, /swarm-priorities | `research-verify.md` |
+| `research-web` | `scout or improver` | `scout or builder` | web search + cited summary | `research-web.md` |
+| `research-docs` | `scout or improver` | `scout or builder` | docs lookup + condensed reference | `research-docs.md` |
+| `research-verify` | `scout or improver` | `scout or builder` | claim check + verdict | `research-verify.md` |
 
 ## Specialist Workers
 | Agent | Category | Usually spawned by | Hands off to | First entrypoints | File | Description |

--- a/.claude/agents/research-docs.md
+++ b/.claude/agents/research-docs.md
@@ -3,6 +3,9 @@ name: research-docs
 description: Documentation researcher. Fetches and reads upstream docs for Rust crates, Perl modules, LSP/DAP protocols, and tooling. Returns condensed API references and usage examples. Use when agents need to verify API signatures, protocol compliance, or library behavior.
 model: sonnet
 color: green
+tools: WebSearch, WebFetch
+permissionMode: default
+maxTurns: 6
 ---
 
 You are a documentation researcher. You fetch upstream docs and return condensed, actionable references.

--- a/.claude/agents/research-verify.md
+++ b/.claude/agents/research-verify.md
@@ -3,6 +3,9 @@ name: research-verify
 description: Verification researcher. Cross-checks claims, validates assumptions, and confirms behavior against authoritative sources. Use when a builder or reviewer needs to verify that their approach is correct before shipping.
 model: sonnet
 color: green
+tools: WebSearch, WebFetch
+permissionMode: default
+maxTurns: 4
 ---
 
 You are a verification researcher. You check whether a claim or assumption is actually true.

--- a/.claude/agents/research-web.md
+++ b/.claude/agents/research-web.md
@@ -3,6 +3,9 @@ name: research-web
 description: Single-shot web researcher. Takes a specific question, searches the web, reads relevant pages, and returns a condensed answer with sources. Keeps web search context out of the caller's window. Use when any agent needs factual verification or external documentation lookup.
 model: sonnet
 color: green
+tools: WebSearch, WebFetch
+permissionMode: default
+maxTurns: 6
 ---
 
 You are a web researcher. You take a specific question, find the answer online, and return a condensed result. The caller doesn't see your search context — only your answer.


### PR DESCRIPTION
## Summary
- add explicit read-only frontmatter contracts to the three one-shot research workers
- stop the agent catalog from pretending those workers start by invoking repo slash entrypoints
- keep the slice limited to research-worker boundaries and catalog accuracy

## Testing
- git diff --check
