### PR TITLE
Improve feature profile normalization

### DIFF
--- a/crates/perl-lsp-feature-policy/src/lib.rs
+++ b/crates/perl-lsp-feature-policy/src/lib.rs
@@ -9,7 +9,7 @@
 
 use perl_lsp_feature_contracts::advertised_features;
 use perl_lsp_feature_flags::{AdvertisedFeatures, BuildFlags};
-use perl_lsp_feature_profile::FeatureProfileKind;
+use perl_lsp_feature_profile::{FeatureProfileKind, parse_profile_token};
 
 /// Parse a user-facing feature profile name into a `FeatureProfile`.
 ///
@@ -64,12 +64,12 @@ impl FeatureProfile {
     /// This API is intended for CLI and editor integration where users may provide
     /// explicit profile controls at runtime.
     pub fn from_cli_argument(raw_profile: &str) -> Self {
-        from_str_name(raw_profile).unwrap_or_else(Self::current)
+        parse_profile_token(raw_profile).map(Self::from_kind).unwrap_or_else(Self::current)
     }
 
-    /// Parse a CLI argument and return `None` for unknown values.
+    /// Parse a CLI argument using the same normalization rules as editor and CLI inputs.
     pub fn parse_profile(raw_profile: &str) -> Option<Self> {
-        from_str_name(raw_profile)
+        parse_profile_token(raw_profile).map(Self::from_kind)
     }
 
     /// Convert this policy into base `BuildFlags`.
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn from_cli_argument_resolves_known_tokens() {
         assert_eq!(FeatureProfile::from_cli_argument("ga-lock"), FeatureProfile::GaLock);
-        assert_eq!(FeatureProfile::from_cli_argument("prod"), FeatureProfile::Production);
+        assert_eq!(FeatureProfile::from_cli_argument(" Prod "), FeatureProfile::Production);
         assert_eq!(FeatureProfile::from_cli_argument("all"), FeatureProfile::All);
     }
 
@@ -222,6 +222,7 @@ mod tests {
     #[test]
     fn parse_profile_returns_some_for_valid() {
         assert_eq!(FeatureProfile::parse_profile("all"), Some(FeatureProfile::All));
+        assert_eq!(FeatureProfile::parse_profile("  GA_LOCK  "), Some(FeatureProfile::GaLock));
     }
 
     // ── build_flags and profile shapes ──────────────────────────────

--- a/crates/perl-lsp-feature-policy/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-feature-policy/tests/extended_unit_tests.rs
@@ -198,22 +198,24 @@ fn from_cli_argument_whitespace_fallback() {
 }
 
 #[test]
-fn from_cli_argument_case_sensitive() {
+fn from_cli_argument_normalizes_case_and_spacing() {
     let lower = FeatureProfile::from_cli_argument("production");
     let upper = FeatureProfile::from_cli_argument("PRODUCTION");
+    let padded = FeatureProfile::from_cli_argument("  ga_lock  ");
     assert_eq!(lower, FeatureProfile::Production);
-    assert_eq!(upper, FeatureProfile::current()); // falls back
+    assert_eq!(upper, FeatureProfile::Production);
+    assert_eq!(padded, FeatureProfile::GaLock);
 }
 
 // ---------------------------------------------------------------------------
-// FeatureProfile::parse_profile – strict parsing
+// FeatureProfile::parse_profile – normalized CLI-style parsing
 // ---------------------------------------------------------------------------
 
 #[test]
-fn parse_profile_strict_none_for_unknown() {
+fn parse_profile_returns_none_for_unknown() {
     assert!(FeatureProfile::parse_profile("").is_none());
     assert!(FeatureProfile::parse_profile("invalid").is_none());
-    assert!(FeatureProfile::parse_profile("PRODUCTION").is_none());
+    assert!(FeatureProfile::parse_profile("prod-debug").is_none());
 }
 
 #[test]
@@ -225,9 +227,10 @@ fn parse_profile_all_valid_aliases() {
 }
 
 #[test]
-fn parse_profile_with_whitespace_fails() {
-    assert!(FeatureProfile::parse_profile(" ga-lock").is_none());
-    assert!(FeatureProfile::parse_profile("ga-lock ").is_none());
+fn parse_profile_normalizes_whitespace_and_case() {
+    assert_eq!(FeatureProfile::parse_profile(" ga-lock"), Some(FeatureProfile::GaLock));
+    assert_eq!(FeatureProfile::parse_profile("ga-lock "), Some(FeatureProfile::GaLock));
+    assert_eq!(FeatureProfile::parse_profile("PRODUCTION"), Some(FeatureProfile::Production));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Make feature-profile parsing consistent across CLI/editor inputs by reusing the existing normalization helper used elsewhere in the workspace.
- Reduce surprising behavior where `from_cli_argument` accepted different tokens than other profile parsers and where `parse_profile` rejected whitespace/case-normalized tokens.

### Description
- Import and use `parse_profile_token` from `perl-lsp-feature-profile` and replace `from_str_name` usage in `FeatureProfile::from_cli_argument` and `FeatureProfile::parse_profile` so both APIs share the same normalization rules.
- Update unit tests in `crates/perl-lsp-feature-policy` to reflect normalized CLI-style parsing (accept case-insensitive and whitespace-padded inputs) and to keep fallback behavior for unknown tokens.
- Adjust extended tests to assert normalized inputs (e.g., `" Prod "`, `"  GA_LOCK  "`) resolve to the expected profiles, and to continue rejecting clearly invalid tokens.

### Testing
- Ran `cargo test -p perl-lsp-feature-policy -p perl-lsp-feature-profile-cli -p perl-lsp-feature-grid` and all tests completed successfully (unit and extended tests passing after changes).
- Ran `cargo test` for `perl-lsp-feature-flags`, `perl-lsp-feature-grid`, and related feature crates as part of the rollout; those test suites completed successfully.
- Ran `cargo clippy -p perl-lsp-feature-policy --tests -- -D warnings` and the linter returned no warnings (green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba142094048333b7f68beec4f2f701)