### PR TITLE
devex: exclude agent worktrees from rust-analyzer (#2031)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,14 @@
   "//": "Team configuration for internal Perl LSP deployment",
   "//": "Copy this file to your workspace .vscode/settings.json",
   "//": "and customize the paths for your environment",
-  
+
+  "//": "Exclude directories that confuse rust-analyzer (agent worktrees, archived code, fuzz harnesses)",
+  "rust-analyzer.files.excludeDirs": [
+    ".claude/worktrees",
+    "archive",
+    "fuzz"
+  ],
+
   "perl-lsp.serverPath": "/path/to/your/perl-lsp",
   "perl-lsp.autoDownload": false,
   "perl-lsp.downloadBaseUrl": "",

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,8 @@
+# rust-analyzer configuration for non-VSCode editors (Neovim, Helix, Zed, etc.)
+#
+# Excludes directories that contain duplicate crate roots and confuse
+# rust-analyzer: agent worktrees, archived legacy code, and fuzz harnesses.
+# See also .vscode/settings.json for the VSCode equivalent.
+
+[files]
+excludeDirs = [".claude/worktrees", "archive", "fuzz"]


### PR DESCRIPTION
## Summary
- Add `rust-analyzer.files.excludeDirs` to `.vscode/settings.json` excluding `.claude/worktrees`, `archive`, and `fuzz`
- Create `rust-analyzer.toml` with the same exclusions for non-VSCode editors (Neovim, Helix, Zed, etc.)

Fixes #2031

## Test plan
- [ ] Open repo in VSCode — verify no diagnostics from worktree crates
- [ ] Open repo in Neovim with rust-analyzer — verify worktree dirs excluded