### PR TITLE
Fix stale lexer prototype mode after `sub` heads

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1866,7 +1866,11 @@ impl<'a> PerlLexer<'a> {
                         self.mode = LexerMode::ExpectTerm;
                     }
                     "sub" => {
+                        // Enter a prototype-candidate state for the declaration head.
+                        // If we later see `(` before `{`/`;`, we stay in prototype mode, but
+                        // body delimiters without a prototype should cancel that state.
                         self.in_prototype = true;
+                        self.prototype_depth = 0;
                     }
                     // Quote operators expect a delimiter next (must be immediately adjacent)
                     op if quote_handler::is_quote_operator(op) => {
@@ -2315,6 +2319,9 @@ impl<'a> PerlLexer<'a> {
             }
             ';' => {
                 self.advance();
+                if self.in_prototype && self.prototype_depth == 0 {
+                    self.in_prototype = false;
+                }
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::Semicolon,
@@ -2355,6 +2362,9 @@ impl<'a> PerlLexer<'a> {
             }
             '{' => {
                 self.advance();
+                if self.in_prototype && self.prototype_depth == 0 {
+                    self.in_prototype = false;
+                }
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::LeftBrace,
@@ -3276,6 +3286,36 @@ mod tests {
         lexer.next_token(); // 10
         let token = lexer.next_token().ok_or("Expected modulo operator token")?;
         assert!(matches!(token.token_type, TokenType::Operator(ref op) if op.as_ref() == "%"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_sub_body_clears_prototype_mode() -> TestResult {
+        let mut lexer = PerlLexer::new("sub demo { print($^W); }");
+        let tokens = lexer.collect_tokens();
+
+        assert!(tokens.iter().any(|token| {
+            matches!(
+                token.token_type,
+                TokenType::Identifier(ref id) if id.as_ref() == "$^W"
+            )
+        }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sub_forward_declaration_clears_prototype_mode() -> TestResult {
+        let mut lexer = PerlLexer::new("sub demo; my $^W;");
+        let tokens = lexer.collect_tokens();
+
+        assert!(tokens.iter().any(|token| {
+            matches!(
+                token.token_type,
+                TokenType::Identifier(ref id) if id.as_ref() == "$^W"
+            )
+        }));
+
         Ok(())
     }
 

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -52,7 +52,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Tier A Tests** | 2100 lib tests (discovered), 0 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2102 lib tests (discovered), 0 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
 | **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
@@ -86,7 +86,7 @@ Key terms:
 - **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
 - **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 2100 lib tests (Tier A), 0 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2102 lib tests (Tier A), 0 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
## Summary

- Fixes stale prototype mode in the lexer after parsing `sub` declarations
- Resets `prototype_depth` when entering the `sub` keyword arm
- Clears `in_prototype` flag when encountering `{` or `;` at depth 0 (body/forward declaration without a prototype)
- Adds two tests: `test_sub_body_clears_prototype_mode` and `test_sub_forward_declaration_clears_prototype_mode`
- Updates `CURRENT_STATUS.md` test count (2100 -> 2102)

This is a rebased version of #1867 which was closed. The original PR failed CI due to stale `CURRENT_STATUS.md` metrics.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p perl-lexer --tests -- -D warnings` passes
- [x] `cargo test -p perl-lexer` passes (all 492 tests)
- [x] `python3 scripts/update-current-status.py --check` passes