### PR TITLE
test(ci): cover extracted LSP runtime contracts

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -623,12 +623,15 @@ gates:
 
   - name: lsp_tier_b
     tier: merge_gate
-    description: "LSP core behavior: definitions, completion, security (2-5 min)"
+    description: "LSP core behavior: definitions, completion, color handling, code lens, inline completion, security (2-5 min)"
     required: true
     command: >-
       env RUST_TEST_THREADS=2
       cargo test -p perl-lsp
       --test semantic_definition --test lsp_completion_tests
+      --test lsp_color_tests
+      --test lsp_code_lens_tests
+      --test lsp_inline_completion_tests
       --test lsp_unhappy_paths --test lsp_code_actions_test
       --test execute_command_security_tests --test lsp_behavioral_tests
       --test lsp_workspace_index_e2e

--- a/justfile
+++ b/justfile
@@ -599,6 +599,12 @@ ci-lsp-microcrates:
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
         cargo test -p perl-lsp-providers --locked --test microcrate_reexports_compatibility -- --test-threads=1
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        cargo test -p perl-lsp --locked --test lsp_color_tests -- --test-threads=1
+    @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        cargo test -p perl-lsp --locked --test lsp_code_lens_tests -- --test-threads=1
+    @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        cargo test -p perl-lsp --locked --test lsp_inline_completion_tests -- --test-threads=1
+    @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
         cargo test --locked -p perl-feature-catalog \
                    -p perl-lsp-feature-ids \
                    -p perl-lsp-feature-profile \


### PR DESCRIPTION
## Summary
- add `lsp_color_tests`, `lsp_code_lens_tests`, and `lsp_inline_completion_tests` to `ci-lsp-microcrates`
- extend the merge-blocking `lsp_tier_b` gate to cover those runtime contracts too
- align the fast merge gate with the extracted LSP provider paths already tracked in `features_sot.toml`

## Why
Recent microcrate extractions for color, code lens, and inline completion all validated locally, but the fast merge gate still missed some of the real `perl-lsp` integration paths. That left re-export or request-dispatch regressions able to merge green even when the feature catalog pointed at those tests.

## Validation
- `just ci-lsp-microcrates`
- `cargo xtask gates --gate lsp_tier_b --receipt`
- `git diff --check`
