### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -46,7 +46,6 @@ tokio = { version = "1.49.0", features = ["full"] }
 
 # Logging
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 # Command-line argument parsing
 clap = { version = "4.5.60", features = ["derive"] }

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 lsp-types = { version = "0.97.0" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-qualified-name = { workspace = true }

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -72,7 +72,6 @@ ropey = { version = "1.6.1" }
 tokio = { version = "1.49.0", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
 once_cell = "1.21.3"
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 
 [build-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-tokenizer/Cargo.toml
+++ b/crates/perl-tokenizer/Cargo.toml
@@ -18,7 +18,6 @@ perl-lexer = { workspace = true }
 perl-token = { workspace = true }
 perl-error = { workspace = true }
 perl-position-tracking = { workspace = true }
-perl-ast = { workspace = true }
 perl-ast-v2 = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Remove 4 unused dependencies detected by `cargo machete`:

- **perl-lsp-navigation**: `serde` — only `serde_json` is used in src; `serde` itself is not imported
- **perl-tokenizer**: `perl-ast` — code uses `perl-ast-v2` (separate crate); the old `perl-ast` import is unused
- **perl-lsp**: `tracing-subscriber` — logging is handled by `perl-lsp-launcher::init_logging`
- **perl-dap**: `tracing-subscriber` — logging is handled by `perl-lsp-launcher::init_logging`

## Verification

- Each dep confirmed unused via grep across src/, tests/, and benches/
- `cargo build -p <crate>` passes for all 4 affected crates
- `cargo test -p <crate> --lib` passes for all 4 affected crates
- `cargo clippy -p <crate> --lib` clean for all 4 affected crates

## Test plan

- [ ] CI passes (build, test, clippy)
- [ ] `cargo machete` no longer reports these 4 deps