### PR TITLE
Extract perl-dap protocol microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "perl-dap-command-args",
  "perl-dap-eval",
  "perl-dap-platform",
+ "perl-dap-protocol",
  "perl-dap-security",
  "perl-dap-stack",
  "perl-dap-variables",
@@ -1629,6 +1630,15 @@ dependencies = [
  "anyhow",
  "perl-dap-shell",
  "perl-tdd-support",
+]
+
+[[package]]
+name = "perl-dap-protocol"
+version = "0.11.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
     "crates/perl-dap-command-args",
     "crates/perl-dap-shell",
     "crates/perl-dap-value",
+    "crates/perl-dap-protocol",
     "crates/perl-dap-security",
     "crates/perl-dap-variables",
     "crates/perl-feature-catalog",
@@ -217,6 +218,7 @@ allow = [
     "perl-dap-breakpoint",
     "perl-dap-eval",
     "perl-dap-command-args",
+    "perl-dap-protocol",
     "perl-dap-platform",
     "perl-dap-shell",
     "perl-dap-security",
@@ -340,6 +342,7 @@ perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.11.0" 
 perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.11.0" }
 perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.11.0" }
 perl-dap-value = { path = "crates/perl-dap-value", version = "0.11.0" }
+perl-dap-protocol = { path = "crates/perl-dap-protocol", version = "0.11.0" }
 perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.11.0" }
 perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.11.0" }
 perl-dap-security = { path = "crates/perl-dap-security", version = "0.11.0" }

--- a/crates/perl-dap-protocol/Cargo.toml
+++ b/crates/perl-dap-protocol/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "perl-dap-protocol"
+version = "0.11.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Debug Adapter Protocol request/response types for perl-dap"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-dap-protocol"
+readme = "README.md"
+keywords = ["perl", "dap", "protocol", "debug-adapter"]
+categories = ["development-tools::debugging"]
+include = [
+  "src/**",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE*"
+]
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+
+[dev-dependencies]
+anyhow = "1.0.102"
+
+[lints]
+workspace = true

--- a/crates/perl-dap-protocol/README.md
+++ b/crates/perl-dap-protocol/README.md
@@ -1,0 +1,3 @@
+# perl-dap-protocol
+
+Shared Debug Adapter Protocol message and payload types for `perl-dap`.

--- a/crates/perl-dap-protocol/src/lib.rs
+++ b/crates/perl-dap-protocol/src/lib.rs
@@ -1141,3 +1141,41 @@ pub struct TerminateThreadsArguments {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_ids: Option<Vec<i64>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::{Breakpoint, Request};
+
+    #[test]
+    fn request_round_trips_through_json() -> Result<()> {
+        let request = Request {
+            seq: 7,
+            msg_type: "request".to_string(),
+            command: "initialize".to_string(),
+            arguments: Some(serde_json::json!({"adapterId": "perl-rs"})),
+        };
+
+        let json = serde_json::to_string(&request)?;
+        let decoded: Request = serde_json::from_str(&json)?;
+
+        assert_eq!(decoded.seq, 7);
+        assert_eq!(decoded.command, "initialize");
+        assert_eq!(decoded.arguments, Some(serde_json::json!({"adapterId": "perl-rs"})));
+        Ok(())
+    }
+
+    #[test]
+    fn breakpoint_omits_optional_fields_when_empty() -> Result<()> {
+        let breakpoint =
+            Breakpoint { id: 1, verified: true, line: 12, column: None, message: None };
+
+        let value = serde_json::to_value(&breakpoint)?;
+
+        assert_eq!(value.get("id"), Some(&serde_json::json!(1)));
+        assert!(value.get("column").is_none());
+        assert!(value.get("message").is_none());
+        Ok(())
+    }
+}

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -57,6 +57,7 @@ perl-dap-platform = { workspace = true }
 perl-dap-command-args = { workspace = true }
 perl-dap-variables = { workspace = true }
 perl-dap-stack = { workspace = true }
+perl-dap-protocol = { workspace = true }
 perl-module-path = { workspace = true }
 perl-dap-security = { workspace = true }
 perl-content-length-framing = { workspace = true }

--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -376,7 +376,7 @@ pub mod dispatcher;
 /// Inline value extraction for DAP `inlineValues` requests.
 pub mod inline_values;
 /// DAP protocol types following the JSON-RPC 2.0 message format.
-pub mod protocol;
+pub use perl_dap_protocol as protocol;
 /// TCP-based attachment to running Perl debugger processes.
 pub mod tcp_attach;
 


### PR DESCRIPTION
### Motivation
- Reduce the responsibility of the `perl-dap` crate by extracting the large DAP request/response type surface into its own SRP-focused microcrate to make the protocol types independently versionable and easier to test.
- Minimize compilation churn and external dependencies for other DAP components by making the protocol a lightweight leaf crate with narrow serde-only dependencies.

### Description
- Added a new workspace crate `crates/perl-dap-protocol` containing the Debug Adapter Protocol request/response types previously defined inline in `perl-dap` (moved `protocol.rs` -> `perl-dap-protocol/src/lib.rs`).
- Wired the new crate into the workspace `Cargo.toml` membership and workspace dependency table and added it to the publish allowlist entries used by the repository metadata.
- Updated `crates/perl-dap` to depend on the new workspace crate and preserved the existing public API surface by re-exporting it as `perl_dap::protocol` (`pub use perl_dap_protocol as protocol;`).
- Added focused serialization/unit tests inside `perl-dap-protocol` to validate `Request`/`Breakpoint` JSON round-trips and optional-field behavior, and added a small README for the microcrate.

### Testing
- Ran `cargo fmt --all` to ensure formatting consistency and it completed successfully.
- Ran `cargo test -p perl-dap-protocol` and the crate unit tests passed (`2 passed; 0 failed`).
- Ran `cargo test -p perl-dap --test protocol_edge_case_tests` and the protocol-focused integration tests passed (`79 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a0879b08333a1ede6f7dd768af8)