### PR TITLE
refactor: extract execute-command path resolution into perl-path-security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "perl-module-rename",
  "perl-module-resolution",
  "perl-parser",
+ "perl-path-security",
  "perl-position-tracking",
  "perl-source-file",
  "perl-symbol-cursor",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -55,6 +55,7 @@ perl-workspace-discovery = { workspace = true }
 perl-workspace-folder = { workspace = true }
 perl-workspace-ignore = { workspace = true }
 perl-keywords = { workspace = true }
+perl-path-security = { workspace = true }
 lsp-types = "0.97.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/crates/perl-lsp/src/execute_command.rs
+++ b/crates/perl-lsp/src/execute_command.rs
@@ -94,6 +94,7 @@
 
 use crate::perl_critic::{BuiltInAnalyzer, CriticAnalyzer, CriticConfig};
 use crate::protocol::JsonRpcError;
+use perl_path_security::{WorkspacePathError, resolve_workspace_file_arg};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -710,90 +711,17 @@ impl ExecuteCommandProvider {
     /// and enforcing workspace boundaries. All paths are resolved relative
     /// to the workspace root when configured.
     fn resolve_path_from_args(&self, arguments: &[Value]) -> Result<PathBuf, String> {
-        // Extract the file path argument
         let raw_path = arguments
             .first()
             .and_then(|v| v.as_str())
             .ok_or_else(|| "Missing file path argument".to_string())?;
 
-        // Defense in depth: cap argument length to prevent abuse
-        const MAX_ARG_LENGTH: usize = 4096;
-        if raw_path.len() > MAX_ARG_LENGTH {
-            return Err(format!(
-                "Argument too long ({} bytes, max {})",
-                raw_path.len(),
-                MAX_ARG_LENGTH
-            ));
-        }
-
-        // Normalize file:// URIs
-        let normalized_path = raw_path.strip_prefix("file://").unwrap_or(raw_path);
-
-        // Defense in depth: reject paths with parent traversal components
-        // even though canonicalize() resolves them, this catches attempts early
-        if normalized_path.contains("..") {
-            return Err("Path traversal attempt detected: path contains '..' component".to_string());
-        }
-
-        // Convert to PathBuf and canonicalize to resolve .. and . components
-        let path = Path::new(normalized_path);
-        let canonical_path = path
-            .canonicalize()
-            .map_err(|e| format!("Failed to canonicalize path '{}': {}", normalized_path, e))?;
-
-        // Determine workspace boundaries
-        // Security: When workspace_roots is empty (single-file mode), use CWD as the
-        // fallback boundary to prevent unrestricted path traversal. This ensures that
-        // even without explicit workspace configuration, files outside the working
-        // directory cannot be accessed via executeCommand.
-        let effective_roots: Vec<PathBuf> = if self.workspace_roots.is_empty() {
-            // Fallback: use CWD as boundary when no workspace roots configured
-            // This prevents unrestricted path traversal in single-file mode
-            match std::env::current_dir() {
-                Ok(cwd) => vec![cwd],
-                Err(_) => {
-                    return Err(
-                        "No workspace roots configured and cannot determine working directory"
-                            .to_string(),
-                    );
-                }
+        resolve_workspace_file_arg(raw_path, &self.workspace_roots).map_err(|error| match error {
+            WorkspacePathError::PathOutsideWorkspace(message) => {
+                format!("Path traversal detected: {message}")
             }
-        } else {
-            self.workspace_roots.clone()
-        };
-
-        let mut allowed = false;
-        for workspace_root in &effective_roots {
-            if let Ok(canonical_root) = workspace_root.canonicalize() {
-                if canonical_path.starts_with(&canonical_root) {
-                    allowed = true;
-                    break;
-                }
-            }
-        }
-
-        if !allowed {
-            return Err(format!(
-                "Path traversal detected: {} is outside workspace boundaries",
-                canonical_path.display()
-            ));
-        }
-
-        // Validate file existence and readability
-        if !canonical_path.exists() {
-            return Err(format!("File not found: {}", canonical_path.display()));
-        }
-
-        if !canonical_path.is_file() {
-            return Err(format!("Path is not a file: {}", canonical_path.display()));
-        }
-
-        // Check basic readability (this will fail fast if permissions are wrong)
-        std::fs::metadata(&canonical_path).map_err(|e| {
-            format!("Cannot read file metadata '{}': {}", canonical_path.display(), e)
-        })?;
-
-        Ok(canonical_path)
+            other => other.to_string(),
+        })
     }
 
     /// Resolve a debug file path with the same workspace security as other commands.

--- a/crates/perl-path-security/src/lib.rs
+++ b/crates/perl-path-security/src/lib.rs
@@ -10,6 +10,15 @@ use perl_path_normalize::{NormalizePathError, normalize_path_within_workspace};
 /// Path validation errors for workspace-bound operations.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum WorkspacePathError {
+    /// Input path exceeded the maximum supported length.
+    #[error("Argument too long ({actual} bytes, max {max})")]
+    ArgumentTooLong {
+        /// Actual argument length in bytes.
+        actual: usize,
+        /// Maximum accepted argument length in bytes.
+        max: usize,
+    },
+
     /// Parent traversal or invalid component escaping workspace constraints.
     #[error("Path traversal attempt detected: {0}")]
     PathTraversalAttempt(String),
@@ -21,6 +30,92 @@ pub enum WorkspacePathError {
     /// Path contains null bytes or disallowed control characters.
     #[error("Invalid path characters detected")]
     InvalidPathCharacters,
+
+    /// The resolved path does not point to an existing file.
+    #[error("File not found: {0}")]
+    FileNotFound(String),
+
+    /// The resolved path exists but is not a file.
+    #[error("Path is not a file: {0}")]
+    NotAFile(String),
+
+    /// The resolved path metadata could not be accessed.
+    #[error("{0}")]
+    MetadataUnavailable(String),
+
+    /// No suitable workspace boundary could be established.
+    #[error("{0}")]
+    WorkspaceUnavailable(String),
+}
+
+/// Resolve a file argument into a canonical workspace-bounded file path.
+///
+/// Accepts plain filesystem paths and `file://` URIs, applies a length cap to
+/// user-controlled input, falls back to the current working directory when no
+/// explicit workspace roots are configured, and ensures the resolved path is an
+/// existing readable file within at least one workspace root.
+pub fn resolve_workspace_file_arg(
+    raw_path: &str,
+    workspace_roots: &[PathBuf],
+) -> Result<PathBuf, WorkspacePathError> {
+    const MAX_ARG_LENGTH: usize = 4096;
+    if raw_path.len() > MAX_ARG_LENGTH {
+        return Err(WorkspacePathError::ArgumentTooLong {
+            actual: raw_path.len(),
+            max: MAX_ARG_LENGTH,
+        });
+    }
+
+    let normalized_path = raw_path.strip_prefix("file://").unwrap_or(raw_path);
+    let candidate = Path::new(normalized_path);
+
+    let effective_roots = if workspace_roots.is_empty() {
+        vec![std::env::current_dir().map_err(|error| {
+            WorkspacePathError::WorkspaceUnavailable(format!(
+                "No workspace roots configured and cannot determine working directory: {error}"
+            ))
+        })?]
+    } else {
+        workspace_roots.to_vec()
+    };
+
+    let mut last_error = None;
+    for workspace_root in &effective_roots {
+        let candidate_for_root = match workspace_root.canonicalize() {
+            Ok(canonical_root) if candidate.is_absolute() => candidate
+                .strip_prefix(&canonical_root)
+                .map_or_else(|_| candidate.to_path_buf(), PathBuf::from),
+            _ => candidate.to_path_buf(),
+        };
+
+        match validate_workspace_path(&candidate_for_root, workspace_root) {
+            Ok(resolved) => {
+                if !resolved.exists() {
+                    return Err(WorkspacePathError::FileNotFound(resolved.display().to_string()));
+                }
+
+                if !resolved.is_file() {
+                    return Err(WorkspacePathError::NotAFile(resolved.display().to_string()));
+                }
+
+                std::fs::metadata(&resolved).map_err(|error| {
+                    WorkspacePathError::MetadataUnavailable(format!(
+                        "Cannot read file metadata '{}': {error}",
+                        resolved.display()
+                    ))
+                })?;
+
+                return Ok(resolved);
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        WorkspacePathError::WorkspaceUnavailable(
+            "No accessible workspace roots available for path resolution".to_string(),
+        )
+    }))
 }
 
 /// Validate and normalize a path so it remains within `workspace_root`.

--- a/crates/perl-path-security/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-path-security/tests/comprehensive_unit_tests.rs
@@ -3,7 +3,7 @@
 //! These tests exercise adversarial inputs that a malicious LSP/DAP client
 //! might send to escape the workspace sandbox.
 
-use perl_path_security::{WorkspacePathError, validate_workspace_path};
+use perl_path_security::{WorkspacePathError, resolve_workspace_file_arg, validate_workspace_path};
 use std::path::PathBuf;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -663,5 +663,57 @@ fn filename_double_extension() -> TestResult {
     let (_tmp, ws) = workspace()?;
     let result = validate_workspace_path(&PathBuf::from("script.pl.bak"), &ws)?;
     assert!(result.starts_with(&ws));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// File argument resolution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_file_arg_accepts_file_uri_within_workspace() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let file = ws.join("lib/Example.pm");
+    std::fs::create_dir_all(file.parent().ok_or("missing parent")?)?;
+    std::fs::write(
+        &file,
+        "package Example; 1;
+",
+    )?;
+
+    let resolved = resolve_workspace_file_arg(
+        &format!("file://{}", file.display()),
+        std::slice::from_ref(&ws),
+    )?;
+    assert_eq!(resolved, file.canonicalize()?);
+    Ok(())
+}
+
+#[test]
+fn resolve_file_arg_rejects_missing_file_inside_workspace() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let missing = ws.join("missing.pl");
+
+    let result = resolve_workspace_file_arg(&missing.to_string_lossy(), std::slice::from_ref(&ws));
+    assert!(matches!(result, Err(WorkspacePathError::FileNotFound(_))));
+    Ok(())
+}
+
+#[test]
+fn resolve_file_arg_rejects_directory_targets() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+
+    let result = resolve_workspace_file_arg(&ws.to_string_lossy(), std::slice::from_ref(&ws));
+    assert!(matches!(result, Err(WorkspacePathError::NotAFile(_))));
+    Ok(())
+}
+
+#[test]
+fn resolve_file_arg_rejects_overlong_arguments() -> TestResult {
+    let (_tmp, ws) = workspace()?;
+    let long_arg = "a".repeat(4097);
+
+    let result = resolve_workspace_file_arg(&long_arg, std::slice::from_ref(&ws));
+    assert!(matches!(result, Err(WorkspacePathError::ArgumentTooLong { actual: 4097, max: 4096 })));
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Reduce the large godfile `crates/perl-lsp/src/execute_command.rs` by extracting its workspace-bounded path resolution logic into a single-responsibility microcrate.
- Provide a reusable, well-tested helper for canonicalizing `file://` URIs and enforcing workspace boundaries used across LSP/DAP tooling.

### Description
- Introduce `resolve_workspace_file_arg(raw_path: &str, workspace_roots: &[PathBuf]) -> Result<PathBuf, WorkspacePathError>` in `crates/perl-path-security/src/lib.rs` and add richer `WorkspacePathError` variants (file-not-found, not-a-file, metadata, argument-too-long, workspace-unavailable).
- Move the path-resolution, URI handling, length cap, workspace fallback, existence/type checks, and metadata checks into `perl-path-security::resolve_workspace_file_arg`.
- Wire `perl-lsp` to depend on `perl-path-security` (update `crates/perl-lsp/Cargo.toml`) and replace the in-file resolution block in `crates/perl-lsp/src/execute_command.rs` with a call to the shared helper while preserving the original security-facing error wording for callers by mapping `WorkspacePathError::PathOutsideWorkspace` to the existing `Path traversal detected:` message.
- Add focused unit tests for the new helper in `crates/perl-path-security/tests/comprehensive_unit_tests.rs` covering `file://` URI resolution, missing file, directory target rejection, and overlong-argument rejection.

### Testing
- Ran `cargo test -p perl-path-security` and all `perl-path-security` tests passed (including the newly added file-argument tests).
- Ran `cargo test -p perl-lsp --lib test_execute_command_workspace_security -- --test-threads=1` and the workspace-security tests passed.
- Ran `cargo test -p perl-lsp --lib test_execute_command_multi_root_security -- --test-threads=1` and it passed.
- Ran `cargo check -p perl-lsp` to validate integration and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a3f31248333aadfc155730ba652)