### PR TITLE
docs: add README badges and GitHub FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [EffortlessMetrics]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # perl-lsp
 
+[![CI](https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
+[![docs.rs](https://docs.rs/perl-lsp/badge.svg)](https://docs.rs/perl-lsp)
+[![License: MIT/Apache-2.0](https://img.shields.io/crates/l/perl-lsp.svg)](LICENSE-MIT)
+[![MSRV: 1.92](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://blog.rust-lang.org/)
+
 `perl-lsp` is a native Rust Perl 5 toolchain centered on editor support. This repository ships the Language Server Protocol server, a separate Debug Adapter Protocol server, embeddable parser and lexer crates, and the corpus, workspace, and status machinery used to harden them together.
 
 > Status: public alpha. APIs, behavior, and packaging are still evolving. See the [Stability Policy](docs/reference/STABILITY.md).


### PR DESCRIPTION
## Summary

- Add CI, crates.io, docs.rs, license, and MSRV badges to the top of README.md
- Create `.github/FUNDING.yml` pointing to EffortlessMetrics GitHub Sponsors

These are the "one-shottable" community trust signals. Companion issues will be filed for larger items (example project improvements, GitHub Discussions setup).

## Badges added

| Badge | Source |
|-------|--------|
| CI | `.github/workflows/ci.yml` on `master` branch |
| crates.io | shields.io for `perl-lsp` crate |
| docs.rs | docs.rs badge for `perl-lsp` |
| License | MIT/Apache-2.0 dual license |
| MSRV | 1.92 (from workspace `Cargo.toml`) |

## Test plan

- [x] Badges use correct repo owner/name (`EffortlessMetrics/perl-lsp`)
- [x] CI badge points to the merge-blocking `ci.yml` workflow
- [x] FUNDING.yml is valid YAML with correct organization name
- [ ] Verify badges render correctly on GitHub after merge