### PR TITLE
docs: add ADR-0035 documenting raw-pointer ParentMap for AST upward traversal

### DIFF
--- a/docs/adr/0035-raw-pointer-parent-map.md
+++ b/docs/adr/0035-raw-pointer-parent-map.md
@@ -1,0 +1,172 @@
+# ADR-0035: Raw-Pointer Parent Map for AST Upward Traversal
+
+**Status**: Accepted
+**Date**: 2026-03-18
+**Decision Makers**: Perl LSP Architecture Team
+**Related**: [ADR-0012](0012-error-handling-strategy.md), [ADR-0031](0031-async-runtime-concurrent-dispatch.md), [ADR-0034](0034-custom-lsp-runtime.md)
+
+## Context
+
+Several editor features need to walk *up* the parsed Perl AST, not just down from the root.
+Declaration lookup, scope analysis, and context-sensitive navigation all need efficient parent
+access after parsing has already produced a tree of child-owned nodes.
+
+The current implementation solves this by building a `ParentMap`:
+
+- `crates/perl-semantic-analyzer/src/analysis/declaration.rs` defines
+  `ParentMap = FxHashMap<*const Node, *const Node>`
+- `DeclarationProvider::build_parent_map()` populates the map during AST traversal
+- `crates/perl-lsp/src/state/document.rs` stores the map alongside each parsed document
+- `crates/perl-lsp/src/runtime/mod.rs` provides manual `Send`/`Sync` impls for `LspServer`
+  because `DocumentState` contains raw pointers through `ParentMap`
+
+This is an unusual design in a Rust codebase because the project deliberately accepts a narrow raw
+pointer escape hatch inside an otherwise strongly synchronized runtime.
+
+### Problem Statement
+
+The project needed a way to support fast upward AST traversal without introducing one of the
+following costs:
+
+1. intrusive parent pointers inside every AST node
+2. repeated root-to-leaf rescans to recover ancestry information
+3. heavy reference-counted interior links that complicate ownership and mutation
+4. broad unsafe traversal code spread across navigation features
+
+The code already used this design, but the rationale and guardrails were not captured as an ADR.
+That made the choice look like an isolated oddity instead of an intentional architecture decision.
+
+## Decision
+
+**The project will keep parent relationships in a sidecar `ParentMap` keyed by raw AST node
+pointers, and will treat the map as a synchronized, document-scoped cache rather than embedding
+parent links directly into AST nodes.**
+
+### Chosen Architecture
+
+| Concern | Decision |
+|---|---|
+| Parent lookup representation | `FxHashMap<*const Node, *const Node>` sidecar map |
+| Ownership model | AST remains child-owned; parent links are external metadata |
+| Lifetime scope | Parent maps live only as long as the parsed document snapshot that created them |
+| Thread-safety boundary | Access is mediated through document storage protected by synchronization |
+| Validation strategy | Debug assertions check freshness, suspicious emptiness, and parent-map cycles |
+
+### Why This Was Chosen
+
+1. **Upward traversal is a hot-path requirement.**
+   Declaration and scope features need O(1) parent lookups once a document has been parsed.
+
+2. **The AST should stay structurally simple.**
+   Embedding parent pointers in every node would make the tree more invasive, harder to evolve,
+   and more tightly coupled to runtime navigation needs.
+
+3. **Document snapshots already provide a natural lifetime boundary.**
+   The parser, AST, document text, and parent map are rebuilt together on refresh, which gives the
+   raw-pointer map a bounded and understandable validity window.
+
+4. **Unsafe surface area is minimized.**
+   Rather than letting many features improvise ancestry recovery, the project centralizes the raw
+   pointer representation in one map type plus narrow runtime synchronization assumptions.
+
+## Alternatives Considered
+
+### Option 1: Store parent pointers directly in AST nodes
+
+**Pros**:
+- Parent traversal would be immediate and explicit on every node
+- No extra sidecar map to build after parsing
+
+**Cons**:
+- Makes AST ownership more complex and more self-referential
+- Couples parser data structures to LSP/navigation concerns
+- Increases risk when cloning, rebuilding, or incrementally replacing trees
+
+**Decision**: Rejected.
+
+### Option 2: Recompute ancestry on demand from the root
+
+**Pros**:
+- Avoids raw pointers entirely
+- Keeps AST representation purely child-directed
+
+**Cons**:
+- Too expensive for latency-sensitive editor operations
+- Repeats work across declaration, scope, and navigation features
+- Makes performance dependent on tree depth and repeated searches
+
+**Decision**: Rejected.
+
+### Option 3: Use reference-counted bidirectional links (`Rc`/`Weak`, `Arc`/`Weak`)
+
+**Pros**:
+- Avoids naked raw pointers in the API surface
+- Encodes ancestry in the object graph itself
+
+**Cons**:
+- Adds allocation and graph-management overhead
+- Complicates parser-owned tree construction
+- Poor fit for document snapshots that are frequently rebuilt wholesale
+
+**Decision**: Rejected.
+
+### Option 4: Keep a raw-pointer sidecar parent map
+
+**Pros**:
+- O(1) parent lookup after a single O(n) build pass
+- Preserves a simple child-owned AST
+- Keeps the unusual memory model localized and reviewable
+- Fits snapshot-style document rebuilds already used by the LSP runtime
+
+**Cons**:
+- Requires explicit synchronization and lifetime discipline
+- Forces manual `Send`/`Sync` reasoning at the server boundary
+- Needs documentation so contributors understand why raw pointers are present
+
+**Decision**: Accepted.
+
+## Consequences
+
+### Positive
+
+- **Fast scope walking** for declaration and semantic features.
+- **Clear separation of concerns** between parser data structures and editor navigation metadata.
+- **Localized unsafety**: the raw-pointer model is confined to parent-map construction and
+  synchronized document storage.
+- **Debug-time guardrails**: the current implementation already checks for stale versions, empty
+  maps in suspicious cases, and cycles.
+
+### Negative / Trade-offs
+
+- **Manual thread-safety reasoning** is required because raw pointers prevent automatic
+  `Send`/`Sync` derivation.
+- **Snapshot invalidation matters**: features must not keep using an old parent map after document
+  refresh.
+- **Contributor surprise**: reviewers may reasonably ask why a Rust project uses raw pointers for a
+  core navigation path.
+
+## Guardrails
+
+This decision depends on the following implementation rules remaining true:
+
+1. Parent maps are rebuilt whenever the AST snapshot is rebuilt.
+2. Parent-map access remains scoped to synchronized document state.
+3. Debug assertions continue to detect stale provider use and obvious structural corruption.
+4. Production code does not widen unsafe access patterns beyond the current narrow boundary.
+
+If these assumptions stop being true, this ADR must be revisited.
+
+## Revisit Triggers
+
+Review this ADR if any of the following happen:
+
+- the AST representation gains a safe and cheap way to store parent links directly
+- incremental parsing starts preserving parent relationships more efficiently in-tree
+- raw-pointer synchronization becomes a recurring source of bugs or review friction
+- declaration/scope performance no longer benefits materially from cached parent links
+
+## References
+
+- `crates/perl-semantic-analyzer/src/analysis/declaration.rs`
+- `crates/perl-lsp/src/state/document.rs`
+- `crates/perl-lsp/src/runtime/mod.rs`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,7 @@ This directory contains Architecture Decision Records (ADRs) for significant des
 | [ADR-0032](0032-skill-scoping-and-hook-enforcement.md) | Accepted | 2026-03-16 | Skill Scoping and Hook Enforcement | Frontmatter-based skill access control plus hook-enforced swarm coordination |
 | [ADR-0033](0033-worktree-first-disposable-workers.md) | Accepted | 2026-03-16 | Worktree-First Disposable Worker Execution | Small persistent coordinators, fresh workers per context shift, and worktree isolation for PR-shaped changes |
 | [ADR-0034](0034-custom-lsp-runtime.md) | Accepted | 2026-03-18 | Custom LSP Runtime over Framework Adoption | Bespoke protocol/transport/runtime stack kept to support governance, transport reuse, and explicit dispatch control |
+| [ADR-0035](0035-raw-pointer-parent-map.md) | Accepted | 2026-03-18 | Raw-Pointer Parent Map for AST Upward Traversal | Document-scoped sidecar parent cache using raw node pointers for fast declaration and scope walking |
 
 ## About ADRs
 


### PR DESCRIPTION
### Motivation
- Record and explain the deliberate use of a raw-pointer `ParentMap` sidecar for O(1) upward AST traversal and the manual `Send`/`Sync` reasoning so contributors and reviewers have an explicit architecture record rather than encountering this as an unexplained code oddity.

### Description
- Add `docs/adr/0035-raw-pointer-parent-map.md` which captures context, decision, alternatives considered, consequences, guardrails, and revisit triggers for the raw-pointer `ParentMap` design.
- Update the ADR index at `docs/adr/README.md` to include the new `ADR-0035` entry so the decision is discoverable alongside existing ADRs.

### Testing
- Ran `git diff --check` which returned clean results.
- Ran `cargo fmt --all --check` which passed (no formatting changes required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb18dea32c8333841af5a29acc7143)