### PR TITLE
ci: add release gate checklist for 0.12.0

### DIFF
--- a/docs/project/RELEASE_CHECKLIST.md
+++ b/docs/project/RELEASE_CHECKLIST.md
@@ -1,0 +1,147 @@
+# Release Checklist for 0.12.0 Public Alpha
+
+This checklist covers all verification steps required before cutting the 0.12.0
+release. Items marked **[automated]** are enforced by `just release-check`.
+Items marked **[manual]** require human verification.
+
+## Prerequisites
+
+```bash
+# Install required tools (if not already available)
+cargo install cargo-audit cargo-sbom cargo-semver-checks --locked
+```
+
+## Automated Gates
+
+Run all automated checks at once:
+
+```bash
+just release-check
+```
+
+This composes the following gates:
+
+### 1. CI Gate (`just ci-gate`) **[automated]**
+
+All merge-blocking gates must pass:
+
+- [ ] Code formatting (`cargo fmt --check --all`)
+- [ ] Clippy lints -- core crates and full workspace
+- [ ] Unit tests -- core crates and full workspace
+- [ ] LSP smoke tests (Tier A) and core behavior tests (Tier B)
+- [ ] LSP semantic definition tests
+- [ ] Common corpus clean (pinned modules parse with zero errors)
+- [ ] Security audit (`cargo audit`)
+- [ ] Policy checks (ExitStatus helper, CURRENT_STATUS freshness, features invariants)
+- [ ] Documentation build (`cargo doc`)
+- [ ] v2 parity and bundle sync
+- [ ] Workflow audit (no ungated expensive jobs)
+- [ ] No nested lockfiles
+
+### 2. Release Build **[automated]**
+
+- [ ] `cargo build -p perl-lsp --release --locked` succeeds
+- [ ] `cargo build -p perl-dap --release --locked` succeeds
+
+### 3. Version Sync **[automated]**
+
+- [ ] All version strings agree across `Cargo.toml` (workspace), `features.toml`,
+      `package.json` (VSCode extension), and any `build.rs` references
+- [ ] Verified by `scripts/check-version-sync.sh`
+
+### 4. SemVer Check **[automated]**
+
+- [ ] No unintended breaking changes in public API
+- [ ] Checked by `cargo-semver-checks` against the last release tag
+
+### 5. SBOM Generation **[automated]**
+
+- [ ] SPDX SBOM generates successfully
+- [ ] CycloneDX SBOM generates successfully
+
+### 6. No Panic Constructs **[automated]**
+
+- [ ] No `unwrap()`, `expect()`, `panic!()`, `todo!()`, `unimplemented!()` in
+      production code (excluding allowed exceptions)
+
+### 7. CHANGELOG **[automated]**
+
+- [ ] `CHANGELOG.md` contains a `## [0.12.0]` section (not just `[Unreleased]`)
+
+### 8. Cargo Publish Dry-Run **[automated]**
+
+- [ ] `cargo publish --dry-run -p perl-parser` succeeds
+- [ ] `cargo publish --dry-run -p perl-lsp` succeeds
+
+## Manual Verification
+
+These steps require human judgment and cannot be fully automated.
+
+### 9. CPAN Corpus Coverage **[manual]**
+
+- [ ] Corpus coverage meets target (current baseline in `.ci/cpan-corpus-baseline.json`)
+- [ ] Common corpus manifest is up to date
+- [ ] Run `just cpan-corpus-sweep` and verify no regressions
+
+### 10. Documentation Review **[manual]**
+
+- [ ] README.md is current and accurate
+- [ ] GETTING_STARTED.md installation instructions work
+- [ ] SUPPORT.md contact information is correct
+- [ ] docs/project/CURRENT_STATUS.md reflects reality (`just status-update`)
+- [ ] docs/project/ROADMAP.md milestones are current
+
+### 11. VSCode Extension **[manual]**
+
+- [ ] Extension version matches workspace version
+- [ ] Extension builds (`cd vscode-extension && npm run package`)
+- [ ] Auto-download of language server binary works
+- [ ] Basic smoke test in VSCode: open a `.pl` file, verify diagnostics, completion, hover
+
+### 12. Installation Paths **[manual]**
+
+- [ ] `cargo install perl-lsp` (from local checkout) works
+- [ ] `perl-lsp --version` prints correct version
+- [ ] `perl-lsp --health` returns healthy status
+
+### 13. Platform Builds **[manual, CI-assisted]**
+
+Cross-platform builds are handled by the Release workflow, but verify:
+
+- [ ] Linux x86_64 binary runs
+- [ ] macOS arm64 binary runs (if available)
+- [ ] Windows x86_64 binary runs (if available)
+
+## Release Execution
+
+Once all checks pass:
+
+1. **Bump version**: `just release-turnkey 0.12.0`
+   - Creates a version-bump PR with CHANGELOG updates
+2. **Merge the version-bump PR** after review
+3. **Trigger release**: Dispatch the Release Orchestration workflow
+   - GitHub Actions: `.github/workflows/release-orchestration.yml`
+   - Input: version=`0.12.0`, prerelease=`false`
+4. **Monitor workflows**: Release, Publish Crates, Publish Extension, Docker
+5. **Verify artifacts**:
+   - GitHub Release page has binaries for all platforms
+   - SHA256SUMS file attached
+   - SBOM attached
+   - crates.io page is live
+   - VSCode Marketplace listing is updated
+6. **Post-release**:
+   - Update Homebrew formula (automated via `brew-bump.yml`)
+   - Verify `cargo install perl-lsp` from crates.io
+   - Announce release
+
+## Automation Reference
+
+| Recipe | What it checks |
+|--------|---------------|
+| `just release-check` | All automated gates (superset of `release-gate`) |
+| `just release-gate` | ci-gate + release-build + sbom-verify + version-check |
+| `just ci-gate` | All merge-blocking gates |
+| `just ci-full` | Nightly-tier deep checks |
+| `just semver-check` | SemVer breaking change detection |
+| `just version-check` | Version string sync |
+| `just sbom-verify` | SBOM generation and verification |

--- a/justfile
+++ b/justfile
@@ -1531,6 +1531,49 @@ release-gate: ci-gate release-build sbom-verify version-check
     @echo "  RELEASE GATE PASSED"
     @echo "=============================================="
 
+# Extended release check: release-gate + semver + changelog + publish dry-run + panic audit
+# Use before cutting a release tag. See docs/project/RELEASE_CHECKLIST.md
+release-check: release-gate semver-check
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Extended release checks ==="
+    echo "Checking CHANGELOG.md for release section..."
+    WORKSPACE_VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+    if ! grep -q "## \[${WORKSPACE_VERSION}\]" CHANGELOG.md; then
+      echo "ERROR: CHANGELOG.md missing section for [${WORKSPACE_VERSION}]"
+      echo "  Found [Unreleased] but need a versioned section before release."
+      exit 1
+    fi
+    echo "  CHANGELOG.md has [${WORKSPACE_VERSION}] section"
+    echo "Checking for banned panic constructs in production code..."
+    PANIC_HITS=$(grep -rn --include='*.rs' \
+      -e '\.unwrap()' -e '\.expect(' -e 'panic!(' \
+      -e 'todo!(' -e 'unimplemented!(' -e 'dbg!(' \
+      crates/*/src/ \
+      --exclude-dir='tests' --exclude-dir='benches' \
+      -- | grep -v '#\[allow' | grep -v '// allow' \
+           | grep -v 'crates/perl-lsp/src/util/uri.rs' \
+           | grep -v '#\[cfg(test)\]' || true)
+    if [ -n "$PANIC_HITS" ]; then
+      echo "WARNING: Potential panic constructs found in production code:"
+      echo "$PANIC_HITS" | head -20
+      echo "  (showing first 20 matches -- review before release)"
+    else
+      echo "  No banned panic constructs found"
+    fi
+    echo "Running cargo publish dry-run..."
+    cargo publish --dry-run -p perl-parser 2>&1 | tail -1
+    cargo publish --dry-run -p perl-lsp 2>&1 | tail -1
+    echo "  Publish dry-run passed"
+    echo "Building perl-dap release binary..."
+    cargo build -p perl-dap --release --locked
+    echo "  perl-dap release build passed"
+    echo "=============================================="
+    echo "  RELEASE CHECK PASSED"
+    echo "  See docs/project/RELEASE_CHECKLIST.md for"
+    echo "  manual verification steps before tagging."
+    echo "=============================================="
+
 # ============================================================================
 # LSP Test Tiering (Slice D: tiered test execution)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `docs/project/RELEASE_CHECKLIST.md` with comprehensive automated and manual verification steps for the 0.12.0 public alpha release
- Add `just release-check` recipe that extends `release-gate` with SemVer checks, CHANGELOG validation, panic construct audit, cargo publish dry-run, and DAP release build
- Covers all items from issue #1655: CI gates, version sync, SBOM, CHANGELOG, platform builds, VSCode extension, installation paths

## Test plan

- [x] `just --list` shows `release-check` recipe
- [x] `just --dry-run release-check` composes correctly: release-gate -> semver-check -> inline script
- [ ] Full `just release-check` run (requires build toolchain)

Closes #1655