### PR TITLE
fix(parser): handle ternary after named-unary operators

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -268,6 +268,32 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
+    /// Continue parsing ternary conditional when we already have the condition
+    /// expression.  Used by the statement-level named-unary tail so that
+    /// `defined $var ? then : else` is correctly wrapped in a Ternary node.
+    fn parse_ternary_with(&mut self, mut expr: Node) -> ParseResult<Node> {
+        if self.peek_kind() == Some(TokenKind::Question) {
+            self.tokens.next()?; // consume ?
+            let then_expr = self.parse_assignment()?;
+            self.expect(TokenKind::Colon)?;
+            let else_expr = self.parse_ternary()?;
+
+            let start = expr.location.start;
+            let end = else_expr.location.end;
+
+            expr = Node::new(
+                NodeKind::Ternary {
+                    condition: Box::new(expr),
+                    then_expr: Box::new(then_expr),
+                    else_expr: Box::new(else_expr),
+                },
+                SourceLocation { start, end },
+            );
+        }
+
+        Ok(expr)
+    }
+
     /// Parse logical OR expression
     fn parse_or(&mut self) -> ParseResult<Node> {
         let expr = self.parse_and()?;

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -430,6 +430,7 @@ impl<'a> Parser<'a> {
         expr = self.parse_bitwise_or_with(expr)?;
         expr = self.parse_and_with(expr)?;
         expr = self.parse_or_with(expr)?;
+        expr = self.parse_ternary_with(expr)?;
         self.parse_word_or_expr(expr)
     }
 

--- a/crates/perl-parser-core/tests/named_unary_ternary_tests.rs
+++ b/crates/perl-parser-core/tests/named_unary_ternary_tests.rs
@@ -1,0 +1,42 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_defined_ternary_basic() {
+    assert_clean_parse("defined $tzname ? $tzname : 'fallback';");
+}
+
+#[test]
+fn test_ref_ternary_basic() {
+    assert_clean_parse("ref $_[0] ? 1 : 0;");
+}
+
+#[test]
+fn test_defined_ternary_function_calls() {
+    assert_clean_parse("defined $base_path ? do_a() : do_b();");
+}
+
+#[test]
+fn test_defined_ternary_assignment() {
+    assert_clean_parse("my $val = defined $x ? $x : $default;");
+}
+
+#[test]
+fn test_ref_ternary_with_comparison() {
+    assert_clean_parse("ref $obj eq 'HASH' ? $obj->{key} : undef;");
+}
+
+#[test]
+fn test_defined_ternary_nested() {
+    assert_clean_parse("defined $a ? defined $b ? $b : $c : $d;");
+}
+
+#[test]
+fn test_exists_ternary() {
+    assert_clean_parse("exists $hash{$key} ? $hash{$key} : 'missing';");
+}
+
+#[test]
+fn test_defined_ternary_in_list_context() {
+    assert_clean_parse("push @result, defined $v ? $v : 0;");
+}


### PR DESCRIPTION
## Summary

- Add `parse_ternary_with` helper method in `precedence.rs` that applies ternary `? : ` parsing to an already-parsed expression node
- Call it from `parse_named_unary_statement_tail` in `statements.rs` between `parse_or_with` and `parse_word_or_expr`, closing the precedence gap
- Add 8 tests covering `defined`, `ref`, `exists` with ternary in various contexts (basic, nested, assignment, list context)

## Root Cause

In `parse_named_unary_statement_tail`, the precedence chain went: relational -> equality -> range -> bitwise_and -> bitwise_xor -> bitwise_or -> and -> or -> word_or_expr. The ternary level was missing between `or` and `word_or_expr`, so `defined $var ? then : else` left the `?` as an unexpected token.

## Test plan

- [x] All 8 new tests in `named_unary_ternary_tests.rs` pass
- [x] All 400 lib unit tests pass
- [x] Integration tests pass
- [x] `cargo clippy -p perl-parser-core --lib -- -D warnings` clean
- [x] Pre-existing failures in `named_unary_precedence_tests` (3 hash-deref tests) confirmed identical on master

Fixes #1888