### PR TITLE
Improve capability snapshot coverage

### DIFF
--- a/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
@@ -6,7 +6,8 @@
 use perl_lsp::protocol::capabilities::{BuildFlags, capabilities_json};
 use perl_tdd_support::must;
 use serde_json::Value;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 /// Snapshot of production capabilities (v0.8.5)
 const PRODUCTION_CAPABILITIES_SNAPSHOT: &str =
@@ -15,65 +16,92 @@ const PRODUCTION_CAPABILITIES_SNAPSHOT: &str =
 /// Snapshot of GA-lock capabilities
 const GA_LOCK_CAPABILITIES_SNAPSHOT: &str = include_str!("snapshots/ga_lock_capabilities.json");
 
-#[test]
-fn test_production_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
-    let actual = capabilities_json(BuildFlags::production());
-    let expected: Value = serde_json::from_str(PRODUCTION_CAPABILITIES_SNAPSHOT)?;
+/// Snapshot of all in-tree capabilities used by CI and tooling.
+const ALL_CAPABILITIES_SNAPSHOT: &str = include_str!("snapshots/all_capabilities.json");
+
+struct SnapshotCase<'a> {
+    name: &'a str,
+    flags: BuildFlags,
+    expected: &'a str,
+    output_file: &'a str,
+    drift_message: &'a str,
+}
+
+fn snapshot_cases() -> Vec<SnapshotCase<'static>> {
+    vec![
+        SnapshotCase {
+            name: "production",
+            flags: BuildFlags::production(),
+            expected: PRODUCTION_CAPABILITIES_SNAPSHOT,
+            output_file: "production_capabilities.json",
+            drift_message: "Production capabilities have changed!\n\
+                If this is intentional:\n\
+                1. Update the changelog\n\
+                2. Validate regeneration with: cargo test -p perl-lsp --test lsp_capabilities_snapshot regenerate_snapshots\n\
+                3. Commit the new snapshot",
+        },
+        SnapshotCase {
+            name: "ga-lock",
+            flags: BuildFlags::ga_lock(),
+            expected: GA_LOCK_CAPABILITIES_SNAPSHOT,
+            output_file: "ga_lock_capabilities.json",
+            drift_message: "GA-lock capabilities have changed!\n\
+                This should NEVER change without a major version bump.",
+        },
+        SnapshotCase {
+            name: "all",
+            flags: BuildFlags::all(),
+            expected: ALL_CAPABILITIES_SNAPSHOT,
+            output_file: "all_capabilities.json",
+            drift_message: "All-capabilities snapshot has changed!\n\
+                Review CI/tooling expectations and commit the refreshed snapshot if intentional.",
+        },
+    ]
+}
+
+fn compare_snapshot(case: &SnapshotCase<'_>) -> Result<(), Box<dyn std::error::Error>> {
+    let actual = capabilities_json(case.flags.clone());
+    let expected: Value = serde_json::from_str(case.expected)?;
 
     if actual != expected {
-        // Pretty print the diff for debugging
         let actual_pretty = serde_json::to_string_pretty(&actual)?;
         let expected_pretty = serde_json::to_string_pretty(&expected)?;
 
         must(Err::<(), _>(format!(
-            "Production capabilities have changed!\n\
-            If this is intentional:\n\
-            1. Update the changelog\n\
-            2. Validate regeneration with: cargo test -p perl-lsp --test lsp_capabilities_snapshot regenerate_snapshots\n\
-            3. Commit the new snapshot\n\n\
-            Expected:\n{}\n\n\
-            Actual:\n{}",
-            expected_pretty, actual_pretty
+            "{}\n\nExpected:\n{}\n\nActual:\n{}",
+            case.drift_message, expected_pretty, actual_pretty
         )));
     }
 
     Ok(())
+}
+
+fn expected_snapshot_paths(root: &Path) -> Vec<PathBuf> {
+    snapshot_cases().into_iter().map(|case| root.join(case.output_file)).collect()
+}
+
+#[test]
+fn test_production_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+    compare_snapshot(&snapshot_cases()[0])
 }
 
 #[test]
 fn test_ga_lock_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
-    let actual = capabilities_json(BuildFlags::ga_lock());
-    let expected: Value = serde_json::from_str(GA_LOCK_CAPABILITIES_SNAPSHOT)?;
+    compare_snapshot(&snapshot_cases()[1])
+}
 
-    if actual != expected {
-        let actual_pretty = serde_json::to_string_pretty(&actual)?;
-        let expected_pretty = serde_json::to_string_pretty(&expected)?;
-
-        must(Err::<(), _>(format!(
-            "GA-lock capabilities have changed!\n\
-            This should NEVER change without a major version bump.\n\n\
-            Expected:\n{}\n\n\
-            Actual:\n{}",
-            expected_pretty, actual_pretty
-        )));
-    }
-
-    Ok(())
+#[test]
+fn test_all_capabilities_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+    compare_snapshot(&snapshot_cases()[2])
 }
 
 fn write_snapshots(snapshots_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    use std::fs;
     fs::create_dir_all(snapshots_dir)?;
 
-    // Generate production snapshot
-    let production_caps = capabilities_json(BuildFlags::production());
-    let production_json = serde_json::to_string_pretty(&production_caps)?;
-    fs::write(snapshots_dir.join("production_capabilities.json"), production_json)?;
-
-    // Generate GA lock snapshot
-    let ga_lock_caps = capabilities_json(BuildFlags::ga_lock());
-    let ga_lock_json = serde_json::to_string_pretty(&ga_lock_caps)?;
-    fs::write(snapshots_dir.join("ga_lock_capabilities.json"), ga_lock_json)?;
+    for case in snapshot_cases() {
+        let rendered = serde_json::to_string_pretty(&capabilities_json(case.flags))?;
+        fs::write(snapshots_dir.join(case.output_file), rendered)?;
+    }
 
     Ok(())
 }
@@ -81,29 +109,34 @@ fn write_snapshots(snapshots_dir: &Path) -> Result<(), Box<dyn std::error::Error
 /// Validates snapshot regeneration logic without mutating repository files.
 #[test]
 fn regenerate_snapshots() -> Result<(), Box<dyn std::error::Error>> {
-    use std::fs;
-
     let temp_dir = tempfile::tempdir()?;
     write_snapshots(temp_dir.path())?;
 
-    let generated_production =
-        fs::read_to_string(temp_dir.path().join("production_capabilities.json"))?;
-    let generated_ga_lock = fs::read_to_string(temp_dir.path().join("ga_lock_capabilities.json"))?;
+    for case in snapshot_cases() {
+        let generated = fs::read_to_string(temp_dir.path().join(case.output_file))?;
+        let expected =
+            serde_json::to_string_pretty(&serde_json::from_str::<Value>(case.expected)?)?;
 
-    let expected_production = serde_json::to_string_pretty(&serde_json::from_str::<Value>(
-        PRODUCTION_CAPABILITIES_SNAPSHOT,
-    )?)?;
-    let expected_ga_lock = serde_json::to_string_pretty(&serde_json::from_str::<Value>(
-        GA_LOCK_CAPABILITIES_SNAPSHOT,
-    )?)?;
+        assert_eq!(
+            generated, expected,
+            "regenerated {} snapshot should match checked-in snapshot",
+            case.name
+        );
+    }
+
+    let mut generated_files = expected_snapshot_paths(temp_dir.path());
+    generated_files.sort();
+
+    let mut expected_files = vec![
+        temp_dir.path().join("all_capabilities.json"),
+        temp_dir.path().join("ga_lock_capabilities.json"),
+        temp_dir.path().join("production_capabilities.json"),
+    ];
+    expected_files.sort();
 
     assert_eq!(
-        generated_production, expected_production,
-        "regenerated production snapshot should match checked-in snapshot"
-    );
-    assert_eq!(
-        generated_ga_lock, expected_ga_lock,
-        "regenerated ga-lock snapshot should match checked-in snapshot"
+        generated_files, expected_files,
+        "regeneration should cover every tracked capability snapshot"
     );
 
     Ok(())

--- a/crates/perl-lsp/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/all_capabilities.json
@@ -1,0 +1,145 @@
+{
+  "callHierarchyProvider": true,
+  "codeActionProvider": {
+    "codeActionKinds": [
+      "quickfix",
+      "source.organizeImports",
+      "refactor.extract"
+    ],
+    "resolveProvider": true
+  },
+  "codeLensProvider": {
+    "resolveProvider": true
+  },
+  "colorProvider": true,
+  "completionProvider": {
+    "resolveProvider": true,
+    "triggerCharacters": [
+      "$",
+      "@",
+      "%",
+      "->"
+    ]
+  },
+  "declarationProvider": true,
+  "definitionProvider": true,
+  "diagnosticProvider": {
+    "identifier": "perl-lsp",
+    "interFileDependencies": false,
+    "workspaceDiagnostics": true
+  },
+  "documentFormattingProvider": true,
+  "documentHighlightProvider": true,
+  "documentLinkProvider": {
+    "resolveProvider": true
+  },
+  "documentOnTypeFormattingProvider": {
+    "firstTriggerCharacter": "}",
+    "moreTriggerCharacter": [
+      ";"
+    ]
+  },
+  "documentRangeFormattingProvider": true,
+  "documentSymbolProvider": true,
+  "executeCommandProvider": {
+    "commands": [
+      "perl.runTests",
+      "perl.runFile",
+      "perl.runTestSub",
+      "perl.runCritic",
+      "perl.runTest",
+      "perl.runTestFile",
+      "perl.debugFile"
+    ]
+  },
+  "experimental": {
+    "inlineCompletionProvider": {}
+  },
+  "foldingRangeProvider": true,
+  "hoverProvider": true,
+  "implementationProvider": true,
+  "inlayHintProvider": {
+    "resolveProvider": true
+  },
+  "inlineValueProvider": true,
+  "linkedEditingRangeProvider": true,
+  "monikerProvider": true,
+  "notebookDocumentSync": {
+    "notebookSelector": [
+      {
+        "cells": [
+          {
+            "language": "perl"
+          }
+        ],
+        "notebook": "jupyter-notebook"
+      }
+    ],
+    "save": true
+  },
+  "referencesProvider": true,
+  "renameProvider": {
+    "prepareProvider": true
+  },
+  "selectionRangeProvider": true,
+  "semanticTokensProvider": {
+    "full": true,
+    "legend": {
+      "tokenModifiers": [
+        "declaration",
+        "definition",
+        "readonly",
+        "static",
+        "deprecated",
+        "abstract",
+        "async",
+        "modification",
+        "documentation",
+        "defaultLibrary"
+      ],
+      "tokenTypes": [
+        "namespace",
+        "type",
+        "class",
+        "interface",
+        "enum",
+        "enumMember",
+        "typeParameter",
+        "function",
+        "method",
+        "property",
+        "macro",
+        "variable",
+        "parameter",
+        "keyword",
+        "modifier",
+        "comment",
+        "string",
+        "number",
+        "regexp",
+        "operator"
+      ]
+    },
+    "range": true
+  },
+  "signatureHelpProvider": {
+    "retriggerCharacters": [
+      ","
+    ],
+    "triggerCharacters": [
+      "(",
+      ","
+    ]
+  },
+  "textDocumentSync": {
+    "change": 2,
+    "openClose": true
+  },
+  "typeDefinitionProvider": true,
+  "typeHierarchyProvider": {
+    "workDoneProgressOptions": {}
+  },
+  "workspaceSymbolProvider": {
+    "resolveProvider": true
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure snapshot-based capability checks cover the full in-tree capability surface used by CI and tooling to prevent undetected drift.
- Add an explicit `BuildFlags::all()` snapshot so regeneration and tooling can rely on a deterministic fixture for the all-capabilities profile.

### Description
- Refactor `crates/perl-lsp/tests/lsp_capabilities_snapshot.rs` to drive checks from a shared `SnapshotCase` struct and `snapshot_cases()` helper. 
- Add an `ALL_CAPABILITIES_SNAPSHOT` constant and a checked-in fixture `crates/perl-lsp/tests/snapshots/all_capabilities.json` representing `BuildFlags::all()`.
- Introduce `compare_snapshot()` and `expected_snapshot_paths()` helpers and update `write_snapshots()` to iterate all tracked cases when regenerating snapshots. 
- Add `test_all_capabilities_snapshot` and update `regenerate_snapshots` to assert that every tracked snapshot file is regenerated.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran the snapshot test set with `cargo test -p perl-lsp --test lsp_capabilities_snapshot` and the suite passed (`4` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a5d82708333be89034644dc1009)