### PR TITLE
test: improve workspace discovery BDD coverage

### DIFF
--- a/crates/perl-workspace-discovery/tests/discovery_bdd_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_bdd_tests.rs
@@ -82,3 +82,83 @@ fn given_git_workspace_when_discovering_then_git_strategy_respects_gitignore() -
 
     Ok(())
 }
+
+#[test]
+fn given_git_workspace_with_untracked_sources_when_discovering_then_git_strategy_includes_them()
+-> TestResult {
+    if !git_available() {
+        return Ok(());
+    }
+
+    let tmp = TempDir::new()?;
+    let root = tmp.path();
+
+    run_git(root, &["init", "--quiet"])?;
+    create_file(root, "tracked/Module.pm")?;
+    create_file(root, "untracked/script.pl")?;
+    create_file(root, "notes.txt")?;
+    run_git(root, &["add", "tracked/Module.pm"])?;
+
+    let result = discover_perl_files(root);
+
+    assert_eq!(result.method, DiscoveryMethod::Git);
+    assert!(result.files.iter().any(|path| path.ends_with("tracked/Module.pm")));
+    assert!(result.files.iter().any(|path| path.ends_with("untracked/script.pl")));
+    assert!(!result.files.iter().any(|path| path.ends_with("notes.txt")));
+
+    Ok(())
+}
+
+#[test]
+fn given_git_workspace_with_tracked_noise_inside_skipped_dir_when_discovering_then_skip_rules_still_win()
+-> TestResult {
+    if !git_available() {
+        return Ok(());
+    }
+
+    let tmp = TempDir::new()?;
+    let root = tmp.path();
+
+    run_git(root, &["init", "--quiet"])?;
+    create_file(root, "lib/Kept.pm")?;
+    create_file(root, "target/generated/Tracked.pm")?;
+    create_file(root, "node_modules/vendor/TrackedToo.pm")?;
+    run_git(root, &["add", "."])?;
+
+    let result = discover_perl_files(root);
+
+    assert_eq!(result.method, DiscoveryMethod::Git);
+    assert_eq!(result.files.len(), 1);
+    assert!(result.files.iter().any(|path| path.ends_with("lib/Kept.pm")));
+    assert!(!result.files.iter().any(|path| path.to_string_lossy().contains("target/generated")));
+    assert!(
+        !result.files.iter().any(|path| path.to_string_lossy().contains("node_modules/vendor"))
+    );
+    assert!(result.excluded_count >= 2);
+
+    Ok(())
+}
+
+#[test]
+fn given_git_workspace_with_only_ignored_or_non_perl_files_when_discovering_then_result_is_empty_but_git_strategy_is_used()
+-> TestResult {
+    if !git_available() {
+        return Ok(());
+    }
+
+    let tmp = TempDir::new()?;
+    let root = tmp.path();
+
+    run_git(root, &["init", "--quiet"])?;
+    fs::write(root.join(".gitignore"), "build/\n")?;
+    create_file(root, "README.md")?;
+    create_file(root, "build/ignored.pm")?;
+
+    let result = discover_perl_files(root);
+
+    assert_eq!(result.method, DiscoveryMethod::Git);
+    assert!(result.files.is_empty());
+    assert!(result.excluded_count >= 1);
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Increase BDD-style coverage for workspace discovery to exercise additional git-mode scenarios and reduce regression risk. 

### Description
- Add three git-focused BDD scenarios to `crates/perl-workspace-discovery/tests/discovery_bdd_tests.rs` that cover untracked Perl files, tracked files placed inside skipped directories, and repos that contain only ignored/non-Perl files. 
- Preserve existing test structure and walk-mode scenario while broadening coverage of `discover_perl_files`'s git and skip-rule behavior. 

### Testing
- Ran formatting with `cargo fmt --all` (success). 
- Ran unit and BDD tests with `cargo test -p perl-workspace-discovery`, which completed successfully with all new and existing tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a5518e08333807a7df0c5f51259)