### PR TITLE
docs: improve documentation navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,30 @@
 
 Documentation for Perl LSP v0.12.0 — a Language Server Protocol implementation for Perl.
 
+## Start here by goal
+
+Choose the path that matches what you want to do:
+
+| I want to... | Start here |
+|---|---|
+| Install or run the project quickly | [Getting Started](tutorials/GETTING_STARTED.md) |
+| Configure an editor | [Editor Setup](how-to/EDITOR_SETUP.md) |
+| Debug Perl code | [DAP User Guide](tutorials/DAP_USER_GUIDE.md) |
+| Work on the codebase as a contributor | [Project Orientation](project/ORIENTATION.md) |
+| Look up commands, configuration, or architecture | [Reference](#reference--look-it-up) |
+| Understand design decisions and tradeoffs | [Explanation](#explanation--understand-why) |
+
+## Documentation map
+
+This documentation set follows the [Diátaxis](https://diataxis.fr/) framework:
+
+- **Tutorials** teach by walking you through a workflow.
+- **How-to guides** help you complete a concrete task.
+- **Reference** provides exact facts, commands, and schemas.
+- **Explanation** gives architectural context and rationale.
+
+For authoring standards and placement rules, see the [Documentation Guide](reference/DOCUMENTATION_GUIDE.md).
+
 ## Repository snapshot
 
 - Workspace version: **v0.12.0**
@@ -36,27 +60,41 @@ Step-by-step guides to get you started.
 
 Task-oriented instructions for common operations.
 
+### Common developer tasks
+
 - [Installation](how-to/INSTALLATION.md) — Install from source or binary
 - [Editor Setup](how-to/EDITOR_SETUP.md) — Configure your editor
 - [Troubleshooting](how-to/TROUBLESHOOTING.md) — Common issues and solutions
+- [Debugging](how-to/DEBUGGING.md) — Diagnose parser, LSP, and test issues
+- [Performance Tuning](how-to/PERFORMANCE_TUNING.md) — Measure and improve runtime behavior
+
+### Maintenance and release tasks
+
 - [Dependency Management](how-to/DEPENDENCY_MANAGEMENT.md) — Automated updates with Dependabot
 - [SemVer Workflow](how-to/SEMVER_WORKFLOW.md) — SemVer checking and API compatibility
 - [Coverage](how-to/COVERAGE.md) — Code coverage reports
 - [Dead Code Detection](how-to/DEAD_CODE_DETECTION.md) — Find unused code
+- [Upgrading](how-to/UPGRADING.md) — Upgrade project versions and workflows
 
 ## Reference — look it up
 
 Precise, complete information for lookup.
 
+### Frequently-used references
+
 - [Commands Reference](reference/COMMANDS_REFERENCE.md) — Full command catalog
-- [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) — System design and components
-- [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md) — Workspace structure and tiers
-- [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md) — Language Server Protocol details
-- [LSP Features](reference/LSP_FEATURES.md) — Supported LSP capabilities
-- [Stability Policy](reference/STABILITY.md) — API versioning and compatibility
 - [Configuration](reference/CONFIG.md) — Configuration options
 - [FAQ](reference/FAQ.md) — Frequently asked questions
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md) — Current constraints and workarounds
+- [Stability Policy](reference/STABILITY.md) — API versioning and compatibility
+
+### Architecture and implementation references
+
+- [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) — System design and components
+- [Crate Architecture Guide](reference/CRATE_ARCHITECTURE_GUIDE.md) — Workspace structure and tiers
+- [Workspace Navigation Guide](reference/WORKSPACE_NAVIGATION_GUIDE.md) — Cross-file navigation behavior
+- [LSP Implementation Guide](reference/LSP_IMPLEMENTATION_GUIDE.md) — Language Server Protocol details
+- [LSP Features](reference/LSP_FEATURES.md) — Supported LSP capabilities
 - [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Diataxis framework and standards
 
 ## Explanation — understand why
@@ -72,6 +110,7 @@ Conceptual discussions and design rationale.
 
 Process, metrics, and project health.
 
+- [Project Orientation](project/ORIENTATION.md) — Contributor overview and onboarding path
 - [Current Status](project/CURRENT_STATUS.md) — Computed metrics and project health
 - [Roadmap](project/ROADMAP.md) — Milestones and release planning
 - [Milestones](project/MILESTONES.md) — GitHub milestones
@@ -80,7 +119,7 @@ Process, metrics, and project health.
 - [CI](project/CI.md) — Continuous integration setup
 - [CI Test Lanes](project/CI_TEST_LANES.md) — Test lane configuration
 
-## Strategic Documents — planning and direction
+## Strategic documents — planning and direction
 
 High-level planning documents for project direction.
 
@@ -107,6 +146,7 @@ High-level planning documents for project direction.
 ## Contributing
 
 - [Contributing Guide](../CONTRIBUTING.md) — Development workflow and contribution process
+- [Documentation Guide](reference/DOCUMENTATION_GUIDE.md) — Where new docs belong and how to keep them consistent
 
 ## Quick verification
 
@@ -115,7 +155,7 @@ nix develop -c just ci-gate       # Canonical local gate
 nix develop -c just status-check  # Verify metrics haven't drifted
 ```
 
-## Canonical Truth Sources
+## Canonical truth sources
 
 | What | Where | Verified By |
 |------|-------|-------------|

--- a/docs/reference/DOCUMENTATION_GUIDE.md
+++ b/docs/reference/DOCUMENTATION_GUIDE.md
@@ -11,6 +11,17 @@ This project organizes user-facing docs with the [Diátaxis](https://diataxis.fr
 
 Use this page to decide where new content belongs and to keep existing docs consistent.
 
+## Quick routing guide
+
+Use these prompts to place content quickly:
+
+| If the reader wants to... | Put the doc in... | Typical shape |
+|---|---|---|
+| Learn the workflow for the first time | `tutorials/` | Ordered steps with expected results |
+| Complete a focused task | `how-to/` | Prerequisites, commands, verification |
+| Look up exact behavior or commands | `reference/` | Tables, headings, terse examples |
+| Understand tradeoffs or architecture | `explanation/` | Narrative about decisions and constraints |
+
 ## Where to put a new document
 
 Ask one question first: **what is the reader trying to do?**
@@ -22,7 +33,7 @@ Ask one question first: **what is the reader trying to do?**
 
 If a document tries to do more than one of these, split it into multiple pages and cross-link them.
 
-## Writing rules by doc type
+## What each doc type should include
 
 ### Tutorials
 
@@ -33,14 +44,14 @@ If a document tries to do more than one of these, split it into multiple pages a
 
 ### How-to guides
 
-- Start with a goal statement (e.g., “Set up Neovim for perl-lsp”).
+- Start with a goal statement (for example, “Set up Neovim for perl-lsp”).
 - Provide prerequisites.
 - Prefer concise command sequences and verification checks.
 - Keep conceptual background short; link to explanation docs instead.
 
 ### Reference
 
-- Be precise and scannable (tables, headings, command blocks).
+- Be precise and scannable with tables, headings, and command blocks.
 - Prefer completeness over storytelling.
 - Avoid implicit assumptions and hidden defaults.
 - Keep examples minimal and behavior-focused.
@@ -50,7 +61,15 @@ If a document tries to do more than one of these, split it into multiple pages a
 - Focus on tradeoffs, constraints, and design decisions.
 - Connect architecture to user/developer impact.
 - Link to reference pages for exact APIs and commands.
-- Avoid procedural step lists (move those to tutorials/how-to).
+- Avoid procedural step lists; move those to tutorials/how-to.
+
+## File naming and structure conventions
+
+- Prefer descriptive uppercase snake case for stable docs already following that convention in `docs/`.
+- Keep one primary subject per file.
+- Start with a short intro that states the document's purpose.
+- Use headings that make sense in isolation when linked directly.
+- Add cross-links to the most relevant neighboring docs instead of duplicating content.
 
 ## Documentation hygiene checklist
 
@@ -60,6 +79,18 @@ Before merging doc changes:
 - Verify command examples run as written where practical.
 - Ensure the page’s style matches its Diátaxis category.
 - Update [docs/README.md](../README.md) when adding or removing docs.
+- Update nearby index pages if the new document changes a common workflow.
+- Remove or qualify stale version-specific claims.
+
+## Reviewing an existing doc
+
+When improving an existing page, check for:
+
+1. **Audience drift**: tutorial content inside reference pages, or vice versa.
+2. **Staleness**: versions, feature counts, and milestone language that may have changed.
+3. **Navigation gaps**: missing “start here,” “see also,” or verification links.
+4. **Command ambiguity**: commands that lack working-directory context or success criteria.
+5. **Duplication**: content that should be linked from a canonical source instead.
 
 ## Current entry points
 
@@ -69,4 +100,4 @@ Start from the documentation hub in [docs/README.md](../README.md):
 - How-to: [Installation](../how-to/INSTALLATION.md)
 - Reference: [Commands Reference](COMMANDS_REFERENCE.md)
 - Explanation: [Pure Rust Parser](../explanation/PURE_RUST_PARSER.md)
-
+- Project status: [Current Status](../project/CURRENT_STATUS.md)


### PR DESCRIPTION
### Motivation
- Make the documentation hub more discoverable by providing a clear, goal-oriented entry point for readers.
- Reduce time-to-first-action for common tasks (install, editor setup, debugging, contributing) by routing users to the appropriate docs quickly.
- Standardize authoring and review practices to reduce stale content and inconsistent placement of material.
- Surface frequently-used reference links and navigation aids so maintainers and contributors find canonical pages faster.

### Description
- Add a `Start here by goal` table to `docs/README.md` that routes readers to common entry points like `tutorials/GETTING_STARTED.md`, `how-to/EDITOR_SETUP.md`, and `project/ORIENTATION.md`.
- Reorganize `docs/README.md` sections to include clearer groups for developer tasks, maintenance/release tasks, frequently-used references, and architecture/implementation references.
- Expand `docs/reference/DOCUMENTATION_GUIDE.md` with a `Quick routing guide`, `File naming and structure conventions`, an enhanced hygiene checklist, and a `Reviewing an existing doc` checklist to guide contributions.
- Add a handful of cross-reference and phrasing improvements to make navigation and authoring guidance more scannable.

### Testing
- Ran a markdown link validation script (`python` snippet) that resolves internal links in `docs/README.md` and `docs/reference/DOCUMENTATION_GUIDE.md`, and it completed successfully with no missing targets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1391a8c4833399f5e93c98618fdf)