### PR TITLE
docs(dap): clarify golden transcript test command

### DIFF
--- a/crates/perl-dap/tests/dap_golden_transcript_tests.rs
+++ b/crates/perl-dap/tests/dap_golden_transcript_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Validates transcript fixtures and replays representative command flows.
 //!
-//! Run with: `cargo test -p perl-dap --features dap-phase2`
+//! Run with: `cargo test -p perl-dap --features dap-phase2 -- golden`
 
 #[cfg(feature = "dap-phase2")]
 mod dap_golden_transcripts {


### PR DESCRIPTION
## Summary
- Clarifies the golden-transcript test file header so it shows the correct filtered command: `cargo test -p perl-dap --features dap-phase2 -- golden`
- Keeps the `dap-phase2` gate intact; this PR no longer changes test gating behavior
- Rebuilt the branch on current `master` to drop stale generated-status drift

## Test plan
- [x] `git diff --check`
- [x] `cargo test -p perl-dap --features dap-phase2 --locked --test dap_golden_transcript_tests -- --list`