### PR TITLE
Fix stale lexer prototype mode after `sub` heads

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1848,7 +1848,11 @@ impl<'a> PerlLexer<'a> {
                         self.mode = LexerMode::ExpectTerm;
                     }
                     "sub" => {
+                        // Enter a prototype-candidate state for the declaration head.
+                        // If we later see `(` before `{`/`;`, we stay in prototype mode, but
+                        // body delimiters without a prototype should cancel that state.
                         self.in_prototype = true;
+                        self.prototype_depth = 0;
                     }
                     // Quote operators expect a delimiter next (must be immediately adjacent)
                     op if quote_handler::is_quote_operator(op) => {
@@ -2297,6 +2301,9 @@ impl<'a> PerlLexer<'a> {
             }
             ';' => {
                 self.advance();
+                if self.in_prototype && self.prototype_depth == 0 {
+                    self.in_prototype = false;
+                }
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::Semicolon,
@@ -2337,6 +2344,9 @@ impl<'a> PerlLexer<'a> {
             }
             '{' => {
                 self.advance();
+                if self.in_prototype && self.prototype_depth == 0 {
+                    self.in_prototype = false;
+                }
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::LeftBrace,
@@ -3258,6 +3268,36 @@ mod tests {
         lexer.next_token(); // 10
         let token = lexer.next_token().ok_or("Expected modulo operator token")?;
         assert!(matches!(token.token_type, TokenType::Operator(ref op) if op.as_ref() == "%"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_sub_body_clears_prototype_mode() -> TestResult {
+        let mut lexer = PerlLexer::new("sub demo { print($^W); }");
+        let tokens = lexer.collect_tokens();
+
+        assert!(tokens.iter().any(|token| {
+            matches!(
+                token.token_type,
+                TokenType::Identifier(ref id) if id.as_ref() == "$^W"
+            )
+        }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sub_forward_declaration_clears_prototype_mode() -> TestResult {
+        let mut lexer = PerlLexer::new("sub demo; my $^W;");
+        let tokens = lexer.collect_tokens();
+
+        assert!(tokens.iter().any(|token| {
+            matches!(
+                token.token_type,
+                TokenType::Identifier(ref id) if id.as_ref() == "$^W"
+            )
+        }));
+
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the lexer from remaining in a prototype-candidate state after a `sub` declaration immediately transitions into a body or a forward declaration so subsequent tokens (e.g. `$^W`) are not mis-lexed as prototype chars.

### Description
- When encountering the `sub` keyword the lexer now initializes a prototype candidate state and sets `prototype_depth = 0` to track whether a real prototype was observed (`(`).
- Clear the `in_prototype` flag when a declaration head is followed directly by a body (`{`) or a forward declaration (`;`) and `prototype_depth == 0` so the candidate state does not persist.
- Added regression tests `test_sub_body_clears_prototype_mode` and `test_sub_forward_declaration_clears_prototype_mode` that assert `$^W` tokenizes correctly after `sub` heads.

### Testing
- Ran `cargo test -p perl-lexer --lib test_sub_ -- --nocapture` and the two new tests passed.
- Ran the full crate test `cargo test -p perl-lexer --lib` and the lexer test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13ee83d483339bf1c16a577e9a9e)