### PR TITLE
Factor declaration attribute parsing and capture method attributes

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -1,4 +1,52 @@
 impl<'a> Parser<'a> {
+    /// Parse declaration attributes like `:lvalue` or `:prototype($)`.
+    fn parse_declaration_attributes(&mut self) -> ParseResult<Vec<String>> {
+        let mut attributes = Vec::new();
+
+        while self.peek_kind() == Some(TokenKind::Colon) {
+            self.tokens.next()?; // consume colon
+
+            // Parse one or more space-separated attributes after the colon.
+            loop {
+                // Attributes can be identifiers or certain keywords.
+                let attr_token = match self.peek_kind() {
+                    Some(TokenKind::Identifier | TokenKind::Method) => self.tokens.next()?,
+                    _ => break,
+                };
+
+                let mut attr_name = attr_token.text.to_string();
+
+                // Check if attribute has a value in parentheses (like :prototype($)).
+                if self.peek_kind() == Some(TokenKind::LeftParen) {
+                    self.consume_token()?; // consume (
+                    attr_name.push('(');
+
+                    // Collect tokens until matching ).
+                    let mut paren_depth = 1;
+                    while paren_depth > 0 && !self.tokens.is_eof() {
+                        let token = self.tokens.next()?;
+                        attr_name.push_str(&token.text);
+
+                        match token.kind {
+                            TokenKind::LeftParen => paren_depth += 1,
+                            TokenKind::RightParen => paren_depth -= 1,
+                            _ => {}
+                        }
+                    }
+                }
+
+                attributes.push(attr_name);
+
+                match self.peek_kind() {
+                    Some(TokenKind::Identifier | TokenKind::Method) => continue,
+                    _ => break,
+                }
+            }
+        }
+
+        Ok(attributes)
+    }
+
     /// Parse subroutine definition
     fn parse_subroutine(&mut self) -> ParseResult<Node> {
         let start = self.current_position();
@@ -28,59 +76,7 @@ impl<'a> Parser<'a> {
         };
 
         // Parse optional attributes first (they come before signature in modern Perl)
-        let mut attributes = Vec::new();
-        while self.peek_kind() == Some(TokenKind::Colon) {
-            self.tokens.next()?; // consume colon
-
-            // Parse one or more space-separated attributes after the colon
-            loop {
-                // Attributes can be identifiers or certain keywords
-                let attr_token = match self.peek_kind() {
-                    Some(TokenKind::Identifier | TokenKind::Method) => self.tokens.next()?,
-                    _ => {
-                        // If it's not an attribute name, we're done with this attribute list
-                        break;
-                    }
-                };
-
-                let mut attr_name = attr_token.text.to_string();
-
-                // Check if attribute has a value in parentheses (like :prototype($))
-                if self.peek_kind() == Some(TokenKind::LeftParen) {
-                    self.consume_token()?; // consume (
-                    attr_name.push('(');
-
-                    // Collect tokens until matching )
-                    let mut paren_depth = 1;
-                    while paren_depth > 0 && !self.tokens.is_eof() {
-                        let token = self.tokens.next()?;
-                        attr_name.push_str(&token.text);
-
-                        match token.kind {
-                            TokenKind::LeftParen => paren_depth += 1,
-                            TokenKind::RightParen => {
-                                paren_depth -= 1;
-                                if paren_depth == 0 {
-                                    attr_name.push(')');
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-
-                attributes.push(attr_name);
-
-                // Check if there's another attribute (not preceded by colon)
-                match self.peek_kind() {
-                    Some(TokenKind::Identifier | TokenKind::Method) => {
-                        // Continue parsing more attributes
-                        continue;
-                    }
-                    _ => break,
-                }
-            }
-        }
+        let attributes = self.parse_declaration_attributes()?;
 
         // Parse optional prototype or signature after attributes
         let (prototype, signature) = if self.peek_kind() == Some(TokenKind::LeftParen) {
@@ -155,6 +151,9 @@ impl<'a> Parser<'a> {
         let name_token = self.expect(TokenKind::Identifier)?;
         let name = name_token.text.to_string();
 
+        // Parse optional attributes before signature, mirroring `sub`.
+        let attributes = self.parse_declaration_attributes()?;
+
         // Parse optional signature
         let signature = if self.peek_kind() == Some(TokenKind::LeftParen) {
             let params = self.parse_signature()?;
@@ -170,7 +169,7 @@ impl<'a> Parser<'a> {
 
         let end = self.previous_position();
         Ok(Node::new(
-            NodeKind::Method { name, signature, attributes: Vec::new(), body: Box::new(body) },
+            NodeKind::Method { name, signature, attributes, body: Box::new(body) },
             SourceLocation { start, end },
         ))
     }

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -32,6 +32,46 @@ fn test_function_definition() {
 }
 
 #[test]
+fn test_method_attributes_parse() {
+    let mut parser = Parser::new("method size :lvalue :prototype($self) ($self) { $self; }");
+    let ast = must(parser.parse());
+
+    match &ast.kind {
+        NodeKind::Program { statements } => match &statements
+            .first()
+            .expect("method statement")
+            .kind
+        {
+            NodeKind::Method { signature, attributes, .. } => {
+                assert!(signature.is_some(), "Expected method signature");
+                assert_eq!(attributes, &vec!["lvalue".to_string(), "prototype($self)".to_string()]);
+            }
+            other => panic!("Expected method declaration, got: {:?}", other),
+        },
+        other => panic!("Expected program node, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_method_attributes_without_signature_parse() {
+    let mut parser = Parser::new("method reset :lvalue { return; }");
+    let ast = must(parser.parse());
+
+    match &ast.kind {
+        NodeKind::Program { statements } => {
+            match &statements.first().expect("method statement").kind {
+                NodeKind::Method { signature, attributes, .. } => {
+                    assert!(signature.is_none(), "Did not expect method signature");
+                    assert_eq!(attributes, &vec!["lvalue".to_string()]);
+                }
+                other => panic!("Expected method declaration, got: {:?}", other),
+            }
+        }
+        other => panic!("Expected program node, got: {:?}", other),
+    }
+}
+
+#[test]
 fn test_list_declarations() {
     // Test simple list declaration
     let mut parser = Parser::new("my ($x, $y);");


### PR DESCRIPTION
### Motivation
- Reduce duplicated attribute-parsing logic and ensure declaration attributes (e.g. `:lvalue`, `:prototype(...)`) are parsed consistently for `sub` and `method` declarations.
- Preserve parenthesized attribute values with balanced delimiters instead of producing malformed attribute text.

### Description
- Introduced `parse_declaration_attributes` in `crates/perl-parser-core/src/engine/parser/declarations.rs` to centralize parsing of colon-prefixed declaration attributes and collect them as `Vec<String>`.
- Updated `parse_subroutine` to reuse the new helper so `sub` attributes are handled by the shared routine.
- Updated `parse_method` to consume and store attributes before an optional signature, and to populate the `Method` AST node's `attributes` field instead of discarding them.
- Fixed parenthesized attribute parsing so attribute values keep balanced parentheses (no extra `)` appended when closing the attribute value).
- Added two parser unit tests in `crates/perl-parser-core/src/engine/parser/tests.rs`: `test_method_attributes_parse` and `test_method_attributes_without_signature_parse` to verify attributes are captured both with and without signatures.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran the focused tests with `cargo test -p perl-parser-core --lib method_attributes -- --nocapture` and observed the new tests pass (`2 passed`).
- Ran the full crate test suite with `cargo test -p perl-parser-core --lib` and observed all tests passed (`402 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13e9e3548333ae2c7700ca2c0acb)