### PR TITLE
fix(parser): allow keyword method names and trailing separators

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -174,7 +174,9 @@ impl<'a> Parser<'a> {
                             }
                         }
 
-                        Some(TokenKind::Identifier | TokenKind::Method) => {
+                        Some(kind)
+                            if kind == TokenKind::Identifier || Self::is_keyword_token(kind) =>
+                        {
                             // Check for ->$#* (postfix last-index dereference, Perl 5.20+).
                             // The lexer produces Identifier("$#") for `$#` when no array
                             // name follows, so we handle it here before the method-call path.

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -714,6 +714,10 @@ impl<'a> Parser<'a> {
                                 while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
                                     self.consume_token()?; // consume comma or fat arrow
 
+                                    if self.is_at_statement_end() {
+                                        break;
+                                    }
+
                                     // Check if we hit a statement modifier
                                     match self.peek_kind() {
                                         Some(TokenKind::If)

--- a/crates/perl-parser-core/tests/fix_c_style_for_loop.rs
+++ b/crates/perl-parser-core/tests/fix_c_style_for_loop.rs
@@ -1,0 +1,134 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_c_style_for_basic() {
+    let source = r#"for (my $i = 0; $i < 10; $i++) { print $i; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_empty_init() {
+    let source = r#"for (; $i < 10; $i++) { print $i; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_empty_all() {
+    let source = r#"for (;;) { last; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_complex_update() {
+    let source = r#"for (my $i = 0; $i < scalar @items; $i += 2) { print $items[$i]; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_multiple_vars() {
+    let source = r#"for (my $i = 0; $i <= $#array; $i++) { $result{$array[$i]} = $i; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_multi_statement_body() {
+    let source = r#"for (my $i = 0; $i < 10; $i++) {
+        my $x = $i * 2;
+        print "$x\n";
+    }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_nested() {
+    let source = r#"for (my $i = 0; $i < 10; $i++) {
+        for (my $j = 0; $j < 10; $j++) {
+            print "$i $j\n";
+        }
+    }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_c_style_for_expression_init() {
+    let source = r#"for ($i = 0; $i < 10; $i++) { print $i; }"#;
+    assert_clean_parse(source);
+}
+
+// Patterns that may cause "expected expression, found ';'" on CPAN
+
+#[test]
+fn test_empty_statement_in_block() {
+    // Double semicolon or empty statement
+    let source = r#"{ my $x = 1;; my $y = 2; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_semicolon_after_close_brace() {
+    let source = r#"if (1) { print "yes"; }; print "done";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_do_while_semicolon() {
+    // do { ... } while (cond); -- the trailing semicolon
+    let source = r#"do { print "hello"; } while (1);"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_eval_block_semicolon() {
+    let source = r#"eval { die "error"; }; print "survived";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_ternary_with_semicolons_nearby() {
+    let source = r#"my $x = $a ? $b : $c;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_chained_method_calls_semicolons() {
+    let source = r#"$obj->method1(); $obj->method2();"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_hash_ref_constructor() {
+    let source = r#"my $h = { a => 1, b => 2 };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_complex_assignment_with_semicolon() {
+    let source = r#"my ($a, $b, $c) = (1, 2, 3);"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_semicolons_in_prototype() {
+    // Prototypes use ; to separate required and optional args
+    let source = r#"sub foo ($$;@) { return @_; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_for_with_last_and_next() {
+    let source = r#"for (my $i = 0; $i < 100; $i++) {
+        next if $i % 2;
+        last if $i > 50;
+        print $i;
+    }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_postfix_deref_with_c_style_for() {
+    let source = r#"for (my $i = 0; $i < $data->@*; $i++) {
+        print $data->[$i];
+    }"#;
+    assert_clean_parse(source);
+}

--- a/crates/perl-parser-core/tests/fix_unexpected_semicolon.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_semicolon.rs
@@ -1,0 +1,84 @@
+use perl_parser_core::{Node, NodeKind, Parser};
+use perl_tdd_support::must;
+
+/// Assert a clean parse by walking the AST for Error nodes directly
+fn assert_no_errors(source: &str) {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+
+    let mut errors = Vec::new();
+    walk_all_errors(&ast, &mut errors);
+
+    assert!(
+        errors.is_empty(),
+        "Found {} error nodes in AST:\n{}\nsexp:\n{}",
+        errors.len(),
+        errors
+            .iter()
+            .map(|(pos, msg)| format!("  byte {}: {}", pos, msg))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        ast.to_sexp()
+    );
+}
+
+fn walk_all_errors(node: &Node, errors: &mut Vec<(usize, String)>) {
+    if let NodeKind::Error { message, .. } = &node.kind {
+        errors.push((node.location.start, message.clone()));
+    }
+    node.for_each_child(|child| {
+        walk_all_errors(child, errors);
+    });
+}
+
+// === Bug A: ->local parsed as keyword instead of method name ===
+
+#[test]
+fn test_arrow_local_method() {
+    assert_no_errors("$self->local;\n");
+}
+
+#[test]
+fn test_arrow_local_method_full_context() {
+    let source = r#"use strict;
+use warnings;
+
+package Test::Deep::Cache 1.205;
+
+use Test::Deep::Cache::Simple;
+
+sub new
+{
+  my $pkg = shift;
+  my $self = bless {}, $pkg;
+  $self->{expects} = [Test::Deep::Cache::Simple->new];
+  $self->{normal} = [Test::Deep::Cache::Simple->new];
+  $self->local;
+  return $self;
+}
+"#;
+    assert_no_errors(source);
+}
+
+// === Local with punctuation special variables ===
+
+#[test]
+fn test_local_dollar_slash_no_init() {
+    assert_no_errors("local $/;\n");
+}
+
+#[test]
+fn test_local_dollar_dot_no_init() {
+    assert_no_errors("local $.;\n");
+}
+
+// === Trailing comma before semicolon ===
+
+#[test]
+fn test_trailing_comma_before_semicolon() {
+    let source = r#"sprintf
+    "defined(%s)",
+    $var,
+    ;"#;
+    assert_no_errors(source);
+}


### PR DESCRIPTION
Fixes two parser gaps: keyword barewords after `->` now parse as method names, and statement-start builtin calls now accept a trailing comma or fat-arrow separator before the statement terminator.

Validation:
- cargo fmt --all
- cargo test -p perl-parser-core --test fix_unexpected_semicolon --test fix_c_style_for_loop --lib --locked
- cargo clippy -p perl-parser-core --lib --test fix_unexpected_semicolon --test fix_c_style_for_loop --locked -- -D warnings
- just status-update