### PR TITLE
Extract workspace index monitoring microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,11 +2716,19 @@ dependencies = [
  "perl-symbol-types",
  "perl-tdd-support",
  "perl-uri",
+ "perl-workspace-index-monitoring",
  "perl-workspace-index-slo",
  "perl-workspace-index-state-machine",
  "serde",
  "tempfile",
  "url",
+]
+
+[[package]]
+name = "perl-workspace-index-monitoring"
+version = "0.11.0"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/perl-parser-pest",
     "crates/perl-semantic-analyzer",
     "crates/perl-workspace-index",
+    "crates/perl-workspace-index-monitoring",
     "crates/perl-workspace-index-state-machine",
     "crates/perl-workspace-index-slo",
     "crates/perl-refactoring",
@@ -385,6 +386,7 @@ perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.
 
 # Tier 3: Two-level dependencies
 perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.11.0" }
+perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.11.0" }
 perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.11.0" }
 perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.11.0" }
 perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.11.0" }

--- a/crates/perl-workspace-index-monitoring/Cargo.toml
+++ b/crates/perl-workspace-index-monitoring/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "perl-workspace-index-monitoring"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Monitoring, limits, and lifecycle instrumentation primitives for workspace index coordination"
+readme = "README.md"
+documentation = "https://docs.rs/perl-workspace-index-monitoring"
+keywords = ["perl", "workspace", "index", "monitoring", "lsp"]
+categories = ["development-tools", "text-editors"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+parking_lot = "0.12.5"
+
+[lints]
+workspace = true

--- a/crates/perl-workspace-index-monitoring/README.md
+++ b/crates/perl-workspace-index-monitoring/README.md
@@ -1,0 +1,12 @@
+# Perl Workspace Index Monitoring
+
+This microcrate provides the narrow monitoring/configuration layer for workspace
+index coordination:
+
+- resource-limit configuration
+- performance-cap budgets
+- pending-parse metrics
+- lifecycle instrumentation snapshots and counters
+
+It exists to keep `perl-workspace-index` focused on symbol indexing and query
+behavior while preserving reusable coordinator primitives.

--- a/crates/perl-workspace-index-monitoring/src/lib.rs
+++ b/crates/perl-workspace-index-monitoring/src/lib.rs
@@ -1,0 +1,353 @@
+//! Monitoring, limits, and lifecycle instrumentation primitives for workspace index coordination.
+//!
+//! This microcrate extracts coordinator support types from the main workspace index
+//! implementation so the indexing engine can stay focused on symbol extraction and
+//! query behavior.
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Instant;
+
+/// Build phase while the index is in `Building` state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum IndexPhase {
+    /// No scan has started yet.
+    Idle,
+    /// Workspace file discovery is in progress.
+    Scanning,
+    /// Symbol indexing is in progress.
+    Indexing,
+}
+
+/// Coarse index state kinds for instrumentation and transition tracking.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum IndexStateKind {
+    /// Index is being built.
+    Building,
+    /// Index is ready for full queries.
+    Ready,
+    /// Index is degraded and serving partial results.
+    Degraded,
+}
+
+/// A state transition for index lifecycle instrumentation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct IndexStateTransition {
+    /// Transition start state.
+    pub from: IndexStateKind,
+    /// Transition end state.
+    pub to: IndexStateKind,
+}
+
+/// A phase transition while building the workspace index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct IndexPhaseTransition {
+    /// Transition start phase.
+    pub from: IndexPhase,
+    /// Transition end phase.
+    pub to: IndexPhase,
+}
+
+/// Early-exit reasons for workspace indexing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EarlyExitReason {
+    /// Initial scan exceeded the configured time budget.
+    InitialTimeBudget,
+    /// Incremental update exceeded the configured time budget.
+    IncrementalTimeBudget,
+    /// Workspace contained too many files to index within limits.
+    FileLimit,
+}
+
+/// Record describing the latest early-exit event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EarlyExitRecord {
+    /// Why the early exit occurred.
+    pub reason: EarlyExitReason,
+    /// Elapsed time in milliseconds when the exit occurred.
+    pub elapsed_ms: u64,
+    /// Files indexed when the exit occurred.
+    pub indexed_files: usize,
+    /// Total files discovered when the exit occurred.
+    pub total_files: usize,
+}
+
+/// Snapshot of index lifecycle instrumentation.
+#[derive(Clone, Debug)]
+pub struct IndexInstrumentationSnapshot {
+    /// Accumulated time spent per state (milliseconds).
+    pub state_durations_ms: HashMap<IndexStateKind, u64>,
+    /// Accumulated time spent per build phase (milliseconds).
+    pub phase_durations_ms: HashMap<IndexPhase, u64>,
+    /// Counts of state transitions.
+    pub state_transition_counts: HashMap<IndexStateTransition, u64>,
+    /// Counts of phase transitions.
+    pub phase_transition_counts: HashMap<IndexPhaseTransition, u64>,
+    /// Counts of early exit reasons.
+    pub early_exit_counts: HashMap<EarlyExitReason, u64>,
+    /// Most recent early exit record.
+    pub last_early_exit: Option<EarlyExitRecord>,
+}
+
+/// Type of resource limit that was exceeded.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResourceKind {
+    /// Maximum number of files in index exceeded.
+    MaxFiles,
+    /// Maximum total symbols exceeded.
+    MaxSymbols,
+    /// Maximum AST cache bytes exceeded.
+    MaxCacheBytes,
+}
+
+/// Reason for index degradation.
+#[derive(Clone, Debug)]
+pub enum DegradationReason {
+    /// Parse storm (too many simultaneous changes).
+    ParseStorm {
+        /// Number of pending parse operations.
+        pending_parses: usize,
+    },
+    /// IO error during indexing.
+    IoError {
+        /// Error message for diagnostics.
+        message: String,
+    },
+    /// Timeout during workspace scan.
+    ScanTimeout {
+        /// Elapsed time in milliseconds.
+        elapsed_ms: u64,
+    },
+    /// Resource limits exceeded.
+    ResourceLimit {
+        /// Which resource limit was exceeded.
+        kind: ResourceKind,
+    },
+}
+
+/// Configurable resource limits for workspace index.
+#[derive(Clone, Debug)]
+pub struct IndexResourceLimits {
+    /// Maximum files to index (default: 10,000).
+    pub max_files: usize,
+    /// Maximum symbols per file (default: 5,000).
+    pub max_symbols_per_file: usize,
+    /// Maximum total symbols (default: 500,000).
+    pub max_total_symbols: usize,
+    /// Maximum AST cache size in bytes (default: 256MB).
+    pub max_ast_cache_bytes: usize,
+    /// Maximum AST cache items (default: 100).
+    pub max_ast_cache_items: usize,
+    /// Maximum workspace scan duration in milliseconds (default: 30,000ms = 30s).
+    pub max_scan_duration_ms: u64,
+}
+
+impl Default for IndexResourceLimits {
+    fn default() -> Self {
+        Self {
+            max_files: 10_000,
+            max_symbols_per_file: 5_000,
+            max_total_symbols: 500_000,
+            max_ast_cache_bytes: 256 * 1024 * 1024,
+            max_ast_cache_items: 100,
+            max_scan_duration_ms: 30_000,
+        }
+    }
+}
+
+/// Performance caps for workspace indexing operations.
+#[derive(Clone, Debug)]
+pub struct IndexPerformanceCaps {
+    /// Initial workspace scan budget in milliseconds (default: 100ms).
+    pub initial_scan_budget_ms: u64,
+    /// Incremental update budget in milliseconds (default: 10ms).
+    pub incremental_budget_ms: u64,
+}
+
+impl Default for IndexPerformanceCaps {
+    fn default() -> Self {
+        Self { initial_scan_budget_ms: 100, incremental_budget_ms: 10 }
+    }
+}
+
+/// Metrics for index lifecycle management and degradation detection.
+pub struct IndexMetrics {
+    pending_parses: AtomicUsize,
+    parse_storm_threshold: usize,
+    #[allow(dead_code)]
+    last_indexed: AtomicU64,
+}
+
+impl IndexMetrics {
+    /// Create new metrics with default threshold (10 pending parses).
+    pub fn new() -> Self {
+        Self {
+            pending_parses: AtomicUsize::new(0),
+            parse_storm_threshold: 10,
+            last_indexed: AtomicU64::new(0),
+        }
+    }
+
+    /// Create new metrics with custom parse storm threshold.
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self {
+            pending_parses: AtomicUsize::new(0),
+            parse_storm_threshold: threshold,
+            last_indexed: AtomicU64::new(0),
+        }
+    }
+
+    /// Get current pending parse count (lock-free).
+    pub fn pending_count(&self) -> usize {
+        self.pending_parses.load(Ordering::SeqCst)
+    }
+
+    /// Increment pending parse count and return the new value.
+    pub fn increment_pending_parses(&self) -> usize {
+        self.pending_parses.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Decrement pending parse count and return the new value.
+    pub fn decrement_pending_parses(&self) -> usize {
+        self.pending_parses.fetch_sub(1, Ordering::SeqCst) - 1
+    }
+
+    /// Determine whether the current pending parse count exceeds the threshold.
+    pub fn is_parse_storm(&self) -> bool {
+        self.pending_count() > self.parse_storm_threshold
+    }
+
+    /// Get the parse-storm threshold.
+    pub fn parse_storm_threshold(&self) -> usize {
+        self.parse_storm_threshold
+    }
+}
+
+impl Default for IndexMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+struct IndexInstrumentationState {
+    current_state: IndexStateKind,
+    current_phase: IndexPhase,
+    state_started_at: Instant,
+    phase_started_at: Instant,
+    state_durations_ms: HashMap<IndexStateKind, u64>,
+    phase_durations_ms: HashMap<IndexPhase, u64>,
+    state_transition_counts: HashMap<IndexStateTransition, u64>,
+    phase_transition_counts: HashMap<IndexPhaseTransition, u64>,
+    early_exit_counts: HashMap<EarlyExitReason, u64>,
+    last_early_exit: Option<EarlyExitRecord>,
+}
+
+impl IndexInstrumentationState {
+    fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            current_state: IndexStateKind::Building,
+            current_phase: IndexPhase::Idle,
+            state_started_at: now,
+            phase_started_at: now,
+            state_durations_ms: HashMap::new(),
+            phase_durations_ms: HashMap::new(),
+            state_transition_counts: HashMap::new(),
+            phase_transition_counts: HashMap::new(),
+            early_exit_counts: HashMap::new(),
+            last_early_exit: None,
+        }
+    }
+}
+
+/// Index lifecycle instrumentation for state durations and transitions.
+#[derive(Debug)]
+pub struct IndexInstrumentation {
+    inner: Mutex<IndexInstrumentationState>,
+}
+
+impl IndexInstrumentation {
+    /// Create a new instrumentation tracker.
+    pub fn new() -> Self {
+        Self { inner: Mutex::new(IndexInstrumentationState::new()) }
+    }
+
+    /// Record a state transition.
+    pub fn record_state_transition(&self, from: IndexStateKind, to: IndexStateKind) {
+        let now = Instant::now();
+        let mut inner = self.inner.lock();
+        let elapsed_ms = now.duration_since(inner.state_started_at).as_millis() as u64;
+        *inner.state_durations_ms.entry(from).or_default() += elapsed_ms;
+
+        let transition = IndexStateTransition { from, to };
+        *inner.state_transition_counts.entry(transition).or_default() += 1;
+
+        if from == IndexStateKind::Building {
+            let phase_elapsed = now.duration_since(inner.phase_started_at).as_millis() as u64;
+            let current_phase = inner.current_phase;
+            *inner.phase_durations_ms.entry(current_phase).or_default() += phase_elapsed;
+        }
+
+        inner.current_state = to;
+        inner.state_started_at = now;
+
+        if to == IndexStateKind::Building || from == IndexStateKind::Building {
+            inner.current_phase = IndexPhase::Idle;
+            inner.phase_started_at = now;
+        }
+    }
+
+    /// Record a build-phase transition.
+    pub fn record_phase_transition(&self, from: IndexPhase, to: IndexPhase) {
+        let now = Instant::now();
+        let mut inner = self.inner.lock();
+        let elapsed_ms = now.duration_since(inner.phase_started_at).as_millis() as u64;
+        *inner.phase_durations_ms.entry(from).or_default() += elapsed_ms;
+
+        let transition = IndexPhaseTransition { from, to };
+        *inner.phase_transition_counts.entry(transition).or_default() += 1;
+
+        inner.current_phase = to;
+        inner.phase_started_at = now;
+    }
+
+    /// Record an early-exit event.
+    pub fn record_early_exit(&self, record: EarlyExitRecord) {
+        let mut inner = self.inner.lock();
+        *inner.early_exit_counts.entry(record.reason).or_default() += 1;
+        inner.last_early_exit = Some(record);
+    }
+
+    /// Return a current snapshot including elapsed time in the active state/phase.
+    pub fn snapshot(&self) -> IndexInstrumentationSnapshot {
+        let now = Instant::now();
+        let inner = self.inner.lock();
+        let mut state_durations_ms = inner.state_durations_ms.clone();
+        let mut phase_durations_ms = inner.phase_durations_ms.clone();
+
+        let state_elapsed = now.duration_since(inner.state_started_at).as_millis() as u64;
+        *state_durations_ms.entry(inner.current_state).or_default() += state_elapsed;
+
+        if inner.current_state == IndexStateKind::Building {
+            let phase_elapsed = now.duration_since(inner.phase_started_at).as_millis() as u64;
+            *phase_durations_ms.entry(inner.current_phase).or_default() += phase_elapsed;
+        }
+
+        IndexInstrumentationSnapshot {
+            state_durations_ms,
+            phase_durations_ms,
+            state_transition_counts: inner.state_transition_counts.clone(),
+            phase_transition_counts: inner.phase_transition_counts.clone(),
+            early_exit_counts: inner.early_exit_counts.clone(),
+            last_early_exit: inner.last_early_exit.clone(),
+        }
+    }
+}
+
+impl Default for IndexInstrumentation {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/perl-workspace-index-monitoring/tests/monitoring_behaviour.rs
+++ b/crates/perl-workspace-index-monitoring/tests/monitoring_behaviour.rs
@@ -1,0 +1,39 @@
+use perl_workspace_index_monitoring::{
+    EarlyExitReason, IndexInstrumentation, IndexMetrics, IndexPhase, IndexStateKind,
+    IndexStateTransition,
+};
+
+#[test]
+fn given_parse_metrics_when_incrementing_then_parse_storm_threshold_is_observed() {
+    let metrics = IndexMetrics::with_threshold(2);
+    assert_eq!(metrics.increment_pending_parses(), 1);
+    assert_eq!(metrics.increment_pending_parses(), 2);
+    assert!(!metrics.is_parse_storm());
+    assert_eq!(metrics.increment_pending_parses(), 3);
+    assert!(metrics.is_parse_storm());
+    assert_eq!(metrics.decrement_pending_parses(), 2);
+}
+
+#[test]
+fn given_instrumentation_when_recording_transitions_then_snapshot_reports_counts() {
+    let instrumentation = IndexInstrumentation::new();
+    instrumentation.record_phase_transition(IndexPhase::Idle, IndexPhase::Scanning);
+    instrumentation.record_state_transition(IndexStateKind::Building, IndexStateKind::Ready);
+    instrumentation.record_early_exit(perl_workspace_index_monitoring::EarlyExitRecord {
+        reason: EarlyExitReason::InitialTimeBudget,
+        elapsed_ms: 7,
+        indexed_files: 3,
+        total_files: 9,
+    });
+
+    let snapshot = instrumentation.snapshot();
+    assert_eq!(
+        snapshot.state_transition_counts.get(&IndexStateTransition {
+            from: IndexStateKind::Building,
+            to: IndexStateKind::Ready,
+        }),
+        Some(&1)
+    );
+    assert_eq!(snapshot.early_exit_counts.get(&EarlyExitReason::InitialTimeBudget), Some(&1));
+    assert!(snapshot.last_early_exit.is_some());
+}

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -27,6 +27,7 @@ perl-parser-core = { workspace = true }
 perl-position-tracking = { workspace = true, features = ["lsp-compat"] }
 perl-symbol-types = { workspace = true }
 perl-uri = { workspace = true }
+perl-workspace-index-monitoring = { workspace = true }
 perl-workspace-index-slo = { workspace = true }
 perl-workspace-index-state-machine = { workspace = true }
 parking_lot = "0.12.5"

--- a/crates/perl-workspace-index/src/workspace/mod.rs
+++ b/crates/perl-workspace-index/src/workspace/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod cache;
 pub mod document_store;
+pub mod monitoring;
 pub mod production_coordinator;
 pub mod slo;
 pub mod state_machine;

--- a/crates/perl-workspace-index/src/workspace/monitoring.rs
+++ b/crates/perl-workspace-index/src/workspace/monitoring.rs
@@ -1,0 +1,7 @@
+//! Monitoring and lifecycle support types for workspace indexing.
+//!
+//! This module was extracted to the `perl-workspace-index-monitoring` microcrate to
+//! keep workspace indexing focused on symbol extraction/query behavior while
+//! retaining the public path.
+
+pub use perl_workspace_index_monitoring::*;

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -65,7 +65,8 @@ use crate::Parser;
 use crate::ast::{Node, NodeKind};
 use crate::document_store::{Document, DocumentStore};
 use crate::position::{Position, Range};
-use parking_lot::{Mutex, RwLock};
+use crate::workspace::monitoring::IndexInstrumentation;
+use parking_lot::RwLock;
 use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
@@ -74,6 +75,12 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Instant;
 use url::Url;
+
+pub use crate::workspace::monitoring::{
+    DegradationReason, EarlyExitReason, EarlyExitRecord, IndexInstrumentationSnapshot,
+    IndexMetrics, IndexPerformanceCaps, IndexPhase, IndexPhaseTransition, IndexResourceLimits,
+    IndexStateKind, IndexStateTransition, ResourceKind,
+};
 
 // Re-export URI utilities for backward compatibility
 #[cfg(not(target_arch = "wasm32"))]
@@ -85,20 +92,6 @@ pub use perl_uri::{is_file_uri, is_special_scheme, uri_extension, uri_key};
 // ============================================================================
 // Index Lifecycle Types (Index Lifecycle v1 Specification)
 // ============================================================================
-
-/// Index build phase while the index is in `Building` state
-///
-/// The build phase makes the lifecycle explicit without forcing LSP handlers
-/// to reason about implicit progress signals.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum IndexPhase {
-    /// No scan has started yet
-    Idle,
-    /// Workspace file discovery is in progress
-    Scanning,
-    /// Symbol indexing is in progress
-    Indexing,
-}
 
 /// Index readiness state - explicit lifecycle management
 ///
@@ -195,446 +188,6 @@ impl IndexState {
             IndexState::Building { started_at, .. } => *started_at,
             IndexState::Ready { completed_at, .. } => *completed_at,
             IndexState::Degraded { since, .. } => *since,
-        }
-    }
-}
-
-/// Coarse index state kinds for instrumentation and transition tracking
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum IndexStateKind {
-    /// Index is being built
-    Building,
-    /// Index is ready for full queries
-    Ready,
-    /// Index is degraded and serving partial results
-    Degraded,
-}
-
-/// A state transition for index lifecycle instrumentation
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct IndexStateTransition {
-    /// Transition start state
-    pub from: IndexStateKind,
-    /// Transition end state
-    pub to: IndexStateKind,
-}
-
-/// A phase transition while building the workspace index
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct IndexPhaseTransition {
-    /// Transition start phase
-    pub from: IndexPhase,
-    /// Transition end phase
-    pub to: IndexPhase,
-}
-
-/// Early-exit reasons for workspace indexing
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum EarlyExitReason {
-    /// Initial scan exceeded the configured time budget
-    InitialTimeBudget,
-    /// Incremental update exceeded the configured time budget
-    IncrementalTimeBudget,
-    /// Workspace contained too many files to index within limits
-    FileLimit,
-}
-
-/// Record describing the latest early-exit event
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EarlyExitRecord {
-    /// Why the early exit occurred
-    pub reason: EarlyExitReason,
-    /// Elapsed time in milliseconds when the exit occurred
-    pub elapsed_ms: u64,
-    /// Files indexed when the exit occurred
-    pub indexed_files: usize,
-    /// Total files discovered when the exit occurred
-    pub total_files: usize,
-}
-
-/// Snapshot of index lifecycle instrumentation
-#[derive(Clone, Debug)]
-pub struct IndexInstrumentationSnapshot {
-    /// Accumulated time spent per state (milliseconds)
-    pub state_durations_ms: HashMap<IndexStateKind, u64>,
-    /// Accumulated time spent per build phase (milliseconds)
-    pub phase_durations_ms: HashMap<IndexPhase, u64>,
-    /// Counts of state transitions
-    pub state_transition_counts: HashMap<IndexStateTransition, u64>,
-    /// Counts of phase transitions
-    pub phase_transition_counts: HashMap<IndexPhaseTransition, u64>,
-    /// Counts of early exit reasons
-    pub early_exit_counts: HashMap<EarlyExitReason, u64>,
-    /// Most recent early exit record
-    pub last_early_exit: Option<EarlyExitRecord>,
-}
-
-/// Reason for index degradation
-///
-/// Categorizes the various failure modes that can cause the workspace index
-/// to enter a degraded state, enabling appropriate recovery strategies and
-/// user messaging.
-///
-/// # LSP Integration
-///
-/// Each degradation reason triggers specific fallback behavior in LSP handlers:
-/// - `ParseStorm`: Return same-file + open document results
-/// - `IoError`: Return cached results with warning message
-/// - `ScanTimeout`: Return partial results from completed scan
-/// - `ResourceLimit`: Trigger eviction and return available results
-#[derive(Clone, Debug)]
-pub enum DegradationReason {
-    /// Parse storm (too many simultaneous changes)
-    ParseStorm {
-        /// Number of pending parse operations
-        pending_parses: usize,
-    },
-
-    /// IO error during indexing
-    IoError {
-        /// Error message for diagnostics
-        message: String,
-    },
-
-    /// Timeout during workspace scan
-    ScanTimeout {
-        /// Elapsed time in milliseconds
-        elapsed_ms: u64,
-    },
-
-    /// Resource limits exceeded
-    ResourceLimit {
-        /// Which resource limit was exceeded
-        kind: ResourceKind,
-    },
-}
-
-#[derive(Clone, Debug, PartialEq)]
-/// Type of resource limit that was exceeded
-///
-/// Identifies which bounded resource triggered index degradation,
-/// enabling targeted eviction strategies and capacity planning.
-pub enum ResourceKind {
-    /// Maximum number of files in index exceeded
-    MaxFiles,
-
-    /// Maximum total symbols exceeded
-    MaxSymbols,
-
-    /// Maximum AST cache bytes exceeded
-    MaxCacheBytes,
-}
-
-#[derive(Clone, Debug)]
-/// Configurable resource limits for workspace index
-///
-/// Defines hard caps on various index resources to prevent unbounded
-/// memory growth in large Perl workspaces. These limits trigger
-/// graceful degradation with LRU eviction when exceeded.
-///
-/// # Performance Characteristics
-///
-/// - Default limits support ~10K files with ~500K total symbols
-/// - AST cache defaults to 256MB with 100 items (LRU eviction)
-/// - Eviction is deterministic for reproducible behavior
-/// - Limits are configurable per workspace via LSP initialization
-///
-/// # Usage
-///
-/// ```rust,ignore
-/// use perl_parser::workspace_index::IndexResourceLimits;
-///
-/// // Use default limits
-/// let limits = IndexResourceLimits::default();
-/// assert_eq!(limits.max_files, 10_000);
-///
-/// // Custom limits for large workspace
-/// let custom = IndexResourceLimits {
-///     max_files: 50_000,
-///     max_total_symbols: 2_000_000,
-///     ..Default::default()
-/// };
-/// ```
-pub struct IndexResourceLimits {
-    /// Maximum files to index (default: 10,000)
-    pub max_files: usize,
-
-    /// Maximum symbols per file (default: 5,000)
-    pub max_symbols_per_file: usize,
-
-    /// Maximum total symbols (default: 500,000)
-    pub max_total_symbols: usize,
-
-    /// Maximum AST cache size in bytes (default: 256MB)
-    pub max_ast_cache_bytes: usize,
-
-    /// Maximum AST cache items (default: 100)
-    pub max_ast_cache_items: usize,
-
-    /// Maximum workspace scan duration in milliseconds (default: 30,000ms = 30s)
-    pub max_scan_duration_ms: u64,
-}
-
-impl Default for IndexResourceLimits {
-    fn default() -> Self {
-        Self {
-            max_files: 10_000,
-            max_symbols_per_file: 5_000,
-            max_total_symbols: 500_000,
-            max_ast_cache_bytes: 256 * 1024 * 1024, // 256MB
-            max_ast_cache_items: 100,
-            max_scan_duration_ms: 30_000, // 30 seconds
-        }
-    }
-}
-
-/// Performance caps for workspace indexing operations
-///
-/// These caps are soft budgets that enable early-exit heuristics to keep
-/// indexing responsive on constrained machines.
-#[derive(Clone, Debug)]
-pub struct IndexPerformanceCaps {
-    /// Initial workspace scan budget in milliseconds (default: 100ms)
-    pub initial_scan_budget_ms: u64,
-    /// Incremental update budget in milliseconds (default: 10ms)
-    pub incremental_budget_ms: u64,
-}
-
-impl Default for IndexPerformanceCaps {
-    fn default() -> Self {
-        Self { initial_scan_budget_ms: 100, incremental_budget_ms: 10 }
-    }
-}
-
-/// Metrics for index lifecycle management and degradation detection
-///
-/// Tracks runtime statistics about index operations to detect parse storms
-/// and other conditions requiring state transitions. Uses atomic operations
-/// for lock-free metric updates in concurrent LSP operations.
-///
-/// # Performance Characteristics
-///
-/// - Lock-free atomic operations for metric updates (<10ns overhead)
-/// - Parse storm detection with configurable threshold (default: 10 pending)
-/// - Thread-safe for concurrent file change notifications
-///
-/// # Usage
-///
-/// ```rust,ignore
-/// use perl_parser::workspace_index::IndexMetrics;
-///
-/// let metrics = IndexMetrics::new();
-/// assert_eq!(metrics.pending_count(), 0);
-/// ```
-pub struct IndexMetrics {
-    /// Pending parse operations (atomic for lock-free access)
-    pending_parses: std::sync::atomic::AtomicUsize,
-
-    /// Parse storm threshold
-    parse_storm_threshold: usize,
-
-    /// Last successful index time (as millis since epoch, atomic)
-    ///
-    /// Currently stored but not actively used. Future enhancements planned:
-    /// - Telemetry: Report index freshness metrics to LSP clients
-    /// - Cache invalidation: Detect stale indexes requiring reindexing
-    /// - Incremental updates: Skip files unchanged since last_indexed timestamp
-    #[allow(dead_code)]
-    last_indexed: std::sync::atomic::AtomicU64,
-}
-
-impl IndexMetrics {
-    /// Create new metrics with default threshold (10 pending parses)
-    ///
-    /// # Returns
-    ///
-    /// A metrics tracker initialized with default parse-storm limits.
-    ///
-    /// Returns: `Ok(())` when indexing succeeds, otherwise an error string.
-    ///
-    /// Returns: A vector of successfully converted LSP locations.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use perl_parser::workspace_index::IndexMetrics;
-    ///
-    /// let metrics = IndexMetrics::new();
-    /// assert_eq!(metrics.pending_count(), 0);
-    /// ```
-    pub fn new() -> Self {
-        Self {
-            pending_parses: std::sync::atomic::AtomicUsize::new(0),
-            parse_storm_threshold: 10,
-            last_indexed: std::sync::atomic::AtomicU64::new(0),
-        }
-    }
-
-    /// Create new metrics with custom parse storm threshold
-    ///
-    /// # Arguments
-    ///
-    /// * `threshold` - Number of pending parses that triggers degradation
-    ///
-    /// # Returns
-    ///
-    /// A metrics tracker configured with the provided threshold.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use perl_parser::workspace_index::IndexMetrics;
-    ///
-    /// let metrics = IndexMetrics::with_threshold(20);
-    /// assert_eq!(metrics.pending_count(), 0);
-    /// ```
-    pub fn with_threshold(threshold: usize) -> Self {
-        Self {
-            pending_parses: std::sync::atomic::AtomicUsize::new(0),
-            parse_storm_threshold: threshold,
-            last_indexed: std::sync::atomic::AtomicU64::new(0),
-        }
-    }
-
-    /// Get current pending parse count (lock-free)
-    ///
-    /// # Returns
-    ///
-    /// The number of pending parse operations tracked so far.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use perl_parser::workspace_index::IndexMetrics;
-    ///
-    /// let metrics = IndexMetrics::new();
-    /// assert_eq!(metrics.pending_count(), 0);
-    /// ```
-    pub fn pending_count(&self) -> usize {
-        self.pending_parses.load(std::sync::atomic::Ordering::SeqCst)
-    }
-}
-
-impl Default for IndexMetrics {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug)]
-struct IndexInstrumentationState {
-    current_state: IndexStateKind,
-    current_phase: IndexPhase,
-    state_started_at: Instant,
-    phase_started_at: Instant,
-    state_durations_ms: HashMap<IndexStateKind, u64>,
-    phase_durations_ms: HashMap<IndexPhase, u64>,
-    state_transition_counts: HashMap<IndexStateTransition, u64>,
-    phase_transition_counts: HashMap<IndexPhaseTransition, u64>,
-    early_exit_counts: HashMap<EarlyExitReason, u64>,
-    last_early_exit: Option<EarlyExitRecord>,
-}
-
-impl IndexInstrumentationState {
-    fn new() -> Self {
-        let now = Instant::now();
-        Self {
-            current_state: IndexStateKind::Building,
-            current_phase: IndexPhase::Idle,
-            state_started_at: now,
-            phase_started_at: now,
-            state_durations_ms: HashMap::new(),
-            phase_durations_ms: HashMap::new(),
-            state_transition_counts: HashMap::new(),
-            phase_transition_counts: HashMap::new(),
-            early_exit_counts: HashMap::new(),
-            last_early_exit: None,
-        }
-    }
-}
-
-/// Index lifecycle instrumentation for state durations and transitions
-#[derive(Debug)]
-struct IndexInstrumentation {
-    inner: Mutex<IndexInstrumentationState>,
-}
-
-impl IndexInstrumentation {
-    fn new() -> Self {
-        Self { inner: Mutex::new(IndexInstrumentationState::new()) }
-    }
-
-    fn record_state_transition(&self, from: IndexStateKind, to: IndexStateKind) {
-        let now = Instant::now();
-        let mut inner = self.inner.lock();
-
-        // Record time spent in the previous state
-        let elapsed_ms = now.duration_since(inner.state_started_at).as_millis() as u64;
-        *inner.state_durations_ms.entry(from).or_insert(0) += elapsed_ms;
-
-        let transition = IndexStateTransition { from, to };
-        *inner.state_transition_counts.entry(transition).or_insert(0) += 1;
-
-        // If we were building, also close out the active phase timer
-        if from == IndexStateKind::Building {
-            let phase_elapsed = now.duration_since(inner.phase_started_at).as_millis() as u64;
-            let current_phase = inner.current_phase;
-            *inner.phase_durations_ms.entry(current_phase).or_insert(0) += phase_elapsed;
-        }
-
-        inner.current_state = to;
-        inner.state_started_at = now;
-
-        if to == IndexStateKind::Building && from != IndexStateKind::Building {
-            inner.current_phase = IndexPhase::Idle;
-            inner.phase_started_at = now;
-        } else if to != IndexStateKind::Building {
-            inner.current_phase = IndexPhase::Idle;
-            inner.phase_started_at = now;
-        }
-    }
-
-    fn record_phase_transition(&self, from: IndexPhase, to: IndexPhase) {
-        let now = Instant::now();
-        let mut inner = self.inner.lock();
-        let elapsed_ms = now.duration_since(inner.phase_started_at).as_millis() as u64;
-        *inner.phase_durations_ms.entry(from).or_insert(0) += elapsed_ms;
-
-        let transition = IndexPhaseTransition { from, to };
-        *inner.phase_transition_counts.entry(transition).or_insert(0) += 1;
-
-        inner.current_phase = to;
-        inner.phase_started_at = now;
-    }
-
-    fn record_early_exit(&self, record: EarlyExitRecord) {
-        let mut inner = self.inner.lock();
-        *inner.early_exit_counts.entry(record.reason).or_insert(0) += 1;
-        inner.last_early_exit = Some(record);
-    }
-
-    fn snapshot(&self) -> IndexInstrumentationSnapshot {
-        let now = Instant::now();
-        let inner = self.inner.lock();
-        let mut state_durations_ms = inner.state_durations_ms.clone();
-        let mut phase_durations_ms = inner.phase_durations_ms.clone();
-
-        // Add elapsed time for the current state/phase to the snapshot
-        let state_elapsed = now.duration_since(inner.state_started_at).as_millis() as u64;
-        *state_durations_ms.entry(inner.current_state).or_insert(0) += state_elapsed;
-
-        if inner.current_state == IndexStateKind::Building {
-            let phase_elapsed = now.duration_since(inner.phase_started_at).as_millis() as u64;
-            *phase_durations_ms.entry(inner.current_phase).or_insert(0) += phase_elapsed;
-        }
-
-        IndexInstrumentationSnapshot {
-            state_durations_ms,
-            phase_durations_ms,
-            state_transition_counts: inner.state_transition_counts.clone(),
-            phase_transition_counts: inner.phase_transition_counts.clone(),
-            early_exit_counts: inner.early_exit_counts.clone(),
-            last_early_exit: inner.last_early_exit.clone(),
         }
     }
 }
@@ -900,11 +453,10 @@ impl IndexCoordinator {
     /// coordinator.notify_change("file:///example.pl");
     /// ```
     pub fn notify_change(&self, _uri: &str) {
-        self.metrics.pending_parses.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let pending = self.metrics.increment_pending_parses();
 
         // Check for parse storm
-        let pending = self.metrics.pending_parses.load(std::sync::atomic::Ordering::SeqCst);
-        if pending > self.metrics.parse_storm_threshold {
+        if self.metrics.is_parse_storm() {
             self.transition_to_degraded(DegradationReason::ParseStorm { pending_parses: pending });
         }
     }
@@ -931,10 +483,9 @@ impl IndexCoordinator {
     /// coordinator.notify_parse_complete("file:///example.pl");
     /// ```
     pub fn notify_parse_complete(&self, _uri: &str) {
-        self.metrics.pending_parses.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        let pending = self.metrics.decrement_pending_parses();
 
         // Check for recovery from parse storm
-        let pending = self.metrics.pending_parses.load(std::sync::atomic::Ordering::SeqCst);
         if pending == 0 {
             if let IndexState::Degraded { reason: DegradationReason::ParseStorm { .. }, .. } =
                 self.state()


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of the large `workspace_index.rs` godfile by moving monitoring, limits, and lifecycle instrumentation to a focused SRP microcrate. 
- Separate coordinator/monitoring concerns from symbol indexing so the indexing engine stays focused on index/query logic and the monitoring primitives are reusable.

### Description
- Added a new microcrate `crates/perl-workspace-index-monitoring` that owns resource limits, performance caps, parse-storm metrics, degradation/early-exit types, and instrumentation primitives. 
- Wired the new crate into the workspace `Cargo.toml` and added a dependency from `crates/perl-workspace-index` to `perl-workspace-index-monitoring`. 
- Replaced the inlined monitoring types in `crates/perl-workspace-index/src/workspace/workspace_index.rs` with re-exports from a small shim `crates/perl-workspace-index/src/workspace/monitoring.rs`, and updated `IndexCoordinator` to use the microcrate API methods (e.g. `increment_pending_parses`, `decrement_pending_parses`, `is_parse_storm`) instead of touching metric internals. 
- Added focused unit tests for the new microcrate under `crates/perl-workspace-index-monitoring/tests/` to validate parse-storm metrics and instrumentation snapshot behavior. 

### Testing
- Ran `cargo fmt --all` successfully. 
- Ran `cargo test -p perl-workspace-index-monitoring` and the microcrate tests passed. 
- Ran targeted `perl-workspace-index` tests (`comprehensive_unit_tests` tests such as `test_index_coordinator_instrumentation`, `test_index_coordinator_parse_storm_triggers_degradation`, and `test_index_coordinator_with_limits_and_caps`) and they passed. 
- Ran `cargo clippy` for the new microcrate and the updated `perl-workspace-index` crate with `-D warnings`, and the checks completed without warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a45f13c83338d24c25d71f517c6)