### PR TITLE
chore(corpus): improve CPAN top-1000 pipeline

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -406,3 +406,61 @@ jobs:
           fuzz/artifacts/
           fuzz/corpus/
         retention-days: 30
+
+  # ============================================================================
+  # CPAN Corpus Sweep (nightly)
+  # ============================================================================
+
+  cpan-corpus:
+    name: CPAN Top-1000 Corpus Sweep
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-cpan-corpus-${{ hashFiles('Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Install Perl and cpanm
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq perl cpanminus
+
+      - name: Cache CPAN install
+        uses: actions/cache@v4
+        with:
+          path: target/cpan-corpus
+          key: cpan-corpus-${{ hashFiles('.ci/cpan-top-1000-distributions.txt') }}
+          restore-keys: cpan-corpus-
+
+      - name: Install CPAN distributions
+        run: cargo run -p xtask -- cpan-corpus install
+
+      - name: Run corpus sweep
+        run: cargo run -p xtask -- cpan-corpus sweep --output target/cpan-corpus-nightly.json
+
+      - name: Show corpus status
+        run: cargo run -p xtask -- cpan-corpus status
+
+      - name: Check against baseline (ratchet)
+        continue-on-error: true
+        run: cargo run -p xtask -- cpan-corpus sweep --enforce
+
+      - name: Upload sweep report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cpan-corpus-report-${{ github.sha }}
+          path: target/cpan-corpus-nightly.json
+          retention-days: 30

--- a/docs/project/CPAN_CORPUS_STRATEGY.md
+++ b/docs/project/CPAN_CORPUS_STRATEGY.md
@@ -180,8 +180,27 @@ added there, `just cpan-corpus-check` verifies it continues to parse cleanly.
 Promotion into the merge-gated common corpus remains a separate, deliberate step
 for a smaller curated subset.
 
----
 
+### Step 6: Check Coverage Status
+
+```bash
+just cpan-corpus-status
+```
+
+Reads the committed baseline JSON and manifest to show a progress summary
+without requiring the corpus to be installed locally. Displays:
+
+- Distribution list count
+- Baseline metrics (total files, clean rate, error count)
+- ASCII progress bar toward the 90% target
+- Top 10 error buckets
+- Known-clean manifest size
+- Local install status (if present)
+
+This command works in CI and in fresh checkouts because it reads committed
+artifacts, not the installed corpus.
+
+---
 ## Wave-Based Fix Plan
 
 Parser improvements follow the wave structure defined in
@@ -267,8 +286,8 @@ The CPAN corpus effort tracks four metrics:
 |------|--------|-------------|------|
 | Tier B (merge) | Common corpus | Strict zero-error | Every PR |
 | Tier B (merge) | System corpus | Ratchet (5 metrics) | Every PR |
-| Nightly / manual | CPAN full corpus | Ratchet (5 metrics) | Scheduled or on-demand |
-| Nightly / manual | CPAN known-clean manifest | Strict zero-error | Scheduled or on-demand |
+| Nightly (ci-nightly.yml) | CPAN full corpus | Ratchet (5 metrics) | Every night at 3am UTC |
+| Nightly (ci-nightly.yml) | CPAN known-clean manifest | Strict zero-error | Every night at 3am UTC |
 
 The CPAN corpus sweep is deliberately excluded from the merge gate. The top 1000
 distributions represent a large install and a multi-minute parse sweep -- too slow

--- a/justfile
+++ b/justfile
@@ -1608,6 +1608,10 @@ cpan-corpus-check:
 cpan-corpus-ratchet:
     cargo run -p xtask -- cpan-corpus ratchet
 
+# Show CPAN corpus progress toward 100% coverage
+cpan-corpus-status:
+    cargo run -p xtask -- cpan-corpus status
+
 # Tier C: full suite (nightly, all integration tests)
 lsp-tier-c:
     @echo "Running LSP Tier C (full suite)..."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -634,6 +634,9 @@ enum CpanCorpusCommand {
         #[arg(long)]
         install_dir: Option<PathBuf>,
     },
+
+    /// Show progress toward 100% CPAN corpus coverage
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -785,6 +788,7 @@ fn main() -> Result<()> {
                     config.verbose = verbose;
                     cpan_corpus::ratchet(&config)
                 }
+                CpanCorpusCommand::Status => cpan_corpus::status(&config),
             }
         }
         Commands::Receipts { tests_only, docs_only, output_dir, test_threads } => {

--- a/xtask/src/tasks/cpan_corpus.rs
+++ b/xtask/src/tasks/cpan_corpus.rs
@@ -497,6 +497,123 @@ pub fn ratchet(config: &CpanCorpusConfig) -> Result<()> {
 }
 
 // --------------------------------------------------------------------------
+// status
+// --------------------------------------------------------------------------
+
+/// Show progress toward 100% CPAN corpus coverage using committed artifacts.
+///
+/// Reads the baseline JSON and manifest without requiring the corpus to be
+/// installed, so it works in CI and in fresh checkouts.
+pub fn status(config: &CpanCorpusConfig) -> Result<()> {
+    let baseline_path = PathBuf::from(CPAN_BASELINE_PATH);
+    let dist_list_count =
+        if config.dist_list.exists() { read_dist_list(&config.dist_list)?.len() } else { 0 };
+    let manifest_count = if config.manifest.exists() {
+        parser_corpus_sweep::parse_manifest(&config.manifest)?.len()
+    } else {
+        0
+    };
+
+    println!("=== CPAN Corpus Status ===\n");
+    println!("Distribution list: {}", config.dist_list.display());
+    if dist_list_count > 0 {
+        println!("  Distributions tracked: {dist_list_count}");
+    } else {
+        println!("  (not fetched yet -- run `just cpan-corpus-fetch`)");
+    }
+    println!();
+
+    if baseline_path.exists() {
+        let report_json = fs::read_to_string(&baseline_path)
+            .with_context(|| format!("Failed to read baseline: {}", baseline_path.display()))?;
+        let report: parser_corpus_sweep::SweepReport = serde_json::from_str(&report_json)
+            .with_context(|| format!("Failed to parse baseline: {}", baseline_path.display()))?;
+        let total = report.total_files;
+        let clean = report.clean_files;
+        let errors = report.files_with_errors;
+        let unreadable = report.files_unreadable;
+        let pct = if total > 0 { (clean as f64 / total as f64) * 100.0 } else { 0.0 };
+
+        println!("Baseline: {}", baseline_path.display());
+        println!("  Commit:      {}", report.commit);
+        println!("  Timestamp:   {}", report.timestamp);
+        println!("  Total files: {total}");
+        println!("  Clean:       {clean} ({pct:.1}%)");
+        println!("  Errors:      {errors}");
+        println!("  Unreadable:  {unreadable}");
+        println!("  Error nodes: {}", report.total_error_nodes);
+        println!();
+
+        let target_pct = 90.0_f64;
+        let bar_width = 40;
+        let filled = ((pct / 100.0) * bar_width as f64).round() as usize;
+        let target_mark = ((target_pct / 100.0) * bar_width as f64).round() as usize;
+        let mut bar = String::with_capacity(bar_width);
+        for i in 0..bar_width {
+            if i < filled {
+                bar.push('#');
+            } else if i == target_mark {
+                bar.push('|');
+            } else {
+                bar.push('.');
+            }
+        }
+        println!("  Progress: [{bar}] {pct:.1}% (target: {target_pct:.0}%)");
+        let remaining = if pct < target_pct {
+            let target_clean = ((target_pct / 100.0) * total as f64).ceil() as usize;
+            target_clean.saturating_sub(clean)
+        } else {
+            0
+        };
+        if remaining > 0 {
+            println!("  Files needed to reach {target_pct:.0}%: {remaining}");
+        } else {
+            println!("  Target reached!");
+        }
+        if !report.first_error_buckets.is_empty() {
+            println!();
+            println!("  Top error buckets:");
+            let mut buckets: Vec<_> = report.first_error_buckets.iter().collect();
+            buckets.sort_by(|a, b| b.1.cmp(a.1));
+            for (bucket, count) in buckets.iter().take(10) {
+                println!("    {count:>5}  {bucket}");
+            }
+            let shown: usize = buckets.iter().take(10).map(|(_, c)| **c).sum();
+            let total_bucket: usize = buckets.iter().map(|(_, c)| **c).sum();
+            if total_bucket > shown {
+                println!(
+                    "    ... and {} more in {} other buckets",
+                    total_bucket - shown,
+                    buckets.len() - 10
+                );
+            }
+        }
+    } else {
+        println!("Baseline: (not established -- run `just cpan-corpus-baseline-update`)");
+    }
+    println!();
+    println!("Known-clean manifest: {}", config.manifest.display());
+    if manifest_count > 0 {
+        println!("  Modules: {manifest_count}");
+    } else {
+        println!("  (empty -- run `just cpan-corpus-ratchet` to seed)");
+    }
+    let lib_perl5 = config.install_dir.join("lib/perl5");
+    println!();
+    if lib_perl5.exists() {
+        let pm_count = walkdir::WalkDir::new(&lib_perl5)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "pm"))
+            .count();
+        println!("Local install: {} ({pm_count} .pm files)", lib_perl5.display());
+    } else {
+        println!("Local install: (not installed -- run `just cpan-corpus-install`)");
+    }
+    Ok(())
+}
+
+// --------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Improves the CPAN top-1000 corpus pipeline per #1650:

- **`cpan-corpus status` subcommand**: Shows coverage progress using committed artifacts (baseline JSON + manifest). Displays distribution count, clean rate with ASCII progress bar, top 10 error buckets, files-to-target, manifest size, and local install status. Works without the corpus installed.
- **`just cpan-corpus-status` recipe**: Convenience recipe for the new status command.
- **Nightly CI job**: Added `cpan-corpus` job to `ci-nightly.yml` that installs the top-1000, runs the sweep, shows status, checks the ratchet, and uploads the report artifact.
- **Updated docs**: `CPAN_CORPUS_STRATEGY.md` now documents Step 6 (status) and reflects the nightly CI job in the CI integration table.

Closes #1650

## Test plan

- [x] `cargo build -p xtask` compiles cleanly
- [x] `cargo clippy -p xtask --tests` passes (no new warnings)
- [x] All 7 cpan_corpus unit tests pass
- [ ] `just cpan-corpus-status` runs and shows expected output
- [ ] CI nightly workflow syntax is valid