### PR TITLE
docs: add rustdoc for public APIs of key crates

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -128,13 +128,19 @@ impl fmt::Display for LexerCheckpoint {
     }
 }
 
-/// Represents the difference between two checkpoints
+/// The difference between two [`LexerCheckpoint`]s, produced by
+/// [`LexerCheckpoint::diff`].
 #[derive(Debug)]
 pub struct CheckpointDiff {
+    /// Signed byte-offset difference between the two checkpoint positions.
     pub position_delta: isize,
+    /// Whether the lexer mode (term vs. operator) changed.
     pub mode_changed: bool,
+    /// Whether the nested delimiter stack differs.
     pub delimiter_stack_changed: bool,
+    /// Whether any prototype-tracking state differs.
     pub prototype_state_changed: bool,
+    /// Whether the [`CheckpointContext`] variant changed.
     pub context_changed: bool,
 }
 

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -365,7 +365,10 @@ impl<'a> PerlLexer<'a> {
         (end, visible_end)
     }
 
-    /// Get the next token from the input
+    /// Advance the lexer and return the next token.
+    ///
+    /// Returns `None` only after an `EOF` token has already been emitted.
+    /// The final meaningful call returns `Some(Token { token_type: TokenType::EOF, .. })`.
     pub fn next_token(&mut self) -> Option<Token> {
         // Normalize file start (BOM) once
         if self.position == 0 {
@@ -676,7 +679,10 @@ impl<'a> PerlLexer<'a> {
         })
     }
 
-    /// Peek at the next token without consuming it
+    /// Peek at the next token without consuming it.
+    ///
+    /// Saves and restores the full lexer state so the next call to
+    /// [`next_token`](Self::next_token) returns the same token.
     pub fn peek_token(&mut self) -> Option<Token> {
         let saved_pos = self.position;
         let saved_mode = self.mode;
@@ -711,7 +717,9 @@ impl<'a> PerlLexer<'a> {
         token
     }
 
-    /// Get all remaining tokens
+    /// Consume all remaining tokens and return them as a vector.
+    ///
+    /// The returned vector always ends with an `EOF` token.
     pub fn collect_tokens(&mut self) -> Vec<Token> {
         let mut tokens = Vec::new();
         while let Some(token) = self.next_token() {
@@ -724,7 +732,10 @@ impl<'a> PerlLexer<'a> {
         tokens
     }
 
-    /// Reset the lexer to the beginning
+    /// Reset the lexer to the beginning of the input.
+    ///
+    /// Clears all internal state (mode, delimiter stack, heredoc queue, etc.)
+    /// so the lexer can re-tokenize the same source from scratch.
     pub fn reset(&mut self) {
         self.position = 0;
         self.mode = LexerMode::ExpectTerm;
@@ -741,7 +752,10 @@ impl<'a> PerlLexer<'a> {
         self.start_time = std::time::Instant::now();
     }
 
-    /// Switch lexer to format body parsing mode
+    /// Switch the lexer into format-body parsing mode.
+    ///
+    /// In this mode the lexer consumes input verbatim until it encounters a
+    /// line containing only `.` (the Perl format terminator).
     pub fn enter_format_mode(&mut self) {
         self.mode = LexerMode::InFormatBody;
     }

--- a/crates/perl-lexer/src/token.rs
+++ b/crates/perl-lexer/src/token.rs
@@ -1,4 +1,7 @@
-//! Token types and structures for the Perl lexer
+//! Token types and structures for the Perl lexer.
+//!
+//! [`TokenType`] classifies every token the lexer can emit, and [`Token`]
+//! bundles a type with its source text and byte span.
 
 use std::sync::Arc;
 
@@ -127,31 +130,34 @@ pub enum TokenType {
     Error(Arc<str>),
 }
 
-/// Token with position information
+/// A single token produced by [`PerlLexer`](crate::PerlLexer).
+///
+/// Carries its [`TokenType`], the original source text (as a cheap-to-clone
+/// `Arc<str>`), and the byte span within the input.
 #[derive(Debug, Clone)]
 pub struct Token {
-    /// The type of token
+    /// Classification of this token (keyword, operator, literal, etc.).
     pub token_type: TokenType,
-    /// The actual text of the token
+    /// Original source text that this token spans.
     pub text: Arc<str>,
-    /// Start position in the input
+    /// Starting byte offset (inclusive) in the source input.
     pub start: usize,
-    /// End position in the input
+    /// Ending byte offset (exclusive) in the source input.
     pub end: usize,
 }
 
 impl Token {
-    /// Create a new token
+    /// Create a new token with the given type, source text, and byte span.
     pub fn new(token_type: TokenType, text: impl Into<Arc<str>>, start: usize, end: usize) -> Self {
         Self { token_type, text: text.into(), start, end }
     }
 
-    /// Get the length of the token
+    /// Return the byte length of this token's span (`end - start`).
     pub fn len(&self) -> usize {
         self.end - self.start
     }
 
-    /// Check if the token is empty
+    /// Return `true` if the token has a zero-length span.
     pub fn is_empty(&self) -> bool {
         self.start == self.end
     }


### PR DESCRIPTION
## Summary

- Enhanced rustdoc documentation for `perl-lexer` public API surface
- Added module-level docs, struct/field docs, and method docs to `token.rs`, `lib.rs`, and `checkpoint.rs`
- The other 4 target crates (`perl-parser`, `perl-ast`, `perl-token`, `perl-lsp-transport`) already had comprehensive rustdoc coverage

## Changes

- **`crates/perl-lexer/src/lib.rs`**: Improved docs for `next_token`, `peek_token`, `collect_tokens`, `reset`, and `enter_format_mode` methods with return value semantics and behavioral details
- **`crates/perl-lexer/src/token.rs`**: Added module-level `//!` docs, `Token` struct and field documentation, improved `Token::new`, `Token::len`, `Token::is_empty` method docs
- **`crates/perl-lexer/src/checkpoint.rs`**: Added `CheckpointDiff` struct-level and field-level documentation

## Test plan

- [x] `cargo doc -p perl-lexer --no-deps` produces zero warnings
- [x] `cargo doc -p perl-parser --no-deps` (pre-existing unrelated failure in `perl-lsp-semantic-tokens`)
- [x] `cargo doc -p perl-ast --no-deps` produces zero warnings
- [x] `cargo doc -p perl-token --no-deps` produces zero warnings
- [x] `cargo doc -p perl-lsp-transport --no-deps` produces zero warnings