### PR TITLE
Add compact corpus fixture to improve low-frequency NodeKind coverage

### DIFF
--- a/test_corpus/nodekind_angles_additional.pl
+++ b/test_corpus/nodekind_angles_additional.pl
@@ -1,13 +1,12 @@
 #!/usr/bin/env perl
 # Test: Additional low-frequency NodeKind angles
-# Impact: Adds alternative clean corpus coverage for low-frequency constructs
-#         using parser-proven syntax borrowed from existing dedicated fixtures.
+# Impact: Adds compact alternative clean corpus coverage for low-frequency
+#         constructs using parser-proven syntax with minimal runtime noise.
 # NodeKinds: Goto, Tie, Untie, Typeglob, Glob, DataSection, Match
 
 use strict;
 use warnings;
 
-# --- Goto in two clean forms ---
 sub tail_dispatch {
     @_ = ('retargeted');
     goto &tail_target;
@@ -18,15 +17,17 @@ sub tail_target {
 }
 
 my $state = 'start';
+my $matched = 0;
+
 FLOW: {
     $state = 'middle';
-    goto FLOW_END if $state =~ /^mid/;
+    $matched = ($state =~ /^mid/);
+    goto FLOW_END if $matched;
     $state = 'unreachable';
     FLOW_END:
     $state = tail_dispatch();
 }
 
-# --- Tie / untie in multiple shapes ---
 tie my %cache, 'Tie::IxHash';
 $cache{status} = $state;
 untie %cache;
@@ -34,21 +35,21 @@ untie %cache;
 tie my $scalar_value, 'Tie::Scalar';
 untie $scalar_value;
 
+*LOG_HANDLE = *STDOUT;
 tie *LOG_HANDLE, 'Tie::StdHandle';
 untie *LOG_HANDLE;
 
-# --- Typeglob and glob alternative angles ---
 *alias_stdout = *STDOUT;
 *helper = \&tail_target;
+my $alias_ref = \*alias_stdout;
 my $stdout_ref = \*STDOUT;
 
 my @glob_fn = glob('test_corpus/*.pl');
 my @glob_angle = <test_corpus/*.pl>;
 my $single_log = glob '*.log';
+my $glob_summary = scalar(@glob_fn) + scalar(@glob_angle) + ($single_log ? 1 : 0);
 
-print alias_stdout scalar(@glob_fn), "\n";
-print helper('helper-call'), "\n" if $stdout_ref;
-print scalar(@glob_angle) + ($single_log ? 1 : 0), "\n";
+my $sink = [$matched, $alias_ref, $stdout_ref, $glob_summary, helper('helper-call')];
 
 __END__
 This trailing section is data, not Perl code.


### PR DESCRIPTION
### Motivation
- Improve corpus-level NodeKind "angles" for low-frequency constructs so the coverage gates in `crates/perl-parser/tests` observe these kinds in a clean parse context.

### Description
- Add a new compact corpus fixture at `test_corpus/nodekind_angles_additional.pl` that exercises `Goto`, `Tie`, `Untie`, `Typeglob`, `Glob`, `DataSection`, and `Match` using small parser-focused examples (tail-call `goto`, `tie`/`untie`, typeglob aliasing, `glob(...)`, and a `__DATA__` section).

### Testing
- Ran `perl -c test_corpus/nodekind_angles_additional.pl`, which succeeded.
- Ran `cargo fmt --all --check`, which produced no failures.
- Attempted `cargo test -p perl-parser corpus_nodekind_coverage_test -- --nocapture`, but the workspace compilation did not complete within the session window (inconclusive).
- Attempted `cargo run -p perl-parser --features cli --bin perl-parse -- -q test_corpus/nodekind_angles_additional.pl`, which was started but workspace compilation did not finish within the session window (inconclusive).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a7e069083339391d5f3d6b329a0)