### PR TITLE
docs: refresh CODEBASE_CURIOSITIES with source-grounded learnings and link from docs hub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ Process, metrics, and project health.
 - [Milestones](project/MILESTONES.md) — GitHub milestones
 - [Lessons](project/LESSONS.md) — What went wrong
 - [Casebook](project/CASEBOOK.md) — What went right
+- [Codebase Curiosities](project/CODEBASE_CURIOSITIES.md) — Source-grounded architecture learnings and oddities
 - [CI](project/CI.md) — Continuous integration setup
 - [CI Test Lanes](project/CI_TEST_LANES.md) — Test lane configuration
 

--- a/docs/project/CODEBASE_CURIOSITIES.md
+++ b/docs/project/CODEBASE_CURIOSITIES.md
@@ -1,196 +1,293 @@
-# Codebase Curiosities: Fun Facts and Deep Cuts from perl-lsp
+# Codebase Curiosities and Learnings
 
-*A tour through the oddities, records, and surprising patterns hiding in a Rust codebase built by humans and AI agents alike.*
+*A source-grounded tour of the architectural habits, unusual patterns, and practical lessons hiding in `perl-lsp`.*
 
----
-
-## By the Numbers
-
-| Metric | Value |
-|--------|-------|
-| First commit | July 17, 2022 |
-| Total commits | 2,104 |
-| Total PRs opened | 1,270 |
-| PRs merged | 643 |
-| PRs rejected (closed without merge) | 428 |
-| Crate directories | 121 |
-| Lines of Rust | ~82,000 |
-| Rust test files | 463 |
-| Perl test fixtures (`.pl` / `.pm` / `.t`) | 3,322 |
-| Markdown files | ~1,850 |
-| Per-crate `CLAUDE.md` files | 52 |
-| Named releases | 11 (from `v0.1.0-pest` to `v0.10.0`) |
-
-The word "Perl" appears 4,112 times in the Rust source. Fair enough -- it *is* a Perl LSP.
+This version is intentionally based on the current tree rather than old PR archaeology. It focuses on what the codebase teaches a contributor who reads the implementation today.
 
 ---
 
-## The 4-Day Parser
+## Snapshot of the Current Tree
 
-The Pest parser-generator framework was introduced on **July 16, 2025** (commit `e7f67f39`). It was tagged as `v0.1.0-pest` on July 20. Four days later, on **July 21**, the hand-written recursive-descent parser (v3) appeared in commit `da94f7b3` ("Implement a modern two-crate architecture for Perl parsing").
+These numbers were derived from the checked-out repository on 2026-03-18.
 
-By July 25, the v3 parser was already claiming "100% edge case coverage" in its release notes. The Pest grammar still exists in the repo as `perl-parser-pest`, but it has been exiled to the `archive/legacy-crates/` directory and excluded from the default workspace build.
+| Metric | Value | Why it matters |
+|---|---:|---|
+| Crate directories under `crates/` | 121 | The workspace is deeply decomposed into microcrates. |
+| Rust source files (`*.rs`) | 1,536 | The codebase is broad as well as deep. |
+| Rust lines | 540,278 | This is far beyond “single-crate side project” scale. |
+| Markdown files (`*.md`) | 2,277 | Documentation is a first-class part of the system. |
+| Perl fixtures / scripts (`*.pl`, `*.pm`, `*.t`) | 196 | Real Perl examples remain embedded in the Rust workspace. |
 
-What happened? The Pest grammar was accumulating features at a ferocious rate -- 96 commits on July 16 alone, with the grammar rapidly expanding to cover heredocs, regex, hash references, and more. But Perl's legendary parsing ambiguity (is `foo /bar/` a function call with a regex, or division?) proved hostile to PEG grammars. By July 18, commit `b45c2dee` was already titled "Implement extensive performance optimizations" -- a sign of trouble. The three-way parser comparison tool appeared on July 21 (`a3b35382`), and by that afternoon the native recursive-descent architecture was born.
+Smallest Rust crates by line count in `src/` today:
 
-The `v0.1.0-pest` tag remains in the repo as a historical marker. Versions v0.2.0, v0.3.0, and v0.4.0 were internal milestones that were never tagged. The next public tag was `v0.5.0` on August 3 -- already running on the native parser.
+| Crate | Rust lines |
+|---|---:|
+| `tree-sitter-perl` | 0 |
+| `perl-module-resolution` | 8 |
+| `perl-module-token-parser` | 36 |
+| `perl-line-index` | 44 |
+| `perl-lsp-uri` | 50 |
+| `perl-percentile` | 60 |
+| `perl-workspace-ignore` | 60 |
 
----
+Largest Rust files today:
 
-## Agent Archaeology
+| File | Lines |
+|---|---:|
+| `crates/perl-workspace-index/src/workspace/workspace_index.rs` | 3,860 |
+| `crates/perl-ci-hygiene/src/main.rs` | 3,826 |
+| `crates/perl-lexer/src/lib.rs` | 3,286 |
+| `crates/perl-refactoring/src/refactor/refactoring.rs` | 3,261 |
+| `crates/perl-semantic-analyzer/src/analysis/semantic.rs` | 3,256 |
+| `crates/perl-dap/src/debug_adapter/mod.rs` | 3,200 |
 
-### The Three Personas
+### Learning
 
-The project used Codex agents with three distinct personas, identifiable by emoji prefixes in their PR titles:
-
-| Persona | Role | PRs Submitted | Merged | Rejected | Merge Rate |
-|---------|------|:---:|:---:|:---:|:---:|
-| **Bolt** | Performance optimization | 47 | 19 | 28 | 40% |
-| **Sentinel** | Security hardening | 35 | 16 | 19 | 46% |
-| **Palette** | UX and polish | 27 | 12 | 15 | 44% |
-
-All three agents had a **golden era** (roughly PRs #473--#647, late January 2026) where their work was consistently merged. Then all three simultaneously entered a **rejection era** (PRs #771--#837, mid-February 2026) where essentially nothing got through.
-
-### Bolt's Obsession with PHF
-
-The performance agent, Bolt, became fixated on replacing the built-in function lookup with a PHF (perfect hash function). Across PRs #780, #782, #785, #791, #798, #804, #805, #811, #829, and #835, Bolt submitted **10 nearly identical PRs** titled variations of "Optimize is_known_function with PHF lookup" -- all rejected. Eventually PR #1167 merged the PHF extraction, but it was not a Bolt PR.
-
-### Sentinel's Security Theatre
-
-Sentinel the security agent found 16 genuine vulnerabilities in its early run (command injection, path traversal, eval bypass). But after those were fixed, it began hallucinating new vulnerabilities. PRs #776 through #837 contain 19 rejected "fixes" for problems like "Fix Infinite Redirect DoS in BinaryDownloader" (submitted three separate times: #771, #786, #822, #832) and "Fix safe evaluation bypass" (submitted at least six times with different phrasings).
-
-### The 18-Way Status Menu Standoff
-
-**18 PRs** were opened about making the VS Code status menu "context-aware." They came from all three agent personas (Palette, generic, even Sentinel got in on it). All 18 were rejected. Titles ranged from the straightforward ("Make status menu items context-aware") to the increasingly desperate ("Context-Aware Status Menu Improvements," "UX: Make status menu context-aware and improve feedback"). Not one shipped.
-
-### The Document Links Extraction: 9 Attempts
-
-Extracting document link detection into its own crate was attempted **9 times** across PRs #1097, #1098, #1108, #1165, #1169, #1175, #1183, #1233, and the finally-merged #1164. Eight identical-in-spirit extraction PRs were rejected before one got through.
-
-### Three Agents, One Problem
-
-PRs #1244, #1245, and #1246 were three different agent runs solving the same problem: adding a `just doctor` developer environment check. #1244 and #1246 were rejected; #1245 merged. The rejected ones had subtly different names -- "dev environment check and README quick-checks" vs. "quick environment check recipe" -- but were essentially the same idea racing to completion.
+The project does not optimize for a small crate graph. It optimizes for **named boundaries**. If a concept can be isolated, it usually becomes its own crate.
 
 ---
 
-## The "Comprehensive" Signal
+## Curiosity #1: The Workspace Is Extremely Modular — but Not Uniformly Small
 
-AI agents have a well-known fondness for the word "comprehensive." In perl-lsp:
+At first glance, `perl-lsp` looks like a “microcrate everything” experiment. That impression is correct, but only partially.
 
-| Buzzword | Occurrences in Commit Messages | PRs with Word in Title |
-|----------|:---:|:---:|
-| "comprehensive" | **277** | **107** |
-| "enhance" | **271** | -- |
-| "robust" | 17 | -- |
-| "enterprise" | 3 | -- |
+- Some crates are tiny wrappers or policy surfaces.
+- Some crates are sharply focused utilities.
+- A few crates still carry a large amount of system complexity.
 
-277 commits and 107 PRs with "comprehensive" in the title. The word also appears in **301 Rust source files**, mostly in test file names like `comprehensive_unit_tests.rs`.
+This creates an interesting split:
 
-The longest commit message in the repo is 411 characters:
+- **Microcrates** express stable seams, ownership, and layering.
+- **Large implementation files** still hold the complexity that cannot easily be fragmented without hurting readability or performance.
 
-> *Remove deprecated test files and parser comparison logs to streamline the codebase. This includes the deletion of various test scripts covering features such as anonymous subroutines, array and hash access, regex operations, and control flow constructs. The parser comparison file has also been removed due to its redundancy. This cleanup enhances maintainability and reduces clutter in the repository.*
+### Learning
 
-Meanwhile, the shortest commit messages are all a single character: **"c"**. There are **21 commits** with just the message "c". Presumably a human in a hurry.
+A large Rust workspace does not necessarily imply fine-grained implementation everywhere. In this codebase, the crate graph is used to make **architecture visible**, while a few “gravity wells” retain the most complicated runtime and indexing logic.
 
 ---
 
-## The SRP Explosion
+## Curiosity #2: Dual Indexing Is Not a Detail — It Is a Foundational Rule
 
-The crate count tells a dramatic story:
+One of the clearest patterns in the codebase is the dual indexing strategy for Perl symbol resolution.
 
-| Version / Date | Crates |
-|---------------|:------:|
-| `v0.1.0-pest` (Jul 2025) | 2 |
-| `v0.5.0` (Aug 2025) | 6 |
-| `v0.8.5` (Aug 2025) | 8 |
-| Jan 2026 | 7 |
-| `v0.9.1` (Feb 2026) | 50 |
-| `v0.10.0` (Feb 2026) | 82 |
-| HEAD (Mar 2026) | **121** |
+When the workspace index sees a function call, it records both:
 
-The workspace went from 7 crates in January 2026 to **45 by February 1** and **83 by March 1**. That is roughly **2.5 new crates per day** for two months straight. The project calls this "SRP microcrate extraction" -- splitting single-responsibility modules into their own crates.
+- the **bare name** (`process_data`)
+- the **qualified name** (`Utils::process_data`)
 
-**70 microcrate extraction PRs were rejected** during this period, meaning agents submitted roughly 2 failed extractions for every one that landed.
+That behavior is documented directly in `workspace_index.rs`, and the implementation stores references under both keys. The tests in `crates/perl-workspace-index/tests/dual_indexing_tests.rs` then treat this as an architectural invariant rather than an implementation accident.
 
----
+Why this matters in Perl:
 
-## Code Curiosities
+- functions may be called unqualified from the current package
+- imports can erase qualification at the callsite
+- users still expect “find references” to work from either spelling
 
-### The Smallest Crate: 47 Lines of Rust
+### Learning
 
-`perl-dap-command-args` weighs in at 47 total lines of Rust, including tests. Its entire purpose: quoting command-line arguments that contain spaces. It has zero dependencies. It has its own `Cargo.toml`, `README.md`, and `LICENSE` files. The build infrastructure for this crate may well be larger than the code.
-
-Other tiny crates: `perl-lsp-uri` (49 lines), `perl-line-index` (59 lines), `perl-workspace-ignore` (60 lines), `perl-percentile` (71 lines).
-
-### The Infinite Loop URI Fallback
-
-`perl-lsp-uri` contains a fallback function that tries four hardcoded URIs, then -- if *all* of those fail to parse -- enters an infinite loop trying `http://localhost/0`, `http://localhost/1`, `http://localhost/2`, and so on until one works. The comment says: "Last-resort fallback that avoids panicking if URI parser behavior changes unexpectedly." The project bans `unwrap()` and `panic!()` in production code, so this loop is the logical extreme of that policy.
-
-### The Largest Files
-
-| Lines | File |
-|------:|------|
-| 6,778 | `perl-dap/src/debug_adapter.rs` |
-| 3,855 | `perl-workspace-index/src/workspace/workspace_index.rs` |
-| 3,833 | `perl-ci-hygiene/src/main.rs` |
-| 3,299 | `perl-parser-core/tests/comprehensive_unit_tests.rs` |
-| 3,261 | `perl-refactoring/src/refactor/refactoring.rs` |
-| 3,123 | `perl-lexer/src/lib.rs` |
-
-The debug adapter at 6,778 lines is the largest file in the workspace -- nearly the size of the 9 smallest crates combined.
-
-### The Archive
-
-The `archive/` directory contains `legacy-crates/` and `legacy-tests/`. Inside `legacy-crates/` sits the banished Pest parser. Inside `legacy-tests/` are benchmark tests and fixtures from the parser comparison era. They are excluded from `cargo test` and the CI gate but preserved for historical reference.
-
-### The Most-Changed File
-
-`crates/perl-parser/src/lsp_server.rs` has been modified in **192 commits** -- more than any other file, including `CLAUDE.md` (144 changes) and `README.md` (132 changes).
+This is a strong example of a codebase choosing **domain truth over purity**. A “cleaner” index might insist on one canonical key, but Perl’s calling conventions reward redundancy. The project accepts extra index entries in exchange for much better navigation behavior.
 
 ---
 
-## Records and Extremes
+## Curiosity #3: “Never Panic” Turns into Real Design, Not Just Style Guidance
 
-### Busiest Single Day: March 4, 2026
+Many repositories say “avoid panics.” This one pushes the idea unusually far.
 
-**152 commits** in one day. The day was a blitz of microcrate extractions and "comprehensive unit test" additions -- an entire test suite scaffolded across dozens of newly-extracted crates. The commit log reads like a factory assembly line: `test(tokenizer): add extended unit tests`, `test(incremental-parsing): add extended unit tests`, `test(symbol-table): add extended unit tests`, one after another after another.
+The most memorable example is `perl-lsp-uri`. Its fallback path tries several hardcoded URIs and, if parsing those ever fails, enters an open-ended loop generating `http://localhost/<n>` until one parses.
 
-### Largest PR: #858
+That is a funny piece of code, but it also reveals something serious: the project would rather produce a synthetic URI than crash because a supposedly impossible parser behavior changed.
 
-PR #858, "fix: harden checksum verification and stabilize incremental parsing CI," added or changed **7,696 lines** -- the largest merged PR in the repo's history.
+The same philosophy shows up elsewhere:
 
-### Fastest Version Churn
+- routing code explicitly prefers partial answers over hard failure
+- workspace features degrade to same-file or open-document fallbacks
+- text-based fallback extractors remain available when AST paths are unavailable
 
-Versions v0.7.2 and v0.7.3 were both tagged on **August 6, 2025** -- two releases on the same day. Then v0.8.0 arrived five days later. The stretch from v0.5.0 (Aug 3) to v0.8.5 (Aug 23) covers **six tagged releases in 20 days**.
+### Learning
 
-### The Missing Versions
-
-The version history jumps from `v0.1.0-pest` straight to `v0.5.0`, skipping v0.2 through v0.4. These were internal milestones for the native parser (the commit log references "v0.2.0 release" and "v0.3.0 release" and "v0.4.0: complete v3 parser") but they were never tagged.
-
-Similarly, there is no `v0.6.x` in the tag list. And `v0.9.0` appears in commit messages ("release: v0.9.0 -- Semantic-Ready milestone") but the first tagged 0.9 release is `v0.9.1`.
+In this codebase, resilience is treated as a product feature. The guiding question is often not “what is the elegant failure mode?” but rather “what useful result can still be returned safely?”
 
 ---
 
-## The CLAUDE.md Per-Crate Convention
+## Curiosity #4: Degraded Mode Is a First-Class Operating State
 
-**52 crates** have their own `CLAUDE.md` -- a file providing crate-specific guidance to Claude Code. These files describe the crate's tier, purpose, dependencies, key types, and commands. They range from minimal (a few lines of build instructions) to detailed architectural overviews.
+The LSP runtime does not treat the workspace index as simply “ready” or “broken.” Instead, it models a lifecycle with explicit states such as:
 
-Combined with the project-root `CLAUDE.md` (which itself has been modified 144 times), this forms a distributed documentation system that serves double duty: human-readable reference material and machine-readable agent context.
+- `Building`
+- `Ready`
+- `Degraded`
+
+The routing layer then maps those states to access modes:
+
+- full workspace access
+- partial access
+- no workspace access
+
+That is notable because many language servers bury this policy inside scattered `if index_ready { ... }` checks. Here, the design is centralized in `runtime/routing.rs`.
+
+The degraded reasons are also explicit:
+
+- parse storm
+- I/O error
+- scan timeout
+- resource limit
+
+### Learning
+
+This is a mature systems pattern: **make partial service explicit**. Contributors do not need to rediscover fallback behavior method by method, because the runtime encodes the operating modes as policy.
 
 ---
 
-## Fun Facts and Easter Eggs
+## Curiosity #5: The LSP Runtime Is a Hybrid, Not a Framework-Default Server
 
-- **The 21 "c" commits**: Someone made 21 commits with the single-letter message "c." They are scattered throughout the history -- likely a human rapid-iterating with a quick alias.
+The `perl-lsp` binary uses a nice hybrid shape:
 
-- **3,322 Perl files**: The Rust project contains more Perl files (test fixtures) than lines of code in several of its smallest crates.
+- a blocking reader thread consumes framed messages from stdin
+- messages are sent through a Tokio `mpsc` channel
+- both stdio and TCP eventually use the same async serving path
 
-- **120 Cargo.toml files**: The workspace has nearly as many `Cargo.toml` build configuration files as it has `lib.rs` source files (119). The ratio of "build system" to "actual library entrypoint" is almost exactly 1:1.
+That is a practical architecture choice.
 
-- **The Codex agent rejection wall**: PRs #771 through #837 form an unbroken block of 67 consecutive PRs, overwhelmingly from the three agent personas, almost all rejected. This corresponds to the period when the low-hanging fruit had been picked and the agents kept regenerating the same stale optimizations.
+It avoids forcing the raw input side into a fully async design while still letting the main dispatch and serving path share one runtime model. The comments in `crates/perl-lsp/src/main.rs` are explicit that stdio and TCP should converge on the same async dispatch path.
 
-- **The night shift**: The most common commit hour is midnight (133 commits at 00:xx), followed by 5 PM (119) and 1 PM (116). The least busy hours are mid-morning -- the codebase is built by night owls and AI agents that never sleep.
+### Learning
 
-- **"Enterprise" count: 3**: Despite 277 uses of "comprehensive" and 271 of "enhance," the word "enterprise" appears in only 3 commit messages. Even the agents have limits.
+This codebase repeatedly favors **operational simplicity over framework purity**. Instead of chasing an all-async ideal, it uses a mixed model that matches the realities of LSP framing and transport.
 
-- **Version v0.10.0 has 82 crates** -- but there are now 121 crate directories at HEAD. Thirty-nine crates were extracted in the two weeks since the last release.
+---
+
+## Curiosity #6: Unsafe Exists, but the Safety Story Is Documented Right Next to It
+
+`LspServer` has explicit `unsafe impl Send` and `unsafe impl Sync` because `ParentMap` holds raw pointers into AST nodes. That is the sort of line that should make a reviewer stop.
+
+The good news is that the file immediately explains the invariant:
+
+- access is synchronized through shared locking
+- the raw pointers are tied to AST lifetime assumptions
+- the surrounding fields are otherwise protected by atomics or mutexes
+
+### Learning
+
+This is a useful model for “necessary unsafe” in Rust infrastructure code:
+
+1. keep the unsafe surface narrow
+2. explain exactly why the compiler cannot prove the invariant
+3. put the explanation at the unsafe boundary, not in a distant design doc only
+
+---
+
+## Curiosity #7: Tests Are Used as Executable Architecture Notes
+
+The test suite does more than verify correctness. It preserves design intent.
+
+A good example is `dual_indexing_tests.rs`, whose file-level commentary explains the rule before the assertions begin. The tests read like a mini-spec:
+
+- qualified lookups must work
+- bare lookups must work
+- references must be discoverable from either query shape
+- re-indexing must cleanly replace prior symbols
+
+### Learning
+
+This is particularly effective in a fast-moving workspace. When the architecture is spread over many crates, well-named tests become one of the best ways to communicate what must not regress.
+
+---
+
+## Curiosity #8: Documentation Is Not Side Material — It Is Part of the Architecture
+
+The repository currently contains more than two thousand Markdown files. That is not normal overhead; it is a design choice.
+
+The docs are doing several jobs at once:
+
+- contributor onboarding
+- architecture explanation
+- CI and validation procedure capture
+- anti-drift truth sourcing
+- project forensics and lessons learned
+
+The interesting part is that this mirrors the code layout itself. The repo likes explicit boundaries in both code and prose.
+
+### Learning
+
+If you contribute here, reading docs is not optional ceremony. It is part of understanding how the project maintains coherence across a very large workspace.
+
+---
+
+## Curiosity #9: The Codebase Likes Specialized Utility Crates More Than Generic Helpers
+
+A recurring pattern is the presence of small crates with very specific jobs:
+
+- URI parsing helpers
+- line indexing
+- percentile calculations
+- workspace ignore handling
+- diagnostic types
+- module token parsing
+
+These are not broad “utils” modules. They are named capabilities.
+
+### Learning
+
+This is an important maintainability lesson. Generic helper buckets tend to grow into junk drawers. The crate graph here pushes in the opposite direction: give a concept a precise name, then make dependencies talk through that named surface.
+
+---
+
+## Curiosity #10: The Largest File Is the Workspace Index, Which Tells You Where the Real Complexity Lives
+
+The biggest Rust file in the workspace is `workspace_index.rs`. That feels right.
+
+For a Perl language server, the hardest practical problem is often not tokenization or AST construction in isolation, but turning parsed code into useful editor behavior across files, packages, imports, and ambiguous naming patterns.
+
+The file contains:
+
+- lifecycle state modeling
+- indexing rules
+- symbol and reference lookup
+- qualified/bare-name reconciliation
+- degradation behavior hooks
+- performance-oriented data structures
+
+### Learning
+
+The center of gravity in language tooling is often the **semantic and indexing layer**, not just the parser. This repository makes that visible.
+
+---
+
+## Practical Takeaways for New Contributors
+
+If you are trying to become productive in this repository, these are the main lessons to internalize first:
+
+1. **Expect named boundaries everywhere.** Before adding to a generic module, check whether an existing crate already owns that concept.
+2. **Preserve fallback behavior.** The codebase values useful degraded behavior over brittle all-or-nothing correctness.
+3. **Treat dual indexing as policy, not optimization.** If you touch navigation or references, verify both qualified and unqualified forms.
+4. **Read the runtime routing before changing handlers.** Index state and degraded behavior are centralized on purpose.
+5. **Do not dismiss the docs as stale by default.** In this repo, docs are part of the operating model.
+6. **Look for the safety invariant when unsafe appears.** The code often documents why an unusual boundary exists.
+
+---
+
+## How This Document Was Derived
+
+This write-up was based on direct inspection of the checked-out tree, especially:
+
+- `crates/perl-workspace-index/src/workspace/workspace_index.rs`
+- `crates/perl-workspace-index/tests/dual_indexing_tests.rs`
+- `crates/perl-lsp/src/runtime/routing.rs`
+- `crates/perl-lsp/src/runtime/mod.rs`
+- `crates/perl-lsp/src/main.rs`
+- `crates/perl-lsp-uri/src/lib.rs`
+
+It also used lightweight repository-wide counts for crate totals, file counts, line counts, and largest/smallest crate snapshots.
+
+---
+
+## Closing Thought
+
+The strongest impression from the current tree is that `perl-lsp` is not merely a parser plus an editor server. It is a repository that has spent a lot of effort encoding **operational knowledge** into code structure:
+
+- explicit states instead of ambient assumptions
+- named crates instead of convenience buckets
+- fallbacks instead of brittle hard stops
+- tests and docs as architecture carriers
+
+That combination makes the codebase feel unusual, but also surprisingly legible once you understand its core habits.


### PR DESCRIPTION
### Motivation

- Refresh the repository "codebase curiosities" narrative so it is directly grounded in the current checked-out tree rather than older PR archaeology. 
- Make the updated analysis discoverable from the documentation hub so contributors can reach the findings from `docs/README.md`.

### Description

- Replace `docs/project/CODEBASE_CURIOSITIES.md` with a current-tree, source-grounded walkthrough that includes repository snapshot metrics, ten curiosities, and practical takeaways for contributors. 
- Add a link to the refreshed curiosities document in `docs/README.md` so it appears in the docs hub navigation. 
- The new curiosities doc references and is derived from specific implementation locations such as `crates/perl-workspace-index/src/workspace/workspace_index.rs`, `crates/perl-workspace-index/tests/dual_indexing_tests.rs`, `crates/perl-lsp/src/runtime/routing.rs`, `crates/perl-lsp/src/main.rs`, and `crates/perl-lsp-uri/src/lib.rs`. 
- This is a documentation-only change with no runtime or behavioral code modifications.

### Testing

- Ran `git diff --check` to validate the working tree for whitespace/merge artifacts and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13abdd608333870f9f826f6071ab)