### PR TITLE
Improve transliteration delimiter parsing

### DIFF
--- a/crates/perl-parser/tests/integration_new_features.rs
+++ b/crates/perl-parser/tests/integration_new_features.rs
@@ -57,6 +57,7 @@ fn test_transliteration_integration() {
         ("tr/a-z/A-Z/", "Basic transliteration"),
         ("y/0-9/a-j/", "y/// form"),
         ("tr{a-z}{A-Z}d", "Braces with delete"),
+        ("tr[a-z]{A-Z}dr", "Mixed paired delimiters with modifiers"),
         ("$str =~ tr/a-z/A-Z/", "Transliteration with =~"),
     ];
 

--- a/crates/perl-quote/src/lib.rs
+++ b/crates/perl-quote/src/lib.rs
@@ -328,18 +328,11 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
     // Parse first body (search pattern)
     let (search, rest1) = extract_delimited_content(content, delimiter, closing);
 
-    // For paired delimiters, skip whitespace and expect new delimiter
+    // For paired delimiters, skip whitespace and allow any paired opening delimiter for the
+    // replacement list. Perl accepts forms like tr[abc]{xyz} in addition to tr[abc][xyz].
     let rest2_owned;
     let rest2 = if is_paired {
-        let trimmed = rest1.trim_start();
-        // For paired delimiters like tr{search}{replace}, we expect another opening delimiter
-        if trimmed.starts_with(delimiter) {
-            // Keep the delimiter - don't strip it since extract_delimited_content expects it
-            trimmed
-        } else {
-            // If no second delimiter found, the replacement is empty
-            ""
-        }
+        rest1.trim_start()
     } else {
         rest2_owned = format!("{}{}", delimiter, rest1);
         &rest2_owned
@@ -375,7 +368,12 @@ pub fn extract_transliteration_parts(text: &str) -> (String, String, String) {
 
         (body, &rest1[end_pos..])
     } else if is_paired {
-        extract_delimited_content(rest2, delimiter, closing)
+        if let Some(repl_delimiter) = starts_with_paired_delimiter(rest2) {
+            let repl_closing = get_closing_delimiter(repl_delimiter);
+            extract_delimited_content(rest2, repl_delimiter, repl_closing)
+        } else {
+            (String::new(), rest2)
+        }
     } else {
         (String::new(), rest1)
     };

--- a/crates/perl-quote/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-quote/tests/comprehensive_unit_tests.rs
@@ -535,6 +535,20 @@ fn tr_braces_delimiter() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn tr_mixed_paired_delimiters() -> Result<(), Box<dyn std::error::Error>> {
+    let (search, repl, mods) = extract_transliteration_parts("tr[a-z]{A-Z}dr");
+    assert_eq!(search, "a-z");
+    assert_eq!(repl, "A-Z");
+    assert_eq!(mods, "dr");
+
+    let (search, repl, mods) = extract_transliteration_parts("y(foo)<bar>r");
+    assert_eq!(search, "foo");
+    assert_eq!(repl, "bar");
+    assert_eq!(mods, "r");
+    Ok(())
+}
+
+#[test]
 fn tr_empty_search_and_replacement() -> Result<(), Box<dyn std::error::Error>> {
     let (search, repl, mods) = extract_transliteration_parts("tr///");
     assert_eq!(search, "");


### PR DESCRIPTION
### Motivation
- Accept mixed paired delimiters for transliteration so forms like `tr[a-z]{A-Z}dr` and `y(foo)<bar>r` are parsed as Perl allows.

### Description
- Update `extract_transliteration_parts` in `crates/perl-quote/src/lib.rs` to allow any paired opening delimiter for the replacement list and to select the correct closing delimiter when present.
- Add handling to detect a different paired replacement delimiter via `starts_with_paired_delimiter` and parse the replacement with the matching closing delimiter.
- Add a focused unit test `tr_mixed_paired_delimiters` in `crates/perl-quote/tests/comprehensive_unit_tests.rs` that verifies mixed paired `tr///`/`y///` cases.
- Extend integration coverage by adding a mixed paired transliteration case to `crates/perl-parser/tests/integration_new_features.rs`.

### Testing
- Ran `cargo test -p perl-quote tr_mixed_paired_delimiters -- --nocapture` and the unit test passed.
- Ran `cargo test -p perl-parser --test integration_new_features test_transliteration_integration -- --nocapture` and the integration test passed.
- Ran `cargo test -p perl-parser --lib` and the parser test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13e9e3548333ae2c7700ca2c0acb)