### PR TITLE
fix(parser): recognize fat-arrow in function argument lists (#2147)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -699,11 +699,14 @@ impl<'a> Parser<'a> {
         } else if self.peek_kind() == Some(TokenKind::LeftParen) {
             self.consume_token()?; // consume (
 
-            // Parse import list (with EOF guard to prevent infinite loop on truncated input)
+            // Parse import list (with EOF guard to prevent infinite loop on truncated input).
+            // Accept strings, identifiers, and numbers as import items to support
+            // both simple import lists and key => value pairs.
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                if self.peek_kind() == Some(TokenKind::String) {
-                    args.push(self.consume_token()?.text.to_string());
-                } else if self.peek_kind() == Some(TokenKind::Identifier) {
+                if matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::String | TokenKind::Identifier | TokenKind::Number)
+                ) {
                     args.push(self.consume_token()?.text.to_string());
                 } else {
                     return Err(ParseError::syntax(
@@ -712,8 +715,12 @@ impl<'a> Parser<'a> {
                     ));
                 }
 
-                if self.peek_kind() == Some(TokenKind::Comma) {
-                    self.consume_token()?; // consume comma
+                // Accept both comma and fat arrow as separators
+                if matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::Comma | TokenKind::FatArrow)
+                ) {
+                    self.consume_token()?;
                 } else if self.peek_kind() != Some(TokenKind::RightParen) {
                     return Err(ParseError::syntax(
                         "Expected comma or closing parenthesis",
@@ -908,11 +915,13 @@ impl<'a> Parser<'a> {
         } else if self.peek_kind() == Some(TokenKind::LeftParen) {
             self.consume_token()?; // consume (
 
-            // Parse argument list (with EOF guard to prevent infinite loop on truncated input)
+            // Parse argument list (with EOF guard to prevent infinite loop on truncated input).
+            // Accept strings, identifiers, and numbers to support key => value pairs.
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                if self.peek_kind() == Some(TokenKind::String) {
-                    args.push(self.consume_token()?.text.to_string());
-                } else if self.peek_kind() == Some(TokenKind::Identifier) {
+                if matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::String | TokenKind::Identifier | TokenKind::Number)
+                ) {
                     args.push(self.consume_token()?.text.to_string());
                 } else {
                     return Err(ParseError::syntax(
@@ -921,8 +930,12 @@ impl<'a> Parser<'a> {
                     ));
                 }
 
-                if self.peek_kind() == Some(TokenKind::Comma) {
-                    self.consume_token()?; // consume comma
+                // Accept both comma and fat arrow as separators
+                if matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::Comma | TokenKind::FatArrow)
+                ) {
+                    self.consume_token()?;
                 } else if self.peek_kind() != Some(TokenKind::RightParen) {
                     return Err(ParseError::syntax(
                         "Expected comma or closing parenthesis",

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -540,7 +540,11 @@ impl<'a> Parser<'a> {
         let mut args = vec![];
         while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
             args.push(self.parse_expression()?);
-            if self.peek_kind() == Some(TokenKind::Comma) {
+            // Accept both comma and fat arrow as separators
+            if matches!(
+                self.peek_kind(),
+                Some(TokenKind::Comma | TokenKind::FatArrow)
+            ) {
                 self.consume_token()?;
             } else if self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
                 return Err(ParseError::syntax(

--- a/crates/perl-parser-core/tests/fat_arrow_args_tests.rs
+++ b/crates/perl-parser-core/tests/fat_arrow_args_tests.rs
@@ -1,0 +1,122 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::parse;
+
+/// Strict clean-parse check that catches ALL error variants including
+/// uppercase `(ERROR "...")` from error recovery.
+fn assert_no_errors(source: &str) {
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    let error_markers = [
+        "(error ",
+        "(Error ",
+        "(ERROR ",
+        "(missing_expression",
+        "(missing_statement",
+        "(missing_identifier",
+        "(missing_block",
+        "MissingExpression",
+        "MissingStatement",
+        "MissingIdentifier",
+        "MissingBlock",
+    ];
+    for marker in &error_markers {
+        assert!(
+            !sexp.contains(marker),
+            "Parse produced error for source:\n{}\n\nMarker: {}\nSexp: {}",
+            source,
+            marker,
+            sexp,
+        );
+    }
+}
+
+// --- Function call argument lists with fat arrow ---
+
+#[test]
+fn test_method_call_with_fat_arrow_args() {
+    assert_no_errors(r#"$obj->has(name => 'foo');"#);
+}
+
+#[test]
+fn test_method_call_with_multiple_fat_arrow_args() {
+    assert_no_errors(r#"$obj->method(key => 'value', another => 42);"#);
+}
+
+#[test]
+fn test_function_call_with_fat_arrow_args() {
+    assert_no_errors(r#"foo(key => 'value');"#);
+}
+
+#[test]
+fn test_function_call_with_multiple_fat_arrow_args() {
+    assert_no_errors(r#"my $x = func(a => 1, b => 2);"#);
+}
+
+#[test]
+fn test_nested_parens_with_fat_arrow() {
+    assert_no_errors(r#"Moo::has(name => (is => 'ro'));"#);
+}
+
+#[test]
+fn test_method_call_mixed_args() {
+    assert_no_errors(r#"$obj->method('positional', key => 'value');"#);
+}
+
+#[test]
+fn test_fat_arrow_with_arrayref_value() {
+    assert_no_errors(r#"$obj->has(isa => ['Str', 'Int']);"#);
+}
+
+#[test]
+fn test_fat_arrow_with_hashref_value() {
+    assert_no_errors(r#"$obj->configure(options => { verbose => 1 });"#);
+}
+
+#[test]
+fn test_fat_arrow_with_coderef_value() {
+    assert_no_errors(r#"$obj->add(trigger => sub { 1 });"#);
+}
+
+#[test]
+fn test_has_moose_style() {
+    assert_no_errors(r#"has 'name' => (is => 'ro', isa => 'Str', default => 'foo');"#);
+}
+
+#[test]
+fn test_has_method_call_moose_style() {
+    assert_no_errors(r#"$meta->add_attribute(name => (is => 'rw', isa => 'Str'));"#);
+}
+
+// --- Issue #2147: use/no parenthesized import list with fat arrow ---
+
+#[test]
+fn test_use_paren_import_with_fat_arrow() {
+    assert_no_errors(r#"use parent (key => 'value');"#);
+}
+
+#[test]
+fn test_use_paren_import_multiple_fat_arrows() {
+    assert_no_errors(r#"use Module (foo => 1, bar => 2);"#);
+}
+
+#[test]
+fn test_use_paren_import_mixed_comma_fat_arrow() {
+    assert_no_errors(r#"use Module ('export1', key => 'value');"#);
+}
+
+#[test]
+fn test_no_paren_import_with_fat_arrow() {
+    assert_no_errors(r#"no Module (key => 'value');"#);
+}
+
+// --- Coderef call with fat arrow args ---
+
+#[test]
+fn test_coderef_call_with_fat_arrow() {
+    assert_no_errors(r#"&$func(key => 'value');"#);
+}
+
+#[test]
+fn test_dbi_connect_style() {
+    assert_no_errors(r#"DBI->connect($dsn, $user, $pass, { RaiseError => 1 });"#);
+}


### PR DESCRIPTION
## Summary

Fixes #2147. Eliminates the entire `expected_comma_or_close_paren` error bucket (46 CPAN files).

Three locations rejected fat-arrow (`=>`) as a separator in argument lists:

1. **`use` parenthesized import lists** (`declarations.rs`) — now accepts `=>` alongside `,`, and accepts `Number` tokens as import items for `key => value` pairs
2. **`no` parenthesized argument lists** (`declarations.rs`) — same fix
3. **`parse_parenthesized_arg_list`** for `&func()` calls (`variables.rs`) — accepts `=>` alongside `,`

## Test plan

- [x] 17 new tests in `fat_arrow_args_tests.rs` covering method calls, function calls, `use`/`no` with parenthesized fat-arrow args, coderef calls
- [x] All perl-parser-core tests pass (only pre-existing `parser_ac3_prevent_recursive_recovery` failure)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] CPAN corpus: `expected_comma_or_close_paren` bucket eliminated (46 -> 0)