### PR TITLE
fix(parser): recover field bareword calls in recovery parser

### DIFF
--- a/crates/perl-parser-core/src/engine/error/recovery_parser.rs
+++ b/crates/perl-parser-core/src/engine/error/recovery_parser.rs
@@ -9,7 +9,7 @@ use crate::{
         ErrorRecovery, ParseError, ParserErrorRecovery, StatementRecovery, SyncPoint,
     },
     parser_context::ParserContext,
-    position::Range,
+    position::{Position, Range},
 };
 use perl_lexer::TokenType;
 
@@ -214,12 +214,85 @@ impl StatementRecovery for RecoveryParser {
 
 // Core parsing methods (simplified for demonstration)
 impl RecoveryParser {
+    /// Returns `true` when `field` is followed by a sigil-prefixed variable.
+    fn is_field_followed_by_sigil(&self) -> bool {
+        self.context.peek_token(1).is_some_and(|token| {
+            matches!(
+                &token.token.token_type,
+                TokenType::Identifier(name)
+                    if matches!(name.chars().next(), Some('$' | '@' | '%' | '*' | '&'))
+            )
+        })
+    }
+
+    /// Consume a parenthesized argument list so recovery stays on one statement.
+    fn skip_parenthesized_suffix(&mut self) -> Result<Position, ParseError> {
+        let mut depth = 0usize;
+        let mut last_end = self.context.current_position();
+
+        loop {
+            let Some(token) = self.context.current_token() else {
+                let error = ParseError::new(
+                    "Expected ')' to close argument list".to_string(),
+                    self.context.current_position_range(),
+                )
+                .with_expected(vec![")".to_string()]);
+                self.context.add_error(error);
+                return Ok(last_end);
+            };
+
+            let token_type = token.token.token_type.clone();
+            let token_end = token.range().end;
+
+            match token_type {
+                TokenType::LeftParen => {
+                    depth += 1;
+                    last_end = token_end;
+                    self.context.advance();
+                }
+                TokenType::RightParen => {
+                    depth = depth.saturating_sub(1);
+                    last_end = token_end;
+                    self.context.advance();
+                    if depth == 0 {
+                        return Ok(last_end);
+                    }
+                }
+                _ => {
+                    last_end = token_end;
+                    self.context.advance();
+                }
+            }
+        }
+    }
+
+    /// Parse a bareword-like expression, optionally consuming a call suffix.
+    fn parse_bareword_expression(&mut self, name: String) -> Result<Node, ParseError> {
+        let start_pos = self.context.current_position();
+        let mut end_pos = self.context.current_position_range().end;
+
+        self.context.advance();
+
+        if self.context.check(&TokenType::LeftParen) {
+            end_pos = self.skip_parenthesized_suffix()?;
+        }
+
+        Ok(Node::new(
+            self.context.id_generator.next_id(),
+            NodeKind::Identifier { name },
+            Range::new(start_pos, end_pos),
+        ))
+    }
+
     /// Try to parse a statement
     fn try_parse_statement(&mut self) -> Result<Node, ParseError> {
         match self.context.current_token() {
             Some(token) => match &token.token.token_type {
                 TokenType::Keyword(kw) => match kw.as_ref() {
-                    "my" | "our" | "local" | "state" | "field" => self.parse_variable_declaration(),
+                    "my" | "our" | "local" | "state" => self.parse_variable_declaration(),
+                    "field" if self.is_field_followed_by_sigil() => {
+                        self.parse_variable_declaration()
+                    }
                     "if" => self.parse_if_statement(),
                     "while" => self.parse_while_statement(),
                     "sub" => self.parse_subroutine(),
@@ -341,7 +414,16 @@ impl RecoveryParser {
                     );
                     Ok(node)
                 }
-                TokenType::Identifier(_) => self.parse_variable(),
+                TokenType::Identifier(name) => {
+                    if matches!(name.chars().next(), Some('$' | '@' | '%' | '*' | '&')) {
+                        self.parse_variable()
+                    } else {
+                        self.parse_bareword_expression(name.to_string())
+                    }
+                }
+                TokenType::Keyword(kw) if kw.as_ref() == "field" => {
+                    self.parse_bareword_expression(kw.to_string())
+                }
                 _ => Err(ParseError::new("Expected expression".to_string(), token.range())),
             },
             None => Err(ParseError::new(

--- a/crates/perl-parser-core/tests/recovery_parser_tests.rs
+++ b/crates/perl-parser-core/tests/recovery_parser_tests.rs
@@ -210,6 +210,71 @@ fn local_declarator() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn field_keyword_with_sigil_is_declaration() -> Result<(), Box<dyn std::error::Error>> {
+    let parser = RecoveryParser::new("field $name".to_string());
+    let (ast, errors) = parser.parse();
+
+    match &ast.kind {
+        V2NodeKind::Program { statements } => {
+            assert_eq!(statements.len(), 1);
+            match &statements[0].kind {
+                V2NodeKind::VariableDeclaration { declarator, .. } => {
+                    assert_eq!(declarator, "field");
+                }
+                other => {
+                    return Err(format!("expected VariableDeclaration, got {:?}", other).into());
+                }
+            }
+        }
+        other => return Err(format!("expected Program, got {:?}", other).into()),
+    }
+
+    assert!(errors.is_empty(), "field declaration should not produce errors");
+    Ok(())
+}
+
+#[test]
+fn field_keyword_call_is_not_treated_as_declaration() -> Result<(), Box<dyn std::error::Error>> {
+    let parser = RecoveryParser::new("field('name')".to_string());
+    let (ast, errors) = parser.parse();
+
+    match &ast.kind {
+        V2NodeKind::Program { statements } => {
+            assert_eq!(statements.len(), 1);
+            match &statements[0].kind {
+                V2NodeKind::Identifier { name } => assert_eq!(name, "field"),
+                other => return Err(format!("expected Identifier, got {:?}", other).into()),
+            }
+        }
+        other => return Err(format!("expected Program, got {:?}", other).into()),
+    }
+
+    assert!(errors.is_empty(), "field(...) should recover as a single bareword expression");
+    Ok(())
+}
+
+#[test]
+fn spaced_field_call_with_variable_args_is_not_declaration()
+-> Result<(), Box<dyn std::error::Error>> {
+    let parser = RecoveryParser::new("field ($x, $y)".to_string());
+    let (ast, errors) = parser.parse();
+
+    match &ast.kind {
+        V2NodeKind::Program { statements } => {
+            assert_eq!(statements.len(), 1);
+            match &statements[0].kind {
+                V2NodeKind::Identifier { name } => assert_eq!(name, "field"),
+                other => return Err(format!("expected Identifier, got {:?}", other).into()),
+            }
+        }
+        other => return Err(format!("expected Program, got {:?}", other).into()),
+    }
+
+    assert!(errors.is_empty(), "field ($x, $y) should stay an expression in recovery mode");
+    Ok(())
+}
+
+#[test]
 fn state_declarator() -> Result<(), Box<dyn std::error::Error>> {
     let parser = RecoveryParser::new("state $counter = 0".to_string());
     let (ast, errors) = parser.parse();


### PR DESCRIPTION
## Summary

- trims this PR down to the remaining recovery-parser follow-up after `#1978` landed the main parser-side `field` disambiguation
- treats `field` as a declaration in `RecoveryParser` only when the next token starts with a sigil
- recovers bareword calls like `field('name')` and `field ($x, $y)` as a single expression by consuming the parenthesized suffix instead of splitting them into bogus follow-on statements
- adds focused recovery-parser tests for declaration vs call behavior

## Why this is still needed

`#1978` fixed the main parser path, but the older `RecoveryParser` still routed every `field` keyword through variable-declaration parsing. That meant recovery-mode parses still misclassified `field` calls, and the original `#1979` branch had gone stale and overlapped heavily with already-merged work. This update keeps only the distinct recovery-parser fix on top of current `master`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p perl-parser-core --test recovery_parser_tests --locked`
- [x] `cargo test -p perl-parser-core --test fix_field_keyword_regression --locked`
- [x] `cargo clippy -p perl-parser-core --test recovery_parser_tests --locked -- -D warnings`