### PR TITLE
chore(swarm): encode cycle 5 learnings into skills and templates

### DIFF
--- a/.claude/skills/swarm/templates/enhancement-builder.md
+++ b/.claude/skills/swarm/templates/enhancement-builder.md
@@ -1,0 +1,47 @@
+# Enhancement Builder Prompt Template
+
+Use this when spawning a worktree worker to add a new feature or enhancement.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Implement <ENHANCEMENT_DESCRIPTION>.
+
+## Context
+- Issue: <ISSUE_NUMBER_OR_LINK>
+- Crate: <PRIMARY_CRATE>
+- Target files: <FILE_SURFACE>
+- Entry point: <WHERE_THE_NEW_CODE_WILL_BE_CALLED_FROM>
+
+## Task List
+1. <STEP_1 — e.g., "Add the new type/struct in src/types.rs">
+   Skill: /coding-standards
+2. <STEP_2 — e.g., "Implement the core logic in src/handler.rs">
+   Skill: /coding-standards
+3. <STEP_3 — e.g., "Wire it into the entry point at src/main.rs:handle_request()">
+   Skill: /coding-standards
+4. Add tests for the new functionality
+   Skill: /verify-build <CRATE>
+5. Run `python3 scripts/update-current-status.py && just status-check` if tests were added
+
+## Decision Budget
+Make at most 3 judgment calls on your own. If you face a 4th ambiguous
+decision, stop and report back to the coordinator with options.
+
+## Wiring Check
+Before marking complete, verify the new code is reachable:
+- The new function/method is called from an existing entry point
+- The call chain is: entry point -> ... -> your new code
+- grep for the function name to confirm at least one call site exists
+
+## Rules
+- Do NOT rebase. Only fix code and verify locally.
+- Do NOT expand scope beyond the declared task list
+- Do NOT add code that is not wired to an entry point
+- If the enhancement requires changes to 3+ crates, stop and report back
+
+## Verification
+cargo fmt --all && cargo clippy -p <CRATE> --tests -- -D warnings && cargo test -p <CRATE>
+```

--- a/.claude/skills/swarm/templates/parser-fix-builder.md
+++ b/.claude/skills/swarm/templates/parser-fix-builder.md
@@ -1,0 +1,34 @@
+# Parser Fix Builder Prompt Template
+
+Use this when spawning a worktree worker to fix a parser bug.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Fix parser bug — <BUG_DESCRIPTION>.
+
+## Context
+- Issue: <ISSUE_NUMBER_OR_LINK>
+- Root cause: <ROOT_CAUSE_SUMMARY_FROM_SCOUT>
+- Target files: <FILE_SURFACE>
+- Construct: <PERL_CONSTRUCT_THAT_FAILS>
+
+## Steps
+1. Read the target files and understand the current parsing path
+2. Add a failing test in the appropriate `*_tests.rs` file
+3. Implement the smallest fix that makes the new test pass
+4. Run verification: `cargo fmt --all && cargo clippy -p perl-parser-core --lib && cargo test -p perl-parser-core && cargo test -p perl-parser`
+5. If tests were added, run `python3 scripts/update-current-status.py` then `just status-check`
+6. Commit: `fix(perl-parser-core): <description>`
+
+## Rules
+- Do NOT rebase. Only fix code and verify locally.
+- Do NOT fix unrelated parser issues found during investigation
+- Do NOT refactor surrounding code
+- If the bug is actually in the lexer, stop and report back
+
+## Verification
+cargo fmt --all && cargo clippy -p perl-parser-core --lib && cargo test -p perl-parser-core && cargo test -p perl-parser
+```

--- a/.claude/skills/swarm/templates/review-agent.md
+++ b/.claude/skills/swarm/templates/review-agent.md
@@ -1,0 +1,45 @@
+# Review Agent Prompt Template
+
+Use this when spawning a subagent to review a single PR.
+
+## Template
+
+```
+Invoke /coding-standards.
+
+Goal: Review PR #<PR_NUMBER> — <PR_TITLE>.
+
+## Context
+- Branch: <BRANCH_NAME>
+- Crate: <PRIMARY_CRATE>
+- Builder receipt: <RECEIPT_SUMMARY>
+
+## Review Checklist
+1. CHECKOUT the branch and BUILD it locally — do not just read diffs:
+   `git fetch origin && git checkout <BRANCH_NAME>`
+   `cargo build -p <PRIMARY_CRATE>`
+2. Run the full verification pipeline:
+   `cargo fmt --all -- --check && cargo clippy -p <PRIMARY_CRATE> --tests -- -D warnings && cargo test -p <PRIMARY_CRATE>`
+3. Check coding standards compliance:
+   - No `unwrap()`, `expect()`, `panic!()`, `todo!()`, `unimplemented!()`, `dbg!()`
+   - Proper error handling with `?` and `Result`/`Option`
+   - `.first()` not `.get(0)`, `or_default()` not `or_insert_with(Vec::new)`
+4. Verify new functions are actually called from an entry point — not just defined
+5. Check tests exist for new functionality
+6. Check PR description is accurate and complete
+7. Check scope — no unrelated changes mixed in
+8. Check commit message follows conventional format: `type(scope): description`
+
+## Decision
+- **Approve**: If all checks pass, report approval to ops coordinator
+- **Request changes**: If issues found, list specific fixes needed and report to builder coordinator
+- Do NOT make code changes yourself — route fixes back to builder
+
+## Report Format
+- PR number and title
+- Build result: compiled / failed
+- Test result: passed / failed (with count)
+- Pass/fail for each checklist item
+- Specific issues found (with file:line references)
+- Verdict: approve / request-changes
+```

--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -19,9 +19,10 @@ This skill verifies a deliverable and produces a receipt. It does not replace
 4. Run clippy unless `--skip-clippy` is present
 5. Run tests unless `--skip-test` is present
 6. If the change added, removed, or materially changed tests, run
-   `just status-update` and `just status-check` before handoff so computed
-   docs stay fresh
-7. Report a receipt with pass/fail status for each step
+   `python3 scripts/update-current-status.py` then `just status-check`
+   before handoff so computed docs stay fresh
+7. Verify new functions are called from an entry point (not just defined)
+8. Report a receipt with pass/fail status for each step
 
 ## Commands
 
@@ -64,12 +65,19 @@ RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 Status refresh (REQUIRED when tests were added, removed, or changed):
 
 ```bash
-just status-update
+python3 scripts/update-current-status.py
 just status-check
 ```
 
 This prevents the `policy_checks` CI gate from failing due to stale derived
 metrics in `docs/project/CURRENT_STATUS.md`. Always run after modifying tests.
+
+Wiring check (REQUIRED for new features and enhancements):
+
+Verify that new public functions or methods are actually called from an entry
+point. Grep for the function name — if no call site exists outside its
+definition and tests, the feature is built but not wired and will be dead code
+in production.
 
 ## Receipt Format
 
@@ -80,6 +88,7 @@ Report:
 - clippy result
 - test result
 - whether status refresh was required and run
+- wiring check result (for new features)
 - overall pass/fail
 - first failure details if anything failed
 

--- a/.claude/swarm-state/known-pitfalls.md
+++ b/.claude/swarm-state/known-pitfalls.md
@@ -18,3 +18,31 @@ Each entry:
 ## Entries
 
 <!-- Agents append new entries below this line -->
+
+### 2026-03-19 — Rebase Burns CI Queue
+
+**Source**: Cycle 5 session learnings
+**Pitfall**: Workers that rebase onto master before creating a PR trigger a new CI run on master. When multiple workers rebase in quick succession, each rebase push cancels the previous CI run, burning the CI queue and delaying validation of already-merged work.
+**Fix**: Workers should NOT rebase. Only fix code and verify locally. The ops coordinator handles rebasing as a controlled batch operation when needed.
+**Affected crates**: all
+
+### 2026-03-19 — Worktree Contention
+
+**Source**: Cycle 5 parallel agent conflicts
+**Pitfall**: Two agents assigned to the same worktree directory can corrupt each other's work — uncommitted changes, staged files, and branch state all collide silently. This happens when worktree names overlap or when an agent is reassigned to a worktree still in use.
+**Fix**: Every agent gets its own uniquely-named worktree. Never reuse a worktree across agents. Before spawning a worker, verify the target worktree does not already exist with `git worktree list`.
+**Affected crates**: all
+
+### 2026-03-19 — Built-But-Not-Wired Pattern
+
+**Source**: Cycle 5 review findings
+**Pitfall**: Agents implement new functions, structs, or modules that compile and pass tests, but are never called from any entry point. The code is dead on arrival — it exists in the crate but no execution path reaches it. This is hard to catch in diff-only review.
+**Fix**: Before marking a PR complete, verify new public functions have at least one call site outside their definition module and tests. Grep for the function name. The `/verify-build` skill now includes a wiring check step.
+**Affected crates**: all
+
+### 2026-03-19 — Repurpose Idle Agents
+
+**Source**: Cycle 5 capacity management
+**Pitfall**: Agents that complete their task early sit idle, wasting capacity. Meanwhile other lanes (review, ops) may be bottlenecked. The idle agent's context is warm and could be repurposed, but the default behavior is to just stop.
+**Fix**: When an agent finishes its task, it should report completion AND check if adjacent work exists in the same lane. If not, send a message to the coordinator offering to take on the next queued task. Coordinators should reassign idle agents to the highest-priority unblocked work rather than spawning new ones.
+**Affected crates**: all


### PR DESCRIPTION
Closes #2116

## Summary

- Add 3 reusable agent prompt templates in `.claude/skills/swarm/templates/`:
  - `parser-fix-builder.md` — no-rebase rule, status update step
  - `review-agent.md` — checkout-and-build discipline (not diff-only review)
  - `enhancement-builder.md` — numbered task list, 3-decision budget, wiring check
- Update `.claude/skills/verify-build/SKILL.md`:
  - Replace `just status-update` with `python3 scripts/update-current-status.py`
  - Add wiring check step (verify new functions are called from entry points)
  - Add wiring check to receipt format
- Add 4 cycle 5 pitfalls to `.claude/swarm-state/known-pitfalls.md`:
  - Rebase burns CI queue
  - Worktree contention
  - Built-but-not-wired pattern
  - Repurpose idle agents

## Test plan

- [ ] Verify markdown files have no syntax errors
- [ ] Verify templates follow established format
- [ ] Verify verify-build step numbering is sequential
- [ ] Verify known-pitfalls entries match the documented format