### PR TITLE
perf(lsp): linear dedup for small highlight sets

### DIFF
--- a/crates/perl-lsp/src/features/document_highlight.rs
+++ b/crates/perl-lsp/src/features/document_highlight.rs
@@ -73,30 +73,74 @@ impl DocumentHighlightProvider {
         self.deduplicate_highlights(highlights)
     }
 
-    /// Deduplicate highlights by location, preferring Write kind over Read
+    /// Deduplicate highlights by location, preferring Write kind over Read.
+    ///
+    /// Uses linear scan for small inputs (<50 items) to avoid HashMap allocation
+    /// overhead, falling back to HashMap for larger inputs.
     fn deduplicate_highlights(&self, highlights: Vec<DocumentHighlight>) -> Vec<DocumentHighlight> {
+        /// Threshold below which linear scan outperforms HashMap
+        const LINEAR_THRESHOLD: usize = 50;
+
+        let mut result = if highlights.len() < LINEAR_THRESHOLD {
+            Self::dedup_linear(highlights)
+        } else {
+            Self::dedup_hashmap(highlights)
+        };
+
+        // Return sorted by position
+        result.sort_by_key(|h| h.location.start);
+        result
+    }
+
+    /// Linear-scan dedup for small inputs -- avoids HashMap allocation overhead.
+    fn dedup_linear(highlights: Vec<DocumentHighlight>) -> Vec<DocumentHighlight> {
+        let mut result: Vec<DocumentHighlight> = Vec::with_capacity(highlights.len());
+
+        for h in highlights {
+            let mut found = false;
+            for existing in &mut result {
+                if existing.location.start == h.location.start
+                    && existing.location.end == h.location.end
+                {
+                    // Prefer Write (3) over Read (2) over Text (1)
+                    if (h.kind as u8) > (existing.kind as u8) {
+                        existing.kind = h.kind;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                result.push(h);
+            }
+        }
+
+        result
+    }
+
+    /// HashMap-based dedup for larger inputs.
+    fn dedup_hashmap(highlights: Vec<DocumentHighlight>) -> Vec<DocumentHighlight> {
         use std::collections::HashMap;
 
-        // Group by location (start, end)
-        let mut by_location: HashMap<(usize, usize), DocumentHighlight> = HashMap::new();
+        let mut by_location: HashMap<(usize, usize), DocumentHighlight> =
+            HashMap::with_capacity(highlights.len());
 
         for h in highlights {
             let key = (h.location.start, h.location.end);
-            by_location
-                .entry(key)
-                .and_modify(|existing| {
+            match by_location.get_mut(&key) {
+                Some(existing) => {
                     // Prefer Write (3) over Read (2) over Text (1)
                     if (h.kind as u8) > (existing.kind as u8) {
-                        *existing = h.clone();
+                        existing.kind = h.kind;
                     }
-                })
-                .or_insert(h);
+                }
+                None => {
+                    by_location.insert(key, h);
+                }
+            }
         }
 
-        // Return sorted by position
-        let mut result: Vec<_> = by_location.into_values().collect();
-        result.sort_by_key(|h| h.location.start);
-        result
+        by_location.into_values().collect()
     }
 
     /// Find the node at the given byte offset


### PR DESCRIPTION
## Summary

- For small highlight vectors (<50 items), switches from HashMap-based dedup to linear scan, avoiding HashMap allocation overhead entirely
- For larger inputs, replaces `.and_modify().or_insert()` with `get_mut`/`insert` and copies only the `kind` field (Copy type) instead of cloning the full `DocumentHighlight` struct
- Adds `HashMap::with_capacity()` pre-allocation on the large-input path

Addresses performance hotspot #4 in document highlight dedup.

## Test plan

- [x] All 160 `perl-lsp` lib tests pass (including 14 document_highlight tests)
- [x] `cargo clippy -p perl-lsp --lib` clean
- [x] `cargo fmt --all` applied