### PR TITLE
fix(parser): handle ternary expressions in use constant declarations

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -956,7 +956,10 @@ impl<'a> Parser<'a> {
             let kind = self.peek_kind();
             let at_top_level = paren_depth == 0 && bracket_depth == 0 && brace_depth == 0;
 
-            if Self::is_statement_terminator(kind) {
+            // Only treat semicolons as terminators at the top level — inside
+            // nested braces/parens/brackets (e.g. `eval { ...; ... }`) the
+            // semicolons are part of the inner expression and must be consumed.
+            if at_top_level && Self::is_statement_terminator(kind) {
                 break;
             }
 

--- a/crates/perl-parser-core/tests/use_constant_ternary_tests.rs
+++ b/crates/perl-parser-core/tests/use_constant_ternary_tests.rs
@@ -89,3 +89,81 @@ fn test_use_constant_ternary_with_nested_fat_arrows() {
         "(use constant (MAP 1 ? { foo => 'a' } : { bar => 'b' }))",
     );
 }
+
+// --- Tests for issue #1895: ternary with variable/expression conditions ---
+
+#[test]
+fn test_use_constant_ternary_variable_condition() {
+    // Variable as ternary condition — the core issue #1895 pattern
+    let source = r#"use constant FOO => $bar ? 1 : 0;"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    for marker in &["(error ", "(Error ", "(ERROR ", "MissingExpression", "MissingStatement"] {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for variable ternary:\n{}\nSexp: {}",
+            source,
+            sexp,
+        );
+    }
+}
+
+#[test]
+fn test_use_constant_ternary_env_hash_condition() {
+    let source = r#"use constant MODE => $ENV{DEBUG} ? 'debug' : 'release';"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    for marker in &["(error ", "(Error ", "(ERROR ", "MissingExpression", "MissingStatement"] {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for ENV ternary:\n{}\nSexp: {}",
+            source,
+            sexp,
+        );
+    }
+}
+
+#[test]
+fn test_use_constant_ternary_perl_version_condition() {
+    let source = r#"use constant HAS_FEATURE => $] >= 5.010 ? 1 : 0;"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    for marker in &["(error ", "(Error ", "(ERROR ", "MissingExpression", "MissingStatement"] {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for version ternary:\n{}\nSexp: {}",
+            source,
+            sexp,
+        );
+    }
+}
+
+#[test]
+fn test_use_constant_ternary_eval_condition() {
+    let source = r#"use constant CAN_DO => eval { require Some::Module; 1 } ? 1 : 0;"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    for marker in &["(error ", "(Error ", "(ERROR ", "MissingExpression", "MissingStatement"] {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for eval ternary:\n{}\nSexp: {}",
+            source,
+            sexp,
+        );
+    }
+}
+
+#[test]
+fn test_use_constant_ternary_defined_or_condition() {
+    let source = r#"use constant VAL => defined($x) ? $x : 'default';"#;
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    for marker in &["(error ", "(Error ", "(ERROR ", "MissingExpression", "MissingStatement"] {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for defined-or ternary:\n{}\nSexp: {}",
+            source,
+            sexp,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1895.

- `consume_use_import_value` in `declarations.rs` had a semicolon check that wasn't depth-aware — `eval { require Foo; 1 } ? 1 : 0` would break at the inner `;` and leave orphaned tokens
- Gate the semicolon-terminates check on `at_top_level` so semicolons inside nested braces/parens/brackets are consumed as part of the value expression

## Test plan

- [x] 5 new tests added: variable condition, ENV hash, Perl version, eval block, defined() in use constant ternary values
- [x] All 12 ternary tests pass (7 existing + 5 new)
- [x] All perl-parser-core tests pass (only pre-existing `parser_ac3_prevent_recursive_recovery` failure)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean