### PR TITLE
fix(parser): accept complex expressions in use/no import lists

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -699,37 +699,31 @@ impl<'a> Parser<'a> {
         } else if self.peek_kind() == Some(TokenKind::LeftParen) {
             self.consume_token()?; // consume (
 
-            // Parse import list (with EOF guard to prevent infinite loop on truncated input).
-            // Accept strings, identifiers, and numbers as import items to support
-            // both simple import lists and key => value pairs.
-            while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                if matches!(
-                    self.peek_kind(),
-                    Some(TokenKind::String | TokenKind::Identifier | TokenKind::Number)
-                ) {
-                    args.push(self.consume_token()?.text.to_string());
-                } else {
-                    return Err(ParseError::syntax(
-                        "Expected string or identifier in import list",
-                        self.current_position(),
-                    ));
-                }
-
-                // Accept both comma and fat arrow as separators
-                if matches!(
-                    self.peek_kind(),
-                    Some(TokenKind::Comma | TokenKind::FatArrow)
-                ) {
-                    self.consume_token()?;
-                } else if self.peek_kind() != Some(TokenKind::RightParen) {
-                    return Err(ParseError::syntax(
-                        "Expected comma or closing parenthesis",
-                        self.current_position(),
-                    ));
+            // Perl import lists can contain arbitrary expressions: backslash refs,
+            // sub blocks, nested parens, fat-arrow pairs, etc.  Instead of
+            // enumerating every legal token we use a depth-tracking consumer that
+            // collects everything until the matching closing paren.
+            let mut depth: u32 = 1;
+            while depth > 0 && !self.tokens.is_eof() {
+                match self.peek_kind() {
+                    Some(TokenKind::LeftParen) => {
+                        depth = depth.saturating_add(1);
+                        args.push(self.consume_token()?.text.to_string());
+                    }
+                    Some(TokenKind::RightParen) => {
+                        depth = depth.saturating_sub(1);
+                        if depth > 0 {
+                            args.push(self.consume_token()?.text.to_string());
+                        } else {
+                            self.consume_token()?; // consume final )
+                        }
+                    }
+                    Some(_) => {
+                        args.push(self.consume_token()?.text.to_string());
+                    }
+                    None => break,
                 }
             }
-
-            self.expect_closing_delimiter(TokenKind::RightParen)?;
         } else if !Self::is_statement_terminator(self.peek_kind()) {
             // Complex `use` arguments can start with tokens outside the bare-arg
             // fast path, such as sigils in `use warnings $ENV{X} ? ...`.

--- a/crates/perl-parser-core/tests/use_import_pattern_tests.rs
+++ b/crates/perl-parser-core/tests/use_import_pattern_tests.rs
@@ -119,3 +119,37 @@ fn use_exporter_import() {
 fn use_constant_hash() {
     assert_clean_parse("use constant { FOO => 1, BAR => 2 };");
 }
+
+// ===========================================================================
+// Complex parenthesized import lists (#2184)
+// ===========================================================================
+
+#[test]
+fn use_backslash_ref_and_number_in_parens() {
+    assert_clean_parse(r#"use Pod::Simple::Debug (\$debuglevel, 0);"#);
+}
+
+#[test]
+fn use_overload_coderef_in_parens() {
+    assert_clean_parse(r#"use overload ('==' => \&equal, '!=' => \&not_equal);"#);
+}
+
+#[test]
+fn use_sub_block_in_import_parens() {
+    assert_clean_parse(r#"use overload ('""' => sub { $_[0]->{name} });"#);
+}
+
+#[test]
+fn use_mixed_strings_and_hashrefs_in_parens() {
+    assert_clean_parse(r#"use Module ('key' => { nested => 'value' });"#);
+}
+
+#[test]
+fn use_nested_parens_in_import_list() {
+    assert_clean_parse(r#"use Module (foo => (1, 2, 3));"#);
+}
+
+#[test]
+fn use_version_and_parens() {
+    assert_clean_parse(r#"use Module 1.23 ('foo', 'bar');"#);
+}


### PR DESCRIPTION
## Summary
- Replaces strict String/Identifier-only parsing in parenthesized `use` import lists with a balanced-paren depth-tracking consumer
- Fixes 12 CPAN corpus files that use backslash refs (`\$var`), coderefs (`\&func`), sub blocks, and nested parens in import lists
- Adds 6 new test cases covering these patterns

Closes #2184

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p perl-parser-core --lib` passes
- [x] All 24 `use_import_pattern_tests` pass (18 existing + 6 new)
- [x] No regressions in full `cargo test -p perl-parser-core` suite