### PR TITLE
Improve LSP async read scheduling

### DIFF
--- a/crates/perl-lsp/src/runtime/scheduler.rs
+++ b/crates/perl-lsp/src/runtime/scheduler.rs
@@ -14,6 +14,7 @@
 use crate::protocol::JsonRpcRequest;
 use crate::transport::log_response;
 use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 
 use super::LspServer;
 
@@ -88,10 +89,14 @@ pub(crate) fn classify(method: &str) -> RequestClass {
 pub(crate) struct Scheduler {
     /// Channel for mutation/lifecycle work (single exclusive worker drains this).
     mutation_tx: tokio::sync::mpsc::Sender<JsonRpcRequest>,
-    /// Channel for read-only work (N workers drain this).
-    read_tx: tokio::sync::mpsc::Sender<JsonRpcRequest>,
-    /// Join handles for background workers (used for shutdown drain).
+    /// Shared server handle used by spawned read-only tasks.
+    server: Arc<LspServer>,
+    /// Concurrency limiter for read-only work.
+    read_permits: Arc<Semaphore>,
+    /// Join handles for long-lived/background workers.
     workers: Vec<tokio::task::JoinHandle<()>>,
+    /// Join handles for spawned read-only request tasks.
+    read_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
 }
 
 /// Bounded channel capacity for both mutation and read queues.
@@ -107,23 +112,18 @@ impl Scheduler {
     /// All workers use `spawn_blocking` for CPU-bound handler execution.
     pub fn new(server: Arc<LspServer>) -> Self {
         let (mutation_tx, mutation_rx) = tokio::sync::mpsc::channel(QUEUE_CAPACITY);
-        let (read_tx, read_rx) = tokio::sync::mpsc::channel(QUEUE_CAPACITY);
-
-        let mut workers = Vec::with_capacity(1 + READ_WORKERS);
 
         // Single exclusive mutation worker — processes lifecycle and mutation
         // requests one at a time, preserving ordering guarantees.
-        workers.push(tokio::spawn(Self::mutation_worker(mutation_rx, Arc::clone(&server))));
+        let workers = vec![tokio::spawn(Self::mutation_worker(mutation_rx, Arc::clone(&server)))];
 
-        // Read pool: N workers share a single receiver via Arc<Mutex<>>.
-        // Each worker competes for the next item (work-stealing pattern).
-        let shared_rx = Arc::new(tokio::sync::Mutex::new(read_rx));
-        for _ in 0..READ_WORKERS {
-            workers
-                .push(tokio::spawn(Self::read_worker(Arc::clone(&shared_rx), Arc::clone(&server))));
+        Self {
+            mutation_tx,
+            server,
+            read_permits: Arc::new(Semaphore::new(READ_WORKERS)),
+            workers,
+            read_tasks: Arc::new(Mutex::new(Vec::new())),
         }
-
-        Self { mutation_tx, read_tx, workers }
     }
 
     /// Send a mutation or lifecycle request to the exclusive worker.
@@ -135,9 +135,18 @@ impl Scheduler {
 
     /// Send a read-only request to the read pool.
     ///
-    /// Returns `Err(())` if all read workers have exited (channel closed).
+    /// Returns `Err(())` if the scheduler is shutting down.
     pub async fn send_read(&self, request: JsonRpcRequest) -> Result<(), ()> {
-        self.read_tx.send(request).await.map_err(|_| ())
+        let permit = Arc::clone(&self.read_permits).acquire_owned().await.map_err(|_| ())?;
+
+        Self::spawn_read_task(
+            Arc::clone(&self.read_tasks),
+            Arc::clone(&self.server),
+            request,
+            permit,
+        )
+        .await;
+        Ok(())
     }
 
     /// Shut down all workers by dropping senders and awaiting completion.
@@ -148,10 +157,18 @@ impl Scheduler {
     pub async fn shutdown(self) {
         // Drop senders so worker recv loops see channel closed.
         drop(self.mutation_tx);
-        drop(self.read_tx);
+        self.read_permits.close();
 
         // Wait for all workers to finish draining.
         for handle in self.workers {
+            let _ = handle.await;
+        }
+
+        let mut read_tasks = self.read_tasks.lock().await;
+        let pending = std::mem::take(&mut *read_tasks);
+        drop(read_tasks);
+
+        for handle in pending {
             let _ = handle.await;
         }
     }
@@ -180,38 +197,31 @@ impl Scheduler {
         }
     }
 
-    /// Read pool worker.
+    /// Spawn a single read-only request under semaphore control.
     ///
-    /// Multiple instances share a single receiver via `Arc<tokio::sync::Mutex<>>`.
-    /// Each worker competes for the next item, runs the handler on the blocking
-    /// thread pool, and sends the response via the outbound channel.
-    async fn read_worker(
-        rx: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<JsonRpcRequest>>>,
+    /// This avoids a shared receiver mutex across workers and lets the ingress
+    /// task dispatch directly into Tokio's scheduler while still bounding
+    /// concurrent CPU-bound work.
+    async fn spawn_read_task(
+        read_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
         server: Arc<LspServer>,
+        request: JsonRpcRequest,
+        permit: OwnedSemaphorePermit,
     ) {
-        loop {
-            // Hold the receiver lock only long enough to get the next item.
-            let request = {
-                let mut guard = rx.lock().await;
-                guard.recv().await
-            };
-
-            let request = match request {
-                Some(r) => r,
-                None => break, // channel closed — all senders dropped
-            };
-
+        let handle = tokio::spawn(async move {
+            let _permit = permit;
             let srv = Arc::clone(&server);
             let outbound = server.outbound.clone();
 
-            // Run CPU-bound handler on blocking thread pool.
             let result = tokio::task::spawn_blocking(move || srv.handle_request(request)).await;
 
             if let Ok(Some(response)) = result {
                 log_response(&response);
                 let _ = outbound.send_response(response);
             }
-        }
+        });
+
+        read_tasks.lock().await.push(handle);
     }
 }
 


### PR DESCRIPTION
### Motivation

- Reduce async dispatch contention for read-only LSP requests by avoiding a single shared receiver lock in the read worker pool.
- Bound concurrent read-only work while allowing the ingress loop to dispatch without serializing on a receiver mutex.
- Ensure in-flight read-only work is awaited during shutdown so responses are not dropped.

### Description

- Replace the shared read-worker `mpsc` + `Arc<Mutex<Receiver>>` design with a semaphore-gated task spawn approach that limits concurrent read work via `Semaphore` (`READ_WORKERS`).
- Add a `server: Arc<LspServer>` handle, `read_permits: Arc<Semaphore>`, and `read_tasks: Arc<Mutex<Vec<JoinHandle<()>>>>` to `Scheduler` to track spawned read tasks and their permits.
- Introduce `spawn_read_task` which takes an owned semaphore permit, runs the handler on `spawn_blocking`, and records the spawned task handle for later shutdown awaiting.
- Update `send_read` to acquire a semaphore permit and call `spawn_read_task`, and update `shutdown` to close the semaphore and await any pending spawned read tasks after the mutation worker drains.

### Testing

- Ran formatting with `cargo fmt --all` and it completed successfully.
- Ran lints with `cargo clippy -p perl-lsp --lib -- -D warnings` and the crate passed without warnings.
- Ran targeted unit tests with `cargo test -p perl-lsp scheduler --lib` and all scheduler tests passed (5 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba137e8e2c8333a22d2efcde7cf163)