### PR TITLE
fix(parser): handle arrow after typeglob, block, sub, and builtins (#1703)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -104,10 +104,12 @@ impl<'a> Parser<'a> {
 
             // print STDOUT ... (uppercase bareword filehandle)
             // But NOT if followed by comma — that's a regular call: open FILE, "..."
+            // And NOT if followed by arrow — that's a class method chain:
+            //   print Data::Dumper->new([$self])->Dump()
             if next_kind == TokenKind::Identifier {
                 if next_text.chars().next().is_some_and(|c| c.is_uppercase()) {
                     if let Ok(third) = self.tokens.peek_third() {
-                        if third.kind == TokenKind::Comma {
+                        if third.kind == TokenKind::Comma || third.kind == TokenKind::Arrow {
                             return false;
                         }
                     }

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1,7 +1,16 @@
 impl<'a> Parser<'a> {
     /// Parse postfix expression
     fn parse_postfix(&mut self) -> ParseResult<Node> {
-        let mut expr = self.parse_primary()?;
+        let expr = self.parse_primary()?;
+        self.parse_postfix_chain(expr)
+    }
+
+    /// Apply postfix operators (arrow chains, subscripts, etc.) to an
+    /// already-parsed expression.  Factored out of `parse_postfix` so
+    /// that callers who build an initial node outside the normal
+    /// `parse_primary` path (e.g. typeglobs in `parse_unary`) can still
+    /// participate in postfix chaining.
+    pub(crate) fn parse_postfix_chain(&mut self, mut expr: Node) -> ParseResult<Node> {
         let mut postfix_chain_depth = 0usize;
 
         let mut record_postfix_layer = || -> ParseResult<()> {

--- a/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
@@ -51,16 +51,18 @@ impl<'a> Parser<'a> {
                     let start = op_token.start;
 
                     // Special case: +{ ... } forces a hash constructor (not a block)
+                    // If followed by ->, allow postfix chaining: +{@_}->{key}
                     if self.peek_kind() == Some(TokenKind::LeftBrace) {
                         // Parse as hash literal
                         let hash = self.parse_hash_or_block()?;
                         let end = hash.location.end;
 
                         // Wrap the hash in a unary plus to preserve the explicit disambiguation
-                        return Ok(Node::new(
+                        let node = Node::new(
                             NodeKind::Unary { op: op_token.text.to_string(), operand: Box::new(hash) },
                             SourceLocation { start, end },
-                        ));
+                        );
+                        return self.parse_postfix_chain(node);
                     }
 
                     // Check if we're at EOF or a terminator (for standalone operators)
@@ -99,10 +101,12 @@ impl<'a> Parser<'a> {
                                 TokenKind::Identifier => {
                                     let id_token = self.tokens.next()?;
                                     let end = id_token.end;
-                                    return Ok(Node::new(
+                                    let node = Node::new(
                                         NodeKind::Typeglob { name: id_token.text.to_string() },
                                         SourceLocation { start, end },
-                                    ));
+                                    );
+                                    // Allow postfix chaining: *$self->{key}
+                                    return self.parse_postfix_chain(node);
                                 }
                                 TokenKind::LeftBrace => {
                                     // Dynamic typeglob *{$name}

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -181,10 +181,16 @@ impl<'a> Parser<'a> {
                 // Check if this is an anonymous subroutine
                 Ok(if let NodeKind::Subroutine { name, .. } = &sub_node.kind {
                     if name.is_none() {
+                        // Anonymous sub may be followed by arrow: sub { 42 }->()
+                        let expr = if self.peek_kind() == Some(TokenKind::Arrow) {
+                            self.parse_postfix_chain(sub_node)?
+                        } else {
+                            sub_node
+                        };
                         // Wrap anonymous subroutines in expression statements
-                        let location = sub_node.location;
+                        let location = expr.location;
                         Node::new(
-                            NodeKind::ExpressionStatement { expression: Box::new(sub_node) },
+                            NodeKind::ExpressionStatement { expression: Box::new(expr) },
                             location,
                         )
                     } else {
@@ -223,8 +229,23 @@ impl<'a> Parser<'a> {
             // Goto statement
             TokenKind::Goto => self.parse_goto(),
 
-            // Block
-            TokenKind::LeftBrace => self.parse_block(),
+            // Block — or hashref/block constructor followed by arrow dereference
+            // e.g. {key => "value"}->{key}
+            TokenKind::LeftBrace => {
+                let block = self.parse_block()?;
+                if self.peek_kind() == Some(TokenKind::Arrow) {
+                    // The block is actually an expression (hash constructor)
+                    // followed by postfix arrow operators.
+                    let chained = self.parse_postfix_chain(block)?;
+                    let loc = chained.location;
+                    Ok(Node::new(
+                        NodeKind::ExpressionStatement { expression: Box::new(chained) },
+                        loc,
+                    ))
+                } else {
+                    Ok(block)
+                }
+            }
 
             // Expression-ish statement
             _ => {
@@ -478,6 +499,24 @@ impl<'a> Parser<'a> {
         expr = self.parse_bitwise_or_with(expr)?;
         expr = self.parse_and_with(expr)?;
         expr = self.parse_or_with(expr)?;
+        // Ternary (?:) sits between || and = in Perl precedence.
+        // Without this, `wantarray ? @list : $list[0]` fails.
+        if self.peek_kind() == Some(TokenKind::Question) {
+            self.tokens.next()?; // consume ?
+            let then_expr = self.parse_assignment()?;
+            self.expect(TokenKind::Colon)?;
+            let else_expr = self.parse_ternary()?;
+            let start = expr.location.start;
+            let end = else_expr.location.end;
+            expr = Node::new(
+                NodeKind::Ternary {
+                    condition: Box::new(expr),
+                    then_expr: Box::new(then_expr),
+                    else_expr: Box::new(else_expr),
+                },
+                SourceLocation { start, end },
+            );
+        }
         self.parse_word_or_expr(expr)
     }
 

--- a/crates/perl-parser-core/tests/fix_method_chain_continuation.rs
+++ b/crates/perl-parser-core/tests/fix_method_chain_continuation.rs
@@ -1,0 +1,264 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+/// Stricter clean-parse check that also catches (ERROR ...) nodes
+/// which `assert_clean_parse` misses due to case sensitivity.
+fn assert_no_errors(source: &str) {
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    let sexp_lower = sexp.to_lowercase();
+    let markers = [
+        "(error ",
+        "(missing_expression",
+        "(missing_statement",
+        "(missing_identifier",
+        "(missing_block",
+    ];
+    for marker in &markers {
+        assert!(
+            !sexp_lower.contains(marker),
+            "Parse error found for source:\n{}\n\nsexp:\n{}",
+            source,
+            sexp,
+        );
+    }
+}
+
+// --- Basic multi-line method chains ---
+
+#[test]
+fn test_method_chain_multiline() {
+    let source = r#"$obj->method1()
+    ->method2()
+    ->method3();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_multiline_no_parens() {
+    let source = r#"$obj->method1
+    ->method2
+    ->method3;"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_same_line() {
+    let source = r#"$obj->method1()->method2()->method3();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_with_args() {
+    let source = r#"$obj->method1("arg1")
+    ->method2($arg2)
+    ->method3();"#;
+    assert_no_errors(source);
+}
+
+// --- Arrow dereference across lines ---
+
+#[test]
+fn test_method_chain_arrow_deref_multiline() {
+    let source = r#"$ref->{key}
+    ->{nested_key};"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_arrow_array_deref_multiline() {
+    let source = r#"$ref->[0]
+    ->[1];"#;
+    assert_no_errors(source);
+}
+
+// --- Method calls with complex arguments ---
+
+#[test]
+fn test_scalar_method_call() {
+    let source = r#"scalar $dh->read;"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_return_method_chain() {
+    let source = r#"return $sock->SUPER::connect(@_);"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_return_ternary_with_method() {
+    let source = r#"return $sock->SUPER::connect(@_ == 1 ? shift : pack_sockaddr_in(@_));"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_chained_method_on_constructor() {
+    let source = r#"My::Class->new()
+    ->init()
+    ->run();"#;
+    assert_no_errors(source);
+}
+
+// --- Patterns from corpus: indirect method syntax with -> continuation ---
+
+#[test]
+fn test_method_on_do_block() {
+    let source = r#"do { $class }->new();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_after_shift() {
+    let source = r#"shift->method();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_after_paren_expr() {
+    let source = r#"($obj || $default)->method();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_super_method_with_ternary_arg() {
+    let source = r#"sub connect {
+    my $sock = shift;
+    return $sock->SUPER::connect(@_ == 1 ? shift : pack_sockaddr_in(@_));
+}"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_complex_chain_with_hash_deref() {
+    let source = r#"$self->{config}
+    ->{database}
+    ->{host};"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_mixed_deref() {
+    let source = r#"$self->get_config()
+    ->{items}
+    ->[0]
+    ->process();"#;
+    assert_no_errors(source);
+}
+
+// --- Arrow in complex expression contexts ---
+
+#[test]
+fn test_arrow_in_ternary_branches() {
+    let source = r#"$cond ? $a->method : $b->method;"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_arrow_after_array_ref_constructor() {
+    let source = r#"[1, 2, 3]->[0];"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_arrow_after_hash_ref_constructor() {
+    let source = r#"{key => "value"}->{key};"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_arrow_after_sub_ref() {
+    let source = r#"sub { 42 }->();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_in_print() {
+    let source = r#"print $obj->method1()->method2();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_chained_method_with_list_arg() {
+    let source = r#"$obj->push(@items)
+    ->sort()
+    ->first();"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_io_socket_inet_configure() {
+    let source = r#"sub configure {
+    my($sock, $arg) = @_;
+    my($lport, $rport, $laddr, $raddr, $proto, $type);
+
+    $arg->{LocalAddr} = $arg->{LocalHost}
+        if exists $arg->{LocalHost} && !exists $arg->{LocalAddr};
+
+    ($laddr, $lport, $proto) = _sock_info(
+        $arg->{LocalAddr}, $arg->{LocalPort}, $arg->{Proto}
+    );
+
+    $sock->socket(AF_INET, $type, $proto) or
+        return _error($sock, $!, "socket");
+
+    return $sock;
+}"#;
+    assert_no_errors(source);
+}
+
+// --- Actual corpus patterns that trigger unexpected_arrow_expr ---
+
+// Pattern 1: Glob dereference *$self followed by arrow hash access
+// From IO::String, IO::Scalar, IO::Compress::Base::Common
+#[test]
+fn test_glob_deref_arrow_hash() {
+    let source = r#"*$self->{buf} = $bufref;"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_glob_deref_arrow_hash_multiple() {
+    let source = r#"*$self->{buf} = $bufref;
+*$self->{pos} = 0;
+*$self->{lno} = 0;"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_glob_deref_arrow_assign() {
+    let source = r#"*$obj->{Closed} = 1;
+*$obj->{Error} = $error_ref;
+*$obj->{ErrorNo} = \$errno;"#;
+    assert_no_errors(source);
+}
+
+// Pattern 2: print builtin consuming class name before ->
+// From ExtUtils::Installed
+#[test]
+fn test_print_class_method_call() {
+    let source = r#"print Data::Dumper->new([$self])->Sortkeys(1)->Indent(1)->Dump();"#;
+    assert_no_errors(source);
+}
+
+// Pattern 3: Unary + on hashref constructor followed by arrow
+// From Log::Dispatch::Output
+#[test]
+fn test_unary_plus_hashref_arrow() {
+    let source = r#"+{@_}->{message} . "\n";"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_arrow_after_wantarray() {
+    let source = r#"wantarray ? @list : $list[0];"#;
+    assert_no_errors(source);
+}
+
+#[test]
+fn test_method_chain_after_conditional_assignment() {
+    let source = r#"my $obj = $factory->create();
+$obj->configure()
+    ->start();"#;
+    assert_no_errors(source);
+}


### PR DESCRIPTION
## Summary

Fixes #1703 — unexpected_arrow_expr errors affecting ~60 CPAN corpus files.

Five root causes identified and fixed:

- **Typeglob arrow dereference** (`*$self->{key}`): `parse_unary` created Typeglob nodes and returned directly, bypassing `parse_postfix`. Fixed by extracting `parse_postfix_chain()` and routing typeglob results through it.
- **Print with class method chain** (`print Data::Dumper->new()->Dump()`): `is_indirect_call_pattern` misclassified uppercase bareword followed by `->` as an indirect object. Fixed by checking for Arrow in the third-token lookahead.
- **Unary plus hashref arrow** (`+{@_}->{key}`): same bypass as typeglob. Fixed by routing `+{hash}` through `parse_postfix_chain`.
- **Block/hashref constructor arrow** (`{k=>v}->{k}`): `LeftBrace` at statement level dispatched to `parse_block`, losing arrow context. Fixed by checking for `->` after block parsing and treating as expression.
- **Anonymous sub arrow** (`sub{42}->()`): similar to block constructor. Fixed by checking for `->` after anonymous sub parsing.

Bonus fix: nullary builtins like `wantarray` now handle the ternary operator (`wantarray ? @list : $list[0]`) via `parse_named_unary_statement_tail`.

## Test plan

- [x] 30 new tests in `fix_method_chain_continuation.rs` covering all 5 patterns
- [x] All 30 tests pass (were 8 failures before fix)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] All pre-existing perl-parser-core tests pass (only pre-existing `parser_ac3_prevent_recursive_recovery` fails, same on master)