### PR TITLE
docs: improve first-run onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,30 @@
 
 ## Quick Start
 
+### Fastest path to a working editor
+
 ```bash
-# 1. Install
+# 1. Install the server
 cargo install perl-lsp
 
-# 2. Verify the install
-perl-lsp --health  # should print: ok X.Y.Z
+# 2. Verify the binary works before touching editor settings
+perl-lsp --health   # should print: ok X.Y.Z
+perl-lsp --version
 
-# 3. Configure your editor (VS Code)
+# 3. Install the VS Code extension (optional, but the quickest editor setup)
 code --install-extension effortlessmetrics.perl-lsp-rs
-
-# 4. Open a Perl file — completions, diagnostics, hover, and navigation work immediately.
 ```
 
-New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a visual feature tour, and troubleshooting tips.
+Then open any `.pl`, `.pm`, or `.t` file. On first run you should get diagnostics, hover, completion, and navigation without extra project configuration.
+
+### First-run checklist
+
+- `perl-lsp --health` prints `ok ...`
+- Your editor can find the `perl-lsp` binary on `PATH`
+- The file is recognized as **Perl** by your editor
+- If you are working in a project, open the project root so workspace indexing can start immediately
+
+If something does not work on the first try, run `just doctor` in this repository for a guided environment check, or see the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a fuller walkthrough with editor-specific setup and troubleshooting tips.
 
 <details>
 <summary><strong>Neovim / Emacs setup</strong></summary>

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Perl Language Server (perl-lsp) v0.10.0 provides a high-performance Language Server Protocol implementation for Perl with ~100% syntax coverage.
+Perl Language Server (`perl-lsp`) provides a high-performance Language Server Protocol implementation for Perl with broad Perl 5 syntax coverage.
 
 ## Install from crates.io
 
@@ -12,47 +12,30 @@ cargo install perl-lsp
 
 ### Pre-compiled Binaries
 
-1. Download the appropriate binary for your system from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
+1. Download the archive for your platform from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases/latest)
 2. Extract the archive
-3. Move the `perl-lsp` binary to a directory in your PATH
+3. Move `perl-lsp` (or `perl-lsp.exe` on Windows) to a directory on your `PATH`
+4. Verify the install with `perl-lsp --health`
 
-#### Linux x86_64
+#### Linux / macOS
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.10.0-x86_64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.10.0-x86_64-unknown-linux-gnu/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
+# Example flow after downloading a release archive
+mkdir -p "$HOME/.local/bin"
+tar xzf perl-lsp-*.tar.gz
+find . -type f -name perl-lsp -exec cp {} "$HOME/.local/bin/perl-lsp" \;
+chmod +x "$HOME/.local/bin/perl-lsp"
+export PATH="$HOME/.local/bin:$PATH"
+perl-lsp --health
 ```
 
-#### Linux aarch64
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-aarch64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.10.0-aarch64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.10.0-aarch64-unknown-linux-gnu/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
-
-#### macOS x86_64
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.10.0-x86_64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.10.0-x86_64-apple-darwin/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
-
-#### macOS aarch64 (Apple Silicon)
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-aarch64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.10.0-aarch64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.10.0-aarch64-apple-darwin/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
-
-#### Windows x86_64
+#### Windows (PowerShell)
 ```powershell
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.10.0/perl-lsp-0.10.0-x86_64-pc-windows-msvc.zip
-Expand-Archive perl-lsp-0.10.0-x86_64-pc-windows-msvc.zip
-Copy-Item perl-lsp-0.10.0-x86_64-pc-windows-msvc\perl-lsp.exe C:\Program Files\perl-lsp\
+# Example flow after downloading a release zip
+Expand-Archive .\perl-lsp-*.zip -DestinationPath .\perl-lsp-release
+New-Item -ItemType Directory -Force "$HOME\bin" | Out-Null
+Copy-Item .\perl-lsp-release\**\perl-lsp.exe "$HOME\bin\perl-lsp.exe"
+$env:Path = "$HOME\bin;" + $env:Path
+perl-lsp.exe --health
 ```
 
 ### Build from Source
@@ -78,8 +61,19 @@ perl-lsp --version
 
 Expected output:
 ```
-perl-lsp 0.10.0
+perl-lsp <version>
 ```
+
+## First-Run Checklist
+
+Before debugging editor integration, confirm the standalone binary works:
+
+- `perl-lsp --version` prints a version
+- `perl-lsp --health` prints `ok ...`
+- your install location is on `PATH`
+- your editor is configured to launch `perl-lsp --stdio`
+
+If you cloned this repository for development, run `just doctor` for a guided environment check.
 
 ## Editor Configuration
 
@@ -183,7 +177,7 @@ export PATH="$PATH:$HOME/.local/bin"
 3. Look for error messages in your editor's LSP logs
 
 #### Slow performance
-1. Ensure you're using the latest version (v0.10.0)
+1. Ensure you're using the latest released version
 2. Check if your workspace has very large Perl files (>100KB)
 3. Consider using `.perl-lspignore` to exclude unnecessary files
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -45,8 +45,16 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.12.0
+# Should output: ok <version>
 ```
+
+If `perl-lsp` is not found, add Cargo's bin directory to your `PATH` before configuring your editor:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+A good first-run rule: do not move on to editor setup until both commands above work in a normal shell.
 
 ## Quick Editor Setup
 
@@ -124,6 +132,22 @@ language-servers = ["perl-lsp"]
 [language-server.perl-lsp]
 command = "perl-lsp"
 args = ["--stdio"]
+```
+
+## First-Run Success Checklist
+
+Before you debug editor-specific settings, confirm these basics:
+
+1. `perl-lsp --health` returns `ok ...`
+2. Your editor launches `perl-lsp --stdio` from the same `PATH` as your shell
+3. You opened a Perl file with a recognized filetype (`.pl`, `.pm`, or `.t`)
+4. You opened the project root, not just a single nested file, so indexing and cross-file navigation can work
+5. If your project uses non-standard module paths, add them with `perl.workspace.includePaths`
+
+If you cloned this repository and want a guided environment check, run:
+
+```bash
+just doctor
 ```
 
 ## Your First 5 Minutes


### PR DESCRIPTION
### Motivation

- Reduce friction for new users by making the Quick Start actionable and ensuring the standalone binary is verified before editor setup.
- Make first-run troubleshooting explicit (PATH, health check, project root) so users can get a working editor in minutes.
- Remove stale, hard-coded release examples in the installation guide and replace them with generic, reproducible install/check flows.

### Description

- Updated `README.md` to add a concise “Fastest path to a working editor” flow that verifies the binary with `perl-lsp --health` and `perl-lsp --version` before editor configuration, and added a short `First-run checklist`. 
- Modified `docs/tutorials/GETTING_STARTED.md` to add PATH guidance (`export PATH="$HOME/.cargo/bin:$PATH"`), a rule to not continue until verification works, and a `First-Run Success Checklist` that includes `just doctor` as a guided environment check. 
- Reworked `docs/how-to/INSTALLATION.md` to remove hard-coded `v0.10.0` examples, add release-agnostic binary install flows (examples copying to `~/.local/bin` or `~\bin`), replace exact-version expectations with `perl-lsp <version>`, and add a standalone `First-Run Checklist` for editor integration. 
- Small wording updates (e.g. "latest released version") and simplifications to reduce onboarding cognitive load.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff-check issues, which passed. 
- Ran repository-wide pattern searches with `rg -n "0\.10\.0|0\.12\.0|just doctor|First-Run|First-run|Fastest path"` across the edited docs to verify updates, which returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a9efdfc8333a2d4eb14bf0bbf5c)