### PR TITLE
fix(parser): support last-index deref in bracket expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -235,6 +235,42 @@ impl<'a> Parser<'a> {
         let mut full_name = name;
         let mut end = token.end;
 
+        // Handle $#$ref — last index of dereferenced array
+        // The lexer sends `$#` as Identifier("$#"), so sigil="$" name="#"
+        if sigil == "$" && full_name == "#" {
+            let next_is_var = self
+                .tokens
+                .peek()
+                .ok()
+                .is_some_and(|t| t.text.starts_with('$'));
+            let next_is_sigil = self.peek_kind() == Some(TokenKind::ScalarSigil);
+            if next_is_var || next_is_sigil {
+                // $#$ref — parse the inner variable and wrap
+                let inner = self.parse_variable()?;
+                let inner_end = inner.location.end;
+                return Ok(Node::new(
+                    NodeKind::Unary {
+                        op: "$#".to_string(),
+                        operand: Box::new(inner),
+                    },
+                    SourceLocation { start: token.start, end: inner_end },
+                ));
+            } else if self.peek_kind() == Some(TokenKind::LeftBrace) {
+                // $#{expr} — last index via block dereference
+                self.tokens.next()?; // consume {
+                let inner = self.parse_expression()?;
+                self.expect(TokenKind::RightBrace)?;
+                let brace_end = self.previous_position();
+                return Ok(Node::new(
+                    NodeKind::Unary {
+                        op: "$#".to_string(),
+                        operand: Box::new(inner),
+                    },
+                    SourceLocation { start: token.start, end: brace_end },
+                ));
+            }
+        }
+
         // The lexer may hand us a sigil-only token (`&`) or a precombined `$$`
         // token followed by the referenced identifier. Preserve the full target
         // name instead of leaving the tail as a stray identifier node.
@@ -399,7 +435,57 @@ impl<'a> Parser<'a> {
                             let token = self.tokens.next()?;
                             if self.peek_kind() == Some(TokenKind::Identifier) {
                                 let var_token = self.tokens.next()?;
-                                (format!("#{}", var_token.text), var_token.end)
+                                let mut var_name = var_token.text.to_string();
+                                let mut var_end = var_token.end;
+
+                                // Handle $#Pkg::Var (package-qualified)
+                                while self.peek_kind() == Some(TokenKind::DoubleColon) {
+                                    self.tokens.next()?;
+                                    var_name.push_str("::");
+                                    if self.peek_kind() == Some(TokenKind::Identifier) {
+                                        let next_token = self.tokens.next()?;
+                                        var_name.push_str(&next_token.text);
+                                        var_end = next_token.end;
+                                    }
+                                }
+
+                                (format!("#{}", var_name), var_end)
+                            } else if matches!(
+                                self.peek_kind(),
+                                Some(TokenKind::ScalarSigil)
+                            ) || self
+                                .tokens
+                                .peek()
+                                .ok()
+                                .is_some_and(|t| t.text.starts_with('$'))
+                            {
+                                // $#$ref — last index of dereferenced array
+                                // Parse the inner variable expression
+                                let inner = self.parse_variable()?;
+                                let end = inner.location.end;
+                                // Wrap in a Unary $#() node
+                                let node = Node::new(
+                                    NodeKind::Unary {
+                                        op: "$#".to_string(),
+                                        operand: Box::new(inner),
+                                    },
+                                    SourceLocation { start, end },
+                                );
+                                return Ok(node);
+                            } else if self.peek_kind() == Some(TokenKind::LeftBrace) {
+                                // $#{expr} — last index of dereferenced array via block
+                                self.tokens.next()?; // consume {
+                                let inner = self.parse_expression()?;
+                                self.expect(TokenKind::RightBrace)?;
+                                let end = self.previous_position();
+                                let node = Node::new(
+                                    NodeKind::Unary {
+                                        op: "$#".to_string(),
+                                        operand: Box::new(inner),
+                                    },
+                                    SourceLocation { start, end },
+                                );
+                                return Ok(node);
                             } else {
                                 // Just $# by itself
                                 ("#".to_string(), token.end)

--- a/crates/perl-parser-core/tests/unclosed_bracket_fixes_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_bracket_fixes_tests.rs
@@ -1,0 +1,132 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// ==========================================================================
+// Fix 1: $#$ref — last-index on scalar deref
+// Perl: $#$arrayref gives the last index of the array pointed to by $arrayref
+// ==========================================================================
+
+#[test]
+fn dollar_hash_deref_simple() {
+    // $#$ref is the last index of @$ref
+    assert_clean_parse("my $last = $#$ref;");
+}
+
+#[test]
+fn dollar_hash_deref_in_range() {
+    // Common pattern: slice using $#$ref
+    assert_clean_parse("my @slice = @$self[0..$#$self];");
+}
+
+#[test]
+fn dollar_hash_deref_in_block_range() {
+    assert_clean_parse("my @rest = @{$self}[2..$#$self];");
+}
+
+#[test]
+fn dollar_hash_deref_in_complex_range() {
+    assert_clean_parse("unshift @cycle, @{$path}[$i+1 .. $#$path];");
+}
+
+#[test]
+fn dollar_hash_deref_in_pair_slice() {
+    assert_clean_parse("my %attrs = (value => $pair->[1], @$pair[2 .. $#$pair]);");
+}
+
+#[test]
+fn dollar_hash_deref_in_return_slice() {
+    assert_clean_parse("return $self->new(@$self[(0 - $size) .. $#$self]);");
+}
+
+#[test]
+fn dollar_hash_deref_in_array_ref() {
+    assert_clean_parse("my $x = [0..$#$ref];");
+}
+
+// ==========================================================================
+// Fix 2: Bare function calls inside array ref [...]
+// Perl: [dirname $filename] is [dirname($filename)]
+// ==========================================================================
+
+#[test]
+fn bare_func_in_arrayref() {
+    assert_clean_parse("$search_paths = [dirname $filename];");
+}
+
+#[test]
+fn bare_func_multiple_args_in_arrayref() {
+    assert_clean_parse("my $x = [join ', ', @items];");
+}
+
+// ==========================================================================
+// Fix 3: Declarations inside bracket subscripts
+// Perl: $ref->[my $n = expr] is valid
+// ==========================================================================
+
+#[test]
+fn my_decl_in_arrow_bracket() {
+    assert_clean_parse("$i->[ my $n = $m->[ _n ]++ ] = $_;");
+}
+
+#[test]
+fn my_decl_in_bracket_subscript() {
+    assert_clean_parse("$ref->[my $x = 0];");
+}
+
+// ==========================================================================
+// Fix 4: Concatenation chains inside array ref (IP-address-like patterns)
+// Perl: [127.0.0.1] contains concatenation (127 . 0 . 0 . 1)
+// ==========================================================================
+
+#[test]
+fn ip_address_in_arrayref() {
+    assert_clean_parse("$args{no_proxy} = [127.0.0.1, 127.0.0.11];");
+}
+
+#[test]
+fn dotted_numbers_in_arrayref() {
+    assert_clean_parse("my $x = [1.2.3];");
+}
+
+// ==========================================================================
+// Fix 5: Complex deref expressions inside array ref wrapper
+// ==========================================================================
+
+#[test]
+fn deref_method_call_in_arrayref() {
+    assert_clean_parse(
+        "return [@{Mojo::Cookie::Response->parse($headers->set_cookie)}] unless @_;",
+    );
+}
+
+// ==========================================================================
+// Fix 6: x repetition operator inside array ref
+// ==========================================================================
+
+#[test]
+fn x_repetition_in_arrayref() {
+    assert_clean_parse("my @x = [ (undef) x scalar(@ordered_values) ];");
+}
+
+// ==========================================================================
+// Fix 7: Block-list functions inside array ref
+// ==========================================================================
+
+#[test]
+fn block_func_indexes_in_arrayref() {
+    assert_clean_parse("[indexes {$_ eq $search} unpack('(A)*', $_[0])];");
+}
+
+#[test]
+fn block_func_indexes_deref_in_arrayref() {
+    assert_clean_parse("[indexes {$_ eq $search} @{$_[0]}];");
+}
+
+// ==========================================================================
+// Fix 8: Complex map inside array ref
+// ==========================================================================
+
+#[test]
+fn map_complex_in_arrayref() {
+    assert_clean_parse(r#"my $methods = [map uc($_), @{ref $_[0] ? $_[0] : [@_]}];"#);
+}


### PR DESCRIPTION
## Summary
- parse `$#$ref` and `$#{expr}` as last-index dereference expressions in both combined-token and split-sigil paths
- cover arrayref and bracket-expression patterns pulled from real parser failures
- add focused regression tests for bracket expressions, slices, and list operators that depend on this syntax

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p perl-parser-core --locked --test unclosed_bracket_fixes_tests --test cpan_real_world_programs`
- [x] `cargo clippy -p perl-parser-core --lib --locked -- -D warnings`