### PR TITLE
fix(lexer): prevent prototype mode leak after sub keyword

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -19,6 +19,8 @@ pub struct LexerCheckpoint {
     pub in_prototype: bool,
     /// Paren depth to track when we exit prototype
     pub prototype_depth: usize,
+    /// Whether we just saw 'sub' and are waiting for a possible prototype
+    pub after_sub: bool,
     /// Current position with line/column tracking
     pub current_pos: Position,
     /// Additional context for complex states
@@ -49,6 +51,7 @@ impl LexerCheckpoint {
             delimiter_stack: Vec::new(),
             in_prototype: false,
             prototype_depth: 0,
+            after_sub: false,
             current_pos: Position::start(),
             context: CheckpointContext::Normal,
         }
@@ -71,7 +74,8 @@ impl LexerCheckpoint {
             mode_changed: self.mode != other.mode,
             delimiter_stack_changed: self.delimiter_stack != other.delimiter_stack,
             prototype_state_changed: self.in_prototype != other.in_prototype
-                || self.prototype_depth != other.prototype_depth,
+                || self.prototype_depth != other.prototype_depth
+                || self.after_sub != other.after_sub,
             context_changed: self.context != other.context,
         }
     }
@@ -89,6 +93,7 @@ impl LexerCheckpoint {
                 self.delimiter_stack.clear();
                 self.in_prototype = false;
                 self.prototype_depth = 0;
+                self.after_sub = false;
                 self.context = CheckpointContext::Normal;
             }
         }
@@ -113,11 +118,12 @@ impl fmt::Display for LexerCheckpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Checkpoint@{} mode={:?} delims={} proto={}",
+            "Checkpoint@{} mode={:?} delims={} proto={} after_sub={}",
             self.position,
             self.mode,
             self.delimiter_stack.len(),
-            self.in_prototype
+            self.in_prototype,
+            self.after_sub
         )
     }
 }

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -246,6 +246,8 @@ pub struct PerlLexer<'a> {
     in_prototype: bool,
     /// Paren depth to track when we exit prototype
     prototype_depth: usize,
+    /// Track if we just saw a 'sub' keyword (waiting for possible prototype)
+    after_sub: bool,
     /// Current position with line/column tracking
     #[allow(dead_code)]
     current_pos: Position,
@@ -282,6 +284,7 @@ impl<'a> PerlLexer<'a> {
             delimiter_stack: Vec::new(),
             in_prototype: false,
             prototype_depth: 0,
+            after_sub: false,
             current_pos: Position::start(),
             after_newline: true, // Start of file counts as after newline
             pending_heredocs: Vec::new(),
@@ -676,6 +679,7 @@ impl<'a> PerlLexer<'a> {
         let saved_delimiter_stack = self.delimiter_stack.clone();
         let saved_prototype = self.in_prototype;
         let saved_depth = self.prototype_depth;
+        let saved_after_sub = self.after_sub;
         let saved_current_pos = self.current_pos;
         let saved_after_newline = self.after_newline;
         let saved_pending_heredocs = self.pending_heredocs.clone();
@@ -691,6 +695,7 @@ impl<'a> PerlLexer<'a> {
         self.delimiter_stack = saved_delimiter_stack;
         self.in_prototype = saved_prototype;
         self.prototype_depth = saved_depth;
+        self.after_sub = saved_after_sub;
         self.current_pos = saved_current_pos;
         self.after_newline = saved_after_newline;
         self.pending_heredocs = saved_pending_heredocs;
@@ -722,6 +727,7 @@ impl<'a> PerlLexer<'a> {
         self.delimiter_stack.clear();
         self.in_prototype = false;
         self.prototype_depth = 0;
+        self.after_sub = false;
         self.current_pos = Position::start();
         self.after_newline = true;
         self.pending_heredocs.clear();
@@ -1866,7 +1872,7 @@ impl<'a> PerlLexer<'a> {
                         self.mode = LexerMode::ExpectTerm;
                     }
                     "sub" => {
-                        self.in_prototype = true;
+                        self.after_sub = true;
                     }
                     // Quote operators expect a delimiter next (must be immediately adjacent)
                     op if quote_handler::is_quote_operator(op) => {
@@ -2245,6 +2251,8 @@ impl<'a> PerlLexer<'a> {
         }
 
         let text = &self.input[start..self.position];
+        // Operator ends prototype window (e.g. `:` for attributes)
+        self.after_sub = false;
         // Postfix ++ and -- complete a term expression, so next token is an operator
         // (e.g., "$x++ / 2" → / is division, not regex)
         if (text == "++" || text == "--") && self.mode == LexerMode::ExpectOperator {
@@ -2292,7 +2300,12 @@ impl<'a> PerlLexer<'a> {
                 }
 
                 self.advance();
-                if self.in_prototype {
+                if self.after_sub {
+                    // Promote after_sub to in_prototype now that we see '('
+                    self.in_prototype = true;
+                    self.after_sub = false;
+                    self.prototype_depth = 1;
+                } else if self.in_prototype {
                     self.prototype_depth += 1;
                 }
                 self.mode = LexerMode::ExpectTerm;
@@ -2321,6 +2334,8 @@ impl<'a> PerlLexer<'a> {
             }
             ';' => {
                 self.advance();
+                // Semicolon ends prototype window (forward declaration)
+                self.after_sub = false;
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::Semicolon,
@@ -2361,6 +2376,8 @@ impl<'a> PerlLexer<'a> {
             }
             '{' => {
                 self.advance();
+                // Opening brace ends prototype window — no prototype follows
+                self.after_sub = false;
                 self.mode = LexerMode::ExpectTerm;
                 Some(Token {
                     token_type: TokenType::LeftBrace,
@@ -3204,6 +3221,7 @@ impl Checkpointable for PerlLexer<'_> {
             delimiter_stack: self.delimiter_stack.clone(),
             in_prototype: self.in_prototype,
             prototype_depth: self.prototype_depth,
+            after_sub: self.after_sub,
             current_pos: self.current_pos,
             context,
         }
@@ -3215,6 +3233,7 @@ impl Checkpointable for PerlLexer<'_> {
         self.delimiter_stack.clone_from(&checkpoint.delimiter_stack);
         self.in_prototype = checkpoint.in_prototype;
         self.prototype_depth = checkpoint.prototype_depth;
+        self.after_sub = checkpoint.after_sub;
         self.current_pos = checkpoint.current_pos;
 
         // Handle special contexts

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -1189,6 +1189,7 @@ fn checkpoint_new_defaults() {
     assert!(cp.delimiter_stack.is_empty());
     assert!(!cp.in_prototype);
     assert_eq!(cp.prototype_depth, 0);
+    assert!(!cp.after_sub);
     assert!(cp.is_at_start());
 }
 

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -1187,3 +1187,104 @@ fn transliteration_with_ranges() -> R {
     assert_eq!(first.text.as_ref(), "tr/a-zA-Z/A-Za-z/");
     Ok(())
 }
+
+// ===========================================================================
+// 7. Prototype mode leak regression tests (after 'sub' keyword)
+// ===========================================================================
+
+/// `sub foo { }` — no prototype, after_sub must not leak into body.
+/// Without the fix, `in_prototype` stays true and `$^W` inside the body
+/// would be mis-lexed (the `^` treated as a literal prototype char).
+#[test]
+fn sub_no_prototype_does_not_leak() -> R {
+    // $^W is a special variable; inside a prototype it would be mishandled
+    let input = "sub foo { my $x = $^W; }";
+    let sig = significant(input);
+
+    // Find the $^W variable token — it should be a single Variable token
+    // containing "^W", not split by prototype mode treating ^ as literal
+    let var_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(&t.token_type, TokenType::Identifier(v) if v.as_ref() == "$^W"))
+        .collect();
+    assert!(
+        !var_tokens.is_empty(),
+        "Expected $^W to be lexed as a Variable containing '^W', got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// `sub foo : lvalue { }` — attribute without prototype should not leak.
+#[test]
+fn sub_attribute_without_prototype_does_not_leak() -> R {
+    let input = "sub foo : lvalue { my $x = $^W; }";
+    let sig = significant(input);
+
+    let var_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(&t.token_type, TokenType::Identifier(v) if v.as_ref() == "$^W"))
+        .collect();
+    assert!(
+        !var_tokens.is_empty(),
+        "Expected $^W to be lexed correctly after sub with attribute, got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// `sub foo ($self) { }` — signature (not prototype) should not leak.
+#[test]
+fn sub_signature_does_not_leak() -> R {
+    // After the signature parens close, prototype mode must be off
+    let input = "sub foo ($self) { my $x = $^W; }";
+    let sig = significant(input);
+
+    let var_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(&t.token_type, TokenType::Identifier(v) if v.as_ref() == "$^W"))
+        .collect();
+    assert!(
+        !var_tokens.is_empty(),
+        "Expected $^W to be lexed correctly after sub with signature, got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// `sub foo ($$) { }` — actual prototype, verify prototype mode engages and exits.
+#[test]
+fn sub_with_prototype_works_correctly() -> R {
+    let input = "sub foo ($$) { my $x = $^W; }";
+    let sig = significant(input);
+
+    // After prototype parens close, $^W should still be lexed correctly
+    let var_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(&t.token_type, TokenType::Identifier(v) if v.as_ref() == "$^W"))
+        .collect();
+    assert!(
+        !var_tokens.is_empty(),
+        "Expected $^W after prototype to be lexed correctly, got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+/// Forward declaration `sub foo;` should not leak prototype mode.
+#[test]
+fn sub_forward_declaration_does_not_leak() -> R {
+    let input = "sub foo; my $x = $^W;";
+    let sig = significant(input);
+
+    let var_tokens: Vec<_> = sig
+        .iter()
+        .filter(|t| matches!(&t.token_type, TokenType::Identifier(v) if v.as_ref() == "$^W"))
+        .collect();
+    assert!(
+        !var_tokens.is_empty(),
+        "Expected $^W after forward declaration to be lexed correctly, got tokens: {:?}",
+        sig.iter().map(|t| (&t.token_type, t.text.as_ref())).collect::<Vec<_>>()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Fix stale `in_prototype` mode leaking into subsequent tokens when `sub` declarations lack a prototype `(...)`.
- The lexer previously set `in_prototype = true` immediately on encountering `sub`, but never cleared it when no parenthesized prototype followed. This caused special variables like `$^W`, `$;`, and `$^` inside the sub body to be mis-lexed.
- Introduce an `after_sub` intermediate flag that only promotes to `in_prototype` when `(` is actually seen. The flag is cleared on `{`, `;`, and operators (`:` for attributes).

## Test plan

- [x] `sub foo { my $x = $^W; }` -- no prototype, `$^W` lexed correctly
- [x] `sub foo : lvalue { my $x = $^W; }` -- attribute without prototype
- [x] `sub foo ($self) { my $x = $^W; }` -- signature (not prototype)
- [x] `sub foo ($$) { my $x = $^W; }` -- actual prototype engages and exits
- [x] `sub foo; my $x = $^W;` -- forward declaration does not leak
- [x] Full `cargo test -p perl-lexer` passes (504 tests, 0 failures)
- [x] `cargo clippy -p perl-lexer --tests -- -D warnings` clean
- [x] `cargo fmt --all` clean