### PR TITLE
docs: improve storybooking guidance

### DIFF
--- a/crates/perl-parser/tests/README_e2e_tests.md
+++ b/crates/perl-parser/tests/README_e2e_tests.md
@@ -124,35 +124,81 @@ When implementing new LSP features:
 ## Storybooking Workflow (Improved)
 
 To keep user-story tests easy to review and maintain, use this lightweight
-"storybooking" flow before writing assertions:
+"storybooking" flow before writing assertions. The goal is to make every test
+read like a compact editor workflow instead of a pile of transport details.
 
-1. **Name the story from user intent**
-   - Prefer `test_user_story_<capability>_<outcome>`.
+### Definition of Ready
+
+Before adding a new scenario, capture these inputs in a short planning note or
+in the test comments themselves:
+
+1. **User intent**
+   - What is the Perl developer trying to accomplish?
+   - Prefer names like `test_user_story_<capability>_<outcome>`.
    - Example: `test_user_story_navigation_goto_definition_across_packages`.
-2. **Describe the scenario in Given / When / Then comments**
+2. **Workspace slice**
+   - Keep the setup to the minimum number of files needed to prove behavior.
+   - Reuse existing fixture patterns before inventing new mock layouts.
+3. **Protocol surface**
+   - Name the exact LSP method(s) under test.
+   - Call out whether the story is request/response, notification-driven, or
+     incremental across multiple edits.
+4. **Observable outcome**
+   - Define the editor-visible result first: cursor jump, completion list,
+     diagnostic range, rename edits, etc.
+   - Avoid implementation-only success criteria.
+
+### Definition of Done
+
+Use this checklist while turning the story into assertions:
+
+1. **Describe the scenario in Given / When / Then comments**
    - `Given`: workspace shape and Perl source setup.
    - `When`: LSP request(s) issued by the editor.
    - `Then`: exact observable protocol behavior.
-3. **Map each Then to one protocol assertion**
+2. **Map each Then to one protocol assertion**
    - Keep one core expectation per assertion block.
    - Include JSON fragments only for fields under test.
-4. **Capture failure intent**
+   - Prefer checking stable fields before optional metadata.
+3. **Capture failure intent**
    - Add one negative-path assertion (or sibling unhappy-path test) that proves
      error handling for the same capability.
-5. **Record feature ownership**
+   - If the unhappy path is intentionally deferred, leave a short `TODO(issue)`
+     comment rather than silently omitting it.
+4. **Keep the story deterministic**
+   - Avoid timing-sensitive sleeps, non-local filesystem dependencies, and
+     unrelated fixture noise.
+   - Use the smallest document text that still demonstrates the behavior.
+5. **Record ownership and coverage movement**
    - Add/update a short note in this README when the story moves from
      `#[ignore]` to active coverage.
+   - If the scenario closes a known gap, mention the related issue, AC, or
+     missing-coverage note in the test comment header.
 
 ### Story Template
+
+A reusable planning template lives in
+[`STORYBOOK_TEMPLATE.md`](./STORYBOOK_TEMPLATE.md). Use it when shaping a new
+story, then collapse the final version into concise test comments.
 
 ```rust
 #[test]
 fn test_user_story_<capability>_<outcome>() {
+    // Story: <one-sentence user goal>
     // Given: <workspace + source setup>
     // When: <LSP request sequence>
     // Then: <editor-visible expectation>
 }
 ```
+
+### Review Heuristics
+
+During review, ask:
+
+- Can a reader identify the user goal in under 10 seconds?
+- Does each assertion correspond to a visible editor outcome?
+- Is there a clear unhappy path for the same capability?
+- Would this story still make sense if the internal implementation changed?
 
 This approach keeps user stories deterministic, reviewable, and aligned with
 real editor behavior instead of implementation details.

--- a/crates/perl-parser/tests/STORYBOOK_TEMPLATE.md
+++ b/crates/perl-parser/tests/STORYBOOK_TEMPLATE.md
@@ -1,0 +1,48 @@
+# Storybooking Template
+
+Use this template before adding or refactoring an end-to-end user-story test.
+Keep it lightweight: a few lines of planning should be enough to make the test
+read clearly and stay focused on observable LSP behavior.
+
+## Story Card
+
+- **Story name**: `test_user_story_<capability>_<outcome>`
+- **User goal**: _What is the Perl developer trying to accomplish?_
+- **Protocol methods**: _Which LSP request(s)/notification(s) are involved?_
+- **Coverage note**: _What gap, issue, or acceptance criterion does this close?_
+
+## Given / When / Then
+
+### Given
+- Minimal workspace layout:
+- Perl source snippet(s):
+- Any configuration or indexing preconditions:
+
+### When
+- Editor action or request sequence:
+- Incremental edits or follow-up requests:
+
+### Then
+- Primary editor-visible outcome:
+- Secondary stable fields worth asserting:
+- Negative-path expectation or sibling unhappy-path test:
+
+## Assertion Plan
+
+- [ ] One core assertion block per `Then`
+- [ ] Assert only the protocol fields under test
+- [ ] Include at least one failure-mode check
+- [ ] Keep fixtures deterministic and minimal
+- [ ] Update README coverage notes if the story becomes active
+
+## Rust Test Skeleton
+
+```rust
+#[test]
+fn test_user_story_<capability>_<outcome>() {
+    // Story: <one-sentence user goal>
+    // Given: <workspace + source setup>
+    // When: <LSP request sequence>
+    // Then: <editor-visible expectation>
+}
+```


### PR DESCRIPTION
### Motivation

- Improve the guidance for writing end-to-end user-story tests so they are easier to review and reliably exercise editor-visible LSP behavior. 
- Provide a lightweight, repeatable planning workflow that reduces fixture noise and keeps tests deterministic.

### Description

- Expanded the Storybooking section in `crates/perl-parser/tests/README_e2e_tests.md` with a `Definition of Ready` and `Definition of Done`, clearer naming guidance, and review heuristics. 
- Added guidance to prefer minimal workspace slices, name the exact LSP methods under test, and focus assertions on editor-visible outcomes instead of transport details. 
- Introduced a new reusable planning template at `crates/perl-parser/tests/STORYBOOK_TEMPLATE.md` that contains a story card, Given/When/Then fields, an assertion checklist, and a Rust test skeleton. 
- Updated the README to reference the new `STORYBOOK_TEMPLATE.md` and added a short review checklist for reviewers.

### Testing

- Ran `git diff --check` to validate whitespace and diff cleanliness, which passed. 
- Ran `cargo fmt --all --check` to ensure formatting compliance, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0acc729c8333bfd95afe29e56808)