### PR TITLE
Fix perl-lexer peek/reset state restoration

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -673,17 +673,31 @@ impl<'a> PerlLexer<'a> {
     pub fn peek_token(&mut self) -> Option<Token> {
         let saved_pos = self.position;
         let saved_mode = self.mode;
+        let saved_delimiter_stack = self.delimiter_stack.clone();
         let saved_prototype = self.in_prototype;
         let saved_depth = self.prototype_depth;
+        let saved_current_pos = self.current_pos;
         let saved_after_newline = self.after_newline;
+        let saved_pending_heredocs = self.pending_heredocs.clone();
+        let saved_line_start_offset = self.line_start_offset;
+        let saved_current_quote_op = self.current_quote_op.clone();
+        let saved_eof_emitted = self.eof_emitted;
+        let saved_start_time = self.start_time;
 
         let token = self.next_token();
 
         self.position = saved_pos;
         self.mode = saved_mode;
+        self.delimiter_stack = saved_delimiter_stack;
         self.in_prototype = saved_prototype;
         self.prototype_depth = saved_depth;
+        self.current_pos = saved_current_pos;
         self.after_newline = saved_after_newline;
+        self.pending_heredocs = saved_pending_heredocs;
+        self.line_start_offset = saved_line_start_offset;
+        self.current_quote_op = saved_current_quote_op;
+        self.eof_emitted = saved_eof_emitted;
+        self.start_time = saved_start_time;
 
         token
     }
@@ -708,9 +722,13 @@ impl<'a> PerlLexer<'a> {
         self.delimiter_stack.clear();
         self.in_prototype = false;
         self.prototype_depth = 0;
+        self.current_pos = Position::start();
         self.after_newline = true;
         self.pending_heredocs.clear();
         self.line_start_offset = 0;
+        self.current_quote_op = None;
+        self.eof_emitted = false;
+        self.start_time = std::time::Instant::now();
     }
 
     /// Switch lexer to format body parsing mode

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -397,6 +397,19 @@ fn peek_token_multiple_times_same_result() -> R {
 }
 
 #[test]
+fn peek_token_preserves_eof_state() -> R {
+    let mut lexer = PerlLexer::new("42");
+    let _number = lexer.next_token().ok_or("missing number token")?;
+    let peeked_eof = lexer.peek_token().ok_or("missing peeked EOF token")?;
+    assert_eq!(peeked_eof.token_type, TokenType::EOF);
+
+    let actual_eof = lexer.next_token().ok_or("missing actual EOF token")?;
+    assert_eq!(actual_eof.token_type, TokenType::EOF);
+    assert!(lexer.next_token().is_none());
+    Ok(())
+}
+
+#[test]
 fn reset_replays_from_beginning() -> R {
     let mut lexer = PerlLexer::new("my $x = 1;");
     let first_pass = lexer.next_token().ok_or("first token")?;
@@ -407,6 +420,22 @@ fn reset_replays_from_beginning() -> R {
     let after_reset = lexer.next_token().ok_or("after reset")?;
     assert_eq!(first_pass.token_type, after_reset.token_type);
     assert_eq!(first_pass.start, after_reset.start);
+    Ok(())
+}
+
+#[test]
+fn reset_after_eof_replays_eof_token() -> R {
+    let mut lexer = PerlLexer::new("1");
+    let _number = lexer.next_token().ok_or("missing number token")?;
+    let eof = lexer.next_token().ok_or("missing EOF token")?;
+    assert_eq!(eof.token_type, TokenType::EOF);
+
+    lexer.reset();
+
+    let replayed_number = lexer.next_token().ok_or("missing replayed number token")?;
+    assert!(matches!(&replayed_number.token_type, TokenType::Number(text) if &**text == "1"));
+    let replayed_eof = lexer.next_token().ok_or("missing replayed EOF token")?;
+    assert_eq!(replayed_eof.token_type, TokenType::EOF);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- `peek_token` only restored a subset of lexer fields which could leave transient state (EOF flag, quote/delimiter stacks, heredoc bookkeeping, timers, etc.) mutated after a peek and cause incorrect behavior when continuing or resetting the lexer. 
- `reset` did not clear some transient bookkeeping (quote operator state, EOF emission flag, start timer), making reuse after EOF unreliable.

### Description
- Restore the full lexer state in `PerlLexer::peek_token` by saving and restoring `delimiter_stack`, `current_pos`, `pending_heredocs`, `line_start_offset`, `current_quote_op`, `eof_emitted`, and `start_time` in addition to the existing fields. 
- Expand `PerlLexer::reset` to reset transient bookkeeping by setting `current_pos = Position::start()`, clearing `current_quote_op`, clearing `eof_emitted`, and resetting `start_time`. 
- Add two regression tests: `peek_token_preserves_eof_state` to ensure peeking an EOF does not consume it, and `reset_after_eof_replays_eof_token` to ensure `reset` replays tokens (including EOF) correctly. 

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perl-lexer peek_token_preserves_eof_state` and the test passed. 
- Ran `cargo test -p perl-lexer reset_after_eof_replays_eof_token` and the test passed. 
- Ran `cargo clippy -p perl-lexer --tests` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13ee83d483339bf1c16a577e9a9e)