### PR TITLE
devex: fail early on Rust toolchain drift (justfile + doctor)

### DIFF
--- a/docs/issues/DEVELOPER_FRICTION.md
+++ b/docs/issues/DEVELOPER_FRICTION.md
@@ -115,7 +115,7 @@ rustup override set 1.92.0
 #### Proposed Solutions
 | Solution | Effort | Status |
 |----------|--------|--------|
-| Automatic version check in justfile | Low | Proposed |
+| Automatic version check in justfile | Low | Implemented |
 | Better error messages for version mismatch | Low | Proposed |
 
 #### Related Documentation

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ _timed name cmd:
     fi
 
 # Tier: PR-fast (required for every PR iteration, must be fast ~1-2 min)
-pr-fast: _check-tools-basic
+pr-fast: _check-tools-basic _check-rust-toolchain
     @echo "=============================================="
     @echo "  PR-FAST GATE (quick validation)"
     @echo "=============================================="
@@ -331,6 +331,35 @@ _check-tools-basic:
         exit 1; \
     fi
 
+# Ensure the active Rust toolchain matches the repo's pinned version.
+[private]
+_check-rust-toolchain:
+    @if [ ! -f rust-toolchain.toml ]; then \
+        echo "⚠️  rust-toolchain.toml not found; skipping toolchain version check"; \
+        exit 0; \
+    fi; \
+    PINNED=$$(awk -F'"' '/channel/{print $$2; exit}' rust-toolchain.toml); \
+    if [ -z "$$PINNED" ]; then \
+        echo "⚠️  Could not parse pinned toolchain from rust-toolchain.toml"; \
+        exit 0; \
+    fi; \
+    if ! command -v rustc >/dev/null 2>&1; then \
+        echo "❌ rustc not found"; \
+        echo "  Install Rust via https://rustup.rs"; \
+        exit 1; \
+    fi; \
+    ACTIVE=$$(rustc --version | awk '{print $$2}'); \
+    if [ "$$ACTIVE" != "$$PINNED" ]; then \
+        echo "❌ Rust toolchain mismatch: active=$$ACTIVE pinned=$$PINNED"; \
+        if command -v rustup >/dev/null 2>&1; then \
+            echo "  Fix: rustup toolchain install $$PINNED && rustup override set $$PINNED"; \
+        else \
+            echo "  Fix: install rustup from https://rustup.rs, then activate $$PINNED"; \
+        fi; \
+        exit 1; \
+    fi; \
+    echo "✅ Rust toolchain matches pinned version ($$PINNED)"
+
 # ============================================================================
 # CI Validation Commands (Issue #211)
 # ============================================================================
@@ -412,7 +441,7 @@ ci-workflow-audit:
 
 # Fast merge gate (~2-5 min) - REQUIRED for all merges
 # This is the canonical pre-push check (same as merge-gate with legacy checks)
-ci-gate:
+ci-gate: _check-tools-basic _check-rust-toolchain
     @echo "Running fast merge gate..."
     just ci-workflow-audit && \
     just ci-check-no-nested-lock && \

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -36,6 +36,44 @@ check_rust_component() {
   return 1
 }
 
+check_toolchain_match() {
+  if [ ! -f rust-toolchain.toml ]; then
+    warn "rust-toolchain.toml not found"
+    return 1
+  fi
+
+  local pinned active
+  pinned=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
+  if [ -z "${pinned:-}" ]; then
+    warn "Could not parse pinned toolchain from rust-toolchain.toml"
+    return 1
+  fi
+
+  if ! has_cmd rustc; then
+    warn "rustc unavailable; cannot compare active toolchain to pinned version"
+    return 1
+  fi
+
+  active=$(rustc --version 2>/dev/null | awk '{print $2}')
+  if [ -z "${active:-}" ]; then
+    warn "Could not determine active rustc version"
+    return 1
+  fi
+
+  if [ "$active" = "$pinned" ]; then
+    pass "Active rustc matches pinned toolchain: $active"
+    return 0
+  fi
+
+  warn "Active rustc ($active) does not match pinned toolchain ($pinned)"
+  if has_cmd rustup; then
+    echo "    Fix: rustup toolchain install $pinned && rustup override set $pinned"
+  else
+    echo "    Fix: install rustup from https://rustup.rs and activate $pinned"
+  fi
+  return 1
+}
+
 check_githook() {
   local hook_path=".git/hooks/pre-push"
   if [ -x "$hook_path" ]; then
@@ -81,6 +119,7 @@ echo
 printf '== Rust components ==\n'
 check_rust_component rustfmt || true
 check_rust_component clippy || true
+check_toolchain_match || true
 
 if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
@@ -95,7 +134,9 @@ fi
 
 echo
 printf '== Suggested next commands ==\n'
+echo "  just doctor"
 echo "  just pr-fast"
+echo "  just devex-targeted"
 echo "  just ci-gate"
 echo "  nix develop -c just ci-gate"
 


### PR DESCRIPTION
### Motivation
- Prevent wasted CI cycles and confusing failures by failing early when the developer's active `rustc` does not match the repository `rust-toolchain.toml` pin.
- Improve onboarding diagnostics so developers get an actionable remediation hint instead of discovering version drift deep in the gate.

### Description
- Add a private `_check-rust-toolchain` recipe to the `justfile` that parses `rust-toolchain.toml`, compares the pinned channel to the active `rustc` version, prints a concrete `rustup` remediation, and exits non-zero on mismatch.
- Wire `_check-rust-toolchain` into both `pr-fast` and `ci-gate` so toolchain drift fails early in PR-fast and merge-gate flows.
- Extend `scripts/devex-doctor.sh` with `check_toolchain_match()` to report whether the active `rustc` matches the pinned toolchain and to surface the exact `rustup` commands to fix mismatches, and add the doctor-friendly suggested commands list.
- Update `docs/issues/DEVELOPER_FRICTION.md` to mark the “Automatic version check in justfile” item as implemented.

### Testing
- Ran `bash scripts/devex-doctor.sh` which completed and reported the pinned toolchain and component checks (success).
- Ran `bash -n scripts/devex-doctor.sh` (syntax check) which succeeded (success).
- Attempted `just doctor` and `just _check-rust-toolchain` in the current environment but they failed to run because the `just` tool is not installed here (environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8ead5c8333a333a4cb7812738d)