### PR TITLE
Fix DAP variables pagination and stabilize child variable references

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1075,6 +1075,16 @@ impl DebugAdapter {
         start: usize,
         count: usize,
     ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
+        let (all_variables, child_cache) =
+            Self::parse_scope_variables_from_lines_all(lines, variables_ref);
+        let paged_variables = all_variables.into_iter().skip(start).take(count).collect();
+        (paged_variables, child_cache)
+    }
+
+    fn parse_scope_variables_from_lines_all(
+        lines: &[String],
+        variables_ref: i32,
+    ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
         let parser = VariableParser::new();
         let renderer = PerlVariableRenderer::new();
         let scope_type = variables_ref % 10;
@@ -1105,7 +1115,7 @@ impl DebugAdapter {
 
         let mut top_level = Vec::new();
         let mut child_cache = HashMap::new();
-        for (idx, (name, value)) in parsed.into_iter().skip(start).take(count).enumerate() {
+        for (idx, (name, value)) in parsed.into_iter().enumerate() {
             let child_ref = variables_ref.saturating_mul(1000).saturating_add(
                 Self::i64_to_i32_saturating(i64::try_from(idx + 1).unwrap_or(i64::from(i32::MAX))),
             );
@@ -1139,7 +1149,10 @@ impl DebugAdapter {
         count: usize,
     ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
         let lines = self.snapshot_recent_output_lines();
-        Self::parse_scope_variables_from_lines(&lines, variables_ref, start, count)
+        let (all_variables, child_cache) =
+            Self::parse_scope_variables_from_lines_all(&lines, variables_ref);
+        let paged_variables = all_variables.into_iter().skip(start).take(count).collect();
+        (paged_variables, child_cache)
     }
 
     /// Parse evaluate output from debugger lines into a DAP result payload.
@@ -2180,6 +2193,74 @@ mod tests {
             DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 20);
         let names = vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>();
         assert_eq!(names, vec!["$alpha", "$mid", "$zeta"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_scope_variables_paginates_without_reassigning_child_references()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let lines = vec![
+            "@alpha = (1, 2)".to_string(),
+            "@beta = (3, 4)".to_string(),
+            "@gamma = (5, 6)".to_string(),
+        ];
+
+        let (all_vars, _child_cache) =
+            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 0, 20);
+        let (paged_vars, _child_cache) =
+            DebugAdapter::parse_scope_variables_from_lines(&lines, 11, 1, 1);
+
+        assert_eq!(all_vars.len(), 3);
+        assert_eq!(paged_vars.len(), 1);
+        assert_eq!(paged_vars[0].name, "@beta");
+        assert_eq!(paged_vars[0].variables_reference, all_vars[1].variables_reference);
+        Ok(())
+    }
+
+    #[test]
+    fn test_handle_variables_cache_respects_pagination_arguments()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut adapter = DebugAdapter::new();
+        {
+            let mut output = lock_or_recover(
+                &adapter.recent_output,
+                "test_handle_variables_cache_pagination.recent_output",
+            );
+            output.push_back("$alpha = 1".to_string());
+            output.push_back("$beta = 2".to_string());
+            output.push_back("$gamma = 3".to_string());
+        }
+
+        let first_page = adapter.handle_request(
+            1,
+            "variables",
+            Some(json!({"variablesReference": 11, "start": 0, "count": 1})),
+        );
+        let second_page = adapter.handle_request(
+            2,
+            "variables",
+            Some(json!({"variablesReference": 11, "start": 1, "count": 1})),
+        );
+
+        let extract_names =
+            |response: DapMessage| -> Result<Vec<String>, Box<dyn std::error::Error>> {
+                match response {
+                    DapMessage::Response { success, body, .. } => {
+                        assert!(success, "variables request should succeed");
+                        Ok(body.ok_or("missing variables body")?["variables"]
+                            .as_array()
+                            .ok_or("missing variables array")?
+                            .iter()
+                            .filter_map(|value| value.get("name").and_then(|name| name.as_str()))
+                            .map(ToString::to_string)
+                            .collect())
+                    }
+                    _ => Err("Expected Response message".into()),
+                }
+            };
+
+        assert_eq!(extract_names(first_page)?, vec!["$alpha".to_string()]);
+        assert_eq!(extract_names(second_page)?, vec!["$beta".to_string()]);
         Ok(())
     }
 

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -49,7 +49,7 @@ impl DebugAdapter {
             // Return cached variables first for stable references and fast repeated expansion.
             if let Some(vars) = session.variables.get(&variables_ref) {
                 used_session_cache = true;
-                parsed_from_output = vars.clone();
+                parsed_from_output = vars.iter().skip(start).take(count).cloned().collect();
             } else {
                 let mut framed_scope_lines = None;
 


### PR DESCRIPTION
### Motivation
- `variables` requests that supply `start`/`count` were returning full cached pages when a scope was already cached, breaking pagination semantics. 
- Child `variablesReference` IDs could shift between pages because they were generated per-page, making expansion unstable. 
- Tests exercise paginated variable listing and cached behavior and need deterministic child references for reliable UI expansion.

### Description
- Return a paged slice of cached variables in `crates/perl-dap/src/debug_adapter/variables.rs` by using `vars.iter().skip(start).take(count).cloned().collect()` so cached reads respect `start`/`count`.
- Refactor scope parsing in `crates/perl-dap/src/debug_adapter/mod.rs` by adding `parse_scope_variables_from_lines_all` which builds the full variable list and child cache once, and have the public parse functions page the result afterwards so child `variablesReference` values are stable and based on absolute positions.
- Update `parse_scope_variables_from_output` to use the new full-parse + page approach so both live output parsing and cached responses share the same stable IDs.
- Add regression tests: `test_parse_scope_variables_paginates_without_reassigning_child_references` (unit test in the adapter module) and `test_handle_variables_cache_respects_pagination_arguments` (session lifecycle test) that verify stable child references and that cached pagination respects `start`/`count`.

### Testing
- Ran the specific unit tests with `cargo test -p perl-dap --lib debug_adapter::tests::test_parse_scope_variables_paginates_without_reassigning_child_references -- --exact` and `cargo test -p perl-dap --lib debug_adapter::tests::test_handle_variables_cache_respects_pagination_arguments -- --exact`, both of which passed. 
- Ran the full DAP crate test suite with `cargo test -p perl-dap --lib` which completed successfully with all tests passing (`121 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8359f48333872dab564a1b5840)