### PR TITLE
fix(parser): handle ternary after named-unary operators

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -294,6 +294,32 @@ impl<'a> Parser<'a> {
         Ok(expr)
     }
 
+    /// Continue parsing ternary conditional when we already have the condition
+    /// expression.  Used by the statement-level named-unary tail so that
+    /// `defined $var ? then : else` is correctly wrapped in a Ternary node.
+    fn parse_ternary_with(&mut self, mut expr: Node) -> ParseResult<Node> {
+        if self.peek_kind() == Some(TokenKind::Question) {
+            self.tokens.next()?; // consume ?
+            let then_expr = self.parse_assignment()?;
+            self.expect(TokenKind::Colon)?;
+            let else_expr = self.parse_ternary()?;
+
+            let start = expr.location.start;
+            let end = else_expr.location.end;
+
+            expr = Node::new(
+                NodeKind::Ternary {
+                    condition: Box::new(expr),
+                    then_expr: Box::new(then_expr),
+                    else_expr: Box::new(else_expr),
+                },
+                SourceLocation { start, end },
+            );
+        }
+
+        Ok(expr)
+    }
+
     /// Parse logical OR expression
     fn parse_or(&mut self) -> ParseResult<Node> {
         let expr = self.parse_and()?;

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -499,24 +499,7 @@ impl<'a> Parser<'a> {
         expr = self.parse_bitwise_or_with(expr)?;
         expr = self.parse_and_with(expr)?;
         expr = self.parse_or_with(expr)?;
-        // Ternary (?:) sits between || and = in Perl precedence.
-        // Without this, `wantarray ? @list : $list[0]` fails.
-        if self.peek_kind() == Some(TokenKind::Question) {
-            self.tokens.next()?; // consume ?
-            let then_expr = self.parse_assignment()?;
-            self.expect(TokenKind::Colon)?;
-            let else_expr = self.parse_ternary()?;
-            let start = expr.location.start;
-            let end = else_expr.location.end;
-            expr = Node::new(
-                NodeKind::Ternary {
-                    condition: Box::new(expr),
-                    then_expr: Box::new(then_expr),
-                    else_expr: Box::new(else_expr),
-                },
-                SourceLocation { start, end },
-            );
-        }
+        expr = self.parse_ternary_with(expr)?;
         self.parse_word_or_expr(expr)
     }
 

--- a/crates/perl-parser-core/tests/named_unary_ternary_tests.rs
+++ b/crates/perl-parser-core/tests/named_unary_ternary_tests.rs
@@ -1,0 +1,42 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_defined_ternary_basic() {
+    assert_clean_parse("defined $tzname ? $tzname : 'fallback';");
+}
+
+#[test]
+fn test_ref_ternary_basic() {
+    assert_clean_parse("ref $_[0] ? 1 : 0;");
+}
+
+#[test]
+fn test_defined_ternary_function_calls() {
+    assert_clean_parse("defined $base_path ? do_a() : do_b();");
+}
+
+#[test]
+fn test_defined_ternary_assignment() {
+    assert_clean_parse("my $val = defined $x ? $x : $default;");
+}
+
+#[test]
+fn test_ref_ternary_with_comparison() {
+    assert_clean_parse("ref $obj eq 'HASH' ? $obj->{key} : undef;");
+}
+
+#[test]
+fn test_defined_ternary_nested() {
+    assert_clean_parse("defined $a ? defined $b ? $b : $c : $d;");
+}
+
+#[test]
+fn test_exists_ternary() {
+    assert_clean_parse("exists $hash{$key} ? $hash{$key} : 'missing';");
+}
+
+#[test]
+fn test_defined_ternary_in_list_context() {
+    assert_clean_parse("push @result, defined $v ? $v : 0;");
+}


### PR DESCRIPTION
## Summary

- Adds `parse_ternary_with` method to continue ternary parsing when we already have the condition expression
- Integrates it into the named-unary tail chain so `defined $var ? then : else` is correctly wrapped in a Ternary node
- Adds 8 test cases covering defined/ref/exists ternary patterns, nested ternary, assignment context, and list context

Rebased from #1930 which was based on a stale master and had regressions.

## Test plan
- [x] All 8 new named_unary_ternary_tests pass
- [x] All 9 pre-existing named_unary_precedence_tests pass (no regression)
- [x] Full perl-parser-core test suite passes (except pre-existing parser_ac3 failure also present on master)
- [x] cargo fmt clean
- [x] cargo clippy clean (lib)