### PR TITLE
docs: add ADRs for module resolution and DAP framing

### DIFF
--- a/docs/adr/0035-deterministic-module-resolution.md
+++ b/docs/adr/0035-deterministic-module-resolution.md
@@ -1,0 +1,119 @@
+# ADR-0035: Deterministic Module Resolution with Canonicalized Names
+
+- **Status**: Accepted
+- **Date**: 2026-03-18
+- **Related**: [ADR-0008](0008-microcrate-architecture.md), [ADR-0017](0017-workspace-exclusion-strategy.md)
+
+## Context
+
+Perl module resolution appears in multiple workflows across the codebase, including module goto-definition/navigation, `documentLink/resolve` for module references, and workspace-aware module lookup inside the LSP runtime. The implementation is intentionally split across microcrates rather than being embedded in a single LSP-only helper:
+
+- `perl-module-name` normalizes canonical `::` names and legacy `'` separators.
+- `perl-module-path` converts between module names and `.pm` file paths.
+- `perl-module-resolution-path` resolves filesystem candidates under a workspace root.
+- `perl-module-resolution-uri` resolves `file://` URIs across open documents, workspace folders, and optional system `@INC` paths.
+- `perl-module-resolution` re-exports the path and URI entry points as the integration surface.
+
+The code also encodes several concrete behavioral decisions that were not previously captured together in a single ADR:
+
+1. **Legacy separator compatibility**: `Foo'Bar` is normalized to `Foo::Bar` before path conversion.
+2. **Deterministic precedence**: URI resolution prefers already-open documents, then workspace folders + include paths, then optional system `@INC`.
+3. **Workspace safety**: include-path candidates are validated against the workspace root and traversal attempts are ignored.
+4. **Pragmatic fallback**: path resolution returns `root/lib/<module>.pm` even when the file is not yet present, so higher layers can still propose or stage a target path.
+5. **Microcrate composition**: name normalization, path conversion, path lookup, and URI lookup evolve independently but are combined through a single facade crate.
+
+Without an ADR, contributors must reconstruct these rules by reading several crates and tests.
+
+## Decision Drivers
+
+- Preserve the repository's microcrate architecture.
+- Keep module-name compatibility for both canonical `::` and legacy `'` syntax.
+- Prefer editor-visible and workspace-local sources over global interpreter state.
+- Prevent include-path traversal from escaping the workspace root.
+- Provide deterministic results even when a target module file has not been created yet.
+
+## Decision
+
+We standardize Perl module resolution around the following architecture and policy.
+
+### 1. Canonicalize names first
+
+All module-resolution entry points treat `::` as the canonical package separator. Legacy `'` separators remain supported at the API edge, but they are normalized before path conversion or URI/path resolution.
+
+### 2. Keep resolution decomposed into microcrates
+
+We preserve the current microcrate split:
+
+- `perl-module-name`: separator normalization and canonical/legacy projections.
+- `perl-module-path`: string-level conversion between module names and paths.
+- `perl-module-resolution-path`: workspace-rooted path lookup.
+- `perl-module-resolution-uri`: URI-first search with timeout budgeting.
+- `perl-module-resolution`: facade crate that re-exports the public integration API.
+
+This matches the repository-wide microcrate architecture while keeping each crate testable in isolation.
+
+### 3. Resolve URIs with explicit precedence
+
+Module URI resolution follows this fixed order:
+
+1. **Open document URIs** matching the relative module path.
+2. **Workspace folders + include paths** after path-security validation.
+3. **System `@INC` paths** only when explicitly enabled.
+
+This order favors editor-visible buffers first, then workspace-local files, and only then global interpreter state.
+
+### 4. Enforce workspace-bound path safety
+
+Workspace-rooted path candidates produced from include paths must pass path validation. Traversal-style include paths are skipped rather than producing an error or escaping the workspace.
+
+### 5. Return stable fallback paths for unresolved local modules
+
+Filesystem resolution returns `root/lib/<module>.pm` as the fallback candidate when no safe include-path hit exists. This is a deliberate design choice for IDE workflows that need a deterministic target path even before a module file exists.
+
+### 6. Bound URI resolution with timeouts
+
+URI resolution remains timeout-aware and may return `TimedOut` rather than blocking indefinitely while scanning workspace folders or system include paths.
+
+## Alternatives Considered
+
+### Single monolithic resolver crate
+
+Rejected. The codebase already separates name normalization, path conversion, filesystem lookup, and URI lookup into dedicated crates. Keeping that split matches the existing architecture and makes focused tests easier to maintain.
+
+### Search system `@INC` before workspace folders
+
+Rejected. Workspace-local modules and already-open editor documents are more relevant to navigation and document-link resolution than interpreter-global installations.
+
+### Return `None` when a local module is missing on disk
+
+Rejected. Higher layers benefit from a stable fallback path for actions such as goto-definition heuristics and rename destination planning.
+
+## Consequences
+
+### Positive
+
+- **Consistent behavior across features**: navigation, document-link resolution, and workspace-facing module lookup all share the same normalization and precedence model.
+- **Backward compatibility**: legacy `'` module references remain supported without forcing downstream crates to carry multiple naming schemes internally.
+- **Security hardening**: path traversal via include paths is rejected by construction.
+- **Predictable UX**: editor buffers win over disk, and unresolved modules still map to a deterministic `lib/` destination.
+- **Testability**: each concern is covered by focused unit tests at the crate boundary.
+
+### Negative
+
+- **Extra indirection**: understanding module resolution requires following several small crates instead of one larger implementation.
+- **Fallback can over-approximate**: `root/lib/<module>.pm` may be returned for a module that does not actually exist yet.
+- **Open-document precedence is suffix-based**: URI matching is intentionally simple and depends on relative path suffix matches.
+
+### Neutral / Follow-up
+
+- Future ADRs may document more specialized module-resolution topics, such as broader static-versus-dynamic resolution boundaries or additional compatibility rules around nonstandard loader behavior.
+
+## Implementation Notes
+
+This ADR describes behavior already present in the codebase:
+
+- Canonical and legacy separator handling lives in `perl-module-name` and `perl-module-path`.
+- Workspace-safe path lookup lives in `perl-module-resolution-path`.
+- URI precedence, timeout handling, and optional `@INC` scanning live in `perl-module-resolution-uri`.
+- Integration tests in `crates/perl-module-resolution/tests/` encode the precedence and fallback behavior.
+- This ADR records the existing implementation; it does not introduce a new module-resolution mechanism.

--- a/docs/adr/0036-marker-framed-debugger-queries.md
+++ b/docs/adr/0036-marker-framed-debugger-queries.md
@@ -1,0 +1,115 @@
+# ADR-0036: Marker-Framed Debugger Queries with Poison-Safe Shared State
+
+- **Status**: Accepted
+- **Date**: 2026-03-18
+- **Related**: [ADR-0011](0011-dap-bridge-mode-architecture.md), [ADR-0019](0019-security-first-dap.md), [ADR-0028](0028-safe-eval-timeout.md), [ADR-0031](0031-async-runtime-concurrent-dispatch.md)
+
+## Context
+
+The native DAP implementation has to communicate with a Perl debugger process whose stdout is a mixed stream of:
+
+- command results,
+- debugger prompts,
+- asynchronous events,
+- warnings or exception text,
+- and user program output.
+
+The codebase already reflects two important architectural decisions for dealing with that reality:
+
+1. **Query framing with degraded fallback**: debugger commands that need structured results are usually wrapped in unique begin/end markers (`DAP_BEGIN_<id>` / `DAP_END_<id>`), but some handlers still fall back to the shared recent-output buffer when framed capture is empty or unavailable.
+2. **Poison-safe shared state**: the adapter stores session state, sequence counters, breakpoint stores, and recent output in `Arc<Mutex<...>>` values and explicitly recovers from poisoned mutexes instead of crashing the adapter.
+
+These decisions are visible in `crates/perl-dap/src/debug_adapter/mod.rs`, `output.rs`, and the DAP tests, but were not previously written down as an explicit ADR. That leaves future contributors to rediscover why the adapter is built around marker framing and recovery-oriented locking instead of assuming stdout order is naturally request-scoped or that mutex poisoning should terminate the process.
+
+## Decision Drivers
+
+- Extract command-specific results from a noisy shared stdout stream.
+- Avoid coupling higher-level parsing to exact stream timing.
+- Keep the adapter responsive when debugger output is incomplete or delayed.
+- Preserve service continuity after non-fatal internal panics that poison mutexes.
+
+## Decision
+
+We adopt the following architecture for native DAP debugger interaction.
+
+### 1. Frame debugger queries with synthetic markers
+
+Whenever the adapter needs to extract structured results from the debugger (for example, `%INC` inspection, variable evaluation, or expression results), it sends:
+
+1. a unique begin marker,
+2. one or more debugger commands,
+3. a matching end marker.
+
+The adapter then prefers the normalized output between those markers.
+
+### 2. Normalize output before parsing
+
+Captured output is normalized by removing ANSI escape sequences, trimming debugger prompt prefixes, and discarding empty lines before higher-level parsing occurs. Parsing logic therefore operates on a deterministic, debugger-noise-reduced view of stdout.
+
+### 3. Maintain a bounded recent-output buffer and fallback path
+
+The adapter keeps a bounded recent-output history and polls that buffer when waiting for a framed query to complete. Some handlers also fall back to that shared buffer when framed capture is empty or unavailable. This avoids tying parsers directly to raw stream timing while still preserving a degraded path for commands that cannot recover a framed slice.
+
+### 4. Treat shared adapter state as recoverable, not fatal
+
+Shared DAP state remains stored behind `Arc<Mutex<...>>`. Lock acquisition uses poison recovery (`into_inner()`) with warning emission instead of panicking or shutting down the adapter.
+
+This policy applies to state such as:
+
+- message sequence numbers,
+- active debug session handles,
+- attached process metadata,
+- recent output history,
+- breakpoint and exception settings,
+- and request-derived caches.
+
+### 5. Prefer graceful degradation over adapter termination
+
+If framed output cannot be captured before the timeout budget expires, the adapter returns an empty or degraded result for that query rather than crashing. In some paths that degraded result comes from parsing the shared recent-output buffer instead of an isolated framed slice. Likewise, a poisoned mutex becomes a warning and recovery path, not a fatal reliability event.
+
+## Alternatives Considered
+
+### Parse the debugger's raw stdout stream without synthetic markers
+
+Rejected. Prompt text, asynchronous output, and user program output make raw stream parsing too ambiguous for request-scoped queries such as evaluation and `%INC` inspection.
+
+### Treat poisoned mutexes as fatal adapter errors
+
+Rejected. The adapter is a long-lived editor service. Preserving availability and returning degraded results is preferable to terminating the whole debug session after one panic path.
+
+### Block indefinitely until a framed response appears
+
+Rejected. The surrounding DAP architecture already prefers bounded waits and graceful degradation over unbounded hangs.
+
+## Consequences
+
+### Positive
+
+- **Deterministic parsing where framing succeeds**: command results can often be separated from surrounding debugger chatter and program output.
+- **Lower protocol coupling**: parsers operate on normalized slices instead of full raw stdout transcripts.
+- **Operational resilience**: a panic while holding one mutex does not automatically take down all subsequent DAP requests.
+- **Concurrency compatibility**: shared state management aligns with the rest of the adapter's thread-safe request handling.
+- **Security/robustness alignment**: bounded waiting and explicit framing fit the repository's broader timeout and degradation strategy.
+
+### Negative
+
+- **Protocol intrusion**: framing depends on injecting extra `p "..."` commands into the debugger stream.
+- **Heuristic parsing remains**: marker framing improves isolation, but output parsing still depends on debugger textual conventions and some commands still fall back to the shared recent-output buffer.
+- **Poison recovery can mask bugs**: recovering a poisoned mutex keeps the adapter alive, but it can preserve partially-updated state after an internal panic.
+
+### Neutral / Follow-up
+
+- A future refactor may replace some mutex-protected state with more precise ownership or async-native synchronization.
+- A future native debugger transport could supersede textual marker framing if the backend exposes structured responses directly.
+
+## Implementation Notes
+
+This ADR documents behavior already implemented in the codebase:
+
+- `lock_or_recover` defines poison-safe locking for adapter state.
+- `send_framed_debugger_commands` and `capture_framed_debugger_output` implement unique marker framing.
+- `normalize_debugger_output_line` strips prompts and ANSI escapes before parsing.
+- `%INC` querying prefers the framed-output path.
+- Evaluation, variable inspection, and stack-trace handling prefer framed output but still contain shared-buffer fallbacks when framed capture is empty or unavailable.
+- Existing tests already verify isolated framed capture behavior and Content-Length transport framing.
+- This ADR records the existing implementation; it does not introduce a new DAP transport.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,7 +23,7 @@ This directory contains Architecture Decision Records (ADRs) for significant des
 | [ADR-006](ADR_006_LSP_CANCELLATION_INFRASTRUCTURE.md) | Draft | 2026-01-28 | LSP Cancellation | Cancellation infrastructure for responsive editor interactions |
 | [ADR-007](ADR_007_SUBSTITUTION_OPERATOR_PARSING.md) | Accepted | 2025-01-20 | Substitution Parsing | Comprehensive s/// parsing with all modifiers |
 
-### Architecture Series (0008–0037)
+### Architecture Series (0008–0036)
 
 | ADR | Status | Date | Title | Description |
 |-----|--------|------|-------|-------------|
@@ -54,49 +54,8 @@ This directory contains Architecture Decision Records (ADRs) for significant des
 | [ADR-0032](0032-skill-scoping-and-hook-enforcement.md) | Accepted | 2026-03-16 | Skill Scoping and Hook Enforcement | Frontmatter-based skill access control plus hook-enforced swarm coordination |
 | [ADR-0033](0033-worktree-first-disposable-workers.md) | Accepted | 2026-03-16 | Worktree-First Disposable Worker Execution | Small persistent coordinators, fresh workers per context shift, and worktree isolation for PR-shaped changes |
 | [ADR-0034](0034-custom-lsp-runtime.md) | Accepted | 2026-03-18 | Custom LSP Runtime over Framework Adoption | Bespoke protocol/transport/runtime stack kept to support governance, transport reuse, and explicit dispatch control |
-| [ADR-0035](0035-raw-pointer-parent-map.md) | Accepted | 2026-03-18 | Raw-Pointer Parent Map for AST Upward Traversal | Document-scoped sidecar parent cache using raw node pointers for fast declaration and scope walking |
-| [ADR-0036](0036-generated-feature-catalog-contracts.md) | Accepted | 2026-03-18 | Generated Feature Catalog Contracts | Build-time compilation of `features.toml` into generated Rust contracts for runtime, CI, and reporting |
-| [ADR-0037](0037-guaranteed-valid-uri-fallbacks.md) | Accepted | 2026-03-18 | Guaranteed-Valid Synthetic URI Fallbacks | Malformed boundary URIs degrade to stable synthetic URIs instead of failing requests or panicking |
-
-
-## Topic Guide
-
-Use this section when you know the area of the system but not the ADR number yet. It highlights ADRs that were previously easy to miss because they were only listed in the chronological index.
-
-### Parser and language semantics
-
-- [ADR-0001](0001-substitution-operator-parsing-architecture.md) / [ADR-007](ADR_007_SUBSTITUTION_OPERATOR_PARSING.md) — substitution operator parsing strategy and legacy record alignment.
-- [ADR-0014](0014-mode-aware-lexer.md) — slash disambiguation and lexer mode design.
-- [ADR-0023](0023-include-macro-architecture.md) — `include!`-based parser composition.
-- [ADR-0024](0024-fifo-heredoc-queue.md) and [ADR-005](ADR_005_HEREDOC_MANUAL_PARSING.md) — heredoc declaration parsing and FIFO content capture.
-
-### LSP runtime, indexing, and editor responsiveness
-
-- [ADR-0009](0009-dual-indexing-strategy.md) — cross-file symbol lookup strategy.
-- [ADR-0010](0010-incremental-parsing-architecture.md) — low-latency edit handling.
-- [ADR-0020](0020-rope-document-management.md) and [ADR-0025](0025-dual-document-representation.md) — text storage and position conversion architecture.
-- [ADR-0021](0021-lsp-capability-contract.md) — advertised capability policy.
-- [ADR-0022](0022-scope-analyzer-hash-context.md) — semantic reference analysis for barewords and hash keys.
-- [ADR-0026](0026-lifecycle-index-routing.md) — index lifecycle states and degraded-mode request routing.
-- [ADR-0035](0035-raw-pointer-parent-map.md) — document-scoped sidecar parent caches for fast upward AST traversal.
-- [ADR-0037](0037-guaranteed-valid-uri-fallbacks.md) — resilience-first synthetic URI policy for malformed protocol-boundary values.
-- [ADR-0030](0030-receipt-gate-system.md) — machine-readable CI gate verification.
-- [ADR-0031](0031-async-runtime-concurrent-dispatch.md) and [ADR-0034](0034-custom-lsp-runtime.md) — bespoke runtime decisions and concurrent dispatch evolution.
-- [ADR-006](ADR_006_LSP_CANCELLATION_INFRASTRUCTURE.md) — cancellation guarantees and parser checkpoints.
-
-### DAP and security
-
-- [ADR-0011](0011-dap-bridge-mode-architecture.md) and [ADR-0027](0027-dap-bridge-native.md) — debugger bridge architecture and native migration plan.
-- [ADR-0015](0015-supply-chain-security.md) — SBOM and provenance requirements for releases.
-- [ADR-0017](0017-workspace-exclusion-strategy.md) — workspace shaping for portability and build isolation.
-- [ADR-0019](0019-security-first-dap.md) and [ADR-0028](0028-safe-eval-timeout.md) — DAP threat model and evaluation timeout policy.
-
-### Documentation, automation, and swarm workflow
-
-- [ADR-0002](0002-api-documentation-infrastructure.md), [ADR-002](ADR_002_API_DOCUMENTATION_INFRASTRUCTURE.md), and [ADR-003](ADR_003_MISSING_DOCUMENTATION_INFRASTRUCTURE.md) — documentation quality gates and validation infrastructure.
-- [ADR-004](ADR_004_EXECUTE_COMMAND_CODE_ACTIONS.md) — executeCommand and code action architecture.
-- [ADR-0036](0036-generated-feature-catalog-contracts.md) — build-time generation of feature governance contracts from `features.toml`.
-- [ADR-001](ADR_001_AGENT_ARCHITECTURE.md), [ADR-0032](0032-skill-scoping-and-hook-enforcement.md), and [ADR-0033](0033-worktree-first-disposable-workers.md) — historical and current swarm orchestration decisions.
+| [ADR-0035](0035-deterministic-module-resolution.md) | Accepted | 2026-03-18 | Deterministic Module Resolution | Canonicalized names, explicit precedence, workspace-safe paths, and lib/ fallback for module lookup |
+| [ADR-0036](0036-marker-framed-debugger-queries.md) | Accepted | 2026-03-18 | Marker-Framed Debugger Queries | Unique debugger output markers plus poison-safe shared state for resilient native DAP queries |
 
 ## About ADRs
 


### PR DESCRIPTION
## Summary
- add ADR-0035 for deterministic module resolution across the module-resolution microcrates
- add ADR-0036 for marker-framed debugger queries plus poison-safe shared DAP state
- update `docs/adr/README.md` to index both ADRs on current `master`

## Review fixes
- narrow the module-resolution ADR to the actual current consumers: navigation, `documentLink/resolve`, and shared LSP module lookup
- document the native DAP shared-buffer fallbacks instead of implying every structured query is fully isolated by framing
- rebuild the branch on current `master` so the ADR numbering and README index match the live series

## Validation
- `git diff --check`
- `cargo test -p perl-module-resolution --locked --test module_resolution_edge_cases uri_open_document_takes_precedence_over_filesystem`
- `cargo test -p perl-dap --lib --locked -- test_capture_framed_debugger_output_isolated_by_marker test_stack_trace_uses_recent_output_when_available test_parse_evaluate_result_from_recent_output`