### PR TITLE
Add path normalization coverage

### DIFF
--- a/crates/perl-path-normalize/src/lib.rs
+++ b/crates/perl-path-normalize/src/lib.rs
@@ -94,4 +94,46 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn collapses_current_and_parent_components_inside_workspace() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let normalized = normalize_path_within_workspace(
+            &PathBuf::from("./lib/../script/./tool.pl"),
+            &workspace,
+        )?;
+
+        assert_eq!(normalized, workspace.join("script/tool.pl"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn allows_returning_to_workspace_root_without_error() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let normalized =
+            normalize_path_within_workspace(&PathBuf::from("src/../lib/../main.pl"), &workspace)?;
+
+        assert_eq!(normalized, workspace.join("main.pl"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_absolute_paths() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let absolute_candidate = workspace.join("outside.pl");
+        let result = normalize_path_within_workspace(&absolute_candidate, &workspace);
+        assert!(
+            matches!(result, Err(NormalizePathError::PathTraversalAttempt(message)) if message.contains("Invalid component in relative path"))
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve unit coverage for `normalize_path_within_workspace` to ensure correct handling of `.` and `..` segments, safe collapse back to the workspace root, and rejection of absolute paths.

### Description
- Add three unit tests in `crates/perl-path-normalize/src/lib.rs`: `collapses_current_and_parent_components_inside_workspace`, `allows_returning_to_workspace_root_without_error`, and `rejects_absolute_paths`.
- The new tests exercise dot-segment collapsing, returning to workspace root without error, and the code path that rejects absolute or root/prefix components.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-path-normalize` and all tests passed (unit tests and boundary tests ran successfully).
- Ran `cargo clippy -p perl-path-normalize --tests -- -D warnings` with no warnings reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba136bd9048333a8a7e0e98e9d21e9)