### PR TITLE
docs: clarify Diátaxis navigation and authoring guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,45 @@ for prefix in perl-module- perl-lsp- perl-lsp-feature- perl-dap- perl-ts- perl-w
 done
 ```
 
+## Use the right doc type first
+
+This documentation hub follows the [Diátaxis framework](reference/DOCUMENTATION_GUIDE.md):
+
+| If you want to… | Start here | What you will get |
+|---|---|---|
+| Learn the system for the first time | [Tutorials](#tutorials--learn-by-doing) | Guided, sequential walkthroughs |
+| Solve a concrete problem | [How-to guides](#how-to-guides--solve-a-problem) | Task-focused steps and verification |
+| Look up commands, capabilities, or contracts | [Reference](#reference--look-it-up) | Precise facts and complete specifications |
+| Understand architecture or tradeoffs | [Explanation](#explanation--understand-why) | Context, rationale, and design intent |
+
+If a page seems to mix several of these jobs, use the [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) to decide whether it should be split or cross-linked.
+
+## Suggested reading paths
+
+### I am new here
+
+1. [Getting Started](tutorials/GETTING_STARTED.md)
+2. [Installation](how-to/INSTALLATION.md)
+3. [Editor Setup](how-to/EDITOR_SETUP.md)
+4. [LSP Features](reference/LSP_FEATURES.md)
+5. [Troubleshooting](how-to/TROUBLESHOOTING.md)
+
+### I want to contribute
+
+1. [Contributing Guide](../CONTRIBUTING.md)
+2. [Documentation Guide](reference/DOCUMENTATION_GUIDE.md)
+3. [Commands Reference](reference/COMMANDS_REFERENCE.md)
+4. [Current Status](project/CURRENT_STATUS.md)
+5. [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md)
+
+### I need architecture context
+
+1. [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md)
+2. [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md)
+3. [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md)
+4. [Pure Rust Parser](explanation/PURE_RUST_PARSER.md)
+5. [Error Handling Strategy](explanation/ERROR_HANDLING_STRATEGY.md)
+
 ## Tutorials — learn by doing
 
 Step-by-step guides to get you started.
@@ -57,7 +96,7 @@ Precise, complete information for lookup.
 - [Configuration](reference/CONFIG.md) — Configuration options
 - [FAQ](reference/FAQ.md) — Frequently asked questions
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md) — Current constraints and workarounds
-- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diataxis framework and standards
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diátaxis framework and standards
 
 ## Explanation — understand why
 
@@ -90,6 +129,8 @@ High-level planning documents for project direction.
 - [Now/Next/Later](../NOW_NEXT_LATER.md) — Current quarter priorities
 
 ## Other directories
+
+These directories contain specialized material that complements the four Diátaxis categories above.
 
 | Directory | Purpose |
 |-----------|---------|

--- a/docs/reference/DOCUMENTATION_GUIDE.md
+++ b/docs/reference/DOCUMENTATION_GUIDE.md
@@ -9,18 +9,61 @@ This project organizes user-facing docs with the [Diátaxis](https://diataxis.fr
 - **Reference** (`docs/reference/`): factual, complete lookup documentation.
 - **Explanation** (`docs/explanation/`): conceptual context and design rationale.
 
-Use this page to decide where new content belongs and to keep existing docs consistent.
+Use this page to decide where new content belongs, keep existing docs consistent, and reduce category drift over time.
 
-## Where to put a new document
+## Fast classification test
 
-Ask one question first: **what is the reader trying to do?**
+Ask one question first: **what is the reader trying to do right now?**
 
 1. **Learn by doing for the first time** → `tutorials/`
 2. **Complete a specific task** → `how-to/`
 3. **Look up exact behavior, interfaces, or commands** → `reference/`
 4. **Understand why the system works this way** → `explanation/`
 
-If a document tries to do more than one of these, split it into multiple pages and cross-link them.
+If a document tries to do more than one of these jobs, split it into multiple pages and cross-link them.
+
+## Decision table
+
+| Reader need | Best category | Typical shape | Should end with |
+|---|---|---|---|
+| “Teach me this from the beginning.” | Tutorial | Sequential steps with checkpoints | Next steps into how-to/reference |
+| “Help me achieve one concrete outcome.” | How-to | Short prerequisite list and focused procedure | Verification and related tasks |
+| “Tell me the exact behavior.” | Reference | Scannable sections, tables, schemas, constraints | Links to explanatory context |
+| “Help me understand the tradeoffs.” | Explanation | Narrative reasoning, alternatives, architecture | Links to reference or implementation details |
+
+## Signs a page is in the wrong category
+
+### Tutorial drift
+
+A tutorial probably needs splitting if it:
+
+- Reads like a command catalog instead of a guided lesson.
+- Assumes prior project knowledge without introducing it.
+- Stops teaching and starts exhaustively documenting edge cases.
+
+### How-to drift
+
+A how-to guide probably needs splitting if it:
+
+- Spends more space on system history than on the task.
+- Covers several unrelated goals in one page.
+- Cannot be followed independently because key prerequisites are missing.
+
+### Reference drift
+
+A reference page probably needs splitting if it:
+
+- Contains long “why we chose this” sections.
+- Walks the reader through a full learning journey.
+- Hides defaults, constraints, or variants inside prose.
+
+### Explanation drift
+
+An explanation page probably needs splitting if it:
+
+- Contains numbered setup instructions.
+- Looks like a checklist for a task.
+- Tries to be the source of truth for command syntax or API details.
 
 ## Writing rules by doc type
 
@@ -33,7 +76,7 @@ If a document tries to do more than one of these, split it into multiple pages a
 
 ### How-to guides
 
-- Start with a goal statement (e.g., “Set up Neovim for perl-lsp”).
+- Start with a goal statement (for example, “Set up Neovim for perl-lsp”).
 - Provide prerequisites.
 - Prefer concise command sequences and verification checks.
 - Keep conceptual background short; link to explanation docs instead.
@@ -52,6 +95,51 @@ If a document tries to do more than one of these, split it into multiple pages a
 - Link to reference pages for exact APIs and commands.
 - Avoid procedural step lists (move those to tutorials/how-to).
 
+## Recommended page template by category
+
+### Tutorial template
+
+1. Goal
+2. Prerequisites
+3. Step 1, Step 2, Step 3…
+4. Verification checkpoints
+5. Next steps
+
+### How-to template
+
+1. Goal
+2. Prerequisites
+3. Procedure
+4. Verify the result
+5. Troubleshooting or adjacent tasks
+
+### Reference template
+
+1. Scope
+2. Commands / schema / API surface
+3. Defaults and constraints
+4. Examples
+5. Related explanation or how-to links
+
+### Explanation template
+
+1. Problem or tension
+2. Design choice
+3. Tradeoffs and alternatives
+4. Operational impact
+5. Links to reference and implementation docs
+
+## What belongs outside the four core categories
+
+Not every repository document is a Diátaxis page. These usually live elsewhere:
+
+- **ADRs** in `docs/adr/` for durable architectural decisions.
+- **Project status and governance** in `docs/project/`.
+- **Specs** in `docs/specs/` when a behavior is being proposed or negotiated.
+- **Archive material** in `docs/archive/` for historical records.
+
+When a non-Diátaxis document starts serving end users directly, add or update a Diátaxis page that points to it.
+
 ## Documentation hygiene checklist
 
 Before merging doc changes:
@@ -60,13 +148,32 @@ Before merging doc changes:
 - Verify command examples run as written where practical.
 - Ensure the page’s style matches its Diátaxis category.
 - Update [docs/README.md](../README.md) when adding or removing docs.
+- Add cross-links when splitting mixed-purpose content.
 
-## Current entry points
+## Applying the guide in this repository
 
-Start from the documentation hub in [docs/README.md](../README.md):
+Use these pages as reference examples:
 
-- Tutorials: [Getting Started](../tutorials/GETTING_STARTED.md)
-- How-to: [Installation](../how-to/INSTALLATION.md)
-- Reference: [Commands Reference](COMMANDS_REFERENCE.md)
-- Explanation: [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
+- **Tutorial**: [Getting Started](../tutorials/GETTING_STARTED.md)
+- **How-to**: [Installation](../how-to/INSTALLATION.md)
+- **Reference**: [Commands Reference](COMMANDS_REFERENCE.md)
+- **Explanation**: [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
 
+Use these directories for non-Diátaxis repository material:
+
+- **Governance and status**: `docs/project/`
+- **Decision records**: `docs/adr/`
+- **Specifications**: `docs/specs/`
+- **Historical records**: `docs/archive/`
+
+## Editing strategy for mixed pages
+
+When you find a page that mixes categories, prefer this sequence:
+
+1. Identify the page's primary reader need.
+2. Keep that material in place.
+3. Move the off-category material into a new page in the correct directory.
+4. Replace the removed content with a short summary and link.
+5. Update [docs/README.md](../README.md) if the new page is a user-facing entry point.
+
+That approach preserves links while gradually improving Diátaxis alignment.


### PR DESCRIPTION
### Motivation

- Make the documentation hub easier to navigate by helping readers pick the correct Diátaxis doc type before diving into the full index.
- Reduce category drift and inconsistent placement of content by giving contributors clear classification heuristics and templates.
- Provide pragmatic guidance for handling mixed-purpose pages and non-Diátaxis repository material so maintainers can iterate documentation improvements safely.

### Description

- Add a Diátaxis-first entry section and curated reading paths to `docs/README.md` so new users, contributors, and architects can find the right starting points quickly.
- Expand `docs/reference/DOCUMENTATION_GUIDE.md` with a fast classification test, a decision table, heuristics for identifying category drift, and reusable page templates for each Diátaxis category.
- Add guidance for what belongs outside the four Diátaxis categories and an editing strategy for incrementally splitting or moving mixed-purpose pages.
- Small editorial updates to wording and link text to emphasise Diátaxis alignment and cross-linking between the hub and guide.

### Testing

- Ran an automated relative link-resolution check across the two edited files and confirmed all internal markdown links resolve for the changed files.
- Reviewed the diff of the edited markdown files to verify structural and formatting consistency.
- No runtime code changes were made, so no unit or integration tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0ac364808333a9eadc7ce0d9f6e3)