### PR TITLE
chore(devex): improve onboarding diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ nix develop -c just ci-gate
 
 # Quick environment diagnostics (recommended when onboarding/troubleshooting)
 just doctor
+# Alias: same diagnostics under a broader devex-oriented name
+just devex
 
 # Fallback without `just`/Nix: run the Rust-native local mirror
 cargo run -p perl-ci-hygiene -- check-local

--- a/docs/issues/DEVELOPER_FRICTION.md
+++ b/docs/issues/DEVELOPER_FRICTION.md
@@ -112,11 +112,11 @@ rustup update stable
 rustup override set 1.92.0
 ```
 
-#### Proposed Solutions
+#### Current Mitigations
 | Solution | Effort | Status |
 |----------|--------|--------|
-| Automatic version check in justfile | Low | Proposed |
-| Better error messages for version mismatch | Low | Proposed |
+| `just doctor` / `just devex` verify pinned vs active Rust toolchain | Low | Implemented |
+| Doctor output includes explicit fix commands for mismatches | Low | Implemented |
 
 #### Related Documentation
 - [`rust-toolchain.toml`](../../rust-toolchain.toml) - Toolchain specification

--- a/justfile
+++ b/justfile
@@ -313,6 +313,8 @@ doctor:
     @echo "=============================================="
     @bash scripts/devex-doctor.sh
 
+# Friendly alias for onboarding / devex checks
+devex: doctor
 
 # Targeted checks for changed crates (fast feedback for active branch)
 devex-targeted base='origin/master' mode='all':

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -57,6 +57,54 @@ show_version() {
   fi
 }
 
+parse_pinned_toolchain() {
+  if [ ! -f rust-toolchain.toml ]; then
+    return 1
+  fi
+
+  awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml
+}
+
+check_toolchain_alignment() {
+  local pinned="$1"
+
+  if [ -z "$pinned" ]; then
+    warn "Could not parse rust-toolchain.toml"
+    return 1
+  fi
+
+  pass "Pinned toolchain: $pinned"
+
+  if ! has_cmd rustc; then
+    warn "rustc unavailable; cannot verify active toolchain version"
+    return 1
+  fi
+
+  local rustc_version
+  rustc_version=$(rustc --version 2>/dev/null | awk '{print $2}')
+  if [ -z "$rustc_version" ]; then
+    warn "Could not determine active rustc version"
+    return 1
+  fi
+
+  if [ "$rustc_version" = "$pinned" ]; then
+    pass "Active rustc matches pinned toolchain: $rustc_version"
+  else
+    warn "Active rustc ($rustc_version) does not match pinned toolchain ($pinned)"
+    warn "Fix with: rustup toolchain install $pinned && rustup override set $pinned"
+  fi
+
+  if has_cmd rustup; then
+    local active_toolchain
+    active_toolchain=$(rustup show active-toolchain 2>/dev/null | awk '{print $1}')
+    if [ -n "$active_toolchain" ]; then
+      pass "rustup active toolchain: $active_toolchain"
+    else
+      warn "Could not determine rustup active toolchain"
+    fi
+  fi
+}
+
 MISSING_REQUIRED=0
 
 echo "Repository: $(pwd)"
@@ -82,20 +130,17 @@ printf '== Rust components ==\n'
 check_rust_component rustfmt || true
 check_rust_component clippy || true
 
-if [ -f rust-toolchain.toml ]; then
-  TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
-  if [ -n "${TOOLCHAIN:-}" ]; then
-    pass "Pinned toolchain: $TOOLCHAIN"
-  else
-    warn "Could not parse rust-toolchain.toml"
-  fi
+if PINNED_TOOLCHAIN=$(parse_pinned_toolchain 2>/dev/null); then
+  check_toolchain_alignment "$PINNED_TOOLCHAIN" || true
 else
   warn "rust-toolchain.toml not found"
 fi
 
 echo
 printf '== Suggested next commands ==\n'
+echo "  just doctor"
 echo "  just pr-fast"
+echo "  just devex-targeted"
 echo "  just ci-gate"
 echo "  nix develop -c just ci-gate"
 


### PR DESCRIPTION
### Motivation
- Reduce onboarding friction by making the developer environment doctor more discoverable and by automatically checking the pinned Rust toolchain vs the active `rustc`.
- Provide clear, actionable guidance when a toolchain mismatch is detected so contributors can fix their environment quickly.
- Surface a friendly `devex` alias to make the diagnostic workflow easier to find alongside existing `devex-targeted` checks.

### Description
- Add `parse_pinned_toolchain` and `check_toolchain_alignment` to `scripts/devex-doctor.sh` to parse `rust-toolchain.toml`, compare the pinned channel with the active `rustc`, and print explicit recovery commands when they differ.
- Replace the previous static pinned-toolchain display with the new alignment check and include reporting of `rustup`'s active toolchain in the doctor output.
- Add a `devex: doctor` alias to the `justfile` so `just devex` runs the existing onboarding diagnostics.
- Update `CONTRIBUTING.md` and `docs/issues/DEVELOPER_FRICTION.md` to document the new alias and mark toolchain-mismatch detection as an implemented mitigation.

### Testing
- Ran `bash scripts/devex-doctor.sh` and verified it reports required tools and the pinned vs active toolchain; the run completed successfully (passed).
- Performed a shell syntax check with `bash -n scripts/devex-doctor.sh`, which returned no syntax errors (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8ead5c8333a333a4cb7812738d)