### PR TITLE
fix(parser): improve delimiter recovery to reduce cascading errors

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -20,7 +20,7 @@ impl<'a> Parser<'a> {
             self.parse_expression()?
         };
 
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         let then_branch = self.parse_block()?;
 
@@ -46,7 +46,7 @@ impl<'a> Parser<'a> {
                 self.parse_expression()?
             };
 
-            self.expect(TokenKind::RightParen)?;
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
             let elsif_block = self.parse_block()?;
             elsif_branches.push((Box::new(elsif_cond), Box::new(elsif_block)));
         }
@@ -80,7 +80,7 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::LeftParen)?;
         self.mark_not_stmt_start();
         let condition = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         // Negate the condition
         let negated_condition = Node::new(
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
                 self.parse_expression()?
             };
 
-            self.expect(TokenKind::RightParen)?;
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
             let elsif_block = self.parse_block()?;
             elsif_branches.push((Box::new(elsif_cond), Box::new(elsif_block)));
         }
@@ -156,7 +156,7 @@ impl<'a> Parser<'a> {
             self.parse_expression()?
         };
 
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         let body = self.parse_block()?;
 
@@ -187,7 +187,7 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::LeftParen)?;
         self.mark_not_stmt_start();
         let condition = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         // Negate the condition
         let negated_condition = Node::new(
@@ -289,7 +289,7 @@ impl<'a> Parser<'a> {
             Some(Box::new(self.parse_expression()?))
         };
 
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
         let body = self.parse_block()?;
 
         // Handle continue block
@@ -331,7 +331,7 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::LeftParen)?;
         self.mark_not_stmt_start();
         let list = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         let body = self.parse_block()?;
 
@@ -370,7 +370,7 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::LeftParen)?;
         self.mark_not_stmt_start();
         let list = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         let body = self.parse_block()?;
 
@@ -518,7 +518,7 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                self.expect(TokenKind::RightParen)?;
+                self.expect_closing_delimiter(TokenKind::RightParen)?;
                 var_name
             } else {
                 None
@@ -575,7 +575,7 @@ impl<'a> Parser<'a> {
         // Parse the expression in parentheses
         self.expect(TokenKind::LeftParen)?;
         let expr = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         // Parse the body block
         let body = self.parse_given_block()?;
@@ -624,7 +624,7 @@ impl<'a> Parser<'a> {
         // Parse the condition in parentheses
         self.expect(TokenKind::LeftParen)?;
         let condition = self.parse_expression()?;
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
 
         // Parse the body block
         let body = self.parse_block()?;
@@ -714,7 +714,7 @@ impl<'a> Parser<'a> {
             self.parse_expression()?
         };
 
-        self.expect(TokenKind::RightParen)?;
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
         let then_branch = self.parse_block()?;
 
         // Continue parsing any following elsif/else chain
@@ -738,7 +738,7 @@ impl<'a> Parser<'a> {
                 self.parse_expression()?
             };
 
-            self.expect(TokenKind::RightParen)?;
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
             let elsif_block = self.parse_block()?;
             elsif_branches.push((Box::new(elsif_cond), Box::new(elsif_block)));
         }

--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -722,7 +722,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            self.expect(TokenKind::RightParen)?;
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
         } else if !Self::is_statement_terminator(self.peek_kind()) {
             // Complex `use` arguments can start with tokens outside the bare-arg
             // fast path, such as sigils in `use warnings $ENV{X} ? ...`.
@@ -931,7 +931,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            self.expect(TokenKind::RightParen)?;
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
         }
 
         // Don't consume semicolon here - let parse_statement handle it uniformly

--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -336,7 +336,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            self.expect(TokenKind::RightParen)?; // consume )
+            self.expect_closing_delimiter(TokenKind::RightParen)?; // consume )
 
             let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
                 self.tokens.next()?; // consume =
@@ -429,7 +429,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            s.expect(TokenKind::RightParen)?;
+            s.expect_closing_delimiter(TokenKind::RightParen)?;
             Ok(args)
         })
     }

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -606,14 +606,14 @@ impl<'a> Parser<'a> {
                         }
                     }
 
-                    self.expect(TokenKind::RightParen)?;
+                    self.expect_closing_delimiter(TokenKind::RightParen)?;
                     let end = self.previous_position();
 
                     // Only convert to hash if we saw a fat comma
                     Ok(Self::build_list_or_hash(elements, saw_fat_comma, start, end))
                 } else {
                     // It's a parenthesized expression
-                    self.expect(TokenKind::RightParen)?;
+                    self.expect_closing_delimiter(TokenKind::RightParen)?;
                     Ok(first)
                 }
             }
@@ -635,7 +635,7 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                self.expect(TokenKind::RightBracket)?;
+                self.expect_closing_delimiter(TokenKind::RightBracket)?;
                 let end = self.previous_position();
 
                 Ok(Node::new(NodeKind::ArrayLiteral { elements }, SourceLocation { start, end }))

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -399,6 +399,56 @@ impl<'a> Parser<'a> {
         &self.errors
     }
 
+
+    /// Expect a closing delimiter, recovering gracefully if missing.
+    /// Records error and returns Ok(()) at sync points instead of Err.
+    fn expect_closing_delimiter(&mut self, kind: TokenKind) -> ParseResult<()> {
+        if self.peek_kind() == Some(kind) {
+            self.consume_token()?;
+            return Ok(());
+        }
+        if self.is_delimiter_recovery_point() {
+            let pos = self.current_position();
+            self.errors.push(ParseError::syntax(
+                format!("Missing '{}' — recovered at statement boundary", kind.display_name()),
+                pos,
+            ));
+            return Ok(());
+        }
+        let pos = self.current_position();
+        Err(ParseError::unexpected(
+            kind.display_name(),
+            self.peek_kind().map(|k| k.display_name()).unwrap_or("end of input"),
+            pos,
+        ))
+    }
+
+    /// Check if current token is a delimiter recovery point.
+    fn is_delimiter_recovery_point(&mut self) -> bool {
+        matches!(
+            self.peek_kind(),
+            Some(TokenKind::Semicolon)
+                | Some(TokenKind::RightBrace)
+                | Some(TokenKind::LeftBrace)
+                | Some(TokenKind::My)
+                | Some(TokenKind::Our)
+                | Some(TokenKind::Local)
+                | Some(TokenKind::State)
+                | Some(TokenKind::Sub)
+                | Some(TokenKind::Package)
+                | Some(TokenKind::Use)
+                | Some(TokenKind::If)
+                | Some(TokenKind::Unless)
+                | Some(TokenKind::Elsif)
+                | Some(TokenKind::Else)
+                | Some(TokenKind::While)
+                | Some(TokenKind::Until)
+                | Some(TokenKind::For)
+                | Some(TokenKind::Foreach)
+                | None
+        )
+    }
+
     /// Check if current token is a synchronization point for error recovery
     fn is_sync_point(&mut self) -> bool {
         match self.peek_kind() {

--- a/crates/perl-parser-core/tests/delimiter_recovery_tests.rs
+++ b/crates/perl-parser-core/tests/delimiter_recovery_tests.rs
@@ -1,0 +1,126 @@
+//! Tests for improved delimiter recovery (#1649).
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+use perl_parser_core::{NodeKind, Parser};
+use perl_tdd_support::must;
+
+fn parse_with_errors(src: &str) -> (perl_parser_core::Node, usize) {
+    let mut parser = Parser::new(src);
+    let ast = must(parser.parse());
+    let n = parser.errors().len();
+    (ast, n)
+}
+
+fn statement_count(ast: &perl_parser_core::Node) -> usize {
+    match &ast.kind {
+        NodeKind::Program { statements } => statements.len(),
+        _ => 0,
+    }
+}
+
+#[test]
+fn unclosed_paren_does_not_cascade_to_next_statement() {
+    let code = "my $x = (1 + 2; print 42;";
+    let (ast, _) = parse_with_errors(code);
+    let count = statement_count(&ast);
+    assert!(
+        count >= 2,
+        "Unclosed paren should not swallow following statement. Got {} stmts",
+        count,
+    );
+}
+
+#[test]
+fn unclosed_paren_in_if_condition_recovers() {
+    let code = "if ($x == 1 { print 1; } print 2;";
+    let (ast, errs) = parse_with_errors(code);
+    assert!(errs > 0);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Missing ) in if should not prevent rest. Got {} stmts", count,);
+}
+
+#[test]
+fn unclosed_bracket_does_not_cascade() {
+    let code = "my @x = [1, 2, 3; my $y = 42;";
+    let (ast, _) = parse_with_errors(code);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Unclosed bracket should not swallow next stmt. Got {} stmts", count,);
+}
+
+#[test]
+fn extra_closing_paren_does_not_cascade() {
+    let code = "my $x = 1); my $y = 2;";
+    let (ast, _) = parse_with_errors(code);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Extra ) should not prevent parsing remaining code. Got {} stmts", count,);
+}
+
+#[test]
+fn unclosed_paren_produces_bounded_errors() {
+    let code = "my $x = (1 + 2;\nmy $y = 3;\nmy $z = 4;\nprint $y;\n";
+    let (ast, error_count) = parse_with_errors(code);
+    assert!(error_count <= 4, "Unclosed paren should produce bounded errors, got {}", error_count);
+    let count = statement_count(&ast);
+    assert!(count >= 3, "Should parse most stmts. Got {}", count);
+}
+
+#[test]
+fn unclosed_paren_in_function_call_recovers() {
+    let code = "foo(1, 2; bar(3);";
+    let (ast, errs) = parse_with_errors(code);
+    assert!(errs > 0);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Unclosed paren in foo() should not prevent bar(). Got {} stmts", count,);
+}
+
+#[test]
+fn nested_unclosed_paren_recovers() {
+    let code = "my $x = ((1 + 2); my $y = 3;";
+    let (ast, _) = parse_with_errors(code);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Nested unclosed paren should allow next stmt. Got {} stmts", count,);
+}
+
+#[test]
+fn clean_paren_expression_still_works() {
+    assert_clean_parse("my $x = (1 + 2);");
+}
+#[test]
+fn clean_bracket_literal_still_works() {
+    assert_clean_parse("my @x = [1, 2, 3];");
+}
+#[test]
+fn clean_if_condition_still_works() {
+    assert_clean_parse("if ($x == 1) { print 1; }");
+}
+#[test]
+fn clean_nested_parens_still_works() {
+    assert_clean_parse("my $x = ((1 + 2) * 3);");
+}
+#[test]
+fn clean_while_condition_still_works() {
+    assert_clean_parse("while ($i < 10) { $i = $i + 1; }");
+}
+#[test]
+fn clean_for_loop_still_works() {
+    assert_clean_parse("for my $i (1..10) { print $i; }");
+}
+
+#[test]
+fn semicolon_inside_parens_triggers_recovery() {
+    let code = "my $x = ($a + $b; my $y = $c;";
+    let (ast, errs) = parse_with_errors(code);
+    assert!(errs > 0);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Semicolon should trigger recovery. Got {} stmts", count,);
+}
+
+#[test]
+fn while_missing_close_paren_recovers() {
+    let code = "while ($x < 10 { $x = $x + 1; } print 'done';";
+    let (ast, errs) = parse_with_errors(code);
+    assert!(errs > 0);
+    let count = statement_count(&ast);
+    assert!(count >= 2, "Missing ) in while should not prevent rest. Got {} stmts", count,);
+}


### PR DESCRIPTION
## Summary

Fixes #1649. Delimiter recovery was the #1 source of cascading parse errors (53% of CPAN failures).

- Adds `expect_closing_delimiter()` — soft-fail variant of `expect()` for `)` and `]` that recovers at statement boundaries instead of propagating errors up the entire call stack
- Adds `is_delimiter_recovery_point()` — recognizes `;`, `}`, `{`, declaration keywords (`my`/`our`/`local`/`state`/`sub`/`package`/`use`), and control flow keywords (`if`/`unless`/`while`/`until`/`for`/`foreach`/`elsif`/`else`) as safe recovery points
- Applied to 21 closing-delimiter sites across `control_flow.rs`, `primary.rs`, `calls.rs`, and `declarations.rs`
- 15 new tests: 7 recovery scenarios (unclosed parens, brackets, function calls, if/while conditions) + 6 clean-parse regression tests + 2 boundary cases

## Test plan

- [x] All 15 new delimiter recovery tests pass
- [x] Full `cargo test -p perl-parser-core` passes (only pre-existing failure in `parser_ac3_prevent_recursive_recovery` which also fails on master)
- [x] `cargo clippy -p perl-parser-core --tests` clean (pre-existing `tests.rs` panics not in this changeset)
- [x] `cargo fmt --all` clean