### PR TITLE
Improve first-run onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,44 @@ cargo install perl-lsp
 
 # 2. Verify the install
 perl-lsp --health  # should print: ok X.Y.Z
+perl-lsp --version
 
-# 3. Configure your editor (VS Code)
+# 3. Configure your editor (VS Code example)
 code --install-extension effortlessmetrics.perl-lsp-rs
 
-# 4. Open a Perl file — completions, diagnostics, hover, and navigation work immediately.
+# 4. Open a Perl project and a .pl or .pm file
 ```
 
-New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a visual feature tour, and troubleshooting tips.
+### First-Run Checklist
+
+If this is your first time using a language server for Perl, aim for this quick win:
+
+- Install `perl-lsp` and confirm `perl-lsp --health` returns `ok ...`.
+- Open a folder, not just a single file, so workspace indexing and cross-file navigation can start immediately.
+- Make sure your project roots are discoverable (`.git`, `cpanfile`, `Makefile.PL`, or `dist.ini` help editors pick the workspace root).
+- If your modules live outside `lib/`, add them via `perl.workspace.includePaths`.
+- Open a Perl file and test three actions: hover on `print`, go to definition on a local variable, and trigger completion after typing `$`.
+
+### 60-Second Smoke Test
+
+Create a file like this and open it in your editor:
+
+```perl
+use strict;
+use warnings;
+
+my $name = 'world';
+print $name;
+```
+
+You should see:
+
+- Hover docs on `print`
+- Completion for `$name` after typing `$na`
+- Go-to-definition from `$name` on line 5 back to line 4
+- Diagnostics if you intentionally break the file
+
+New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a first-day checklist, a copy/paste smoke test, and troubleshooting tips.
 
 <details>
 <summary><strong>Neovim / Emacs setup</strong></summary>

--- a/crates/perl-lsp/README.md
+++ b/crates/perl-lsp/README.md
@@ -9,7 +9,12 @@ Standalone **Language Server Protocol (LSP) server for Perl**, providing IDE fea
 
 ```bash
 cargo install perl-lsp
+perl-lsp --health
 ```
+
+## First-Time Check
+
+After installing, verify the binary is on your `PATH`, then open a Perl project folder in your editor instead of a single loose file. For most cross-file features, add custom module directories with `perl.workspace.includePaths` if your code does not live under `lib/`.
 
 ## Usage
 

--- a/crates/perl-lsp/src/lib.rs
+++ b/crates/perl-lsp/src/lib.rs
@@ -11,6 +11,12 @@
 //!
 //! ## Running the Server
 //!
+//! For the best first-run experience, install the binary, confirm `perl-lsp --health` succeeds,
+//! and open a project folder in your editor so workspace indexing can discover related files.
+//! If your Perl modules live outside `lib/`, configure editor-side include paths before testing
+//! go-to-definition across files.
+//!
+//!
 //! The simplest way to start the server is via the binary:
 //!
 //! ```bash

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started with perl-lsp
 
-This guide gets you from zero to a working Perl language server in your editor.
+This guide gets you from zero to a working Perl language server in your editor, with the fastest path to a successful first run.
 
 ## What is a Language Server?
 
@@ -48,16 +48,51 @@ perl-lsp --health
 # Should output: ok 0.12.0
 ```
 
+## First-Run Success Checklist
+
+Before configuring keybindings or advanced settings, make sure the basics are in place:
+
+1. **Open a folder or project root**, not just an individual file. This lets perl-lsp build a workspace index for definitions, references, and symbols.
+2. **Verify the workspace root is recognizable**. Editors usually pick roots from markers like `.git`, `cpanfile`, `Makefile.PL`, or `dist.ini`.
+3. **Keep Perl modules in discoverable paths** such as `lib/`, or add custom directories with `perl.workspace.includePaths`.
+4. **Test with a tiny known-good file first** so you can separate install problems from project-specific issues.
+5. **Expect some features to depend on the editor UI**. The server may be healthy even if you still need to map keys or install an editor extension.
+
+## 60-Second Smoke Test
+
+Create `hello.pl` with the following contents:
+
+```perl
+use strict;
+use warnings;
+
+my $name = 'world';
+print $name;
+```
+
+Then confirm this sequence inside your editor:
+
+1. Open `hello.pl` inside a folder workspace.
+2. Hover over `print` and confirm documentation appears.
+3. Type `$na` on a new line and confirm `$name` appears in completion results.
+4. Jump to definition on `$name` in `print $name;` and confirm the cursor moves to `my $name = 'world';`.
+5. Introduce a syntax error, such as deleting the semicolon, and confirm a diagnostic appears.
+
+If those five checks pass, your first-time setup is working. From there you can add include paths, formatting, debugger support, and editor-specific keybindings.
+
 ## Quick Editor Setup
 
 ### VS Code
+
+This is the fastest path for most users because the extension wires up the server automatically.
 
 1. Install the extension:
    ```bash
    code --install-extension EffortlessMetrics.perl-lsp-rs
    ```
 
-2. Open a `.pl` or `.pm` file - the server starts automatically.
+2. Open a project folder, then open a `.pl` or `.pm` file - the server starts automatically.
+3. If nothing happens, open the VS Code Output panel and select the `perl-lsp` channel.
 
 ### Neovim
 
@@ -101,7 +136,7 @@ lspconfig.perl_lsp.setup({
 })
 ```
 
-**Verify it works**: open a `.pl` file and run `:LspInfo` -- you should see `perl_lsp` attached.
+**Verify it works**: open a `.pl` file and run `:LspInfo` -- you should see `perl_lsp` attached. If the server does not attach, confirm the filetype is `perl` with `:set filetype?`.
 
 ### Emacs (with eglot, Emacs 29+)
 
@@ -110,7 +145,7 @@ lspconfig.perl_lsp.setup({
              '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
 ```
 
-Then run `M-x eglot` in a Perl buffer.
+Then run `M-x eglot` in a Perl buffer. If eglot prompts for a server command, use `perl-lsp --stdio`.
 
 ### Helix
 
@@ -240,6 +275,8 @@ For project-specific settings, the server reads configuration from your editor's
 }
 ```
 
+Common first-day setting: if your modules are not under `lib/`, add those directories to `includePaths` so definition lookup and diagnostics can find them early.
+
 See [CONFIG.md](../reference/CONFIG.md) for all configuration options.
 
 ## Troubleshooting
@@ -247,6 +284,8 @@ See [CONFIG.md](../reference/CONFIG.md) for all configuration options.
 Quick fixes for the most common first-run problems. For the full guide, see [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
 
 ### "Binary not found" after install
+
+This is the single most common first-run problem.
 
 `cargo install` places the binary in `~/.cargo/bin/`. If your shell cannot find `perl-lsp`, that directory is not on your `PATH`.
 


### PR DESCRIPTION
### Motivation

- Make the first-time user experience simpler and more reliable by giving new users a short, actionable checklist and a quick smoke test they can run in minutes.  
- Surface the most common first-run failure modes (workspace root discovery, include paths, editor attaching) earlier in README and crate docs so users can resolve them before spending time on advanced configuration.

### Description

- Expanded the root `README.md` quick start with `perl-lsp --version` verification, a **First-Run Checklist**, and a copy/paste **60-Second Smoke Test** demonstrating hover, completion, go-to-definition, and diagnostics.  
- Strengthened `docs/tutorials/GETTING_STARTED.md` by adding a **First-Run Success Checklist**, the same smoke test, clearer VS Code guidance, Neovim/Emacs verification tips, and explicit advice about `perl.workspace.includePaths`.  
- Updated the published crate `crates/perl-lsp/README.md` to include a short `First-Time Check` and `--health` verification so crates.io readers see onboarding guidance.  
- Augmented crate-level rustdoc in `crates/perl-lsp/src/lib.rs` to call out best practices for first-run (health check, open a project folder, configure include paths if modules live outside `lib/`).

### Testing

- Ran formatter: `cargo fmt --all` (succeeded).  
- Ran documentation tests: `cargo test -p perl-lsp --doc` (doctests compiled and passed).  
- Ran unit and integration tests: `cargo test -p perl-lsp --lib` (158 tests passed; 0 failed; doctests and lib tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a9efdfc8333a2d4eb14bf0bbf5c)