### PR TITLE
fix(parser): allow keyword barewords as subroutine names

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -54,27 +54,15 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'sub'
 
-        let (name, name_span) = match self.peek_kind() {
-            // Regular identifier
-            Some(TokenKind::Identifier)
-            | Some(TokenKind::Method)
-            | Some(TokenKind::Class)
-            | Some(TokenKind::Try)
-            | Some(TokenKind::Catch)
-            | Some(TokenKind::Finally)
-            | Some(TokenKind::Given)
-            | Some(TokenKind::When)
-            | Some(TokenKind::Default)
-            | Some(TokenKind::Continue)
-            | Some(TokenKind::Format) => {
-                let token = self.tokens.next()?;
-                (
-                    Some(token.text.to_string()),
-                    Some(SourceLocation { start: token.start, end: token.end }),
-                )
-            }
-            // No name - anonymous subroutine
-            _ => (None, None),
+        let (name, name_span) = if self.peek_kind().is_some_and(Self::can_be_sub_name) {
+            let token = self.tokens.next()?;
+            (
+                Some(token.text.to_string()),
+                Some(SourceLocation { start: token.start, end: token.end }),
+            )
+        } else {
+            // No name - anonymous subroutine (next token is {, (, :, or similar)
+            (None, None)
         };
 
         // Parse optional attributes first (they come before signature in modern Perl)

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -590,4 +590,71 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Check if a token kind can appear as a subroutine name after `sub`.
+    ///
+    /// In Perl, any bareword can be a subroutine name, including reserved
+    /// keywords and word-operators:
+    /// ```perl
+    /// sub return { ... }   # autodie/exception.pm
+    /// sub eval { ... }     # perl5db.pl
+    /// sub next { ... }     # Net/NNTP.pm
+    /// sub cmp { ... }      # IO/Compress/Base/Common.pm
+    /// ```
+    ///
+    /// Returns `false` for tokens that signal anonymous sub syntax: `{`, `(`,
+    /// `:` (attribute), `;` (forward decl), sigils, operators, etc.
+    #[inline]
+    pub(crate) fn can_be_sub_name(kind: TokenKind) -> bool {
+        matches!(
+            kind,
+            // Regular identifiers
+            TokenKind::Identifier
+            // All keyword tokens (valid sub names in Perl)
+            | TokenKind::If
+            | TokenKind::Unless
+            | TokenKind::While
+            | TokenKind::Until
+            | TokenKind::For
+            | TokenKind::Foreach
+            | TokenKind::My
+            | TokenKind::Our
+            | TokenKind::State
+            | TokenKind::Local
+            | TokenKind::Field
+            | TokenKind::Sub
+            | TokenKind::Return
+            | TokenKind::Next
+            | TokenKind::Last
+            | TokenKind::Redo
+            | TokenKind::Goto
+            | TokenKind::Eval
+            | TokenKind::Do
+            | TokenKind::Use
+            | TokenKind::No
+            | TokenKind::Package
+            | TokenKind::Class
+            | TokenKind::Method
+            | TokenKind::Try
+            | TokenKind::Catch
+            | TokenKind::Finally
+            | TokenKind::Given
+            | TokenKind::When
+            | TokenKind::Default
+            | TokenKind::Continue
+            | TokenKind::Format
+            | TokenKind::Begin
+            | TokenKind::End
+            | TokenKind::Check
+            | TokenKind::Init
+            | TokenKind::Unitcheck
+            | TokenKind::Undef
+            // Word-operators (also valid bareword sub names)
+            | TokenKind::WordAnd    // sub and { ... }
+            | TokenKind::WordOr     // sub or { ... }
+            | TokenKind::WordNot    // sub not { ... }
+            | TokenKind::WordXor    // sub xor { ... }
+            | TokenKind::StringCompare  // sub cmp { ... }
+        )
+    }
+
 }

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -325,27 +325,10 @@ impl<'a> Parser<'a> {
 
         // Check if next token is an identifier or a keyword that should be treated as identifier
         let next_kind = self.peek_kind();
-        let can_be_sub_name = |k: TokenKind| {
-            matches!(
-                k,
-                TokenKind::Sub
-                    | TokenKind::My
-                    | TokenKind::Our
-                    | TokenKind::If
-                    | TokenKind::Unless
-                    | TokenKind::While
-                    | TokenKind::For
-                    | TokenKind::Return
-                    | TokenKind::Do
-                    | TokenKind::Eval
-                    | TokenKind::Use
-                    | TokenKind::Package
-            )
-        };
 
         let (name, end) = if next_kind == Some(TokenKind::Identifier) ||
                              // Keywords that can be used as subroutine names with & sigil
-                             (sigil == "&" && matches!(next_kind, Some(k) if can_be_sub_name(k)))
+                             (sigil == "&" && matches!(next_kind, Some(k) if Self::can_be_sub_name(k)))
         {
             let name_token = self.tokens.next()?;
             let mut name = name_token.text.to_string();

--- a/crates/perl-parser-core/tests/fix_expected_left_brace.rs
+++ b/crates/perl-parser-core/tests/fix_expected_left_brace.rs
@@ -1,0 +1,218 @@
+mod cpan_test_helpers;
+
+use perl_parser_core::Parser;
+
+/// Assert that parsing produces no diagnostics AND no error markers in sexp.
+fn assert_no_diagnostics(source: &str) {
+    let mut parser = Parser::new(source);
+    let output = parser.parse_with_recovery();
+
+    // Check diagnostics
+    assert!(
+        output.diagnostics.is_empty(),
+        "Expected no diagnostics for source:\n{}\n\nDiagnostics:\n{}",
+        source,
+        output.diagnostics.iter().map(|d| format!("  {}", d)).collect::<Vec<_>>().join("\n"),
+    );
+
+    // Also check sexp for error markers
+    let sexp = output.ast.to_sexp();
+    let error_markers = [
+        "(error ",
+        "(Error ",
+        "(missing_expression",
+        "(missing_statement",
+        "(missing_identifier",
+        "(missing_block",
+        "MissingExpression",
+        "MissingStatement",
+        "MissingIdentifier",
+        "MissingBlock",
+    ];
+
+    for marker in &error_markers {
+        assert!(
+            !sexp.contains(marker),
+            "Clean-parse assertion failed: found '{}' in sexp for source:\n{}\n\nsexp:\n{}",
+            marker,
+            source,
+            sexp,
+        );
+    }
+}
+
+// ---- Tests for expected_left_brace bucket fix ----
+//
+// The core issue: the parser doesn't allow many Perl keywords as subroutine
+// names after `sub`. In Perl, `sub <ANY_BAREWORD> { ... }` is valid.
+// Similarly, `&<keyword>(...)` should work for calling subs named after keywords.
+
+// == Sub definitions with keyword names (the main source of the bucket) ==
+
+#[test]
+fn test_sub_named_return() {
+    // autodie/exception.pm: sub return { ... }
+    assert_no_diagnostics(r#"sub return { return $_[0]->{return} }"#);
+}
+
+#[test]
+fn test_sub_named_eval() {
+    // perl5db.pl, DB.pm, Thread.pm: sub eval { ... }
+    assert_no_diagnostics(r#"sub eval { die "not implemented" }"#);
+}
+
+#[test]
+fn test_sub_named_last() {
+    // Net/POP3.pm, Net/NNTP.pm: sub last { ... }
+    assert_no_diagnostics(r#"sub last { $_[0]->{last} }"#);
+}
+
+#[test]
+fn test_sub_named_next() {
+    // Net/NNTP.pm, DB.pm, CPAN/Distroprefs.pm: sub next { ... }
+    assert_no_diagnostics(r#"sub next { $_[0]->() }"#);
+}
+
+#[test]
+fn test_sub_named_sub() {
+    // DB.pm: sub sub { ... }
+    assert_no_diagnostics(r#"sub sub { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_package() {
+    // Test2/EventFacet/Trace.pm: sub package { ... }
+    assert_no_diagnostics(r#"sub package { $_[0]->{frame}->[0] }"#);
+}
+
+#[test]
+fn test_sub_named_state() {
+    // Test2/API/InterceptResult.pm: sub state { ... }
+    assert_no_diagnostics(r#"sub state { $_[0]->{state} }"#);
+}
+
+#[test]
+fn test_sub_named_goto() {
+    // CPAN/Distribution.pm: sub goto { ... }
+    assert_no_diagnostics(r#"sub goto { my $self = shift; }"#);
+}
+
+#[test]
+fn test_sub_named_cmp() {
+    // IO/Compress/Base/Common.pm: sub cmp { ... }
+    assert_no_diagnostics("sub cmp\n{\n  my $self = shift;\n}");
+}
+
+#[test]
+fn test_sub_named_for() {
+    assert_no_diagnostics(r#"sub for { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_foreach() {
+    assert_no_diagnostics(r#"sub foreach { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_if() {
+    assert_no_diagnostics(r#"sub if { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_unless() {
+    assert_no_diagnostics(r#"sub unless { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_while() {
+    assert_no_diagnostics(r#"sub while { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_until() {
+    assert_no_diagnostics(r#"sub until { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_my() {
+    assert_no_diagnostics(r#"sub my { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_our() {
+    assert_no_diagnostics(r#"sub our { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_local() {
+    assert_no_diagnostics(r#"sub local { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_no() {
+    assert_no_diagnostics(r#"sub no { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_use() {
+    assert_no_diagnostics(r#"sub use { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_do() {
+    assert_no_diagnostics(r#"sub do { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_redo() {
+    assert_no_diagnostics(r#"sub redo { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_begin() {
+    // Benchmark.pm: sub BEGIN { ... }
+    assert_no_diagnostics(r#"sub BEGIN { 1 }"#);
+}
+
+#[test]
+fn test_sub_named_end() {
+    assert_no_diagnostics(r#"sub END { 1 }"#);
+}
+
+// == Subroutine call via & with keyword names ==
+
+#[test]
+fn test_ampersand_call_try() {
+    // Test2/Util.pm: &try($code)
+    assert_no_diagnostics(r#"my ($ok, $err) = &try($code);"#);
+}
+
+#[test]
+fn test_ampersand_call_next() {
+    assert_no_diagnostics(r#"&next();"#);
+}
+
+#[test]
+fn test_ampersand_call_last() {
+    assert_no_diagnostics(r#"&last();"#);
+}
+
+#[test]
+fn test_ampersand_call_goto() {
+    assert_no_diagnostics(r#"&goto($label);"#);
+}
+
+#[test]
+fn test_ampersand_call_state() {
+    assert_no_diagnostics(r#"&state();"#);
+}
+
+#[test]
+fn test_ampersand_call_redo() {
+    assert_no_diagnostics(r#"&redo();"#);
+}
+
+#[test]
+fn test_ampersand_call_begin() {
+    assert_no_diagnostics(r#"&BEGIN();"#);
+}


### PR DESCRIPTION
## Summary
- allow `sub <keyword>` declarations to treat keyword and word-operator tokens as valid bareword sub names
- reuse the same helper for `&keyword(...)` calls so keyword-named subs resolve consistently through both declaration and sigil-call paths
- add regression coverage for CPAN-style cases like `sub return {}`, `sub cmp {}`, `sub BEGIN {}`, and `&try(...)`

## Validation
- cargo fmt --all
- cargo test -p perl-parser-core --locked --test fix_expected_left_brace --test cpan_real_world_programs
- cargo test -p perl-parser-core --locked --test cpan_moose_moo
- cargo clippy -p perl-parser-core --lib --locked -- -D warnings
