### PR TITLE
Improve general fuzz target coverage

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,7 +1,105 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use perl_parser::{
+    position::{offset_to_utf16_line_col, utf16_line_col_to_offset},
+    quote_parser::{
+        extract_regex_parts, extract_substitution_parts, extract_transliteration_parts,
+    },
+    Parser,
+};
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
+fn parse_without_panicking(input: &str) {
+    let mut parser = Parser::new(input);
+    if let Ok(ast) = parser.parse() {
+        let _ = ast.count_nodes();
+        let _ = ast.to_sexp();
+    }
+
+    let _ = parser.errors().len();
+}
+
+fn exercise_utf16_roundtrip(input: &str) {
+    let mut offsets = vec![0, input.len()];
+
+    for (offset, _) in input.char_indices() {
+        offsets.push(offset);
+    }
+
+    offsets.sort_unstable();
+    offsets.dedup();
+
+    for offset in offsets {
+        let (line, col) = offset_to_utf16_line_col(input, offset);
+        let roundtrip = utf16_line_col_to_offset(input, line, col);
+        let _ = roundtrip <= input.len();
+    }
+}
 
 fuzz_target!(|data: &[u8]| {
-    // fuzzed code goes here
+    let input = bounded_utf8_lossy(data);
+
+    parse_without_panicking(&input);
+
+    let parser_wrappers = [
+        format!("my $value = {};", input),
+        format!("sub fuzzed {{ {} }}", input),
+        format!("package Fuzz::Case; {}", input),
+        format!("if ({}) {{ {} }}", input, input),
+        format!("my $regex = qr/{}/;", input),
+        format!("$value =~ s/{0}/{0}/gr;", input),
+        format!("$value =~ tr/{0}/{0}/d;", input),
+        format!("print <<'EOF';\n{}\nEOF", input),
+    ];
+
+    for wrapper in &parser_wrappers {
+        if wrapper.len() <= MAX_INPUT_BYTES * 2 {
+            parse_without_panicking(wrapper);
+            exercise_utf16_roundtrip(wrapper);
+        }
+    }
+
+    let quote_inputs = [
+        format!("m/{}/", input),
+        format!("qr{{{}}}ims", input),
+        format!("s/{0}/{0}/gr", input),
+        format!("s[{0}][{0}]e", input),
+        format!("tr/{0}/{0}/cd", input),
+        format!("y{{{0}}}{{{0}}}r", input),
+    ];
+
+    for quote_input in &quote_inputs {
+        let (pattern, body, modifiers) = extract_regex_parts(quote_input);
+        let _ = pattern.len() <= quote_input.len();
+        let _ = body.len() <= quote_input.len();
+        let _ = modifiers.len() <= quote_input.len();
+
+        let (search, replacement, sub_modifiers) = extract_substitution_parts(quote_input);
+        let _ = search.len() <= quote_input.len();
+        let _ = replacement.len() <= quote_input.len();
+        let _ = sub_modifiers.len() <= quote_input.len();
+
+        let (from, to, tr_modifiers) = extract_transliteration_parts(quote_input);
+        let _ = from.len() <= quote_input.len();
+        let _ = to.len() <= quote_input.len();
+        let _ = tr_modifiers.len() <= quote_input.len();
+    }
+
+    exercise_utf16_roundtrip(&input);
 });


### PR DESCRIPTION
### Motivation
- Broaden fuzzing attack surface to exercise more parser code paths including quote parsing and UTF-16 position mapping.
- Replace an empty placeholder fuzz target with a real stress harness to increase likelihood of finding regressions across multiple parsing subsystems.

### Description
- Implement a general-purpose cargo-fuzz target at `fuzz/fuzz_targets/fuzz_target_1.rs` that converts raw bytes to bounded UTF-8 and feeds them to the parser and helpers.
- Add parser wrappers that construct subs, packages, conditionals, regexes, substitutions, transliterations, and heredocs from the same fuzz input to exercise end-to-end parsing.
- Invoke quote-parser helpers `extract_regex_parts`, `extract_substitution_parts`, and `extract_transliteration_parts` directly for each generated quote input to cover extraction logic.
- Add UTF-16 roundtrip checks using `offset_to_utf16_line_col` and `utf16_line_col_to_offset` to exercise position-mapping invariants.

### Testing
- Ran `cargo check --manifest-path fuzz/Cargo.toml` which completed successfully.
- Ran `cargo test -p perl-parser --test fuzz_regression_test` and observed all regression tests pass (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a6bdea883338975bc7d81b0caa1)