### PR TITLE
Improve VS Code extension controls

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -90,10 +90,20 @@ cargo install --git https://github.com/EffortlessMetrics/perl-lsp --bin perl-lsp
   // Additional library include paths
   "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
 
+  // Enable VS Code testing integration
+  "perl-lsp.enableTestIntegration": true,
+
   // LSP trace level for debugging
   "perl-lsp.trace.server": "off"
 }
 ```
+
+## 🧰 VS Code Integration
+
+- **Status bar control center** — click the `Perl LSP` status item to restart the server, show logs, organize imports, run tests, or re-download the bundled server binary.
+- **Testing view support** — `.t` and runnable `.pl` files can appear in the VS Code Testing panel when `perl-lsp.enableTestIntegration` is enabled.
+- **Trace-aware diagnostics** — `perl-lsp.trace.server` now feeds the VS Code LSP trace controls so protocol logs are visible in the output channel.
+- **Binary recovery** — run `Perl: Reinstall Language Server Binary` from the command palette if an auto-downloaded binary becomes corrupted.
 
 ## 🎯 Supported Perl Features
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -310,6 +310,12 @@
         "icon": "$(menu)"
       },
       {
+        "command": "perl-lsp.reinstall",
+        "title": "Reinstall Language Server Binary",
+        "category": "Perl",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "perl-lsp.organizeImports",
         "title": "Organize Use Statements",
         "category": "Perl",
@@ -334,6 +340,10 @@
         },
         {
           "command": "perl-lsp.showStatusMenu",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.reinstall",
           "when": "editorLangId == perl"
         },
         {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,7 +7,8 @@ import {
     LanguageClientOptions,
     ServerOptions,
     TransportKind,
-    State
+    State,
+    Trace
 } from 'vscode-languageclient/node';
 import { PerlTestAdapter } from './testAdapter';
 import { activateDebugger } from './debugAdapter';
@@ -78,6 +79,8 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     };
 
+    const traceLevel = getTraceLevel();
+
     // Client options
     const clientOptions: LanguageClientOptions = {
         documentSelector: [
@@ -88,7 +91,8 @@ export async function activate(context: vscode.ExtensionContext) {
             // Notify the server about file changes to .perltidyrc files
             fileEvents: vscode.workspace.createFileSystemWatcher('**/.perltidyrc')
         },
-        outputChannel
+        outputChannel,
+        traceOutputChannel: outputChannel
     };
 
     // Create and start the language client
@@ -98,6 +102,7 @@ export async function activate(context: vscode.ExtensionContext) {
         serverOptions,
         clientOptions
     );
+    client.setTrace(traceLevel);
 
     // Create status bar item - show immediately with starting state
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -130,9 +135,15 @@ export async function activate(context: vscode.ExtensionContext) {
     // Start the client
     await client.start();
     
-    // Initialize test adapter
-    testAdapter = new PerlTestAdapter(client);
-    context.subscriptions.push(testAdapter);
+    // Initialize test adapter when enabled
+    const enableTestIntegration = vscode.workspace.getConfiguration('perl-lsp').get<boolean>('enableTestIntegration', true);
+    if (enableTestIntegration) {
+        testAdapter = new PerlTestAdapter(client);
+        context.subscriptions.push(testAdapter);
+    } else {
+        testAdapter = undefined;
+        outputChannel.appendLine('Perl test integration is disabled by configuration.');
+    }
     
     // Initialize debug adapter
     activateDebugger(context);
@@ -197,11 +208,16 @@ export async function activate(context: vscode.ExtensionContext) {
         });
     });
 
+    const reinstallCommand = vscode.commands.registerCommand('perl-lsp.reinstall', async () => {
+        await reinstallServerBinary(context);
+    });
+
     const statusMenuCommand = vscode.commands.registerCommand('perl-lsp.showStatusMenu', async () => {
         const editor = vscode.window.activeTextEditor;
         const isPerl = editor ? editor.document.languageId === 'perl' : false;
         const filePath = editor ? editor.document.uri.fsPath : '';
-        const isTestFile = isPerl && (filePath.endsWith('.t') || filePath.endsWith('.pl'));
+        const testIntegrationEnabled = vscode.workspace.getConfiguration('perl-lsp').get<boolean>('enableTestIntegration', true);
+        const isTestFile = testIntegrationEnabled && isPerl && (filePath.endsWith('.t') || filePath.endsWith('.pl'));
 
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
@@ -242,6 +258,7 @@ export async function activate(context: vscode.ExtensionContext) {
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+            { label: '$(cloud-download) Reinstall Server Binary', detail: 'Re-download the perl-lsp binary for this machine', command: 'perl-lsp.reinstall' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(gear) Configure Settings', detail: 'Open Perl LSP settings', command: 'workbench.action.openSettings', args: ['@ext:EffortlessMetrics.perl-lsp-rs'] }
@@ -256,7 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
     
-    context.subscriptions.push(restartCommand, organizeImportsCommand, runTestsCommand, showVersionCommand, statusMenuCommand);
+    context.subscriptions.push(restartCommand, organizeImportsCommand, runTestsCommand, showVersionCommand, reinstallCommand, statusMenuCommand);
     
     outputChannel.appendLine('Perl Language Server started successfully');
 }
@@ -268,6 +285,61 @@ export async function deactivate() {
     if (client) {
         await client.stop();
     }
+}
+
+
+function getTraceLevel(): Trace {
+    const traceSetting = vscode.workspace.getConfiguration('perl-lsp').get<string>('trace.server', 'off');
+
+    switch ((traceSetting || 'off').toLowerCase()) {
+        case 'messages':
+            return Trace.Messages;
+        case 'verbose':
+            return Trace.Verbose;
+        default:
+            return Trace.Off;
+    }
+}
+
+async function reinstallServerBinary(context: vscode.ExtensionContext) {
+    const localDapPath = BinaryDownloader.getLocalDapPath(context);
+    const localBinaryPath = localDapPath.replace(/perl-dap(\.exe)?$/, (_match, exeSuffix: string | undefined) => `perl-lsp${exeSuffix || ''}`);
+
+    for (const targetPath of [localBinaryPath, localDapPath]) {
+        if (fs.existsSync(targetPath)) {
+            fs.rmSync(targetPath, { force: true });
+            outputChannel.appendLine(`Removed cached binary: ${targetPath}`);
+        }
+    }
+
+    const nextPath = await getServerPath(context);
+    if (!nextPath) {
+        vscode.window.showErrorMessage('Unable to reinstall perl-lsp. See output for details.', 'Show Output').then(selection => {
+            if (selection === 'Show Output') {
+                outputChannel.show();
+            }
+        });
+        return;
+    }
+
+    const healthOk = await runHealthCheck(nextPath);
+    if (!healthOk) {
+        vscode.window.showErrorMessage('Reinstalled perl-lsp failed its health check.', 'Show Output').then(selection => {
+            if (selection === 'Show Output') {
+                outputChannel.show();
+            }
+        });
+        return;
+    }
+
+    vscode.window.showInformationMessage('perl-lsp was reinstalled successfully.', 'Restart Server', 'Show Output').then(async selection => {
+        if (selection === 'Restart Server') {
+            await restartServer(context);
+        }
+        if (selection === 'Show Output') {
+            outputChannel.show();
+        }
+    });
 }
 
 async function getServerPath(context: vscode.ExtensionContext): Promise<string | null> {


### PR DESCRIPTION
### Motivation
- Make the VS Code extension more robust and user-friendly by surfacing LSP protocol traces, honoring the test-integration toggle, and providing a recovery path when an auto-downloaded server binary becomes corrupted.

### Description
- Wire the `perl-lsp.trace.server` setting into the language client so trace output is routed to the extension output channel and the client trace level is applied (`client.setTrace` and `traceOutputChannel`).
- Honor `perl-lsp.enableTestIntegration` when creating the Testing adapter and gate status-menu test actions so the Testing view is only enabled when configured.
- Add a `perl-lsp.reinstall` command and status-menu action, and implement `reinstallServerBinary` which removes cached binaries, re-downloads (via existing downloader flow), and validates the new binary with the health check before prompting to restart.
- Update `package.json` to expose the new `reinstall` command and menu entry and update the extension `README.md` with notes about testing integration, trace behavior, the status-bar control center, and binary recovery.

### Testing
- Ran the extension TypeScript build with `npm --prefix vscode-extension run compile` and it completed successfully.
- Verified the changes were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba140ecfd48333b95769b8e1a90f91)