### PR TITLE
refactor: extract perltidy tooling microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-perltidy"
+version = "0.11.0"
+dependencies = [
+ "perl-subprocess-runtime",
+ "perl-tdd-support",
+ "serde",
+]
+
+[[package]]
 name = "perl-lsp-protocol"
 version = "0.11.0"
 dependencies = [
@@ -2193,6 +2202,7 @@ dependencies = [
  "lsp-types",
  "perl-lsp-critic-parser",
  "perl-lsp-performance",
+ "perl-lsp-perltidy",
  "perl-parser-core",
  "perl-subprocess-runtime",
  "perl-tdd-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/perl-lsp-transport",
     "crates/perl-lsp-on-type-formatting",
     "crates/perl-lsp-tooling",
+    "crates/perl-lsp-perltidy",
     "crates/perl-lsp-symbol-query",
     "crates/perl-lsp-performance",
     "crates/perl-lsp-critic-parser",
@@ -196,6 +197,7 @@ allow = [
     "perl-lsp-document-links",
     "perl-lsp-workspace-symbols",
     "perl-lsp-tooling",
+    "perl-lsp-perltidy",
     "perl-lsp-performance",
     "perl-lsp-critic-parser",
     "perl-lsp-formatting-types",
@@ -354,6 +356,7 @@ perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "
 perl-parser-core = { path = "crates/perl-parser-core", version = "0.11.0" }
 perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.11.0" }
 perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.11.0" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.11.0" }
 perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.11.0" }
 perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.11.0" }
 perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.11.0" }

--- a/crates/perl-lsp-perltidy/Cargo.toml
+++ b/crates/perl-lsp-perltidy/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "perl-lsp-perltidy"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "SRP microcrate for perltidy-based Perl formatting helpers"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-perltidy"
+keywords = ["perl", "lsp", "perltidy", "formatting"]
+categories = ["development-tools", "text-editors"]
+
+[lib]
+doctest = false
+
+[dependencies]
+perl-subprocess-runtime = { workspace = true }
+serde = { version = "1.0.228", features = ["derive"] }
+
+[dev-dependencies]
+perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-perltidy/README.md
+++ b/crates/perl-lsp-perltidy/README.md
@@ -1,0 +1,8 @@
+# perl-lsp-perltidy
+
+Standalone SRP microcrate for Perl formatting via `perltidy`.
+
+This crate owns one responsibility: translating formatter configuration into
+`perltidy` command-line invocations, caching formatted output, and providing a
+small built-in formatter fallback for environments where `perltidy` is not
+available.

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -1,7 +1,15 @@
-//! Perltidy integration for code formatting
+//! Perltidy integration for code formatting.
 //!
-//! This module provides integration with perltidy for automatic code formatting
-//! and beautification of Perl code.
+//! This microcrate owns one responsibility: formatting Perl code through
+//! `perltidy`, including command-line configuration rendering, subprocess
+//! execution, cached formatting results, and a lightweight built-in fallback.
+
+#![deny(unsafe_code)]
+#![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+#![allow(clippy::empty_line_after_outer_attr)]
 
 use perl_subprocess_runtime::SubprocessRuntime;
 use serde::{Deserialize, Serialize};
@@ -9,30 +17,30 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-/// Configuration for perltidy
+/// Configuration for perltidy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PerlTidyConfig {
-    /// Maximum line length
+    /// Maximum line length.
     pub maximum_line_length: Option<u32>,
-    /// Indent size (spaces)
+    /// Indent size (spaces).
     pub indent_columns: Option<u32>,
-    /// Use tabs instead of spaces
+    /// Use tabs instead of spaces.
     pub tabs: Option<bool>,
-    /// Opening brace on same line
+    /// Opening brace on same line.
     pub opening_brace_on_new_line: Option<bool>,
-    /// Cuddled else
+    /// Cuddled else.
     pub cuddled_else: Option<bool>,
-    /// Space after keyword
+    /// Space after keyword.
     pub space_after_keyword: Option<bool>,
-    /// Add trailing commas
+    /// Add trailing commas.
     pub add_trailing_commas: Option<bool>,
-    /// Vertical alignment
+    /// Vertical alignment.
     pub vertical_alignment: Option<bool>,
-    /// Block comment indentation
+    /// Block comment indentation.
     pub block_comment_indentation: Option<u32>,
-    /// Custom perltidyrc file path
+    /// Custom perltidyrc file path.
     pub profile: Option<String>,
-    /// Additional command line arguments
+    /// Additional command line arguments.
     pub extra_args: Vec<String>,
 }
 
@@ -55,7 +63,7 @@ impl Default for PerlTidyConfig {
 }
 
 impl PerlTidyConfig {
-    /// Create a config for PBP (Perl Best Practices) style
+    /// Create a config for PBP (Perl Best Practices) style.
     pub fn pbp() -> Self {
         Self {
             maximum_line_length: Some(78),
@@ -72,7 +80,7 @@ impl PerlTidyConfig {
         }
     }
 
-    /// Create a config for GNU style
+    /// Create a config for GNU style.
     pub fn gnu() -> Self {
         Self {
             maximum_line_length: Some(79),
@@ -89,22 +97,21 @@ impl PerlTidyConfig {
         }
     }
 
-    /// Convert to perltidy command line arguments
-    fn to_args(&self) -> Vec<String> {
+    /// Convert to perltidy command line arguments.
+    pub fn to_args(&self) -> Vec<String> {
         let mut args = Vec::new();
 
         if let Some(profile) = &self.profile {
-            args.push(format!("--profile={}", profile));
-            // If using a profile, don't add other options
+            args.push(format!("--profile={profile}"));
             return args;
         }
 
         if let Some(len) = self.maximum_line_length {
-            args.push(format!("--maximum-line-length={}", len));
+            args.push(format!("--maximum-line-length={len}"));
         }
 
         if let Some(indent) = self.indent_columns {
-            args.push(format!("--indent-columns={}", indent));
+            args.push(format!("--indent-columns={indent}"));
         }
 
         if let Some(tabs) = self.tabs {
@@ -156,23 +163,21 @@ impl PerlTidyConfig {
         }
 
         if let Some(indent) = self.block_comment_indentation {
-            args.push(format!("--block-comment-indentation={}", indent));
+            args.push(format!("--block-comment-indentation={indent}"));
         }
 
-        // Add extra args
         args.extend(self.extra_args.clone());
-
         args
     }
 }
 
-/// Perltidy formatter
+/// Perltidy formatter.
 pub struct PerlTidyFormatter {
     /// Configuration settings for perltidy invocation.
     config: PerlTidyConfig,
     /// Cache mapping source code to formatted output.
     cache: HashMap<String, String>,
-    /// Subprocess runtime for executing perltidy
+    /// Subprocess runtime for executing perltidy.
     runtime: Arc<dyn SubprocessRuntime>,
 }
 
@@ -189,21 +194,16 @@ impl PerlTidyFormatter {
         Self::new(config, Arc::new(OsSubprocessRuntime::new()))
     }
 
-    /// Format Perl code
+    /// Format Perl code.
     pub fn format(&mut self, code: &str) -> Result<String, String> {
-        // Check cache
         if let Some(cached) = self.cache.get(code) {
             return Ok(cached.clone());
         }
 
-        // Build argument list
         let mut args: Vec<String> = self.config.to_args();
-        args.push("-st".to_string()); // Output to stdout
+        args.push("-st".to_string());
+        let args_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-        // Convert to &str slice for the runtime
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        // Run perltidy via the runtime
         let output = self
             .runtime
             .run_command("perltidy", &args_refs, Some(code.as_bytes()))
@@ -214,27 +214,19 @@ impl PerlTidyFormatter {
         }
 
         let formatted = String::from_utf8(output.stdout)
-            .map_err(|e| format!("Invalid UTF-8 from perltidy: {}", e))?;
+            .map_err(|e| format!("Invalid UTF-8 from perltidy: {e}"))?;
 
-        // Cache result
         self.cache.insert(code.to_string(), formatted.clone());
-
         Ok(formatted)
     }
 
-    /// Format a file in place
+    /// Format a file in place.
     pub fn format_file(&self, file_path: &Path) -> Result<(), String> {
-        // Build argument list
         let mut args: Vec<String> = self.config.to_args();
-        // SECURITY: Add `--` to prevent argument injection via filenames starting with `-`
-        // (e.g., a file named `-rf` would otherwise be interpreted as a flag)
         args.push("--".to_string());
         args.push(file_path.to_string_lossy().into_owned());
+        let args_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
-        // Convert to &str slice for the runtime
-        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-        // Run perltidy via the runtime
         let output =
             self.runtime.run_command("perltidy", &args_refs, None).map_err(|e| e.message)?;
 
@@ -245,43 +237,32 @@ impl PerlTidyFormatter {
         Ok(())
     }
 
-    /// Clear cache
+    /// Clear cache.
     pub fn clear_cache(&mut self) {
         self.cache.clear();
     }
 
-    /// Format a range of code
+    /// Format a range of code.
     pub fn format_range(
         &mut self,
         code: &str,
         start_line: u32,
         end_line: u32,
     ) -> Result<String, String> {
-        // Split code into lines
         let lines: Vec<&str> = code.lines().collect();
 
         if start_line as usize >= lines.len() || end_line as usize >= lines.len() {
             return Err("Line range out of bounds".to_string());
         }
 
-        // Extract the range to format
         let range_code = lines[start_line as usize..=end_line as usize].join("\n");
-
-        // Format the range
         let formatted_range = self.format(&range_code)?;
 
-        // Reconstruct the full code
         let mut result = Vec::new();
-
-        // Add lines before range
         if start_line > 0 {
             result.extend_from_slice(&lines[0..start_line as usize]);
         }
-
-        // Add formatted range
         result.extend(formatted_range.lines());
-
-        // Add lines after range
         if (end_line as usize) < lines.len() - 1 {
             result.extend_from_slice(&lines[(end_line as usize + 1)..]);
         }
@@ -289,17 +270,14 @@ impl PerlTidyFormatter {
         Ok(result.join("\n"))
     }
 
-    /// Get formatting suggestions without applying them
+    /// Get formatting suggestions without applying them.
     pub fn get_suggestions(&mut self, code: &str) -> Result<Vec<FormatSuggestion>, String> {
         let formatted = self.format(code)?;
-
         if formatted == code {
             return Ok(Vec::new());
         }
 
-        // Compare original and formatted to generate suggestions
         let mut suggestions = Vec::new();
-
         let orig_lines: Vec<&str> = code.lines().collect();
         let fmt_lines: Vec<&str> = formatted.lines().collect();
 
@@ -318,7 +296,7 @@ impl PerlTidyFormatter {
     }
 }
 
-/// A formatting suggestion
+/// A formatting suggestion.
 #[derive(Debug, Clone)]
 pub struct FormatSuggestion {
     /// Zero-based line number where the change applies.
@@ -331,7 +309,7 @@ pub struct FormatSuggestion {
     pub description: String,
 }
 
-/// Built-in formatter for when perltidy is not available
+/// Built-in formatter for when perltidy is not available.
 pub struct BuiltInFormatter {
     /// Configuration settings controlling formatting behavior.
     config: PerlTidyConfig,
@@ -343,7 +321,7 @@ impl BuiltInFormatter {
         Self { config }
     }
 
-    /// Basic formatting without perltidy
+    /// Basic formatting without perltidy.
     pub fn format(&self, code: &str) -> String {
         let mut result = String::new();
         let mut indent_level: i32 = 0;
@@ -356,12 +334,10 @@ impl BuiltInFormatter {
         for line in code.lines() {
             let trimmed = line.trim();
 
-            // Decrease indent for closing braces
             if trimmed.starts_with('}') || trimmed.starts_with(')') || trimmed.starts_with(']') {
                 indent_level = indent_level.saturating_sub(1);
             }
 
-            // Add indentation
             if !trimmed.is_empty() {
                 for _ in 0..indent_level {
                     result.push_str(&indent_str);
@@ -370,7 +346,6 @@ impl BuiltInFormatter {
             }
             result.push('\n');
 
-            // Increase indent for opening braces
             if trimmed.ends_with('{') || trimmed.ends_with('(') || trimmed.ends_with('[') {
                 indent_level += 1;
             }
@@ -386,7 +361,7 @@ mod tests {
     use perl_tdd_support::{must, must_some};
 
     #[test]
-    fn test_config_to_args() {
+    fn config_to_args_contains_defaults() {
         let config = PerlTidyConfig::default();
         let args = config.to_args();
 
@@ -396,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pbp_config() {
+    fn pbp_config_adds_best_practices_flag() {
         let config = PerlTidyConfig::pbp();
         let args = config.to_args();
 
@@ -405,18 +380,18 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_formatter() {
+    fn builtin_formatter_indents_nested_lines() {
         let config = PerlTidyConfig::default();
         let formatter = BuiltInFormatter::new(config);
 
         let code = "if ($x) {\nprint $x;\n}\n";
         let formatted = formatter.format(code);
 
-        assert!(formatted.contains("    print")); // Should be indented
+        assert!(formatted.contains("    print"));
     }
 
     #[test]
-    fn test_formatter_with_mock_runtime() {
+    fn formatter_invokes_runtime_with_stdout_flag() {
         use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
@@ -436,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn test_formatter_caching() {
+    fn formatter_caches_repeated_requests() {
         use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
@@ -445,21 +420,16 @@ mod tests {
         let config = PerlTidyConfig::default();
         let mut formatter = PerlTidyFormatter::new(config, runtime.clone());
 
-        // First call should invoke runtime
         let result1 = formatter.format("original");
-        assert!(result1.is_ok());
-
-        // Second call should use cache, not invoke runtime again
         let result2 = formatter.format("original");
+        assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert_eq!(must(result1), must(result2));
-
-        // Only one invocation should have occurred
         assert_eq!(runtime.invocations().len(), 1);
     }
 
     #[test]
-    fn test_formatter_error_handling() {
+    fn formatter_surfaces_runtime_errors() {
         use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
@@ -470,7 +440,7 @@ mod tests {
 
         let result = formatter.format("invalid code");
         match result {
-            Err(e) => assert!(format!("{:?}", e).contains("syntax error")),
+            Err(message) => assert!(message.contains("syntax error")),
             Ok(_) => {
                 must(Err::<(), _>("Expected error, got Ok"));
             }
@@ -478,11 +448,11 @@ mod tests {
     }
 
     #[test]
-    fn test_format_file_with_mock_runtime() {
+    fn format_file_uses_argument_separator_for_security() {
         use perl_subprocess_runtime::mock::{MockResponse, MockSubprocessRuntime};
 
         let runtime = Arc::new(MockSubprocessRuntime::new());
-        runtime.add_response(MockResponse::success(b"".to_vec()));
+        runtime.add_response(MockResponse::success(Vec::new()));
 
         let config = PerlTidyConfig::default();
         let formatter = PerlTidyFormatter::new(config, runtime.clone());
@@ -493,12 +463,9 @@ mod tests {
         let invocations = runtime.invocations();
         assert_eq!(invocations.len(), 1);
         assert_eq!(invocations[0].program, "perltidy");
-
-        // Ensure argument separator is used for security
         assert!(invocations[0].args.contains(&"--".to_string()));
-        // Ensure the separator comes before the file path
-        let sep_pos = must_some(invocations[0].args.iter().position(|a| a == "--"));
-        let file_pos = must_some(invocations[0].args.iter().position(|a| a == "test.pl"));
-        assert!(sep_pos < file_pos, "-- separator must come before file path");
+        let separator = must_some(invocations[0].args.iter().position(|arg| arg == "--"));
+        let file = must_some(invocations[0].args.iter().position(|arg| arg == "test.pl"));
+        assert!(separator < file, "-- separator must come before file path");
     }
 }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -4,13 +4,13 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-description = "Tooling integration for Perl LSP (perltidy, perlcritic, subprocess abstraction)"
+description = "Tooling integration for Perl LSP (perlcritic, subprocess abstraction, performance re-exports)"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository.workspace = true
 homepage.workspace = true
 documentation = "https://docs.rs/perl-lsp-tooling"
-keywords = ["perl", "lsp", "perltidy", "perlcritic", "tooling"]
+keywords = ["perl", "lsp", "perlcritic", "tooling", "subprocess"]
 categories = ["development-tools", "text-editors"]
 
 [lib]
@@ -22,7 +22,7 @@ lsp-compat = ["dep:lsp-types"]
 
 [dependencies]
 perl-subprocess-runtime = { workspace = true }
-perl-tdd-support = { workspace = true }
+perl-lsp-perltidy = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-lsp-performance = { workspace = true }
 perl-lsp-critic-parser = { workspace = true }

--- a/crates/perl-lsp-tooling/README.md
+++ b/crates/perl-lsp-tooling/README.md
@@ -5,14 +5,14 @@ External tool integration and performance infrastructure for the Perl LSP ecosys
 ## Features
 
 - **Subprocess abstraction**: `SubprocessRuntime` trait with `OsSubprocessRuntime` (non-WASM) and test mocks
-- **Perltidy integration**: `PerlTidyFormatter` for code formatting with caching, range formatting, and a `BuiltInFormatter` fallback
+- **Perltidy integration**: compatibility re-exports of `perl-lsp-perltidy` for code formatting with caching, range formatting, and a `BuiltInFormatter` fallback
 - **Perlcritic integration**: `CriticAnalyzer` for static analysis with `BuiltInAnalyzer` and `Policy` trait for custom policies
 - **Performance**: `AstCache` (moka-based concurrent cache with TTL), `IncrementalParser`, `SymbolIndex` (trie + fuzzy), parallel file processing
 - **LSP compatibility**: Optional `lsp-compat` feature for `lsp_types` diagnostic conversion
 
 ## Workspace Role
 
-Tier 2 infrastructure crate in the `tree-sitter-perl-rs` workspace. Used by formatting, diagnostics, and code analysis layers of the Perl LSP server.
+Tier 2 infrastructure crate in the `tree-sitter-perl-rs` workspace. Used by formatting, diagnostics, and code analysis layers of the Perl LSP server. The crate now composes the dedicated `perl-lsp-perltidy` microcrate instead of owning the formatter implementation directly.
 
 ## Quick Start
 

--- a/crates/perl-lsp-tooling/src/lib.rs
+++ b/crates/perl-lsp-tooling/src/lib.rs
@@ -32,7 +32,9 @@ pub mod performance {
 /// Perl::Critic integration for code quality analysis.
 pub mod perl_critic;
 /// Perltidy integration for code formatting.
-pub mod perltidy;
+pub mod perltidy {
+    pub use perl_lsp_perltidy::*;
+}
 
 pub use perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
 


### PR DESCRIPTION
### Motivation
- Reduce responsibilities in `perl-lsp-tooling` by extracting the Perltidy formatter into a single-responsibility microcrate to improve modularity and incremental compilation. 
- `perltidy` functionality is cohesive and widely reused, so isolating it enables clearer API boundaries and easier independent testing and publishing.

### Description
- Added a new crate `perl-lsp-perltidy` under `crates/perl-lsp-perltidy/` which contains the `PerlTidyConfig`, `PerlTidyFormatter`, `BuiltInFormatter`, and associated unit tests moved from the original module. 
- Rewired `perl-lsp-tooling` to depend on and re-export the new microcrate via `pub mod perltidy { pub use perl_lsp_perltidy::*; }` so downstream code keeps working. 
- Updated workspace configuration in `Cargo.toml` to add the new member and workspace dependency entries and refreshed `Cargo.lock` to include the new package. 
- Updated documentation in `crates/perl-lsp-tooling/README.md` to reflect the composition boundary and replaced the original `perltidy.rs` implementation with the re-exporting compatibility shim.

### Testing
- Ran formatter and unit-test targets with `cargo fmt --all` which completed successfully. 
- Ran targeted unit tests `cargo test -p perl-lsp-perltidy`, `cargo test -p perl-lsp-tooling`, and `cargo test -p perl-lsp-formatting`, and all tests passed. 
- Re-ran the SRP inventory generator with `cargo run -p xtask -- srp-microcrates` to validate the microcrate inventory and workspace wiring which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a2a7dac83338376d206336f9e6d)