### PR TITLE
Improve Pest delimiter parsing for substitution and transliteration

### DIFF
--- a/crates/perl-parser-pest/src/grammar.pest
+++ b/crates/perl-parser-pest/src/grammar.pest
@@ -837,20 +837,130 @@ regex_flags = @{ ("i" | "m" | "s" | "x" | "g" | "o" | "a" | "u" | "l" | "n" | "p
 delimiter = @{ !ASCII_ALPHANUMERIC ~ ANY }
 
 substitution = {
-    ("_SUB_" ~ delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter ~ regex_flags?) |
-    ("s" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter ~ regex_flags?)
+    (
+        "_SUB_" ~ (
+            "/" ~ sub_slash_pattern ~ "/" ~ replacement_slash_pattern ~ "/" |
+            "!" ~ sub_exclaim_pattern ~ "!" ~ replacement_exclaim_pattern ~ "!" |
+            "#" ~ sub_hash_pattern ~ "#" ~ replacement_hash_pattern ~ "#" |
+            "(" ~ sub_paren_pattern ~ ")" ~ replacement_paren_pattern ~ ")" |
+            "[" ~ sub_bracket_pattern ~ "]" ~ replacement_bracket_pattern ~ "]" |
+            "{" ~ sub_brace_pattern ~ "}" ~ replacement_brace_pattern ~ "}" |
+            "<" ~ sub_angle_pattern ~ ">" ~ replacement_angle_pattern ~ ">" |
+            delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter
+        ) ~ regex_flags?
+    ) |
+    (
+        "s" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ sub_slash_pattern ~ "/" ~ replacement_slash_pattern ~ "/" |
+            "!" ~ sub_exclaim_pattern ~ "!" ~ replacement_exclaim_pattern ~ "!" |
+            "#" ~ sub_hash_pattern ~ "#" ~ replacement_hash_pattern ~ "#" |
+            "(" ~ sub_paren_pattern ~ ")" ~ replacement_paren_pattern ~ ")" |
+            "[" ~ sub_bracket_pattern ~ "]" ~ replacement_bracket_pattern ~ "]" |
+            "{" ~ sub_brace_pattern ~ "}" ~ replacement_brace_pattern ~ "}" |
+            "<" ~ sub_angle_pattern ~ ">" ~ replacement_angle_pattern ~ ">" |
+            delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter
+        ) ~ regex_flags?
+    )
 }
+sub_slash_pattern = @{ (!"/" ~ (regex_escape | regex_group | ANY))* }
+sub_exclaim_pattern = @{ (!"!" ~ (regex_escape | regex_group | ANY))* }
+sub_hash_pattern = @{ (!"#" ~ (regex_escape | regex_group | ANY))* }
+
+sub_paren_pattern = { sub_paren_part* }
+sub_paren_part = { regex_escape | regex_group | sub_nested_parens | (!(")" | "\\" | "(") ~ ANY) }
+sub_nested_parens = { "(" ~ sub_paren_pattern ~ ")" }
+
+sub_bracket_pattern = { sub_bracket_part* }
+sub_bracket_part = { regex_escape | regex_group | sub_nested_brackets | (!("]" | "\\" | "[") ~ ANY) }
+sub_nested_brackets = { "[" ~ sub_bracket_pattern ~ "]" }
+
+sub_brace_pattern = { sub_brace_part* }
+sub_brace_part = { regex_escape | regex_group | sub_nested_braces | (!("}" | "\\" | "{") ~ ANY) }
+sub_nested_braces = { "{" ~ sub_brace_pattern ~ "}" }
+
+sub_angle_pattern = { sub_angle_part* }
+sub_angle_part = { regex_escape | regex_group | sub_nested_angles | (!(">" | "\\" | "<") ~ ANY) }
+sub_nested_angles = { "<" ~ sub_angle_pattern ~ ">" }
+
 sub_pattern = @{ (!delimiter ~ (regex_escape | regex_group | ANY))* }
+
+replacement_slash_pattern = @{ (!"/" ~ (regex_escape | ANY))* }
+replacement_exclaim_pattern = @{ (!"!" ~ (regex_escape | ANY))* }
+replacement_hash_pattern = @{ (!"#" ~ (regex_escape | ANY))* }
+
+replacement_paren_pattern = { replacement_paren_part* }
+replacement_paren_part = { regex_escape | replacement_nested_parens | (!(")" | "\\" | "(") ~ ANY) }
+replacement_nested_parens = { "(" ~ replacement_paren_pattern ~ ")" }
+
+replacement_bracket_pattern = { replacement_bracket_part* }
+replacement_bracket_part = { regex_escape | replacement_nested_brackets | (!("]" | "\\" | "[") ~ ANY) }
+replacement_nested_brackets = { "[" ~ replacement_bracket_pattern ~ "]" }
+
+replacement_brace_pattern = { replacement_brace_part* }
+replacement_brace_part = { regex_escape | replacement_nested_braces | (!("}" | "\\" | "{") ~ ANY) }
+replacement_nested_braces = { "{" ~ replacement_brace_pattern ~ "}" }
+
+replacement_angle_pattern = { replacement_angle_part* }
+replacement_angle_part = { regex_escape | replacement_nested_angles | (!(">" | "\\" | "<") ~ ANY) }
+replacement_nested_angles = { "<" ~ replacement_angle_pattern ~ ">" }
 
 replacement = @{ (!delimiter ~ ANY)* }
 
 transliteration = {
-    ("_TRANS_" ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?) |
-    ("tr" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?) |
-    ("y" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?)
+    (
+        "_TRANS_" ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    ) |
+    (
+        "tr" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    ) |
+    (
+        "y" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    )
 }
 
+search_list_slash = @{ (!"/" ~ ANY)* }
+search_list_exclaim = @{ (!"!" ~ ANY)* }
+search_list_hash = @{ (!"#" ~ ANY)* }
+search_list_paren = { (!")" ~ ANY)* }
+search_list_bracket = { (!"]" ~ ANY)* }
+search_list_brace = { (!"}" ~ ANY)* }
+search_list_angle = { (!">" ~ ANY)* }
 search_list = @{ (!delimiter ~ ANY)* }
+
+replace_list_slash = @{ (!"/" ~ ANY)* }
+replace_list_exclaim = @{ (!"!" ~ ANY)* }
+replace_list_hash = @{ (!"#" ~ ANY)* }
+replace_list_paren = { (!")" ~ ANY)* }
+replace_list_bracket = { (!"]" ~ ANY)* }
+replace_list_brace = { (!"}" ~ ANY)* }
+replace_list_angle = { (!">" ~ ANY)* }
 replace_list = @{ (!delimiter ~ ANY)* }
 trans_flags = @{ ASCII_ALPHA* }
 

--- a/crates/perl-parser-pest/src/pure_rust_parser.rs
+++ b/crates/perl-parser-pest/src/pure_rust_parser.rs
@@ -2783,4 +2783,20 @@ mod tests {
         println!("Hash assignment AST: {:?}", ast);
         println!("S-expression: {}", sexp);
     }
+
+    #[test]
+    fn test_substitution_with_non_slash_delimiters() {
+        let mut parser = PureRustPerlParser::new();
+        let source = r#"$text =~ s!foo/bar!baz/qux!gr;"#;
+        let result = parser.parse(source);
+        assert!(result.is_ok(), "Failed to parse substitution with ! delimiters: {source}");
+    }
+
+    #[test]
+    fn test_transliteration_with_brace_delimiters() {
+        let mut parser = PureRustPerlParser::new();
+        let source = r#"$text =~ tr{a-z}{A-Z}d;"#;
+        let result = parser.parse(source);
+        assert!(result.is_ok(), "Failed to parse transliteration with brace delimiters: {source}");
+    }
 }

--- a/crates/tree-sitter-perl-rs/src/grammar.pest
+++ b/crates/tree-sitter-perl-rs/src/grammar.pest
@@ -837,20 +837,130 @@ regex_flags = @{ ("i" | "m" | "s" | "x" | "g" | "o" | "a" | "u" | "l" | "n" | "p
 delimiter = @{ !ASCII_ALPHANUMERIC ~ ANY }
 
 substitution = {
-    ("_SUB_" ~ delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter ~ regex_flags?) |
-    ("s" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter ~ regex_flags?)
+    (
+        "_SUB_" ~ (
+            "/" ~ sub_slash_pattern ~ "/" ~ replacement_slash_pattern ~ "/" |
+            "!" ~ sub_exclaim_pattern ~ "!" ~ replacement_exclaim_pattern ~ "!" |
+            "#" ~ sub_hash_pattern ~ "#" ~ replacement_hash_pattern ~ "#" |
+            "(" ~ sub_paren_pattern ~ ")" ~ replacement_paren_pattern ~ ")" |
+            "[" ~ sub_bracket_pattern ~ "]" ~ replacement_bracket_pattern ~ "]" |
+            "{" ~ sub_brace_pattern ~ "}" ~ replacement_brace_pattern ~ "}" |
+            "<" ~ sub_angle_pattern ~ ">" ~ replacement_angle_pattern ~ ">" |
+            delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter
+        ) ~ regex_flags?
+    ) |
+    (
+        "s" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ sub_slash_pattern ~ "/" ~ replacement_slash_pattern ~ "/" |
+            "!" ~ sub_exclaim_pattern ~ "!" ~ replacement_exclaim_pattern ~ "!" |
+            "#" ~ sub_hash_pattern ~ "#" ~ replacement_hash_pattern ~ "#" |
+            "(" ~ sub_paren_pattern ~ ")" ~ replacement_paren_pattern ~ ")" |
+            "[" ~ sub_bracket_pattern ~ "]" ~ replacement_bracket_pattern ~ "]" |
+            "{" ~ sub_brace_pattern ~ "}" ~ replacement_brace_pattern ~ "}" |
+            "<" ~ sub_angle_pattern ~ ">" ~ replacement_angle_pattern ~ ">" |
+            delimiter ~ sub_pattern ~ delimiter ~ replacement ~ delimiter
+        ) ~ regex_flags?
+    )
 }
+sub_slash_pattern = @{ (!"/" ~ (regex_escape | regex_group | ANY))* }
+sub_exclaim_pattern = @{ (!"!" ~ (regex_escape | regex_group | ANY))* }
+sub_hash_pattern = @{ (!"#" ~ (regex_escape | regex_group | ANY))* }
+
+sub_paren_pattern = { sub_paren_part* }
+sub_paren_part = { regex_escape | regex_group | sub_nested_parens | (!(")" | "\\" | "(") ~ ANY) }
+sub_nested_parens = { "(" ~ sub_paren_pattern ~ ")" }
+
+sub_bracket_pattern = { sub_bracket_part* }
+sub_bracket_part = { regex_escape | regex_group | sub_nested_brackets | (!("]" | "\\" | "[") ~ ANY) }
+sub_nested_brackets = { "[" ~ sub_bracket_pattern ~ "]" }
+
+sub_brace_pattern = { sub_brace_part* }
+sub_brace_part = { regex_escape | regex_group | sub_nested_braces | (!("}" | "\\" | "{") ~ ANY) }
+sub_nested_braces = { "{" ~ sub_brace_pattern ~ "}" }
+
+sub_angle_pattern = { sub_angle_part* }
+sub_angle_part = { regex_escape | regex_group | sub_nested_angles | (!(">" | "\\" | "<") ~ ANY) }
+sub_nested_angles = { "<" ~ sub_angle_pattern ~ ">" }
+
 sub_pattern = @{ (!delimiter ~ (regex_escape | regex_group | ANY))* }
+
+replacement_slash_pattern = @{ (!"/" ~ (regex_escape | ANY))* }
+replacement_exclaim_pattern = @{ (!"!" ~ (regex_escape | ANY))* }
+replacement_hash_pattern = @{ (!"#" ~ (regex_escape | ANY))* }
+
+replacement_paren_pattern = { replacement_paren_part* }
+replacement_paren_part = { regex_escape | replacement_nested_parens | (!(")" | "\\" | "(") ~ ANY) }
+replacement_nested_parens = { "(" ~ replacement_paren_pattern ~ ")" }
+
+replacement_bracket_pattern = { replacement_bracket_part* }
+replacement_bracket_part = { regex_escape | replacement_nested_brackets | (!("]" | "\\" | "[") ~ ANY) }
+replacement_nested_brackets = { "[" ~ replacement_bracket_pattern ~ "]" }
+
+replacement_brace_pattern = { replacement_brace_part* }
+replacement_brace_part = { regex_escape | replacement_nested_braces | (!("}" | "\\" | "{") ~ ANY) }
+replacement_nested_braces = { "{" ~ replacement_brace_pattern ~ "}" }
+
+replacement_angle_pattern = { replacement_angle_part* }
+replacement_angle_part = { regex_escape | replacement_nested_angles | (!(">" | "\\" | "<") ~ ANY) }
+replacement_nested_angles = { "<" ~ replacement_angle_pattern ~ ">" }
 
 replacement = @{ (!delimiter ~ ANY)* }
 
 transliteration = {
-    ("_TRANS_" ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?) |
-    ("tr" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?) |
-    ("y" ~ !(ASCII_ALPHANUMERIC | "_") ~ delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter ~ trans_flags?)
+    (
+        "_TRANS_" ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    ) |
+    (
+        "tr" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    ) |
+    (
+        "y" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+            "/" ~ search_list_slash ~ "/" ~ replace_list_slash ~ "/" |
+            "!" ~ search_list_exclaim ~ "!" ~ replace_list_exclaim ~ "!" |
+            "#" ~ search_list_hash ~ "#" ~ replace_list_hash ~ "#" |
+            "(" ~ search_list_paren ~ ")" ~ replace_list_paren ~ ")" |
+            "[" ~ search_list_bracket ~ "]" ~ replace_list_bracket ~ "]" |
+            "{" ~ search_list_brace ~ "}" ~ replace_list_brace ~ "}" |
+            "<" ~ search_list_angle ~ ">" ~ replace_list_angle ~ ">" |
+            delimiter ~ search_list ~ delimiter ~ replace_list ~ delimiter
+        ) ~ trans_flags?
+    )
 }
 
+search_list_slash = @{ (!"/" ~ ANY)* }
+search_list_exclaim = @{ (!"!" ~ ANY)* }
+search_list_hash = @{ (!"#" ~ ANY)* }
+search_list_paren = { (!")" ~ ANY)* }
+search_list_bracket = { (!"]" ~ ANY)* }
+search_list_brace = { (!"}" ~ ANY)* }
+search_list_angle = { (!">" ~ ANY)* }
 search_list = @{ (!delimiter ~ ANY)* }
+
+replace_list_slash = @{ (!"/" ~ ANY)* }
+replace_list_exclaim = @{ (!"!" ~ ANY)* }
+replace_list_hash = @{ (!"#" ~ ANY)* }
+replace_list_paren = { (!")" ~ ANY)* }
+replace_list_bracket = { (!"]" ~ ANY)* }
+replace_list_brace = { (!"}" ~ ANY)* }
+replace_list_angle = { (!">" ~ ANY)* }
 replace_list = @{ (!delimiter ~ ANY)* }
 trans_flags = @{ ASCII_ALPHA* }
 


### PR DESCRIPTION
### Motivation
- The v2/Pest parser did not robustly handle common non-slash or paired delimiters in `s///` and `tr///`/`y///` forms, causing regressions for `s!…!…!`, `s{…}{…}`, `tr{…}{…}`, etc.
- The legacy v2 grammar is shared between `perl-parser-pest` and `tree-sitter-perl-rs` and must remain synchronized when the grammar is extended.

### Description
- Extend the `substitution` rule in `crates/perl-parser-pest/src/grammar.pest` to explicitly support common paired and non-slash delimiters (paired delimiters like `()`, `{}`, `[]`, `<>` and symbols like `!`, `#`) and to parse their corresponding replacement parts separately for correct nesting and escapes.
- Add matching `replacement_*` and `sub_*` helper rules to the same grammar so replacements and patterns with nested delimiters and escapes are handled safely.
- Extend the `transliteration` rule with analogous delimiter-aware branches and helper rules (`search_list_*` / `replace_list_*`) so `tr{}`/`y[]` style operators parse reliably.
- Sync the same grammar changes into the bundle copy at `crates/tree-sitter-perl-rs/src/grammar.pest` to keep the v2 bundle in sync.
- Add two regression unit tests to `crates/perl-parser-pest/src/pure_rust_parser.rs` to cover a non-slash substitution (`s!…!…!`) and a brace-delimited transliteration (`tr{…}{…}`).

Files changed:
- `crates/perl-parser-pest/src/grammar.pest` (grammar extensions)
- `crates/tree-sitter-perl-rs/src/grammar.pest` (synced v2 copy)
- `crates/perl-parser-pest/src/pure_rust_parser.rs` (added unit tests)

### Testing
- Ran `cargo test -p perl-parser-pest substitution_with_non_slash_delimiters -- --nocapture` and the test passed.
- Ran `cargo test -p perl-parser-pest transliteration_with_brace_delimiters -- --nocapture` and the test passed.
- Ran the full crate test suite `cargo test -p perl-parser-pest` and all unit tests completed successfully (`12 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13f34ab88333bc6eb31daf73848e)