### PR TITLE
feat(completion): rank local symbols by scope distance

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -97,6 +97,7 @@ mod keywords;
 mod methods;
 mod packages;
 mod regex_patterns;
+pub(crate) mod scope_distance;
 mod sort;
 mod test_more;
 mod variables;
@@ -711,7 +712,7 @@ impl CompletionProvider {
         let in_regex = Self::is_in_regex(source, position);
         let in_comment = self.is_in_comment(source, position);
 
-        CompletionContext::new(
+        let mut context = CompletionContext::new(
             &self.symbol_table,
             position,
             trigger_character,
@@ -720,7 +721,10 @@ impl CompletionProvider {
             in_comment,
             word_prefix,
             prefix_start,
-        )
+        );
+        context.cursor_scope_id =
+            scope_distance::scope_at_position(&self.symbol_table, source, position);
+        context
     }
 
     /// Add file path completions with comprehensive security and performance safeguards
@@ -1135,6 +1139,75 @@ $"#;
         let pos_bar = code.len();
         let ctx_bar = provider.analyze_context(code, pos_bar);
         assert_eq!(ctx_bar.current_package, "Bar");
+    }
+
+    #[test]
+    fn test_incomplete_nested_block_scope_context() {
+        let code = concat!(
+            "my $file_var = 0;\n",
+            "sub process {\n",
+            "    my $sub_var = 1;\n",
+            "    if (1) {\n",
+            "        my $block_var = 2;\n",
+            "        $"
+        );
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+        let context = provider.analyze_context(code, code.len());
+
+        let sub_scope = must_some(
+            provider
+                .symbol_table
+                .symbols
+                .get("sub_var")
+                .and_then(|symbols| symbols.first())
+                .map(|symbol| symbol.scope_id),
+        );
+        let block_scope = must_some(
+            provider
+                .symbol_table
+                .symbols
+                .get("block_var")
+                .and_then(|symbols| symbols.first())
+                .map(|symbol| symbol.scope_id),
+        );
+
+        assert_eq!(
+            context.cursor_scope_id, block_scope,
+            "expected cursor scope to match block_var scope in incomplete nested block; cursor={:?} sub={:?} block={:?}",
+            context.cursor_scope_id, sub_scope, block_scope
+        );
+    }
+
+    #[test]
+    fn test_incomplete_nested_block_variable_sorting() {
+        let code = concat!(
+            "my $file_var = 0;\n",
+            "sub process {\n",
+            "    my $sub_var = 1;\n",
+            "    if (1) {\n",
+            "        my $block_var = 2;\n",
+            "        $"
+        );
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+        let completions = provider.get_completions(code, code.len());
+
+        let block_item =
+            must_some(completions.iter().find(|completion| completion.label == "$block_var"));
+        let sub_item =
+            must_some(completions.iter().find(|completion| completion.label == "$sub_var"));
+
+        assert!(
+            block_item.sort_text < sub_item.sort_text,
+            "expected incomplete block variable to outrank parent variable, got block={:?} sub={:?}",
+            block_item.sort_text,
+            sub_item.sort_text
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-completion/src/completion/context.rs
+++ b/crates/perl-lsp-completion/src/completion/context.rs
@@ -1,6 +1,6 @@
 //! Completion context analysis
 
-use perl_semantic_analyzer::symbol::{ScopeKind, SymbolKind, SymbolTable};
+use perl_semantic_analyzer::symbol::{ScopeId, ScopeKind, SymbolKind, SymbolTable};
 
 /// Context for completion
 #[derive(Debug, Clone)]
@@ -23,6 +23,8 @@ pub struct CompletionContext {
     pub prefix: String,
     /// Start position of the prefix (for text edit range calculation)
     pub prefix_start: usize,
+    /// The innermost scope containing the cursor position
+    pub cursor_scope_id: ScopeId,
 }
 
 impl CompletionContext {
@@ -94,6 +96,7 @@ impl CompletionContext {
             current_package,
             prefix,
             prefix_start,
+            cursor_scope_id: 0,
         }
     }
 }

--- a/crates/perl-lsp-completion/src/completion/functions.rs
+++ b/crates/perl-lsp-completion/src/completion/functions.rs
@@ -1,11 +1,16 @@
 //! Function completion for Perl
 //!
-//! Provides completion for user-defined subroutines.
+//! Provides completion for user-defined subroutines with scope-distance ranking.
+//! Functions defined in the same package rank higher than those from outer scopes.
 
+use super::scope_distance::compute_scope_distance;
 use super::{context::CompletionContext, items::CompletionItem};
 use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
 
-/// Add function completions
+/// Add function completions with scope-distance ranking.
+///
+/// User-defined subroutines are ranked by proximity to the cursor's scope,
+/// so locally-defined helpers appear above package-level or outer-scope functions.
 pub fn add_function_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -16,13 +21,15 @@ pub fn add_function_completions(
     for (name, symbols) in &symbol_table.symbols {
         for symbol in symbols {
             if symbol.kind == SymbolKind::Subroutine && name.starts_with(prefix_without_amp) {
+                let distance =
+                    compute_scope_distance(symbol_table, context.cursor_scope_id, symbol.scope_id);
                 completions.push(CompletionItem {
                     label: name.clone(),
                     kind: crate::completion::items::CompletionItemKind::Function,
                     detail: Some("sub".to_string()),
                     documentation: symbol.documentation.clone(),
                     insert_text: Some(format!("{}()", name)),
-                    sort_text: Some(format!("2_{}", name)),
+                    sort_text: Some(format!("2{}_{}", distance.sort_key(), name)),
                     filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),

--- a/crates/perl-lsp-completion/src/completion/scope_distance.rs
+++ b/crates/perl-lsp-completion/src/completion/scope_distance.rs
@@ -1,0 +1,375 @@
+//! Scope-distance ranking for completion items.
+//!
+//! Computes a distance tier from the cursor's scope to each symbol's definition
+//! scope. Closer symbols rank higher in completion results:
+//!
+//! - **Immediate**: symbol defined in the same scope as the cursor
+//! - **Parent**: symbol defined in an enclosing scope (1+ hops up the chain)
+//! - **Package**: symbol defined at package/global scope level
+//! - **Workspace**: symbol from another file via the workspace index
+
+use perl_semantic_analyzer::symbol::{ScopeId, ScopeKind, SymbolTable};
+
+/// Scope-distance tier for sorting completions.
+///
+/// Variants are ordered from closest (highest priority) to farthest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ScopeDistance {
+    /// Symbol defined in the same scope as the cursor.
+    Immediate,
+    /// Symbol defined in an enclosing (parent) scope.
+    Parent,
+    /// Symbol defined at package or global scope.
+    PackageLevel,
+    /// Symbol from the workspace index (another file).
+    Workspace,
+}
+
+impl ScopeDistance {
+    /// Returns a single-character sort key for embedding in `sort_text`.
+    ///
+    /// Lexicographic ordering: `'a'` < `'b'` < `'c'` < `'d'` ensures that
+    /// immediate-scope items sort before parent, before package, before workspace.
+    pub fn sort_key(self) -> char {
+        match self {
+            Self::Immediate => 'a',
+            Self::Parent => 'b',
+            Self::PackageLevel => 'c',
+            Self::Workspace => 'd',
+        }
+    }
+}
+
+fn last_unmatched_open_brace(source: &str) -> Option<usize> {
+    let mut stack = Vec::new();
+    for (idx, ch) in source.char_indices() {
+        match ch {
+            '{' => stack.push(idx),
+            '}' => {
+                stack.pop();
+            }
+            _ => {}
+        }
+    }
+    stack.pop()
+}
+
+fn scope_depth(symbol_table: &SymbolTable, scope_id: ScopeId) -> usize {
+    let mut depth = 0usize;
+    let mut current = scope_id;
+
+    while let Some(scope) = symbol_table.scopes.get(&current) {
+        let Some(parent) = scope.parent else {
+            break;
+        };
+        depth += 1;
+        current = parent;
+    }
+
+    depth
+}
+
+/// Find the innermost scope relevant to `position`.
+///
+/// Walks all scopes in the symbol table and returns the one whose location
+/// range contains the position and has the latest start (i.e., most specific).
+///
+/// During interactive editing the semantic analyzer may leave an unfinished
+/// child block with an `end` range before EOF even though the user is still
+/// typing inside it. When the cursor is at EOF, we use the last unmatched `{`
+/// as a scope hint and prefer the deepest scope that started before that brace.
+pub fn scope_at_position(symbol_table: &SymbolTable, source: &str, position: usize) -> ScopeId {
+    let mut containing: Option<(ScopeId, usize, usize)> = None;
+
+    for scope in symbol_table.scopes.values() {
+        if scope.location.start <= position && position <= scope.location.end {
+            let depth = scope_depth(symbol_table, scope.id);
+            let is_better_containing = containing.is_none_or(|(_, best_start, best_depth)| {
+                scope.location.start > best_start
+                    || (scope.location.start == best_start && depth > best_depth)
+            });
+            if is_better_containing {
+                containing = Some((scope.id, scope.location.start, depth));
+            }
+        }
+    }
+
+    if position == source.len()
+        && let Some(brace_pos) = last_unmatched_open_brace(source)
+    {
+        let mut eof_hint = containing;
+        for scope in symbol_table.scopes.values() {
+            if scope.location.start <= brace_pos {
+                let depth = scope_depth(symbol_table, scope.id);
+                let is_better_hint = eof_hint.is_none_or(|(_, best_start, best_depth)| {
+                    scope.location.start > best_start
+                        || (scope.location.start == best_start && depth > best_depth)
+                });
+                if is_better_hint {
+                    eof_hint = Some((scope.id, scope.location.start, depth));
+                }
+            }
+        }
+        return eof_hint.map_or(0, |(id, _, _)| id);
+    }
+
+    containing.map_or(0, |(id, _, _)| id)
+}
+
+/// Compute the scope distance from `cursor_scope` to `symbol_scope`.
+///
+/// Walks the parent chain from `cursor_scope` upward:
+/// - If `symbol_scope` is the cursor's own scope, returns `Immediate`.
+/// - If `symbol_scope` is an ancestor, returns `Parent`.
+/// - If the walk reaches a `Package` or `Global` scope that contains the symbol,
+///   returns `PackageLevel`.
+/// - Otherwise (e.g., different branch, different file), returns `Workspace`.
+pub fn compute_scope_distance(
+    symbol_table: &SymbolTable,
+    cursor_scope: ScopeId,
+    symbol_scope: ScopeId,
+) -> ScopeDistance {
+    if cursor_scope == symbol_scope {
+        return ScopeDistance::Immediate;
+    }
+
+    // Walk up from cursor scope looking for the symbol's scope
+    let mut current = cursor_scope;
+    let mut hops = 0u32;
+
+    while let Some(scope) = symbol_table.scopes.get(&current) {
+        if let Some(parent_id) = scope.parent {
+            hops += 1;
+
+            if parent_id == symbol_scope {
+                // Check if the symbol scope is a package/global scope
+                if let Some(parent_scope) = symbol_table.scopes.get(&parent_id)
+                    && matches!(parent_scope.kind, ScopeKind::Global | ScopeKind::Package)
+                {
+                    return ScopeDistance::PackageLevel;
+                }
+                return ScopeDistance::Parent;
+            }
+
+            current = parent_id;
+        } else {
+            // Reached the root without finding the symbol scope
+            break;
+        }
+
+        // Safety limit to prevent infinite loops on malformed scope trees
+        if hops > 100 {
+            break;
+        }
+    }
+
+    // The symbol scope was not found in our parent chain.
+    // Check if the symbol is at package/global level.
+    if let Some(sym_scope) = symbol_table.scopes.get(&symbol_scope)
+        && matches!(sym_scope.kind, ScopeKind::Global | ScopeKind::Package)
+    {
+        return ScopeDistance::PackageLevel;
+    }
+
+    ScopeDistance::Workspace
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser_core::SourceLocation;
+    use perl_semantic_analyzer::symbol::{Scope, ScopeKind, SymbolTable};
+    use std::collections::HashSet;
+
+    /// Build a minimal symbol table with a known scope hierarchy for testing.
+    fn build_test_table() -> SymbolTable {
+        // Hierarchy:
+        //   0 (Global, 0..100)
+        //   +-- 1 (Package, 5..95)
+        //       +-- 2 (Subroutine, 10..80)
+        //           +-- 3 (Block, 20..50)
+        let mut table = SymbolTable::new();
+
+        // Override scope 0 to have end=100
+        table.scopes.insert(
+            0,
+            Scope {
+                id: 0,
+                parent: None,
+                kind: ScopeKind::Global,
+                location: SourceLocation { start: 0, end: 100 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        table.scopes.insert(
+            1,
+            Scope {
+                id: 1,
+                parent: Some(0),
+                kind: ScopeKind::Package,
+                location: SourceLocation { start: 5, end: 95 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        table.scopes.insert(
+            2,
+            Scope {
+                id: 2,
+                parent: Some(1),
+                kind: ScopeKind::Subroutine,
+                location: SourceLocation { start: 10, end: 80 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        table.scopes.insert(
+            3,
+            Scope {
+                id: 3,
+                parent: Some(2),
+                kind: ScopeKind::Block,
+                location: SourceLocation { start: 20, end: 50 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        table
+    }
+
+    #[test]
+    fn test_scope_at_position_innermost_block() {
+        let table = build_test_table();
+        // Position 30 is inside scope 3 (Block, 20..50)
+        assert_eq!(scope_at_position(&table, "", 30), 3);
+    }
+
+    #[test]
+    fn test_scope_at_position_subroutine() {
+        let table = build_test_table();
+        // Position 60 is inside scope 2 (Subroutine, 10..80) but outside scope 3
+        assert_eq!(scope_at_position(&table, "", 60), 2);
+    }
+
+    #[test]
+    fn test_scope_at_position_global() {
+        let table = build_test_table();
+        // Position 98 is inside scope 0 (Global) but outside scope 1 (Package, 5..95)
+        assert_eq!(scope_at_position(&table, "", 98), 0);
+    }
+
+    #[test]
+    fn test_scope_at_position_uses_eof_unmatched_brace_hint() {
+        let mut table = build_test_table();
+        // Simulate an incomplete block whose recorded end does not yet reach
+        // the live cursor position.
+        if let Some(scope) = table.scopes.get_mut(&3) {
+            scope.location.end = 25;
+        }
+
+        let source = "sub process {\n    if (1) {\n        $";
+        assert_eq!(scope_at_position(&table, source, source.len()), 3);
+    }
+
+    #[test]
+    fn test_scope_at_position_does_not_revive_closed_child_block() {
+        let mut table = build_test_table();
+        if let Some(scope) = table.scopes.get_mut(&3) {
+            scope.location.end = 25;
+        }
+        let source = "sub process {\n    if (1) {\n    }\n    $";
+        assert_eq!(scope_at_position(&table, source, source.len()), 2);
+    }
+
+    #[test]
+    fn test_scope_at_position_prefers_deeper_scope_when_ranges_match() {
+        let mut table = SymbolTable::new();
+        table.scopes.insert(
+            0,
+            Scope {
+                id: 0,
+                parent: None,
+                kind: ScopeKind::Global,
+                location: SourceLocation { start: 0, end: 100 },
+                symbols: HashSet::new(),
+            },
+        );
+        table.scopes.insert(
+            1,
+            Scope {
+                id: 1,
+                parent: Some(0),
+                kind: ScopeKind::Block,
+                location: SourceLocation { start: 10, end: 90 },
+                symbols: HashSet::new(),
+            },
+        );
+        table.scopes.insert(
+            2,
+            Scope {
+                id: 2,
+                parent: Some(1),
+                kind: ScopeKind::Block,
+                location: SourceLocation { start: 10, end: 90 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        assert_eq!(scope_at_position(&table, "", 50), 2);
+    }
+
+    #[test]
+    fn test_scope_distance_immediate() {
+        let table = build_test_table();
+        assert_eq!(compute_scope_distance(&table, 3, 3), ScopeDistance::Immediate);
+    }
+
+    #[test]
+    fn test_scope_distance_parent_subroutine() {
+        let table = build_test_table();
+        // Cursor in scope 3, symbol in scope 2 (subroutine = parent)
+        assert_eq!(compute_scope_distance(&table, 3, 2), ScopeDistance::Parent);
+    }
+
+    #[test]
+    fn test_scope_distance_package_level() {
+        let table = build_test_table();
+        // Cursor in scope 3, symbol in scope 1 (package)
+        assert_eq!(compute_scope_distance(&table, 3, 1), ScopeDistance::PackageLevel);
+    }
+
+    #[test]
+    fn test_scope_distance_global_level() {
+        let table = build_test_table();
+        // Cursor in scope 3, symbol in scope 0 (global)
+        assert_eq!(compute_scope_distance(&table, 3, 0), ScopeDistance::PackageLevel);
+    }
+
+    #[test]
+    fn test_scope_distance_different_branch() {
+        let mut table = build_test_table();
+        // Add a sibling scope 4 under Package scope 1
+        table.scopes.insert(
+            4,
+            Scope {
+                id: 4,
+                parent: Some(1),
+                kind: ScopeKind::Subroutine,
+                location: SourceLocation { start: 82, end: 94 },
+                symbols: HashSet::new(),
+            },
+        );
+
+        // Cursor in scope 3 (under scope 2), symbol in scope 4 (sibling branch)
+        // scope 4 is Subroutine, not Global/Package, so it returns Workspace
+        assert_eq!(compute_scope_distance(&table, 3, 4), ScopeDistance::Workspace);
+    }
+
+    #[test]
+    fn test_sort_key_ordering() {
+        assert!(ScopeDistance::Immediate.sort_key() < ScopeDistance::Parent.sort_key());
+        assert!(ScopeDistance::Parent.sort_key() < ScopeDistance::PackageLevel.sort_key());
+        assert!(ScopeDistance::PackageLevel.sort_key() < ScopeDistance::Workspace.sort_key());
+    }
+}

--- a/crates/perl-lsp-completion/src/completion/variables.rs
+++ b/crates/perl-lsp-completion/src/completion/variables.rs
@@ -1,11 +1,18 @@
 //! Variable completion for Perl
 //!
 //! Provides completion for scalar, array, and hash variables with scope analysis.
+//! Variables are ranked by scope distance: immediate scope > parent scope >
+//! package level, giving users the most relevant completions first.
 
+use super::scope_distance::compute_scope_distance;
 use super::{context::CompletionContext, items::CompletionItem};
 use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
 
-/// Add variable completions with thread-safe symbol table access
+/// Add variable completions with scope-distance ranking.
+///
+/// Variables from the immediate scope rank highest, then parent scopes,
+/// then package/global scope. This produces more relevant completion
+/// lists when the same prefix matches variables at multiple scope depths.
 pub fn add_variable_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -19,6 +26,9 @@ pub fn add_variable_completions(
         for symbol in symbols {
             if symbol.kind == kind && name.starts_with(prefix_without_sigil) {
                 let insert_text = format!("{}{}", sigil, name);
+
+                let distance =
+                    compute_scope_distance(symbol_table, context.cursor_scope_id, symbol.scope_id);
 
                 completions.push(CompletionItem {
                     label: insert_text.clone(),
@@ -35,7 +45,7 @@ pub fn add_variable_completions(
                     ),
                     documentation: symbol.documentation.clone(),
                     insert_text: Some(insert_text),
-                    sort_text: Some(format!("1_{}", name)), // Variables have high priority
+                    sort_text: Some(format!("1{}_{}", distance.sort_key(), name)),
                     filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
@@ -103,6 +113,9 @@ pub fn add_special_variables(
 }
 
 /// Add all variables without sigils (for interpolation contexts)
+///
+/// Uses scope-distance ranking so closer variables sort before distant ones,
+/// while keeping the `5x_` prefix to rank below sigil-prefixed completions.
 pub fn add_all_variables(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -114,6 +127,11 @@ pub fn add_all_variables(
             for symbol in symbols {
                 if symbol.kind.is_variable() && name.starts_with(&context.prefix) {
                     let sigil = symbol.kind.sigil().unwrap_or("");
+                    let distance = compute_scope_distance(
+                        symbol_table,
+                        context.cursor_scope_id,
+                        symbol.scope_id,
+                    );
                     completions.push(CompletionItem {
                         label: format!("{}{}", sigil, name),
                         kind: crate::completion::items::CompletionItemKind::Variable,
@@ -123,7 +141,7 @@ pub fn add_all_variables(
                         )),
                         documentation: symbol.documentation.clone(),
                         insert_text: Some(format!("{}{}", sigil, name)),
-                        sort_text: Some(format!("5_{}", name)),
+                        sort_text: Some(format!("5{}_{}", distance.sort_key(), name)),
                         filter_text: Some(name.clone()),
                         additional_edits: vec![],
                         text_edit_range: Some((context.prefix_start, context.position)),

--- a/crates/perl-lsp-completion/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/comprehensive_unit_tests.rs
@@ -947,3 +947,165 @@ fn multiline_code_completion() {
     assert!(has_label(&items, "$line2"));
     assert!(has_label(&items, "$line3"));
 }
+
+// ===========================================================================
+// Scope-distance ranking tests
+// ===========================================================================
+
+fn find_item<'a>(items: &'a [CompletionItem], label: &str) -> Option<&'a CompletionItem> {
+    items.iter().find(|i| i.label == label)
+}
+
+fn sort_text_of(items: &[CompletionItem], label: &str) -> Option<String> {
+    find_item(items, label).and_then(|i| i.sort_text.clone())
+}
+
+#[test]
+fn scope_distance_immediate_variable_ranks_before_outer() {
+    // $inner is in the same scope as cursor (immediate),
+    // $outer is in a parent scope.
+    let code = "my $outer = 1;\nsub foo {\n    my $inner = 2;\n    $";
+    let items = completions_at_end(code);
+
+    let inner_sort = sort_text_of(&items, "$inner");
+    let outer_sort = sort_text_of(&items, "$outer");
+
+    assert!(inner_sort.is_some(), "$inner should be in completions");
+    assert!(outer_sort.is_some(), "$outer should be in completions");
+
+    // Immediate scope variable should sort before parent scope variable
+    assert!(
+        inner_sort < outer_sort,
+        "immediate scope $inner ({:?}) should sort before outer $outer ({:?})",
+        inner_sort,
+        outer_sort
+    );
+}
+
+#[test]
+fn scope_distance_nested_blocks_rank_closer_first() {
+    // $block_var is in the if-block (immediate),
+    // $sub_var is in the enclosing sub (parent),
+    // $file_var is at file scope (package level).
+    let code = concat!(
+        "my $file_var = 0;\n",
+        "sub process {\n",
+        "    my $sub_var = 1;\n",
+        "    if (1) {\n",
+        "        my $block_var = 2;\n",
+        "        $"
+    );
+    let items = completions_at_end(code);
+
+    let block_sort = sort_text_of(&items, "$block_var");
+    let sub_sort = sort_text_of(&items, "$sub_var");
+    let file_sort = sort_text_of(&items, "$file_var");
+
+    assert!(block_sort.is_some(), "$block_var should be in completions");
+    assert!(sub_sort.is_some(), "$sub_var should be in completions");
+    assert!(file_sort.is_some(), "$file_var should be in completions");
+
+    assert!(
+        block_sort < sub_sort,
+        "immediate $block_var ({:?}) should sort before parent $sub_var ({:?})",
+        block_sort,
+        sub_sort
+    );
+    assert!(
+        sub_sort < file_sort,
+        "parent $sub_var ({:?}) should sort before file-level $file_var ({:?})",
+        sub_sort,
+        file_sort
+    );
+}
+
+#[test]
+fn scope_distance_function_ranking() {
+    // Test with a shared prefix so both functions match
+    let code2 = concat!(
+        "sub utility_a { }\n",
+        "sub process {\n",
+        "    sub utility_b { }\n",
+        "    utility_"
+    );
+    let items2 = completions_at_end(code2);
+
+    let inner_sort = sort_text_of(&items2, "utility_b");
+    let outer_sort = sort_text_of(&items2, "utility_a");
+
+    assert!(inner_sort.is_some(), "utility_b should be in completions");
+    assert!(outer_sort.is_some(), "utility_a should be in completions");
+
+    assert!(
+        inner_sort < outer_sort,
+        "inner utility_b ({:?}) should sort before outer utility_a ({:?})",
+        inner_sort,
+        outer_sort
+    );
+}
+
+#[test]
+fn scope_distance_same_scope_variables_alphabetical() {
+    // Two variables in the same scope should be ordered alphabetically
+    let code = "my $zebra = 1;\nmy $alpha = 2;\n$";
+    let items = completions_at_end(code);
+
+    let alpha_sort = sort_text_of(&items, "$alpha");
+    let zebra_sort = sort_text_of(&items, "$zebra");
+
+    assert!(alpha_sort.is_some(), "$alpha should be in completions");
+    assert!(zebra_sort.is_some(), "$zebra should be in completions");
+
+    // Same scope distance, so should be alphabetical by name
+    assert!(
+        alpha_sort < zebra_sort,
+        "$alpha ({:?}) should sort before $zebra ({:?}) at same scope depth",
+        alpha_sort,
+        zebra_sort
+    );
+}
+
+#[test]
+fn scope_distance_workspace_variables_rank_last() {
+    // Workspace symbols (sort prefix 3_) should rank after local variables (1x_)
+    let index = Arc::new(WorkspaceIndex::new());
+    let file_url = must(Url::parse("file:///other.pm"));
+    let module_code = r#"
+package Other;
+our $ws_item = 42;
+sub ws_func { }
+1;
+"#;
+    must(index.index_file(file_url, module_code.to_string()));
+
+    // Use a prefix that matches both a local variable and a workspace function
+    let code = "my $local_var = 1;\nws_";
+    let provider = parse_provider_with_index(code, index);
+    let items = provider.get_completions(code, code.len());
+
+    // Find a workspace function completion (sort prefix 3_) vs nothing local
+    // The workspace function should appear with sort prefix starting with 3
+    let ws_func = find_item(&items, "ws_func");
+    if let Some(ws_item) = ws_func {
+        let sort_text = ws_item.sort_text.as_deref().unwrap_or("");
+        assert!(
+            sort_text.starts_with('3'),
+            "workspace function sort_text ({:?}) should start with '3' (workspace tier)",
+            sort_text
+        );
+    }
+
+    // Also verify that local variables use scope-distance sort keys (1a-1d)
+    let code2 = "my $local_var = 1;\n$lo";
+    let provider2 = parse_and_provider(code2);
+    let items2 = provider2.get_completions(code2, code2.len());
+    let local_sort = sort_text_of(&items2, "$local_var");
+    assert!(local_sort.is_some(), "$local_var should be in completions");
+
+    let sort = local_sort.as_deref().unwrap_or("");
+    assert!(
+        sort.starts_with("1a") || sort.starts_with("1b") || sort.starts_with("1c"),
+        "local variable sort_text ({:?}) should use scope-distance prefix (1a/1b/1c)",
+        sort
+    );
+}

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -783,7 +783,9 @@ fn user_variable_sort_priority() {
     let items = completions_at_end(code);
     let item = must_some(find_item(&items, "$foo"));
     let sort_text = must_some(item.sort_text.as_ref());
-    assert!(sort_text.starts_with("1_"), "user variable sort_text should start with 1_");
+    // sort_text format is "1{distance}_name" where distance is a-d for scope proximity
+    assert!(sort_text.starts_with("1"), "user variable sort_text should start with 1");
+    assert!(sort_text.contains('_'), "user variable sort_text should contain underscore separator");
 }
 
 #[test]
@@ -792,7 +794,9 @@ fn user_function_sort_priority() {
     let items = completions_at_end(code);
     let item = must_some(find_item(&items, "handler"));
     let sort_text = must_some(item.sort_text.as_ref());
-    assert!(sort_text.starts_with("2_"), "user function sort_text should start with 2_");
+    // sort_text format is "2{distance}_name" where distance is a-d for scope proximity
+    assert!(sort_text.starts_with("2"), "user function sort_text should start with 2");
+    assert!(sort_text.contains('_'), "user function sort_text should contain underscore separator");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- rank local variable and function completions by scope distance so immediate-scope symbols sort ahead of parent and package-level matches
- add cursor-scope inference for incomplete blocks, including deterministic tie-breaking when nested scopes share the same source range
- extend completion tests to cover nested block ranking, same-scope ordering, workspace fallback ordering, and the unfinished-block regression

## Validation
- cargo test -p perl-lsp-completion --locked
- cargo clippy -p perl-lsp-completion --lib --tests --locked -- -D warnings -A missing_docs