### PR TITLE
chore(devex): add quick environment alias

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ You **must** run the local CI gate before pushing. The canonical command uses Ni
 nix develop -c just ci-gate
 
 # Quick environment diagnostics (recommended when onboarding/troubleshooting)
-just doctor
+just devex (alias: just doctor)
 
 # Fallback without `just`/Nix: run the Rust-native local mirror
 cargo run -p perl-ci-hygiene -- check-local

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ code --install-extension effortlessmetrics.perl-lsp-rs
 
 New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a visual feature tour, and troubleshooting tips.
 
+Contributing locally? Run `just devex` (or `just doctor`) for a quick environment check before diving into `just pr-fast` or the full CI gate.
+
 <details>
 <summary><strong>Neovim / Emacs setup</strong></summary>
 

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -36,6 +36,19 @@ cargo install --path crates/perl-parser --bin perl-dap
 perl-dap --stdio  # Standard DAP transport
 ```
 
+## Developer Workflow
+
+```bash
+# Quick local environment diagnostics
+just devex          # Alias: just doctor
+
+# Fast validation before a larger test run
+just pr-fast
+
+# Canonical local gate
+nix develop -c just ci-gate
+```
+
 ## Build Commands (*Diataxis: How-to Guide* - Development builds)
 
 ### Published Crates

--- a/justfile
+++ b/justfile
@@ -313,6 +313,8 @@ doctor:
     @echo "=============================================="
     @bash scripts/devex-doctor.sh
 
+# Short alias for the developer environment quick check
+devex: doctor
 
 # Targeted checks for changed crates (fast feedback for active branch)
 devex-targeted base='origin/master' mode='all':

--- a/scripts/devex-doctor.sh
+++ b/scripts/devex-doctor.sh
@@ -74,6 +74,8 @@ echo
 printf '== Recommended ==\n'
 check_cmd just "just" || true
 check_cmd nix "nix" || true
+check_cmd git "git" || true
+check_cmd rg "ripgrep (rg)" || true
 check_cmd cargo-audit "cargo-audit" || true
 check_githook
 
@@ -95,8 +97,9 @@ fi
 
 echo
 printf '== Suggested next commands ==\n'
-echo "  just pr-fast"
-echo "  just ci-gate"
+echo "  just devex            # quick environment diagnostics"
+echo "  just pr-fast          # fast validation before a full gate"
+echo "  just ci-gate          # repo-native local gate"
 echo "  nix develop -c just ci-gate"
 
 if [ "$MISSING_REQUIRED" -ne 0 ]; then


### PR DESCRIPTION
### Motivation
- Bring docs and tooling into alignment by adding a short, discoverable entry point for the developer environment check where docs previously referenced `just devex` but only `doctor` existed.
- Make onboarding easier by surfacing the quick-check workflow directly in the doctor output and commands reference.

### Description
- Add a `devex: doctor` alias to `justfile` so `just devex` runs the existing doctor recipe.
- Enhance `scripts/devex-doctor.sh` to report `git` and `rg` (ripgrep) availability and to suggest the new `just devex` quick-check in the suggested next commands output.
- Document the shortcut and quick workflow in `README.md`, `CONTRIBUTING.md`, and `docs/reference/COMMANDS_REFERENCE.md` so contributor-facing docs consistently reference `just devex` (with `just doctor` noted as an alias).
- Minor wording/ordering adjustments in the doctor/help output for clearer onboarding guidance.

### Testing
- Executed `bash scripts/devex-doctor.sh` and the script completed successfully in this environment.
- Attempted `just devex` in the runner but it failed to run because the `just` binary is not installed in this environment (expected on developer machines), so the alias was verified via file changes rather than executing `just` here.
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8ead5c8333a333a4cb7812738d)