### PR TITLE
fix(lexer): disambiguate regex after bare builtins

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1951,7 +1951,13 @@ impl<'a> PerlLexer<'a> {
                 }
                 TokenType::Keyword(Arc::from(text))
             } else {
-                self.mode = LexerMode::ExpectOperator;
+                // Mirror parser bare-builtin handling so `/` after builtins like
+                // `join` or `print` is lexed as a regex term, not division.
+                if is_builtin_function(text) {
+                    self.mode = LexerMode::ExpectTerm;
+                } else {
+                    self.mode = LexerMode::ExpectOperator;
+                }
                 TokenType::Identifier(Arc::from(text))
             };
 
@@ -3094,6 +3100,18 @@ fn is_keyword(word: &str) -> bool {
     matches!(word.len(), 1..=9) && is_lexer_keyword(word)
 }
 
+#[inline]
+fn is_builtin_function(word: &str) -> bool {
+    BARE_TERM_BUILTINS.binary_search(&word).is_ok()
+}
+
+const BARE_TERM_BUILTINS: &[&str] = &[
+    "abs", "chomp", "chop", "chr", "close", "defined", "delete", "each", "exists", "hex", "int",
+    "join", "keys", "lc", "lcfirst", "length", "oct", "open", "ord", "pack", "print", "push",
+    "read", "ref", "reverse", "rindex", "say", "scalar", "splice", "sprintf", "sqrt", "substr",
+    "tie", "uc", "ucfirst", "unpack", "unshift", "untie", "values", "write",
+];
+
 /// Fast lookup table for compound operator second characters
 const COMPOUND_SECOND_CHARS: &[u8] = b"=<>&|+->.~*";
 
@@ -3299,6 +3317,39 @@ mod tests {
         lexer.next_token(); // 2
         let token = lexer.next_token().ok_or("Expected exponent operator token")?;
         assert!(matches!(token.token_type, TokenType::Operator(ref op) if op.as_ref() == "**"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_regex_disambiguation() -> TestResult {
+        let mut lexer = PerlLexer::new("join /,/, @parts");
+        let token = lexer.next_token().ok_or("Expected join token")?;
+        assert!(matches!(token.token_type, TokenType::Identifier(ref id) if id.as_ref() == "join"));
+
+        let token = lexer.next_token().ok_or("Expected regex token")?;
+        assert_eq!(token.token_type, TokenType::RegexMatch);
+        Ok(())
+    }
+
+    #[test]
+    fn test_builtin_regex_disambiguation() -> TestResult {
+        for code in ["print /pattern/", "defined /pattern/", "keys /pattern/"] {
+            let mut lexer = PerlLexer::new(code);
+            lexer.next_token();
+            let token = lexer.next_token().ok_or("Expected regex token")?;
+            assert_eq!(token.token_type, TokenType::RegexMatch, "{code}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_nullary_builtin_division_disambiguation() -> TestResult {
+        let mut lexer = PerlLexer::new("time / 2");
+        let token = lexer.next_token().ok_or("Expected time token")?;
+        assert!(matches!(token.token_type, TokenType::Identifier(ref id) if id.as_ref() == "time"));
+
+        let token = lexer.next_token().ok_or("Expected division token")?;
+        assert_eq!(token.token_type, TokenType::Division);
         Ok(())
     }
 }

--- a/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
+++ b/crates/perl-lexer/tests/hang_risk_slash_ambiguity_tests.rs
@@ -700,10 +700,9 @@ fn lexer_slash_ambiguity_real_world_regex_in_map_grep() -> TestResult {
 // ═══════════════════════════════════════════════════════════════════════
 // Split/join/grep/map/sort slash disambiguation tests
 //
-// These tests verify that `/pattern/` after list-operator keywords is
-// correctly interpreted as a regex, while `$x / $y` and `10 / 2` remain
-// division.  The lexer sets `LexerMode::ExpectTerm` after split, grep,
-// map, and sort, which causes `/` to be parsed as a regex delimiter.
+// These tests verify that `/pattern/` after list operators and bare
+// builtins is correctly interpreted as a regex, while `$x / $y` and
+// `10 / 2` remain division.
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Test `split /,/, $string` — regex separator after split
@@ -757,22 +756,16 @@ fn lexer_slash_split_regex_whitespace_quantifier() -> TestResult {
     Ok(())
 }
 
-/// Test `join /,/, @parts` — slash after join
+/// Test `join /,/, @parts` — regex separator after bare builtin
 ///
-/// `join` is NOT in the lexer's `LEXER_KEYWORDS` list, so it is treated as
-/// an `Identifier` rather than a `Keyword`.  After an identifier the lexer
-/// enters `ExpectOperator` mode, so the slash is interpreted as division.
-///
-/// This is a known limitation: in Perl, `join /,/, @parts` uses a regex as
-/// the separator, but the lexer currently treats the `/` as division.  If
-/// `join` is added to `LEXER_KEYWORDS` and the `ExpectTerm` list in the
-/// future, this test should be updated to expect `RegexMatch`.
+/// `join` stays an identifier token, but as a builtin that takes a term
+/// argument it should still put the lexer into `ExpectTerm`.
 #[test]
-fn lexer_slash_join_slash_is_division() -> TestResult {
+fn lexer_slash_join_regex_separator() -> TestResult {
     let code = "join /,/, @parts";
     let mut lexer = PerlLexer::new(code);
 
-    // First token: join is treated as an identifier (not in LEXER_KEYWORDS)
+    // First token: join is still lexed as an identifier.
     let tok = lexer.next_token().ok_or("Expected join token")?;
     assert!(
         matches!(tok.token_type, TokenType::Identifier(ref id) if id.as_ref() == "join"),
@@ -780,18 +773,13 @@ fn lexer_slash_join_slash_is_division() -> TestResult {
         tok.token_type
     );
 
-    // After an identifier, lexer is in ExpectOperator mode, so the slash
-    // is treated as division.
-    let tok = lexer.next_token().ok_or("Expected division token after join")?;
+    let tok = lexer.next_token().ok_or("Expected regex token after join")?;
     assert!(
-        matches!(tok.token_type, TokenType::Division),
-        "Expected division after join (current behavior), got {:?}",
+        matches!(tok.token_type, TokenType::RegexMatch),
+        "Expected regex after join, got {:?}",
         tok.token_type
     );
 
-    // The lexer should not hang — collect remaining tokens to verify termination.
-    // Use `while let` since the lexer may return `None` before an explicit EOF
-    // when input is exhausted in an unusual token state.
     while let Some(tok) = lexer.next_token() {
         if matches!(tok.token_type, TokenType::EOF) {
             break;

--- a/crates/perl-parser-core/tests/fix_builtin_regex_disambiguation.rs
+++ b/crates/perl-parser-core/tests/fix_builtin_regex_disambiguation.rs
@@ -1,0 +1,27 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn split_bare_regex_separator_parses_cleanly() {
+    assert_clean_parse("my @parts = split /,/, $string;");
+}
+
+#[test]
+fn join_bare_regex_separator_parses_cleanly() {
+    assert_clean_parse("my $joined = join /,/, @parts;");
+}
+
+#[test]
+fn grep_bare_regex_expression_parses_cleanly() {
+    assert_clean_parse("my @matches = grep /pattern/, @list;");
+}
+
+#[test]
+fn map_bare_regex_expression_parses_cleanly() {
+    assert_clean_parse("my @flags = map /pattern/, @list;");
+}
+
+#[test]
+fn print_bare_regex_argument_parses_cleanly() {
+    assert_clean_parse("print /pattern/;");
+}


### PR DESCRIPTION
## Summary
- treat bare builtins like `join`, `print`, and `defined` as term contexts so a following `/.../` is lexed as regex instead of division
- update the slash ambiguity regression suite to expect the real `join /,/, @parts` behavior instead of documenting it as a limitation
- add parser-core integration coverage for split/join/grep/map/print forms that depend on the lexer fix

## Validation
- cargo fmt --all
- cargo test -p perl-lexer --locked
- cargo test -p perl-parser-core --locked --test fix_builtin_regex_disambiguation
- cargo clippy -p perl-lexer --tests --locked -- -D warnings
