### PR TITLE
Expand property tests for module token boundary and separator cases

### DIFF
--- a/crates/perl-module-token-core/tests/module_token_core_prop.rs
+++ b/crates/perl-module-token-core/tests/module_token_core_prop.rs
@@ -38,6 +38,16 @@ fn module_name() -> impl Strategy<Value = String> {
         })
 }
 
+fn left_boundary_char() -> impl Strategy<Value = char> {
+    prop_oneof![
+        proptest::char::range('a', 'z'),
+        proptest::char::range('A', 'Z'),
+        proptest::char::range('0', '9'),
+        Just('_'),
+        Just(':'),
+    ]
+}
+
 proptest! {
     #[test]
     fn prop_parsed_span_in_use_line_matches_length(module in module_name()) {
@@ -57,6 +67,53 @@ proptest! {
 
         prop_assert_eq!(token, &line[span.start..span.end]);
         prop_assert!(has_standalone_module_token_boundaries(&line, span.start, span.end));
+    }
+
+    #[test]
+    fn prop_left_boundary_rejects_embedded_tokens(module in module_name(), prefix in left_boundary_char()) {
+        let line = format!("{prefix}{module};");
+        let start = prefix.len_utf8();
+        let span = parse_module_token(&line, start)
+            .ok_or_else(|| TestCaseError::Fail("embedded token should still parse from explicit offset".into()))?;
+
+        prop_assert_eq!(span, ModuleTokenSpan { start, end: start + module.len() });
+        prop_assert!(!has_standalone_module_token_boundaries(&line, span.start, span.end));
+    }
+
+    #[test]
+    fn prop_right_boundary_rejects_colon_context(module in module_name()) {
+        let line = format!("use {module}:");
+        let span = parse_module_token(&line, 4)
+            .ok_or_else(|| TestCaseError::Fail("token before colon should parse from explicit offset".into()))?;
+
+        prop_assert_eq!(span, ModuleTokenSpan { start: 4, end: 4 + module.len() });
+        prop_assert!(!has_standalone_module_token_boundaries(&line, span.start, span.end));
+    }
+
+    #[test]
+    fn prop_apostrophe_context_breaks_standalone_boundaries(
+        module in module_name(),
+        left_ident in token_segment(),
+        right_ident in token_segment(),
+    ) {
+        let left_line = format!("{left_ident}'{module};");
+        let left_start = left_ident.len() + 1;
+        let left_span = parse_module_token(&left_line, left_start)
+            .ok_or_else(|| TestCaseError::Fail("token after legacy separator should parse from explicit offset".into()))?;
+        prop_assert!(!has_standalone_module_token_boundaries(&left_line, left_span.start, left_span.end));
+
+        let right_line = format!("use {module}::{right_ident}'{right_ident}");
+        let right_end = 4 + module.len();
+        prop_assert!(!has_standalone_module_token_boundaries(&right_line, 4, right_end));
+    }
+
+    #[test]
+    fn prop_trailing_separators_are_rejected(
+        module in module_name(),
+        separator in prop_oneof![Just("::"), Just("'")],
+    ) {
+        let line = format!("{module}{separator}");
+        prop_assert!(parse_module_token(&line, 0).is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve property-test coverage for module token parsing to catch boundary/context edge-cases (embedded left/right contexts, apostrophe adjacency and trailing separators). 

### Description
- Add a dedicated left-side boundary character strategy `left_boundary_char()` to generate embedded-left contexts for property tests in `crates/perl-module-token-core/tests/module_token_core_prop.rs`.
- Add property tests that assert non-standalone behavior when a token is embedded on the left, when a token is followed by a colon, and when apostrophe/legacy separators appear adjacent to tokens.
- Add a property verifying that trailing canonical (`::`) and legacy (`'`) separators are rejected for generated module names, and keep the existing random-offset panic-safety property.

### Testing
- Ran `cargo test -p perl-module-token-core --test module_token_core_prop` and the property suite passed (all property tests succeeded).
- Ran `cargo test -p perl-module-token-core --tests` and all unit/integration/property tests in that crate passed.
- Ran `cargo test -p perl-module-token-parser --tests` and the parser crate tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a65815c83338934f5046f155d35)