### PR TITLE
docs: improve Diátaxis guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,135 +1,143 @@
 # Perl LSP Documentation
 
-Documentation for Perl LSP v0.12.0 — a Language Server Protocol implementation for Perl.
+This directory is the main documentation hub for `perl-lsp`.
 
-## Repository snapshot
+The user-facing documentation is organized with the [Diátaxis](https://diataxis.fr/) framework so readers can quickly choose the right kind of page for what they need right now:
 
-- Workspace version: **v0.12.0**
-- Workspace members: **112 crates**
-- Family counts (from `crates/`):
-  - `perl-module-*`: 13
-  - `perl-lsp-*`: 38
-  - `perl-lsp-feature-*`: 8
-  - `perl-dap-*`: 9
-  - `perl-ts-*`: 5
-  - `perl-workspace-*`: 6
+| Need | Start here | Expect |
+|------|------------|--------|
+| I am new and want a guided path | [`tutorials/`](tutorials/) | Sequential learning, examples, and checkpoints |
+| I need to complete a task | [`how-to/`](how-to/) | Short, goal-oriented instructions |
+| I need exact facts or commands | [`reference/`](reference/) | Lookup tables, schemas, and authoritative details |
+| I need to understand design choices | [`explanation/`](explanation/) | Rationale, tradeoffs, and architecture context |
 
-To refresh counts:
+If you are unsure where to begin, open the [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) for the repository's Diátaxis rules and writing standards.
 
-```bash
-for prefix in perl-module- perl-lsp- perl-lsp-feature- perl-dap- perl-ts- perl-workspace-; do
-  printf "%-18s %s\n" "$prefix" "$(find crates -maxdepth 1 -mindepth 1 -type d -name "${prefix}*" | wc -l)"
-done
-```
+## Recommended entry points
 
-## Tutorials — learn by doing
+### Start here if you are a user
 
-Step-by-step guides to get you started.
+- [Getting Started](tutorials/GETTING_STARTED.md) — install `perl-lsp`, connect an editor, and verify the setup.
+- [DAP User Guide](tutorials/DAP_USER_GUIDE.md) — configure debugging with the DAP bridge.
+- [Editor Setup](how-to/EDITOR_SETUP.md) — jump directly to editor-specific configuration.
+- [Troubleshooting](how-to/TROUBLESHOOTING.md) — resolve common installation and runtime issues.
 
-- [Getting Started](tutorials/GETTING_STARTED.md) — Installation and first steps
-- [DAP User Guide](tutorials/DAP_USER_GUIDE.md) — Debug Adapter Protocol setup and usage
-- [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) — Build and extend the LSP server
-- [Execute Command Tutorial](tutorials/EXECUTE_COMMAND_TUTORIAL.md) — Custom LSP commands
-- [Comprehensive Testing Guide](tutorials/COMPREHENSIVE_TESTING_GUIDE.md) — Testing workflows
+### Start here if you are contributing
 
-## How-to guides — solve a problem
+- [Contributing Guide](../CONTRIBUTING.md) — repository workflow and expectations.
+- [Commands Reference](reference/COMMANDS_REFERENCE.md) — canonical build, test, lint, and CI commands.
+- [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md) — workspace structure and crate families.
+- [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md) — feature architecture and protocol behavior.
+- [Current Status](project/CURRENT_STATUS.md) — computed project metrics and health signals.
 
-Task-oriented instructions for common operations.
+## Documentation by Diátaxis category
 
-- [Installation](how-to/INSTALLATION.md) — Install from source or binary
-- [Editor Setup](how-to/EDITOR_SETUP.md) — Configure your editor
-- [Troubleshooting](how-to/TROUBLESHOOTING.md) — Common issues and solutions
-- [Dependency Management](how-to/DEPENDENCY_MANAGEMENT.md) — Automated updates with Dependabot
-- [SemVer Workflow](how-to/SEMVER_WORKFLOW.md) — SemVer checking and API compatibility
-- [Coverage](how-to/COVERAGE.md) — Code coverage reports
-- [Dead Code Detection](how-to/DEAD_CODE_DETECTION.md) — Find unused code
+### Tutorials — learn by doing
 
-## Reference — look it up
+Use these when you want a guided path from zero to a working outcome.
 
-Precise, complete information for lookup.
+- [Getting Started](tutorials/GETTING_STARTED.md)
+- [DAP User Guide](tutorials/DAP_USER_GUIDE.md)
+- [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md)
+- [Execute Command Tutorial](tutorials/EXECUTE_COMMAND_TUTORIAL.md)
+- [Comprehensive Testing Guide](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
+- [DAP Bridge Setup Guide](tutorials/DAP_BRIDGE_SETUP_GUIDE.md)
+- [Workspace Refactoring Tutorial](tutorials/WORKSPACE_REFACTORING_TUTORIAL.md)
+- [AI Build Guide](tutorials/AI_BUILD_GUIDE.md)
 
-- [Commands Reference](reference/COMMANDS_REFERENCE.md) — Full command catalog
-- [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) — System design and components
-- [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md) — Workspace structure and tiers
-- [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md) — Language Server Protocol details
-- [LSP Features](reference/LSP_FEATURES.md) — Supported LSP capabilities
-- [Stability Policy](reference/STABILITY.md) — API versioning and compatibility
-- [Configuration](reference/CONFIG.md) — Configuration options
-- [FAQ](reference/FAQ.md) — Frequently asked questions
-- [Known Limitations](reference/KNOWN_LIMITATIONS.md) — Current constraints and workarounds
-- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diataxis framework and standards
+### How-to guides — solve a problem
 
-## Explanation — understand why
+Use these when you know the result you want and need the shortest path to it.
 
-Conceptual discussions and design rationale.
+- [Installation](how-to/INSTALLATION.md)
+- [Editor Setup](how-to/EDITOR_SETUP.md)
+- [Troubleshooting](how-to/TROUBLESHOOTING.md)
+- [Performance Tuning](how-to/PERFORMANCE_TUNING.md)
+- [Threading Configuration Guide](how-to/THREADING_CONFIGURATION_GUIDE.md)
+- [Coverage](how-to/COVERAGE.md)
+- [Dead Code Detection](how-to/DEAD_CODE_DETECTION.md)
+- [Dependency Management](how-to/DEPENDENCY_MANAGEMENT.md)
+- [Security Development Guide](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
+- [Contributing LSP](how-to/CONTRIBUTING_LSP.md)
 
-- [Pure Rust Parser](explanation/PURE_RUST_PARSER.md) — Why we built a native parser
-- [Error Handling Strategy](explanation/ERROR_HANDLING_STRATEGY.md) — Error philosophy and patterns
-- [Debt Tracking](explanation/DEBT_TRACKING.md) — Technical debt management
-- [Slash Disambiguation](explanation/SLASH_DISAMBIGUATION.md) — Perl regex vs division parsing
+For the full set of task-oriented guides, browse [`docs/how-to/`](how-to/).
 
-## Project — status and governance
+### Reference — look it up
 
-Process, metrics, and project health.
+Use these when accuracy, completeness, and scannability matter more than narrative.
 
-- [Current Status](project/CURRENT_STATUS.md) — Computed metrics and project health
-- [Roadmap](project/ROADMAP.md) — Milestones and release planning
-- [Milestones](project/MILESTONES.md) — GitHub milestones
-- [Lessons](project/LESSONS.md) — What went wrong
-- [Casebook](project/CASEBOOK.md) — What went right
-- [CI](project/CI.md) — Continuous integration setup
-- [CI Test Lanes](project/CI_TEST_LANES.md) — Test lane configuration
+- [Commands Reference](reference/COMMANDS_REFERENCE.md)
+- [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md)
+- [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md)
+- [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md)
+- [LSP Features](reference/LSP_FEATURES.md)
+- [Configuration](reference/CONFIG.md)
+- [Configuration Schema](reference/CONFIGURATION_SCHEMA.md)
+- [Stability Policy](reference/STABILITY.md)
+- [Known Limitations](reference/KNOWN_LIMITATIONS.md)
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md)
 
-## Strategic Documents — planning and direction
+For the full reference corpus, browse [`docs/reference/`](reference/).
 
-High-level planning documents for project direction.
+### Explanation — understand why
 
-- [Strategic Documentation Index](STRATEGIC_DOCUMENTATION.md) — Navigation hub for all strategic docs
-- [Technical Vision](../TECHNICAL_VISION.md) — Long-term technical direction (3-5 years)
-- [Roadmap](../ROADMAP.md) — Version milestones and deliverables
-- [Now/Next/Later](../NOW_NEXT_LATER.md) — Current quarter priorities
+Use these when you need context, design rationale, or tradeoff analysis.
 
-## Other directories
+- [Pure Rust Parser](explanation/PURE_RUST_PARSER.md)
+- [Error Handling Strategy](explanation/ERROR_HANDLING_STRATEGY.md)
+- [Slash Disambiguation](explanation/SLASH_DISAMBIGUATION.md)
+- [Cancellation Architecture Guide](explanation/CANCELLATION_ARCHITECTURE_GUIDE.md)
+- [Builtin Function Parsing](explanation/BUILTIN_FUNCTION_PARSING.md)
+- [LSP Documentation](explanation/LSP_DOCUMENTATION.md)
+- [Debt Tracking](explanation/DEBT_TRACKING.md)
+
+For the full set of conceptual docs, browse [`docs/explanation/`](explanation/).
+
+## Project, governance, and supporting material
+
+These directories support delivery, status tracking, and deeper internal process work. They complement the Diátaxis categories above rather than replacing them.
 
 | Directory | Purpose |
 |-----------|---------|
+| [project/](project/) | Status reports, health metrics, roadmap, and governance |
 | [adr/](adr/) | Architecture Decision Records |
-| [archive/](archive/) | Historical documents |
-| [benchmarks/](benchmarks/) | Benchmark framework docs |
+| [benchmarks/](benchmarks/) | Benchmark and performance documentation |
 | [ci/](ci/) | CI-specific documentation |
-| [design/](design/) | Semantic analyzer design |
-| [EDITORS/](EDITORS/) | Editor-specific setup |
-| [forensics/](forensics/) | PR archaeology |
-| [issues/](issues/) | Corpus gap tracking |
-| [semantic/](semantic/) | Semantic validation |
-| [specs/](specs/) | Specification documents |
+| [design/](design/) | Design notes and working documents |
+| [EDITORS/](EDITORS/) | Editor-specific reference material |
+| [forensics/](forensics/) | PR archaeology and historical investigations |
+| [issues/](issues/) | Known issues, corpus gaps, and resolution plans |
+| [semantic/](semantic/) | Semantic analysis planning and validation |
+| [specs/](specs/) | Specifications and lifecycle documents |
+| [archive/](archive/) | Historical documents retained for reference |
+| [handoff/](handoff/) | Handoff and swarm workflow material |
 
-## Contributing
+## Canonical truth sources
 
-- [Contributing Guide](../CONTRIBUTING.md) — Development workflow and contribution process
+Use these when you need the authoritative source for a class of information.
+
+| What | Where | Notes |
+|------|-------|-------|
+| Project metrics | [CURRENT_STATUS.md](project/CURRENT_STATUS.md) | Computed status lives here |
+| Feature catalog | [features.toml](../features.toml) | Canonical advertised capability list |
+| Build and test commands | [COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md) | Preferred command source |
+| API and release stability | [STABILITY.md](reference/STABILITY.md) | Compatibility expectations |
+| Project direction | [ROADMAP.md](../ROADMAP.md) | Release and milestone planning |
+| Documentation standards | [DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md) | Diátaxis placement and writing rules |
+
+## Documentation maintenance rules
+
+When adding or revising docs:
+
+1. Put the page in the Diátaxis category that matches the reader's need.
+2. Cross-link neighboring material instead of combining tutorial, how-to, reference, and explanation into one page.
+3. Update this index when you add a new major entry point or move an existing one.
+4. Prefer linking dynamic project facts to canonical sources rather than copying numbers that will drift.
+5. Verify commands and internal links where practical before merging.
 
 ## Quick verification
 
 ```bash
-nix develop -c just ci-gate       # Canonical local gate
-nix develop -c just status-check  # Verify metrics haven't drifted
+nix develop -c just ci-gate
+nix develop -c just status-check
 ```
-
-## Canonical Truth Sources
-
-| What | Where | Verified By |
-|------|-------|-------------|
-| Metrics | [CURRENT_STATUS.md](project/CURRENT_STATUS.md) | `just status-check` |
-| Plans | [ROADMAP.md](project/ROADMAP.md) | Human review |
-| Milestones | [MILESTONES.md](project/MILESTONES.md) | GitHub Milestones |
-| Capability catalog | [features.toml](../features.toml) | `just ci-gate` |
-| CI lanes | [CI_TEST_LANES.md](project/CI_TEST_LANES.md) | `just ci-gate` |
-| Local validation | [CI_LOCAL_VALIDATION.md](project/CI_LOCAL_VALIDATION.md) | `just ci-gate` |
-| What went wrong | [LESSONS.md](project/LESSONS.md) | Human review |
-| What went right | [CASEBOOK.md](project/CASEBOOK.md) | Human review |
-
-**Rule**: All metrics are computed and live in `CURRENT_STATUS.md`. If you see a number elsewhere, treat it as stale.
-
----
-
-Version: v0.12.0

--- a/docs/reference/DOCUMENTATION_GUIDE.md
+++ b/docs/reference/DOCUMENTATION_GUIDE.md
@@ -1,72 +1,144 @@
-> For the documentation hub, see [README.md](../README.md).
+> For the documentation hub, see [docs/README.md](../README.md).
 
 # Documentation Guide
 
-This project organizes user-facing docs with the [Diátaxis](https://diataxis.fr/) framework:
+This repository uses the [Diátaxis](https://diataxis.fr/) framework to keep documentation predictable for readers and maintainable for contributors.
 
-- **Tutorials** (`docs/tutorials/`): learning-oriented, step-by-step material.
-- **How-to guides** (`docs/how-to/`): task-oriented instructions to solve a concrete problem.
-- **Reference** (`docs/reference/`): factual, complete lookup documentation.
-- **Explanation** (`docs/explanation/`): conceptual context and design rationale.
+## The four documentation modes
 
-Use this page to decide where new content belongs and to keep existing docs consistent.
+| Mode | Reader mindset | Primary question | Typical content | Avoid |
+|------|----------------|------------------|-----------------|-------|
+| **Tutorial** | Learning | “Can you teach me?” | Guided steps, checkpoints, expected outcomes | Exhaustive option lists |
+| **How-to** | Doing | “How do I accomplish X?” | Short procedure, prerequisites, verification | Long conceptual detours |
+| **Reference** | Looking up | “What exactly does it do?” | Facts, defaults, commands, schemas, tables | Narrative storytelling |
+| **Explanation** | Understanding | “Why is it designed this way?” | Rationale, tradeoffs, architecture, history | Step-by-step instructions |
 
-## Where to put a new document
+## Choose the right home for a page
 
-Ask one question first: **what is the reader trying to do?**
+Ask one question first: **what does the reader need at the moment they open this page?**
 
-1. **Learn by doing for the first time** → `tutorials/`
-2. **Complete a specific task** → `how-to/`
-3. **Look up exact behavior, interfaces, or commands** → `reference/`
-4. **Understand why the system works this way** → `explanation/`
+1. **A guided first experience** → `docs/tutorials/`
+2. **A direct path to a specific outcome** → `docs/how-to/`
+3. **Precise facts or complete behavior** → `docs/reference/`
+4. **Context, rationale, or tradeoffs** → `docs/explanation/`
 
-If a document tries to do more than one of these, split it into multiple pages and cross-link them.
+If a draft tries to do more than one of these jobs, split it into multiple pages and connect them with links.
+
+## A simple decision test
+
+Use this quick triage before creating or moving a document:
+
+- If the reader should follow the page from top to bottom, it is usually a **tutorial**.
+- If the reader will likely arrive from a search query like “how do I…”, it is usually a **how-to**.
+- If the reader may scan headings, tables, or command snippets for one exact fact, it is usually **reference**.
+- If the page answers “why not the alternative?” or “what constraint shaped this?”, it is usually **explanation**.
 
 ## Writing rules by doc type
 
 ### Tutorials
 
+**Purpose:** help a newcomer succeed for the first time.
+
+**Do:**
+
 - Assume minimal prior context.
-- Use numbered steps with expected outcomes.
-- Keep narrative flow; avoid large API dumps.
-- End with “next steps” links into how-to/reference content.
+- Use numbered steps in a meaningful sequence.
+- Include checkpoints or expected outcomes after important steps.
+- Keep the reader moving toward a concrete end state.
+- End with “next steps” links to relevant how-to and reference pages.
+
+**Do not:**
+
+- Dump every configuration option.
+- Branch heavily for many variants unless the tutorial remains readable.
+- Turn the page into a maintenance checklist.
 
 ### How-to guides
 
-- Start with a goal statement (e.g., “Set up Neovim for perl-lsp”).
-- Provide prerequisites.
-- Prefer concise command sequences and verification checks.
-- Keep conceptual background short; link to explanation docs instead.
+**Purpose:** help a reader complete a known task efficiently.
+
+**Do:**
+
+- Start with a single goal statement.
+- List prerequisites and assumptions up front.
+- Prefer concise command sequences and short explanations.
+- Include a verification step when possible.
+- Link to explanation docs for background and reference docs for exact details.
+
+**Do not:**
+
+- Re-teach the full product from scratch.
+- Mix multiple unrelated goals into one page.
+- Hide required prerequisites in the middle of the procedure.
 
 ### Reference
 
-- Be precise and scannable (tables, headings, command blocks).
-- Prefer completeness over storytelling.
-- Avoid implicit assumptions and hidden defaults.
-- Keep examples minimal and behavior-focused.
+**Purpose:** provide authoritative facts for lookup.
+
+**Do:**
+
+- Optimize for scanning with headings, tables, and short focused examples.
+- Record defaults, edge cases, interfaces, and exact command syntax.
+- Be explicit about assumptions, limits, and version-sensitive behavior.
+- Keep wording precise and stable.
+
+**Do not:**
+
+- Tell a long story.
+- Rely on implied context or unstated defaults.
+- Use a reference page as a tutorial substitute.
 
 ### Explanation
 
-- Focus on tradeoffs, constraints, and design decisions.
-- Connect architecture to user/developer impact.
+**Purpose:** help readers build a correct mental model.
+
+**Do:**
+
+- Focus on design choices, tradeoffs, constraints, and architecture.
+- Compare alternatives when that clarifies why the current design exists.
+- Connect implementation decisions to user or contributor impact.
 - Link to reference pages for exact APIs and commands.
-- Avoid procedural step lists (move those to tutorials/how-to).
 
-## Documentation hygiene checklist
+**Do not:**
 
-Before merging doc changes:
+- Present step-by-step task flows as the main content.
+- Bury the key rationale under procedural detail.
+- Duplicate long reference sections.
 
-- Verify internal links resolve.
-- Verify command examples run as written where practical.
-- Ensure the page’s style matches its Diátaxis category.
-- Update [docs/README.md](../README.md) when adding or removing docs.
+## Cross-linking rules
 
-## Current entry points
+Good Diátaxis docs are connected, not isolated.
 
-Start from the documentation hub in [docs/README.md](../README.md):
+- Tutorials should link forward to relevant how-to and reference pages.
+- How-to guides should link sideways to explanation for rationale and to reference for exact syntax.
+- Reference pages should link outward to tutorials or how-to guides only when a task-oriented next step helps.
+- Explanation pages should link to reference pages for exact interfaces and to tutorials/how-to guides when readers may want to apply the idea.
 
-- Tutorials: [Getting Started](../tutorials/GETTING_STARTED.md)
-- How-to: [Installation](../how-to/INSTALLATION.md)
-- Reference: [Commands Reference](COMMANDS_REFERENCE.md)
-- Explanation: [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
+## Repository-specific expectations
 
+For this repository:
+
+- Update [docs/README.md](../README.md) when you add a new major entry point, rename a page, or move a page between categories.
+- Prefer pointing volatile facts such as metrics, counts, and status to [project/CURRENT_STATUS.md](../project/CURRENT_STATUS.md) instead of duplicating numbers.
+- Keep editor-specific setup primarily in `docs/EDITORS/` and link to it from task-oriented pages in `docs/how-to/`.
+- Treat ADRs in `docs/adr/` as decision records, not substitutes for tutorials or reference pages.
+
+## Review checklist for doc changes
+
+Before merging documentation work, verify that:
+
+- The page clearly fits one Diátaxis mode.
+- The title and opening paragraphs match the page's job.
+- Internal links resolve.
+- Command examples are still valid where practical.
+- The page links to adjacent material instead of absorbing unrelated content.
+- `docs/README.md` still reflects the best entry points.
+
+## Examples from this repository
+
+- **Tutorial:** [Getting Started](../tutorials/GETTING_STARTED.md)
+- **How-to:** [Installation](../how-to/INSTALLATION.md)
+- **Reference:** [Commands Reference](COMMANDS_REFERENCE.md)
+- **Explanation:** [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
+
+When in doubt, optimize for reader intent, keep each page narrow in purpose, and split mixed content into linked pages.


### PR DESCRIPTION
### Motivation

- Make the repository documentation easier to navigate by explicitly aligning the docs hub with the Diátaxis framework and reader intent.
- Replace stale snapshot-style content with a lightweight chooser and clear entry points for both users and contributors.
- Provide maintainers with concrete decision rules and a review checklist to keep future docs consistent with Diátaxis principles.

### Description

- Replace the top-level documentation hub in `docs/README.md` with a Diátaxis-oriented chooser, recommended user/contributor entry points, curated category indexes, canonical truth sources, and maintenance rules.
- Expand `docs/reference/DOCUMENTATION_GUIDE.md` into a practical Diátaxis playbook that includes a four-mode comparison table, a decision test, concrete do/don't guidance for each doc type, cross-linking rules, repository-specific expectations, and a review checklist.
- Clean up links and phrasing so the guidance is actionable and suitable for contributors adding or moving documentation.

### Testing

- Ran a markdown link-existence check (Python script that inspects links in `docs/README.md` and `docs/reference/DOCUMENTATION_GUIDE.md`) and it succeeded (`All checked markdown links resolve`).
- Ran `git diff --check` to validate diff whitespace/format issues and it returned no problems.
- Confirmed working-tree status with `git status --short` to ensure the intended doc files were staged/updated as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0ac364808333a9eadc7ce0d9f6e3)