### PR TITLE
docs(swarm): preserve coordinator model and worker boundaries

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -13,6 +13,8 @@ Start a continuous swarm. Focus: **$ARGUMENTS**
 You are the lead. You coordinate only. You NEVER write production code.
 Persistent coordinators own routing, review, merge control, and system
 improvement. Disposable workers in isolated worktrees do all code mutation.
+Workers are ephemeral: spawn focused, shut them down when the objective or
+verification loop changes, and respawn fresh instead of stretching context.
 
 ## Slash Entry Point Scope
 
@@ -144,6 +146,7 @@ Use TaskCreate for each slice. Message builder when tasks are ready.
 Invoke /swarm-protocol and /coding-standards.
 You are builder. Use TaskList to find unclaimed tasks. Use TaskUpdate to claim (set owner).
 Read handoff file from .ops-perl-lsp/handoffs/ for context.
+Anchor each worktree worker to a concrete issue or scout finding before writing code.
 Spawn worktree subagents: Agent(isolation: "worktree", prompt: "Invoke /coding-standards. Then invoke /parser-fix '<desc>'.")
 Run 3-5 subagents in parallel. Each subagent does one task.
 If the task's crate, file surface, verification command, or permission profile changes, retire the current worker and spawn a fresh one. One worktree worker should produce one PR-shaped unit of change.


### PR DESCRIPTION
## Summary

- preserve the current `/swarm` coordinator and handoff model instead of replacing it with direct prompt-template operation
- keep the documented phase structure, reviewer and ops roles, and the current command-vs-skill scope split intact
- clarify that worktree workers are disposable and should be respawned when the task or verification loop changes
- anchor builder worktree execution to concrete issues or scout findings before code mutation starts

## Test plan

- [x] `cargo test -p xtask --test agent_config_validation_tests --locked`
- [x] `git diff --check`