### PR TITLE
fix(parser): handle complex expressions in parenthesized arguments (#1704)

### DIFF
--- a/crates/perl-parser-core/tests/complex_paren_args_tests.rs
+++ b/crates/perl-parser-core/tests/complex_paren_args_tests.rs
@@ -1,0 +1,202 @@
+//! Tests for issue #1704: unclosed_paren errors from complex arg expressions.
+//! Patterns extracted from actual corpus files that fail with this error.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// === Pattern 1: *$self->{key} (glob deref without ${}) ===
+// From IO::Compress::Gzip, IO::Compress::Zip, IO::Uncompress::Base
+
+#[test]
+fn glob_deref_arrow_hash() {
+    // *$self->{Compress}->crc32()
+    assert_clean_parse(r#"my $crc = *$self->{Compress}->crc32();"#);
+}
+
+#[test]
+fn glob_deref_arrow_hash_in_pack() {
+    // pack("V V", *$self->{Compress}->crc32(), *$self->{UnCompSize}->get32bit())
+    assert_clean_parse(
+        r#"return pack("V V", *$self->{Compress}->crc32(), *$self->{UnCompSize}->get32bit());"#,
+    );
+}
+
+#[test]
+fn glob_deref_arrow_hash_in_if() {
+    // if (*$self->{ZipData}{Sparse})
+    assert_clean_parse(r#"if (*$self->{ZipData}{Sparse}) { print "sparse" }"#);
+}
+
+#[test]
+fn glob_deref_arrow_hash_defined() {
+    // if (defined *$self->{InputLength})
+    assert_clean_parse(r#"if (defined *$self->{InputLength}) { return 0 }"#);
+}
+
+#[test]
+fn glob_deref_hash_access_no_braces() {
+    // *$oldglob{$slot}
+    assert_clean_parse(r#"next unless defined(*$oldglob{$slot});"#);
+}
+
+#[test]
+fn glob_deref_hash_assign() {
+    // *alias = *$oldglob{$slot};
+    assert_clean_parse(r#"*alias = *$oldglob{$slot};"#);
+}
+
+// === Pattern 2: Symbolic dereference with string expressions ===
+// From Digest.pm, Test::Builder, autodie::hints
+
+#[test]
+fn symbolic_deref_hash_version() {
+    // exists ${"$class\::"}{"VERSION"}
+    assert_clean_parse(r#"unless (exists ${"$class\::"}{"VERSION"}) { print "no version" }"#);
+}
+
+#[test]
+fn symbolic_deref_hash_todo() {
+    // ${"$cpkg\::TODO"} if $cpkg
+    assert_clean_parse(r#"$todo = ${"$cpkg\::TODO"} if $cpkg;"#);
+}
+
+#[test]
+fn symbolic_deref_hash_does() {
+    // ${"${package}::DOES"}{HINTS_PROVIDER.""}
+    assert_clean_parse(r#"if (${"${package}::DOES"}{HINTS_PROVIDER.""}) { print "ok" }"#);
+}
+
+#[test]
+fn symbolic_deref_encoding() {
+    // return ${"ENCODING_" . uc(shift)};
+    assert_clean_parse(r#"return ${"ENCODING_" . uc(shift)};"#);
+}
+
+// === Pattern 3: (caller N)[index] ===
+// From charnames.pm, warnings.pm
+
+#[test]
+fn caller_subscript() {
+    // (caller 0)[8]
+    assert_clean_parse(r#"my $bits = (caller 0)[8];"#);
+}
+
+#[test]
+fn caller_subscript_in_condition() {
+    // return chr ... || ! ((caller 0)[8] & $bytes::hint_bits);
+    assert_clean_parse(
+        r#"return chr $ord if $ord <= 255 || !((caller 0)[8] & $bytes::hint_bits);"#,
+    );
+}
+
+#[test]
+fn caller_1_subscript() {
+    // my $sub = (caller 1)[3];
+    assert_clean_parse(r#"my $sub = (caller 1)[3];"#);
+}
+
+// === Pattern 4: ref eq without parens ===
+// From base.pm
+
+#[test]
+fn ref_eq_string() {
+    // ref eq 'CODE'
+    assert_clean_parse(r#"my @filtered = grep !(ref eq 'CODE' && $_ == $_[0]), @INC;"#);
+}
+
+#[test]
+fn ref_eq_simple() {
+    assert_clean_parse(r#"print "ok" if ref eq 'HASH';"#);
+}
+
+// === Pattern 5: Complex nested calls in args ===
+// From Test2::API
+
+#[test]
+fn blessed_new_with_dclone() {
+    // blessed($_[0])->new(@{dclone($_[0])})
+    assert_clean_parse(r#"sub clone { blessed($_[0])->new(@{dclone($_[0])}) }"#);
+}
+
+#[test]
+fn facet_class_new_with_dclone() {
+    // $self->_facet_class($name)->new(%{dclone($data)})
+    assert_clean_parse(
+        r#"return $self->_facet_class($name)->new(%{dclone($data)}) if $type eq 'HASH';"#,
+    );
+}
+
+// === Pattern 6: Exponentiation in complex math ===
+// From Math::Complex
+
+#[test]
+fn complex_math_with_exponent() {
+    // 1/(2 * $z) - 1/(8 * $z**3)
+    assert_clean_parse(r#"$t = 1/(2 * $z) - 1/(8 * $z**3) + 1/(16 * $z**5);"#);
+}
+
+#[test]
+fn exponent_chain() {
+    assert_clean_parse(r#"my $x = $z**3 + $z**5 - $z**7;"#);
+}
+
+// === Pattern 7: Complex foreach with ref ternary ===
+// From Net::SMTP
+
+#[test]
+fn foreach_ref_ternary() {
+    // foreach my $h (@{ref($hosts) ? $hosts : [$hosts]})
+    assert_clean_parse(r#"foreach my $h (@{ref($hosts) ? $hosts : [$hosts]}) { print $h }"#);
+}
+
+// === Pattern 8: utf8::downgrade with "or croak" ===
+// From Compress::Zlib
+
+#[test]
+fn utf8_downgrade_or_croak() {
+    // $] >= 5.008 and (utf8::downgrade($_[0], 1) or croak "Wide character in gzwrite");
+    assert_clean_parse(
+        r#"$] >= 5.008 and (utf8::downgrade($_[0], 1) or croak "Wide character in gzwrite");"#,
+    );
+}
+
+// === Pattern 9: _estr helper in function call ===
+// From ExtUtils::Install
+
+#[test]
+fn estr_in_croak() {
+    // _croak( _estr "ERROR: Cannot copy '$from' to '$to': $!" );
+    assert_clean_parse(r#"_croak(_estr "ERROR: Cannot copy '$from' to '$to': $!");"#);
+}
+
+// === Pattern 10: reftype in condition ===
+// From Test2::API::InterceptResult::Event
+
+#[test]
+fn reftype_or_confess() {
+    assert_clean_parse(r#"my $type = reftype($data) or confess "Facet has a bad value";"#);
+}
+
+// === Already-passing patterns (from issue description, kept as regression tests) ===
+
+#[test]
+fn use_constant_hashref() {
+    assert_clean_parse(
+        r#"
+use constant {
+    UNICODE_VERSION => "15.0.0",
+    CLDR_VERSION    => "42",
+};
+"#,
+    );
+}
+
+#[test]
+fn return_list_with_or_undef() {
+    assert_clean_parse(r#"return ($addr || undef, $port || undef, $proto || undef);"#);
+}
+
+#[test]
+fn xsloader_load_with_package() {
+    assert_clean_parse(r#"XSLoader::load(__PACKAGE__, $XS_VERSION);"#);
+}

--- a/crates/perl-parser-core/tests/corpus_context_tests.rs
+++ b/crates/perl-parser-core/tests/corpus_context_tests.rs
@@ -1,0 +1,276 @@
+//! Test patterns in their actual file context to find the real failures.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn io_compress_gzip_mktrailer() {
+    // This is the exact context from IO::Compress::Gzip
+    assert_clean_parse(
+        r#"
+sub mkTrailer
+{
+    my $self = shift ;
+    return pack("V V", *$self->{Compress}->crc32(),
+                       *$self->{UnCompSize}->get32bit());
+}
+"#,
+    );
+}
+
+#[test]
+fn io_compress_zip_sparse_check() {
+    assert_clean_parse(
+        r#"
+sub something {
+    my $self = shift ;
+    if (*$self->{ZipData}{Sparse} ) {
+        my $inc = 1024 * 100 ;
+        my $NULLS = ("\x00" x $inc) ;
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn io_uncompress_base_input_length() {
+    assert_clean_parse(
+        r#"
+sub something {
+    if (defined *$self->{InputLength}) {
+        return 0
+            if *$self->{InputLengthRemaining} <= 0 ;
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn digest_version_check() {
+    assert_clean_parse(
+        r#"
+sub new {
+    my $class = shift;
+    ( $class, @args ) = @$class if ref($class);
+    no strict 'refs';
+    unless ( exists ${"$class\::"}{"VERSION"} ) {
+        my $pm_file = $class . ".pm";
+        $pm_file =~ s{::}{/}g;
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn test_builder_todo() {
+    assert_clean_parse(
+        r#"
+sub something {
+    no warnings 'once';
+    my $todo;
+    $todo = ${"$cpkg\::TODO"} if $cpkg;
+    $todo = ${"$epkg\::TODO"} if $epkg && !$todo;
+}
+"#,
+    );
+}
+
+#[test]
+fn base_pm_unhook() {
+    // From base.pm - ref eq 'CODE' without parens
+    assert_clean_parse(
+        r#"sub base::__inc::unhook { @INC = grep !(ref eq 'CODE' && $_ == $_[0]), @INC }"#,
+    );
+}
+
+#[test]
+fn charnames_caller_subscript() {
+    assert_clean_parse(
+        r#"
+sub something {
+    my $ord = CORE::hex $1;
+    return chr utf8::unicode_to_native($ord) if $ord <= 255
+                                         || ! ((caller 0)[8] & $bytes::hint_bits);
+}
+"#,
+    );
+}
+
+#[test]
+fn warnings_caller_subscript() {
+    assert_clean_parse(
+        r#"
+sub something {
+    if ($has_level) {
+        if (@_ != ($has_message ? 3 : 2)) {
+            my $sub = (caller 1)[3];
+        }
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn net_smtp_foreach_ref() {
+    assert_clean_parse(
+        r#"
+sub new {
+    my $self = shift;
+    my $type = ref($self) || $self;
+    my ($host, %arg) = @_;
+    $arg{Timeout} = 120 if ! defined $arg{Timeout};
+
+    foreach my $h (@{ref($hosts) ? $hosts : [$hosts]}) {
+        $obj = $type->SUPER::new(
+            PeerAddr => ($host = $h),
+        );
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn compress_zlib_downgrade() {
+    assert_clean_parse(
+        r#"
+sub gzwrite {
+    $] >= 5.008 and (utf8::downgrade($_[0], 1)
+        or croak "Wide character in gzwrite");
+
+    my $status = $gz->write($_[0]) ;
+}
+"#,
+    );
+}
+
+#[test]
+fn extutils_install_estr() {
+    assert_clean_parse(
+        r#"
+sub something {
+    if (!$dry_run) {
+        File::Copy::copy($from,$to)
+            or _croak( _estr "ERROR: Cannot copy '$from' to '$to': $!" );
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn extutils_locale_encoding() {
+    assert_clean_parse(
+        r#"
+sub something {
+    no warnings 'once';
+    return ${"ENCODING_" . uc(shift)};
+}
+"#,
+    );
+}
+
+#[test]
+fn test2_clone_dclone() {
+    assert_clean_parse(r#"sub clone { blessed($_[0])->new(@{dclone($_[0])}) }"#);
+}
+
+#[test]
+fn test2_facet_class_new() {
+    assert_clean_parse(
+        r#"
+sub something {
+    my $type = reftype($data) or confess "Facet has a bad value";
+
+    return $self->_facet_class($name)->new(%{dclone($data)})
+        if $type eq 'HASH';
+}
+"#,
+    );
+}
+
+#[test]
+fn math_complex_exponent() {
+    assert_clean_parse(
+        r#"
+sub something {
+    $t = 1/(2 * $z) - 1/(8 * $z**3) + 1/(16 * $z**5) - 5/(128 * $z**7)
+        if $t == 0;
+    my $u = &log($t);
+}
+"#,
+    );
+}
+
+#[test]
+fn autodie_util_glob_slot() {
+    assert_clean_parse(
+        r#"
+sub something {
+    foreach my $slot (qw( SCALAR ARRAY HASH IO ) ) {
+        next unless defined(*$oldglob{$slot});
+        *alias = *$oldglob{$slot};
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn autodie_hints_does() {
+    assert_clean_parse(
+        r#"
+sub something {
+    if ($hints_available) {
+        print "ok";
+    }
+    elsif ( ${"${package}::DOES"}{HINTS_PROVIDER.""} ) {
+        $hints_available = 1;
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn carp_return_glob_scalar() {
+    assert_clean_parse(
+        r#"
+sub something {
+    return unless ref \$_ eq 'GLOB' && *$_{HASH} && exists $$_{$sub};
+    return ${*$_{SCALAR}};
+}
+"#,
+    );
+}
+
+#[test]
+fn file_fetch_return_error() {
+    assert_clean_parse(
+        r#"
+sub something {
+    for my $i (1..5) {
+        return 1 if $success;
+    }
+    return $self->_error("Fetch failed! Gave up after 5 tries");
+}
+"#,
+    );
+}
+
+// Test closure over sub argument in different context
+#[test]
+fn extutils_locale_sub_closure() {
+    assert_clean_parse(
+        r#"
+Memoize::memoize('_langinfo', NORMALIZER => sub {
+    no warnings 'once';
+    return ${"ENCODING_" . uc(shift)};
+}, "locale");
+"#,
+    );
+}

--- a/crates/perl-parser-core/tests/glob_deref_arrow_tests.rs
+++ b/crates/perl-parser-core/tests/glob_deref_arrow_tests.rs
@@ -1,0 +1,120 @@
+//! Tests for *$self->{key} glob dereference patterns.
+//! These are the primary driver of unclosed_paren errors in the corpus.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// The core issue: *$self->{key} at various positions
+
+#[test]
+fn glob_deref_hash_in_if_condition() {
+    // IO::Uncompress::Base L39 - first error in file
+    assert_clean_parse(r#"if (defined *$self->{InputLength}) { return 0 }"#);
+}
+
+#[test]
+fn glob_deref_hash_simple_stmt() {
+    assert_clean_parse(r#"*$self->{key};"#);
+}
+
+#[test]
+fn glob_deref_hash_in_assignment() {
+    assert_clean_parse(r#"my $x = *$self->{key};"#);
+}
+
+#[test]
+fn glob_deref_hash_in_return() {
+    assert_clean_parse(r#"return *$self->{key};"#);
+}
+
+#[test]
+fn glob_deref_hash_method_call() {
+    // IO::Compress::Gzip L164
+    assert_clean_parse(r#"return pack("V V", *$self->{Compress}->crc32());"#);
+}
+
+#[test]
+fn glob_deref_hash_double_key() {
+    // IO::Compress::Zip L114
+    assert_clean_parse(r#"if (*$self->{ZipData}{Sparse}) { print "ok" }"#);
+}
+
+#[test]
+fn glob_deref_hash_method_chain_in_pack() {
+    assert_clean_parse(
+        r#"return pack("V V", *$self->{Compress}->crc32(), *$self->{UnCompSize}->get32bit());"#,
+    );
+}
+
+// *$glob{SLOT} patterns (from Carp.pm, autodie)
+
+#[test]
+fn glob_hash_slot() {
+    // *$_{HASH}
+    assert_clean_parse(r#"if (*$_{HASH}) { print "ok" }"#);
+}
+
+#[test]
+fn glob_code_slot() {
+    // *$_{CODE}
+    assert_clean_parse(r#"return *$_{CODE};"#);
+}
+
+#[test]
+fn glob_scalar_slot() {
+    // ${*$_{SCALAR}}
+    assert_clean_parse(r#"return ${*$_{SCALAR}};"#);
+}
+
+#[test]
+fn glob_hash_slot_defined() {
+    // defined(*$oldglob{$slot})
+    assert_clean_parse(r#"next unless defined(*$oldglob{$slot});"#);
+}
+
+#[test]
+fn glob_hash_slot_assign() {
+    // *alias = *$oldglob{$slot};
+    assert_clean_parse(r#"*alias = *$oldglob{$slot};"#);
+}
+
+// Full context patterns from real files
+
+#[test]
+fn io_uncompress_base_full_sub() {
+    assert_clean_parse(
+        r#"
+sub smartRead {
+    my $self = $_[0];
+    my $out = $_[1];
+    my $size = $_[2];
+    $$out = "";
+    my $offset = 0;
+    my $status = 1;
+    if (defined *$self->{InputLength}) {
+        return 0 if *$self->{InputLengthRemaining} <= 0;
+        $size = $size;
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn carp_fetch_sub_full() {
+    assert_clean_parse(
+        r#"
+sub _fetch_sub {
+    my($pack, $sub) = @_;
+    $pack .= '::';
+    return unless exists($::{$pack});
+    for ($::{$pack}) {
+        return unless ref \$_ eq 'GLOB' && *$_{HASH} && exists $$_{$sub};
+        for ($$_{$sub}) {
+            return ref \$_ eq 'GLOB' ? *$_{CODE} : undef
+        }
+    }
+}
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

- Typeglob nodes (`*foo`) were returned immediately from `parse_unary` without entering the postfix loop, so patterns like `*$self->{key}`, `*$glob{SLOT}`, and `*$self->{Compress}->crc32()` left `->` and `{}` tokens unparsed, cascading into `unclosed_paren` errors across 134 corpus files.
- Extracted `parse_postfix_chain` from `parse_postfix` so pre-built nodes can enter the postfix operator loop.
- Modified the typeglob handler in `parse_unary` to call `parse_postfix_chain` on the typeglob node.

## Test plan

- [x] 60 new regression tests across 3 test files covering:
  - `*$self->{key}` glob deref with arrow/hash access (IO::Compress, Carp patterns)
  - `*$glob{SLOT}` glob hash slot access (autodie::Util patterns)
  - Symbolic deref (`${"$class\::"}`), caller subscripts, `ref eq`, nested calls
  - Complex math with exponentiation, foreach ref ternary, utf8 downgrade
  - Full sub-context patterns from real corpus files
- [x] All pre-existing tests pass (only pre-existing `parser_ac3_prevent_recursive_recovery` failure)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --tests` clean (4 pre-existing `panic` errors in tests.rs only)

Closes #1704