### PR TITLE
fix(ci): unblock clippy_full and v2 bundle sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
  "perl-tdd-support",
  "pest",
  "pest_derive",
+ "regex",
  "serde",
  "stacker",
  "thiserror",

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -959,7 +959,7 @@ impl DebugAdapter {
         if std::env::var_os("LLVM_PROFILE_FILE").is_some()
             || std::env::var_os("CARGO_LLVM_COV").is_some()
         {
-            base.max(15_000).min(30_000)
+            base.clamp(15_000, 30_000)
         } else {
             base
         }

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -18,6 +18,7 @@ include = ["src/**", "src/grammar.pest", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 pest = "2.8.6"
 pest_derive = "2.8.6"
+regex = "1.12.2"
 stacker = "0.1.23"
 thiserror = "2.0.18"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-parser-pest/src/grammar.pest
+++ b/crates/perl-parser-pest/src/grammar.pest
@@ -196,15 +196,23 @@ for_statement = {
         // C-style for loop
         ("(" ~ (for_init | assignment_expression)? ~ ";" ~ expression? ~ ";" ~ expression? ~ ")" ~ block) |
         // foreach-style for loop with variable declaration
-        (("my" | "our" | "local" | "state")? ~ variable ~ "(" ~ expression ~ ")" ~ block) |
+        (loop_variable_declarator ~ variable ~ "(" ~ expression ~ ")" ~ block) |
+        // foreach-style for loop with explicit variable
+        (variable ~ "(" ~ expression ~ ")" ~ block) |
         // foreach-style for loop without variable (uses $_)
         ("(" ~ expression ~ ")" ~ block)
     )
 }
 
 foreach_statement = {
-    label? ~ "foreach" ~ !(ASCII_ALPHANUMERIC | "_") ~ variable? ~ "(" ~ expression ~ ")" ~ block
+    label? ~ "foreach" ~ !(ASCII_ALPHANUMERIC | "_") ~ (
+        (loop_variable_declarator ~ variable ~ "(" ~ expression ~ ")" ~ block) |
+        (variable ~ "(" ~ expression ~ ")" ~ block) |
+        ("(" ~ expression ~ ")" ~ block)
+    )
 }
+
+loop_variable_declarator = { "my" | "our" | "local" | "state" }
 
 for_init = { declaration | assignment_expression | expression }
 
@@ -305,9 +313,10 @@ assignment_expression = {
 }
 
 assignment_operator = {
-    "=" ~ !("~") | "+=" | "-=" | "*=" | "_DIV_=" | "/=" | "%=" | "**=" | ".=" | "<<=" | ">>=" | "&=" | "|=" | "^="
+    assignment_eq | "+=" | "-=" | "*=" | "_DIV_=" | "/=" | "%=" | "**=" | ".=" | "<<=" | ">>=" | "&=" | "|=" | "^="
     | "&&=" | "||=" | "//=" | "&.=" | "|.=" | "^.="
 }
+assignment_eq = @{ "=" ~ !"~" }
 
 ternary_expression = {
     logical_or_expression ~ ("?" ~ expression ~ ":" ~ expression)?

--- a/crates/perl-parser-pest/src/pure_rust_parser.rs
+++ b/crates/perl-parser-pest/src/pure_rust_parser.rs
@@ -9,8 +9,9 @@ use pest::{
     iterators::{Pair, Pairs},
 };
 use pest_derive::Parser;
+use regex::Regex;
 use stacker;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
@@ -115,6 +116,10 @@ pub enum AstNode {
         false_expr: Box<AstNode>,
     },
     PostfixDereference {
+        expr: Box<AstNode>,
+        deref_type: Arc<str>,
+    },
+    Dereference {
         expr: Box<AstNode>,
         deref_type: Arc<str>,
     },
@@ -323,13 +328,61 @@ impl PureRustPerlParser {
 
     #[inline(always)]
     pub fn parse(&mut self, source: &str) -> Result<AstNode, Box<dyn std::error::Error>> {
-        match <PerlParser as Parser<Rule>>::parse(Rule::program, source) {
+        let normalized = Self::normalize_source(source);
+
+        match <PerlParser as Parser<Rule>>::parse(Rule::program, &normalized) {
             Ok(pairs) => self.build_ast(pairs),
             Err(e) => {
                 // Attempt partial parsing by trying to parse individual statements
-                self.parse_with_recovery(source, e)
+                self.parse_with_recovery(&normalized, e)
             }
         }
+    }
+
+    fn normalize_source(source: &str) -> String {
+        static LOOP_DECL_RE: OnceLock<Option<Regex>> = OnceLock::new();
+        static SIMPLE_SCALAR_DEREF_RE: OnceLock<Option<Regex>> = OnceLock::new();
+        static ASSIGN_BITNOT_RE: OnceLock<Option<Regex>> = OnceLock::new();
+
+        // These are fixed patterns; if one ever fails to compile, skip normalization
+        // rather than panicking inside production parser code.
+        let Some(loop_decl_re) = LOOP_DECL_RE
+            .get_or_init(|| {
+                Regex::new(
+                    r"\b(?P<kw>for(?:each)?)\s+(?:my|our|local|state)\s+(?P<var>\$[A-Za-z_][A-Za-z0-9_:]*)\s*(?P<paren>\()",
+                )
+                .ok()
+            })
+            .as_ref()
+        else {
+            return source.to_string();
+        };
+        let Some(scalar_deref_re) = SIMPLE_SCALAR_DEREF_RE
+            .get_or_init(|| Regex::new(r"\$\$(?P<name>[A-Za-z_][A-Za-z0-9_:]*)").ok())
+            .as_ref()
+        else {
+            return source.to_string();
+        };
+        let Some(assign_bitnot_re) = ASSIGN_BITNOT_RE
+            .get_or_init(|| Regex::new(r"=\s+~\s*(?P<expr>\$[A-Za-z_][A-Za-z0-9_:]*)").ok())
+            .as_ref()
+        else {
+            return source.to_string();
+        };
+
+        let normalized_loops = loop_decl_re.replace_all(source, "$kw $var $paren").into_owned();
+        let normalized_derefs = scalar_deref_re
+            .replace_all(&normalized_loops, |caps: &regex::Captures<'_>| {
+                let variable = format!("${}", &caps["name"]);
+                format!("${{{}}}", variable)
+            })
+            .into_owned();
+
+        assign_bitnot_re
+            .replace_all(&normalized_derefs, |caps: &regex::Captures<'_>| {
+                format!("= bitnot({})", &caps["expr"])
+            })
+            .into_owned()
     }
 
     fn parse_with_recovery(
@@ -1815,11 +1868,15 @@ impl PureRustPerlParser {
                 let mut variable = None;
                 let mut list = None;
                 let mut block = None;
+                let mut declarator = None;
 
                 for p in inner {
                     match p.as_rule() {
                         Rule::label => {
                             label = Some(Arc::from(p.as_str().trim_end_matches(':')));
+                        }
+                        Rule::loop_variable_declarator => {
+                            declarator = Some(Arc::from(p.as_str()));
                         }
                         Rule::variable => {
                             variable = Some(Box::new(
@@ -1840,9 +1897,21 @@ impl PureRustPerlParser {
                     }
                 }
 
+                let final_variable = if let Some(decl) = declarator {
+                    variable.map(|var| {
+                        Box::new(AstNode::VariableDeclaration {
+                            scope: decl,
+                            variables: vec![*var],
+                            initializer: None,
+                        })
+                    })
+                } else {
+                    variable
+                };
+
                 Ok(Some(AstNode::ForeachStatement {
                     label,
-                    variable,
+                    variable: final_variable,
                     list: list.unwrap_or_else(|| Box::new(AstNode::EmptyExpression)),
                     block: block.unwrap_or_else(|| Box::new(AstNode::EmptyExpression)),
                 }))
@@ -1896,16 +1965,13 @@ impl PureRustPerlParser {
                                 self.build_node(p)?.unwrap_or(AstNode::EmptyExpression),
                             ));
                         }
+                        Rule::loop_variable_declarator => {
+                            declarator = Some(Arc::from(p.as_str()));
+                        }
                         Rule::block => {
                             block = self.build_node(p)?.map(Box::new);
                         }
-                        _ => {
-                            // Check for declarators (my, our, local, state)
-                            let text = p.as_str();
-                            if matches!(text, "my" | "our" | "local" | "state") {
-                                declarator = Some(Arc::from(text));
-                            }
-                        }
+                        _ => {}
                     }
                 }
 
@@ -2026,6 +2092,10 @@ impl PureRustPerlParser {
                 let inner = pair.into_inner().next().ok_or("Empty reference")?;
                 self.build_node(inner)
             }
+            Rule::dereference => {
+                let inner = pair.into_inner().next().ok_or("Empty dereference")?;
+                self.build_node(inner)
+            }
             Rule::scalar_reference => {
                 // Since these are atomic rules, use the whole pair's text
                 Ok(Some(AstNode::ScalarReference(Arc::from(pair.as_str()))))
@@ -2046,6 +2116,11 @@ impl PureRustPerlParser {
                 // Since these are atomic rules, use the whole pair's text
                 Ok(Some(AstNode::GlobReference(Arc::from(pair.as_str()))))
             }
+            Rule::scalar_dereference => self.build_dereference_node(pair, "$"),
+            Rule::array_dereference => self.build_dereference_node(pair, "@"),
+            Rule::hash_dereference => self.build_dereference_node(pair, "%"),
+            Rule::code_dereference => self.build_dereference_node(pair, "&"),
+            Rule::glob_dereference => self.build_dereference_node(pair, "*"),
             Rule::primary_expression => {
                 // Handle primary expressions including parenthesized expressions
                 let inner: Vec<_> = pair.into_inner().collect();
@@ -2208,6 +2283,30 @@ impl PureRustPerlParser {
         Ok(args)
     }
 
+    fn build_dereference_node(
+        &mut self,
+        pair: Pair<Rule>,
+        deref_type: &'static str,
+    ) -> Result<Option<AstNode>, Box<dyn std::error::Error>> {
+        let mut inner = pair.into_inner();
+        let expr = if let Some(inner_pair) = inner.next() {
+            match inner_pair.as_rule() {
+                Rule::expression => {
+                    Box::new(self.build_node(inner_pair)?.unwrap_or(AstNode::EmptyExpression))
+                }
+                Rule::variable_name => {
+                    let variable = Arc::<str>::from(format!("${}", inner_pair.as_str()));
+                    Box::new(AstNode::ScalarVariable(variable))
+                }
+                _ => Box::new(self.build_node(inner_pair)?.unwrap_or(AstNode::EmptyExpression)),
+            }
+        } else {
+            Box::new(AstNode::EmptyExpression)
+        };
+
+        Ok(Some(AstNode::Dereference { expr, deref_type: Arc::from(deref_type) }))
+    }
+
     pub fn to_sexp(&self, node: &AstNode) -> String {
         Self::node_to_sexp(node)
     }
@@ -2312,6 +2411,9 @@ impl PureRustPerlParser {
             }
             AstNode::PostfixDereference { expr, deref_type } => {
                 format!("(postfix_deref {} {})", Self::node_to_sexp(expr), deref_type)
+            }
+            AstNode::Dereference { expr, deref_type } => {
+                format!("(dereference {} {})", Self::node_to_sexp(expr), deref_type)
             }
             AstNode::TypeglobSlotAccess { typeglob, slot } => {
                 format!("(typeglob_slot_access {} {})", Self::node_to_sexp(typeglob), slot)

--- a/crates/perl-ts-advanced-parsers/src/full_parser.rs
+++ b/crates/perl-ts-advanced-parsers/src/full_parser.rs
@@ -294,6 +294,7 @@ impl FullPerlParser {
                 self.restore_node_content_with_depth(index, placeholder_map, next_depth);
             }
             AstNode::PostfixDereference { expr, .. }
+            | AstNode::Dereference { expr, .. }
             | AstNode::TypeglobSlotAccess { typeglob: expr, .. } => {
                 self.restore_node_content_with_depth(expr, placeholder_map, next_depth);
             }

--- a/crates/tree-sitter-perl-rs/src/pure_rust_parser.rs
+++ b/crates/tree-sitter-perl-rs/src/pure_rust_parser.rs
@@ -340,24 +340,35 @@ impl PureRustPerlParser {
     }
 
     fn normalize_source(source: &str) -> String {
-        static LOOP_DECL_RE: OnceLock<Regex> = OnceLock::new();
-        static SIMPLE_SCALAR_DEREF_RE: OnceLock<Regex> = OnceLock::new();
-        static ASSIGN_BITNOT_RE: OnceLock<Regex> = OnceLock::new();
+        static LOOP_DECL_RE: OnceLock<Option<Regex>> = OnceLock::new();
+        static SIMPLE_SCALAR_DEREF_RE: OnceLock<Option<Regex>> = OnceLock::new();
+        static ASSIGN_BITNOT_RE: OnceLock<Option<Regex>> = OnceLock::new();
 
-        let loop_decl_re = LOOP_DECL_RE.get_or_init(|| {
-            Regex::new(
-                r"\b(?P<kw>for(?:each)?)\s+(?:my|our|local|state)\s+(?P<var>\$[A-Za-z_][A-Za-z0-9_:]*)\s*(?P<paren>\()",
-            )
-            .expect("valid loop declarator normalization regex")
-        });
-        let scalar_deref_re = SIMPLE_SCALAR_DEREF_RE.get_or_init(|| {
-            Regex::new(r"\$\$(?P<name>[A-Za-z_][A-Za-z0-9_:]*)")
-                .expect("valid scalar dereference normalization regex")
-        });
-        let assign_bitnot_re = ASSIGN_BITNOT_RE.get_or_init(|| {
-            Regex::new(r"=\s+~\s*(?P<expr>\$[A-Za-z_][A-Za-z0-9_:]*)")
-                .expect("valid bitwise-not normalization regex")
-        });
+        // These are fixed patterns; if one ever fails to compile, skip normalization
+        // rather than panicking inside production parser code.
+        let Some(loop_decl_re) = LOOP_DECL_RE
+            .get_or_init(|| {
+                Regex::new(
+                    r"\b(?P<kw>for(?:each)?)\s+(?:my|our|local|state)\s+(?P<var>\$[A-Za-z_][A-Za-z0-9_:]*)\s*(?P<paren>\()",
+                )
+                .ok()
+            })
+            .as_ref()
+        else {
+            return source.to_string();
+        };
+        let Some(scalar_deref_re) = SIMPLE_SCALAR_DEREF_RE
+            .get_or_init(|| Regex::new(r"\$\$(?P<name>[A-Za-z_][A-Za-z0-9_:]*)").ok())
+            .as_ref()
+        else {
+            return source.to_string();
+        };
+        let Some(assign_bitnot_re) = ASSIGN_BITNOT_RE
+            .get_or_init(|| Regex::new(r"=\s+~\s*(?P<expr>\$[A-Za-z_][A-Za-z0-9_:]*)").ok())
+            .as_ref()
+        else {
+            return source.to_string();
+        };
 
         let normalized_loops = loop_decl_re.replace_all(source, "$kw $var $paren").into_owned();
         let normalized_derefs = scalar_deref_re


### PR DESCRIPTION
## Summary
- replace the manual clamp in perl-dap so clippy_full no longer fails on manual_clamp
- resynchronize the v2 pest bundle between tree-sitter-perl-rs and perl-parser-pest
- add the missing regex dependency to perl-parser-pest and remove panic-on-regex-init paths from the synced parser bundle
- update perl-ts-advanced-parsers to recurse through the restored AstNode::Dereference variant

## Why
Multiple unrelated open PRs are currently blocked by the same merge-gate failures on master: clippy_full and v2_bundle_sync. This cleanup branch fixes the shared blockers so the queue can move again.

## Test plan
- [x] bash scripts/check-v2-bundle-sync.sh
- [x] cargo clippy --workspace --lib --locked -- -D warnings -A missing_docs && cargo clippy --workspace --bins --locked --no-deps -- -D clippy::unwrap_used -D clippy::expect_used
- [x] cargo test -p perl-parser-pest --lib --locked
- [x] cargo test -p perl-ts-advanced-parsers --lib --locked
- [x] cargo test -p perl-dap --lib --locked