### PR TITLE
docs: strengthen Diátaxis guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,51 +22,79 @@ for prefix in perl-module- perl-lsp- perl-lsp-feature- perl-dap- perl-ts- perl-w
 done
 ```
 
+## Read docs by intent
+
+This documentation hub follows the [Diátaxis](https://diataxis.fr/) framework. Pick the section that matches what you need **right now**:
+
+| If you want to… | Start here | Why |
+|---|---|---|
+| Learn the product from scratch | [Tutorials](#tutorials--learn-by-doing) | Guided, sequential learning with minimal assumptions |
+| Complete a concrete task | [How-to guides](#how-to-guides--solve-a-problem) | Goal-oriented instructions with verification steps |
+| Look up commands, behavior, or policy | [Reference](#reference--look-it-up) | Concise, factual lookup material |
+| Understand architecture and design tradeoffs | [Explanation](#explanation--understand-why) | Context, rationale, and system-level thinking |
+
+### Quick start paths
+
+- **New user** → [Getting Started](tutorials/GETTING_STARTED.md) → [Installation](how-to/INSTALLATION.md) → [Editor Setup](how-to/EDITOR_SETUP.md)
+- **LSP contributor** → [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) → [Commands Reference](reference/COMMANDS_REFERENCE.md) → [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md)
+- **DAP user** → [DAP User Guide](tutorials/DAP_USER_GUIDE.md) → [DAP Bridge Setup Guide](tutorials/DAP_BRIDGE_SETUP_GUIDE.md)
+- **Docs contributor** → [Documentation Guide](reference/DOCUMENTATION_GUIDE.md)
+
 ## Tutorials — learn by doing
 
-Step-by-step guides to get you started.
+Step-by-step guides to get you started and build confidence through practice.
 
 - [Getting Started](tutorials/GETTING_STARTED.md) — Installation and first steps
 - [DAP User Guide](tutorials/DAP_USER_GUIDE.md) — Debug Adapter Protocol setup and usage
+- [DAP Bridge Setup Guide](tutorials/DAP_BRIDGE_SETUP_GUIDE.md) — End-to-end bridge debugging workflow
 - [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) — Build and extend the LSP server
 - [Execute Command Tutorial](tutorials/EXECUTE_COMMAND_TUTORIAL.md) — Custom LSP commands
+- [Workspace Refactoring Tutorial](tutorials/WORKSPACE_REFACTORING_TUTORIAL.md) — Guided workspace-wide rename workflows
 - [Comprehensive Testing Guide](tutorials/COMPREHENSIVE_TESTING_GUIDE.md) — Testing workflows
+- [AI Build Guide](tutorials/AI_BUILD_GUIDE.md) — Agent-assisted development setup
 
 ## How-to guides — solve a problem
 
-Task-oriented instructions for common operations.
+Task-oriented instructions for common operations and operational troubleshooting.
 
 - [Installation](how-to/INSTALLATION.md) — Install from source or binary
 - [Editor Setup](how-to/EDITOR_SETUP.md) — Configure your editor
 - [Troubleshooting](how-to/TROUBLESHOOTING.md) — Common issues and solutions
+- [Upgrading](how-to/UPGRADING.md) — Safely move between releases
 - [Dependency Management](how-to/DEPENDENCY_MANAGEMENT.md) — Automated updates with Dependabot
 - [SemVer Workflow](how-to/SEMVER_WORKFLOW.md) — SemVer checking and API compatibility
 - [Coverage](how-to/COVERAGE.md) — Code coverage reports
 - [Dead Code Detection](how-to/DEAD_CODE_DETECTION.md) — Find unused code
+- [Performance Tuning](how-to/PERFORMANCE_TUNING.md) — Optimize performance-sensitive paths
+- [Security Development Guide](how-to/SECURITY_DEVELOPMENT_GUIDE.md) — Secure development practices
+- [Contributing LSP](how-to/CONTRIBUTING_LSP.md) — Common LSP contribution tasks
 
 ## Reference — look it up
 
-Precise, complete information for lookup.
+Precise, complete information for lookup and verification.
 
 - [Commands Reference](reference/COMMANDS_REFERENCE.md) — Full command catalog
 - [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) — System design and components
 - [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md) — Workspace structure and tiers
 - [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md) — Language Server Protocol details
 - [LSP Features](reference/LSP_FEATURES.md) — Supported LSP capabilities
-- [Stability Policy](reference/STABILITY.md) — API versioning and compatibility
 - [Configuration](reference/CONFIG.md) — Configuration options
-- [FAQ](reference/FAQ.md) — Frequently asked questions
+- [Configuration Schema](reference/CONFIGURATION_SCHEMA.md) — Structured config schema details
+- [Stability Policy](reference/STABILITY.md) — API versioning and compatibility
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md) — Current constraints and workarounds
-- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diataxis framework and standards
+- [FAQ](reference/FAQ.md) — Frequently asked questions
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diátaxis framework, doc placement, and writing standards
 
 ## Explanation — understand why
 
-Conceptual discussions and design rationale.
+Conceptual discussions, design rationale, and tradeoff analysis.
 
 - [Pure Rust Parser](explanation/PURE_RUST_PARSER.md) — Why we built a native parser
 - [Error Handling Strategy](explanation/ERROR_HANDLING_STRATEGY.md) — Error philosophy and patterns
+- [LSP Documentation](explanation/LSP_DOCUMENTATION.md) — Documentation design for LSP features
 - [Debt Tracking](explanation/DEBT_TRACKING.md) — Technical debt management
 - [Slash Disambiguation](explanation/SLASH_DISAMBIGUATION.md) — Perl regex vs division parsing
+- [Tree-sitter Compatibility](explanation/TREE_SITTER_COMPATIBILITY.md) — Parser compatibility tradeoffs
 
 ## Project — status and governance
 
@@ -79,8 +107,9 @@ Process, metrics, and project health.
 - [Casebook](project/CASEBOOK.md) — What went right
 - [CI](project/CI.md) — Continuous integration setup
 - [CI Test Lanes](project/CI_TEST_LANES.md) — Test lane configuration
+- [Documentation Truth System](project/DOCUMENTATION_TRUTH_SYSTEM.md) — Governance for source-of-truth docs
 
-## Strategic Documents — planning and direction
+## Strategic documents — planning and direction
 
 High-level planning documents for project direction.
 
@@ -104,9 +133,20 @@ High-level planning documents for project direction.
 | [semantic/](semantic/) | Semantic validation |
 | [specs/](specs/) | Specification documents |
 
-## Contributing
+## Contributing to docs
 
 - [Contributing Guide](../CONTRIBUTING.md) — Development workflow and contribution process
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Choose the right Diátaxis category before writing
+
+### Diátaxis review checklist
+
+Use this quick check before opening a documentation PR:
+
+- Does the page serve **one primary intent**: tutorial, how-to, reference, or explanation?
+- Does the title make the page’s promise clear?
+- Does the page link outward to adjacent doc types instead of mixing them together?
+- Did you update this hub if you added, removed, or renamed an entry-point document?
+- Did you verify commands and internal links where practical?
 
 ## Quick verification
 
@@ -115,7 +155,7 @@ nix develop -c just ci-gate       # Canonical local gate
 nix develop -c just status-check  # Verify metrics haven't drifted
 ```
 
-## Canonical Truth Sources
+## Canonical truth sources
 
 | What | Where | Verified By |
 |------|-------|-------------|

--- a/docs/reference/DOCUMENTATION_GUIDE.md
+++ b/docs/reference/DOCUMENTATION_GUIDE.md
@@ -2,64 +2,206 @@
 
 # Documentation Guide
 
-This project organizes user-facing docs with the [Diátaxis](https://diataxis.fr/) framework:
+This project organizes user-facing documentation with the [Diátaxis](https://diataxis.fr/) framework:
 
 - **Tutorials** (`docs/tutorials/`): learning-oriented, step-by-step material.
 - **How-to guides** (`docs/how-to/`): task-oriented instructions to solve a concrete problem.
 - **Reference** (`docs/reference/`): factual, complete lookup documentation.
-- **Explanation** (`docs/explanation/`): conceptual context and design rationale.
+- **Explanation** (`docs/explanation/`): conceptual context, tradeoffs, and design rationale.
 
-Use this page to decide where new content belongs and to keep existing docs consistent.
+Use this page to decide where new content belongs, keep existing docs consistent, and avoid mixing multiple reader intents into a single page.
 
-## Where to put a new document
+## The first question to ask
 
-Ask one question first: **what is the reader trying to do?**
+Before writing, ask: **what does the reader need from this page right now?**
 
-1. **Learn by doing for the first time** → `tutorials/`
-2. **Complete a specific task** → `how-to/`
-3. **Look up exact behavior, interfaces, or commands** → `reference/`
-4. **Understand why the system works this way** → `explanation/`
+| Reader need | Best doc type | Typical opening |
+|---|---|---|
+| “Teach me this from the beginning.” | Tutorial | A guided scenario with sequential steps |
+| “Help me complete a task.” | How-to | A goal statement and prerequisites |
+| “Tell me the exact behavior.” | Reference | A definition, table, schema, or API surface |
+| “Help me understand the rationale.” | Explanation | A design problem, constraint, or tradeoff |
 
-If a document tries to do more than one of these, split it into multiple pages and cross-link them.
+If the page answers more than one of those needs equally, split it into separate pages and cross-link them.
+
+## Decision tree for new docs
+
+1. **Is the reader expected to learn while following the page?**
+   - Yes → write a **tutorial**.
+2. **Is the reader trying to finish a known task?**
+   - Yes → write a **how-to guide**.
+3. **Is the reader mainly verifying facts, interfaces, defaults, or commands?**
+   - Yes → write **reference** material.
+4. **Is the reader trying to understand why the system behaves this way?**
+   - Yes → write an **explanation**.
+
+When none of the above feels dominant, the page is probably trying to do too much.
 
 ## Writing rules by doc type
 
 ### Tutorials
 
+**Purpose**: Help a newcomer succeed through guided practice.
+
+Use tutorials when the reader benefits from a sequence, context, and expected results.
+
+**Do**
+
 - Assume minimal prior context.
 - Use numbered steps with expected outcomes.
-- Keep narrative flow; avoid large API dumps.
-- End with “next steps” links into how-to/reference content.
+- Keep a single learning path from start to finish.
+- End with next steps into how-to and reference material.
+
+**Avoid**
+
+- Large API dumps.
+- Comprehensive edge-case coverage.
+- Branching into multiple alternative workflows unless the comparison is itself the lesson.
 
 ### How-to guides
 
-- Start with a goal statement (e.g., “Set up Neovim for perl-lsp”).
-- Provide prerequisites.
+**Purpose**: Help a reader solve a specific problem quickly.
+
+Use how-to guides when the reader already understands the general area and needs practical instructions.
+
+**Do**
+
+- Start with a goal statement such as “Set up Neovim for perl-lsp”.
+- Include prerequisites and constraints.
 - Prefer concise command sequences and verification checks.
-- Keep conceptual background short; link to explanation docs instead.
+- Keep conceptual background short and link to explanation docs instead.
+
+**Avoid**
+
+- Long conceptual introductions.
+- Teaching the entire subsystem from scratch.
+- Reference-style exhaustiveness.
 
 ### Reference
 
-- Be precise and scannable (tables, headings, command blocks).
-- Prefer completeness over storytelling.
-- Avoid implicit assumptions and hidden defaults.
+**Purpose**: Provide exact information for lookup.
+
+Use reference pages for command syntax, config fields, schemas, policies, capability catalogs, and API contracts.
+
+**Do**
+
+- Be precise and scannable with tables, headings, and focused code blocks.
+- Prefer completeness over narrative flow.
+- State defaults, invariants, and edge behavior explicitly.
 - Keep examples minimal and behavior-focused.
+
+**Avoid**
+
+- Storytelling or motivational prose.
+- Long procedural walkthroughs.
+- Hidden assumptions.
 
 ### Explanation
 
-- Focus on tradeoffs, constraints, and design decisions.
-- Connect architecture to user/developer impact.
+**Purpose**: Build understanding.
+
+Use explanation pages for architecture, tradeoffs, historical choices, and conceptual models.
+
+**Do**
+
+- Focus on constraints, tradeoffs, and design decisions.
+- Connect architecture to user or developer impact.
 - Link to reference pages for exact APIs and commands.
-- Avoid procedural step lists (move those to tutorials/how-to).
+- Help readers build mental models.
+
+**Avoid**
+
+- Checklists that primarily exist to complete a task.
+- Numbered procedures better suited for tutorials or how-to guides.
+- Exhaustive API documentation.
+
+## Common anti-patterns
+
+These are the most common ways docs drift out of Diátaxis alignment:
+
+- **Tutorials turning into reference**: a guided page starts accumulating every option and exception.
+- **How-to guides turning into explanation**: task pages open with long architecture essays.
+- **Reference turning into tutorial**: lookup pages embed end-to-end walkthroughs.
+- **Explanation turning into operations runbooks**: conceptual pages become procedural incident docs.
+
+When this happens, keep the current page focused on its primary job and move the overflow into a separate, linked page.
+
+## Cross-linking rules
+
+Good Diátaxis documentation is connected, not isolated.
+
+- Tutorials should link to how-to or reference pages for deeper follow-up.
+- How-to guides should link to explanation pages for rationale and reference pages for exact syntax.
+- Reference pages should link outward sparingly to the most relevant tutorial or how-to for practical application.
+- Explanation pages should link to reference pages whenever readers may need exact details next.
+
+A useful pattern is: **one page, one job, many links**.
+
+## Recommended page shapes
+
+Use these lightweight templates when creating or refactoring a page.
+
+### Tutorial shape
+
+1. Goal and what you will build or prove
+2. Prerequisites
+3. Numbered steps
+4. Verification or expected outcome
+5. Next steps
+
+### How-to shape
+
+1. Goal
+2. Prerequisites or environment assumptions
+3. Procedure
+4. Verification
+5. Troubleshooting or related links
+
+### Reference shape
+
+1. Scope
+2. Definitions, commands, schema, or tables
+3. Examples of exact behavior
+4. Constraints, defaults, edge cases
+5. Related docs
+
+### Explanation shape
+
+1. Problem or design context
+2. Constraints and tradeoffs
+3. Chosen approach
+4. Implications
+5. Related reference/how-to material
+
+## Repository-specific guidance
+
+In this repository, the docs hub at [docs/README.md](../README.md) is the main entry point for user-facing content.
+
+- Add new top-level entry-point docs to the relevant section of `docs/README.md`.
+- Prefer placing operational guidance in `docs/how-to/`.
+- Prefer placing architecture rationale in `docs/explanation/`.
+- Keep specs, governance, and exact interfaces in `docs/reference/` unless they are explicitly project planning artifacts.
+- Use `docs/project/` for project status, governance, roadmap, and process health rather than end-user product docs.
 
 ## Documentation hygiene checklist
 
-Before merging doc changes:
+Before merging documentation changes:
 
 - Verify internal links resolve.
 - Verify command examples run as written where practical.
 - Ensure the page’s style matches its Diátaxis category.
-- Update [docs/README.md](../README.md) when adding or removing docs.
+- Update [docs/README.md](../README.md) when adding or removing entry-point docs.
+- Check whether an oversized page should be split instead of expanded.
+
+## Refactoring an existing page
+
+When improving an existing doc, use this sequence:
+
+1. Identify the page’s **primary reader intent**.
+2. Remove or relocate sections that serve a different intent.
+3. Add links to the new destination pages instead of duplicating content.
+4. Normalize the opening so the purpose is obvious within the first screenful.
+5. Update the docs hub if the page becomes a recommended entry point.
 
 ## Current entry points
 
@@ -69,4 +211,3 @@ Start from the documentation hub in [docs/README.md](../README.md):
 - How-to: [Installation](../how-to/INSTALLATION.md)
 - Reference: [Commands Reference](COMMANDS_REFERENCE.md)
 - Explanation: [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
-


### PR DESCRIPTION
### Motivation

- Make the repository documentation hub actionable for readers by surfacing the Diátaxis intent model at the entry point. 
- Reduce scope drift and mixed-intent pages by giving writers a clear decision tree and repo-specific placement guidance. 
- Provide lightweight, practical templates and a short review checklist to speed consistent contributions and refactors.

### Description

- Updated `docs/README.md` to add an intent-based navigation table, role-specific quick-start paths, curated entry points across sections, and a short Diátaxis review checklist for doc contributors. 
- Expanded `docs/reference/DOCUMENTATION_GUIDE.md` into a fuller Diátaxis playbook that adds a reader-intent table, a decision tree for choosing doc types, per-type `Do`/`Avoid` rules, common anti-patterns, cross-linking guidance, and lightweight page-shape templates. 
- Added repository-specific placement and refactoring guidance to help authors split or relocate content rather than mixing tutorial/how-to/reference/explanation material. 
- Performed link validation and formatted docs; no code or runtime changes were made.

### Testing

- Ran a link validation script that checks internal Markdown links in `docs/README.md` and `docs/reference/DOCUMENTATION_GUIDE.md` using a short Python script and it reported `OK`. 
- Ran `cargo fmt --all` to ensure formatting changes are normalized and it completed successfully. 
- No unit or integration tests were required because this change is documentation-only and introduced no code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0ac364808333a9eadc7ce0d9f6e3)