### PR TITLE
docs(adr): document custom LSP runtime decision (ADR-0034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ single responsibility. This keeps compile times fast and boundaries clear.
 For the full tier system, architecture decision records, and design rationale, see:
 
 - [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md)
-- [Architecture Decision Records](docs/adr/README.md) (microcrate architecture, dual indexing, incremental parsing, supply chain security)
+- [Architecture Decision Records](docs/adr/README.md) (microcrate architecture, dual indexing, incremental parsing, custom LSP runtime, supply chain security)
 - [CLAUDE.md](CLAUDE.md) for the complete developer command reference
 
 ## Published Crates

--- a/docs/STRATEGIC_DOCUMENTATION.md
+++ b/docs/STRATEGIC_DOCUMENTATION.md
@@ -32,6 +32,7 @@ Located in [`docs/adr/`](adr/), these documents capture significant architectura
 | [0010](adr/0010-incremental-parsing-architecture.md) | Incremental Parsing | <1ms update target |
 | [0011](adr/0011-dap-bridge-mode-architecture.md) | DAP Bridge Mode | Debug Adapter Protocol bridge |
 | [0012](adr/0012-error-handling-strategy.md) | Error Handling Strategy | No-panic reliability |
+| [0034](adr/0034-custom-lsp-runtime-and-protocol-stack.md) | Custom LSP Runtime | Project-owned LSP transport, dispatch, and cancellation stack |
 
 See [docs/adr/README.md](adr/README.md) for the complete ADR index.
 

--- a/docs/adr/0034-custom-lsp-runtime-and-protocol-stack.md
+++ b/docs/adr/0034-custom-lsp-runtime-and-protocol-stack.md
@@ -1,0 +1,121 @@
+# ADR-0034: Custom LSP Runtime and Protocol Stack
+
+**Status**: Accepted
+**Date**: 2026-03-18
+**Decision Makers**: Perl LSP Architecture Team
+**Related**: [ADR-0012](0012-error-handling-strategy.md), [ADR-0016](0016-feature-governance.md), [ADR-0021](0021-lsp-capability-contract.md), [ADR-0031](0031-async-runtime-concurrent-dispatch.md), [Custom LSP Runtime](../project/CUSTOM_LSP_RUNTIME.md)
+
+## Context
+
+The codebase implements its own LSP runtime instead of depending on `tower-lsp` or another
+framework-managed server stack. That decision is visible in multiple places:
+
+- `crates/perl-lsp/src/runtime/serving.rs` owns the ingress loop and request classification.
+- `crates/perl-lsp/src/runtime/routing.rs` centralizes index-aware fallback policy.
+- `perl-lsp-protocol`, `perl-lsp-transport`, `perl-content-length-framing`, and
+  `perl-lsp-cancellation` decompose protocol, framing, and cancellation into focused crates.
+- `.github/dependabot.yml` still tracks `tower-lsp` updates as a defensive watch item, but the
+  workspace does not use `tower-lsp` as a production dependency.
+
+This runtime decision already shaped multiple accepted ADRs:
+
+- ADR-0012 requires explicit error propagation and graceful recovery rather than framework-driven
+  panics.
+- ADR-0016 and ADR-0021 require profile-aware capability advertisement and enforcement.
+- ADR-0031 adds bounded concurrent dispatch and inline cancellation on top of the custom runtime.
+
+What was missing was a single ADR that states the higher-level architectural choice: the project
+owns the LSP transport and dispatch stack itself, and other runtime decisions build on that base.
+
+## Alternatives Considered
+
+1. **Adopt `tower-lsp` as the primary runtime**.
+   Rejected because the project needs direct control over capability advertisement, cancellation,
+   malformed-frame handling, and cross-crate transport reuse.
+
+2. **Use `lsp-server` or another thin transport crate for framing/dispatch while keeping custom
+   feature governance**.
+   Rejected because it would still split ownership of core runtime behavior and make profile-driven
+   dispatch policy harder to reason about.
+
+3. **Keep the current architecture but leave the rationale scattered across implementation docs**.
+   Rejected because contributors can see the custom runtime in code, but not the explicit decision
+   drivers, boundaries, and trade-offs in the ADR index.
+
+## Decision
+
+The project will continue to own a **custom LSP runtime and protocol stack**, implemented as
+focused workspace crates and `perl-lsp` runtime modules, rather than adopting an external LSP
+server framework as the primary execution model.
+
+### Runtime boundaries
+
+The custom runtime includes:
+
+- **Protocol types and method constants** in `perl-lsp-protocol`
+- **Content-Length framing and JSON-RPC transport** in `perl-lsp-transport` and
+  `perl-content-length-framing`
+- **Cancellation registry and cleanup contracts** in `perl-lsp-cancellation`
+- **Input validation and path hardening** in `perl-lsp-input-validation`
+- **Feature-profile-to-capability mapping** in the `perl-lsp-feature-*` crates
+- **Request ingress, classification, routing, and egress integration** in `crates/perl-lsp/src/runtime/`
+
+### Decision drivers
+
+1. **Capability governance is a first-class architectural concern**.
+   The server must advertise different capability sets based on build flags and runtime profile.
+   That requirement is directly tied to ADR-0016 and ADR-0021.
+
+2. **Cancellation must be inline and low-overhead**.
+   Control requests such as `$/cancelRequest` are processed according to explicit runtime policy,
+   now reinforced by ADR-0031's worker-queue design.
+
+3. **Transport behavior must be shared across products**.
+   `perl-content-length-framing` is reusable between LSP and DAP, which would be harder if framing
+   lived inside an external LSP framework.
+
+4. **Malformed input handling must match the project's no-panic policy**.
+   The server prefers explicit recovery, bounded failure, and predictable fallbacks over opaque
+   framework behavior.
+
+5. **The project values inspectable control flow**.
+   A direct match-based dispatch path and explicit routing helpers make policy visible in code and
+   easier to test at protocol boundaries.
+
+## Consequences
+
+### Positive
+
+- **Policy is owned locally**: transport, dispatch, cancellation, and capability rules evolve with
+  the rest of the workspace instead of around a framework abstraction.
+- **Cross-protocol reuse**: Content-Length framing stays shareable between LSP and DAP.
+- **Strong alignment with existing ADRs**: error handling, feature governance, capability contract,
+  and concurrent dispatch all compose cleanly on top of the custom runtime.
+- **Better contributor orientation**: the ADR index now explicitly explains why the codebase has a
+  runtime subsystem instead of a framework adapter layer.
+
+### Negative / Trade-offs
+
+- **Higher maintenance cost**: the team owns message framing, dispatch, runtime evolution, and
+  integration testing.
+- **Framework features are not free**: new middleware-style behavior must be designed in-house.
+- **Architectural drift risk**: implementation docs can become stale if the ADR is not updated when
+  runtime architecture changes.
+
+## Guardrails
+
+To keep this decision sustainable:
+
+- New runtime behavior should be implemented in the existing runtime crates/modules rather than by
+  introducing an overlapping framework.
+- Any proposal to add `tower-lsp` or similar as a production dependency should include a superseding
+  ADR that explains how feature governance, cancellation, and shared framing would be preserved.
+- Runtime documentation should be kept aligned with ADR-0031 and this ADR whenever request
+  scheduling or transport ownership changes.
+
+## References
+
+- `crates/perl-lsp/src/runtime/serving.rs`
+- `crates/perl-lsp/src/runtime/routing.rs`
+- `docs/project/CUSTOM_LSP_RUNTIME.md`
+- `.github/dependabot.yml`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ This directory contains Architecture Decision Records (ADRs) for significant des
 | [ADR-0031](0031-async-runtime-concurrent-dispatch.md) | Accepted | 2026-03-16 | Async Runtime with Concurrent Dispatch | Two-lane scheduler (exclusive + 4-worker read pool) for concurrent LSP request handling |
 | [ADR-0032](0032-skill-scoping-and-hook-enforcement.md) | Accepted | 2026-03-16 | Skill Scoping and Hook Enforcement | Frontmatter-based skill access control plus hook-enforced swarm coordination |
 | [ADR-0033](0033-worktree-first-disposable-workers.md) | Accepted | 2026-03-16 | Worktree-First Disposable Worker Execution | Small persistent coordinators, fresh workers per context shift, and worktree isolation for PR-shaped changes |
+| [ADR-0034](0034-custom-lsp-runtime-and-protocol-stack.md) | Accepted | 2026-03-18 | Custom LSP Runtime and Protocol Stack | Project-owned transport, dispatch, cancellation, and capability stack instead of tower-lsp |
 
 ## About ADRs
 


### PR DESCRIPTION
### Motivation

- Capture the apparent, repository-wide architectural decision to own a custom LSP runtime and protocol stack (rather than adopt `tower-lsp`) so the rationale, drivers, and trade-offs are discoverable in the ADR index.

### Description

- Add `docs/adr/0034-custom-lsp-runtime-and-protocol-stack.md` which records context, alternatives, decision drivers, consequences, and guardrails for the project-owned runtime.
- Register ADR-0034 in `docs/adr/README.md` and surface the ADR in `docs/STRATEGIC_DOCUMENTATION.md`.
- Update the root `README.md` ADR summary to mention the custom LSP runtime and commit the three documentation changes.

### Testing

- Ran formatter checks with `cargo fmt --all` and `cargo fmt --all --check`, both completed successfully.
- Verified working tree with `git status --short` to confirm the intended doc changes were staged and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13b5dbe88333811511ac47d46a50)