### PR TITLE
docs(swarm): track durable findings with schema

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -8,7 +8,7 @@ The canonical runtime surfaces are:
 - `.claude/skills/` — canonical skill layer for swarm control and core worker procedures
 - `.claude/commands/` — slash entrypoints that currently live as command files
 - `.claude/settings.json` — shared permissions and hook enforcement
-- `.claude/swarm-state/` — durable queue and dedup state
+- `.claude/swarm-state/` — durable queue, dedup, pitfalls, and findings state
 
 The pack under `docs/handoff/swarm-pack/` is a derived export, not a co-equal
 design source.
@@ -59,6 +59,12 @@ The canonical roster mapping lives in
 [agents/AGENT_CATALOG.md](./agents/AGENT_CATALOG.md). It records who usually
 spawns each tracked agent, where it hands work next, and which slash
 entrypoints it should invoke first.
+
+The tracked swarm-state contract lives in
+[swarm-state/README.md](./swarm-state/README.md). Use `findings.json` there for
+durable control-plane conclusions, `discovered-issues.md` for product leads,
+`known-pitfalls.md` for reusable failure lessons, and `completed-slices.md` for
+dedup and lifecycle tracking.
 
 ## Compatibility Note
 

--- a/.claude/commands/swarm-status.md
+++ b/.claude/commands/swarm-status.md
@@ -25,6 +25,7 @@ gh pr list --state merged --limit 20 --json number,title,mergedAt
 echo "=== Queue Depth ==="
 grep -c "in-progress" .claude/swarm-state/completed-slices.md 2>/dev/null || echo "0 in-progress"
 wc -l < .claude/swarm-state/discovered-issues.md 2>/dev/null || echo "0 discoveries"
+jq -r '(.findings // []) | length | "\(.) tracked findings"' .claude/swarm-state/findings.json 2>/dev/null || echo "0 tracked findings"
 ls .ops-perl-lsp/handoffs/*.md 2>/dev/null | wc -l || echo "0 active handoffs"
 
 echo "=== Agent Patches Pending Review ==="
@@ -40,6 +41,9 @@ tail -50 .ops-perl-lsp/swarm-metrics.jsonl 2>/dev/null
 
 echo "=== Known Pitfalls ==="
 cat .claude/swarm-state/known-pitfalls.md 2>/dev/null
+
+echo "=== Tracked Findings ==="
+jq -r '.findings[]? | "\(.id) | \(.status) | \(.summary)"' .claude/swarm-state/findings.json 2>/dev/null
 
 echo "=== Worktrees ==="
 git worktree list

--- a/.claude/skills/swarm-protocol/SKILL.md
+++ b/.claude/skills/swarm-protocol/SKILL.md
@@ -38,6 +38,10 @@ Use GitHub and tracked swarm state as the durable ledger:
 
 Do not treat transcript memory as proof.
 
+Use `.claude/swarm-state/findings.json` for durable control-plane conclusions.
+Use `discovered-issues.md` for product leads and `known-pitfalls.md` for
+repeatable failure lessons.
+
 ## Metrics And Receipts
 
 After each task, leave a durable receipt:
@@ -60,6 +64,9 @@ Check the queue and state before creating new work:
 4. existing handoffs and receipts
 
 If the slice already exists, update or route it instead of duplicating it.
+
+If the work changes how the swarm should describe or operate itself, update the
+findings ledger instead of hiding that conclusion in chat or a one-off handoff.
 
 ## Worktree And Worker Boundaries
 

--- a/.claude/swarm-state/README.md
+++ b/.claude/swarm-state/README.md
@@ -1,0 +1,47 @@
+# Swarm State
+
+Tracked swarm state lives here. These files are committed and survive across
+sessions, worktrees, and operators.
+
+Use this directory for durable coordination knowledge:
+
+- `swarm-queue.json` — active overlap tracking
+- `completed-slices.md` — dedup log for work that already exists
+- `discovered-issues.md` — leads noticed during other slices
+- `known-pitfalls.md` — reusable traps and lessons
+- `findings.json` — durable control-plane findings and decisions
+- `findings.schema.json` — machine-readable contract for `findings.json`
+
+## Which File To Update
+
+- Product or codebase work you noticed outside the current slice:
+  `discovered-issues.md`
+- Reusable lesson from a failure or bad fix:
+  `known-pitfalls.md`
+- Branch or slice lifecycle status:
+  `completed-slices.md`
+- Active overlap / ownership state:
+  `swarm-queue.json`
+- Durable swarm conclusion about the control plane, roster, workflow, or docs:
+  `findings.json`
+
+`findings.json` is not a bug tracker and not a handoff file. It records stable
+findings that should change how the repo describes or operates the swarm.
+
+## Findings Contract
+
+Each finding in `findings.json` captures:
+
+- a stable ID
+- what kind of finding it is
+- whether it is active, landed, or superseded
+- the conclusion the repo should follow
+- the live surfaces affected
+- evidence pointers
+- follow-up PRs or notes
+
+Validate the ledger with:
+
+```bash
+python3 scripts/validate_swarm_findings.py
+```

--- a/.claude/swarm-state/findings.json
+++ b/.claude/swarm-state/findings.json
@@ -1,0 +1,182 @@
+{
+  "_comment": "Durable control-plane findings for the tracked swarm surface. Product bugs belong in discovered-issues.md or GitHub issues instead.",
+  "schema_version": 1,
+  "last_updated": "2026-03-17",
+  "findings": [
+    {
+      "id": "SWARM-FINDING-0001",
+      "kind": "runtime_invariant",
+      "status": "landed",
+      "recorded_on": "2026-03-17",
+      "summary": "Anything under .claude/agents/ is part of the active tracked swarm surface.",
+      "decision": "Keep active tracked agents in .claude/agents/ only. Move donor or compatibility material out of that directory, and catalog every live agent there.",
+      "surfaces": [
+        ".claude/agents/",
+        ".claude/agents/AGENT_CATALOG.md",
+        ".claude/agents/README.md",
+        ".claude/agents-compat/"
+      ],
+      "evidence": [
+        {
+          "type": "pr",
+          "ref": "#1734"
+        },
+        {
+          "type": "pr",
+          "ref": "#1736"
+        },
+        {
+          "type": "file",
+          "ref": ".claude/agents/AGENT_CATALOG.md"
+        }
+      ],
+      "follow_up": [
+        "Keep future donor material outside .claude/agents/."
+      ],
+      "notes": "Untracked or ambiguous files in .claude/agents/ are treated as a control-plane bug, not local scratch state."
+    },
+    {
+      "id": "SWARM-FINDING-0002",
+      "kind": "control_plane",
+      "status": "landed",
+      "recorded_on": "2026-03-17",
+      "summary": "Commands and skills are one slash-entrypoint surface unless frontmatter or bundled files change behavior.",
+      "decision": "Document commands and skills as interchangeable slash entrypoints at the call site. Use skills when preloading into agents, using supporting files, or applying frontmatter controls such as disable-model-invocation, user-invocable, allowed-tools, context: fork, or hooks.",
+      "surfaces": [
+        ".claude/commands/",
+        ".claude/skills/",
+        ".claude/README.md",
+        "docs/reference/SKILL_AND_AGENT_DESIGN.md"
+      ],
+      "evidence": [
+        {
+          "type": "pr",
+          "ref": "#1737"
+        },
+        {
+          "type": "pr",
+          "ref": "#1739"
+        },
+        {
+          "type": "doc",
+          "ref": "https://code.claude.com/docs/en/skills"
+        }
+      ],
+      "follow_up": [
+        "Prefer skills for procedures that agents must preload via frontmatter skills:."
+      ]
+    },
+    {
+      "id": "SWARM-FINDING-0003",
+      "kind": "control_plane",
+      "status": "landed",
+      "recorded_on": "2026-03-17",
+      "summary": "The tracked .claude/ tree is canonical; swarm-pack is a derived export.",
+      "decision": "Land runtime and documentation changes in the main repo .claude/ surfaces first. Update docs/handoff/swarm-pack/ as an intentionally derived export, not a peer design source.",
+      "surfaces": [
+        ".claude/",
+        "docs/handoff/swarm-pack/",
+        ".claude/README.md"
+      ],
+      "evidence": [
+        {
+          "type": "pr",
+          "ref": "#1725"
+        },
+        {
+          "type": "pr",
+          "ref": "#1736"
+        },
+        {
+          "type": "file",
+          "ref": ".claude/README.md"
+        }
+      ],
+      "follow_up": [
+        "Mirror structural changes into the pack when the export surface changes."
+      ]
+    },
+    {
+      "id": "SWARM-FINDING-0004",
+      "kind": "runtime_invariant",
+      "status": "landed",
+      "recorded_on": "2026-03-17",
+      "summary": "WorktreeCreate and WorktreeRemove stay unregistered until the repo intentionally owns worktree lifecycle.",
+      "decision": "Do not register WorktreeCreate or WorktreeRemove as passive metrics hooks. In Claude Code those hooks replace default worktree behavior, so reserve them until the hook itself provisions or removes the working copy.",
+      "surfaces": [
+        ".claude/settings.json",
+        "docs/reference/SKILL_AND_AGENT_DESIGN.md",
+        "docs/handoff/SWARM_DESIGN.md"
+      ],
+      "evidence": [
+        {
+          "type": "pr",
+          "ref": "#1726"
+        },
+        {
+          "type": "doc",
+          "ref": "https://code.claude.com/docs/en/hooks"
+        },
+        {
+          "type": "setting",
+          "ref": ".claude/settings.json"
+        }
+      ],
+      "follow_up": [
+        "If worktree lifecycle ownership becomes necessary, add explicit provisioning hooks in a separate PR."
+      ]
+    },
+    {
+      "id": "SWARM-FINDING-0005",
+      "kind": "tracking_gap",
+      "status": "landed",
+      "recorded_on": "2026-03-17",
+      "summary": "Control-plane findings need a machine-readable ledger instead of living only in chat transcripts and prose docs.",
+      "decision": "Track durable swarm findings in .claude/swarm-state/findings.json and keep them valid against findings.schema.json. Use discovered-issues.md for product leads and known-pitfalls.md for repeatable failure lessons.",
+      "surfaces": [
+        ".claude/swarm-state/findings.json",
+        ".claude/swarm-state/findings.schema.json",
+        ".claude/swarm-state/README.md"
+      ],
+      "evidence": [
+        {
+          "type": "file",
+          "ref": ".claude/swarm-state/discovered-issues.md"
+        },
+        {
+          "type": "file",
+          "ref": ".claude/swarm-state/known-pitfalls.md"
+        }
+      ],
+      "follow_up": [
+        "Validate findings.json in control-plane documentation and before export snapshots."
+      ]
+    },
+    {
+      "id": "SWARM-FINDING-0006",
+      "kind": "docs_drift",
+      "status": "active",
+      "recorded_on": "2026-03-17",
+      "summary": "The legacy .claude/commands/swarm-protocol.md mirror still reflects older .ops-perl-lsp paths and workflow language.",
+      "decision": "Either align the command mirror with the live skill-backed protocol or retire it as a clearly marked compatibility surface. Do not let the command file quietly teach older pathing and persistence rules.",
+      "surfaces": [
+        ".claude/commands/swarm-protocol.md",
+        ".claude/skills/swarm-protocol/SKILL.md"
+      ],
+      "evidence": [
+        {
+          "type": "file",
+          "ref": ".claude/commands/swarm-protocol.md"
+        },
+        {
+          "type": "file",
+          "ref": ".claude/skills/swarm-protocol/SKILL.md"
+        }
+      ],
+      "follow_up": [
+        "Open a narrow PR to align or retire the command mirror."
+      ],
+      "notes": "The skill-backed /swarm-protocol surface is current, but the legacy command file still exists in the live repo and should not drift indefinitely."
+    }
+  ]
+}

--- a/.claude/swarm-state/findings.schema.json
+++ b/.claude/swarm-state/findings.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/.claude/swarm-state/findings.schema.json",
+  "title": "Swarm Findings Ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "last_updated",
+    "findings"
+  ],
+  "properties": {
+    "_comment": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "status",
+        "recorded_on",
+        "summary",
+        "decision",
+        "surfaces",
+        "evidence",
+        "follow_up"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^SWARM-FINDING-[0-9]{4}$"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "control_plane",
+            "runtime_invariant",
+            "docs_drift",
+            "workflow_gap",
+            "tracking_gap"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "landed",
+            "watching",
+            "superseded"
+          ]
+        },
+        "recorded_on": {
+          "type": "string",
+          "format": "date"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "surfaces": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        },
+        "follow_up": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "ref"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "file",
+            "pr",
+            "issue",
+            "doc",
+            "hook",
+            "setting"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/handoff/SWARM_DESIGN.md
+++ b/docs/handoff/SWARM_DESIGN.md
@@ -338,12 +338,13 @@ Every ~10 merges, the lead triggers a data-driven check:
 
 ## Self-Improvement
 
-### Four Persistence Layers
+### Five Persistence Layers
 
 | Layer | Lifetime | What |
 |-------|----------|------|
 | **Handoffs** | Until merge | Context transfer: scout→builder→reviewer |
-| **Ops files** | Current session | known-pitfalls, completed-slices, discovered-issues, metrics, agent-patches |
+| **Tracked swarm state** | Cross-session, committed | findings, known-pitfalls, completed-slices, discovered-issues, queue |
+| **Ops runtime** | Current session | metrics, agent-patches |
 | **GitHub** | Permanent | Issues (swarm-discovered, swarm-architectural), PRs (labeled), CI status |
 | **Claude Code memories** | Cross-session | Critical lessons, session progress, architectural decisions |
 
@@ -351,12 +352,13 @@ Every ~10 merges, the lead triggers a data-driven check:
 
 1. **Fixers** → `known-pitfalls.md` → scouts/builders avoid repeating known traps
 2. **All agents** → `discovered-issues.md` → scouts pick up pre-investigated leads
-3. **All agents** → GitHub issues (`--label swarm-discovered`) → persistent, searchable backlog
-4. **All agents** → `swarm-metrics.jsonl` → ops + improver spot performance patterns
-5. **Failing agents** → `agent-patches/` → bootstrapper improves agent definitions
-6. **Improver** → reads handoff lessons → crystallizes into ADRs and friction logs
-7. **Ops** → analyzes metrics → reports which domains/agents need attention
-8. **Lead** → Claude Code memories → carries critical knowledge to future sessions
+3. **Coordinators + improver** → `findings.json` → durable control-plane conclusions survive beyond the session
+4. **All agents** → GitHub issues (`--label swarm-discovered`) → persistent, searchable backlog
+5. **All agents** → `swarm-metrics.jsonl` → ops + improver spot performance patterns
+6. **Failing agents** → `agent-patches/` → bootstrapper improves agent definitions
+7. **Improver** → reads handoff lessons → crystallizes into ADRs and friction logs
+8. **Ops** → analyzes metrics → reports which domains/agents need attention
+9. **Lead** → Claude Code memories → carries critical knowledge to future sessions
 
 ### Agent Self-Improvement
 
@@ -421,7 +423,7 @@ All lanes run concurrently. Scouts feed builders feed reviewers feed ops. Improv
 ~5 minutes: broadcast STOP → snapshot state → enable auto-merge on green PRs → write memory → halt team → leave worktrees for next session
 
 ### Session Resumption
-Next `/swarm` picks up: in-progress slices from `completed-slices.md`, open PRs (some auto-merged), active worktrees, pending agent patches, discovered issues.
+Next `/swarm` picks up: in-progress slices from `completed-slices.md`, open PRs (some auto-merged), active worktrees, pending agent patches, discovered issues, and the tracked findings ledger.
 
 ## Portable Pack
 

--- a/docs/handoff/swarm-pack/QUICKREF.md
+++ b/docs/handoff/swarm-pack/QUICKREF.md
@@ -71,6 +71,8 @@ all agents ─→ TaskUpdate ────→ shared task list
 | `known-pitfalls.md` | Failure knowledge | fixer | scout, builder |
 | `completed-slices.md` | Dedup log | scout, ops | scout, improvers |
 | `discovered-issues.md` | Agent-flagged leads | all agents | scout |
+| `findings.json` | Durable control-plane findings | scout, improver, reviewer, ops | all lanes |
+| `findings.schema.json` | Contract for findings ledger | repo maintainers | all lanes |
 | `swarm-queue.json` | Overlap tracking | scout, lead | scout, lead |
 
 ### Ephemeral (`.ops/` — gitignored, per-session runtime)

--- a/docs/handoff/swarm-pack/README.md
+++ b/docs/handoff/swarm-pack/README.md
@@ -105,6 +105,8 @@ entrypoint.
     known-pitfalls.md     # Failure knowledge base
     completed-slices.md   # Scout dedup log
     discovered-issues.md  # Agent-flagged leads
+    findings.json         # Durable control-plane findings ledger
+    findings.schema.json  # Machine-readable contract for findings.json
     swarm-queue.json      # Overlap tracking
   settings.json           # Hook registrations (PostToolUse, TeammateIdle,
                           # TaskCompleted, SubagentStart, SubagentStop,
@@ -119,9 +121,10 @@ entrypoint.
 ## Command And Skill Layer
 
 The portable pack installs both `.claude/skills/swarm/` and compatible
-`.claude/commands/` files. Prefer the skill layer for the coordinator
-playbook; keep the command layer as a compatibility surface and operator
-entrypoint.
+`.claude/commands/` files. Treat them as one slash-entrypoint surface at the
+call site. Skills become the better packaging when you need supporting files,
+agent preloading, or frontmatter controls such as `disable-model-invocation`,
+`user-invocable`, `allowed-tools`, `context: fork`, or hooks.
 
 Key frontmatter fields for that repo-local skill layer:
 

--- a/docs/handoff/swarm-pack/SWARM_DESIGN.md
+++ b/docs/handoff/swarm-pack/SWARM_DESIGN.md
@@ -255,12 +255,13 @@ Every ~10 merges, the lead triggers a data-driven check:
 
 ## Self-Improvement
 
-### Four Persistence Layers
+### Five Persistence Layers
 
 | Layer | Lifetime | What |
 |-------|----------|------|
 | **Handoffs** | Until merge | Context transfer: scout→builder→reviewer |
-| **Ops files** | Current session | known-pitfalls, completed-slices, discovered-issues, metrics, agent-patches |
+| **Tracked swarm state** | Cross-session, committed | findings, known-pitfalls, completed-slices, discovered-issues, queue |
+| **Ops runtime** | Current session | metrics, agent-patches |
 | **GitHub** | Permanent | Issues (swarm-discovered, swarm-architectural), PRs (labeled), CI status |
 | **Claude Code memories** | Cross-session | Critical lessons, session progress, architectural decisions |
 
@@ -268,12 +269,13 @@ Every ~10 merges, the lead triggers a data-driven check:
 
 1. **Fixers** → `known-pitfalls.md` → scouts/builders avoid repeating known traps
 2. **All agents** → `discovered-issues.md` → scouts pick up pre-investigated leads
-3. **All agents** → GitHub issues (`--label swarm-discovered`) → persistent, searchable backlog
-4. **All agents** → `swarm-metrics.jsonl` → ops + improver spot performance patterns
-5. **Failing agents** → `agent-patches/` → bootstrapper improves agent definitions
-6. **Improver** → reads handoff lessons → crystallizes into ADRs and friction logs
-7. **Ops** → analyzes metrics → reports which domains/agents need attention
-8. **Lead** → Claude Code memories → carries critical knowledge to future sessions
+3. **Coordinators + improver** → `findings.json` → durable control-plane conclusions survive beyond the session
+4. **All agents** → GitHub issues (`--label swarm-discovered`) → persistent, searchable backlog
+5. **All agents** → `swarm-metrics.jsonl` → ops + improver spot performance patterns
+6. **Failing agents** → `agent-patches/` → bootstrapper improves agent definitions
+7. **Improver** → reads handoff lessons → crystallizes into ADRs and friction logs
+8. **Ops** → analyzes metrics → reports which domains/agents need attention
+9. **Lead** → Claude Code memories → carries critical knowledge to future sessions
 
 ### Agent Self-Improvement
 
@@ -338,7 +340,7 @@ All lanes run concurrently. Scouts feed builders feed reviewers feed ops. Improv
 ~5 minutes: broadcast STOP → snapshot state → enable auto-merge on green PRs → write memory → halt team → leave worktrees for next session
 
 ### Session Resumption
-Next `/swarm` picks up: in-progress slices from `completed-slices.md`, open PRs (some auto-merged), active worktrees, pending agent patches, discovered issues.
+Next `/swarm` picks up: in-progress slices from `completed-slices.md`, open PRs (some auto-merged), active worktrees, pending agent patches, discovered issues, and the tracked findings ledger.
 
 ## Portable Pack
 

--- a/docs/handoff/swarm-pack/SWARM_PROTOCOL.md
+++ b/docs/handoff/swarm-pack/SWARM_PROTOCOL.md
@@ -37,6 +37,10 @@ Create issues for: security vulnerabilities, design flaws, missing features, rec
 **Discovery log** (`.claude/swarm-state/discovered-issues.md`):
 For smaller items not worth a full issue. Scouts read this as an input source.
 
+**Findings ledger** (`.claude/swarm-state/findings.json`):
+For durable control-plane conclusions that should change how the swarm
+describes or operates itself.
+
 ## 2. Direct Communication
 
 Message other teammates directly. Don't route through the lead.
@@ -125,13 +129,15 @@ Before starting work:
 1. `.claude/swarm-state/completed-slices.md` — done already?
 2. `.claude/swarm-state/known-pitfalls.md` — known trap?
 3. `.claude/swarm-state/discovered-issues.md` — already flagged?
-4. `gh issue list --label "swarm-discovered"` — already an issue?
-5. `gh pr list --state open` — already a PR?
+4. `.claude/swarm-state/findings.json` — durable swarm conclusion already recorded?
+5. `gh issue list --label "swarm-discovered"` — already an issue?
+6. `gh pr list --state open` — already a PR?
 
 After completing:
 1. `completed-slices.md` — `in-progress` (scout) or `merged` (ops)
 2. `known-pitfalls.md` — if you learned a reusable lesson
-3. `swarm-metrics.jsonl` — always
+3. `findings.json` — if the conclusion changes how the swarm should operate or document itself
+4. `swarm-metrics.jsonl` — always
 
 ## 7. User Interaction
 
@@ -170,13 +176,13 @@ Include in handoffs: code excerpts, error messages, decision rationale, file:lin
 
 ## 9. Learning Loop
 
-The swarm writes to four persistence layers, each with different lifetimes:
+The swarm writes to five persistence layers, each with different lifetimes:
 
 | Layer | Lifetime | Location | What |
 |-------|----------|----------|------|
 | **Handoffs** | Until merge | `.ops/handoffs/` | Context transfer: scout→builder→reviewer |
 | **Runtime** | Current session | `.ops/` | metrics, agent-patches, salvage |
-| **Knowledge** | Across sessions | `.claude/swarm-state/` | known-pitfalls, completed-slices, discovered-issues, queue |
+| **Knowledge** | Across sessions | `.claude/swarm-state/` | findings, known-pitfalls, completed-slices, discovered-issues, queue |
 | **GitHub** | Permanent | Issues, PRs, labels | Work items, discoveries, architectural decisions |
 | **Memory** | Across sessions | Claude Code memories | Critical lessons future sessions need |
 
@@ -192,12 +198,13 @@ Don't write memories for ephemeral state (which PRs are open, which slices are i
 ### Flow
 1. **Fixers** → `known-pitfalls.md` → scouts/builders avoid traps
 2. **All agents** → `discovered-issues.md` → scouts pick up pre-investigated leads
-3. **All agents** → `swarm-metrics.jsonl` → lead spots patterns
-4. **Failing agents** → `agent-patches/` → bootstrapper improves definitions
-5. **Improver-docs** → ADRs and docs from handoff lessons
-6. **Improver-devex** → fixes friction from handoff lessons
-7. **Merger** → analyzes metrics, reports patterns
-8. **All agents** → GitHub issues/labels for permanent visibility
-9. **Lead** → Claude Code memories for cross-session knowledge
+3. **Coordinators + improver** → `findings.json` → durable control-plane conclusions survive beyond the session
+4. **All agents** → `swarm-metrics.jsonl` → lead spots patterns
+5. **Failing agents** → `agent-patches/` → bootstrapper improves definitions
+6. **Improver-docs** → ADRs and docs from handoff lessons
+7. **Improver-devex** → fixes friction from handoff lessons
+8. **Merger** → analyzes metrics, reports patterns
+9. **All agents** → GitHub issues/labels for permanent visibility
+10. **Lead** → Claude Code memories for cross-session knowledge
 
 The system gets better with each cycle AND each session.

--- a/docs/handoff/swarm-pack/commands/swarm-protocol.md
+++ b/docs/handoff/swarm-pack/commands/swarm-protocol.md
@@ -41,6 +41,10 @@ Create issues for: security vulnerabilities, design flaws, missing features, rec
 **Discovery log** (`.claude/swarm-state/discovered-issues.md`):
 For smaller items not worth a full issue. Scouts read this as an input source.
 
+**Findings ledger** (`.claude/swarm-state/findings.json`):
+For durable control-plane conclusions that should change how the swarm
+describes or operates itself.
+
 ## 2. Direct Communication
 
 Message other teammates directly. Don't route through the lead.
@@ -129,13 +133,15 @@ Before starting work:
 1. `.claude/swarm-state/completed-slices.md` — done already?
 2. `.claude/swarm-state/known-pitfalls.md` — known trap?
 3. `.claude/swarm-state/discovered-issues.md` — already flagged?
-4. `gh issue list --label "swarm-discovered"` — already an issue?
-5. `gh pr list --state open` — already a PR?
+4. `.claude/swarm-state/findings.json` — durable swarm conclusion already recorded?
+5. `gh issue list --label "swarm-discovered"` — already an issue?
+6. `gh pr list --state open` — already a PR?
 
 After completing:
 1. `completed-slices.md` — `in-progress` (scout) or `merged` (ops)
 2. `known-pitfalls.md` — if you learned a reusable lesson
-3. `swarm-metrics.jsonl` — always
+3. `findings.json` — if the conclusion changes how the swarm should operate or document itself
+4. `swarm-metrics.jsonl` — always
 
 ## 7. User Interaction
 
@@ -174,13 +180,13 @@ Include in handoffs: code excerpts, error messages, decision rationale, file:lin
 
 ## 9. Learning Loop
 
-The swarm writes to four persistence layers, each with different lifetimes:
+The swarm writes to five persistence layers, each with different lifetimes:
 
 | Layer | Lifetime | Location | What |
 |-------|----------|----------|------|
 | **Handoffs** | Until merge | `.ops/handoffs/` | Context transfer: scout→builder→reviewer |
 | **Runtime** | Current session | `.ops/` | metrics, agent-patches, salvage |
-| **Knowledge** | Across sessions | `.claude/swarm-state/` | known-pitfalls, completed-slices, discovered-issues, queue |
+| **Knowledge** | Across sessions | `.claude/swarm-state/` | findings, known-pitfalls, completed-slices, discovered-issues, queue |
 | **GitHub** | Permanent | Issues, PRs, labels | Work items, discoveries, architectural decisions |
 | **Memory** | Across sessions | Claude Code memories | Critical lessons future sessions need |
 
@@ -196,12 +202,13 @@ Don't write memories for ephemeral state (which PRs are open, which slices are i
 ### Flow
 1. **Fixers** → `known-pitfalls.md` → scouts/builders avoid traps
 2. **All agents** → `discovered-issues.md` → scouts pick up pre-investigated leads
-3. **All agents** → `swarm-metrics.jsonl` → lead spots patterns
-4. **Failing agents** → `agent-patches/` → bootstrapper improves definitions
-5. **Improver-docs** → ADRs and docs from handoff lessons
-6. **Improver-devex** → fixes friction from handoff lessons
-7. **Merger** → analyzes metrics, reports patterns
-8. **All agents** → GitHub issues/labels for permanent visibility
-9. **Lead** → Claude Code memories for cross-session knowledge
+3. **Coordinators + improver** → `findings.json` → durable control-plane conclusions survive beyond the session
+4. **All agents** → `swarm-metrics.jsonl` → lead spots patterns
+5. **Failing agents** → `agent-patches/` → bootstrapper improves definitions
+6. **Improver-docs** → ADRs and docs from handoff lessons
+7. **Improver-devex** → fixes friction from handoff lessons
+8. **Merger** → analyzes metrics, reports patterns
+9. **All agents** → GitHub issues/labels for permanent visibility
+10. **Lead** → Claude Code memories for cross-session knowledge
 
 The system gets better with each cycle AND each session.

--- a/docs/handoff/swarm-pack/commands/swarm-status.md
+++ b/docs/handoff/swarm-pack/commands/swarm-status.md
@@ -25,6 +25,7 @@ gh pr list --state merged --limit 20 --json number,title,mergedAt
 echo "=== Queue Depth ==="
 grep -c "in-progress" .claude/swarm-state/completed-slices.md 2>/dev/null || echo "0 in-progress"
 wc -l < .claude/swarm-state/discovered-issues.md 2>/dev/null || echo "0 discoveries"
+jq -r '(.findings // []) | length | "\(.) tracked findings"' .claude/swarm-state/findings.json 2>/dev/null || echo "0 tracked findings"
 ls .ops/handoffs/*.md 2>/dev/null | wc -l || echo "0 active handoffs"
 
 echo "=== Agent Patches Pending Review ==="
@@ -40,6 +41,9 @@ tail -50 .ops/swarm-metrics.jsonl 2>/dev/null
 
 echo "=== Known Pitfalls ==="
 cat .claude/swarm-state/known-pitfalls.md 2>/dev/null
+
+echo "=== Tracked Findings ==="
+jq -r '.findings[]? | "\(.id) | \(.status) | \(.summary)"' .claude/swarm-state/findings.json 2>/dev/null
 
 echo "=== Worktrees ==="
 git worktree list

--- a/docs/handoff/swarm-pack/setup.sh
+++ b/docs/handoff/swarm-pack/setup.sh
@@ -162,7 +162,9 @@ fi
 SWARM_STATE="${CLAUDE_DIR}/swarm-state"
 mkdir -p "${SWARM_STATE}"
 
-for artifact in swarm-queue.json known-pitfalls.md completed-slices.md discovered-issues.md; do
+TODAY="$(date +%F)"
+
+for artifact in swarm-queue.json known-pitfalls.md completed-slices.md discovered-issues.md findings.json findings.schema.json; do
     dest="${SWARM_STATE}/${artifact}"
     if [ -f "$dest" ]; then
         echo "  SKIP: swarm-state/${artifact} (exists)"
@@ -193,6 +195,153 @@ ARTEOF
 # Discovered Issues
 Any agent can append here when they notice something outside their scope.
 <!-- Agents append below -->
+ARTEOF
+                ;;
+            findings.json)
+                cat > "$dest" <<ARTEOF
+{
+  "_comment": "Durable control-plane findings for the tracked swarm surface. Product bugs belong in discovered-issues.md or GitHub issues instead.",
+  "schema_version": 1,
+  "last_updated": "${TODAY}",
+  "findings": []
+}
+ARTEOF
+                ;;
+            findings.schema.json)
+                cat > "$dest" <<'ARTEOF'
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Swarm Findings Ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "last_updated",
+    "findings"
+  ],
+  "properties": {
+    "_comment": {
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "status",
+        "recorded_on",
+        "summary",
+        "decision",
+        "surfaces",
+        "evidence",
+        "follow_up"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^SWARM-FINDING-[0-9]{4}$"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "control_plane",
+            "runtime_invariant",
+            "docs_drift",
+            "workflow_gap",
+            "tracking_gap"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "landed",
+            "watching",
+            "superseded"
+          ]
+        },
+        "recorded_on": {
+          "type": "string",
+          "format": "date"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "surfaces": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        },
+        "follow_up": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "ref"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "file",
+            "pr",
+            "issue",
+            "doc",
+            "hook",
+            "setting"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}
 ARTEOF
                 ;;
         esac
@@ -381,7 +530,7 @@ echo "   - ${SKILL_COUNT} skills in .claude/skills/"
 echo "   - ${COMMAND_COUNT} slash command files in .claude/commands/"
 echo "   - ${HOOK_COUNT} hook scripts in .claude/hooks/"
 echo "   - hooks registered in .claude/settings.json (7 event types)"
-echo "   - .claude/swarm-state/  — tracked knowledge (pitfalls, slices, discoveries, queue)"
+echo "   - .claude/swarm-state/  — tracked knowledge (pitfalls, slices, discoveries, findings, queue)"
 echo "   - ${OPS_DIR}/           — ephemeral runtime (gitignored: handoffs, metrics, patches, salvage)"
 echo "   - GitHub labels (7)"
 echo ""

--- a/docs/reference/SKILL_AND_AGENT_DESIGN.md
+++ b/docs/reference/SKILL_AND_AGENT_DESIGN.md
@@ -96,6 +96,9 @@ Stable, reusable instructions belong in structural artifacts:
 - coordinator prompts: role boundaries and operating loops
 
 Durable knowledge is pre-encoded so it is not restated in every spawn prompt.
+Stable swarm conclusions should also be recorded in the tracked findings ledger
+at [`../../.claude/swarm-state/findings.json`](../../.claude/swarm-state/findings.json)
+instead of being left in chat transcripts.
 
 ### Volatile State
 
@@ -109,6 +112,19 @@ Task-specific or branch-specific state belongs in:
 
 Volatile state should move forward through handoffs, not by keeping a worker
 alive indefinitely.
+
+### Tracked Swarm Findings
+
+Use `.claude/swarm-state/findings.json` for durable control-plane findings:
+
+- roster invariants
+- slash-entrypoint surface rules
+- export-versus-trunk decisions
+- hook lifecycle constraints
+- other findings that should change how the swarm operates or documents itself
+
+Do not put product bugs there. Product or codebase leads belong in
+`discovered-issues.md`. Reusable failure lessons belong in `known-pitfalls.md`.
 
 ## Skills, Hooks, And Handoffs
 
@@ -191,6 +207,10 @@ step:
 
 This keeps procedure attached to the current task instead of relying on
 ambient remembered instructions.
+
+When a task produces a durable swarm finding, capture it in
+`.claude/swarm-state/findings.json` and validate it with
+`python3 scripts/validate_swarm_findings.py`.
 
 ## Spawn Rules
 

--- a/scripts/validate_swarm_findings.py
+++ b/scripts/validate_swarm_findings.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate the tracked swarm findings ledger."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FINDINGS_PATH = ROOT / ".claude" / "swarm-state" / "findings.json"
+
+ALLOWED_ROOT_KEYS = {"_comment", "schema_version", "last_updated", "findings"}
+ALLOWED_FINDING_KEYS = {
+    "id",
+    "kind",
+    "status",
+    "recorded_on",
+    "summary",
+    "decision",
+    "surfaces",
+    "evidence",
+    "follow_up",
+    "notes",
+}
+ALLOWED_EVIDENCE_KEYS = {"type", "ref"}
+ALLOWED_KINDS = {
+    "control_plane",
+    "runtime_invariant",
+    "docs_drift",
+    "workflow_gap",
+    "tracking_gap",
+}
+ALLOWED_STATUSES = {"active", "landed", "watching", "superseded"}
+ALLOWED_EVIDENCE_TYPES = {"file", "pr", "issue", "doc", "hook", "setting"}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_date(raw: str, field: str) -> date:
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        fail(f"{field} must be ISO date YYYY-MM-DD: {exc}")
+    raise AssertionError("unreachable")
+
+
+def ensure_nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{field} must be a non-empty string")
+    return value
+
+
+def main() -> None:
+    raw = FINDINGS_PATH.read_text(encoding="utf-8")
+    data = json.loads(raw)
+
+    extra_root = set(data) - ALLOWED_ROOT_KEYS
+    if extra_root:
+        fail(f"unexpected root keys: {sorted(extra_root)}")
+
+    if data.get("schema_version") != 1:
+        fail("schema_version must be 1")
+
+    last_updated = parse_date(ensure_nonempty_string(data.get("last_updated"), "last_updated"), "last_updated")
+
+    findings = data.get("findings")
+    if not isinstance(findings, list):
+        fail("findings must be an array")
+
+    seen_ids: set[str] = set()
+    seen_surfaces: set[str] = set()
+    latest_recorded = date.min
+
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            fail(f"finding #{index + 1} must be an object")
+
+        extra_finding = set(finding) - ALLOWED_FINDING_KEYS
+        if extra_finding:
+            fail(f"finding #{index + 1} has unexpected keys: {sorted(extra_finding)}")
+
+        finding_id = ensure_nonempty_string(finding.get("id"), f"finding #{index + 1}.id")
+        if finding_id in seen_ids:
+            fail(f"duplicate finding id: {finding_id}")
+        seen_ids.add(finding_id)
+
+        kind = ensure_nonempty_string(finding.get("kind"), f"{finding_id}.kind")
+        if kind not in ALLOWED_KINDS:
+            fail(f"{finding_id}.kind must be one of {sorted(ALLOWED_KINDS)}")
+
+        status = ensure_nonempty_string(finding.get("status"), f"{finding_id}.status")
+        if status not in ALLOWED_STATUSES:
+            fail(f"{finding_id}.status must be one of {sorted(ALLOWED_STATUSES)}")
+
+        recorded_on = parse_date(
+            ensure_nonempty_string(finding.get("recorded_on"), f"{finding_id}.recorded_on"),
+            f"{finding_id}.recorded_on",
+        )
+        latest_recorded = max(latest_recorded, recorded_on)
+
+        ensure_nonempty_string(finding.get("summary"), f"{finding_id}.summary")
+        ensure_nonempty_string(finding.get("decision"), f"{finding_id}.decision")
+
+        surfaces = finding.get("surfaces")
+        if not isinstance(surfaces, list) or not surfaces:
+            fail(f"{finding_id}.surfaces must be a non-empty array")
+        for surface_index, surface in enumerate(surfaces):
+            surface_value = ensure_nonempty_string(surface, f"{finding_id}.surfaces[{surface_index}]")
+            seen_surfaces.add(surface_value)
+
+        evidence = finding.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            fail(f"{finding_id}.evidence must be a non-empty array")
+        for evidence_index, item in enumerate(evidence):
+            if not isinstance(item, dict):
+                fail(f"{finding_id}.evidence[{evidence_index}] must be an object")
+            extra_evidence = set(item) - ALLOWED_EVIDENCE_KEYS
+            if extra_evidence:
+                fail(f"{finding_id}.evidence[{evidence_index}] has unexpected keys: {sorted(extra_evidence)}")
+            evidence_type = ensure_nonempty_string(item.get("type"), f"{finding_id}.evidence[{evidence_index}].type")
+            if evidence_type not in ALLOWED_EVIDENCE_TYPES:
+                fail(
+                    f"{finding_id}.evidence[{evidence_index}].type must be one of {sorted(ALLOWED_EVIDENCE_TYPES)}"
+                )
+            ensure_nonempty_string(item.get("ref"), f"{finding_id}.evidence[{evidence_index}].ref")
+
+        follow_up = finding.get("follow_up")
+        if not isinstance(follow_up, list):
+            fail(f"{finding_id}.follow_up must be an array")
+        for follow_up_index, step in enumerate(follow_up):
+            ensure_nonempty_string(step, f"{finding_id}.follow_up[{follow_up_index}]")
+
+        notes = finding.get("notes")
+        if notes is not None:
+            ensure_nonempty_string(notes, f"{finding_id}.notes")
+
+    if latest_recorded > last_updated:
+        fail("last_updated must be on or after the newest finding.recorded_on date")
+
+    if not seen_surfaces:
+        fail("at least one surface must be referenced across findings")
+
+    print(f"Validated {len(findings)} findings in {FINDINGS_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a structured swarm findings ledger with a tracked schema and validator
- document how findings relate to discovered issues, pitfalls, completed slices, and queue state
- mirror the new findings surface into the live swarm docs and the derived swarm-pack setup/docs

## Testing
- python3 scripts/validate_swarm_findings.py
- python3 -m py_compile scripts/validate_swarm_findings.py
- bash -n docs/handoff/swarm-pack/setup.sh
- git diff --check
