### PR TITLE
test: improve NodeKind goto coverage

### DIFF
--- a/crates/perl-corpus/src/cases.rs
+++ b/crates/perl-corpus/src/cases.rs
@@ -24,7 +24,7 @@ pub struct ComplexDataStructureCase {
     pub source: &'static str,
 }
 
-static EDGE_CASES: [EdgeCase; 100] = [
+static EDGE_CASES: [EdgeCase; 101] = [
     EdgeCase {
         id: "heredoc.basic",
         description: "Basic quoted heredoc with multiple lines.",
@@ -646,6 +646,15 @@ print $_ for @items;
 START:
 $count++;
 goto START if $count < 2;
+"#,
+    },
+    EdgeCase {
+        id: "goto.label.simple",
+        description: "Goto with a plain label target and explicit statement terminators.",
+        tags: &["goto", "labels", "flow", "smoke", "edge-case"],
+        source: r#"goto FINISH;
+FINISH:
+1;
 "#,
     },
     EdgeCase {

--- a/crates/perl-parser/tests/nodekind_combination_control_flow.rs
+++ b/crates/perl-parser/tests/nodekind_combination_control_flow.rs
@@ -107,6 +107,39 @@ longwordwithoutvowels
     assert!(!if_nodes.is_empty(), "Should have if statements");
 }
 
+/// Test goto statements with label and subroutine targets.
+#[test]
+fn test_goto_statements_cover_label_and_sub_targets() {
+    let code = r#"
+START:
+my $step = 0;
+goto FINISH if $step;
+
+sub target {
+    return 1;
+}
+
+sub bounce {
+    goto &target;
+}
+
+FINISH:
+$step++;
+"#;
+
+    let mut parser = Parser::new(code);
+    use perl_tdd_support::must;
+    let ast = must(parser.parse());
+
+    let goto_nodes = find_nodes_of_kind(&ast, |k| matches!(k, NodeKind::Goto { .. }));
+    let labeled_nodes =
+        find_nodes_of_kind(&ast, |k| matches!(k, NodeKind::LabeledStatement { .. }));
+
+    assert!(!goto_nodes.is_empty(), "Should have goto statements");
+    assert!(goto_nodes.len() >= 2, "Should cover both label and subroutine goto targets");
+    assert!(!labeled_nodes.is_empty(), "Should have labeled statements for goto targets");
+}
+
 /// Test statement modifiers with complex expressions and subroutines
 #[test]
 fn test_statement_modifiers_complex_expressions() {

--- a/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
+++ b/crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs
@@ -210,6 +210,17 @@ $name, $age, $salary
                 foreach my $item (1, 2, 3) { print $item; }
             "#,
         ),
+        (
+            "goto_and_labels",
+            r#"
+                goto FINISH;
+                FINISH:
+                1;
+
+                sub bounce { goto &target; }
+                sub target { return 1; }
+            "#,
+        ),
     ];
 
     let mut observed = BTreeSet::new();


### PR DESCRIPTION
### Motivation
- Improve NodeKind coverage for `Goto` forms so semantic analysis and corpus coverage include both label-target and subroutine-target `goto` patterns.

### Description
- Add a small corpus fixture `goto.label.simple` and increment the static `EDGE_CASES` size from `100` to `101` in `crates/perl-corpus/src/cases.rs`.
- Extend the semantic coverage matrix with a `goto_and_labels` case in `crates/perl-parser/tests/semantic_nodekind_coverage_tests.rs` to exercise `goto` variants under semantic analysis.
- Add a focused control-flow test `test_goto_statements_cover_label_and_sub_targets` in `crates/perl-parser/tests/nodekind_combination_control_flow.rs` that asserts `NodeKind::Goto` and labeled statements are present for both label and subroutine targets.
- Run `cargo fmt --all` as part of changes.

### Testing
- Ran `cargo test -p perl-parser --test nodekind_combination_control_flow test_goto_statements_cover_label_and_sub_targets -- --exact --nocapture`, which passed.
- Ran `cargo test -p perl-parser --test semantic_nodekind_coverage_tests test_semantic_nodekind_coverage_is_total -- --exact --nocapture`, which passed.
- Ran `cargo test -p perl-parser --test corpus_nodekind_coverage_test -- --nocapture`, which passed (the test emits a warning about recovery-only observations for `Goto` for visibility).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a7e069083339391d5f3d6b329a0)