### PR TITLE
Centralize server logging setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,8 @@ dependencies = [
  "clap",
  "perl-lsp-feature-governance",
  "perl-tdd-support",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/perl-dap/src/main.rs
+++ b/crates/perl-dap/src/main.rs
@@ -5,8 +5,7 @@
 
 use clap::Parser;
 use perl_dap::{DapConfig, DapMode, DapServer};
-use std::io;
-use tracing_subscriber::{EnvFilter, fmt};
+use perl_lsp_launcher::{init_stderr_logging, log_server_startup};
 
 /// Perl Debug Adapter Protocol server
 #[derive(Parser, Debug)]
@@ -24,19 +23,11 @@ struct Args {
     log_level: String,
 }
 
-fn init_logging(log_level: &str) {
-    let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(log_level))
-        .unwrap_or_else(|_| EnvFilter::new("info"));
-
-    fmt().with_env_filter(filter).with_writer(io::stderr).init();
-}
-
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    init_logging(&args.log_level);
-    tracing::info!("perl-dap: Debug Adapter Protocol server starting");
+    let _logging_initialized = init_stderr_logging(&args.log_level);
+    log_server_startup("perl-dap", args.transport.mode(), None, Some(&args.log_level));
 
     let config = DapConfig {
         log_level: args.log_level,

--- a/crates/perl-lsp-launcher/Cargo.toml
+++ b/crates/perl-lsp-launcher/Cargo.toml
@@ -18,6 +18,8 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 perl-lsp-feature-governance = { workspace = true }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [features]
 lsp-ga-lock = ["perl-lsp-feature-governance/lsp-ga-lock"]

--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -9,6 +9,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::io;
 
 use clap::{Args, Parser};
 pub use perl_lsp_feature_governance::{
@@ -16,6 +17,7 @@ pub use perl_lsp_feature_governance::{
     to_json_for_profile,
 };
 use perl_lsp_feature_governance::{feature_profile_supported_tokens, parse_feature_profile_arg};
+use tracing_subscriber::EnvFilter;
 
 /// Default port used by socket transport.
 pub const DEFAULT_LSP_PORT: u16 = 9257;
@@ -173,6 +175,64 @@ impl LaunchConfig {
     pub fn advertised_feature_ids(&self) -> Vec<&'static str> {
         catalog_advertised_feature_ids(self.feature_profile)
     }
+}
+
+fn logging_filter(default_directive: &str) -> EnvFilter {
+    let filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(default_directive))
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    filter
+}
+
+/// Initialize stderr logging using `RUST_LOG` or a fallback directive.
+///
+/// Returns `true` when the subscriber was installed and `false` when another
+/// global subscriber was already active.
+pub fn init_stderr_logging(default_directive: &str) -> bool {
+    tracing_subscriber::fmt()
+        .with_env_filter(logging_filter(default_directive))
+        .with_writer(io::stderr)
+        .try_init()
+        .is_ok()
+}
+
+/// Build a human-readable startup summary used by server binaries.
+pub fn format_startup_summary(
+    server_name: &str,
+    transport: TransportMode,
+    feature_profile: Option<FeatureProfile>,
+    log_level: Option<&str>,
+) -> String {
+    let mut summary = format!("{server_name} starting via {}", transport.label());
+
+    if let Some(port) = transport.port() {
+        summary.push_str(&format!(" on port {port}"));
+    }
+    if let Some(profile) = feature_profile {
+        summary.push_str(&format!(" with profile {}", profile.as_str()));
+    }
+    if let Some(level) = log_level {
+        summary.push_str(&format!(" at level {level}"));
+    }
+
+    summary
+}
+
+/// Emit a standardized startup log line for a server binary.
+pub fn log_server_startup(
+    server_name: &str,
+    transport: TransportMode,
+    feature_profile: Option<FeatureProfile>,
+    log_level: Option<&str>,
+) {
+    let summary = format_startup_summary(server_name, transport, feature_profile, log_level);
+    let port = transport.port();
+    let transport = transport.label();
+    let feature_profile = feature_profile.map(FeatureProfile::as_str);
+    let log_level = log_level.unwrap_or("env");
+
+    tracing::info!(server = server_name, transport, port, feature_profile, log_level, "{summary}");
 }
 
 /// Fully resolved launch request.
@@ -787,5 +847,31 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("tcsh"));
         assert!(msg.contains("bash"));
+    }
+
+    #[test]
+    fn startup_summary_includes_optional_fields() {
+        let summary = super::format_startup_summary(
+            "perl-lsp",
+            TransportMode::Socket { port: 9257 },
+            Some(super::FeatureProfile::current()),
+            Some("debug"),
+        );
+
+        assert!(summary.contains("perl-lsp"));
+        assert!(summary.contains("socket"));
+        assert!(summary.contains("9257"));
+        assert!(summary.contains(super::FeatureProfile::current().as_str()));
+        assert!(summary.contains("debug"));
+    }
+
+    #[test]
+    fn startup_summary_omits_absent_optional_fields() {
+        let summary = super::format_startup_summary("perl-dap", TransportMode::Stdio, None, None);
+
+        assert!(summary.contains("perl-dap"));
+        assert!(summary.contains("stdio"));
+        assert!(!summary.contains("profile"));
+        assert!(!summary.contains("level"));
     }
 }

--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -11,7 +11,7 @@
 use perl_lsp::LspServer;
 use perl_lsp_launcher::{
     LaunchAction, LaunchConfig, TransportMode, format_health_output, format_info_output, help_text,
-    parse_args, port_in_use_message, shell_completion,
+    init_stderr_logging, log_server_startup, parse_args, port_in_use_message, shell_completion,
 };
 use std::env;
 use std::process;
@@ -160,12 +160,13 @@ fn is_terminal_stdout() -> bool {
 
 fn run_server(launch_config: LaunchConfig) {
     if launch_config.enable_logging {
-        eprintln!("Perl Language Server starting...");
-        eprintln!("Mode: {}", launch_config.transport.label());
-        if let Some(port) = launch_config.transport.port() {
-            eprintln!("Port: {port}");
-        }
-        eprintln!("Feature profile: {}", launch_config.feature_profile.as_str());
+        let _logging_initialized = init_stderr_logging("info");
+        log_server_startup(
+            "perl-lsp",
+            launch_config.transport,
+            Some(launch_config.feature_profile),
+            None,
+        );
     }
 
     match launch_config.transport {


### PR DESCRIPTION
### Motivation
- Avoid duplicated ad-hoc stderr/bootstrap logging in each server binary by centralizing logging initialization and startup metadata emission. 
- Provide a consistent, structured startup log line across server binaries so telemetry and troubleshooting are uniform.

### Description
- Add `tracing` and `tracing-subscriber` dependencies to `crates/perl-lsp-launcher/Cargo.toml` and implement centralized helpers in `crates/perl-lsp-launcher/src/lib.rs`: `init_stderr_logging`, `logging_filter`, `format_startup_summary`, and `log_server_startup` used to initialize a stderr subscriber and emit a standardized startup summary. 
- Replace ad-hoc `eprintln!`/local subscriber initialization in `crates/perl-lsp/src/main.rs` with calls to `init_stderr_logging` and `log_server_startup` when logging is enabled. 
- Replace ad-hoc subscriber initialization in `crates/perl-dap/src/main.rs` with the launcher helpers and emit the shared structured startup log. 
- Add unit tests in `perl-lsp-launcher` for the new `format_startup_summary` behavior (populated and minimal contexts).

### Testing
- Ran formatting with `cargo fmt --all` and it completed successfully. 
- Ran unit tests for the launcher with `cargo test -p perl-lsp-launcher`, and all launcher tests passed. 
- Performed a workspace sanity check with `cargo check -p perl-lsp -p perl-dap`, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba10d0cbbc833394b44bacd1953588)