### PR TITLE
Improve module property test coverage

### DIFF
--- a/crates/perl-module-boundary/tests/module_boundary_prop.rs
+++ b/crates/perl-module-boundary/tests/module_boundary_prop.rs
@@ -1,9 +1,35 @@
 use perl_module_boundary::{contains_standalone_module_token, find_standalone_module_token_ranges};
+use perl_module_name::legacy_package_separator;
 use proptest::prelude::*;
 
 fn module_name_strategy() -> impl Strategy<Value = String> {
     proptest::collection::vec("[A-Za-z_][A-Za-z0-9_]{0,7}", 1..5)
         .prop_map(|segments| segments.join("::"))
+}
+
+fn boundary_padding_strategy() -> impl Strategy<Value = String> {
+    let boundary_char = prop_oneof![
+        Just(' '),
+        Just('\t'),
+        Just(';'),
+        Just(','),
+        Just('('),
+        Just(')'),
+        Just('['),
+        Just(']'),
+        Just('{'),
+        Just('}'),
+        Just('/'),
+        Just('-'),
+        Just('"'),
+    ];
+
+    proptest::collection::vec(boundary_char, 0..4).prop_map(|chars| chars.into_iter().collect())
+}
+
+fn nonempty_boundary_padding_strategy() -> impl Strategy<Value = String> {
+    boundary_padding_strategy()
+        .prop_filter("boundary padding must not be empty", |padding| !padding.is_empty())
 }
 
 proptest! {
@@ -19,12 +45,44 @@ proptest! {
     }
 
     #[test]
+    fn prop_finds_exact_range_for_direct_use_lines_with_legacy_separators(module in module_name_strategy()) {
+        let legacy_module = legacy_package_separator(&module).into_owned();
+        let line = format!("use {legacy_module};");
+        let ranges = find_standalone_module_token_ranges(&line, &legacy_module).collect::<Vec<_>>();
+
+        prop_assert_eq!(ranges.len(), 1);
+        prop_assert_eq!(ranges[0].start, 4);
+        prop_assert_eq!(ranges[0].end, 4 + legacy_module.len());
+        prop_assert!(contains_standalone_module_token(&line, &legacy_module));
+    }
+
+    #[test]
     fn prop_rejects_embedded_module_name_in_larger_identifier(module in module_name_strategy()) {
         let line = format!("use {module}Suffix;");
 
         let ranges = find_standalone_module_token_ranges(&line, &module).collect::<Vec<_>>();
         prop_assert!(ranges.is_empty());
         prop_assert!(!contains_standalone_module_token(&line, &module));
+    }
+
+    #[test]
+    fn prop_repeated_standalone_matches_are_non_overlapping_and_complete(
+        module in module_name_strategy(),
+        prefix in boundary_padding_strategy(),
+        infix in nonempty_boundary_padding_strategy(),
+        suffix in boundary_padding_strategy(),
+    ) {
+        let line = format!("{prefix}{module}{infix}{module}{suffix}");
+        let ranges = find_standalone_module_token_ranges(&line, &module).collect::<Vec<_>>();
+
+        prop_assert_eq!(ranges.len(), 2);
+        prop_assert!(contains_standalone_module_token(&line, &module));
+
+        let first = ranges[0];
+        let second = ranges[1];
+        prop_assert_eq!(&line[first.start..first.end], module.as_str());
+        prop_assert_eq!(&line[second.start..second.end], module.as_str());
+        prop_assert!(first.end <= second.start);
     }
 
     #[test]

--- a/crates/perl-module-token/tests/module_token_prop.rs
+++ b/crates/perl-module-token/tests/module_token_prop.rs
@@ -1,3 +1,4 @@
+use perl_module_name::legacy_package_separator;
 use perl_module_token::{contains_module_token, replace_module_token};
 use proptest::prelude::*;
 
@@ -24,6 +25,11 @@ fn boundary_padding_strategy() -> impl Strategy<Value = String> {
     ];
 
     proptest::collection::vec(boundary_char, 0..8).prop_map(|chars| chars.into_iter().collect())
+}
+
+fn nonempty_boundary_padding_strategy() -> impl Strategy<Value = String> {
+    boundary_padding_strategy()
+        .prop_filter("boundary padding must not be empty", |padding| !padding.is_empty())
 }
 
 fn module_char_strategy() -> impl Strategy<Value = char> {
@@ -54,6 +60,24 @@ proptest! {
     }
 
     #[test]
+    fn prop_replacement_occurs_for_legacy_module_tokens(
+        prefix in boundary_padding_strategy(),
+        suffix in boundary_padding_strategy(),
+        from in module_name_strategy(),
+        to in module_name_strategy(),
+    ) {
+        prop_assume!(from != to);
+
+        let legacy_from = legacy_package_separator(&from).into_owned();
+        let legacy_to = legacy_package_separator(&to).into_owned();
+        let line = format!("{prefix}{legacy_from}{suffix}");
+        let (rewritten, changed) = replace_module_token(&line, &legacy_from, &legacy_to);
+
+        prop_assert!(changed);
+        prop_assert_eq!(rewritten, format!("{prefix}{legacy_to}{suffix}"));
+    }
+
+    #[test]
     fn prop_replacement_does_not_trigger_on_partial_module_names(
         left in module_char_strategy(),
         right in module_char_strategy(),
@@ -71,11 +95,32 @@ proptest! {
     }
 
     #[test]
-    fn prop_contains_matches_self_replacement_change_flag(
+    fn prop_replacement_updates_every_standalone_occurrence(
+        prefix in boundary_padding_strategy(),
+        infix in nonempty_boundary_padding_strategy(),
+        suffix in boundary_padding_strategy(),
+        from in module_name_strategy(),
+        to in module_name_strategy(),
+    ) {
+        prop_assume!(from != to);
+
+        let line = format!("{prefix}{from}{infix}{from}{suffix}");
+        let (rewritten, changed) = replace_module_token(&line, &from, &to);
+
+        prop_assert!(changed);
+        let expected = format!("{prefix}{to}{infix}{to}{suffix}");
+        prop_assert_eq!(rewritten.as_str(), expected.as_str());
+        prop_assert!(!contains_module_token(&rewritten, &from));
+        prop_assert!(contains_module_token(&rewritten, &to));
+    }
+
+    #[test]
+    fn prop_self_replacement_preserves_the_line(
         line in "(?s).{0,256}",
         module in module_name_strategy(),
     ) {
-        let (_, changed) = replace_module_token(&line, &module, &module);
+        let (rewritten, changed) = replace_module_token(&line, &module, &module);
         prop_assert_eq!(contains_module_token(&line, &module), changed);
+        prop_assert_eq!(rewritten, line);
     }
 }


### PR DESCRIPTION
### Motivation
- Increase generative test coverage for module boundary/token microcrates to catch edge cases around legacy separators and repeated occurrences.
- Strengthen invariants to ensure standalone module matches are complete, non-overlapping, and that replacement logic updates every standalone occurrence.

### Description
- Add new proptest cases in `crates/perl-module-boundary/tests/module_boundary_prop.rs` including a reusable `nonempty_boundary_padding_strategy`, a legacy-separator exact-range property using `legacy_package_separator`, and a repeated-match invariant verifying non-overlapping matches.
- Extend `crates/perl-module-token/tests/module_token_prop.rs` with properties that exercise legacy-separator replacements, multi-occurrence replacements, and self-replacement stability while preserving partial-match rejection checks.
- Adjust assertion usage to avoid moved-value borrows by comparing `as_str()` where needed and introduce non-empty padding for multi-occurrence scenarios.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-module-boundary --test module_boundary_prop` and all tests passed.
- Ran `cargo test -p perl-module-token --test module_token_prop` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a65815c83338934f5046f155d35)