### PR TITLE
Improve DAP pagination handling

### DIFF
--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -10,8 +10,12 @@ impl DebugAdapter {
         request_seq: i64,
         arguments: Option<Value>,
     ) -> DapMessage {
-        let _args: Option<StackTraceArguments> =
+        let args: Option<StackTraceArguments> =
             arguments.and_then(|v| serde_json::from_value(v).ok());
+        let start_frame =
+            args.as_ref().and_then(|value| value.start_frame).unwrap_or(0).max(0) as usize;
+        let levels = args.as_ref().and_then(|value| value.levels).unwrap_or(0);
+        let requested_count = if levels <= 0 { None } else { Some(levels as usize) };
         let mut framed_output_lines = None;
 
         // Ask the debugger for an explicit stack snapshot when a live session is present.
@@ -101,6 +105,7 @@ impl DebugAdapter {
                 end_column: None,
             }]
         };
+        let stack_frames = Self::paginate_stack_frames(stack_frames, start_frame, requested_count);
 
         DapMessage::Response {
             seq,
@@ -174,6 +179,20 @@ impl DebugAdapter {
             command: "scopes".to_string(),
             body: serde_json::to_value(&scopes_body).ok(),
             message: None,
+        }
+    }
+}
+
+impl DebugAdapter {
+    fn paginate_stack_frames(
+        stack_frames: Vec<StackFrame>,
+        start_frame: usize,
+        levels: Option<usize>,
+    ) -> Vec<StackFrame> {
+        let iter = stack_frames.into_iter().skip(start_frame);
+        match levels {
+            Some(limit) => iter.take(limit).collect(),
+            None => iter.collect(),
         }
     }
 }

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1190,8 +1190,8 @@ impl DebugAdapter {
     }
 
     /// Build deterministic placeholder variables used when debugger output is unavailable.
-    fn fallback_scope_variables(variables_ref: i32) -> Vec<Variable> {
-        match variables_ref % 10 {
+    fn fallback_scope_variables(variables_ref: i32, start: usize, count: usize) -> Vec<Variable> {
+        let variables = match variables_ref % 10 {
             1 => vec![
                 Variable {
                     name: "$self".to_string(),
@@ -1227,7 +1227,9 @@ impl DebugAdapter {
                 indexed_variables: None,
             }],
             _ => Vec::new(),
-        }
+        };
+
+        variables.into_iter().skip(start).take(count).collect()
     }
 
     /// Parse stack trace output from Perl debugger "T" command

--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -149,7 +149,7 @@ impl DebugAdapter {
         }
 
         let variables = if parsed_from_output.is_empty() {
-            Self::fallback_scope_variables(variables_ref)
+            Self::fallback_scope_variables(variables_ref, start, count)
         } else {
             parsed_from_output
         };

--- a/crates/perl-dap/tests/dap_edge_cases_test.rs
+++ b/crates/perl-dap/tests/dap_edge_cases_test.rs
@@ -200,7 +200,7 @@ fn test_dap_stack_trace_edge_cases() -> TestResult {
     // Test stack trace with various thread IDs and scenarios
     let test_cases = [
         Some(json!({"threadId": 1, "startFrame": 0, "levels": 10})),
-        Some(json!({"threadId": 1, "startFrame": 5, "levels": 5})),
+        Some(json!({"threadId": 1, "startFrame": 1, "levels": 5})),
         Some(json!({"threadId": 999})), // Invalid thread
         Some(json!({"levels": 0})),     // Zero levels
         None,                           // No arguments
@@ -217,11 +217,11 @@ fn test_dap_stack_trace_edge_cases() -> TestResult {
                         .get("stackFrames")
                         .and_then(|f| f.as_array())
                         .ok_or("Expected frames array")?;
-                    // Without active session, should return 1 placeholder frame
+                    let expected_len = if i == 1 { 0 } else { 1 };
                     assert_eq!(
                         frames.len(),
-                        1,
-                        "Should return 1 placeholder frame for case: {}",
+                        expected_len,
+                        "Should honor stackTrace pagination for case: {}",
                         i
                     );
                 }
@@ -387,5 +387,30 @@ fn test_dap_attach_process_id_mode() -> TestResult {
         }
         _ => return Err("Expected attach response".into()),
     }
+    Ok(())
+}
+
+#[test]
+fn test_dap_stack_trace_zero_levels_returns_remaining_frames() -> TestResult {
+    let mut adapter = DebugAdapter::new();
+    let response = adapter.handle_request(
+        1,
+        "stackTrace",
+        Some(json!({"threadId": 1, "startFrame": 0, "levels": 0})),
+    );
+
+    match response {
+        DapMessage::Response { success, body, .. } => {
+            assert!(success);
+            let body = body.ok_or("Expected body in successful response")?;
+            let frames = body
+                .get("stackFrames")
+                .and_then(|f| f.as_array())
+                .ok_or("Expected frames array")?;
+            assert_eq!(frames.len(), 1);
+        }
+        _ => return Err("Expected stackTrace response".into()),
+    }
+
     Ok(())
 }

--- a/crates/perl-dap/tests/variable_rendering_tests.rs
+++ b/crates/perl-dap/tests/variable_rendering_tests.rs
@@ -310,3 +310,24 @@ fn test_scope_expensive_flags() -> Result<(), Box<dyn std::error::Error>> {
     }
     Ok(())
 }
+
+#[test]
+fn test_variables_placeholder_pagination() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = create_test_adapter();
+    let args = json!({ "variablesReference": 11, "start": 1, "count": 1 });
+    let response = adapter.handle_request(1, "variables", Some(args));
+
+    if let DapMessage::Response { success, body, .. } = response {
+        assert!(success);
+        let body_val = body.ok_or("Expected body in response")?;
+        let vars = body_val
+            .get("variables")
+            .ok_or("Expected variables field")?
+            .as_array()
+            .ok_or("Expected variables array")?;
+
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].get("name").and_then(|name| name.as_str()), Some("@_"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Placeholder and cached DAP responses were returning full stacks/variable sets regardless of `stackTrace` pagination (`startFrame`/`levels`) or `variables` pagination (`start`/`count`), causing incorrect behavior for paged requests.

### Description

- Honor `stackTrace` pagination arguments by extracting `startFrame` and `levels` and applying them to cached, attached-process, and placeholder frame responses.  
- Add a centralized `paginate_stack_frames` helper to perform frame slicing consistently.  
- Apply `start`/`count` pagination to deterministic placeholder scope variables by changing `fallback_scope_variables` to accept `(start, count)` and updating callers.  
- Add regression tests: `test_variables_placeholder_pagination` and stackTrace pagination tests (including `levels: 0` semantics) and update existing edge-case tests; also fix a string escaping issue uncovered during build.

### Testing

- Ran targeted unit tests: `cargo test -p perl-dap --test variable_rendering_tests --test dap_edge_cases_test`, and all tests passed.  
- Ran linter: `cargo clippy -p perl-dap --tests -- -D warnings`, and clippy passed with no warnings.  
- Verified formatting with `cargo fmt` on modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a8359f48333872dab564a1b5840)