### PR TITLE
chore: add pre-push hook to update test counts in CURRENT_STATUS.md

### DIFF
--- a/.claude/hooks/task-completed.sh
+++ b/.claude/hooks/task-completed.sh
@@ -9,5 +9,19 @@ if ! cargo fmt --all -- --check 2>/dev/null; then
   exit 2
 fi
 
+# Check if test files were modified and CURRENT_STATUS.md needs updating
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+if git diff --cached --name-only 2>/dev/null | grep -qE '^crates/.*/tests/.*\.rs$' || \
+   git diff --name-only HEAD~1 2>/dev/null | grep -qE '^crates/.*/tests/.*\.rs$'; then
+  if command -v python3 &>/dev/null && [ -f "$REPO_ROOT/scripts/update-current-status.py" ]; then
+    python3 "$REPO_ROOT/scripts/update-current-status.py" 2>/dev/null || true
+    if ! git diff --quiet -- docs/project/CURRENT_STATUS.md 2>/dev/null; then
+      echo "Task completion blocked: test files changed but CURRENT_STATUS.md has stale counts."
+      echo "Run: python3 scripts/update-current-status.py && git add docs/project/CURRENT_STATUS.md"
+      exit 2
+    fi
+  fi
+fi
+
 # Allow completion
 exit 0

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1806,6 +1806,37 @@ echo "🚪 Running local gate before push: nix develop -c just ci-gate"
 echo "   (Skip with: git push --no-verify)"
 echo ""
 
+# --- Check if test files changed and CURRENT_STATUS.md needs updating ---
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Detect test file changes in the commits being pushed
+# stdin provides: <local ref> <local sha> <remote ref> <remote sha>
+TEST_FILES_CHANGED=false
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    # For new branches, compare against merge-base with origin/master
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        remote_sha="$(git merge-base "$local_sha" origin/master 2>/dev/null || echo "$local_sha")"
+    fi
+    if git diff --name-only "$remote_sha" "$local_sha" 2>/dev/null | grep -qE '^crates/.*/tests/.*\.rs$'; then
+        TEST_FILES_CHANGED=true
+        break
+    fi
+done
+
+if [ "$TEST_FILES_CHANGED" = true ] && [ -f "$REPO_ROOT/scripts/update-current-status.py" ]; then
+    echo "📊 Test files changed — checking if CURRENT_STATUS.md is up to date..."
+    if command -v python3 &>/dev/null; then
+        python3 "$REPO_ROOT/scripts/update-current-status.py" 2>/dev/null || true
+        if ! git diff --quiet -- docs/project/CURRENT_STATUS.md 2>/dev/null; then
+            echo ""
+            echo "⚠️  CURRENT_STATUS.md has stale test counts!"
+            echo "   Run: python3 scripts/update-current-status.py"
+            echo "   Then commit the updated file before pushing."
+            echo ""
+            exit 1
+        fi
+    fi
+fi
+
 # Try nix develop first, fall back to just alone
 if command -v nix &>/dev/null && [ -f flake.nix ]; then
     nix develop -c just ci-gate


### PR DESCRIPTION
## Summary

- Add test-count staleness detection to the git pre-push hook (in `perl-ci-hygiene`). When commits being pushed modify files matching `crates/*/tests/*.rs`, the hook runs `update-current-status.py` and blocks the push if `CURRENT_STATUS.md` has stale counts.
- Add the same check to `.claude/hooks/task-completed.sh` for agent enforcement — agents that add tests must update status before completing tasks.

## Motivation

The #1 merge friction point is `policy_checks` failing because `CURRENT_STATUS.md` test counts go stale after adding tests. This catches the issue before push rather than after CI.

## Test plan

- [ ] Run `bash scripts/install-githooks.sh` to install the updated hook
- [ ] Modify a test file, push without updating status — should be blocked
- [ ] Run `python3 scripts/update-current-status.py`, commit, push — should succeed
- [ ] Verify `cargo clippy -p perl-ci-hygiene` is clean