### PR TITLE
docs(contributing): update for 0.12.0 public alpha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,9 @@ Add these labels to trigger additional CI checks:
 
 | Label | What it runs |
 |-------|--------------|
+| `ci:coverage` | Code coverage analysis |
 | `ci:bench` | Performance benchmarks |
+| `ci:mutation` | Mutation testing |
 | `ci:strict` | Pedantic clippy |
 | `ci:mac` | macOS build |
 | `ci:semver` | Breaking change detection |


### PR DESCRIPTION
## Summary

- Rewrites CONTRIBUTING.md from ~740 lines to ~200 lines
- Removes content duplicated from COMMANDS_REFERENCE.md and CLAUDE.md
- Adds "Finding Issues to Work On" section with label guidance
- Streamlines development workflow into a clear 5-step process
- Links to detailed docs instead of inlining everything
- Keeps coding standards summary, CI gate tiers, and SemVer policy concise

## Test plan

- [ ] Verify all internal links resolve (CLAUDE.md, COMMANDS_REFERENCE.md, STABILITY.md, etc.)
- [ ] Verify markdown renders correctly on GitHub
- [ ] Check that no essential contributor information was lost