### PR TITLE
Add `perl-lsp.reinstall` command to recover auto-downloaded server binary

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -55,6 +55,9 @@ The extension automatically downloads the correct language server for your platf
 - macOS (Intel, Apple Silicon)
 - Linux (x64, ARM64)
 
+If an auto-downloaded server becomes corrupted or you want to force a fresh download,
+run **`Perl: Reinstall Server Binary`** from the Command Palette or the status bar menu.
+
 Manual installation options:
 ```bash
 # Homebrew (macOS/Linux)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -49,6 +49,7 @@
   "activationEvents": [
     "onLanguage:perl",
     "onCommand:perl-lsp.restart",
+    "onCommand:perl-lsp.reinstall",
     "onCommand:perl-lsp.showVersion"
   ],
   "contributes": {
@@ -298,6 +299,12 @@
         "icon": "$(info)"
       },
       {
+        "command": "perl-lsp.reinstall",
+        "title": "Reinstall Server Binary",
+        "category": "Perl",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "perl-lsp.showOutput",
         "title": "Show Output Channel",
         "category": "Perl",
@@ -330,6 +337,10 @@
         },
         {
           "command": "perl-lsp.showOutput",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.reinstall",
           "when": "editorLangId == perl"
         },
         {

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -99,6 +99,22 @@ export class BinaryDownloader {
             statusBar.dispose();
         }
     }
+
+    clearCachedBinaries(): void {
+        const installRoot = path.join(
+            this.context.globalStorageUri.fsPath,
+            'bin',
+            `${process.platform}-${process.arch}`
+        );
+
+        if (!fs.existsSync(installRoot)) {
+            this.outputChannel.appendLine(`No cached binaries to remove at: ${installRoot}`);
+            return;
+        }
+
+        fs.rmSync(installRoot, { recursive: true, force: true });
+        this.outputChannel.appendLine(`Removed cached binaries from: ${installRoot}`);
+    }
     
     private async downloadWithProgress(): Promise<string> {
         return vscode.window.withProgress({

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,7 @@ import { BinaryDownloader } from './downloader';
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel;
 let testAdapter: PerlTestAdapter | undefined;
+let resolvedServerPath: string | null = null;
 
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel('Perl Language Server');
@@ -28,6 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
     
     // Get the path to perl-lsp
     const serverPath = await getServerPath(context);
+    resolvedServerPath = serverPath;
     if (!serverPath) {
         vscode.window.showErrorMessage(
             'Perl Language Server (perl-lsp) not found.',
@@ -142,6 +144,10 @@ export async function activate(context: vscode.ExtensionContext) {
         await restartServer(context);
     });
 
+    const reinstallCommand = vscode.commands.registerCommand('perl-lsp.reinstall', async () => {
+        await reinstallServer(context);
+    });
+
     const organizeImportsCommand = vscode.commands.registerCommand('perl-lsp.organizeImports', async () => {
         await vscode.commands.executeCommand('editor.action.organizeImports');
     });
@@ -218,6 +224,11 @@ export async function activate(context: vscode.ExtensionContext) {
                 command: 'perl-lsp.restart'
             },
             {
+                label: '$(cloud-download) Reinstall Server Binary',
+                detail: 'Clear the cached download and fetch perl-lsp again',
+                command: 'perl-lsp.reinstall'
+            },
+            {
                 label: '$(organization) Organize Imports',
                 description: 'Shift+Alt+O',
                 detail: isPerl ? 'Sort and organize use statements' : 'Sort and organize use statements (Only available for Perl files)',
@@ -256,7 +267,14 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
     
-    context.subscriptions.push(restartCommand, organizeImportsCommand, runTestsCommand, showVersionCommand, statusMenuCommand);
+    context.subscriptions.push(
+        restartCommand,
+        reinstallCommand,
+        organizeImportsCommand,
+        runTestsCommand,
+        showVersionCommand,
+        statusMenuCommand
+    );
     
     outputChannel.appendLine('Perl Language Server started successfully');
 }
@@ -333,6 +351,63 @@ async function getServerPath(context: vscode.ExtensionContext): Promise<string |
     
     outputChannel.appendLine('Failed to obtain perl-lsp');
     return null;
+}
+
+async function reinstallServer(context: vscode.ExtensionContext): Promise<void> {
+    outputChannel.show(true);
+    outputChannel.appendLine('Starting perl-lsp reinstall...');
+
+    const downloader = new BinaryDownloader(context, outputChannel);
+    const previousPath = resolvedServerPath;
+
+    try {
+        if (client) {
+            await client.stop();
+        }
+
+        downloader.clearCachedBinaries();
+        resolvedServerPath = await getServerPath(context);
+
+        if (!resolvedServerPath) {
+            throw new Error('perl-lsp could not be located after reinstall.');
+        }
+
+        const healthOk = await runHealthCheck(resolvedServerPath);
+        if (!healthOk) {
+            throw new Error(`Health check failed for reinstalled binary: ${resolvedServerPath}`);
+        }
+
+        if (client) {
+            await client.start();
+        }
+
+        const detail = previousPath && previousPath !== resolvedServerPath
+            ? `Reinstalled perl-lsp and switched from ${previousPath} to ${resolvedServerPath}.`
+            : `Reinstalled perl-lsp at ${resolvedServerPath}.`;
+
+        vscode.window.showInformationMessage(detail, 'Show Output').then(selection => {
+            if (selection === 'Show Output') {
+                outputChannel.show();
+            }
+        });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        outputChannel.appendLine(`Failed to reinstall perl-lsp: ${message}`);
+        vscode.window.showErrorMessage(`Failed to reinstall Perl Language Server: ${message}`, 'Show Output').then(selection => {
+            if (selection === 'Show Output') {
+                outputChannel.show();
+            }
+        });
+
+        if (client) {
+            try {
+                await client.start();
+            } catch (restartError: unknown) {
+                const restartMessage = restartError instanceof Error ? restartError.message : String(restartError);
+                outputChannel.appendLine(`Failed to restart client after reinstall error: ${restartMessage}`);
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Provide a straightforward recovery path when the auto-downloaded `perl-lsp` binary is corrupted, incompatible, or otherwise broken so users don't need to leave VS Code to fix it.
- Give operators a single command to clear cached downloads and force a fresh fetch of the server binary to reduce support friction.

### Description
- Add a `perl-lsp.reinstall` command and `reinstallServer` workflow which stops the client, clears cached auto-downloaded binaries, re-resolves/downloads the server, runs the `--health` check, and restarts the client when successful (`vscode-extension/src/extension.ts`).
- Track the resolved binary path in a new `resolvedServerPath` variable so the reinstall flow can report changes and decide whether the binary moved (`vscode-extension/src/extension.ts`).
- Add `clearCachedBinaries()` to the `BinaryDownloader` to remove the extension's auto-download install directory for the current platform/arch (`vscode-extension/src/downloader.ts`).
- Expose the reinstall action in the extension manifest and status menu by updating `package.json` and the status quick menu, and document the command in the VS Code extension `README.md` so users know how to trigger a fresh download.

### Testing
- Ran the TypeScript build with `npm run compile` in `vscode-extension` and it completed successfully.
- No additional automated tests were modified; the changes are exercised by the compiled extension code paths (activation/command registration and downloader path removal).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba140ecfd48333b95769b8e1a90f91)