### PR TITLE
Centralize CLI logging setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "winapi",
 ]
 
@@ -2080,6 +2079,7 @@ dependencies = [
  "clap",
  "perl-lsp-feature-governance",
  "perl-tdd-support",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -46,7 +46,6 @@ tokio = { version = "1.49.0", features = ["full"] }
 
 # Logging
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 # Command-line argument parsing
 clap = { version = "4.5.60", features = ["derive"] }

--- a/crates/perl-dap/src/main.rs
+++ b/crates/perl-dap/src/main.rs
@@ -5,8 +5,7 @@
 
 use clap::Parser;
 use perl_dap::{DapConfig, DapMode, DapServer};
-use std::io;
-use tracing_subscriber::{EnvFilter, fmt};
+use perl_lsp_launcher::{LoggingMode, init_stderr_tracing};
 
 /// Perl Debug Adapter Protocol server
 #[derive(Parser, Debug)]
@@ -24,18 +23,10 @@ struct Args {
     log_level: String,
 }
 
-fn init_logging(log_level: &str) {
-    let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(log_level))
-        .unwrap_or_else(|_| EnvFilter::new("info"));
-
-    fmt().with_env_filter(filter).with_writer(io::stderr).init();
-}
-
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    init_logging(&args.log_level);
+    init_stderr_tracing(&LoggingMode::On { default_directive: args.log_level.clone() });
     tracing::info!("perl-dap: Debug Adapter Protocol server starting");
 
     let config = DapConfig {

--- a/crates/perl-lsp-launcher/Cargo.toml
+++ b/crates/perl-lsp-launcher/Cargo.toml
@@ -18,6 +18,7 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 perl-lsp-feature-governance = { workspace = true }
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [features]
 lsp-ga-lock = ["perl-lsp-feature-governance/lsp-ga-lock"]

--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -16,9 +16,48 @@ pub use perl_lsp_feature_governance::{
     to_json_for_profile,
 };
 use perl_lsp_feature_governance::{feature_profile_supported_tokens, parse_feature_profile_arg};
+use std::io;
+use tracing_subscriber::{EnvFilter, fmt as tracing_fmt};
 
 /// Default port used by socket transport.
 pub const DEFAULT_LSP_PORT: u16 = 9257;
+
+/// Logging mode for CLI binaries that use shared startup plumbing.
+#[derive(Debug, Clone)]
+pub enum LoggingMode {
+    /// Logging disabled by default unless enabled by CLI or `RUST_LOG`.
+    Off,
+    /// Logging enabled with the provided fallback directive when `RUST_LOG` is unset.
+    On {
+        /// Fallback directive used when `RUST_LOG` is unavailable or invalid.
+        default_directive: String,
+    },
+}
+
+impl LoggingMode {
+    /// Build a logging mode from a simple enabled/disabled flag.
+    pub fn from_flag(enabled: bool, default_directive: impl Into<String>) -> Self {
+        if enabled { Self::On { default_directive: default_directive.into() } } else { Self::Off }
+    }
+}
+
+/// Initialize stderr tracing for a CLI binary.
+///
+/// When logging is disabled, this still honors `RUST_LOG` so operators can turn
+/// on diagnostics without changing CLI flags. Invalid directives fall back to a
+/// safe default.
+pub fn init_stderr_tracing(mode: &LoggingMode) {
+    let default_directive = match mode {
+        LoggingMode::Off => "warn",
+        LoggingMode::On { default_directive } => default_directive.as_str(),
+    };
+
+    let filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(default_directive))
+        .unwrap_or_else(|_| EnvFilter::new("warn"));
+
+    let _ = tracing_fmt().with_env_filter(filter).with_writer(io::stderr).try_init();
+}
 
 /// Transport options shared by server binaries.
 #[derive(Args, Debug, Clone)]

--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -10,8 +10,9 @@
 #![deny(clippy::option_env_unwrap)]
 use perl_lsp::LspServer;
 use perl_lsp_launcher::{
-    LaunchAction, LaunchConfig, TransportMode, format_health_output, format_info_output, help_text,
-    parse_args, port_in_use_message, shell_completion,
+    LaunchAction, LaunchConfig, LoggingMode, TransportMode, format_health_output,
+    format_info_output, help_text, init_stderr_tracing, parse_args, port_in_use_message,
+    shell_completion,
 };
 use std::env;
 use std::process;
@@ -159,13 +160,13 @@ fn is_terminal_stdout() -> bool {
 }
 
 fn run_server(launch_config: LaunchConfig) {
+    init_stderr_tracing(&LoggingMode::from_flag(launch_config.enable_logging, "info"));
+
     if launch_config.enable_logging {
-        eprintln!("Perl Language Server starting...");
-        eprintln!("Mode: {}", launch_config.transport.label());
+        tracing::info!(transport = %launch_config.transport.label(), feature_profile = %launch_config.feature_profile.as_str(), "Perl Language Server starting");
         if let Some(port) = launch_config.transport.port() {
-            eprintln!("Port: {port}");
+            tracing::info!(port, "Configured TCP listener port");
         }
-        eprintln!("Feature profile: {}", launch_config.feature_profile.as_str());
     }
 
     match launch_config.transport {
@@ -222,30 +223,30 @@ fn run_server(launch_config: LaunchConfig) {
                         process::exit(1);
                     }
                 };
-                eprintln!("Perl LSP listening on {}", local_addr);
+                tracing::info!(local_addr = %local_addr, "Perl LSP listening");
 
                 loop {
                     match listener.accept().await {
                         Ok((stream, peer_addr)) => {
-                            eprintln!("Accepted connection from {peer_addr}");
+                            tracing::info!(peer_addr = %peer_addr, "Accepted LSP connection");
                             tokio::spawn(async move {
                                 let std_stream = match stream.into_std() {
                                     Ok(std_stream) => std_stream,
                                     Err(error) => {
-                                        eprintln!("Failed to convert stream to std: {error}");
+                                        tracing::error!(%error, "Failed to convert stream to std");
                                         return;
                                     }
                                 };
 
                                 if let Err(e) = std_stream.set_nonblocking(false) {
-                                    eprintln!("Failed to set blocking mode: {}", e);
+                                    tracing::error!(error = %e, "Failed to set blocking mode");
                                     return;
                                 }
 
                                 let writer = match std_stream.try_clone() {
                                     Ok(w) => w,
                                     Err(e) => {
-                                        eprintln!("Failed to clone stream: {e}");
+                                        tracing::error!(error = %e, "Failed to clone stream");
                                         return;
                                     }
                                 };
@@ -270,7 +271,7 @@ fn run_server(launch_config: LaunchConfig) {
                             });
                         }
                         Err(e) => {
-                            eprintln!("Failed to accept: {e}");
+                            tracing::error!(error = %e, "Failed to accept incoming LSP connection");
                             sleep(Duration::from_millis(100)).await;
                         }
                     }


### PR DESCRIPTION
### Motivation

- Reduce duplicated logging bootstrap across binaries and provide a single, testable initializer for stderr tracing so operators can enable diagnostics via `RUST_LOG` without changing CLI flags.
- Replace ad-hoc `eprintln!` startup messages with structured `tracing` events for consistent runtime observability.
- Keep dependency ownership consistent by moving `tracing-subscriber` into the shared launcher crate so binaries reuse the same setup.

### Description

- Add `LoggingMode` and `init_stderr_tracing` to `crates/perl-lsp-launcher/src/lib.rs` to provide a shared stderr tracing initializer and fallback logic that honors `RUST_LOG` or a provided default directive.
- Add `tracing-subscriber` to `crates/perl-lsp-launcher/Cargo.toml` and remove the duplicated `tracing-subscriber` usage from `crates/perl-dap`.
- Update `crates/perl-lsp/src/main.rs` to call `init_stderr_tracing` and replace startup and socket lifecycle `eprintln!` calls with `tracing::info!`/`tracing::error!` instrumentation for connection accept, bind, and error paths.
- Update `crates/perl-dap/src/main.rs` to use the same `init_stderr_tracing` helper and remove the local `init_logging` bootstrap code.
- Small lockfile and manifest updates reflect moved dependency ownership (`Cargo.lock`, `crates/*/Cargo.toml`).

### Testing

- Ran `cargo test -p perl-lsp-launcher`, and unit tests passed (`26` + `65` tests across suites; all passed).
- Ran `cargo check -p perl-lsp --bin perl-lsp`, which completed successfully.
- Ran `cargo check -p perl-dap --bin perl-dap`, which completed successfully.
- Ran formatting checks `cargo fmt --all --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba10d0cbbc833394b44bacd1953588)