### PR TITLE
chore(swarm): add agent prompt templates and cycle 4 pitfalls

### DIFF
--- a/.claude/skills/swarm/templates/parser-fix-builder.md
+++ b/.claude/skills/swarm/templates/parser-fix-builder.md
@@ -1,0 +1,33 @@
+# Parser Fix Builder Prompt Template
+
+Use this when spawning a worktree worker to fix a parser bug.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Fix parser bug — <BUG_DESCRIPTION>.
+
+## Context
+- Issue: <ISSUE_NUMBER_OR_LINK>
+- Root cause: <ROOT_CAUSE_SUMMARY_FROM_SCOUT>
+- Target files: <FILE_SURFACE>
+- Construct: <PERL_CONSTRUCT_THAT_FAILS>
+
+## Steps
+1. Read the target files and understand the current parsing path
+2. Add a failing test in the appropriate `*_tests.rs` file
+3. Implement the smallest fix that makes the new test pass
+4. Run verification: `cargo fmt --all && cargo clippy -p perl-parser-core --lib && cargo test -p perl-parser-core && cargo test -p perl-parser`
+5. If tests were added, run `just status-update && just status-check`
+6. Commit: `fix(perl-parser-core): <description>`
+
+## Out of Scope
+- Do not fix unrelated parser issues found during investigation
+- Do not refactor surrounding code
+- If the bug is actually in the lexer, stop and report back
+
+## Verification
+cargo fmt --all && cargo clippy -p perl-parser-core --lib && cargo test -p perl-parser-core && cargo test -p perl-parser
+```

--- a/.claude/skills/swarm/templates/refactoring-builder.md
+++ b/.claude/skills/swarm/templates/refactoring-builder.md
@@ -1,0 +1,36 @@
+# Refactoring Builder Prompt Template
+
+Use this when spawning a worktree worker for a refactoring task (SRP splits, dead code removal, API cleanup).
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Refactor <CRATE_NAME> — <REFACTORING_DESCRIPTION>.
+
+## Context
+- Issue: <ISSUE_NUMBER_OR_LINK>
+- Motivation: <WHY_THIS_REFACTORING>
+- Target files: <FILE_SURFACE>
+- Downstream dependents: <CRATES_THAT_DEPEND_ON_THIS>
+
+## Steps
+1. Read the target files and map the current structure
+2. Identify all callers/dependents with grep before moving code
+3. Make the structural change in small, verifiable steps
+4. Ensure all public APIs remain backward-compatible unless explicitly breaking
+5. Run verification against this crate AND downstream dependents
+6. Commit: `refactor(<CRATE>): <description>`
+
+## Verification
+cargo fmt --all && cargo clippy -p <CRATE> --tests -- -D warnings && cargo test -p <CRATE>
+
+If 3+ crates affected:
+nix develop -c just ci-gate
+
+## Out of Scope
+- Do not change behavior — this is a structural change only
+- Do not add features or fix bugs alongside the refactoring
+- Do not touch files outside the declared file surface
+```

--- a/.claude/skills/swarm/templates/review-agent.md
+++ b/.claude/skills/swarm/templates/review-agent.md
@@ -1,0 +1,39 @@
+# Review Agent Prompt Template
+
+Use this when spawning a subagent to review a single PR.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Review PR #<PR_NUMBER> — <PR_TITLE>.
+
+## Context
+- Branch: <BRANCH_NAME>
+- Crate: <PRIMARY_CRATE>
+- Builder receipt: <RECEIPT_SUMMARY>
+
+## Review Checklist
+1. Read the PR diff: `gh pr diff <PR_NUMBER>`
+2. Read the PR description: `gh pr view <PR_NUMBER>`
+3. Check coding standards compliance:
+   - No `unwrap()`, `expect()`, `panic!()`, `todo!()`, `unimplemented!()`, `dbg!()`
+   - Proper error handling with `?` and `Result`/`Option`
+   - `.first()` not `.get(0)`, `or_default()` not `or_insert_with(Vec::new)`
+4. Check tests exist for new functionality
+5. Check PR description is accurate and complete
+6. Check scope — no unrelated changes mixed in
+7. Check commit message follows conventional format: `type(scope): description`
+
+## Decision
+- **Approve**: If all checks pass, report approval to ops coordinator
+- **Request changes**: If issues found, list specific fixes needed and report to builder coordinator
+- Do NOT make code changes yourself — route fixes back to builder
+
+## Report Format
+- PR number and title
+- Pass/fail for each checklist item
+- Specific issues found (with file:line references)
+- Verdict: approve / request-changes
+```

--- a/.claude/skills/swarm/templates/scout-agent.md
+++ b/.claude/skills/swarm/templates/scout-agent.md
@@ -1,0 +1,37 @@
+# Scout Agent Prompt Template
+
+Use this when spawning an Explore subagent for discovery work.
+
+## Template
+
+```
+Goal: Scout <FOCUS_AREA> for improvement opportunities.
+
+## Context
+- Focus: <SPECIFIC_AREA — e.g., "parser error bucket: heredoc", "DAP test gaps", "dead code in perl-lsp-*">
+- Priority tier: <P1-P4>
+- Read .claude/swarm-state/discovered-issues.md for dedup
+- Read .claude/swarm-state/completed-slices.md for already-done work
+
+## Investigation Steps
+1. Identify the scope of the problem
+2. Find concrete failing examples or gaps
+3. Locate the exact file surface that needs changes
+4. Determine the verification command
+5. Estimate the size: small (1 file), medium (2-3 files), large (4+ files or cross-crate)
+
+## Deliverable
+Report back with a structured finding:
+- One-sentence summary
+- Root cause (with file:line references)
+- Exact file surface
+- Suggested verification command
+- Priority tier
+- Whether this overlaps with any existing issue or PR
+
+## Rules
+- Do NOT make code changes
+- Do NOT create PRs or branches
+- If you find multiple independent issues, report each as a separate finding
+- Verify findings against current master — stale snapshots waste builder time
+```

--- a/.claude/skills/swarm/templates/test-coverage-builder.md
+++ b/.claude/skills/swarm/templates/test-coverage-builder.md
@@ -1,0 +1,37 @@
+# Test Coverage Builder Prompt Template
+
+Use this when spawning a worktree worker to add tests to a crate.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Add test coverage for <CRATE_NAME> — <FOCUS_AREA>.
+
+## Context
+- Issue: <ISSUE_NUMBER_OR_LINK>
+- Current coverage gap: <WHAT_IS_UNTESTED>
+- Target files: <FILE_SURFACE>
+
+## Steps
+1. Read the source files to understand the API surface
+2. Identify untested code paths, edge cases, and error conditions
+3. Add tests following the naming convention: `test_<what>_<scenario>_<expected>`
+4. Use `Result<()>` returns or `perl_tdd_support::must` / `must_some`
+5. Run verification: `cargo fmt --all && cargo clippy -p <CRATE> --tests -- -D warnings && cargo test -p <CRATE>`
+6. Run `just status-update && just status-check` (required when adding tests)
+7. Commit: `test(<CRATE>): <description>`
+
+## Test Standards
+- No `unwrap()` or `expect()` in tests — use `Result<()>` or `must`/`must_some`
+- Descriptive names: `test_<what>_<scenario>_<expected>`
+- For perl-lsp: `RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2`
+
+## Out of Scope
+- Do not fix bugs found during testing (file an issue instead)
+- Do not refactor production code
+
+## Verification
+cargo fmt --all && cargo clippy -p <CRATE> --tests -- -D warnings && cargo test -p <CRATE>
+```

--- a/.claude/swarm-state/known-pitfalls.md
+++ b/.claude/swarm-state/known-pitfalls.md
@@ -18,3 +18,45 @@ Each entry:
 ## Entries
 
 <!-- Agents append new entries below this line -->
+
+### 2026-03-19 — Worktree Base Drift
+
+**Source**: Cycle 4 session learnings
+**Pitfall**: Worktrees created early in a session drift from master as other PRs merge. By the time a PR is created, the worktree may be many commits behind, causing rebase conflicts or stale code references.
+**Fix**: Before creating a PR from a worktree, rebase onto current master and re-run verification. If the worktree is very stale (10+ commits behind), consider starting fresh.
+**Affected crates**: all
+
+### 2026-03-19 — CI Cancellation Cascades
+
+**Source**: Cycle 4 merge waves
+**Pitfall**: Merging PRs in rapid succession causes GitHub Actions to cancel in-progress CI runs for the master branch. Each new push to master cancels the previous run, so only the last merge in a rapid batch gets a full CI pass.
+**Fix**: Merge in batches of 3, then wait for the CI run to complete before merging the next batch. Use `gh run list --branch master --limit 5 --json status,conclusion` to check.
+**Affected crates**: all
+
+### 2026-03-19 — Clippy Gate After Merge Waves
+
+**Source**: Cycle 4 post-merge failures
+**Pitfall**: Individual PRs pass clippy in isolation, but the merge commit combining multiple PRs can introduce new clippy warnings (unused imports from removed functions, new lints from dependency updates).
+**Fix**: After merging a wave of PRs, check the master CI run. If clippy fails, spawn a fixer agent. Run `cargo clippy --workspace --lib -- -D warnings` locally after pulling merged master.
+**Affected crates**: all
+
+### 2026-03-19 — Draft PR Cleanup
+
+**Source**: Cycle 4 PR queue bloat
+**Pitfall**: Draft PRs accumulate when builders create them but reviewers do not pick them up. The PR list grows unwieldy and stale drafts cause confusion about work status.
+**Fix**: Triage draft PRs at session start. Close stale drafts (no updates in 2+ days). For active drafts, mark ready or note blockers.
+**Affected crates**: all
+
+### 2026-03-19 — Status Update After Test Changes
+
+**Source**: Cycle 4 CI failures
+**Pitfall**: Adding or modifying tests changes computed metrics in `docs/project/CURRENT_STATUS.md`. If `just status-update && just status-check` is not run, the `policy_checks` CI gate fails.
+**Fix**: Always run `just status-update && just status-check` after modifying test files, before committing.
+**Affected crates**: all
+
+### 2026-03-19 — Rebase Ours/Theirs Inversion
+
+**Source**: Multiple cycle 3-4 rebase failures
+**Pitfall**: During `git rebase`, `--ours` and `--theirs` are inverted compared to `git merge`. In rebase, `--ours` = upstream (master), `--theirs` = your commits being replayed.
+**Fix**: During rebase, `--theirs` keeps YOUR changes. When in doubt, resolve conflicts manually.
+**Affected crates**: all


### PR DESCRIPTION
## Summary

- Add 5 reusable prompt templates for common swarm worker types under `.claude/skills/swarm/templates/`:
  - `parser-fix-builder.md` — parser bug fix workers
  - `test-coverage-builder.md` — test addition workers
  - `refactoring-builder.md` — SRP split and refactoring workers
  - `review-agent.md` — PR review subagents
  - `scout-agent.md` — discovery/exploration subagents
- Populate `.claude/swarm-state/known-pitfalls.md` with 6 lessons from cycle 4 operations:
  - Worktree base drift
  - CI cancellation cascades
  - Clippy gate after merge waves
  - Draft PR cleanup needed
  - Status update after test changes
  - Rebase ours/theirs inversion
- Created `.ops-perl-lsp/known-pitfalls.md` and `.ops-perl-lsp/friction-log.md` locally (gitignored, for operational use)

## Test plan

- [ ] Verify markdown files have no syntax errors
- [ ] Verify templates follow the established format from teammate-prompt-template.md
- [ ] Verify known-pitfalls entries match the documented format