### PR TITLE
feat(dist): add cargo-binstall configuration for perl-lsp

### DIFF
--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -123,6 +123,11 @@ parking_lot = "0.12.5"
 criterion = "0.8.1"
 uuid = { version = "1.21.0", features = ["v4"] }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [[bench]]
 name = "rope_performance_benchmark"
 harness = false


### PR DESCRIPTION
## Summary
- Adds `[package.metadata.binstall]` section to `crates/perl-lsp/Cargo.toml`
- Configures cargo-binstall to download pre-built binaries from GitHub releases
- Enables `cargo binstall perl-lsp` for quick installation

Closes #2071

## Test plan
- [x] `cargo check -p perl-lsp` passes
- [x] Change is metadata-only — no code compilation impact