### PR TITLE
refactor: extract perl-dap session model microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "perl-dap-platform",
  "perl-dap-security",
  "perl-dap-stack",
+ "perl-dap-types",
  "perl-dap-variables",
  "perl-feature-catalog",
  "perl-keywords",
@@ -1656,6 +1657,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "perl-dap-types"
+version = "0.11.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
     "crates/perl-dap-platform",
     "crates/perl-dap-command-args",
     "crates/perl-dap-shell",
+    "crates/perl-dap-types",
     "crates/perl-dap-value",
     "crates/perl-dap-security",
     "crates/perl-dap-variables",
@@ -219,6 +220,7 @@ allow = [
     "perl-dap-command-args",
     "perl-dap-platform",
     "perl-dap-shell",
+    "perl-dap-types",
     "perl-dap-security",
     "perl-dap-stack",
     "perl-dap-value",
@@ -342,6 +344,7 @@ perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.11.0" }
 perl-dap-value = { path = "crates/perl-dap-value", version = "0.11.0" }
 perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.11.0" }
 perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.11.0" }
+perl-dap-types = { path = "crates/perl-dap-types", version = "0.11.0" }
 perl-dap-security = { path = "crates/perl-dap-security", version = "0.11.0" }
 perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.11.0" }
 perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.11.0" }

--- a/crates/perl-dap-types/Cargo.toml
+++ b/crates/perl-dap-types/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "perl-dap-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Shared DAP model types for perl-dap session handling"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["perl", "dap", "debug", "types"]
+categories = ["development-tools::debugging"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[lib]
+name = "perl_dap_types"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0.149"
+
+[lints]
+workspace = true

--- a/crates/perl-dap-types/README.md
+++ b/crates/perl-dap-types/README.md
@@ -1,0 +1,3 @@
+# perl-dap-types
+
+Shared session model types for the Perl Debug Adapter Protocol implementation.

--- a/crates/perl-dap-types/src/lib.rs
+++ b/crates/perl-dap-types/src/lib.rs
@@ -1,0 +1,76 @@
+//! Shared DAP session model types for Perl debugging.
+
+use serde::{Deserialize, Serialize};
+
+/// Stack frame information used by the debug adapter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StackFrame {
+    pub id: i32,
+    pub name: String,
+    pub source: Source,
+    pub line: i32,
+    pub column: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_column: Option<i32>,
+}
+
+impl StackFrame {
+    #[must_use]
+    pub fn new(id: i32, name: impl Into<String>, source: Source, line: i32) -> Self {
+        Self { id, name: name.into(), source, line, column: 1, end_line: None, end_column: None }
+    }
+
+    #[must_use]
+    pub fn with_column(mut self, column: i32) -> Self {
+        self.column = column;
+        self
+    }
+
+    #[must_use]
+    pub fn with_end(mut self, end_line: i32, end_column: i32) -> Self {
+        self.end_line = Some(end_line);
+        self.end_column = Some(end_column);
+        self
+    }
+}
+
+/// Source file information for stack frames.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Source {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_reference: Option<i32>,
+}
+
+impl Source {
+    #[must_use]
+    pub fn new(path: impl Into<String>) -> Self {
+        let path = path.into();
+        let name = std::path::Path::new(&path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(ToOwned::to_owned);
+
+        Self { name, path, source_reference: None }
+    }
+}
+
+/// Variable information returned by the debug adapter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Variable {
+    pub name: String,
+    pub value: String,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub type_: Option<String>,
+    pub variables_reference: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub named_variables: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed_variables: Option<i32>,
+}

--- a/crates/perl-dap-types/tests/shared_types.rs
+++ b/crates/perl-dap-types/tests/shared_types.rs
@@ -1,0 +1,40 @@
+use perl_dap_types::{Source, StackFrame, Variable};
+
+#[test]
+fn source_derives_name_from_path() {
+    let source = Source::new("/tmp/example.pl");
+
+    assert_eq!(source.name.as_deref(), Some("example.pl"));
+    assert_eq!(source.path, "/tmp/example.pl");
+    assert_eq!(source.source_reference, None);
+}
+
+#[test]
+fn stack_frame_builders_preserve_state() {
+    let frame = StackFrame::new(7, "main::run", Source::new("/tmp/example.pl"), 42)
+        .with_column(3)
+        .with_end(44, 9);
+
+    assert_eq!(frame.id, 7);
+    assert_eq!(frame.name, "main::run");
+    assert_eq!(frame.source.name.as_deref(), Some("example.pl"));
+    assert_eq!(frame.column, 3);
+    assert_eq!(frame.end_line, Some(44));
+    assert_eq!(frame.end_column, Some(9));
+}
+
+#[test]
+fn variable_serializes_type_field() -> Result<(), serde_json::Error> {
+    let variable = Variable {
+        name: "$answer".to_string(),
+        value: "42".to_string(),
+        type_: Some("scalar".to_string()),
+        variables_reference: 0,
+        named_variables: None,
+        indexed_variables: None,
+    };
+
+    let json = serde_json::to_string(&variable)?;
+    assert!(json.contains("\"type\":\"scalar\""));
+    Ok(())
+}

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -57,6 +57,7 @@ perl-dap-platform = { workspace = true }
 perl-dap-command-args = { workspace = true }
 perl-dap-variables = { workspace = true }
 perl-dap-stack = { workspace = true }
+perl-dap-types = { workspace = true }
 perl-module-path = { workspace = true }
 perl-dap-security = { workspace = true }
 perl-content-length-framing = { workspace = true }

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -33,6 +33,7 @@ use perl_content_length_framing::{ContentLengthFramer, frame};
 use perl_dap_breakpoint::{AstBreakpointValidator, BreakpointValidator};
 use perl_dap_eval::SafeEvaluator;
 use perl_dap_stack::{PerlStackParser, is_internal_frame_name_and_path};
+use perl_dap_types::{Source, StackFrame, Variable};
 use perl_dap_variables::{
     PerlVariableRenderer, RenderedVariable, VariableParser, VariableRenderer,
 };
@@ -506,46 +507,6 @@ pub enum DapMessage {
         #[serde(skip_serializing_if = "Option::is_none")]
         body: Option<Value>,
     },
-}
-
-/// Stack frame information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct StackFrame {
-    id: i32,
-    name: String,
-    source: Source,
-    line: i32,
-    column: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    end_line: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    end_column: Option<i32>,
-}
-
-/// Source file information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Source {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    source_reference: Option<i32>,
-}
-
-/// Variable information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Variable {
-    name: String,
-    value: String,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    type_: Option<String>,
-    variables_reference: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    named_variables: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    indexed_variables: Option<i32>,
 }
 
 impl Default for DebugAdapter {


### PR DESCRIPTION
### Motivation
- Reduce the large godfile surface in the DAP adapter by extracting the shared debug-session model types (`StackFrame`, `Source`, `Variable`) into a focused SRP microcrate.
- Improve reuse and testability of session model types so other DAP-related crates can depend on a single canonical definition.

### Description
- Add a new crate `crates/perl-dap-types` containing `StackFrame`, `Source`, and `Variable` model types with small constructors/builders and serde annotations (`src/lib.rs`).
- Wire the new microcrate into the workspace by updating `Cargo.toml` and `crates/perl-dap/Cargo.toml` to list and depend on `perl-dap-types`.
- Remove the duplicated inline `StackFrame`/`Source`/`Variable` type definitions from `crates/perl-dap/src/debug_adapter/mod.rs` and import them from `perl_dap_types` instead.
- Add focused unit tests for the extracted crate (`crates/perl-dap-types/tests/shared_types.rs`) and adjust the test to avoid `expect()` so it passes clippy.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-dap-types` and the crate tests passed (`3` tests passed).
- Ran `cargo test -p perl-dap --lib` and the perl-dap library tests passed (all reported tests passed, e.g. `119` tests in the run passed).
- Ran `cargo clippy -p perl-dap-types -p perl-dap --all-targets -- -D warnings` after fixing the test and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a3f31248333aadfc155730ba652)