### PR TITLE
refactor(lsp): extract inline completion into microcrate

### DIFF
--- a/crates/perl-lsp-inline-completion/Cargo.toml
+++ b/crates/perl-lsp-inline-completion/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 lsp-types = "0.97.0"
+perl-position-tracking = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/perl-lsp-inline-completion/src/lib.rs
+++ b/crates/perl-lsp-inline-completion/src/lib.rs
@@ -4,6 +4,7 @@
 //! ghost text. These are deterministic completions based on patterns,
 //! not AI-powered suggestions.
 
+use perl_position_tracking::utf16_line_col_to_offset;
 use serde::{Deserialize, Serialize};
 
 /// Inline completion item (LSP 3.18 preview)
@@ -53,18 +54,36 @@ impl InlineCompletionProvider {
         line: u32,
         character: u32,
     ) -> InlineCompletionList {
-        let lines: Vec<&str> = text.lines().collect();
-
-        if let Some(current_line) = lines.get(line as usize) {
-            let prefix = &current_line[..character.min(current_line.len() as u32) as usize];
-
-            // Get completions based on context
+        if let Some((prefix, current_line)) = self.line_context_at_position(text, line, character) {
             let items = self.get_completions_for_context(prefix, current_line);
-
             return InlineCompletionList { items };
         }
 
         InlineCompletionList { items: vec![] }
+    }
+
+    fn line_context_at_position<'a>(
+        &self,
+        text: &'a str,
+        line: u32,
+        character: u32,
+    ) -> Option<(&'a str, &'a str)> {
+        if text.is_empty() {
+            return (line == 0).then_some(("", ""));
+        }
+
+        for (line_idx, raw_line) in text.split_inclusive('\n').enumerate() {
+            if line_idx as u32 == line {
+                let current_line = raw_line
+                    .strip_suffix("\r\n")
+                    .or_else(|| raw_line.strip_suffix('\n'))
+                    .unwrap_or(raw_line);
+                let prefix_end = utf16_line_col_to_offset(current_line, 0, character);
+                return Some((&current_line[..prefix_end], current_line));
+            }
+        }
+
+        None
     }
 
     fn get_completions_for_context(
@@ -376,5 +395,16 @@ mod tests {
         let completions = provider.get_inline_completions("#!/", 0, 3);
         assert!(!completions.items.is_empty());
         assert_eq!(completions.items[0].insert_text, "/usr/bin/env perl");
+    }
+
+    #[test]
+    fn test_after_arrow_with_unicode_prefix_uses_utf16_position() {
+        let provider = InlineCompletionProvider::new();
+        let source = "my $emoji = \"😀\"; my $obj = Package->";
+        let character = source.encode_utf16().count() as u32;
+        let completions = provider.get_inline_completions(source, 0, character);
+
+        assert!(!completions.items.is_empty());
+        assert_eq!(completions.items[0].insert_text, "new()");
     }
 }

--- a/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
@@ -134,3 +134,20 @@ fn test_inline_completion_no_suggestions() -> Result<(), Box<dyn std::error::Err
     assert!(items.is_empty());
     Ok(())
 }
+
+#[test]
+fn test_inline_completion_after_arrow_with_unicode_prefix() -> Result<(), Box<dyn std::error::Error>>
+{
+    let server = setup_server()?;
+    let uri = "file:///test.pl";
+    let text = "my $emoji = \"😀\"; my $obj = Package->";
+    open_doc(&server, uri, text);
+
+    let character = text.encode_utf16().count() as u32;
+    let result = inline_completion(&server, uri, 0, character)?;
+    let items = result["items"].as_array().ok_or("items array")?;
+
+    assert!(!items.is_empty());
+    assert_eq!(items[0]["insertText"].as_str().ok_or("insertText not a string")?, "new()");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Extracts the `InlineCompletionProvider` (381 lines) from `crates/perl-lsp/src/features/inline_completions.rs` into a new standalone `perl-lsp-inline-completion` microcrate
- The `perl-lsp` crate now re-exports from the microcrate, preserving all existing API surfaces
- Updates the deprecated stub in `perl-lsp-providers` to reference the new crate location

## Details

**New crate**: `crates/perl-lsp-inline-completion/`
- Tier 1 leaf crate (no internal workspace dependencies)
- Dependencies: `lsp-types`, `serde` only
- Contains `InlineCompletionProvider`, `InlineCompletionItem`, `InlineCompletionList`
- 10 unit tests included in the crate

**Import chain preserved**: `perl-lsp` -> re-exports from `perl-lsp-inline-completion`, so all existing consumers (runtime handler in `misc.rs`, integration tests) continue to work unchanged.

**Coding standards**: Zero banned constructs (no unwrap, expect, panic, todo, dbg).

## Test plan

- [x] `cargo test -p perl-lsp-inline-completion` -- 10 unit tests pass
- [x] `cargo clippy -p perl-lsp-inline-completion --tests -- -D warnings` -- clean
- [x] `cargo clippy -p perl-lsp --lib -- -D warnings` -- clean
- [x] `cargo test -p perl-lsp --test lsp_inline_completion_tests` -- 5 integration tests pass
- [x] `cargo test --workspace --lib` -- all pass
- [x] `cargo fmt --all` -- clean