### PR TITLE
docs: improve documentation site pipeline visualization

### DIFF
--- a/docs/project/DOCUMENTATION_SITE.md
+++ b/docs/project/DOCUMENTATION_SITE.md
@@ -43,14 +43,48 @@ Documentation content comes from two sources:
 
 This approach maintains a single source of truth (the `docs/` directory) while providing a structured reading experience.
 
+The visualization below separates the pipeline into source, generation, build, and publish stages so it is easier to see which steps are editable by hand versus automated in CI.
+
 ### Build Process
 
 ```mermaid
-graph LR
-    A[docs/*.md] -->|populate-book.sh| B[book/src/]
-    C[book/src/*.md] --> B
-    B -->|mdbook build| D[book/book/]
-    D -->|GitHub Actions| E[GitHub Pages]
+flowchart LR
+    subgraph Sources[Source content]
+        DOCS[docs/**/*.md
+canonical project docs]
+        BOOK[book/src/*.md
+book-only pages]
+        SUMMARY[book/src/SUMMARY.md
+navigation tree]
+    end
+
+    subgraph Generate[Book generation]
+        POPULATE[scripts/populate-book.sh
+copy + normalize docs]
+        STAGING[book/src/**
+staged mdBook content]
+    end
+
+    subgraph Build[Static site build]
+        MDBOOK[mdbook build]
+        OUTPUT[book/book/**
+rendered HTML + search index]
+    end
+
+    subgraph Publish[Deployment]
+        ACTIONS[.github/workflows/docs-deploy.yml]
+        PAGES[GitHub Pages
+live documentation site]
+    end
+
+    DOCS --> POPULATE
+    BOOK --> STAGING
+    SUMMARY --> STAGING
+    POPULATE --> STAGING
+    STAGING --> MDBOOK
+    MDBOOK --> OUTPUT
+    OUTPUT --> ACTIONS
+    ACTIONS --> PAGES
 ```
 
 ## Usage


### PR DESCRIPTION
### Motivation
- Make the documentation site build pipeline easier to understand by clarifying which steps are edited by humans versus automated in CI.

### Description
- Replace the simple Mermaid graph in `docs/project/DOCUMENTATION_SITE.md` with a staged `flowchart` that separates `Sources`, `Generate`, `Build`, and `Publish` phases.
- Add explanatory copy above the diagram to note that the visualization distinguishes hand-edited steps (docs/book sources) from CI-driven steps (populate, build, deploy).

### Testing
- Ran `cargo fmt --all` to ensure formatting consistency, which succeeded.
- Ran `bash scripts/populate-book.sh` to verify doc population works, which succeeded.
- Attempted `just docs-build` to run the full docs build, but it failed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba12a455348333bae997dc0663a9aa)