### PR TITLE
test(parser-core): add paren recovery test coverage

### DIFF
--- a/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
+++ b/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
@@ -42,6 +42,46 @@ pub fn assert_clean_parse(source: &str) {
     }
 }
 
+/// Error markers used by both `assert_clean_parse` and `assert_has_error`.
+const ERROR_MARKERS: &[&str] = &[
+    "(error ",
+    "(Error ",
+    "(ERROR ",
+    "(missing_expression",
+    "(missing_statement",
+    "(missing_identifier",
+    "(missing_block",
+    "MissingExpression",
+    "MissingStatement",
+    "MissingIdentifier",
+    "MissingBlock",
+];
+
+/// Assert that a parsed AST contains at least one Error or Missing* node
+/// whose sexp representation contains the given `needle` substring.
+///
+/// This is the inverse of `assert_clean_parse` — it verifies that the parser
+/// correctly reports an error for malformed input.
+pub fn assert_has_error(source: &str, needle: &str) {
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    let sexp_lower = sexp.to_lowercase();
+    let needle_lower = needle.to_lowercase();
+
+    // First verify there IS an error node somewhere.
+    let has_any_error = ERROR_MARKERS.iter().any(|marker| sexp.contains(marker));
+    assert!(has_any_error, "Expected an error node for source:\n{}\n\nsexp:\n{}", source, sexp,);
+
+    // Then verify the needle appears (case-insensitive) in the sexp.
+    assert!(
+        sexp_lower.contains(&needle_lower),
+        "Expected error containing '{}' for source:\n{}\n\nsexp:\n{}",
+        needle,
+        source,
+        sexp,
+    );
+}
+
 /// Extract top-level statement kinds from a Program node.
 pub fn top_level_kinds(ast: &perl_parser_core::Node) -> Vec<&str> {
     match &ast.kind {

--- a/crates/perl-parser-core/tests/paren_recovery_tests.rs
+++ b/crates/perl-parser-core/tests/paren_recovery_tests.rs
@@ -1,0 +1,59 @@
+//! Tests for parenthesis recovery — the #1 test gap (288 error nodes).
+//!
+//! Validates that the parser produces error nodes for unclosed/malformed
+//! parenthesized expressions and parses well-formed ones cleanly.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// ── Error cases: malformed parenthesized expressions ───────────────────
+
+#[test]
+fn test_unclosed_paren_with_identifier_tail_produces_error() {
+    // Parser should report an error for the unexpected identifier inside parens.
+    assert_has_error("print($foo bar)", "expected");
+}
+
+#[test]
+fn test_unclosed_paren_at_eof_produces_error() {
+    // Missing closing paren at end of input.
+    assert_has_error("my @x = (1, 2, 3", "expected");
+}
+
+#[test]
+fn test_mixed_sigils_in_unclosed_paren_produces_error() {
+    // Missing closing paren with mixed variable sigils.
+    assert_has_error("foo($x, @y, %z", "expected");
+}
+
+// ── Clean cases: well-formed parenthesized expressions ─────────────────
+
+#[test]
+fn test_function_call_with_scalar_args_parses_clean() {
+    assert_clean_parse("print($foo, $bar);");
+}
+
+#[test]
+fn test_array_assignment_with_paren_list_parses_clean() {
+    assert_clean_parse("my @x = (1, 2, 3);");
+}
+
+#[test]
+fn test_function_call_with_mixed_sigils_parses_clean() {
+    assert_clean_parse("foo($x, @y, %z);");
+}
+
+#[test]
+fn test_map_block_with_paren_list_parses_clean() {
+    assert_clean_parse("map { $_ + 1 } (1, 2, 3);");
+}
+
+#[test]
+fn test_list_declaration_with_assignment_parses_clean() {
+    assert_clean_parse("my ($a, $b) = @_;");
+}
+
+#[test]
+fn test_list_assignment_parses_clean() {
+    assert_clean_parse("($a, $b, $c) = (1, 2, 3);");
+}


### PR DESCRIPTION
## Summary

- Adds 9 tests in `paren_recovery_tests.rs` covering the #1 test gap (288 error nodes) for parenthesis recovery
- 3 error-case tests verify the parser produces error nodes for unclosed/malformed paren expressions (unclosed with identifier tail, unclosed at EOF, mixed sigils unclosed)
- 6 clean-parse tests verify well-formed parenthesized expressions parse without errors (function calls, array assignments, mixed sigils, map blocks, list declarations, list assignments)
- Adds reusable `assert_has_error(source, needle)` helper to `cpan_test_helpers` for future error-detection tests

## Test plan

- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy -p perl-parser-core --test paren_recovery_tests` -- clean
- [x] `cargo test -p perl-parser-core --test paren_recovery_tests` -- 9/9 pass
- [x] `cargo test -p perl-parser-core` -- no regressions (3 pre-existing failures in `named_unary_precedence_tests` unrelated to this PR)