### PR TITLE
Improve feature flagging: feature-id helpers and profile parsing normalization

### DIFF
--- a/crates/perl-lsp-feature-flags/src/lib.rs
+++ b/crates/perl-lsp-feature-flags/src/lib.rs
@@ -145,6 +145,103 @@ pub struct BuildFlags {
 }
 
 impl BuildFlags {
+    /// Return whether a canonical or compatibility feature identifier is enabled.
+    pub fn has_feature_id(&self, feature_id: &str) -> bool {
+        match feature_id {
+            LSP_COMPLETION => self.completion,
+            LSP_HOVER => self.hover,
+            LSP_DEFINITION => self.definition,
+            LSP_TYPE_DEFINITION => self.type_definition,
+            LSP_IMPLEMENTATION => self.implementation,
+            LSP_REFERENCES => self.references,
+            LSP_DOCUMENT_SYMBOL => self.document_symbol,
+            LSP_WORKSPACE_SYMBOL => self.workspace_symbol,
+            LSP_INLAY_HINT => self.inlay_hints,
+            LSP_PULL_DIAGNOSTICS => self.pull_diagnostics,
+            LSP_WORKSPACE_SYMBOL_RESOLVE => self.workspace_symbol_resolve,
+            LSP_SEMANTIC_TOKENS => self.semantic_tokens,
+            LSP_CODE_ACTION => self.code_actions,
+            LSP_EXECUTE_COMMAND => self.execute_command,
+            LSP_RENAME | LSP_PREPARE_RENAME => self.rename,
+            LSP_DOCUMENT_LINK | LSP_DOCUMENT_LINK_RESOLVE => self.document_links,
+            LSP_SELECTION_RANGE => self.selection_ranges,
+            LSP_ON_TYPE_FORMATTING => self.on_type_formatting,
+            LSP_CODE_LENS | LSP_CODE_LENS_RESOLVE | LSP_CODE_LENS_REFRESH => self.code_lens,
+            LSP_CALL_HIERARCHY => self.call_hierarchy,
+            LSP_TYPE_HIERARCHY => self.type_hierarchy,
+            LSP_LINKED_EDITING_RANGE => self.linked_editing,
+            LSP_INLINE_COMPLETION => self.inline_completion,
+            LSP_INLINE_VALUE | LSP_INLINE_VALUES | LSP_INLINE_VALUE_REFRESH => self.inline_values,
+            LSP_NOTEBOOK_DOCUMENT_SYNC => self.notebook_document_sync,
+            LSP_NOTEBOOK_CELL_EXECUTION => self.notebook_cell_execution,
+            LSP_MONIKER => self.moniker,
+            LSP_DOCUMENT_COLOR | LSP_COLOR | LSP_COLOR_PRESENTATION => self.document_color,
+            LSP_FORMATTING => self.formatting,
+            LSP_RANGE_FORMATTING | LSP_RANGES_FORMATTING => self.range_formatting,
+            LSP_FOLDING_RANGE | LSP_FOLDING_RANGE_REFRESH => self.folding_range,
+            LSP_SIGNATURE_HELP => self.signature_help,
+            LSP_DOCUMENT_HIGHLIGHT => self.document_highlight,
+            LSP_DECLARATION => self.declaration,
+            LSP_CODE_ACTION_RESOLVE => self.code_actions,
+            LSP_COMPLETION_ITEM_RESOLVE => self.completion,
+            LSP_INLAY_HINT_RESOLVE | LSP_INLAY_HINT_REFRESH => self.inlay_hints,
+            LSP_SEMANTIC_TOKENS_REFRESH => self.semantic_tokens,
+            LSP_DIAGNOSTIC_REFRESH => self.pull_diagnostics,
+            _ => false,
+        }
+    }
+
+    /// Update a canonical or compatibility feature identifier and report whether it was known.
+    pub fn set_feature_id(&mut self, feature_id: &str, enabled: bool) -> bool {
+        match feature_id {
+            LSP_COMPLETION | LSP_COMPLETION_ITEM_RESOLVE => self.completion = enabled,
+            LSP_HOVER => self.hover = enabled,
+            LSP_DEFINITION => self.definition = enabled,
+            LSP_TYPE_DEFINITION => self.type_definition = enabled,
+            LSP_IMPLEMENTATION => self.implementation = enabled,
+            LSP_REFERENCES => self.references = enabled,
+            LSP_DOCUMENT_SYMBOL => self.document_symbol = enabled,
+            LSP_WORKSPACE_SYMBOL => self.workspace_symbol = enabled,
+            LSP_INLAY_HINT | LSP_INLAY_HINT_RESOLVE | LSP_INLAY_HINT_REFRESH => {
+                self.inlay_hints = enabled
+            }
+            LSP_PULL_DIAGNOSTICS | LSP_DIAGNOSTIC_REFRESH => self.pull_diagnostics = enabled,
+            LSP_WORKSPACE_SYMBOL_RESOLVE => self.workspace_symbol_resolve = enabled,
+            LSP_SEMANTIC_TOKENS | LSP_SEMANTIC_TOKENS_REFRESH => self.semantic_tokens = enabled,
+            LSP_CODE_ACTION | LSP_CODE_ACTION_RESOLVE => self.code_actions = enabled,
+            LSP_EXECUTE_COMMAND => self.execute_command = enabled,
+            LSP_RENAME | LSP_PREPARE_RENAME => self.rename = enabled,
+            LSP_DOCUMENT_LINK | LSP_DOCUMENT_LINK_RESOLVE => self.document_links = enabled,
+            LSP_SELECTION_RANGE => self.selection_ranges = enabled,
+            LSP_ON_TYPE_FORMATTING => self.on_type_formatting = enabled,
+            LSP_CODE_LENS | LSP_CODE_LENS_RESOLVE | LSP_CODE_LENS_REFRESH => {
+                self.code_lens = enabled
+            }
+            LSP_CALL_HIERARCHY => self.call_hierarchy = enabled,
+            LSP_TYPE_HIERARCHY => self.type_hierarchy = enabled,
+            LSP_LINKED_EDITING_RANGE => self.linked_editing = enabled,
+            LSP_INLINE_COMPLETION => self.inline_completion = enabled,
+            LSP_INLINE_VALUE | LSP_INLINE_VALUES | LSP_INLINE_VALUE_REFRESH => {
+                self.inline_values = enabled
+            }
+            LSP_NOTEBOOK_DOCUMENT_SYNC => self.notebook_document_sync = enabled,
+            LSP_NOTEBOOK_CELL_EXECUTION => self.notebook_cell_execution = enabled,
+            LSP_MONIKER => self.moniker = enabled,
+            LSP_DOCUMENT_COLOR | LSP_COLOR | LSP_COLOR_PRESENTATION => {
+                self.document_color = enabled
+            }
+            LSP_FORMATTING => self.formatting = enabled,
+            LSP_RANGE_FORMATTING | LSP_RANGES_FORMATTING => self.range_formatting = enabled,
+            LSP_FOLDING_RANGE | LSP_FOLDING_RANGE_REFRESH => self.folding_range = enabled,
+            LSP_SIGNATURE_HELP => self.signature_help = enabled,
+            LSP_DOCUMENT_HIGHLIGHT => self.document_highlight = enabled,
+            LSP_DECLARATION => self.declaration = enabled,
+            _ => return false,
+        }
+
+        true
+    }
+
     /// Convert build flags to advertised features.
     pub fn to_advertised_features(&self) -> AdvertisedFeatures {
         AdvertisedFeatures {
@@ -413,7 +510,9 @@ impl BuildFlags {
 mod tests {
     use super::{AdvertisedFeatures, BuildFlags};
     use perl_lsp_feature_contracts::all_features;
-    use perl_lsp_feature_ids::LSP_DOCUMENT_COLOR;
+    use perl_lsp_feature_ids::{
+        LSP_COLOR, LSP_DOCUMENT_COLOR, LSP_INLINE_VALUES, LSP_RANGES_FORMATTING,
+    };
 
     #[test]
     fn feature_ids_are_stable_and_sorted() {
@@ -444,6 +543,33 @@ mod tests {
     fn document_color_uses_bdd_catalog_id() {
         let flags = BuildFlags { document_color: true, ..Default::default() };
         assert_eq!(flags.to_feature_ids(), vec![LSP_DOCUMENT_COLOR]);
+    }
+
+    #[test]
+    fn compatibility_aliases_are_queryable() {
+        let flags = BuildFlags {
+            document_color: true,
+            inline_values: true,
+            range_formatting: true,
+            ..Default::default()
+        };
+
+        assert!(flags.has_feature_id(LSP_COLOR));
+        assert!(flags.has_feature_id(LSP_INLINE_VALUES));
+        assert!(flags.has_feature_id(LSP_RANGES_FORMATTING));
+    }
+
+    #[test]
+    fn set_feature_id_updates_known_aliases() {
+        let mut flags = BuildFlags::default();
+
+        assert!(flags.set_feature_id(LSP_COLOR, true));
+        assert!(flags.document_color);
+        assert!(flags.set_feature_id(LSP_INLINE_VALUES, true));
+        assert!(flags.inline_values);
+        assert!(flags.set_feature_id(LSP_RANGES_FORMATTING, true));
+        assert!(flags.range_formatting);
+        assert!(!flags.set_feature_id("lsp.unknown_flag", true));
     }
 
     #[test]

--- a/crates/perl-lsp-feature-policy/src/lib.rs
+++ b/crates/perl-lsp-feature-policy/src/lib.rs
@@ -9,7 +9,7 @@
 
 use perl_lsp_feature_contracts::advertised_features;
 use perl_lsp_feature_flags::{AdvertisedFeatures, BuildFlags};
-use perl_lsp_feature_profile::FeatureProfileKind;
+use perl_lsp_feature_profile::{FeatureProfileKind, parse_profile_token};
 
 /// Parse a user-facing feature profile name into a `FeatureProfile`.
 ///
@@ -21,7 +21,7 @@ use perl_lsp_feature_profile::FeatureProfileKind;
 ///
 /// Unknown values return `None`.
 pub fn from_str_name(s: &str) -> Option<FeatureProfile> {
-    FeatureProfileKind::from_str_name(s).map(FeatureProfile::from_kind)
+    parse_profile_token(s).map(FeatureProfile::from_kind)
 }
 
 /// Known feature profiles for runtime capability selection.

--- a/crates/perl-lsp-feature-policy/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-feature-policy/tests/comprehensive_unit_tests.rs
@@ -51,7 +51,7 @@ fn from_str_name_auto_resolves() -> Result<(), String> {
 fn from_str_name_unknown_returns_none() {
     assert!(from_str_name("bogus").is_none());
     assert!(from_str_name("").is_none());
-    assert!(from_str_name("GA-LOCK").is_none()); // case-sensitive
+    assert_eq!(from_str_name("GA-LOCK"), Some(FeatureProfile::GaLock));
 }
 
 // ---------------------------------------------------------------------------
@@ -105,6 +105,7 @@ fn current_is_a_valid_profile() {
 fn from_cli_argument_known_token() {
     assert_eq!(FeatureProfile::from_cli_argument("prod"), FeatureProfile::Production);
     assert_eq!(FeatureProfile::from_cli_argument("all"), FeatureProfile::All);
+    assert_eq!(FeatureProfile::from_cli_argument("  GA_LOCK  "), FeatureProfile::GaLock);
 }
 
 #[test]

--- a/crates/perl-lsp-feature-policy/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-feature-policy/tests/extended_unit_tests.rs
@@ -14,20 +14,20 @@ use perl_lsp_feature_policy::{
 // ---------------------------------------------------------------------------
 
 #[test]
-fn from_str_name_whitespace_is_not_trimmed() {
-    assert!(from_str_name(" ga-lock").is_none());
-    assert!(from_str_name("ga-lock ").is_none());
-    assert!(from_str_name(" ga-lock ").is_none());
-    assert!(from_str_name("\tga-lock").is_none());
+fn from_str_name_normalizes_whitespace() {
+    assert_eq!(from_str_name(" ga-lock"), Some(FeatureProfile::GaLock));
+    assert_eq!(from_str_name("ga-lock "), Some(FeatureProfile::GaLock));
+    assert_eq!(from_str_name(" ga-lock "), Some(FeatureProfile::GaLock));
+    assert_eq!(from_str_name("\tga-lock"), Some(FeatureProfile::GaLock));
 }
 
 #[test]
-fn from_str_name_mixed_case_variants_all_invalid() {
-    assert!(from_str_name("GA-Lock").is_none());
-    assert!(from_str_name("Ga-lock").is_none());
-    assert!(from_str_name("Production").is_none());
-    assert!(from_str_name("PRODUCTION").is_none());
-    assert!(from_str_name("ALL").is_none());
+fn from_str_name_normalizes_case() {
+    assert_eq!(from_str_name("GA-Lock"), Some(FeatureProfile::GaLock));
+    assert_eq!(from_str_name("Ga-lock"), Some(FeatureProfile::GaLock));
+    assert_eq!(from_str_name("Production"), Some(FeatureProfile::Production));
+    assert_eq!(from_str_name("PRODUCTION"), Some(FeatureProfile::Production));
+    assert_eq!(from_str_name("ALL"), Some(FeatureProfile::All));
 }
 
 #[test]
@@ -198,11 +198,11 @@ fn from_cli_argument_whitespace_fallback() {
 }
 
 #[test]
-fn from_cli_argument_case_sensitive() {
+fn from_cli_argument_normalizes_case() {
     let lower = FeatureProfile::from_cli_argument("production");
     let upper = FeatureProfile::from_cli_argument("PRODUCTION");
     assert_eq!(lower, FeatureProfile::Production);
-    assert_eq!(upper, FeatureProfile::current()); // falls back
+    assert_eq!(upper, FeatureProfile::Production);
 }
 
 // ---------------------------------------------------------------------------
@@ -213,7 +213,7 @@ fn from_cli_argument_case_sensitive() {
 fn parse_profile_strict_none_for_unknown() {
     assert!(FeatureProfile::parse_profile("").is_none());
     assert!(FeatureProfile::parse_profile("invalid").is_none());
-    assert!(FeatureProfile::parse_profile("PRODUCTION").is_none());
+    assert_eq!(FeatureProfile::parse_profile("PRODUCTION"), Some(FeatureProfile::Production));
 }
 
 #[test]
@@ -225,9 +225,9 @@ fn parse_profile_all_valid_aliases() {
 }
 
 #[test]
-fn parse_profile_with_whitespace_fails() {
-    assert!(FeatureProfile::parse_profile(" ga-lock").is_none());
-    assert!(FeatureProfile::parse_profile("ga-lock ").is_none());
+fn parse_profile_with_whitespace_normalizes() {
+    assert_eq!(FeatureProfile::parse_profile(" ga-lock"), Some(FeatureProfile::GaLock));
+    assert_eq!(FeatureProfile::parse_profile("ga-lock "), Some(FeatureProfile::GaLock));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Make runtime feature flagging easier to query and mutate by LSP feature identifier (including legacy/compatibility aliases).
- Normalize feature-profile parsing so CLI tokens and governance APIs handle whitespace, case, and underscore/hyphen aliases consistently.

### Description
- Add `BuildFlags::has_feature_id(&self, feature_id: &str) -> bool` to query whether a canonical or compatibility feature id is enabled, mapping many `lsp.*` ids and legacy aliases to the corresponding boolean flags in `BuildFlags`.
- Add `BuildFlags::set_feature_id(&mut self, feature_id: &str, enabled: bool) -> bool` to update flags by canonical or compatibility feature id and return whether the id was known.
- Route `perl-lsp-feature-policy::from_str_name` through `parse_profile_token` so profile parsing performs trimming, case normalization, and underscore-to-hyphen alias handling consistently at the policy layer.
- Update and expand tests to cover compatibility aliases and the new profile normalization behavior in both the feature-flags and feature-policy crates, and add unit tests demonstrating read/write of compatibility aliases via the new helpers.
- Changes are localized to `crates/perl-lsp-feature-flags/src/lib.rs`, `crates/perl-lsp-feature-policy/src/lib.rs`, and test files under `crates/perl-lsp-feature-policy/tests`.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran targeted unit tests with `cargo test -p perl-lsp-feature-flags -p perl-lsp-feature-policy` and the test suites for both crates passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba142094048333b7f68beec4f2f701)