### PR TITLE
Improve fuzz target integration coverage

### DIFF
--- a/docs/project/PARSER_EVOLUTION.md
+++ b/docs/project/PARSER_EVOLUTION.md
@@ -422,7 +422,7 @@ The parser is validated against a comprehensive test corpus:
 
 Seven fuzz targets exercise the most fragile parsing paths:
 
-- `fuzz_target_1` -- general parsing
+- `parser_integration` -- parser, trivia, and symbol-extraction integration
 - `heredoc_parsing` -- heredoc edge cases
 - `substitution_parsing` -- s/// variants
 - `builtin_functions` -- list operator argument parsing

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -60,4 +60,11 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "parser_integration"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,7 +1,53 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use perl_parser::{format_with_trivia, Parser, SymbolExtractor, TriviaPreservingParser};
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
+fn truncate_chars(input: &str, max_chars: usize) -> String {
+    input.chars().take(max_chars).collect()
+}
 
 fuzz_target!(|data: &[u8]| {
-    // fuzzed code goes here
+    let input = bounded_utf8_lossy(data);
+    let source = input.as_ref();
+
+    let snippets = [
+        source.to_string(),
+        format!("package {}::Pkg; sub handler {{ {} }}", truncate_chars(source, 12), source),
+        format!("use strict;\n# fuzz\nmy $value = q{{{}}};\n", source),
+        format!("sub {} {{\n    return {}\n}}", truncate_chars(source, 8), source),
+        format!("my @items = map {{ {} }} grep {{ {} }} @ARGV;", source, source),
+    ];
+
+    for snippet in &snippets {
+        let mut parser = Parser::new(snippet);
+        let result = parser.parse();
+
+        let trivia_tree = TriviaPreservingParser::new(snippet.clone()).parse();
+        let _formatted = format_with_trivia(&trivia_tree);
+
+        if let Ok(ast) = &result {
+            let extractor = SymbolExtractor::new_with_source(snippet);
+            let symbol_table = extractor.extract(ast);
+            let _symbol_count = symbol_table.symbols.len();
+            let _reference_count = symbol_table.references.len();
+        }
+
+    }
 });

--- a/justfile
+++ b/justfile
@@ -275,6 +275,7 @@ fuzz-bounded:
     @cargo +nightly fuzz run heredoc_parsing -- -max_total_time=60 || echo "  Heredoc fuzzing complete"
     @cargo +nightly fuzz run lsp_cancellation_registry -- -max_total_time=60 || echo "  LSP cancellation registry fuzzing complete"
     @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
+    @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
     @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
     @echo "✅ Fuzz testing complete"
@@ -1327,6 +1328,7 @@ fuzz-regression duration='30':
     @just fuzz builtin_functions {{duration}} || true
     @just fuzz heredoc_parsing {{duration}} || true
     @just fuzz lsp_cancellation_registry {{duration}} || true
+    @just fuzz parser_integration {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true


### PR DESCRIPTION
### Motivation
- Replace a placeholder general fuzz target with a richer integration harness to exercise end-to-end parser subsystems and increase fuzzing coverage of parser → trivia → symbol-extraction code paths.
- Ensure CI/local bounded fuzz runs exercise the new integration target and update documentation to reflect the improved coverage.

### Description
- Add a parser integration fuzz harness into `fuzz/fuzz_targets/fuzz_target_1.rs` that bounds arbitrary input, synthesizes multiple Perl snippet shapes, runs `Parser`, `TriviaPreservingParser`/`format_with_trivia`, and `SymbolExtractor` on each snippet.
- Register the new harness as `parser_integration` in `fuzz/Cargo.toml` so it can be executed via `cargo fuzz` like the other targets.
- Wire `parser_integration` into the bounded nightly/local fuzz recipes in `justfile` so `just fuzz-bounded` and `just fuzz-regression` exercise the new target.
- Update `docs/project/PARSER_EVOLUTION.md` to document the new `parser_integration` target in the list of fuzz targets.

### Testing
- Ran `cargo check --manifest-path fuzz/Cargo.toml`, which completed successfully. 
- Ran `cargo fmt --all --check`, which passed formatting checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a6bdea883338975bc7d81b0caa1)