### PR TITLE
perf(completion): reduce unnecessary clones in completion hot path

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -528,14 +528,12 @@ impl CompletionProvider {
                         .chars()
                         .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '-')
                 {
-                    let mut file_context = context.clone();
-                    file_context.prefix = path_prefix.to_string();
-                    file_context.prefix_start = start + 1;
-                    self.add_file_completions_with_cancellation(
-                        &mut completions,
-                        &file_context,
-                        is_cancelled,
+                    let file_context = file_path::FileCompletionContext::new(
+                        path_prefix,
+                        start + 1,
+                        context.position,
                     );
+                    completions.extend(file_path::complete_file_paths(&file_context, is_cancelled));
                 }
             }
         } else {
@@ -583,14 +581,7 @@ impl CompletionProvider {
         }
 
         // Remove duplicates and sort completions by relevance
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            sort::deduplicate_and_sort(completions.clone())
-        })) {
-            Ok(sorted_completions) => sorted_completions,
-            Err(_) => {
-                completions // Return unsorted completions as fallback
-            }
-        }
+        sort::deduplicate_and_sort(completions)
     }
 
     /// Get completions at a given position for Perl script development
@@ -745,10 +736,6 @@ impl CompletionProvider {
 
     /// Analyze the context at the cursor position
     fn analyze_context(&self, source: &str, position: usize) -> CompletionContext {
-        // Find the prefix (text before cursor on the same line)
-        let line_start = source[..position].rfind('\n').map(|p| p + 1).unwrap_or(0);
-        let _prefix = source[line_start..position].to_string();
-
         // Find the word being typed
         // Special handling for method calls: include the -> and the receiver
         let (word_prefix, prefix_start) =
@@ -777,8 +764,13 @@ impl CompletionProvider {
                 (source[word_start..position].to_string(), word_start)
             };
 
-        // Detect trigger character
-        let trigger_character = if position > 0 { source.chars().nth(position - 1) } else { None };
+        // Detect trigger character (trigger chars are ASCII, so byte access is safe)
+        let trigger_character = if position > 0 {
+            let b = source.as_bytes()[position - 1];
+            if b.is_ascii() { Some(b as char) } else { None }
+        } else {
+            None
+        };
 
         // Simple heuristics for context detection
         let in_string = self.is_in_string(source, position);
@@ -836,7 +828,7 @@ impl CompletionProvider {
     ) {
         completions.extend(file_path::complete_file_paths(
             &file_path::FileCompletionContext::new(
-                context.prefix.clone(),
+                &context.prefix,
                 context.prefix_start,
                 context.position,
             ),

--- a/crates/perl-lsp-completion/src/completion/methods.rs
+++ b/crates/perl-lsp-completion/src/completion/methods.rs
@@ -125,7 +125,7 @@ pub fn add_method_completions(
     source: &str,
     symbol_table: &SymbolTable,
 ) {
-    let mut seen = HashSet::new();
+    let mut seen: HashSet<&str> = HashSet::new();
 
     // Prefer discovered in-file methods first (including synthesized framework accessors).
     let method_prefix = context.prefix.rsplit("->").next().unwrap_or(&context.prefix);
@@ -157,7 +157,7 @@ pub fn add_method_completions(
             ("method".to_string(), doc)
         };
 
-        if seen.insert(name.clone()) {
+        if seen.insert(name.as_str()) {
             completions.push(CompletionItem {
                 label: name.clone(),
                 kind: crate::completion::items::CompletionItemKind::Function,
@@ -192,16 +192,15 @@ pub fn add_method_completions(
     };
 
     for (method, desc) in methods {
-        let method_name = method.to_string();
-        if seen.insert(method_name.clone()) {
+        if seen.insert(method) {
             completions.push(CompletionItem {
-                label: method_name.clone(),
+                label: method.to_string(),
                 kind: crate::completion::items::CompletionItemKind::Function,
                 detail: Some("method".to_string()),
                 documentation: Some(desc.to_string()),
                 insert_text: Some(format!("{}()", method)),
                 sort_text: Some(format!("2_{}", method)),
-                filter_text: Some(method_name),
+                filter_text: Some(method.to_string()),
                 additional_edits: vec![],
                 text_edit_range: Some((context.prefix_start, context.position)),
             });
@@ -214,16 +213,15 @@ pub fn add_method_completions(
             ("isa", "Check if object is of given class"),
             ("can", "Check if object can call method"),
         ] {
-            let method_name = method.to_string();
-            if seen.insert(method_name.clone()) {
+            if seen.insert(method) {
                 completions.push(CompletionItem {
-                    label: method_name.clone(),
+                    label: method.to_string(),
                     kind: crate::completion::items::CompletionItemKind::Function,
                     detail: Some("method".to_string()),
                     documentation: Some(desc.to_string()),
                     insert_text: Some(format!("{}()", method)),
                     sort_text: Some(format!("9_{}", method)), // Lower priority
-                    filter_text: Some(method_name),
+                    filter_text: Some(method.to_string()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });

--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -51,20 +51,16 @@ pub fn add_workspace_symbol_completions(
         match symbol.kind {
             WsSymbolKind::Subroutine | WsSymbolKind::Method => {
                 // Add function completion
-                let label = if let Some(ref qname) = symbol.qualified_name {
-                    qname.clone()
-                } else {
-                    symbol.name.clone()
-                };
+                let label = symbol.qualified_name.as_ref().unwrap_or(&symbol.name).clone();
 
                 completions.push(CompletionItem {
-                    label: label.clone(),
+                    insert_text: Some(symbol.name.clone()),
+                    sort_text: Some(format!("3_{}", label)), // Sort after local symbols
+                    filter_text: Some(label.clone()),
+                    label,
                     kind: CompletionItemKind::Function,
                     detail: symbol.container_name.clone().or_else(|| Some("workspace".to_string())),
                     documentation: symbol.documentation.clone(),
-                    insert_text: Some(symbol.name.clone()),
-                    sort_text: Some(format!("3_{}", label)), // Sort after local symbols
-                    filter_text: Some(label),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
@@ -89,55 +85,58 @@ pub fn add_workspace_symbol_completions(
                 }
 
                 completions.push(CompletionItem {
-                    label: label.clone(),
+                    insert_text: Some(label.clone()),
+                    sort_text: Some(format!("3_{}", label)), // Sort after local symbols
+                    filter_text: Some(label.clone()),
+                    label,
                     kind: CompletionItemKind::Variable,
                     detail: symbol.container_name.clone().or_else(|| Some("workspace".to_string())),
                     documentation: symbol.documentation.clone(),
-                    insert_text: Some(label.clone()),
-                    sort_text: Some(format!("3_{}", label)), // Sort after local symbols
-                    filter_text: Some(label),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
             }
             WsSymbolKind::Package => {
                 // Add package completion
+                let name = &symbol.name;
                 completions.push(CompletionItem {
-                    label: symbol.name.clone(),
+                    label: name.clone(),
                     kind: CompletionItemKind::Module,
                     detail: Some("package".to_string()),
                     documentation: symbol.documentation.clone(),
-                    insert_text: Some(symbol.name.clone()),
-                    sort_text: Some(format!("3_{}", symbol.name)),
-                    filter_text: Some(symbol.name.clone()),
+                    insert_text: Some(name.clone()),
+                    sort_text: Some(format!("3_{name}")),
+                    filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
             }
             WsSymbolKind::Constant => {
                 // Add constant completion
+                let name = &symbol.name;
                 completions.push(CompletionItem {
-                    label: symbol.name.clone(),
+                    label: name.clone(),
                     kind: CompletionItemKind::Constant,
                     detail: symbol.container_name.clone().or_else(|| Some("workspace".to_string())),
                     documentation: symbol.documentation.clone(),
-                    insert_text: Some(symbol.name.clone()),
-                    sort_text: Some(format!("3_{}", symbol.name)),
-                    filter_text: Some(symbol.name.clone()),
+                    insert_text: Some(name.clone()),
+                    sort_text: Some(format!("3_{name}")),
+                    filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
             }
             WsSymbolKind::Export => {
                 // Add exported symbol completion
+                let name = &symbol.name;
                 completions.push(CompletionItem {
-                    label: symbol.name.clone(),
+                    label: name.clone(),
                     kind: CompletionItemKind::Function,
                     detail: Some("exported".to_string()),
                     documentation: symbol.documentation.clone(),
-                    insert_text: Some(symbol.name.clone()),
-                    sort_text: Some(format!("2_{}", symbol.name)), // Prioritize exports
-                    filter_text: Some(symbol.name.clone()),
+                    insert_text: Some(name.clone()),
+                    sort_text: Some(format!("2_{name}")), // Prioritize exports
+                    filter_text: Some(name.clone()),
                     additional_edits: vec![],
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
@@ -168,7 +167,7 @@ pub fn add_use_module_completions(
         return;
     }
 
-    let mut seen = HashSet::new();
+    let mut seen: HashSet<String> = HashSet::new();
 
     // Search for package symbols matching the prefix
     let all_symbols = if context.prefix.is_empty() {
@@ -191,17 +190,18 @@ pub fn add_use_module_completions(
             continue;
         }
 
+        let name = &symbol.name;
         completions.push(CompletionItem {
-            label: symbol.name.clone(),
+            label: name.clone(),
             kind: CompletionItemKind::Module,
             detail: Some("module".to_string()),
             documentation: symbol
                 .documentation
                 .clone()
-                .or_else(|| Some(format!("Package `{}`", symbol.name))),
-            insert_text: Some(symbol.name.clone()),
-            sort_text: Some(format!("1_{}", symbol.name)), // High priority in use context
-            filter_text: Some(symbol.name.clone()),
+                .or_else(|| Some(format!("Package `{name}`"))),
+            insert_text: Some(name.clone()),
+            sort_text: Some(format!("1_{name}")), // High priority in use context
+            filter_text: Some(name.clone()),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
         });
@@ -231,7 +231,7 @@ pub fn add_use_qw_import_completions(
         return;
     }
 
-    let mut seen = HashSet::new();
+    let mut seen: HashSet<&str> = HashSet::new();
     let members = index.get_package_members(module_name);
 
     for symbol in &members {
@@ -249,7 +249,7 @@ pub fn add_use_qw_import_completions(
         }
 
         // Deduplicate
-        if !seen.insert(symbol.name.clone()) {
+        if !seen.insert(&symbol.name) {
             continue;
         }
 
@@ -259,8 +259,9 @@ pub fn add_use_qw_import_completions(
             _ => "function",
         };
 
+        let name = &symbol.name;
         completions.push(CompletionItem {
-            label: symbol.name.clone(),
+            label: name.clone(),
             kind: match symbol.kind {
                 WsSymbolKind::Constant => CompletionItemKind::Constant,
                 _ => CompletionItemKind::Function,
@@ -269,10 +270,10 @@ pub fn add_use_qw_import_completions(
             documentation: symbol
                 .documentation
                 .clone()
-                .or_else(|| Some(format!("`{module_name}::{}`", symbol.name))),
-            insert_text: Some(symbol.name.clone()),
-            sort_text: Some(format!("1_{}", symbol.name)),
-            filter_text: Some(symbol.name.clone()),
+                .or_else(|| Some(format!("`{module_name}::{name}`"))),
+            insert_text: Some(name.clone()),
+            sort_text: Some(format!("1_{name}")),
+            filter_text: Some(name.clone()),
             additional_edits: vec![],
             text_edit_range: Some((context.prefix_start, context.position)),
         });

--- a/crates/perl-lsp/src/runtime/language/completion.rs
+++ b/crates/perl-lsp/src/runtime/language/completion.rs
@@ -178,7 +178,7 @@ impl LspServer {
                     seen.insert(label.clone());
 
                     completions.push(crate::completion::CompletionItem {
-                        label: label.clone(),
+                        label,
                         kind: Self::workspace_symbol_kind(&symbol),
                         detail,
                         insert_text,


### PR DESCRIPTION
## Summary

- Eliminate `completions.clone()` in `deduplicate_and_sort` call — was cloning the entire completion Vec on every request for an unused `catch_unwind` fallback
- Remove `CompletionContext` clone for file path completions by constructing `FileCompletionContext` directly from source data
- Remove unused `_prefix` String allocation in `analyze_context`
- Replace O(n) `chars().nth()` trigger character detection with O(1) byte access for ASCII trigger characters
- Use `HashSet<&str>` instead of `HashSet<String>` for method/workspace dedup sets (borrows from symbol table keys instead of cloning)
- Reduce `method_name` clones in static method lists by inserting `&str` directly into seen set
- Move `label` into `CompletionItem` instead of cloning in runtime workspace completions

Closes #2073

## Test plan

- [x] All 116 `perl-lsp-completion` tests pass
- [x] clippy clean on `perl-lsp-completion`
- [ ] CI gate