### PR TITLE
Improve Rust toolchain devex checks

### DIFF
--- a/docs/issues/DEVELOPER_FRICTION.md
+++ b/docs/issues/DEVELOPER_FRICTION.md
@@ -110,12 +110,16 @@ rustup update stable
 
 # Use exact version
 rustup override set 1.92.0
+
+# Or let repo tooling validate it for you
+just pr-fast
+just doctor
 ```
 
 #### Proposed Solutions
 | Solution | Effort | Status |
 |----------|--------|--------|
-| Automatic version check in justfile | Low | Proposed |
+| Automatic version check in justfile | Low | Implemented via `scripts/check-rust-toolchain.sh` |
 | Better error messages for version mismatch | Low | Proposed |
 
 #### Related Documentation

--- a/justfile
+++ b/justfile
@@ -330,6 +330,7 @@ _check-tools-basic:
         echo "  Install Rust: https://rustup.rs"; \
         exit 1; \
     fi
+    @bash scripts/check-rust-toolchain.sh
 
 # ============================================================================
 # CI Validation Commands (Issue #211)

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-check}"
+
+pass() { printf '✅ %s\n' "$1"; }
+warn() { printf '⚠️  %s\n' "$1"; }
+fail() { printf '❌ %s\n' "$1"; }
+
+if [ ! -f rust-toolchain.toml ]; then
+  warn "rust-toolchain.toml not found; skipping pinned toolchain check"
+  exit 0
+fi
+
+REQUIRED_TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
+if [ -z "${REQUIRED_TOOLCHAIN:-}" ]; then
+  warn "Could not parse pinned toolchain from rust-toolchain.toml"
+  exit 0
+fi
+
+REQUIRED_VERSION="$REQUIRED_TOOLCHAIN"
+CURRENT_VERSION=""
+if command -v rustc >/dev/null 2>&1; then
+  CURRENT_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}')
+fi
+
+if [ -z "$CURRENT_VERSION" ]; then
+  fail "rustc is not available; install Rust via https://rustup.rs"
+  exit 1
+fi
+
+if [ "$CURRENT_VERSION" = "$REQUIRED_VERSION" ]; then
+  pass "Rust toolchain matches pinned version: $CURRENT_VERSION"
+  exit 0
+fi
+
+LOWEST=$(printf '%s\n%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)
+if [ "$LOWEST" = "$REQUIRED_VERSION" ]; then
+  if [ "$MODE" = "doctor" ]; then
+    warn "Using Rust $CURRENT_VERSION while rust-toolchain.toml pins $REQUIRED_VERSION; builds should still work, but use 'rustup override set $REQUIRED_TOOLCHAIN' for exact parity"
+  else
+    pass "Rust $CURRENT_VERSION satisfies pinned MSRV $REQUIRED_VERSION"
+  fi
+  exit 0
+fi
+
+fail "Rust $CURRENT_VERSION is older than pinned MSRV $REQUIRED_VERSION"
+printf '   Fix: rustup toolchain install %s && rustup override set %s\n' "$REQUIRED_TOOLCHAIN" "$REQUIRED_TOOLCHAIN"
+exit 1

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -86,6 +86,9 @@ if [ -f rust-toolchain.toml ]; then
   TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
   if [ -n "${TOOLCHAIN:-}" ]; then
     pass "Pinned toolchain: $TOOLCHAIN"
+    if ! bash scripts/check-rust-toolchain.sh doctor; then
+      MISSING_REQUIRED=1
+    fi
   else
     warn "Could not parse rust-toolchain.toml"
   fi


### PR DESCRIPTION
### Motivation
- Reduce onboarding friction by surfacing a clear, early failure when the local `rustc` is older than the repository-pinned toolchain in `rust-toolchain.toml` so PR/merge gates fail fast with actionable guidance.

### Description
- Add `scripts/check-rust-toolchain.sh`, a small helper that reads the pinned channel from `rust-toolchain.toml`, compares it to the active `rustc`, and prints pass/warn/fail messages (supports a `doctor` mode).
- Wire the toolchain check into the `just` preflight `_check-tools-basic` recipe so `pr-fast`/merge gates run the validation early via `just`.
- Integrate the check into `scripts/devex-doctor.sh` so the doctor flow reports toolchain mismatches and sets a failure status when appropriate.
- Update `docs/issues/DEVELOPER_FRICTION.md` to mark the automatic version check as implemented and to point users to `just pr-fast` / `just doctor` as validation commands.

### Testing
- Ran `bash scripts/check-rust-toolchain.sh` and `bash scripts/check-rust-toolchain.sh doctor`, both succeeded on the test host.
- Ran `bash scripts/devex-doctor.sh` which executed the new check and completed successfully.
- Ran formatting and syntax checks with `cargo fmt --all -- --check` and `bash -n scripts/check-rust-toolchain.sh scripts/devex-doctor.sh`, both succeeded.
- Note: `just` was not installed in the environment so `just pr-fast` / `just doctor` were not executed; the `justfile` wiring was validated by modifying the file and running the underlying scripts directly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8ead5c8333a333a4cb7812738d)