### PR TITLE
Improve VS Code first-run experience

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -55,6 +55,14 @@ The extension automatically downloads the correct language server for your platf
 - macOS (Intel, Apple Silicon)
 - Linux (x64, ARM64)
 
+### First-run checklist
+
+1. Install the extension from the Marketplace.
+2. Open any `.pl`, `.pm`, or `.t` file.
+3. Wait for the **Perl LSP** status item to switch to a check mark.
+4. If you want a guided setup, run **`Perl: Open Getting Started Guide`** from the Command Palette.
+5. If startup fails, run **`Perl: Show Output Channel`** to see download and health-check logs.
+
 Manual installation options:
 ```bash
 # Homebrew (macOS/Linux)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -304,6 +304,12 @@
         "icon": "$(output)"
       },
       {
+        "command": "perl-lsp.gettingStarted",
+        "title": "Open Getting Started Guide",
+        "category": "Perl",
+        "icon": "$(book)"
+      },
+      {
         "command": "perl-lsp.showStatusMenu",
         "title": "Show Status Menu",
         "category": "Perl",
@@ -335,6 +341,9 @@
         {
           "command": "perl-lsp.showStatusMenu",
           "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.gettingStarted"
         },
         {
           "command": "perl-lsp.organizeImports",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,8 @@ import { BinaryDownloader } from './downloader';
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel;
 let testAdapter: PerlTestAdapter | undefined;
+const WELCOME_STATE_KEY = 'perl-lsp.welcome.dismissed';
+const GETTING_STARTED_URL = 'https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/tutorials/GETTING_STARTED.md';
 
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel('Perl Language Server');
@@ -24,20 +26,26 @@ export async function activate(context: vscode.ExtensionContext) {
     const showOutputCommand = vscode.commands.registerCommand('perl-lsp.showOutput', () => {
         outputChannel.show();
     });
-    context.subscriptions.push(showOutputCommand);
+    const gettingStartedCommand = vscode.commands.registerCommand('perl-lsp.gettingStarted', async () => {
+        await vscode.env.openExternal(vscode.Uri.parse(GETTING_STARTED_URL));
+    });
+    context.subscriptions.push(showOutputCommand, gettingStartedCommand);
     
     // Get the path to perl-lsp
     const serverPath = await getServerPath(context);
     if (!serverPath) {
         vscode.window.showErrorMessage(
-            'Perl Language Server (perl-lsp) not found.',
+            'Perl Language Server (perl-lsp) could not be located or downloaded.',
             'Install (cargo install perl-lsp)',
+            'Open Getting Started',
             'Open Settings'
         ).then((choice: string | undefined) => {
             if (choice === 'Install (cargo install perl-lsp)') {
                 vscode.window.showInformationMessage(
                     'Run in your terminal: cargo install perl-lsp\nThen reload VS Code.'
                 );
+            } else if (choice === 'Open Getting Started') {
+                vscode.commands.executeCommand('perl-lsp.gettingStarted');
             } else if (choice === 'Open Settings') {
                 vscode.commands.executeCommand('workbench.action.openSettings', 'perl-lsp.serverPath');
             }
@@ -129,6 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Start the client
     await client.start();
+    await maybeShowWelcome(context);
     
     // Initialize test adapter
     testAdapter = new PerlTestAdapter(client);
@@ -242,6 +251,7 @@ export async function activate(context: vscode.ExtensionContext) {
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+            { label: '$(book) Getting Started', detail: 'Open setup and first-run guide', command: 'perl-lsp.gettingStarted' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:EffortlessMetrics.perl-lsp-rs'] }
@@ -333,6 +343,28 @@ async function getServerPath(context: vscode.ExtensionContext): Promise<string |
     
     outputChannel.appendLine('Failed to obtain perl-lsp');
     return null;
+}
+
+async function maybeShowWelcome(context: vscode.ExtensionContext): Promise<void> {
+    const dismissed = context.globalState.get<boolean>(WELCOME_STATE_KEY, false);
+    if (dismissed) {
+        return;
+    }
+
+    const selection = await vscode.window.showInformationMessage(
+        'Perl LSP is ready. Open a .pl, .pm, or .t file to start getting completions, diagnostics, hover, and navigation.',
+        'Open Getting Started',
+        'Show Output',
+        "Don't Show Again"
+    );
+
+    if (selection === 'Open Getting Started') {
+        await vscode.commands.executeCommand('perl-lsp.gettingStarted');
+    } else if (selection === 'Show Output') {
+        outputChannel.show();
+    } else if (selection === "Don't Show Again") {
+        await context.globalState.update(WELCOME_STATE_KEY, true);
+    }
 }
 
 /**


### PR DESCRIPTION
### Motivation

- New users can be confused when the language server binary is missing or when the extension starts for the first time, so a lightweight, discoverable getting-started flow is needed.
- The extension should provide an immediate, actionable path to documentation and simple diagnostics output when startup or download fails.

### Description

- Added a `perl-lsp.gettingStarted` VS Code command that opens the project Getting Started guide and registered it in `vscode-extension/package.json` and the Command Palette.
- Show a one-time welcome message after the LSP client starts via a new `maybeShowWelcome` function that stores dismissal state in `context.globalState` under the key `perl-lsp.welcome.dismissed`.
- Improved missing-binary guidance text and added an `Open Getting Started` action to the initial error prompt, and surfaced the Getting Started command in the status menu.
- Documented a concise First-run checklist in `vscode-extension/README.md` to give Marketplace users a clear startup path and troubleshooting step to view the output channel.

### Testing

- Ran the extension TypeScript build with `npm run compile` which completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a9efdfc8333a2d4eb14bf0bbf5c)