### PR TITLE
docs: improve root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">perl-lsp</h1>
 
 <p align="center">
-  A fast, native <strong>Perl language server</strong> written in Rust — bringing modern IDE features to Perl 5.
+  A fast, native <strong>Perl language server</strong>, parser, and debugging toolkit written in Rust.
 </p>
 
 <p align="center">
@@ -20,204 +20,222 @@
 
 ---
 
-> **Note**: perl-lsp is in public alpha. Core features work well, but expect some rough edges. [Report issues](https://github.com/EffortlessMetrics/perl-lsp/issues).
+> **Status:** Public alpha (`v0.10.0`). Core features are already useful today, but the project is still moving quickly. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues) and rough edges.
 
-## Quick Start
+## What this repository contains
 
-```bash
-# 1. Install
-cargo install perl-lsp
+This repository is more than a single binary crate. It is a Rust workspace that currently contains **121 crates** covering:
 
-# 2. Verify the install
-perl-lsp --health  # should print: ok X.Y.Z
+- **`perl-lsp`** — the Language Server Protocol server for editors.
+- **`perl-dap`** — a Debug Adapter Protocol server for interactive debugging.
+- **`perl-parser`** — the native recursive-descent Perl parser.
+- **`perl-lexer`** — the mode-aware tokenizer that powers parsing.
+- **LSP provider crates** — completion, navigation, diagnostics, formatting, semantic tokens, code actions, and more.
+- **Workspace and symbol infrastructure** — indexing, URI handling, file safety, and cross-file analysis.
 
-# 3. Configure your editor (VS Code)
-code --install-extension effortlessmetrics.perl-lsp-rs
-
-# 4. Open a Perl file — completions, diagnostics, hover, and navigation work immediately.
-```
-
-New to language servers? See the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for a full walkthrough with editor-specific setup, a visual feature tour, and troubleshooting tips.
-
-<details>
-<summary><strong>Neovim / Emacs setup</strong></summary>
-
-**Neovim** (nvim-lspconfig):
-
-```lua
-require('lspconfig').perl_ls.setup {
-  cmd = { "perl-lsp", "--stdio" },
-}
-```
-
-**Emacs** (eglot):
-
-```elisp
-(add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
-```
-
-</details>
-
-## Features
-
-| Feature | Description |
-|---------|-------------|
-| **Completion** | Symbols, keywords, modules, variables, snippets, built-in function signatures |
-| **Navigation** | Go-to-definition, find references, workspace symbols, document symbols |
-| **Hover** | Documentation and type information |
-| **Diagnostics** | Real-time error detection |
-| **Refactoring** | Rename, code actions, formatting |
-| **Debug Adapter** | Breakpoints, stepping, variable inspection via DAP bridge |
-| **Fast** | Sub-millisecond incremental parsing, native Rust binary |
-| **Zero Perl dependency** | No Perl runtime needed for parsing or LSP |
-| **Cross-file navigation** | Dual-indexed workspace with broad reference coverage |
-| **Unicode-safe** | Full UTF-8/UTF-16 position conversion |
-
-Full LSP coverage: all 53 advertised capabilities implemented (see [`features.toml`](features.toml)).
-For live metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
+If you just want to **use** the editor integration, install `perl-lsp`. If you want to **hack on parser or editor infrastructure**, this workspace has the full stack.
 
 ## Why perl-lsp?
 
-| | perl-lsp | Perl::LanguageServer | PLS |
-|---|----------|---------------------|-----|
-| **Language** | Rust (native binary) | Perl | Perl |
-| **Requires Perl runtime** | No | Yes | Yes |
-| **LSP feature coverage** | 53/53 advertised | Partial | Partial |
-| **Incremental parsing** | Yes (sub-ms updates) | N/A | N/A |
-| **Debug adapter** | Built-in (DAP bridge) | Built-in | No |
-| **Supply chain security** | SBOM + SLSA Level 2 | N/A | N/A |
+- **Native Rust implementation** — no Perl runtime required for parsing or core LSP features.
+- **Modern editor support** — completion, hover, rename, code actions, formatting, diagnostics, semantic tokens, and symbol search.
+- **Cross-file navigation** — dual indexing improves references and workspace discovery.
+- **Fast incremental parsing** — optimized for interactive IDE workloads.
+- **Integrated debugging** — `perl-dap` provides DAP support alongside the LSP stack.
+- **Security-focused engineering** — path-safety checks, hardened input handling, SBOM generation, and provenance attestation.
 
-## Parser Coverage
+## Quick start
 
-The v3 parser is a native recursive-descent implementation covering broad Perl 5 syntax
-(5.8 through 5.40), including heredocs, regex, quoting constructs, formats, and more.
-It is tested continuously against real-world Perl code to drive coverage improvements:
-
-- **Corpus test suite** -- 600+ test sections in `tree-sitter-perl/test/corpus/` plus 70+ standalone `.pl` fixtures.
-- **System Perl corpus sweep** -- benchmarked against all `.pm` and `.pl` files found in the system Perl installation. Current parse rates are tracked in [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and the baseline file (`.ci/parser-corpus-baseline.json`).
-- **Common-files gate** -- a curated set of core modules that must parse with zero errors on every PR (`.ci/common-corpus-manifest.txt`).
-- **Ratcheting CI gate** -- the overall parse rate can only go up, never down. Regressions fail the build.
-- **CPAN top 1000 goal** -- the long-term target is for 90%+ of the most-downloaded CPAN distributions to parse cleanly, driving parser improvements toward real-world Perl idioms.
-
-For detailed parse rates and the edge-case roadmap, see [PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md).
-
-### Corpus Commands
-
-```bash
-just corpus-sweep          # Sweep system Perl corpus and print results
-just corpus-sweep-check    # Check against baseline (fails on regression)
-just corpus-sweep-update   # Update baseline with current results
-just common-corpus-check   # Check pinned modules parse cleanly (PR gate)
-just cpan-corpus-fetch     # Fetch CPAN top-1000 distribution list
-just cpan-corpus-install   # Install CPAN corpus locally; auto-fetches the list, bootstraps cpanm, and reuses a local cache
-just cpan-corpus-baseline-update  # Seed/update CPAN ratchet baseline
-just cpan-corpus-check     # Check CPAN baseline + known-clean manifest
-```
-
-See [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for the latest computed metrics.
-
-## Install
-
-### From crates.io
+### Install from crates.io
 
 ```bash
 cargo install perl-lsp
-perl-lsp --health  # should print: ok X.Y.Z
+perl-lsp --health
 ```
 
-### From source
+Expected output:
+
+```text
+ok X.Y.Z
+```
+
+### Install from source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
 cargo install --path crates/perl-lsp
-perl-lsp --health  # should print: ok X.Y.Z
+perl-lsp --health
 ```
 
-### Pre-built binaries
+### Prebuilt binaries
 
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
+Download release artifacts from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
-## Architecture
+## Editor setup
+
+### VS Code
+
+```bash
+code --install-extension effortlessmetrics.perl-lsp-rs
+```
+
+Open any `.pl`, `.pm`, or related Perl file and the extension will launch `perl-lsp` automatically.
+
+### Neovim (`nvim-lspconfig`)
+
+```lua
+require('lspconfig').perl_ls.setup {
+  cmd = { 'perl-lsp', '--stdio' },
+}
+```
+
+### Emacs (`eglot`)
+
+```elisp
+(add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
+```
+
+New to language servers? Start with the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)** for editor-specific setup, screenshots, and troubleshooting.
+
+## Core commands
+
+```bash
+perl-lsp --stdio      # editor integration over stdio
+perl-lsp --health     # installation sanity check
+perl-lsp --version    # version output
+perl-dap              # launch the debug adapter
+cargo build -p perl-parser --release
+cargo test --workspace --lib
+```
+
+## Feature overview
+
+| Area | Highlights |
+|------|------------|
+| **Editing** | Completion, hover, signature help, formatting, on-type formatting, inlay hints |
+| **Navigation** | Go to definition, find references, document symbols, workspace symbols |
+| **Refactoring** | Rename and code actions |
+| **Diagnostics** | Parser-driven feedback plus LSP diagnostics plumbing |
+| **Debugging** | Breakpoints, stepping, variable inspection through `perl-dap` |
+| **Performance** | Incremental parsing and native binaries optimized for IDE feedback loops |
+| **Correctness & safety** | Unicode-safe UTF-8/UTF-16 conversion, path traversal prevention, hardened file handling |
+
+The workspace tracks **53/53 advertised user-visible LSP capabilities** in [`features.toml`](features.toml). For computed project metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
+
+## Workspace architecture
 
 ```text
 Editor / IDE
     |  JSON-RPC (stdio)
     v
-perl-lsp  (LSP server)
+perl-lsp
     |
-    +-- LSP Providers (completion, hover, diagnostics, ...)
-    +-- Workspace Index (dual-indexed symbol lookup)
-    +-- perl-dap (Debug Adapter Protocol bridge)
+    +-- LSP provider crates
+    +-- Workspace indexing and symbol services
+    +-- perl-dap (debug adapter bridge)
     |
-perl-parser  (v3 recursive-descent)
+perl-parser
     |
-perl-lexer   (mode-aware tokenizer)
+perl-lexer
 ```
 
-The workspace is organized as a family of focused Rust crates (115+), each with a
-single responsibility. This keeps compile times fast and boundaries clear.
+### Major crate families
 
-For the full tier system, architecture decision records, and design rationale, see:
+| Family | Count | Role |
+|--------|------:|------|
+| `perl-lsp-*` | 41 | LSP protocol, providers, feature governance, utilities |
+| `perl-module-*` | 13 | Module resolution, naming, imports, and refactoring helpers |
+| `perl-dap-*` | 9 | Debug adapter components |
+| `perl-lsp-feature-*` | 8 | Feature-flag and governance infrastructure |
+| `perl-workspace-*` | 6 | Workspace discovery and indexing |
+| `perl-ts-*` | 5 | Tree-sitter interoperability and analysis tooling |
 
-- [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md)
-- [Architecture Decision Records](docs/adr/README.md) (microcrate architecture, dual indexing, incremental parsing, supply chain security)
-- [CLAUDE.md](CLAUDE.md) for the complete developer command reference
-
-## Published Crates
+### Important crates
 
 | Crate | Purpose |
 |-------|---------|
-| [`perl-lsp`](https://crates.io/crates/perl-lsp) | Language Server Protocol binary |
-| [`perl-dap`](https://crates.io/crates/perl-dap) | Debug Adapter Protocol binary |
-| [`perl-parser`](https://crates.io/crates/perl-parser) | Recursive-descent Perl parser library |
-| [`perl-lexer`](https://crates.io/crates/perl-lexer) | Context-aware Perl tokenizer |
-| [`perl-corpus`](https://crates.io/crates/perl-corpus) | Parser and LSP test corpus |
+| [`crates/perl-lsp`](crates/perl-lsp/) | Top-level LSP server binary |
+| [`crates/perl-dap`](crates/perl-dap/) | Top-level DAP server binary |
+| [`crates/perl-parser`](crates/perl-parser/) | Recursive-descent Perl parser |
+| [`crates/perl-lexer`](crates/perl-lexer/) | Context-aware tokenizer |
+| [`crates/perl-semantic-analyzer`](crates/perl-semantic-analyzer/) | Semantic analysis infrastructure |
+| [`crates/perl-corpus`](crates/perl-corpus/) | Shared parser and LSP test corpus |
+
+## Parser coverage and quality gates
+
+The current parser is the **v3 native recursive-descent parser**. It targets broad Perl 5 syntax coverage across modern language constructs, including heredocs, regexes, quoting operators, substitution operators, and formats.
+
+Coverage is enforced with multiple feedback loops:
+
+- **Corpus tests** covering dedicated grammar scenarios and standalone fixtures.
+- **System Perl corpus sweeps** against `.pl` and `.pm` files from installed Perl distributions.
+- **Pinned common-file gates** that must stay clean on every pull request.
+- **Ratcheting CI checks** that reject parser regressions.
+- **CPAN corpus tooling** for measuring real-world package compatibility over time.
+
+### Corpus commands
+
+```bash
+just corpus-sweep
+just corpus-sweep-check
+just corpus-sweep-update
+just common-corpus-check
+just cpan-corpus-fetch
+just cpan-corpus-install
+just cpan-corpus-baseline-update
+just cpan-corpus-check
+```
+
+For roadmap details and current parse-rate tracking, see [PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md) and [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
 
 ## Development
 
+### Day-to-day commands
+
 ```bash
-cargo build --workspace            # Build everything
-cargo test --workspace             # Run all tests
-cargo clippy --workspace --lib     # Lint
-cargo fmt --all                    # Format
-nix develop -c just ci-gate        # Full local gate (required before push)
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --lib
+cargo fmt --all
+nix develop -c just ci-gate
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines,
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards,
-and [SUPPORT.md](SUPPORT.md) for how to get help.
+### Development guidelines
 
-## Security
+- Prefer the crate closest to the change you are making: parser work in `crates/perl-parser`, LSP entrypoints in `crates/perl-lsp`, DAP work in `crates/perl-dap`, and provider logic in `crates/perl-lsp-*` crates.
+- Production Rust code in this workspace avoids `unwrap()`, `expect()`, `panic!()`, `todo!()`, and `unimplemented!()`.
+- Tests should prefer `Result<()>`-style flows and the project helpers where applicable.
 
-Release artifacts include SBOM generation (SPDX and CycloneDX) and SLSA Level 2
-provenance attestations. Production code enforces zero `unsafe`, zero `unwrap`/`expect`,
-and zero `panic!`-family macros via CI ratchets. Path traversal and command injection
-vectors are hardened.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contributor workflow details.
 
-See [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) for details.
-
-## Documentation
+## Documentation map
 
 | Resource | Description |
 |----------|-------------|
-| **[Getting Started](docs/tutorials/GETTING_STARTED.md)** | **Installation, editor setup, and first-run walkthrough** |
-| [Book](book/) | Comprehensive user and developer guide |
-| [docs/](docs/README.md) | Documentation index |
-| [features.toml](features.toml) | Canonical LSP feature catalog |
-| [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) | Live project metrics |
-| [ROADMAP.md](ROADMAP.md) | Version milestones and planning |
-| [Getting Started](docs/tutorials/GETTING_STARTED.md) | Installation and first steps |
-| [Stability Policy](docs/reference/STABILITY.md) | API versioning and compatibility |
+| **[Getting Started](docs/tutorials/GETTING_STARTED.md)** | Installation, editor setup, and first-run walkthrough |
+| [docs/README.md](docs/README.md) | Documentation index |
+| [book/](book/) | User and developer book |
+| [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md) | Server architecture and provider structure |
+| [Current Status](docs/project/CURRENT_STATUS.md) | Computed metrics and health indicators |
+| [Stability Policy](docs/reference/STABILITY.md) | API compatibility expectations |
 | [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) | Debugger setup and usage |
+| [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) | SBOMs, attestations, and release hardening |
+| [ROADMAP.md](ROADMAP.md) | Version milestones and planning |
 
-## History
+## Security
 
-This project began as a fork of [tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl) in July 2025. It has since been rewritten as a native Rust recursive-descent parser and grown into a full-featured LSP/DAP toolkit with over 115 crates.
+Release artifacts include SBOM generation in SPDX and CycloneDX formats plus **SLSA Level 2 provenance attestations**. The codebase also enforces strict safety and reliability guardrails, including a ban on `unsafe` code and panic-style production constructs in CI.
+
+See [docs/reference/SUPPLY_CHAIN_SECURITY.md](docs/reference/SUPPLY_CHAIN_SECURITY.md) for the full policy and implementation details.
+
+## Project history
+
+This project started as a fork of [tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl) in July 2025. It has since evolved into a native Rust parser and a full LSP/DAP workspace for Perl development tooling.
 
 ## License
 
-Dual licensed under MIT or Apache-2.0:
+Dual licensed under either of the following, at your option:
 
-- [LICENSE-MIT](LICENSE-MIT)
-- [LICENSE-APACHE](LICENSE-APACHE)
+- [MIT](LICENSE-MIT)
+- [Apache-2.0](LICENSE-APACHE)


### PR DESCRIPTION
### Motivation
- Make the root README clearly explain that the repository is a full Rust workspace (LSP, DAP, parser, tooling), not just a single binary crate. 
- Improve first-run onboarding by consolidating installation, editor setup, and core commands into a concise Quick Start. 
- Surface architecture, major crate families, parser quality-gates, documentation map, and security posture up front so contributors and users can find relevant information quickly.

### Description
- Rewrote the README introduction and status text to emphasize workspace scope and public alpha status. 
- Added a "What this repository contains" section that enumerates top-level components and reports current crate counts (workspace scale). 
- Expanded Quick Start with `crates.io` and source install instructions, prebuilt binaries, and editor setup examples for VS Code, Neovim, and Emacs, plus a compact "Core commands" block. 
- Reorganized feature, architecture, parser coverage, corpus commands, development guidance, documentation map, and security sections to be clearer and more actionable for users and contributors.

### Testing
- Ran `git diff --check` locally and there were no whitespace or formatting issues reported. 
- Verified presence of key docs with a file-existence check (`test -f docs/... && echo docs-ok`) which returned success. 
- This is a documentation-only change; no code was modified and no crate build or unit tests were required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba13fa5588833392545779c3f945bb)