### PR TITLE
feat(vscode): auto-populate new Perl files with boilerplate

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -284,6 +284,11 @@
           ],
           "default": "auto",
           "markdownDescription": "Select runtime LSP feature profile (`auto` follows binary build mode)."
+        },
+        "perl-lsp.autoPopulateNewFiles": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Automatically populate new `.pm` and `.t` files with standard Perl boilerplate (package declaration, `use strict`, `use warnings`, etc.)."
         }
       }
     },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -202,6 +202,26 @@ export async function activate(context: vscode.ExtensionContext) {
         configurationWatcher,
     );
 
+    // Auto-populate new Perl files with boilerplate
+    const fileCreationWatcher = vscode.workspace.onDidCreateFiles(async (event) => {
+        const config = vscode.workspace.getConfiguration('perl-lsp');
+        if (!config.get<boolean>('autoPopulateNewFiles', true)) {
+            return;
+        }
+
+        for (const fileUri of event.files) {
+            const filePath = fileUri.fsPath;
+
+            if (filePath.endsWith('.pm')) {
+                await populateModuleFile(fileUri, filePath);
+            } else if (filePath.endsWith('.t')) {
+                await populateTestFile(fileUri);
+            }
+        }
+    });
+
+    context.subscriptions.push(fileCreationWatcher);
+
     // Initialize debug adapter
     activateDebugger(context);
     await initializeLanguageClient(context);
@@ -209,6 +229,66 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     await disposeLanguageClient();
+}
+
+function inferPackageName(filePath: string): string {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    let relativePath = filePath;
+
+    if (workspaceFolders) {
+        for (const folder of workspaceFolders) {
+            const folderPath = folder.uri.fsPath;
+            if (filePath.startsWith(folderPath)) {
+                relativePath = filePath.slice(folderPath.length + 1);
+                break;
+            }
+        }
+    }
+
+    // Strip common lib prefixes
+    const libPrefixes = ['lib/', 'lib\\'];
+    for (const prefix of libPrefixes) {
+        if (relativePath.startsWith(prefix)) {
+            relativePath = relativePath.slice(prefix.length);
+            break;
+        }
+    }
+
+    // Remove .pm extension and convert path separators to ::
+    return relativePath
+        .replace(/\.pm$/, '')
+        .replace(/[/\\]/g, '::');
+}
+
+async function populateModuleFile(fileUri: vscode.Uri, filePath: string): Promise<void> {
+    try {
+        const stat = await vscode.workspace.fs.stat(fileUri);
+        if (stat.size > 0) {
+            return;
+        }
+    } catch {
+        return;
+    }
+
+    const packageName = inferPackageName(filePath);
+    const content = `package ${packageName};\nuse strict;\nuse warnings;\n\n\n\n1;\n`;
+    const encoder = new TextEncoder();
+    await vscode.workspace.fs.writeFile(fileUri, encoder.encode(content));
+}
+
+async function populateTestFile(fileUri: vscode.Uri): Promise<void> {
+    try {
+        const stat = await vscode.workspace.fs.stat(fileUri);
+        if (stat.size > 0) {
+            return;
+        }
+    } catch {
+        return;
+    }
+
+    const content = `use strict;\nuse warnings;\nuse Test::More;\n\n\n\ndone_testing;\n`;
+    const encoder = new TextEncoder();
+    await vscode.workspace.fs.writeFile(fileUri, encoder.encode(content));
 }
 
 async function getServerPath(context: vscode.ExtensionContext): Promise<string | null> {


### PR DESCRIPTION
## Summary

- Adds `onDidCreateFiles` listener that auto-populates new `.pm` files with `package` declaration (inferred from path), `use strict`, `use warnings`, and trailing `1;`
- Auto-populates new `.t` files with `use strict`, `use warnings`, `use Test::More`, and `done_testing`
- Only triggers on empty files to avoid overwriting existing content
- Configurable via `perl-lsp.autoPopulateNewFiles` setting (default: `true`)

## Test plan

- [ ] Create a new `.pm` file in a workspace under `lib/` — verify package name is inferred correctly
- [ ] Create a new `.pm` file outside `lib/` — verify path-based package name
- [ ] Create a new `.t` file — verify test boilerplate
- [ ] Create a non-empty `.pm` file (e.g. paste content) — verify no overwrite
- [ ] Set `perl-lsp.autoPopulateNewFiles` to `false` — verify no auto-population
- [ ] `npm run compile` passes cleanly