### PR TITLE
Add all-features capability snapshot and profile-difference tests

### DIFF
--- a/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
@@ -15,6 +15,9 @@ const PRODUCTION_CAPABILITIES_SNAPSHOT: &str =
 /// Snapshot of GA-lock capabilities
 const GA_LOCK_CAPABILITIES_SNAPSHOT: &str = include_str!("snapshots/ga_lock_capabilities.json");
 
+/// Snapshot of all feature-gated capabilities
+const ALL_CAPABILITIES_SNAPSHOT: &str = include_str!("snapshots/all_capabilities.json");
+
 #[test]
 fn test_production_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
     let actual = capabilities_json(BuildFlags::production());
@@ -61,6 +64,78 @@ fn test_ga_lock_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
+#[test]
+fn test_all_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+    let actual = capabilities_json(BuildFlags::all());
+    let expected: Value = serde_json::from_str(ALL_CAPABILITIES_SNAPSHOT)?;
+
+    if actual != expected {
+        let actual_pretty = serde_json::to_string_pretty(&actual)?;
+        let expected_pretty = serde_json::to_string_pretty(&expected)?;
+
+        must(Err::<(), _>(format!(
+            "All-features capabilities have changed!\n\
+Expected:\n{}\n\nActual:\n{}",
+            expected_pretty, actual_pretty
+        )));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_profile_snapshots_capture_expected_differences() -> Result<(), Box<dyn std::error::Error>> {
+    let production = capabilities_json(BuildFlags::production());
+    let ga_lock = capabilities_json(BuildFlags::ga_lock());
+    let all = capabilities_json(BuildFlags::all());
+
+    assert!(
+        production.get("inlineValueProvider").is_some(),
+        "production snapshot should retain inline values"
+    );
+    assert!(
+        ga_lock.get("inlineValueProvider").is_none(),
+        "ga-lock snapshot should keep inline values disabled"
+    );
+    assert!(
+        all.get("inlineValueProvider").is_some(),
+        "all-features snapshot should include inline values"
+    );
+
+    assert!(
+        production.get("documentFormattingProvider").is_none(),
+        "production snapshot should keep runtime-dependent formatting disabled"
+    );
+    assert_eq!(
+        ga_lock.get("documentFormattingProvider"),
+        Some(&Value::Bool(true)),
+        "ga-lock snapshot should expose formatting"
+    );
+    assert_eq!(
+        all.get("documentFormattingProvider"),
+        Some(&Value::Bool(true)),
+        "all-features snapshot should expose formatting"
+    );
+
+    assert_eq!(
+        production.get("documentRangeFormattingProvider"),
+        None,
+        "production snapshot should keep range formatting disabled"
+    );
+    assert_eq!(
+        ga_lock.get("documentRangeFormattingProvider"),
+        Some(&Value::Bool(true)),
+        "ga-lock snapshot should expose range formatting"
+    );
+    assert_eq!(
+        all.get("documentRangeFormattingProvider"),
+        Some(&Value::Bool(true)),
+        "all-features snapshot should expose range formatting"
+    );
+
+    Ok(())
+}
+
 fn write_snapshots(snapshots_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
     fs::create_dir_all(snapshots_dir)?;
@@ -74,6 +149,11 @@ fn write_snapshots(snapshots_dir: &Path) -> Result<(), Box<dyn std::error::Error
     let ga_lock_caps = capabilities_json(BuildFlags::ga_lock());
     let ga_lock_json = serde_json::to_string_pretty(&ga_lock_caps)?;
     fs::write(snapshots_dir.join("ga_lock_capabilities.json"), ga_lock_json)?;
+
+    // Generate all-features snapshot
+    let all_caps = capabilities_json(BuildFlags::all());
+    let all_json = serde_json::to_string_pretty(&all_caps)?;
+    fs::write(snapshots_dir.join("all_capabilities.json"), all_json)?;
 
     Ok(())
 }
@@ -89,6 +169,7 @@ fn regenerate_snapshots() -> Result<(), Box<dyn std::error::Error>> {
     let generated_production =
         fs::read_to_string(temp_dir.path().join("production_capabilities.json"))?;
     let generated_ga_lock = fs::read_to_string(temp_dir.path().join("ga_lock_capabilities.json"))?;
+    let generated_all = fs::read_to_string(temp_dir.path().join("all_capabilities.json"))?;
 
     let expected_production = serde_json::to_string_pretty(&serde_json::from_str::<Value>(
         PRODUCTION_CAPABILITIES_SNAPSHOT,
@@ -96,6 +177,8 @@ fn regenerate_snapshots() -> Result<(), Box<dyn std::error::Error>> {
     let expected_ga_lock = serde_json::to_string_pretty(&serde_json::from_str::<Value>(
         GA_LOCK_CAPABILITIES_SNAPSHOT,
     )?)?;
+    let expected_all =
+        serde_json::to_string_pretty(&serde_json::from_str::<Value>(ALL_CAPABILITIES_SNAPSHOT)?)?;
 
     assert_eq!(
         generated_production, expected_production,
@@ -104,6 +187,10 @@ fn regenerate_snapshots() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(
         generated_ga_lock, expected_ga_lock,
         "regenerated ga-lock snapshot should match checked-in snapshot"
+    );
+    assert_eq!(
+        generated_all, expected_all,
+        "regenerated all-features snapshot should match checked-in snapshot"
     );
 
     Ok(())

--- a/crates/perl-lsp/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/all_capabilities.json
@@ -1,0 +1,145 @@
+{
+  "callHierarchyProvider": true,
+  "codeActionProvider": {
+    "codeActionKinds": [
+      "quickfix",
+      "source.organizeImports",
+      "refactor.extract"
+    ],
+    "resolveProvider": true
+  },
+  "codeLensProvider": {
+    "resolveProvider": true
+  },
+  "colorProvider": true,
+  "completionProvider": {
+    "resolveProvider": true,
+    "triggerCharacters": [
+      "$",
+      "@",
+      "%",
+      "->"
+    ]
+  },
+  "declarationProvider": true,
+  "definitionProvider": true,
+  "diagnosticProvider": {
+    "identifier": "perl-lsp",
+    "interFileDependencies": false,
+    "workspaceDiagnostics": true
+  },
+  "documentFormattingProvider": true,
+  "documentHighlightProvider": true,
+  "documentLinkProvider": {
+    "resolveProvider": true
+  },
+  "documentOnTypeFormattingProvider": {
+    "firstTriggerCharacter": "}",
+    "moreTriggerCharacter": [
+      ";"
+    ]
+  },
+  "documentRangeFormattingProvider": true,
+  "documentSymbolProvider": true,
+  "executeCommandProvider": {
+    "commands": [
+      "perl.runTests",
+      "perl.runFile",
+      "perl.runTestSub",
+      "perl.runCritic",
+      "perl.runTest",
+      "perl.runTestFile",
+      "perl.debugFile"
+    ]
+  },
+  "experimental": {
+    "inlineCompletionProvider": {}
+  },
+  "foldingRangeProvider": true,
+  "hoverProvider": true,
+  "implementationProvider": true,
+  "inlayHintProvider": {
+    "resolveProvider": true
+  },
+  "inlineValueProvider": true,
+  "linkedEditingRangeProvider": true,
+  "monikerProvider": true,
+  "notebookDocumentSync": {
+    "notebookSelector": [
+      {
+        "cells": [
+          {
+            "language": "perl"
+          }
+        ],
+        "notebook": "jupyter-notebook"
+      }
+    ],
+    "save": true
+  },
+  "referencesProvider": true,
+  "renameProvider": {
+    "prepareProvider": true
+  },
+  "selectionRangeProvider": true,
+  "semanticTokensProvider": {
+    "full": true,
+    "legend": {
+      "tokenModifiers": [
+        "declaration",
+        "definition",
+        "readonly",
+        "static",
+        "deprecated",
+        "abstract",
+        "async",
+        "modification",
+        "documentation",
+        "defaultLibrary"
+      ],
+      "tokenTypes": [
+        "namespace",
+        "type",
+        "class",
+        "interface",
+        "enum",
+        "enumMember",
+        "typeParameter",
+        "function",
+        "method",
+        "property",
+        "macro",
+        "variable",
+        "parameter",
+        "keyword",
+        "modifier",
+        "comment",
+        "string",
+        "number",
+        "regexp",
+        "operator"
+      ]
+    },
+    "range": true
+  },
+  "signatureHelpProvider": {
+    "retriggerCharacters": [
+      ","
+    ],
+    "triggerCharacters": [
+      "(",
+      ","
+    ]
+  },
+  "textDocumentSync": {
+    "change": 2,
+    "openClose": true
+  },
+  "typeDefinitionProvider": true,
+  "typeHierarchyProvider": {
+    "workDoneProgressOptions": {}
+  },
+  "workspaceSymbolProvider": {
+    "resolveProvider": true
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve snapshot-based coverage of LSP server capabilities by including a checked-in snapshot for the fully-enabled `BuildFlags::all()` profile so differences between production/GA-lock/all profiles are detected and prevented from regressing.

### Description
- Add a new checked-in snapshot file `crates/perl-lsp/tests/snapshots/all_capabilities.json` containing the JSON output for `BuildFlags::all()`.
- Extend `crates/perl-lsp/tests/lsp_capabilities_snapshot.rs` with `ALL_CAPABILITIES_SNAPSHOT` and a `test_all_capabilities_snapshot` that asserts `capabilities_json(BuildFlags::all())` matches the checked-in snapshot.
- Add `test_profile_snapshots_capture_expected_differences` to assert expected differences across `production`, `ga_lock`, and `all` profiles (checks for `inlineValueProvider`, `documentFormattingProvider`, and `documentRangeFormattingProvider`).
- Update the snapshot regeneration helper `write_snapshots` and the `regenerate_snapshots` test so the helper produces and validates the `all_capabilities.json` file alongside the existing production and GA-lock snapshots.

### Testing
- Ran `cargo test -p perl-lsp --test lsp_capabilities_snapshot` and all tests passed. (5 tests: `test_all_capabilities_snapshot`, `test_ga_lock_capabilities_snapshot`, `test_production_capabilities_snapshot`, `test_profile_snapshots_capture_expected_differences`, `regenerate_snapshots`.)
- Ran `cargo test -p perl-lsp --test lsp_capabilities_snapshot -- --exact regenerate_snapshots` and the regeneration test passed. 
- Ran `cargo fmt --all --check` and formatting check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a5d82708333be89034644dc1009)