### PR TITLE
docs: add documentation index and improve Getting Started / Installation guides

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,90 @@
+# Documentation Index
+
+This page is the documentation front door for the `perl-lsp` workspace.
+
+## Start Here
+
+Choose the path that matches what you are trying to do:
+
+| I want to... | Read this first |
+|---|---|
+| Install the language server | [Installation Guide](how-to/INSTALLATION.md) |
+| Get a working editor setup quickly | [Getting Started](tutorials/GETTING_STARTED.md) |
+| Configure editor or workspace settings | [Configuration Reference](reference/CONFIG.md) |
+| Troubleshoot startup, indexing, or editor issues | [Troubleshooting](how-to/TROUBLESHOOTING.md) |
+| Understand the server architecture | [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) |
+| Work on LSP features as a contributor | [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) |
+| Run builds, tests, and CI commands | [Commands Reference](reference/COMMANDS_REFERENCE.md) |
+| Understand stability and compatibility | [Stability Policy](reference/STABILITY.md) |
+
+## Documentation Map
+
+### Tutorials
+Hands-on guides for learning the system by doing.
+
+- [Getting Started](tutorials/GETTING_STARTED.md)
+- [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md)
+- [DAP User Guide](tutorials/DAP_USER_GUIDE.md)
+- [Comprehensive Testing Guide](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
+- [AI Build Guide](tutorials/AI_BUILD_GUIDE.md)
+
+### How-to Guides
+Task-focused instructions for common operational and development workflows.
+
+- [Installation Guide](how-to/INSTALLATION.md)
+- [Editor Setup](how-to/EDITOR_SETUP.md)
+- [Troubleshooting](how-to/TROUBLESHOOTING.md)
+- [Contributing LSP Features](how-to/CONTRIBUTING_LSP.md)
+- [Threading Configuration Guide](how-to/THREADING_CONFIGURATION_GUIDE.md)
+- [Performance Tuning](how-to/PERFORMANCE_TUNING.md)
+- [Security Development Guide](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
+
+### Reference
+Authoritative descriptions of configuration, architecture, commands, and feature contracts.
+
+- [Commands Reference](reference/COMMANDS_REFERENCE.md)
+- [Configuration Reference](reference/CONFIG.md)
+- [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md)
+- [LSP Features](reference/LSP_FEATURES.md)
+- [FAQ](reference/FAQ.md)
+- [Parser Feature Matrix](reference/PARSER_FEATURE_MATRIX.md)
+- [Known Limitations](reference/KNOWN_LIMITATIONS.md)
+
+### Explanation
+Background material that explains why the system is designed the way it is.
+
+- [LSP Documentation](explanation/LSP_DOCUMENTATION.md)
+- [Cancellation Architecture Guide](explanation/CANCELLATION_ARCHITECTURE_GUIDE.md)
+- [Pure Rust Parser](explanation/PURE_RUST_PARSER.md)
+- [Slash Disambiguation](explanation/SLASH_DISAMBIGUATION.md)
+
+### Project / ADR / Specs
+Decision records, project status, and planning documents.
+
+- [ADR Index](adr/README.md)
+- [Project Milestones](project/MILESTONES.md)
+- [Feature Governance](project/FEATURE_GOVERNANCE.md)
+- [Latency Caps SLO Spec](specs/LATENCY_CAPS_SLO_SPEC.md)
+- [Release Candidate Baseline](specs/RELEASE_CANDIDATE_BASELINE.md)
+
+## Suggested Reading Order for New Contributors
+
+1. [Getting Started](tutorials/GETTING_STARTED.md)
+2. [Installation Guide](how-to/INSTALLATION.md)
+3. [Commands Reference](reference/COMMANDS_REFERENCE.md)
+4. [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md)
+5. [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md)
+
+## CLI Quick Reference
+
+These commands are especially useful when validating an installation or triaging an environment issue:
+
+```bash
+perl-lsp --version
+perl-lsp --health
+perl-lsp --info
+perl-lsp --check path/to/file.pl
+perl-lsp --completion bash
+```
+
+For the complete option list and behavior, see the [Commands Reference](reference/COMMANDS_REFERENCE.md).

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -8,6 +8,12 @@ Perl Language Server (perl-lsp) v0.10.0 provides a high-performance Language Ser
 cargo install perl-lsp
 ```
 
+If you already have an older version installed, upgrade in place:
+
+```bash
+cargo install perl-lsp --force
+```
+
 ## Manual Installation
 
 ### Pre-compiled Binaries
@@ -74,12 +80,15 @@ After installation, verify that perl-lsp is working:
 
 ```bash
 perl-lsp --version
+perl-lsp --health
+perl-lsp --info
 ```
 
 Expected output:
-```
-perl-lsp 0.10.0
-```
+
+- `--version` prints the installed package version.
+- `--health` prints `ok <version>`.
+- `--info` prints version, build metadata, feature profile, and coverage summary.
 
 ## Editor Configuration
 
@@ -89,16 +98,24 @@ perl-lsp 0.10.0
 3. The language server will start automatically
 
 ### Neovim
-Add to your `init.lua` or `init.vim`:
+Add to your `init.lua`:
 
 ```lua
-require'lspconfig'.perllsp.setup{
-  cmd = {"perl-lsp", "--stdio"},
-  filetypes = {"perl", "perl6"},
-  root_dir = function(fname)
-    return require'lspconfig'.util.find_git_ancestor(fname) or vim.fn.getcwd()
-  end,
-}
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+if not configs.perl_lsp then
+  configs.perl_lsp = {
+    default_config = {
+      cmd = { 'perl-lsp', '--stdio' },
+      filetypes = { 'perl' },
+      root_dir = lspconfig.util.root_pattern('.git', 'Makefile.PL', 'cpanfile', 'dist.ini'),
+      single_file_support = true,
+    },
+  }
+end
+
+lspconfig.perl_lsp.setup({})
 ```
 
 ### Emacs
@@ -175,7 +192,19 @@ export PATH="$PATH:$HOME/.local/bin"
 [Environment]::SetEnvironmentVariable('Path', "$env:Path;$HOME\.local\bin", 'User')
 ```
 
-### Runtime Issues
+## Useful CLI Checks
+
+These commands are helpful both after installation and when debugging editor integration:
+
+```bash
+perl-lsp --version                 # Confirm the binary resolves on PATH
+perl-lsp --health                  # Fast readiness check
+perl-lsp --info                    # Print build and feature-profile information
+perl-lsp --check lib/My/Module.pm  # Validate a file without starting an editor
+perl-lsp --completion bash         # Generate shell completions
+```
+
+## Runtime Issues
 
 #### LSP server not starting
 1. Verify the binary is executable: `perl-lsp --version`
@@ -194,7 +223,8 @@ export PATH="$PATH:$HOME/.local/bin"
 
 ## Getting Help
 
-- **Documentation**: [Full Documentation](https://github.com/EffortlessMetrics/perl-lsp)
+- **Documentation Index**: [docs/INDEX.md](../INDEX.md)
+- **Full Documentation**: [Repository Docs](https://github.com/EffortlessMetrics/perl-lsp/tree/master/docs)
 - **Issues**: [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/EffortlessMetrics/perl-lsp/discussions)
 - **Changelog**: [Release Notes](https://github.com/EffortlessMetrics/perl-lsp/releases)

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -45,8 +45,16 @@ perl-lsp --version
 
 # Quick health check
 perl-lsp --health
-# Should output: ok 0.12.0
+# Should output: ok <installed-version>
+
+# Optional: show feature/profile information
+perl-lsp --info
+
+# Optional: validate a Perl file from the CLI
+perl-lsp --check script.pl
 ```
+
+If `--version` and `--health` work but your editor still cannot connect, jump to [Troubleshooting](../how-to/TROUBLESHOOTING.md).
 
 ## Quick Editor Setup
 
@@ -240,7 +248,7 @@ For project-specific settings, the server reads configuration from your editor's
 }
 ```
 
-See [CONFIG.md](../reference/CONFIG.md) for all configuration options.
+See [CONFIG.md](../reference/CONFIG.md) for all configuration options, including workspace paths, inlay hints, test-runner settings, and resource limits.
 
 ## Troubleshooting
 
@@ -342,11 +350,13 @@ For the full troubleshooting guide including DAP debugging, parser edge cases, a
 ## Next Steps
 
 - **[EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md)** - Detailed editor configurations
+- **[INSTALLATION.md](../how-to/INSTALLATION.md)** - Platform-specific installation and verification steps
 - **[CONFIG.md](../reference/CONFIG.md)** - All configuration options
 - **[LSP_FEATURES.md](../reference/LSP_FEATURES.md)** - Complete feature documentation
 - **[FAQ.md](../reference/FAQ.md)** - Frequently asked questions
+- **[Documentation Index](../INDEX.md)** - Documentation front door and routing guide
 
 ## Getting Help
 
 - **Issues**: [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
-- **Documentation**: [docs/INDEX.md](INDEX.md)
+- **Documentation**: [docs/INDEX.md](../INDEX.md)


### PR DESCRIPTION
### Motivation

- Provide a clear documentation front door so readers can quickly find install, editor setup, configuration, and contributor guides.
- Replace stale examples and add more accurate CLI verification steps so users can validate an installation without guessing a hard-coded version string.
- Make editor onboarding easier by modernizing the Neovim snippet and surfacing common CLI troubleshooting checks.

### Description

- Added a new `docs/INDEX.md` that groups documentation by Diataxis-style categories and exposes a short CLI quick reference.
- Updated `docs/tutorials/GETTING_STARTED.md` to remove the hard-coded health output, and added `--info` and `--check` examples, a pointer to `how-to/TROUBLESHOOTING.md`, and an expanded `CONFIG.md` reference.
- Updated `docs/how-to/INSTALLATION.md` to include an upgrade command (`cargo install perl-lsp --force`), richer verification steps (`--version`, `--health`, `--info`), a modernized Neovim `lspconfig` snippet, and a new `Useful CLI Checks` section; also added a link back to the new docs index.
- All edits are documentation-only and do not modify runtime code paths or library APIs.

### Testing

- Ran an automated local link checker (Python script) against `docs/INDEX.md`, `docs/tutorials/GETTING_STARTED.md`, and `docs/how-to/INSTALLATION.md`, and it reported `ok` with no broken relative links.
- No code changes were made, so no crate unit/integration tests were required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1391a8c4833399f5e93c98618fdf)