### PR TITLE
test(parser): add heredoc edge case tests from scout findings

### DIFF
--- a/crates/perl-parser/tests/sprint_a_heredoc_body_tests.rs
+++ b/crates/perl-parser/tests/sprint_a_heredoc_body_tests.rs
@@ -14,6 +14,19 @@ fn collect_heredocs(node: &mut Node, out: &mut Vec<(String, String, bool, bool)>
     });
 }
 
+/// Extended helper that also captures the `command` flag for backtick heredocs
+fn collect_heredocs_full(node: &mut Node, out: &mut Vec<(String, String, bool, bool, bool)>) {
+    if let NodeKind::Heredoc { delimiter, content, interpolated, indented, command, .. } =
+        &node.kind
+    {
+        out.push((delimiter.clone(), content.clone(), *interpolated, *indented, *command));
+    }
+
+    node.for_each_child_mut(|child| {
+        collect_heredocs_full(child, out);
+    });
+}
+
 #[test]
 fn heredoc_body_basic() -> Result<(), Box<dyn std::error::Error>> {
     let src = "print <<EOT;\nhello\nworld\nEOT\n";
@@ -162,5 +175,106 @@ fn heredoc_indented_mixed_spaces_tabs() -> Result<(), Box<dyn std::error::Error>
         "Terminator's 2-space indent should strip exactly 2 leading bytes per line"
     );
     assert!(*indented, "<<~ heredoc should be marked as indented");
+    Ok(())
+}
+
+// ============================================================================
+// Edge cases identified by scout
+// ============================================================================
+
+/// Backtick heredoc (command execution): <<`CMD`
+///
+/// Validates that backtick-quoted heredocs are parsed with the `command` flag
+/// set, indicating the body should be executed as a shell command.
+#[test]
+fn heredoc_body_backtick_command_execution() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "my $output = <<`CMD`;\necho \"hello\"\nCMD\n";
+    let mut parser = Parser::new(src);
+    let mut root = parser.parse()?;
+
+    let mut heredocs = Vec::new();
+    collect_heredocs_full(&mut root, &mut heredocs);
+
+    assert_eq!(heredocs.len(), 1, "Expected exactly one heredoc node");
+    let (delimiter, content, _interpolated, indented, command) = &heredocs[0];
+    assert_eq!(delimiter, "CMD");
+    assert_eq!(content, "echo \"hello\"");
+    assert!(!*indented, "Backtick heredoc should not be indented");
+    assert!(*command, "Backtick heredoc should have command flag set");
+    Ok(())
+}
+
+/// Indented + single-quoted heredoc: <<~'END'
+///
+/// Validates that indented heredocs with single-quoted labels disable
+/// interpolation while still stripping leading whitespace.
+#[test]
+fn heredoc_body_indented_single_quoted() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "my $text = <<~'END';\n    indented content\n    END\n";
+    let mut parser = Parser::new(src);
+    let mut root = parser.parse()?;
+
+    let mut heredocs = Vec::new();
+    collect_heredocs(&mut root, &mut heredocs);
+
+    assert_eq!(heredocs.len(), 1, "Expected exactly one heredoc node");
+    let (delimiter, content, interpolated, indented) = &heredocs[0];
+    assert_eq!(delimiter, "END");
+    assert_eq!(content, "indented content", "Content should have indent stripped");
+    assert!(!*interpolated, "Single-quoted heredoc should not be interpolated");
+    assert!(*indented, "<<~ heredoc should be marked as indented");
+    Ok(())
+}
+
+/// Three heredocs on one line
+///
+/// Validates FIFO body association when three heredocs are declared in a
+/// single statement, extending the existing two-heredoc test.
+#[test]
+fn heredoc_body_three_on_one_line() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "print <<A, <<B, <<C;\nalpha\nA\nbeta\nB\ngamma\nC\n";
+    let mut parser = Parser::new(src);
+    let mut root = parser.parse()?;
+
+    let mut heredocs = Vec::new();
+    collect_heredocs(&mut root, &mut heredocs);
+
+    assert_eq!(heredocs.len(), 3, "Should find all three heredocs");
+
+    let (delim1, content1, _, _) = &heredocs[0];
+    assert_eq!(delim1, "A");
+    assert_eq!(content1, "alpha");
+
+    let (delim2, content2, _, _) = &heredocs[1];
+    assert_eq!(delim2, "B");
+    assert_eq!(content2, "beta");
+
+    let (delim3, content3, _, _) = &heredocs[2];
+    assert_eq!(delim3, "C");
+    assert_eq!(content3, "gamma");
+    Ok(())
+}
+
+/// Content containing the terminator string as a substring
+///
+/// Validates that the terminator is only matched on a line by itself,
+/// not when it appears as part of a longer line.
+#[test]
+fn heredoc_body_content_contains_terminator_string() -> Result<(), Box<dyn std::error::Error>> {
+    let src = "my $text = <<'END';\nThe word END appears here but is not a terminator\nEND\n";
+    let mut parser = Parser::new(src);
+    let mut root = parser.parse()?;
+
+    let mut heredocs = Vec::new();
+    collect_heredocs(&mut root, &mut heredocs);
+
+    assert_eq!(heredocs.len(), 1, "Expected exactly one heredoc node");
+    let (delimiter, content, interpolated, _indented) = &heredocs[0];
+    assert_eq!(delimiter, "END");
+    assert_eq!(
+        content, "The word END appears here but is not a terminator",
+        "Line containing the terminator word should be body content, not terminate the heredoc"
+    );
+    assert!(!*interpolated, "Single-quoted heredoc should not be interpolated");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Adds 4 heredoc edge case tests identified by scout to `sprint_a_heredoc_body_tests.rs`
- Covers backtick heredoc (`<<\`CMD\``), indented single-quoted (`<<~'END'`), three heredocs on one line, and content containing the terminator string as a substring
- Adds `collect_heredocs_full` helper to capture the `command` flag for backtick heredoc assertions

## Test plan
- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy -p perl-parser --test sprint_a_heredoc_body_tests -- -D warnings` -- clean
- [x] `cargo test -p perl-parser --test sprint_a_heredoc_body_tests` -- all 12 tests pass (8 existing + 4 new)