### PR TITLE
Add unit tests for perl-lexer unicode and quote helper functions

### DIFF
--- a/crates/perl-lexer/src/quote_handler.rs
+++ b/crates/perl-lexer/src/quote_handler.rs
@@ -150,3 +150,44 @@ pub fn get_mod_spec(operator: &str) -> Option<&'static ModSpec> {
         _ => None, // q, qq, qw, qx don't take modifiers
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_tail_handles_charset_suffixes_and_canonical_run_order() {
+        let parsed = split_tail_for_spec("xmisaa", &QR_SPEC);
+
+        assert_eq!(parsed, Some(("imsx".to_string(), Some("aa"))));
+    }
+
+    #[test]
+    fn split_tail_rejects_invalid_or_misplaced_modifiers() {
+        assert_eq!(split_tail_for_spec("mx1", &M_SPEC), None);
+        assert_eq!(split_tail_for_spec("am", &M_SPEC), None);
+        assert_eq!(split_tail_for_spec("rx", &TR_SPEC), None);
+    }
+
+    #[test]
+    fn quote_operator_helpers_cover_known_and_unknown_values() {
+        assert_eq!(paired_close('{'), Some('}'));
+        assert_eq!(paired_close('/'), None);
+
+        assert!(is_quote_operator("qr"));
+        assert!(!is_quote_operator("say"));
+
+        assert_eq!(get_quote_token_type("y"), TokenType::Transliteration);
+
+        let unknown = get_quote_token_type("unknown");
+        assert!(
+            matches!(&unknown, TokenType::Error(message) if message.contains("Unknown quote operator: unknown"))
+        );
+
+        let tr_spec = get_mod_spec("tr");
+        assert!(
+            matches!(tr_spec, Some(spec) if spec.run == TR_SPEC.run && spec.allow_charset == TR_SPEC.allow_charset)
+        );
+        assert!(get_mod_spec("qq").is_none());
+    }
+}

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -102,3 +102,42 @@ pub fn analyze_unicode_complexity(text: &str) -> (usize, usize, usize) {
 
     (char_count, emoji_count, complex_char_count)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_start_accepts_ascii_unicode_and_emoji() {
+        reset_unicode_stats();
+
+        assert!(is_perl_identifier_start('_'));
+        assert!(is_perl_identifier_start('λ'));
+        assert!(is_perl_identifier_start('🚀'));
+        assert!(!is_perl_identifier_start('1'));
+
+        let (checks, emoji_hits) = get_unicode_stats();
+        assert_eq!(checks, 4);
+        assert_eq!(emoji_hits, 1);
+    }
+
+    #[test]
+    fn identifier_continue_accepts_joiners_variation_and_skin_tones() {
+        assert!(is_perl_identifier_continue('a'));
+        assert!(is_perl_identifier_continue('\''));
+        assert!(is_perl_identifier_continue('\u{200D}'));
+        assert!(is_perl_identifier_continue('\u{FE0F}'));
+        assert!(is_perl_identifier_continue('\u{1F3FD}'));
+        assert!(!is_perl_identifier_continue('-'));
+    }
+
+    #[test]
+    fn unicode_complexity_counts_complex_scalars_and_emoji() {
+        let text = "aé🚀\u{1F3FD}";
+        let (char_count, emoji_count, complex_char_count) = analyze_unicode_complexity(text);
+
+        assert_eq!(char_count, 4);
+        assert_eq!(emoji_count, 2);
+        assert_eq!(complex_char_count, 2);
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve focused unit test coverage for low-level `perl-lexer` helpers that were previously exercised only indirectly by larger lexer tests.
- Exercise Unicode identifier classification, emoji/stat tracking, and complexity accounting to catch regressions in boundary logic.
- Validate quote operator helper logic (modifier tail parsing, canonical ordering, paired delimiters, unknown operator reporting).

### Description
- Added tests to `crates/perl-lexer/src/unicode.rs` that cover `is_perl_identifier_start`, `is_perl_identifier_continue`, `analyze_unicode_complexity`, and the Unicode stats API (`reset_unicode_stats`, `get_unicode_stats`).
- Added tests to `crates/perl-lexer/src/quote_handler.rs` that cover `split_tail_for_spec`, `canon_run` behaviour, `paired_close`, `is_quote_operator`, `get_quote_token_type` for unknown operators, and `get_mod_spec` expectations.
- Fixed test assertions to avoid using `panic!` and to compare `ModSpec` fields rather than raw pointer equality, and adjusted a test input string to match expected parsing behaviour.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lexer` which completed successfully and reported all `perl-lexer` tests passing after the changes.
- Ran `cargo clippy -p perl-lexer --lib --tests -- -D warnings` which completed successfully with no warnings treated as errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba136bd9048333a8a7e0e98e9d21e9)