### PR TITLE
Improve Open VSX extension publishing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -71,7 +71,22 @@ jobs:
         working-directory: vscode-extension
         run: |
           npm run verify:marketplace
+          npm run verify:openvsx
           echo "VSIX_FILE=$(ls -1 *.vsix | head -n 1)" >> "$GITHUB_ENV"
+
+      - name: Report publish targets
+        run: |
+          if [ -n "$VSCE_PAT" ]; then
+            echo "Visual Studio Marketplace publish enabled"
+          else
+            echo "::notice::VSCE_PAT not configured; skipping Visual Studio Marketplace publish."
+          fi
+
+          if [ -n "$OVSX_PAT" ]; then
+            echo "Open VSX publish enabled"
+          else
+            echo "::notice::OVSX_PAT not configured; skipping Open VSX publish."
+          fi
 
       - name: Publish to VSCode Marketplace
         if: ${{ env.VSCE_PAT != '' }}

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Perl Language Server extension will be documented in 
 
 ## [Unreleased]
 
+### Added
+- Open VSX badges and installation guidance in the extension README for VSCodium/Open VSX users.
+- `npm run publish:openvsx` and `npm run verify:openvsx` helper scripts for local publishing workflows.
+
+### Changed
+- Publishing workflow now validates the VSIX for both marketplace paths and emits notices when Open VSX or VS Marketplace tokens are not configured.
+- Publishing documentation now covers Open VSX login, publish, and post-release verification steps.
+
 ## [0.11.0] - 2026-03-11
 
 ### Fixed

--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -9,6 +9,7 @@
    npm install -g @vscode/vsce
    ```
 4. **Publisher account** on Visual Studio Marketplace
+5. **Open VSX access token** if you want to publish to Open VSX / VSCodium users
 
 ## Build Process
 
@@ -30,7 +31,7 @@ npm install
 npm run verify:marketplace
 ```
 
-`verify:marketplace` runs TypeScript compilation, bundles the local platform binary, and generates a `.vsix` package suitable for pre-release validation.
+`verify:marketplace` runs TypeScript compilation, bundles the local platform binary, and generates a `.vsix` package suitable for pre-release validation. `verify:openvsx` currently reuses the same VSIX validation flow so the exact package that goes to Visual Studio Marketplace is also ready for Open VSX.
 
 ### 3. Test Locally
 
@@ -103,6 +104,18 @@ vsce publish major  # 0.5.0 -> 0.9.x
 vsce publish 0.5.1  # Specific version
 ```
 
+### 8. Publish to Open VSX
+
+```bash
+# Publish from the current workspace
+npx ovsx publish --pat "$OVSX_PAT"
+
+# Or publish the prebuilt VSIX explicitly
+npx ovsx publish perl-lsp-rs-*.vsix --pat "$OVSX_PAT"
+```
+
+Open VSX is the canonical distribution channel for VSCodium and many marketplace-compatible editors. Publishing the same verified VSIX keeps the VS Code and Open VSX releases aligned.
+
 ## Post-Publishing
 
 1. **Verify on Marketplace**
@@ -110,12 +123,16 @@ vsce publish 0.5.1  # Specific version
    - Search for "Perl Language Server"
    - Verify description, screenshots, etc.
 
-2. **Update Documentation**
+2. **Verify on Open VSX**
+   - Go to https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs
+   - Confirm version, readme rendering, and download/install instructions for VSCodium users
+
+3. **Update Documentation**
    - Update main README.md with marketplace link
    - Add installation instructions
    - Update CHANGELOG.md
 
-3. **Create GitHub Release**
+4. **Create GitHub Release**
    - Tag the release: `git tag vscode-extension-v0.5.0`
    - Create release on GitHub
    - Attach the .vsix file
@@ -153,9 +170,10 @@ Check `.vscodeignore` is excluding unnecessary files.
 Before first public launch:
 
 - [ ] Confirm `package.json` metadata is complete (`publisher`, `icon`, repository links, categories, keywords).
-- [ ] Ensure `README.md` has clear install + configuration guidance.
+- [ ] Ensure `README.md` has clear install + configuration guidance for both VS Code and Open VSX-compatible editors.
 - [ ] Ensure `CHANGELOG.md` includes release notes for the exact published version.
 - [ ] Run `npm run verify:marketplace` and install the generated `.vsix` locally.
 - [ ] Validate extension activation in a clean profile (`code --user-data-dir <tmpdir>`).
 - [ ] Verify binary download fallback works when no bundled binary exists for the host platform.
 - [ ] Publish as pre-release first (recommended for initial alpha), then promote to stable after validation feedback.
+- [ ] Confirm the Open VSX listing resolves and the README renders after publish.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -2,6 +2,8 @@
 
 [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/EffortlessMetrics.perl-lsp-rs?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 [![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/EffortlessMetrics.perl-lsp-rs)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
+[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20Downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 
 Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
 
@@ -48,7 +50,10 @@ Lightning-fast Perl language support with 26+ IDE features powered by perl-lsp.
 
 ## 📦 Installation
 
-Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs).
+Install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) or [Open VSX](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs).
+
+- **VS Code**: install from the Visual Studio Marketplace or run `code --install-extension EffortlessMetrics.perl-lsp-rs`.
+- **VSCodium / Open VSX-compatible editors**: install from Open VSX or run `codium --install-extension EffortlessMetrics.perl-lsp-rs`.
 
 The extension automatically downloads the correct language server for your platform:
 - Windows (x64, ARM64)
@@ -119,7 +124,7 @@ Complete signatures for 150+ Perl built-ins with parameter documentation.
 
 Works with any LSP-compatible editor:
 - Visual Studio Code
-- VSCodium  
+- VSCodium / Open VSX-compatible editors
 - Cursor
 - Gitpod
 - GitHub Codespaces

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -20,7 +20,9 @@
     "perl5",
     "language-server",
     "lsp",
-    "tree-sitter"
+    "tree-sitter",
+    "vscodium",
+    "open-vsx"
   ],
   "extensionKind": [
     "workspace"
@@ -417,7 +419,9 @@
     "bundle-lsp": "node ./scripts/bundle-lsp.js",
     "package": "npx @vscode/vsce package",
     "publish": "npx @vscode/vsce publish",
-    "verify:marketplace": "npm run compile && npm run bundle-lsp && npm run package"
+    "publish:openvsx": "npx ovsx publish",
+    "verify:marketplace": "npm run compile && npm run bundle-lsp && npm run package",
+    "verify:openvsx": "npm run verify:marketplace"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",


### PR DESCRIPTION
### Motivation
- Add first-class Open VSX support so VSCodium and other Open VSX-compatible editors can install and receive the same verified VSIX as VS Code users.
- Make the CI publishing workflow and documentation explicit about Open VSX so maintainers can validate and publish to both registries reliably.

### Description
- Add Open VSX-related keywords and two npm scripts to `vscode-extension/package.json`: `publish:openvsx` (runs `npx ovsx publish`) and `verify:openvsx` (reuses the VSIX validation flow). 
- Update the GitHub Actions publish job in `.github/workflows/publish-extension.yml` to run `npm run verify:openvsx` during VSIX build and to emit notices when `VSCE_PAT` or `OVSX_PAT` are missing, while retaining conditional publish steps for each registry.
- Update `vscode-extension/README.md` to include Open VSX badges, install instructions for VSCodium/Open VSX-compatible editors, and note Open VSX in compatibility text.
- Extend `vscode-extension/PUBLISHING.md` and `vscode-extension/CHANGELOG.md` with Open VSX publishing guidance, verification steps, and checklist items.

### Testing
- Ran `npm --prefix vscode-extension run compile` to ensure TypeScript builds; the command completed successfully.
- Executed a Node one-liner to validate `package.json` contains `publish:openvsx` and `verify:openvsx`; the script printed the scripts and succeeded.
- Ran a small Python check that verifies the workflow contains `npm run verify:openvsx` and the CI notice strings; the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba14137ce08333b7bf349b874af23e)