### PR TITLE
fix(swarm): add status update step to verify-build skill

### DIFF
--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -55,6 +55,16 @@ For `perl-lsp`, use:
 RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 ```
 
+Status update (REQUIRED when tests were added, removed, or changed):
+
+```bash
+just status-update
+just status-check
+```
+
+This prevents the `policy_checks` CI gate from failing due to stale derived
+metrics in `docs/project/CURRENT_STATUS.md`. Always run after modifying tests.
+
 ## Receipt Format
 
 Report:


### PR DESCRIPTION
## Summary
- Adds `just status-update` and `just status-check` to the `/verify-build` skill when tests were added, removed, or changed
- Prevents the `policy_checks` CI gate from failing due to stale derived metrics in `docs/project/CURRENT_STATUS.md`
- Keeps `/verify-build` as the existing verification-only skill shape; this does not roll in the broader finish-line refactor

## Test plan
- [x] Rewrote the branch to a single intended skill-file change on current `master`
- [x] `git diff --check`
- [x] Verified `justfile` defines both `status-update` and `status-check`