### PR TITLE
Tighten LSP capability feature gating

### DIFF
--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -32,7 +32,9 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
         save: None,
     }));
 
-    caps.hover_provider = Some(HoverProviderCapability::Simple(true));
+    if build.hover {
+        caps.hover_provider = Some(HoverProviderCapability::Simple(true));
+    }
 
     if build.document_highlight {
         caps.document_highlight_provider = Some(OneOf::Left(true));
@@ -50,20 +52,24 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
         caps.declaration_provider = Some(DeclarationCapability::Simple(true));
     }
 
-    caps.completion_provider = Some(CompletionOptions {
-        resolve_provider: Some(true),
-        trigger_characters: Some(vec![
-            "$".to_string(),
-            "@".to_string(),
-            "%".to_string(),
-            "->".to_string(),
-        ]),
-        all_commit_characters: None,
-        work_done_progress_options: WorkDoneProgressOptions::default(),
-        completion_item: None,
-    });
+    if build.completion {
+        caps.completion_provider = Some(CompletionOptions {
+            resolve_provider: Some(true),
+            trigger_characters: Some(vec![
+                "$".to_string(),
+                "@".to_string(),
+                "%".to_string(),
+                "->".to_string(),
+            ]),
+            all_commit_characters: None,
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+            completion_item: None,
+        });
+    }
 
-    caps.definition_provider = Some(OneOf::Left(true));
+    if build.definition {
+        caps.definition_provider = Some(OneOf::Left(true));
+    }
 
     if build.type_definition {
         caps.type_definition_provider =
@@ -75,9 +81,15 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
             Some(lsp_types::ImplementationProviderCapability::Simple(true));
     }
 
-    caps.references_provider = Some(OneOf::Left(true));
-    caps.document_symbol_provider = Some(OneOf::Left(true));
-    caps.workspace_symbol_provider = Some(OneOf::Left(true));
+    if build.references {
+        caps.references_provider = Some(OneOf::Left(true));
+    }
+    if build.document_symbol {
+        caps.document_symbol_provider = Some(OneOf::Left(true));
+    }
+    if build.workspace_symbol {
+        caps.workspace_symbol_provider = Some(OneOf::Left(true));
+    }
 
     if build.notebook_document_sync {
         caps.notebook_document_sync = Some(OneOf::Left(NotebookDocumentSyncOptions {
@@ -96,7 +108,9 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
         caps.document_range_formatting_provider = Some(OneOf::Left(true));
     }
 
-    caps.folding_range_provider = Some(FoldingRangeProviderCapability::Simple(true));
+    if build.folding_range {
+        caps.folding_range_provider = Some(FoldingRangeProviderCapability::Simple(true));
+    }
 
     // Conditional capabilities
     if build.inlay_hints {

--- a/crates/perl-lsp-protocol/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-protocol/tests/comprehensive_unit_tests.rs
@@ -587,8 +587,7 @@ fn req_range_empty_params() {
 #[test]
 fn capabilities_for_production_has_core_features() {
     let caps = capabilities::capabilities_for(perl_lsp_feature_flags::BuildFlags::production());
-    // Always-on: text document sync, hover, completion, definition, references,
-    // document symbols, workspace symbols, folding range
+    // Production profile enables the core advertised navigation/editing surface.
     assert!(caps.text_document_sync.is_some());
     assert!(caps.hover_provider.is_some());
     assert!(caps.completion_provider.is_some());
@@ -638,10 +637,15 @@ fn capabilities_for_minimal_flags_omits_conditional() {
     // Default derives all-false for bool fields
     let flags = perl_lsp_feature_flags::BuildFlags::default();
     let caps = capabilities::capabilities_for(flags);
-    // Core always-on
+    // Only text sync is unconditional; feature-gated providers should stay off.
     assert!(caps.text_document_sync.is_some());
-    assert!(caps.hover_provider.is_some());
-    assert!(caps.completion_provider.is_some());
+    assert!(caps.hover_provider.is_none());
+    assert!(caps.completion_provider.is_none());
+    assert!(caps.definition_provider.is_none());
+    assert!(caps.references_provider.is_none());
+    assert!(caps.document_symbol_provider.is_none());
+    assert!(caps.workspace_symbol_provider.is_none());
+    assert!(caps.folding_range_provider.is_none());
     // Conditional should be off
     assert!(caps.document_highlight_provider.is_none());
     assert!(caps.signature_help_provider.is_none());

--- a/crates/perl-lsp-protocol/tests/protocol_unit_tests.rs
+++ b/crates/perl-lsp-protocol/tests/protocol_unit_tests.rs
@@ -1016,41 +1016,41 @@ fn capabilities_signature_help_disabled() {
 }
 
 // ============================================================================
-// Capabilities — always-on features
+// Capabilities — core feature flags
 // ============================================================================
 
 #[test]
-fn capabilities_always_has_hover() {
+fn capabilities_production_has_hover() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.hover_provider.is_some());
 }
 
 #[test]
-fn capabilities_always_has_completion() {
+fn capabilities_production_has_completion() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.completion_provider.is_some());
 }
 
 #[test]
-fn capabilities_always_has_definition() {
+fn capabilities_production_has_definition() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.definition_provider.is_some());
 }
 
 #[test]
-fn capabilities_always_has_references() {
+fn capabilities_production_has_references() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.references_provider.is_some());
 }
 
 #[test]
-fn capabilities_always_has_document_symbol() {
+fn capabilities_production_has_document_symbol() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.document_symbol_provider.is_some());
 }
 
 #[test]
-fn capabilities_always_has_folding_range() {
+fn capabilities_production_has_folding_range() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.folding_range_provider.is_some());
 }
@@ -1059,6 +1059,19 @@ fn capabilities_always_has_folding_range() {
 fn capabilities_always_has_text_document_sync() {
     let caps = capabilities_for(BuildFlags::production());
     assert!(caps.text_document_sync.is_some());
+}
+
+#[test]
+fn capabilities_default_omits_flagged_core_features() {
+    let caps = capabilities_for(BuildFlags::default());
+    assert!(caps.text_document_sync.is_some());
+    assert!(caps.hover_provider.is_none());
+    assert!(caps.completion_provider.is_none());
+    assert!(caps.definition_provider.is_none());
+    assert!(caps.references_provider.is_none());
+    assert!(caps.document_symbol_provider.is_none());
+    assert!(caps.workspace_symbol_provider.is_none());
+    assert!(caps.folding_range_provider.is_none());
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation
- Reduce accidental capability surface by ensuring advertised capabilities are driven by the `BuildFlags` profile rather than being unconditionally exposed.
- Keep the minimal/default runtime surface minimal (only `textDocumentSync` unconditional) so feature-gated clients/tools are not misled by advertised capabilities.
- Ensure tests and tooling reflect the runtime feature policy so `features.toml` / BDD tooling remain accurate.

### Description
- Update `capabilities_for` in `crates/perl-lsp-protocol/src/capabilities.rs` to gate `hover`, `completion`, `definition`, `references`, `document_symbol`, `workspace_symbol`, and `folding_range` behind their corresponding `BuildFlags` fields instead of advertising them unconditionally.
- Adjust existing protocol tests in `crates/perl-lsp-protocol/tests/comprehensive_unit_tests.rs` and `crates/perl-lsp-protocol/tests/protocol_unit_tests.rs` to assert both `production` profile behavior and that `BuildFlags::default()` (all-false) does not leak those gated capabilities.
- Add a focused unit test that verifies `BuildFlags::default()` omits the flagged core providers and rename a few test functions for clarity to reflect production vs default expectations.

### Testing
- Ran `cargo test -p perl-lsp-protocol` and all protocol tests passed successfully.
- Ran `cargo test -p perl-lsp-feature-flags` and all feature-flag unit tests passed successfully.
- Ran `cargo clippy -p perl-lsp-protocol --all-targets -- -D warnings` with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba142094048333b7f68beec4f2f701)