### PR TITLE
test(parser): improve NodeKind corpus coverage

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -962,7 +962,7 @@ fn cmd_quick_bench(repo_root: &Path) -> Result<i32> {
 
     let files = vec![
         repo_root.join("test_corpus/simple.pl"),
-        repo_root.join("test_corpus/low_frequency_nodekinds.rs"),
+        repo_root.join("test_corpus/low_frequency_nodekinds.pl"),
         repo_root.join("test_corpus/parser_stress_cases.pl"),
         repo_root.join("test_corpus/performance_stress_scenarios.pl"),
         repo_root.join("test_corpus/basic_constructs.pl"),

--- a/crates/perl-parser/tests/corpus_gap_tests.rs
+++ b/crates/perl-parser/tests/corpus_gap_tests.rs
@@ -137,6 +137,11 @@ mod corpus_gap_tests {
         test_corpus_file("tie_interface.pl")
     }
 
+    #[test]
+    fn test_nodekind_additional_angles() -> Result<(), Box<dyn std::error::Error>> {
+        test_corpus_file("nodekind_additional_angles.pl")
+    }
+
     /// Regression: anonymous sub as expression initializer (`my $c = sub { 1 };`)
     /// must produce a subroutine node inside the initializer (locks down peek_second() fix).
     #[test]

--- a/test_corpus/nodekind_additional_angles.pl
+++ b/test_corpus/nodekind_additional_angles.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+# Test: Additional clean NodeKind angles for rare constructs
+# Impact: Improves corpus diversity for low-frequency NodeKinds in clean parses
+# NodeKinds: Goto, DataSection, Readline, Typeglob, Format, PhaseBlock, Do, Transliteration
+
+use strict;
+use warnings;
+
+BEGIN {
+    our $BOOTSTRAPPED = 1;
+}
+
+sub dynamic_dispatch {
+    my ($code_ref, @args) = @_;
+    goto &$code_ref;
+}
+
+sub uppercase_joined {
+    my (@parts) = @_;
+    my $joined = do {
+        my $value = join q{ }, @parts;
+        $value =~ tr/a-z/A-Z/;
+        $value;
+    };
+    return $joined;
+}
+
+format STDOUT =
+@<<<<<<<<<<<<<<<<<<<<<<<< @>>>>>
+$main::report_name,         $main::report_total
+.
+
+our ($report_name, $report_total) = ("summary", 12);
+*REPORT = *STDOUT;
+
+my $headline = dynamic_dispatch(\&uppercase_joined, qw(alpha beta));
+print REPORT "$headline\n";
+
+my $first_data_line = <DATA>;
+print REPORT $first_data_line if defined $first_data_line;
+
+write;
+
+1;
+
+__DATA__
+payload line


### PR DESCRIPTION
### Motivation

- Improve corpus-level NodeKind coverage by providing an additional clean fixture that exercises low-frequency kinds and reduces brittle/recovery-only coverage.
- Ensure the new fixture is validated by the existing parser corpus gap tests so coverage is enforced by CI.
- Fix the quick parser benchmark input list to reference the existing `.pl` corpus file instead of a non-existent `.rs` path.

### Description

- Add a new clean corpus fixture `test_corpus/nodekind_additional_angles.pl` exercising rare NodeKinds including `Goto`, `DataSection`, `Readline`, `Typeglob`, `Format`, `PhaseBlock`, `Do`, and `Transliteration`.
- Register a focused corpus-gap test `test_nodekind_additional_angles` in `crates/perl-parser/tests/corpus_gap_tests.rs` that parses the new fixture.
- Update `crates/perl-ci-hygiene/src/main.rs` to use `test_corpus/low_frequency_nodekinds.pl` in the quick benchmark file list (replace incorrect `.rs` entry).

### Testing

- Ran formatting with `cargo fmt --all`, which completed successfully.
- Linted/compiled and executed the focused parser test with `cargo test -p perl-parser --test corpus_gap_tests nodekind_additional_angles -- --nocapture`, and the test passed.
- Verified the new Perl fixture syntax with `perl -c test_corpus/nodekind_additional_angles.pl`, which returned `syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a7e069083339391d5f3d6b329a0)