### PR TITLE
test: expand code action BDD coverage

### DIFF
--- a/crates/perl-lsp-code-actions/tests/behavior_spec_tests.rs
+++ b/crates/perl-lsp-code-actions/tests/behavior_spec_tests.rs
@@ -143,6 +143,16 @@ fn when_cursor_on_undefined_variable_my_is_preferred_over_our() {
     );
 }
 
+#[test]
+fn when_cursor_on_undeclared_variable_alias_offers_same_declarations() {
+    let source = "print $missing;";
+    let diagnostics = [diag(6, 14, "undeclared-variable", "Undefined variable '$missing'")];
+    let actions = actions_for(source, &diagnostics);
+
+    assert!(has_action(&actions, "Declare '$missing' with 'my'"));
+    assert!(has_action(&actions, "Declare '$missing' with 'our'"));
+}
+
 // ===========================================================================
 // Quick-fix scenarios: assignment in condition
 // ===========================================================================
@@ -260,6 +270,19 @@ fn when_unclosed_brace_offers_add_closing_brace() {
 }
 
 #[test]
+fn when_unclosed_block_offers_add_closing_brace() {
+    let source = "if ($x) {";
+    let diagnostics = [diag(0, 9, "parse-error-unclosedblock", "Unclosed block")];
+    let actions = actions_for(source, &diagnostics);
+
+    assert!(
+        has_action(&actions, "Add closing brace"),
+        "should offer to close an unclosed block, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn when_unclosed_string_offers_add_closing_quote() {
     let source = r#"my $x = "hello"#;
     let diagnostics = [diag(8, 14, "parse-error-unclosedstring", "Unclosed string")];
@@ -301,6 +324,30 @@ fn when_deprecated_defined_array_offers_replacement() {
         "should offer to replace deprecated defined() call, got: {:?}",
         actions.iter().map(|a| &a.title).collect::<Vec<_>>()
     );
+}
+
+// ===========================================================================
+// Quick-fix scenarios: numeric comparison with undef
+// ===========================================================================
+
+#[test]
+fn when_numeric_comparison_uses_undef_offers_defined_check_and_fallback() {
+    let source = "if ($value == undef) { }";
+    let diagnostics = [diag(4, 19, "numeric-undef", "Numeric comparison with undef")];
+    let actions = actions_for(source, &diagnostics);
+
+    assert!(has_action(&actions, "Add defined check"));
+    assert!(has_action(&actions, "defined-or operator"));
+}
+
+#[test]
+fn when_numeric_undef_range_has_no_equality_operator_skips_defined_or_fallback() {
+    let source = "print $value;";
+    let diagnostics = [diag(6, 12, "numeric-undef", "Numeric comparison with undef")];
+    let actions = actions_for(source, &diagnostics);
+
+    assert!(has_action(&actions, "Add defined check"));
+    assert!(!has_action(&actions, "defined-or operator"));
 }
 
 // ===========================================================================
@@ -461,6 +508,36 @@ fn when_source_lacks_strict_enhanced_offers_add_pragmas() {
         "should offer to add missing pragmas when strict is absent, got: {:?}",
         actions.iter().map(|a| &a.title).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn when_source_starts_with_shebang_pragmas_are_inserted_after_it() {
+    let source = "#!/usr/bin/env perl\nmy $x = 1;";
+    let actions = enhanced_actions_for(source, (0, source.len()));
+    let pragma_action = actions
+        .iter()
+        .find(|action| action.title.contains("missing pragmas"))
+        .expect("expected pragma insertion action");
+
+    assert_eq!(pragma_action.edit.changes.len(), 1);
+    let change = &pragma_action.edit.changes[0];
+    assert_eq!(change.location.start, "#!/usr/bin/env perl\n".len());
+    assert!(change.new_text.contains("use strict;"));
+    assert!(change.new_text.contains("use warnings;"));
+}
+
+#[test]
+fn when_imports_are_out_of_order_enhanced_actions_offer_organization() {
+    let source = "use My::Local;\nuse strict;\nuse warnings;\n";
+    let actions = enhanced_actions_for(source, (0, source.len()));
+    let organize = actions
+        .iter()
+        .find(|action| action.title == "Organize imports")
+        .expect("expected organize imports action");
+
+    assert_eq!(organize.kind, CodeActionKind::SourceOrganizeImports);
+    let change = &organize.edit.changes[0];
+    assert_eq!(change.new_text, "use strict;\nuse warnings;\nuse My::Local;\n");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Increase behavioral (BDD-style) test coverage for the Code Actions provider to exercise alias diagnostic codes, numeric-undef handling, parse-error variants and enhanced action edit semantics.
- Verify not only presence of suggested actions but also the produced edit locations and replacement text for important user-visible actions like pragma insertion and import organization.

### Description
- Added multiple BDD tests to `crates/perl-lsp-code-actions/tests/behavior_spec_tests.rs` covering `undeclared-variable` as an alias of `undefined-variable` and ensuring both `my`/`our` declarations are offered.
- Added tests for `numeric-undef` quick fixes that assert both the `Add defined check` action and a `defined-or` fallback when an equality operator is present and the absence of the fallback when it is not.
- Added a test for `parse-error-unclosedblock` so unclosed block errors produce the same closing-brace quickfix as `parse-error-unclosedbrace`.
- Added enhanced-action assertions that check pragma insertion respects shebang placement and that `Organize imports` produces the expected sorted `new_text` edit.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran the targeted behavioral test binary with `cargo test -p perl-lsp-code-actions --test behavior_spec_tests` which passed (41 tests, 0 failures).
- Ran the full crate test suite with `cargo test -p perl-lsp-code-actions` which completed successfully (all unit and integration tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a5646f48333851a4e64262325c3)