### PR TITLE
test: expand perl-builtins-phf coverage

### DIFF
--- a/crates/perl-builtins-phf/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-builtins-phf/tests/comprehensive_unit_tests.rs
@@ -1,0 +1,50 @@
+use perl_builtins_phf::{
+    BUILTIN_FULL_SIGS, BUILTIN_SIGS, builtin_count, get_param_names, is_builtin,
+};
+
+#[test]
+fn get_param_names_returns_empty_slice_for_unknown_builtin() {
+    assert_eq!(get_param_names("not_a_builtin"), &[""; 0]);
+}
+
+#[test]
+fn builtin_count_matches_primary_signature_map_length() {
+    assert_eq!(builtin_count(), BUILTIN_SIGS.len());
+    assert!(BUILTIN_FULL_SIGS.len() < builtin_count());
+    assert!(BUILTIN_FULL_SIGS.len() >= 40);
+}
+
+#[test]
+fn file_test_operators_are_available_in_primary_signature_map() {
+    for operator in ["-e", "-f", "-d", "-r", "-w", "-x", "-T", "-B", "-M", "-C"] {
+        assert!(is_builtin(operator), "expected {operator} to be recognized as a builtin");
+        assert_eq!(get_param_names(operator), ["FILE"]);
+    }
+}
+
+#[test]
+fn zero_argument_builtins_are_preserved() {
+    for name in ["fork", "wait", "time", "endhostent"] {
+        assert!(is_builtin(name), "expected {name} to be recognized as a builtin");
+        assert_eq!(get_param_names(name), &[""; 0], "expected {name} to remain zero-argument");
+    }
+}
+
+#[test]
+fn full_signatures_keep_multi_variant_lookup_entries() {
+    assert_eq!(
+        BUILTIN_FULL_SIGS.get("system").copied(),
+        Some(&["system PROGRAM, LIST", "system PROGRAM"][..])
+    );
+    assert_eq!(
+        BUILTIN_FULL_SIGS.get("open").copied(),
+        Some(&["open FILEHANDLE, MODE, FILENAME", "open FILEHANDLE, EXPR", "open FILEHANDLE",][..])
+    );
+}
+
+#[test]
+fn builtin_lookup_is_case_sensitive() {
+    assert!(is_builtin("print"));
+    assert!(!is_builtin("Print"));
+    assert!(BUILTIN_FULL_SIGS.get("Print").is_none());
+}


### PR DESCRIPTION
### Motivation
- Increase unit/integration test coverage for the builtin signature tables to catch regressions in lookup behavior and catalog invariants.
- Exercise primary and full-signature maps and common edge cases such as unknown lookups, case sensitivity, and zero-argument builtins.
- Provide lightweight assertions that validate the relationship between the compact `BUILTIN_SIGS` map and the richer `BUILTIN_FULL_SIGS` table.

### Description
- Add `crates/perl-builtins-phf/tests/comprehensive_unit_tests.rs` containing focused tests that exercise `get_param_names`, `is_builtin`, and `builtin_count`.
- Verify unknown builtin lookups return an empty slice via `get_param_names("not_a_builtin")` and that lookup is case-sensitive (`is_builtin("Print")` is false).
- Assert file-test operators and zero-argument builtins are present in the primary map and confirm multi-variant entries exist in `BUILTIN_FULL_SIGS` for `system` and `open`.
- Validate catalog invariants by checking `builtin_count()` equals `BUILTIN_SIGS.len()` and that `BUILTIN_FULL_SIGS` is intentionally smaller but non-trivial.

### Testing
- Ran `cargo test -p perl-builtins-phf` and the new test suite passed (all tests in `comprehensive_unit_tests.rs` passed).
- Ran formatting with `cargo fmt --all` and a workspace lint pass with `cargo clippy --workspace`, both completed successfully.
- The changes were committed (message: `test: expand perl-builtins-phf coverage`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba136bd9048333a8a7e0e98e9d21e9)