### PR TITLE
feat(completion): add workspace-aware completion candidates (#1653)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -1880,4 +1880,48 @@ sub do_work { }
         assert!(detail.contains("MyLib"), "detail should mention module name, got: {detail:?}");
         Ok(())
     }
+    #[test]
+    fn test_workspace_symbols_dedup_with_local_functions() {
+        let index = Arc::new(WorkspaceIndex::new());
+        let module_uri = must(Url::parse("file:///workspace/Worker.pm"));
+        let module_code = "package Worker;\nsub process_data { }\n1;\n";
+        must(index.index_file(module_uri, module_code.to_string()));
+
+        let code = "sub process_data { }\nproc";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, Some(index));
+        let completions = provider.get_completions(code, code.len());
+
+        let process_items: Vec<_> =
+            completions.iter().filter(|c| c.label == "process_data").collect();
+        assert!(
+            process_items.len() <= 1,
+            "workspace should not duplicate local process_data, found {}: {:?}",
+            process_items.len(),
+            process_items.iter().map(|c| (&c.label, &c.detail)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_workspace_subroutine_completion() {
+        let index = Arc::new(WorkspaceIndex::new());
+        let module_uri = must(Url::parse("file:///workspace/MyApp.pm"));
+        let module_code = "package MyApp;\nsub run_app { }\n1;\n";
+        must(index.index_file(module_uri, module_code.to_string()));
+
+        let code = "run_";
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, Some(index));
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions.iter().any(|c| c.label.contains("run_app")),
+            "should suggest run_app from workspace, got: {:?}",
+            completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 ///
 /// Queries the workspace index to provide completions for symbols from other files.
 /// This enables cross-file completion when the user types a symbol name.
+/// Deduplicates against already-collected local completions by label.
 pub fn add_workspace_symbol_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -37,6 +38,10 @@ pub fn add_workspace_symbol_completions(
         return;
     }
 
+    // Collect existing labels to deduplicate workspace symbols against local ones
+    let existing_labels: HashSet<String> =
+        completions.iter().map(|item| item.label.clone()).collect();
+
     // Search for symbols matching the prefix
     let matching_symbols = index.find_symbols(&context.prefix);
 
@@ -56,6 +61,11 @@ pub fn add_workspace_symbol_completions(
                 } else {
                     symbol.name.clone()
                 };
+
+                // Skip if already provided by local completion (bare name match)
+                if existing_labels.contains(&label) || existing_labels.contains(&symbol.name) {
+                    continue;
+                }
 
                 completions.push(CompletionItem {
                     label: label.clone(),
@@ -88,6 +98,11 @@ pub fn add_workspace_symbol_completions(
                     continue;
                 }
 
+                // Skip if already provided by local completion
+                if existing_labels.contains(&label) {
+                    continue;
+                }
+
                 completions.push(CompletionItem {
                     label: label.clone(),
                     kind: CompletionItemKind::Variable,
@@ -101,7 +116,10 @@ pub fn add_workspace_symbol_completions(
                 });
             }
             WsSymbolKind::Package => {
-                // Add package completion
+                if existing_labels.contains(&symbol.name) {
+                    continue;
+                }
+
                 completions.push(CompletionItem {
                     label: symbol.name.clone(),
                     kind: CompletionItemKind::Module,
@@ -115,7 +133,10 @@ pub fn add_workspace_symbol_completions(
                 });
             }
             WsSymbolKind::Constant => {
-                // Add constant completion
+                if existing_labels.contains(&symbol.name) {
+                    continue;
+                }
+
                 completions.push(CompletionItem {
                     label: symbol.name.clone(),
                     kind: CompletionItemKind::Constant,
@@ -129,7 +150,10 @@ pub fn add_workspace_symbol_completions(
                 });
             }
             WsSymbolKind::Export => {
-                // Add exported symbol completion
+                if existing_labels.contains(&symbol.name) {
+                    continue;
+                }
+
                 completions.push(CompletionItem {
                     label: symbol.name.clone(),
                     kind: CompletionItemKind::Function,
@@ -142,8 +166,29 @@ pub fn add_workspace_symbol_completions(
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
             }
+            WsSymbolKind::Import => {
+                if existing_labels.contains(&symbol.name) {
+                    continue;
+                }
+
+                completions.push(CompletionItem {
+                    label: symbol.name.clone(),
+                    kind: CompletionItemKind::Function,
+                    detail: symbol
+                        .container_name
+                        .clone()
+                        .map(|c| format!("imported from {c}"))
+                        .or_else(|| Some("imported".to_string())),
+                    documentation: symbol.documentation.clone(),
+                    insert_text: Some(symbol.name.clone()),
+                    sort_text: Some(format!("2_{}", symbol.name)),
+                    filter_text: Some(symbol.name.clone()),
+                    additional_edits: vec![],
+                    text_edit_range: Some((context.prefix_start, context.position)),
+                });
+            }
             _ => {
-                // Skip other symbol types
+                // Skip other symbol types (Class, Role, Label, Format)
             }
         }
     }

--- a/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
+++ b/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
@@ -498,3 +498,179 @@ fn special_variables_appear_for_dollar_prefix() {
         labels(&items)
     );
 }
+
+// ===========================================================================
+// 12. Workspace-aware completion (issue #1653)
+// ===========================================================================
+
+fn workspace_with_modules() -> Arc<WorkspaceIndex> {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri1 = must(Url::parse("file:///workspace/MyApp/Config.pm"));
+    must(
+        index.index_file(
+            uri1,
+            "package MyApp::Config;
+sub load_config { }
+sub save_config { }
+1;
+"
+            .to_string(),
+        ),
+    );
+    let uri2 = must(Url::parse("file:///workspace/MyApp/Logger.pm"));
+    must(
+        index.index_file(
+            uri2,
+            "package MyApp::Logger;
+sub log_info { }
+sub log_error { }
+sub log_debug { }
+1;
+"
+            .to_string(),
+        ),
+    );
+    let uri3 = must(Url::parse("file:///workspace/Utils.pm"));
+    must(
+        index.index_file(
+            uri3,
+            "package Utils;
+use Exporter 'import';
+our @EXPORT_OK = qw(trim_string format_date);
+sub trim_string { }
+sub format_date { }
+1;
+"
+            .to_string(),
+        ),
+    );
+    index
+}
+
+#[test]
+fn workspace_use_suggests_module_names() {
+    let index = workspace_with_modules();
+    let code = "use MyApp";
+    let items = completions_with_index(code, code.len(), index);
+    assert!(
+        has_label(&items, "MyApp::Config"),
+        "should suggest MyApp::Config, got: {:?}",
+        labels(&items)
+    );
+    assert!(
+        has_label(&items, "MyApp::Logger"),
+        "should suggest MyApp::Logger, got: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn workspace_use_suggests_at_least_three_modules() {
+    let index = workspace_with_modules();
+    let code = "use ";
+    let items = completions_with_index(code, code.len(), index);
+    let module_items: Vec<_> =
+        items.iter().filter(|i| i.detail.as_deref() == Some("module")).collect();
+    assert!(
+        module_items.len() >= 3,
+        "should suggest >=3 modules, found {}: {:?}",
+        module_items.len(),
+        module_items.iter().map(|i| &i.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn workspace_subroutine_completion_in_general_context() {
+    let index = workspace_with_modules();
+    let code = "log_i";
+    let items = completions_with_index(code, code.len(), index);
+    assert!(
+        items.iter().any(|i| i.label.contains("log_info")),
+        "should suggest log_info, got: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn workspace_method_completion_with_inferred_type() {
+    let index = workspace_with_modules();
+    let code = "my $cfg = MyApp::Config->new;\n$cfg->";
+    let items = completions_with_index(code, code.len(), index);
+    assert!(
+        items.iter().any(|i| i.label == "load_config"),
+        "should suggest load_config, got: {:?}",
+        labels(&items)
+    );
+    assert!(
+        items.iter().any(|i| i.label == "save_config"),
+        "should suggest save_config, got: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn workspace_package_member_completion_after_colons() {
+    let index = workspace_with_modules();
+    let code = "MyApp::Logger::";
+    let items = completions_with_index(code, code.len(), index);
+    assert!(has_label(&items, "log_info"), "should suggest log_info, got: {:?}", labels(&items));
+    assert!(has_label(&items, "log_error"), "should suggest log_error, got: {:?}", labels(&items));
+}
+
+#[test]
+fn workspace_completions_dedup_with_local() {
+    let index = workspace_with_modules();
+    let code = "sub log_info { }
+log_i";
+    let items = completions_with_index(code, code.len(), index);
+    let log_info_items: Vec<_> = items.iter().filter(|i| i.label == "log_info").collect();
+    assert!(
+        log_info_items.len() <= 1,
+        "should not duplicate local log_info, found {}",
+        log_info_items.len()
+    );
+}
+
+#[test]
+fn workspace_completions_sort_after_local() {
+    let index = workspace_with_modules();
+    let code = "sub load_local { }
+load";
+    let items = completions_with_index(code, code.len(), index);
+    let local_item = items.iter().find(|i| i.label == "load_local");
+    let ws_item = items.iter().find(|i| i.label.contains("load_config"));
+    if let (Some(local), Some(ws)) = (local_item, ws_item) {
+        let local_sort = local.sort_text.as_deref().unwrap_or(&local.label);
+        let ws_sort = ws.sort_text.as_deref().unwrap_or(&ws.label);
+        assert!(
+            local_sort < ws_sort,
+            "local should sort before workspace: local={local_sort:?} ws={ws_sort:?}"
+        );
+    }
+}
+
+#[test]
+fn workspace_use_qw_suggests_module_exports() {
+    let index = workspace_with_modules();
+    let code = "use Utils qw(tri";
+    let items = completions_with_index(code, code.len(), index);
+    assert!(
+        has_label(&items, "trim_string"),
+        "should suggest trim_string, got: {:?}",
+        labels(&items)
+    );
+}
+
+#[test]
+fn workspace_empty_prefix_does_not_suggest_all_symbols() {
+    let index = workspace_with_modules();
+    let code = "";
+    let items = completions_with_index(code, code.len(), index);
+    let ws_items: Vec<_> =
+        items.iter().filter(|i| i.detail.as_deref() == Some("workspace")).collect();
+    assert!(
+        ws_items.is_empty(),
+        "should not suggest workspace symbols with empty prefix, found: {:?}",
+        ws_items.iter().map(|i| &i.label).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1653

- Deduplicate workspace symbols against already-collected local completions by checking existing labels before adding workspace entries, preventing duplicate suggestions when a symbol exists both locally and in the workspace index
- Handle `Import` symbol kind in `add_workspace_symbol_completions` to suggest imported symbols from `use` statements
- Add 9 behavior tests and 2 unit tests covering all issue acceptance criteria:
  - Module name completion after `use` (including >=3 modules test)
  - Subroutine completion from workspace index by prefix
  - Method completion via type inference (`$obj = Package->new; $obj->`)
  - Package member completion after `::`
  - Deduplication between local and workspace symbols
  - Sort ordering (local symbols before workspace)
  - `qw()` import suggestions
  - Empty prefix guard

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p perl-lsp-completion --tests` passes clean
- [x] `cargo test -p perl-lsp-completion --lib` — 52 passed (50 original + 2 new)
- [x] `cargo test -p perl-lsp-completion --test completion_behavior_tests` — 37 passed (28 original + 9 new)
- [x] `cargo test -p perl-lsp-completion --test extended_unit_tests` — 116 passed