### PR TITLE
fix(parser): add RightBrace to indirect call argument terminators

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -312,7 +312,13 @@ impl<'a> Parser<'a> {
             && !self.is_statement_modifier_keyword()
             && !matches!(
                 self.peek_kind(),
-                Some(TokenKind::WordOr | TokenKind::WordAnd | TokenKind::WordXor | TokenKind::WordNot)
+                Some(
+                    TokenKind::WordOr
+                        | TokenKind::WordAnd
+                        | TokenKind::WordXor
+                        | TokenKind::WordNot
+                        | TokenKind::RightBrace
+                )
             )
         {
             // Use parse_assignment instead of parse_expression to avoid grouping by comma operator

--- a/crates/perl-parser-core/tests/fix_rbrace_terminator_tests.rs
+++ b/crates/perl-parser-core/tests/fix_rbrace_terminator_tests.rs
@@ -1,0 +1,32 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_delete_last_expr_in_block() {
+    assert_clean_parse(r"sub close { delete $_[0]{cb} }");
+}
+
+#[test]
+fn test_exists_last_expr_in_block() {
+    assert_clean_parse(r"sub has_foo { exists $_[0]{foo} }");
+}
+
+#[test]
+fn test_delete_in_foreach_block() {
+    assert_clean_parse(r"foreach $sym (@names) { delete $imports{$sym} }");
+}
+
+#[test]
+fn test_exists_in_grep_block() {
+    assert_clean_parse(r"grep { exists $h{$_} } @list");
+}
+
+#[test]
+fn test_say_stderr_in_block() {
+    assert_clean_parse(r"sub debug { say STDERR 'debug' }");
+}
+
+#[test]
+fn test_print_stderr_in_block() {
+    assert_clean_parse(r"sub warn_user { print STDERR 'warning' }");
+}


### PR DESCRIPTION
## Summary

- Adds `TokenKind::RightBrace` to the while-loop terminator match in `parse_indirect_call` (calls.rs line 311)
- When builtins like `delete`, `exists`, `say`, `print`, `scalar` are the last expression in a block without trailing `;`, the parser was consuming the block's closing `}` as an argument, producing `unexpected_rbrace_expr` errors (~50 corpus files)
- Adds 6 regression tests covering `delete`/`exists`/`say`/`print` in sub blocks, foreach blocks, and grep blocks

Closes #2222

## Test plan

- [x] All 6 new tests pass (`cargo test -p perl-parser-core --test fix_rbrace_terminator_tests`)
- [x] All existing perl-parser-core tests pass (no regressions)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean