### PR TITLE
test(parser): add regression tests for non-builtin unary calls (#1943)

### DIFF
--- a/crates/perl-parser-core/tests/nonbuiltin_unary_call_tests.rs
+++ b/crates/perl-parser-core/tests/nonbuiltin_unary_call_tests.rs
@@ -1,0 +1,153 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Tests for issue #1943: non-builtin unary function calls without parens
+// in parenthesized context (e.g., `if (blessed $self)`)
+//
+// The `looks_like_bare_call` heuristic in postfix.rs handles these cases
+// by detecting that an unknown identifier is followed by a sigil-bearing
+// argument and parsing it as a function call.
+
+#[test]
+fn test_blessed_in_if_condition() {
+    let source = r#"if (blessed $self) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_in_unless_condition() {
+    let source = r#"unless (blessed $ref) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_with_and_operator() {
+    let source = r#"if (blessed $err and $err->isa("Foo")) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_reftype_with_eq() {
+    let source = r#"if (reftype $x eq 'ARRAY') { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_in_elsif() {
+    let source = r#"if (0) { 1; } elsif (blessed $element && $element->isa("Foo")) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_looks_like_number_in_condition() {
+    let source = r#"if (looks_like_number $val) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_weaken_as_statement() {
+    let source = r#"weaken $self;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_croak_with_variable() {
+    let source = r#"croak $msg;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_in_ternary() {
+    let source = r#"my $x = blessed $obj ? 1 : 0;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_double_ampersand() {
+    let source = r#"if (blessed $self && $self->isa("Foo")) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_scalar_util_blessed_qualified() {
+    let source = r#"if (Scalar::Util::blessed($self)) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nested_paren_blessed() {
+    let source = r#"my $x = (blessed $obj) ? 1 : 0;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_or_operator() {
+    let source = r#"if (blessed $self or $fallback) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_multiple_nonbuiltin_unary_in_expression() {
+    let source = r#"if (blessed $a && blessed $b) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_confess_with_variable() {
+    let source = r#"confess $error;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_carp_with_variable() {
+    let source = r#"carp $warning;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nonbuiltin_unary_in_while() {
+    let source = r#"while (defined $line && chomp $line) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_blessed_with_deref() {
+    let source = r#"if (blessed $self->{obj}) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nonbuiltin_in_return() {
+    let source = r#"return blessed $obj;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nonbuiltin_in_assignment() {
+    let source = r#"my $type = blessed $obj;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nonbuiltin_unary_negated() {
+    let source = r#"if (!blessed $obj) { 1; }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_croak_with_string_literal() {
+    let source = r#"croak "something went wrong";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_confess_with_string_in_condition() {
+    let source = r#"confess "error: $msg" if $bad;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nonbuiltin_unary_with_array_arg() {
+    let source = r#"my @sorted = shuffle @items;"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

- Adds 24 regression tests for non-builtin unary function calls without parens in parenthesized contexts (e.g., `if (blessed $self)`)
- The `looks_like_bare_call` heuristic in `postfix.rs` already handles these cases correctly — these tests document and protect that behavior
- Covers: blessed, reftype, weaken, croak, carp, confess, looks_like_number, shuffle with various argument types and expression contexts

## Context

Issue #1943 described `unclosed_paren_identifier` errors for patterns like `if (blessed $self)`. Investigation shows the `looks_like_bare_call` method (line 497 of `postfix.rs`) already catches these non-builtin unary calls via sigil-peek heuristic. No parser fix was needed — only test coverage was missing.

## Test plan

- [x] `cargo test -p perl-parser-core --test nonbuiltin_unary_call_tests` — 24/24 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p perl-parser-core --lib` — clean

Closes #1943