### PR TITLE
Allow namespace-qualified bare function calls in v2 (Pest) parser

### DIFF
--- a/crates/perl-parser-pest/src/grammar.pest
+++ b/crates/perl-parser-pest/src/grammar.pest
@@ -442,7 +442,7 @@ primary_expression = {
 
 // User-defined function calls (with optional arguments)
 user_function_call = {
-    identifier ~ list_op_args
+    qualified_name_or_identifier ~ list_op_args
 }
 
 class_method_call = { identifier ~ ("::" ~ identifier)+ ~ "->" ~ method_name ~ function_args? }

--- a/crates/perl-parser-pest/src/pure_rust_parser.rs
+++ b/crates/perl-parser-pest/src/pure_rust_parser.rs
@@ -1159,7 +1159,9 @@ impl PureRustPerlParser {
 
                 for p in inner {
                     match p.as_rule() {
-                        Rule::identifier => {
+                        Rule::identifier
+                        | Rule::qualified_name
+                        | Rule::qualified_name_or_identifier => {
                             name = Arc::from(p.as_str());
                         }
                         Rule::list_op_args => {
@@ -2782,5 +2784,44 @@ mod tests {
         let sexp = parser.to_sexp(&ast);
         println!("Hash assignment AST: {:?}", ast);
         println!("S-expression: {}", sexp);
+    }
+
+    #[test]
+    fn test_qualified_function_call_without_parentheses() {
+        let mut parser = PureRustPerlParser::new();
+        let source = "My::Package::run $value, 42;";
+        let ast = must(parser.parse(source));
+
+        let statements = match ast {
+            AstNode::Program(statements) => statements,
+            other => {
+                assert!(matches!(other, AstNode::Program(_)), "expected program root");
+                unreachable!();
+            }
+        };
+        let inner_statements = match statements.first() {
+            Some(AstNode::Program(inner_statements)) => inner_statements,
+            other => {
+                assert!(matches!(other, Some(AstNode::Program(_))), "expected nested program node");
+                unreachable!();
+            }
+        };
+        let statement = match inner_statements.first() {
+            Some(AstNode::Statement(statement)) => statement,
+            other => {
+                assert!(matches!(other, Some(AstNode::Statement(_))), "expected statement");
+                unreachable!();
+            }
+        };
+
+        assert!(
+            matches!(statement.as_ref(), AstNode::FunctionCall { .. }),
+            "expected function call"
+        );
+
+        if let AstNode::FunctionCall { function, args } = statement.as_ref() {
+            assert_eq!(function.as_ref(), &AstNode::Identifier(Arc::from("My::Package::run")));
+            assert_eq!(args.len(), 2);
+        }
     }
 }

--- a/crates/tree-sitter-perl-rs/src/grammar.pest
+++ b/crates/tree-sitter-perl-rs/src/grammar.pest
@@ -442,7 +442,7 @@ primary_expression = {
 
 // User-defined function calls (with optional arguments)
 user_function_call = {
-    identifier ~ list_op_args
+    qualified_name_or_identifier ~ list_op_args
 }
 
 class_method_call = { identifier ~ ("::" ~ identifier)+ ~ "->" ~ method_name ~ function_args? }

--- a/crates/tree-sitter-perl-rs/src/pure_rust_parser.rs
+++ b/crates/tree-sitter-perl-rs/src/pure_rust_parser.rs
@@ -1159,7 +1159,9 @@ impl PureRustPerlParser {
 
                 for p in inner {
                     match p.as_rule() {
-                        Rule::identifier => {
+                        Rule::identifier
+                        | Rule::qualified_name
+                        | Rule::qualified_name_or_identifier => {
                             name = Arc::from(p.as_str());
                         }
                         Rule::list_op_args => {


### PR DESCRIPTION
### Motivation
- The v2/Pest parser treated bare function calls as plain `identifier` only, which caused namespace-qualified bare calls like `My::Package::run $value, 42;` to be mis-parsed and regressions to surface.
- The change aims to make the legacy Pest grammar and AST builder accept qualified names for list-style (no-parentheses) calls so the v2 bundle remains a faithful compatibility reference.

### Description
- Updated the Pest grammar rule `user_function_call` to use `qualified_name_or_identifier` instead of only `identifier` in `crates/perl-parser-pest/src/grammar.pest` and the synced copy in `crates/tree-sitter-perl-rs/src/grammar.pest`.
- Updated the AST builder in `pure_rust_parser.rs` to accept `Rule::identifier | Rule::qualified_name | Rule::qualified_name_or_identifier` when constructing `FunctionCall` nodes, and applied the same change to the synced `tree-sitter-perl-rs` copy.
- Added a regression test `test_qualified_function_call_without_parentheses` to `crates/perl-parser-pest/src/pure_rust_parser.rs` which verifies a `My::Package::run $value, 42;` call parses into a `FunctionCall` with the expected callee and arguments.
- Ran formatting (`cargo fmt`) and kept the v2 bundle copies synchronized between `perl-parser-pest` and `tree-sitter-perl-rs`.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran the targeted unit tests `cargo test -p perl-parser-pest test_qualified_function_call_without_parentheses -- --nocapture` and `cargo test -p perl-parser-pest test_function_declaration -- --nocapture`, both of which passed.
- Ran `cargo clippy -p perl-parser-pest --all-targets -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13f34ab88333bc6eb31daf73848e)