### PR TITLE
docs: improve first-time setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,38 @@ code --install-extension effortlessmetrics.perl-lsp-rs
 # 4. Open a Perl file — completions, diagnostics, hover, and navigation work immediately.
 ```
 
+### First-Run Checklist
+
+Use this when you are installing `perl-lsp` for the first time:
+
+- [ ] `perl-lsp --health` prints `ok ...`
+- [ ] `which perl-lsp` points to the binary you just installed
+- [ ] Your editor is configured to launch `perl-lsp --stdio`
+- [ ] Opening a `.pl`, `.pm`, or `.t` file attaches the language server
+- [ ] Hover, completion, and diagnostics work in a test file
+
+### 30-Second Smoke Test
+
+If you want a fast confidence check before touching your real project, paste this into a new file named `hello.pl`:
+
+```perl
+use strict;
+use warnings;
+
+my $name = "world";
+prin "Hello, $name\n";
+```
+
+On first open you should see all of the following:
+
+1. A diagnostic on `prin` because Perl's built-in is `print`.
+2. Completion suggesting `print` when your cursor is after `prin`.
+3. Hover documentation when your cursor is on `use warnings` or `print` after fixing the typo.
+
+If that works, your first-time setup is complete.
+
+> **Tip:** if `perl-lsp` works in your terminal but not in your editor, launch the editor from the same shell once (`code .`, `nvim`, `hx`, etc.). Desktop launchers often do not inherit your Cargo `PATH`.
+
 New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a visual feature tour, and troubleshooting tips.
 
 <details>

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -46,7 +46,46 @@ perl-lsp --version
 # Quick health check
 perl-lsp --health
 # Should output: ok 0.12.0
+
+# Confirm the editor will be able to find the same binary
+which perl-lsp
 ```
+
+If `which perl-lsp` prints nothing, add Cargo's bin directory to your `PATH` before configuring your editor:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+## First-Run Success Checklist
+
+Before you spend time debugging editor-specific settings, make sure these basics are true:
+
+- `perl-lsp --health` returns `ok ...`
+- `which perl-lsp` resolves to the binary you installed
+- Your editor launches `perl-lsp --stdio`
+- The file is detected as Perl (`.pl`, `.pm`, or `.t` is the easiest path)
+- Opening a test file shows at least one diagnostic, one completion, and one hover result
+
+## 30-Second Smoke Test
+
+Create a file named `hello.pl` with this content:
+
+```perl
+use strict;
+use warnings;
+
+my $name = "world";
+prin "Hello, $name\n";
+```
+
+What to expect on first open:
+
+1. **A diagnostic** under `prin`, because the built-in is `print`.
+2. **A completion suggestion** for `print` when your cursor is after `prin`.
+3. **A hover card** for `print`, `warnings`, or `$name` once the server is attached.
+
+This tiny file gives you a quick end-to-end signal that installation, editor startup, parsing, diagnostics, and completion are all wired correctly.
 
 ## Quick Editor Setup
 
@@ -58,6 +97,11 @@ perl-lsp --health
    ```
 
 2. Open a `.pl` or `.pm` file - the server starts automatically.
+
+3. If VS Code says the server cannot be found, launch VS Code once from a shell where `which perl-lsp` works:
+   ```bash
+   code .
+   ```
 
 ### Neovim
 
@@ -128,7 +172,7 @@ args = ["--stdio"]
 
 ## Your First 5 Minutes
 
-Once installed, open any Perl file and try these features. Each heading describes what you will see in your editor.
+Once installed, open any Perl file and try these features. If you want the most predictable first-run experience, use the `hello.pl` smoke-test file above before opening a large existing codebase. Each heading describes what you will see in your editor.
 
 ### 1. Real-Time Diagnostics
 


### PR DESCRIPTION
### Motivation

- Make the first-time experience more predictable by giving users a minimal, copy/paste smoke test and a short checklist to confirm their install and editor wiring before debugging editor-specific issues.
- Reduce common PATH/editor-launch confusion by adding an explicit `which perl-lsp` verification and a short recovery step for VS Code when the binary is not found.

### Description

- Add a `First-Run Checklist` and a `30-Second Smoke Test` to the top-level `README.md` so users can quickly verify diagnostics, completion, and hover on a tiny `hello.pl` file.
- Update `docs/tutorials/GETTING_STARTED.md` to include `which perl-lsp` verification, a suggested `export PATH="$HOME/.cargo/bin:$PATH"` fix when needed, the same first-run checklist and smoke test, and a VS Code launch tip (`code .`) for PATH-related startup issues.
- Clarify the “Your First 5 Minutes” guidance to recommend running the smoke test before opening large codebases for a more predictable initial success signal.

### Testing

- Ran repository hygiene checks including `git diff --check`, which reported no issues.
- Verified documentation formatting and code blocks render correctly in the modified files; no runtime code changes or unit tests were required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a9efdfc8333a2d4eb14bf0bbf5c)