### PR TITLE
docs: expand ADR coverage summaries

### DIFF
--- a/book/src/resources/adr.md
+++ b/book/src/resources/adr.md
@@ -9,7 +9,7 @@ The project currently maintains ADRs in `docs/adr/` across several groups:
 - **Legacy foundations**: ADR-0001 through ADR-0002.
 - **Historical current-series ADRs**: ADR-001 through ADR-007, preserved for earlier documentation and workflow decisions.
 - **Core architecture ADRs**: ADR-0008 through ADR-0030, covering parser architecture, indexing, DAP, UTF-16 position handling, error strategy, rope-backed documents, lifecycle/index routing, and delivery gates.
-- **Current direction ADRs**: ADR-0031 through ADR-0034, covering concurrent dispatch, skill/hook enforcement, disposable worktrees, and the custom LSP runtime.
+- **Current direction ADRs**: ADR-0031 through ADR-0037, covering concurrent dispatch, skill/hook enforcement, disposable worktrees, the custom LSP runtime, parent-map traversal, generated feature contracts, and synthetic URI fallbacks.
 
 For the canonical index, including status and date metadata for every ADR, see [`docs/adr/README.md`](../../docs/adr/README.md).
 


### PR DESCRIPTION
### Motivation

- High-level documentation and the mdBook ADR page only referenced a small subset of ADRs, making it harder for readers to discover the full set and recent decisions. 
- Provide clear guidance that the canonical ADR index is `docs/adr/README.md` while giving an at-a-glance grouping and recommended starting points for newcomers.

### Description

- Expanded `docs/STRATEGIC_DOCUMENTATION.md` to add an "ADR coverage at a glance" table that groups ADRs by series (legacy, historical, core architecture, runtime/operational, current 2026 direction) and links representative ADRs including `0031` and `0034`.
- Updated `book/src/resources/adr.md` (mdBook resource) to summarize ADR groupings, point readers to the canonical `docs/adr/README.md`, and add a short "Suggested starting points" list of ADRs for new contributors.
- Updated the documentation "last updated" timestamp to reflect the changes and adjusted a small phrasing change in the ADR format sentence; no source code or behavior changed.

### Testing

- Verified presence of the new ADR references and canonical index links with a small content scan that looked for `0031-async-runtime-concurrent-dispatch.md`, `0034-custom-lsp-runtime.md`, and `docs/adr/README.md` in the updated files.
- Confirmed the changed files contain the expected summary text and suggested starting points by opening `docs/STRATEGIC_DOCUMENTATION.md` and `book/src/resources/adr.md` and inspecting the updated sections.
- Confirmed only documentation files were modified by the change; an unrelated pre-existing modification in `vscode-extension/pnpm-lock.yaml` was detected but left unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb18d3f4648333be40f9f84edd4f63)