### PR TITLE
test: expand perl-source-editing coverage

### DIFF
--- a/crates/perl-source-editing/src/lib.rs
+++ b/crates/perl-source-editing/src/lib.rs
@@ -75,3 +75,75 @@ pub fn truncate_expr(expr: &str, max_len: usize) -> String {
 pub fn has_non_ascii_content(source: &str) -> bool {
     !source.is_ascii()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        find_import_insert_position, find_pragma_insert_position, find_statement_start,
+        get_indent_at, has_non_ascii_content, truncate_expr,
+    };
+
+    #[test]
+    fn finds_statement_start_after_semicolon() {
+        let source = "my $x = 1;\n    my $y = 2;";
+        let pos = source.find("$y").unwrap_or_default();
+
+        assert_eq!(find_statement_start(source, pos), source.find('\n').unwrap_or_default() + 1);
+    }
+
+    #[test]
+    fn finds_statement_start_from_start_when_no_delimiter_exists() {
+        let source = "my $x = 1";
+
+        assert_eq!(find_statement_start(source, usize::MAX), 0);
+    }
+
+    #[test]
+    fn gets_indent_for_current_line_with_clamped_position() {
+        let source = "sub demo {\n\t    my $x = 1;\n}\n";
+
+        assert_eq!(get_indent_at(source, usize::MAX), "");
+        assert_eq!(get_indent_at(source, source.find("my").unwrap_or_default()), "\t    ");
+    }
+
+    #[test]
+    fn finds_pragma_insert_position_with_and_without_shebang() {
+        let with_shebang = "#!/usr/bin/env perl\nuse strict;\n";
+        let without_shebang = "use strict;\n";
+
+        assert_eq!(find_pragma_insert_position(with_shebang), 20);
+        assert_eq!(find_pragma_insert_position(without_shebang), 0);
+    }
+
+    #[test]
+    fn finds_import_insert_position_after_existing_imports_and_comments() {
+        let source = "#!/usr/bin/env perl\n# comment\nuse strict;\nrequire Foo;\nmy $x = 1;\n";
+        let lines = source.lines().map(str::to_string).collect::<Vec<_>>();
+
+        assert_eq!(
+            find_import_insert_position(source, &lines),
+            source.find("my $x").unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn stops_import_scan_at_first_non_import_code_line() {
+        let source = "#!/usr/bin/env perl\nmy $x = 1;\nuse strict;\n";
+        let lines = source.lines().map(str::to_string).collect::<Vec<_>>();
+
+        assert_eq!(find_import_insert_position(source, &lines), 20);
+    }
+
+    #[test]
+    fn truncates_utf8_expressions_without_splitting_codepoints() {
+        assert_eq!(truncate_expr("héllo🙂world", 7), "héll...");
+        assert_eq!(truncate_expr("héllo", 10), "héllo");
+        assert_eq!(truncate_expr("abcdef", 2), "..");
+    }
+
+    #[test]
+    fn detects_non_ascii_content() {
+        assert!(!has_non_ascii_content("plain ascii"));
+        assert!(has_non_ascii_content("naïve"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for helper functions in the `perl-source-editing` crate to exercise common editing heuristics and Unicode edge cases.

### Description
- Added a `#[cfg(test)]` test module in `crates/perl-source-editing/src/lib.rs` with focused unit tests for `find_statement_start`, `get_indent_at`, `find_pragma_insert_position`, `find_import_insert_position`, `truncate_expr`, and `has_non_ascii_content`.
- Tests exercise semicolon/newline statement boundary behavior, clamped positions for indentation lookup, shebang handling, comment-skipping and stopping at the first non-import code line, UTF-8-safe truncation without splitting codepoints, and ASCII detection.

### Testing
- Ran `cargo test -p perl-source-editing` and all tests passed.
- Ran `cargo fmt --all --check` and the formatting check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba136bd9048333a8a7e0e98e9d21e9)