### PR TITLE
fix(parser): handle for/foreach without explicit loop variable

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -223,7 +223,14 @@ impl<'a> Parser<'a> {
         self.tokens.next()?; // consume 'for'
 
         // Check if it's a foreach-style for loop
-        if matches!(self.peek_kind(), Some(TokenKind::My)) || self.is_variable_start() {
+        if matches!(
+            self.peek_kind(),
+            Some(TokenKind::My)
+                | Some(TokenKind::Our)
+                | Some(TokenKind::Local)
+                | Some(TokenKind::State)
+        ) || self.is_variable_start()
+        {
             return self.parse_foreach_style_for();
         }
 
@@ -314,7 +321,13 @@ impl<'a> Parser<'a> {
 
         // Set flag to prevent semicolon consumption in variable declaration
         self.in_for_loop_init = true;
-        let variable = if self.peek_kind() == Some(TokenKind::My) {
+        let variable = if matches!(
+            self.peek_kind(),
+            Some(TokenKind::My)
+                | Some(TokenKind::Our)
+                | Some(TokenKind::Local)
+                | Some(TokenKind::State)
+        ) {
             self.parse_variable_declaration()?
         } else if self.peek_kind() == Some(TokenKind::LeftParen) {
             // foreach (LIST) — implicit $_ topic variable
@@ -359,7 +372,13 @@ impl<'a> Parser<'a> {
     fn parse_foreach_style_for(&mut self) -> ParseResult<Node> {
         // Set flag to prevent semicolon consumption in variable declaration
         self.in_for_loop_init = true;
-        let variable = if self.peek_kind() == Some(TokenKind::My) {
+        let variable = if matches!(
+            self.peek_kind(),
+            Some(TokenKind::My)
+                | Some(TokenKind::Our)
+                | Some(TokenKind::Local)
+                | Some(TokenKind::State)
+        ) {
             self.parse_variable_declaration()?
         } else {
             // for $var (LIST) — bare scalar without my

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -315,9 +315,24 @@ impl<'a> Parser<'a> {
         self.tokens.peek()
     }
 
-    /// Check if the next token starts a variable
+    /// Check if the next token starts a variable.
+    ///
+    /// This checks both dedicated sigil tokens (`ScalarSigil`, `ArraySigil`,
+    /// `HashSigil`) and combined `Identifier` tokens whose text begins with
+    /// a variable sigil character (`$`, `@`, `%`).
     fn is_variable_start(&mut self) -> bool {
-        Self::is_variable_sigil(self.peek_kind())
+        if Self::is_variable_sigil(self.peek_kind()) {
+            return true;
+        }
+        // The lexer sometimes emits variables as Identifier("$x") tokens
+        if self.peek_kind() == Some(TokenKind::Identifier) {
+            if let Ok(tok) = self.peek_token() {
+                return tok.text.starts_with('$')
+                    || tok.text.starts_with('@')
+                    || tok.text.starts_with('%');
+            }
+        }
+        false
     }
 
     /// Expect a specific token kind

--- a/crates/perl-parser-core/tests/fix_foreach_no_variable_tests.rs
+++ b/crates/perl-parser-core/tests/fix_foreach_no_variable_tests.rs
@@ -1,0 +1,92 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+/// Strict clean parse check that also catches `(ERROR ...)` nodes.
+fn assert_strict_clean_parse(source: &str) {
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    let markers = [
+        "(error ",
+        "(Error ",
+        "(ERROR ",
+        "(missing_expression",
+        "(missing_statement",
+        "(missing_identifier",
+        "(missing_block",
+        "MissingExpression",
+        "MissingStatement",
+        "MissingIdentifier",
+        "MissingBlock",
+    ];
+    for marker in &markers {
+        assert!(
+            !sexp.contains(marker),
+            "Clean-parse assertion failed: found '{}' in sexp for source:\n{}\n\nsexp:\n{}",
+            marker,
+            source,
+            sexp,
+        );
+    }
+}
+
+// --- foreach with variable declarators ---
+
+#[test]
+fn test_foreach_our_variable() {
+    assert_strict_clean_parse("foreach our $item (@list) { print $item; }");
+}
+
+#[test]
+fn test_for_our_variable() {
+    assert_strict_clean_parse("for our $item (@list) { print $item; }");
+}
+
+// --- foreach/for with implicit $_ ---
+
+#[test]
+fn test_foreach_implicit_topic() {
+    assert_strict_clean_parse("foreach (@list) { print; }");
+}
+
+#[test]
+fn test_for_implicit_topic() {
+    assert_strict_clean_parse("for (@array) { print; }");
+}
+
+// --- foreach/for with bare scalar ---
+
+#[test]
+fn test_foreach_bare_scalar() {
+    assert_strict_clean_parse("foreach $item (@list) { print $item; }");
+}
+
+#[test]
+fn test_for_bare_scalar() {
+    assert_strict_clean_parse("for $item (@list) { print $item; }");
+}
+
+// --- foreach/for my (standard) ---
+
+#[test]
+fn test_foreach_my_variable() {
+    assert_strict_clean_parse("foreach my $item (@list) { print $item; }");
+}
+
+#[test]
+fn test_for_my_variable() {
+    assert_strict_clean_parse("for my $item (@list) { print $item; }");
+}
+
+// --- nested, continue, complex lists ---
+
+#[test]
+fn test_foreach_nested_implicit() {
+    assert_strict_clean_parse("for (@outer) { for (@inner) { print; } }");
+}
+
+#[test]
+fn test_foreach_with_continue() {
+    assert_strict_clean_parse(
+        r#"foreach my $item (@list) { print $item; } continue { print "next\n"; }"#,
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1700: `for`/`foreach` without explicit loop variable (or with `our`/`local`/`state` declarators) failed to parse.

- `parse_foreach_statement` and `parse_foreach_style_for` now accept `our`/`local`/`state` in addition to `my`
- `parse_for_statement` routing check now includes `Our`/`Local`/`State` to properly dispatch to foreach-style parsing
- `is_variable_start()` now detects combined `Identifier("$x")` tokens (where the lexer merges sigil + name)

## Test plan

- 10 new tests in `fix_foreach_no_variable_tests.rs` covering:
  - `foreach our $var (@list)` and `for our $var (@list)`
  - `for $var (@list)` and `foreach $var (@list)` (bare scalar)
  - `for (@list)` and `foreach (@list)` (implicit `$_`)
  - `for my $var` and `foreach my $var` (standard)
  - Nested implicit loops and continue blocks
- `cargo fmt --all` clean
- `cargo clippy -p perl-parser-core --lib` clean
- All pre-existing perl-parser-core tests pass