### PR TITLE
perf(parser): eliminate clones in hash pair conversion

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
@@ -92,15 +92,22 @@ impl<'a> Parser<'a> {
             self.tokens.next()?; // consume }
             let end = self.previous_position();
 
-            // Check if the expression is an array literal that should be a hash
-            // This happens when parse_comma creates an array from key => value pairs
-            if let NodeKind::ArrayLiteral { elements } = &first_expr.kind {
-                // Check if this looks like hash pairs (even number of elements)
-                if elements.len() % 2 == 0 && !elements.is_empty() {
-                    // Convert array elements to hash pairs
-                    let mut pairs = Vec::new();
-                    for i in (0..elements.len()).step_by(2) {
-                        pairs.push((elements[i].clone(), elements[i + 1].clone()));
+            // Destructure first_expr to consume its kind by move, avoiding clones
+            let Node { kind: first_kind, location: first_loc } = first_expr;
+
+            match first_kind {
+                // Array literal that should be a hash: convert pairs via move
+                // This happens when parse_comma creates an array from key => value pairs
+                NodeKind::ArrayLiteral { elements }
+                    if elements.len() % 2 == 0 && !elements.is_empty() =>
+                {
+                    let mut pairs = Vec::with_capacity(elements.len() / 2);
+                    let mut iter = elements.into_iter();
+                    while let Some(key) = iter.next() {
+                        // Safety: len is even and non-zero, so values are always paired
+                        if let Some(value) = iter.next() {
+                            pairs.push((key, value));
+                        }
                     }
 
                     self.exit_recursion();
@@ -109,21 +116,24 @@ impl<'a> Parser<'a> {
                         SourceLocation { start, end },
                     ));
                 }
-            }
 
-            // If the expression is already a HashLiteral, return it directly
-            // This happens when parse_comma creates a HashLiteral from key => value pairs
-            if matches!(first_expr.kind, NodeKind::HashLiteral { .. }) {
-                self.exit_recursion();
-                return Ok(first_expr);
-            }
+                // Already a HashLiteral — return it directly
+                // This happens when parse_comma creates a HashLiteral from key => value pairs
+                kind @ NodeKind::HashLiteral { .. } => {
+                    self.exit_recursion();
+                    return Ok(Node::new(kind, first_loc));
+                }
 
-            // Otherwise it's a block with a single expression
-            self.exit_recursion();
-            return Ok(Node::new(
-                NodeKind::Block { statements: vec![first_expr] },
-                SourceLocation { start, end },
-            ));
+                // Otherwise it's a block with a single expression
+                other_kind => {
+                    let expr_node = Node::new(other_kind, first_loc);
+                    self.exit_recursion();
+                    return Ok(Node::new(
+                        NodeKind::Block { statements: vec![expr_node] },
+                        SourceLocation { start, end },
+                    ));
+                }
+            }
         }
 
         // If there's more content, we need to determine if it's hash pairs or block statements


### PR DESCRIPTION
## Summary

- Replaced linear indexed-clone loop in hash pair conversion with move semantics using `into_iter()`, eliminating O(n) deep clones of AST Node elements
- Restructured sequential `if let` / `if matches!` checks into a single exhaustive `match` on the owned `NodeKind`, enabling the compiler to move data instead of copying
- Added `Vec::with_capacity` pre-allocation for the pairs vector

## Details

File: `crates/perl-parser-core/src/engine/parser/expressions/hashes.rs` (~line 97)

The original code borrowed `first_expr.kind` via `&first_expr.kind` and then cloned each element pair:
```rust
pairs.push((elements[i].clone(), elements[i + 1].clone()));
```

The fix destructures the owned `first_expr` and uses `elements.into_iter()` to move elements directly into pairs with zero clones. This is a pure performance improvement with no behavioral change.

## Test plan

- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy -p perl-parser-core --lib` -- clean (no warnings)
- [x] `cargo test -p perl-parser-core` -- all 400+ lib tests pass; 3 pre-existing failures in external test files (same on master)