### PR TITLE
Extract shared LSP execute-command microcrate (perl-lsp-command)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-lsp-command"
+version = "0.11.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "perl-lsp-completion"
 version = "0.11.0"
 dependencies = [
@@ -2067,6 +2074,7 @@ name = "perl-lsp-input-validation"
 version = "0.11.0"
 dependencies = [
  "anyhow",
+ "perl-lsp-command",
  "perl-path-security",
  "perl-tdd-support",
  "serde_json",
@@ -2125,6 +2133,7 @@ name = "perl-lsp-protocol"
 version = "0.11.0"
 dependencies = [
  "lsp-types",
+ "perl-lsp-command",
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/perl-lsp-providers",
     "crates/perl-lsp-rename",
     "crates/perl-lsp-protocol",
+    "crates/perl-lsp-command",
     "crates/perl-lsp-transport",
     "crates/perl-lsp-on-type-formatting",
     "crates/perl-lsp-tooling",
@@ -140,6 +141,7 @@ allow = [
     "perl-percentile",
     "perl-subprocess-runtime",
     "perl-lsp-protocol",
+    "perl-lsp-command",
     "perl-lsp-symbol-query",
     "perl-keywords",
     "perl-regex",
@@ -331,6 +333,7 @@ perl-percentile = { path = "crates/perl-percentile", version = "0.11.0" }
 perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.11.0" }
 perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.11.0" }
 perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.11.0" }
+perl-lsp-command = { path = "crates/perl-lsp-command", version = "0.11.0" }
 perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.11.0" }
 perl-path-security = { path = "crates/perl-path-security", version = "0.11.0" }
 perl-corpus = { path = "crates/perl-corpus", version = "0.11.0" }

--- a/crates/perl-lsp-command/Cargo.toml
+++ b/crates/perl-lsp-command/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "perl-lsp-command"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-command"
+description = "Shared execute-command identifiers and validation helpers for perl-lsp"
+readme = "README.md"
+keywords = ["perl", "lsp", "command", "executecommand"]
+categories = ["development-tools", "text-editors"]
+include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-command/README.md
+++ b/crates/perl-lsp-command/README.md
@@ -1,0 +1,10 @@
+# perl-lsp-command
+
+Shared execute-command identifiers and validation helpers for the `perl-lsp` workspace.
+
+## API
+
+- `supported_execute_commands()`
+- `supported_execute_command_strings()`
+- `is_supported_execute_command(command)`
+- `is_refactor_command(command)`

--- a/crates/perl-lsp-command/src/lib.rs
+++ b/crates/perl-lsp-command/src/lib.rs
@@ -1,0 +1,122 @@
+//! Shared execute-command identifiers for `perl-lsp` crates.
+//!
+//! This microcrate has one narrow responsibility: define the canonical LSP
+//! `workspace/executeCommand` identifiers used across capability advertisement,
+//! request validation, and command classification.
+
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+#![warn(missing_docs)]
+#![warn(clippy::all)]
+
+/// Execute `prove`/test-suite style workflows for a file.
+pub const RUN_TESTS: &str = "perl.runTests";
+/// Execute a Perl file directly.
+pub const RUN_FILE: &str = "perl.runFile";
+/// Execute a specific test subroutine.
+pub const RUN_TEST_SUB: &str = "perl.runTestSub";
+/// Run Perl::Critic or the built-in critic fallback.
+pub const RUN_CRITIC: &str = "perl.runCritic";
+/// Run a single test target.
+pub const RUN_TEST: &str = "perl.runTest";
+/// Run a test file target.
+pub const RUN_TEST_FILE: &str = "perl.runTestFile";
+/// Launch debugging for a file.
+pub const DEBUG_FILE: &str = "perl.debugFile";
+/// Extract a variable refactor.
+pub const EXTRACT_VARIABLE: &str = "perl.extractVariable";
+/// Extract a subroutine refactor.
+pub const EXTRACT_SUBROUTINE: &str = "perl.extractSubroutine";
+/// Organize and optimize imports.
+pub const OPTIMIZE_IMPORTS: &str = "perl.optimizeImports";
+/// Format the current document.
+pub const FORMAT_DOCUMENT: &str = "perl.formatDocument";
+
+const ADVERTISED_EXECUTE_COMMANDS: &[&str] =
+    &[RUN_TESTS, RUN_FILE, RUN_TEST_SUB, RUN_CRITIC, RUN_TEST, RUN_TEST_FILE, DEBUG_FILE];
+
+const VALIDATED_EXECUTE_COMMANDS: &[&str] =
+    &[RUN_CRITIC, FORMAT_DOCUMENT, EXTRACT_VARIABLE, EXTRACT_SUBROUTINE, OPTIMIZE_IMPORTS];
+
+const REFACTOR_COMMANDS: &[&str] = &[EXTRACT_VARIABLE, EXTRACT_SUBROUTINE, OPTIMIZE_IMPORTS];
+
+/// Borrow the canonical supported command identifiers advertised in server capabilities.
+#[must_use]
+pub const fn advertised_execute_commands() -> &'static [&'static str] {
+    ADVERTISED_EXECUTE_COMMANDS
+}
+
+/// Clone the advertised command list into owned strings.
+#[must_use]
+pub fn advertised_execute_command_strings() -> Vec<String> {
+    advertised_execute_commands().iter().map(|command| (*command).to_string()).collect()
+}
+
+/// Borrow the canonical command identifiers accepted by input validation.
+#[must_use]
+pub const fn validated_execute_commands() -> &'static [&'static str] {
+    VALIDATED_EXECUTE_COMMANDS
+}
+
+/// Check whether a command is in the input-validation allowlist.
+#[must_use]
+pub fn is_validated_execute_command(command: &str) -> bool {
+    validated_execute_commands().contains(&command)
+}
+
+/// Check whether a command belongs to the refactor/import-management subset.
+#[must_use]
+pub fn is_refactor_command(command: &str) -> bool {
+    REFACTOR_COMMANDS.contains(&command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEBUG_FILE, EXTRACT_SUBROUTINE, EXTRACT_VARIABLE, FORMAT_DOCUMENT, OPTIMIZE_IMPORTS,
+        RUN_CRITIC, RUN_FILE, RUN_TEST, RUN_TEST_FILE, RUN_TEST_SUB, RUN_TESTS,
+        advertised_execute_command_strings, advertised_execute_commands, is_refactor_command,
+        is_validated_execute_command, validated_execute_commands,
+    };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn advertised_commands_are_unique_and_stable() {
+        let commands = advertised_execute_commands();
+        let unique = commands.iter().copied().collect::<BTreeSet<_>>();
+
+        assert_eq!(commands.len(), unique.len());
+        assert_eq!(
+            commands,
+            &[RUN_TESTS, RUN_FILE, RUN_TEST_SUB, RUN_CRITIC, RUN_TEST, RUN_TEST_FILE, DEBUG_FILE,]
+        );
+    }
+
+    #[test]
+    fn validation_allowlist_matches_security_expectations() {
+        assert_eq!(
+            validated_execute_commands(),
+            &[RUN_CRITIC, FORMAT_DOCUMENT, EXTRACT_VARIABLE, EXTRACT_SUBROUTINE, OPTIMIZE_IMPORTS,]
+        );
+
+        for command in validated_execute_commands() {
+            assert!(is_validated_execute_command(command));
+        }
+
+        assert!(!is_validated_execute_command(RUN_TESTS));
+        assert!(!is_validated_execute_command("perl.unknownCommand"));
+    }
+
+    #[test]
+    fn owned_string_list_matches_borrowed_advertised_list() {
+        let borrowed = advertised_execute_commands();
+        let owned = advertised_execute_command_strings();
+
+        assert_eq!(owned.len(), borrowed.len());
+        assert!(owned.iter().zip(borrowed.iter()).all(|(left, right)| left == right));
+        assert!(is_refactor_command(EXTRACT_VARIABLE));
+        assert!(is_refactor_command(EXTRACT_SUBROUTINE));
+        assert!(is_refactor_command(OPTIMIZE_IMPORTS));
+        assert!(!is_refactor_command(RUN_TESTS));
+    }
+}

--- a/crates/perl-lsp-input-validation/Cargo.toml
+++ b/crates/perl-lsp-input-validation/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
+perl-lsp-command = { workspace = true }
 anyhow = "1.0.102"
 serde_json = { workspace = true }
 perl-path-security = { workspace = true }

--- a/crates/perl-lsp-input-validation/src/lib.rs
+++ b/crates/perl-lsp-input-validation/src/lib.rs
@@ -2,6 +2,7 @@
 //! Input validation and sanitization utilities for production hardening.
 
 use anyhow::{Result, anyhow};
+use perl_lsp_command::is_validated_execute_command;
 use perl_path_security::validate_workspace_path;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -135,18 +136,10 @@ fn validate_text_document_params(params: &serde_json::Value) -> Result<()> {
 }
 
 fn validate_execute_command_params(params: &serde_json::Value) -> Result<()> {
-    if let Some(command) = params.get("command").and_then(serde_json::Value::as_str) {
-        let allowed_commands = [
-            "perl.runCritic",
-            "perl.formatDocument",
-            "perl.extractVariable",
-            "perl.extractSubroutine",
-            "perl.optimizeImports",
-        ];
-
-        if !allowed_commands.contains(&command) {
-            return Err(anyhow!("Command not allowed: {}", command));
-        }
+    if let Some(command) = params.get("command").and_then(serde_json::Value::as_str)
+        && !is_validated_execute_command(command)
+    {
+        return Err(anyhow!("Command not allowed: {}", command));
     }
 
     Ok(())

--- a/crates/perl-lsp-protocol/Cargo.toml
+++ b/crates/perl-lsp-protocol/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 ]
 
 [dependencies]
+perl-lsp-command = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 perl-lsp-feature-flags = { workspace = true }

--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -14,6 +14,7 @@
 //! - **Analyze**: Drives diagnostics, code actions, and refactoring support
 
 use lsp_types::*;
+use perl_lsp_command::advertised_execute_command_strings;
 use serde_json::Value;
 
 pub use perl_lsp_feature_flags::{AdvertisedFeatures, BuildFlags};
@@ -287,15 +288,7 @@ pub fn capabilities_json(build: BuildFlags) -> Value {
 /// Returns all command identifiers that can be executed via the LSP executeCommand
 /// method. This list is used for capability registration and command validation.
 pub fn get_supported_commands() -> Vec<String> {
-    vec![
-        "perl.runTests".to_string(),
-        "perl.runFile".to_string(),
-        "perl.runTestSub".to_string(),
-        "perl.runCritic".to_string(),
-        "perl.runTest".to_string(),
-        "perl.runTestFile".to_string(),
-        "perl.debugFile".to_string(),
-    ]
+    advertised_execute_command_strings()
 }
 
 /// Check if a capability is a boolean or object (for flexible assertions)


### PR DESCRIPTION
### Motivation
- Reduce duplication and follow SRP by centralizing LSP `workspace/executeCommand` identifiers and small helpers in a single microcrate. 
- Allow both capability advertisement and input validation to consume the same canonical command list to avoid drift. 
- Prepare a narrow, easily-reviewable extraction that other LSP crates can depend on without changing behavior.

### Description
- Added a new microcrate `crates/perl-lsp-command` that defines canonical command constants, advertised and validated command subsets, and helpers such as `advertised_execute_command_strings()` and `is_validated_execute_command()`.
- Rewrote `crates/perl-lsp-protocol/src/capabilities.rs` to advertise execute-command identifiers via `perl_lsp_command::advertised_execute_command_strings()` instead of an inline list.
- Rewrote `crates/perl-lsp-input-validation/src/lib.rs` to validate `workspace/executeCommand` requests using `perl_lsp_command::is_validated_execute_command()` instead of a duplicated hard-coded allowlist.
- Registered the new crate in the workspace members and the workspace publish/dependency tables (`Cargo.toml`) and added the crate `Cargo.toml` and tests in `crates/perl-lsp-command`.

### Testing
- Ran unit tests: `cargo test -p perl-lsp-command -p perl-lsp-input-validation -p perl-lsp-protocol` and all targeted test suites passed. 
- Ran linting: `cargo clippy -p perl-lsp-command -p perl-lsp-input-validation -p perl-lsp-protocol --all-targets -- -D warnings` with no warnings or errors. 
- Verified formatting with `cargo fmt --all` during the change (formatting applied).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba0a0879b08333a1ede6f7dd768af8)