### PR TITLE
chore: bump workspace versions to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1518,14 +1518,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-builtins"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-builtins-phf",
  "perl-tdd-support",
@@ -1533,14 +1533,14 @@ dependencies = [
 
 [[package]]
 name = "perl-builtins-phf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "phf",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1553,11 +1553,11 @@ dependencies = [
 
 [[package]]
 name = "perl-content-length-framing"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-corpus"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-breakpoint"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser",
  "perl-tdd-support",
@@ -1620,11 +1620,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-command-args"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-dap-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-eval"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-platform"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "perl-dap-shell",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-security"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -1664,11 +1664,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-shell"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-dap-stack"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-value"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-variables"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "perl-dap-value",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-workspace-index",
  "serde",
@@ -1718,14 +1718,14 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics-codes"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perl-edit"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "perl-error"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "perl-feature-catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
  "serde",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "perl-heredoc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -1781,11 +1781,11 @@ dependencies = [
 
 [[package]]
 name = "perl-keywords"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lexer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "memchr",
@@ -1800,14 +1800,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1878,14 +1878,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ast-utils"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-cancellation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-capability-map"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-ids",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-actions"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-ast-utils",
  "perl-lsp-diagnostics",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-lens"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser",
  "perl-parser-core",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-color-provider"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "perl-position-tracking",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "perl-keywords",
@@ -1952,28 +1952,28 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion-item"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-critic-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp-diagnostic-catalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-diagnostics-codes",
  "serde_json",
@@ -1981,11 +1981,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-diagnostic-types"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lsp-diagnostics"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-diagnostic-types",
  "perl-parser",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-highlight"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast",
  "perl-parser",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-links"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-import",
  "perl-module-path",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-contracts"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-flags"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-ids",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-governance"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-grid",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-grid"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-policy",
@@ -2059,11 +2059,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-ids"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lsp-feature-policy"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
@@ -2072,14 +2072,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-profile"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-contracts",
 ]
 
 [[package]]
 name = "perl-lsp-feature-profile-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-feature-policy",
  "perl-lsp-feature-profile",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-file-completion"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-completion-item",
  "perl-path-security",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-folding"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-formatting-types",
  "perl-lsp-tooling",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2124,11 +2124,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-import-management"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lsp-inlay-hints"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-builtins",
  "perl-parser-core",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-input-validation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-launcher"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "perl-lsp-feature-governance",
@@ -2162,14 +2162,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-limits"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-navigation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2186,14 +2186,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-on-type-formatting"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-performance"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "moka",
  "perl-parser-core",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-protocol"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-contracts",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-providers"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
  "nix",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rename"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-keywords",
  "perl-parser-core",
@@ -2260,14 +2260,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-selection-range"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-semantic-tokens"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2277,15 +2277,15 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-symbol-query"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lsp-text-utils"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-lsp-tooling"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-content-length-framing",
  "perl-lsp-protocol",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-type-hierarchy"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-core",
  "perl-position-tracking",
@@ -2321,14 +2321,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-uri"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-workspace-symbols"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-lsp-symbol-query",
  "perl-module-path",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-boundary"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-path",
  "perl-module-token",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import-match"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-boundary",
  "perl-module-import",
@@ -2372,21 +2372,21 @@ dependencies = [
 
 [[package]]
 name = "perl-module-name"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-path"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-name",
 ]
 
 [[package]]
 name = "perl-module-reference"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-rename"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-import-match",
  "perl-module-path",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-resolution-path",
  "perl-module-resolution-uri",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-path"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-uri"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-boundary",
  "perl-module-name",
@@ -2452,14 +2452,14 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-token-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-reference",
  "perl-module-token-core",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-normalize"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-security"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-path-normalize",
  "tempfile",
@@ -2563,14 +2563,14 @@ dependencies = [
 
 [[package]]
 name = "perl-percentile"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast",
  "perl-tdd-support",
@@ -2589,14 +2589,14 @@ dependencies = [
 
 [[package]]
 name = "perl-qualified-name"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-quote"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
  "proptest",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-path",
  "perl-parser-core",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
  "thiserror",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-core",
  "perl-symbol-types",
@@ -2640,33 +2640,33 @@ dependencies = [
 
 [[package]]
 name = "perl-source-editing"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-source-file"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-cursor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-index"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-symbol-table"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-position-tracking",
  "perl-symbol-types",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "perl-symbol-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "perl-text-line"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-module-token-parser",
  "perl-tdd-support",
@@ -2704,11 +2704,11 @@ dependencies = [
 
 [[package]]
 name = "perl-token"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-tokenizer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-advanced-parsers"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-analysis"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "encoding_rs",
  "perl-tdd-support",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-logos-lexer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chumsky",
  "logos",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-partial-ast"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2778,11 +2778,11 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-statement-tracker"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-uri"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-tdd-support",
  "perl-uri-classify",
@@ -2792,14 +2792,14 @@ dependencies = [
 
 [[package]]
 name = "perl-uri-classify"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "url",
 ]
 
 [[package]]
 name = "perl-workspace-discovery"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-source-file",
  "perl-workspace-ignore",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-folder"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "perl-uri",
  "proptest",
@@ -2821,11 +2821,11 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-ignore"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "perl-workspace-index"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2846,14 +2846,14 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-monitoring"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "perl-workspace-index-slo"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "parking_lot",
  "perl-percentile",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-state-machine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "parking_lot",
 ]
@@ -4020,7 +4020,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4669,7 +4669,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtask"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,7 +290,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -300,139 +300,139 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.11.0" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.0" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.11.0" }
-perl-quote = { path = "crates/perl-quote", version = "0.11.0" }
-perl-edit = { path = "crates/perl-edit", version = "0.11.0" }
-perl-builtins = { path = "crates/perl-builtins", version = "0.11.0" }
-perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.11.0" }
-perl-regex = { path = "crates/perl-regex", version = "0.11.0" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.11.0" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.11.0" }
-perl-ast = { path = "crates/perl-ast", version = "0.11.0" }
-perl-heredoc = { path = "crates/perl-heredoc", version = "0.11.0" }
-perl-error = { path = "crates/perl-error", version = "0.11.0" }
-perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.11.0" }
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.11.0" }
-perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.11.0" }
-perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.11.0" }
-perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.11.0" }
-perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.11.0" }
-perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.11.0" }
-perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.11.0" }
-perl-module-token = { path = "crates/perl-module-token", version = "0.11.0" }
-perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.11.0" }
-perl-module-name = { path = "crates/perl-module-name", version = "0.11.0" }
-perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.11.0" }
-perl-module-reference = { path = "crates/perl-module-reference", version = "0.11.0" }
-perl-module-import = { path = "crates/perl-module-import", version = "0.11.0" }
-perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.11.0" }
-perl-module-path = { path = "crates/perl-module-path", version = "0.11.0" }
-perl-module-rename = { path = "crates/perl-module-rename", version = "0.11.0" }
-perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.11.0" }
-perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.11.0" }
-perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.11.0" }
-perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.11.0" }
-perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.11.0" }
-perl-keywords = { path = "crates/perl-keywords", version = "0.11.0" }
-perl-source-file = { path = "crates/perl-source-file", version = "0.11.0" }
-perl-text-line = { path = "crates/perl-text-line", version = "0.11.0" }
-perl-source-editing = { path = "crates/perl-source-editing", version = "0.11.0" }
-perl-line-index = { path = "crates/perl-line-index", version = "0.11.0" }
-perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.11.0" }
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.11.0" }
-perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.11.0" }
-perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.11.0" }
-perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.11.0" }
-perl-lsp-ast-utils = { path = "crates/perl-lsp-ast-utils", version = "0.11.0" }
-perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.11.0" }
-perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.11.0" }
-perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.11.0" }
-perl-uri = { path = "crates/perl-uri", version = "0.11.0" }
-perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.11.0" }
-perl-percentile = { path = "crates/perl-percentile", version = "0.11.0" }
-perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.11.0" }
-perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.11.0" }
-perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.11.0" }
-perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.11.0" }
-perl-path-security = { path = "crates/perl-path-security", version = "0.11.0" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.11.0" }
-perl-dap = { path = "crates/perl-dap", version = "0.11.0" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.11.0" }
-perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.11.0" }
-perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.11.0" }
-perl-dap-config = { path = "crates/perl-dap-config", version = "0.11.0" }
-perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.11.0" }
-perl-dap-value = { path = "crates/perl-dap-value", version = "0.11.0" }
-perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.11.0" }
-perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.11.0" }
-perl-dap-types = { path = "crates/perl-dap-types", version = "0.11.0" }
-perl-dap-security = { path = "crates/perl-dap-security", version = "0.11.0" }
-perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.11.0" }
-perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.11.0" }
-perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.11.0" }
-perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.11.0" }
-perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.11.0" }
-perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.11.0" }
+perl-token = { path = "crates/perl-token", version = "0.12.0" }
+perl-quote = { path = "crates/perl-quote", version = "0.12.0" }
+perl-edit = { path = "crates/perl-edit", version = "0.12.0" }
+perl-builtins = { path = "crates/perl-builtins", version = "0.12.0" }
+perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.12.0" }
+perl-regex = { path = "crates/perl-regex", version = "0.12.0" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.12.0" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.12.0" }
+perl-ast = { path = "crates/perl-ast", version = "0.12.0" }
+perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.0" }
+perl-error = { path = "crates/perl-error", version = "0.12.0" }
+perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.0" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.0" }
+perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.12.0" }
+perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.12.0" }
+perl-symbol-table = { path = "crates/perl-symbol-table", version = "0.12.0" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.12.0" }
+perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.12.0" }
+perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.12.0" }
+perl-module-token = { path = "crates/perl-module-token", version = "0.12.0" }
+perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.12.0" }
+perl-module-name = { path = "crates/perl-module-name", version = "0.12.0" }
+perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.12.0" }
+perl-module-reference = { path = "crates/perl-module-reference", version = "0.12.0" }
+perl-module-import = { path = "crates/perl-module-import", version = "0.12.0" }
+perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.12.0" }
+perl-module-path = { path = "crates/perl-module-path", version = "0.12.0" }
+perl-module-rename = { path = "crates/perl-module-rename", version = "0.12.0" }
+perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.12.0" }
+perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.12.0" }
+perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.12.0" }
+perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.12.0" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.12.0" }
+perl-keywords = { path = "crates/perl-keywords", version = "0.12.0" }
+perl-source-file = { path = "crates/perl-source-file", version = "0.12.0" }
+perl-text-line = { path = "crates/perl-text-line", version = "0.12.0" }
+perl-source-editing = { path = "crates/perl-source-editing", version = "0.12.0" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.12.0" }
+perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.12.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.0" }
+perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.12.0" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.12.0" }
+perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.12.0" }
+perl-lsp-ast-utils = { path = "crates/perl-lsp-ast-utils", version = "0.12.0" }
+perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.12.0" }
+perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.12.0" }
+perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.12.0" }
+perl-uri = { path = "crates/perl-uri", version = "0.12.0" }
+perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.12.0" }
+perl-percentile = { path = "crates/perl-percentile", version = "0.12.0" }
+perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.12.0" }
+perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.12.0" }
+perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.12.0" }
+perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.12.0" }
+perl-path-security = { path = "crates/perl-path-security", version = "0.12.0" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.12.0" }
+perl-dap = { path = "crates/perl-dap", version = "0.12.0" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.0" }
+perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.12.0" }
+perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.12.0" }
+perl-dap-config = { path = "crates/perl-dap-config", version = "0.12.0" }
+perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.12.0" }
+perl-dap-value = { path = "crates/perl-dap-value", version = "0.12.0" }
+perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.12.0" }
+perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.12.0" }
+perl-dap-types = { path = "crates/perl-dap-types", version = "0.12.0" }
+perl-dap-security = { path = "crates/perl-dap-security", version = "0.12.0" }
+perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.12.0" }
+perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.12.0" }
+perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.12.0" }
+perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.12.0" }
+perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.12.0" }
+perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.12.0" }
 
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.11.0" }
-perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.11.0" }
-perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.11.0" }
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.11.0" }
-perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.11.0" }
-perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.11.0" }
-perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.11.0" }
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.11.0" }
-perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.11.0" }
-perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.11.0" }
-perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.11.0" }
-perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.11.0" }
-perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.11.0" }
-perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.11.0" }
-perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.11.0" }
-perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.11.0" }
-perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.11.0" }
-perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.11.0" }
-perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.11.0" }
-perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.11.0" }
-perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.11.0" }
-perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.11.0" }
-perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.11.0" }
-perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.11.0" }
-perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.11.0" }
-perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.11.0" }
-perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.11.0" }
-perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.11.0" }
-perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.11.0" }
-perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.11.0" }
-perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.11.0" }
-perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.11.0" }
-perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.11.0" }
-perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.11.0" }
-perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.11.0" }
-perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.11.0" }
-perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.11.0" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.0" }
+perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.12.0" }
+perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.12.0" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.0" }
+perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.12.0" }
+perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.12.0" }
+perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.12.0" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.0" }
+perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.12.0" }
+perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.12.0" }
+perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.12.0" }
+perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.12.0" }
+perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.12.0" }
+perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.12.0" }
+perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.12.0" }
+perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.12.0" }
+perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.12.0" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.12.0" }
+perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.12.0" }
+perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.12.0" }
+perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.12.0" }
+perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.12.0" }
+perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.12.0" }
+perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.12.0" }
+perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.12.0" }
+perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.12.0" }
+perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.12.0" }
+perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.12.0" }
+perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.12.0" }
+perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.12.0" }
+perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.12.0" }
+perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.12.0" }
+perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.0" }
+perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.0" }
+perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.0" }
+perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.0" }
+perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.0" }
 
 # Tier 3: Two-level dependencies
-perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.11.0" }
-perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.11.0" }
-perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.11.0" }
-perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.11.0" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.11.0" }
-perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.11.0" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.11.0" }
+perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.12.0" }
+perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.12.0" }
+perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.12.0" }
+perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.12.0" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.0" }
+perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.12.0" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.0" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.11.0" }
-perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.11.0", default-features = false }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.0" }
+perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.12.0", default-features = false }
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.11.0" }
+perl-parser = { path = "crates/perl-parser", version = "0.12.0" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.11.0" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.0" }
 
 # External dependencies
 tree-sitter-perl = { path = "crates/tree-sitter-perl-rs", features = ["pure-rust"] }

--- a/crates/perl-ast-v2/Cargo.toml
+++ b/crates/perl-ast-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ast-v2"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-ast/Cargo.toml
+++ b/crates/perl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ast"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins-phf/Cargo.toml
+++ b/crates/perl-builtins-phf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins-phf"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins/Cargo.toml
+++ b/crates/perl-builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ keywords = ["perl", "builtins", "parser", "lsp", "signatures"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.11.0" }
+perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.12.0" }
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-corpus"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-breakpoint/Cargo.toml
+++ b/crates/perl-dap-breakpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-breakpoint"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ categories = ["development-tools::debugging", "development-tools"]
 
 [dependencies]
 # Perl parser for AST-based validation
-perl-parser = { path = "../perl-parser", version = "0.11.0" }
+perl-parser = { path = "../perl-parser", version = "0.12.0" }
 
 # Rope for position mapping
 ropey = "1.6.1"

--- a/crates/perl-dap-eval/Cargo.toml
+++ b/crates/perl-dap-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-eval"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-platform/Cargo.toml
+++ b/crates/perl-dap-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-platform"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-security/Cargo.toml
+++ b/crates/perl-dap-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-security"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-shell/Cargo.toml
+++ b/crates/perl-dap-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-shell"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-stack"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-variables/Cargo.toml
+++ b/crates/perl-dap-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-variables"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dead-code"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-diagnostics-codes/Cargo.toml
+++ b/crates/perl-diagnostics-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-diagnostics-codes"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-edit/Cargo.toml
+++ b/crates/perl-edit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-edit"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-error/Cargo.toml
+++ b/crates/perl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-error"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-feature-catalog/Cargo.toml
+++ b/crates/perl-feature-catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-feature-catalog"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-heredoc/Cargo.toml
+++ b/crates/perl-heredoc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-heredoc"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-incremental-parsing"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lexer"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-capability-map"
-version = "0.11.0"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-document-highlight/Cargo.toml
+++ b/crates/perl-lsp-document-highlight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-document-highlight"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-contracts"
-version = "0.11.0"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-grid/Cargo.toml
+++ b/crates/perl-lsp-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-grid"
-version = "0.11.0"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-policy"
-version = "0.11.0"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-profile/Cargo.toml
+++ b/crates/perl-lsp-feature-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-profile"
-version = "0.11.0"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-folding/Cargo.toml
+++ b/crates/perl-lsp-folding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-folding"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-protocol/Cargo.toml
+++ b/crates/perl-lsp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-protocol"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-providers"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-selection-range/Cargo.toml
+++ b/crates/perl-lsp-selection-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-selection-range"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-core"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-pest"
-version = "0.11.0"
+version = "0.12.0"
 publish = false
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-pragma"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-quote/Cargo.toml
+++ b/crates/perl-quote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-quote"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-refactoring/Cargo.toml
+++ b/crates/perl-refactoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-refactoring"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-regex/Cargo.toml
+++ b/crates/perl-regex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-regex"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-semantic-analyzer"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-symbol-table/Cargo.toml
+++ b/crates/perl-symbol-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-symbol-table"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-symbol-types/Cargo.toml
+++ b/crates/perl-symbol-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-symbol-types"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tdd-support"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-token"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tokenizer/Cargo.toml
+++ b/crates/perl-tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tokenizer"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-ts-advanced-parsers/Cargo.toml
+++ b/crates/perl-ts-advanced-parsers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-advanced-parsers"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Composed parser experiments for Perl"

--- a/crates/perl-ts-heredoc-analysis/Cargo.toml
+++ b/crates/perl-ts-heredoc-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-analysis"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Standalone heredoc analysis tools for Perl parsing"

--- a/crates/perl-ts-heredoc-parser/Cargo.toml
+++ b/crates/perl-ts-heredoc-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-parser"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Heredoc parsing pipeline for Perl"

--- a/crates/perl-ts-logos-lexer/Cargo.toml
+++ b/crates/perl-ts-logos-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-logos-lexer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Logos-based token parser for Perl"

--- a/crates/perl-ts-partial-ast/Cargo.toml
+++ b/crates/perl-ts-partial-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-partial-ast"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Partial parse and anti-pattern AST for Perl"

--- a/crates/perl-ts-statement-tracker/Cargo.toml
+++ b/crates/perl-ts-statement-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-statement-tracker"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Statement boundary and heredoc context tracking for Perl tree-sitter tooling"

--- a/crates/perl-uri/Cargo.toml
+++ b/crates/perl-uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-uri"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-workspace-index"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-perl-c"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Tree-sitter Perl grammar with C scanner (legacy implementation)"

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -57,8 +57,7 @@ Key terms:
 
 | Metric | Value | Target | Status |
 | --- | --- | --- | --- |
-| **Current release line** | `v0.11.0` public alpha | Truthful docs and receipts | Active |
-| **Active milestone** | `v0.12.0` public-alpha hardening sprint | Exit hardening sprint cleanly | In progress |
+| **Current release line** | `v0.12.0` public alpha | Truthful docs and receipts | Active |
 | **Merge gate** | `nix develop -c just ci-gate` | Green before merge | Required |
 | **Tier A Tests** | 2559 lib tests (discovered), 0 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
@@ -73,7 +72,7 @@ Key terms:
 
 ## What's True Right Now
 
-- **Release posture**: the current release line is `v0.11.0` public alpha; the active milestone is `v0.12.0` hardening, not a shipped release
+- **Release posture**: the current release line is `v0.12.0` public alpha
 - **Status discipline**: this file is for evidence, [ROADMAP.md](ROADMAP.md) is for planning, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `bash scripts/ignored-test-count.sh` is the tracked-test-debt source
@@ -105,7 +104,7 @@ Key terms:
 
 ## What's Next
 
-**Now (active milestone: v0.12.0 hardening sprint on top of the v0.11.0 release line)**
+**Now (v0.12.0 public alpha)**
 - Raise the CPAN top-1000 full-corpus baseline from `72.1%` (`3139/4355`) to `90%+` clean parses while keeping the strict known-clean manifest at `100%`
 - Close repo-corpus coverage gaps (`63/68` NodeKinds currently covered) and retire the remaining parser audit `P2` hang-risk candidate
 - Land Moo/Moose/Class::Accessor, `use parent`/`use base`, and export-list disambiguation work needed for public-alpha expectations

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -6,8 +6,7 @@
 
 ## Current Framing
 
-- Current release line: `v0.11.0` public alpha
-- Active milestone: `v0.12.0` public-alpha hardening sprint
+- Current release line: `v0.12.0` public alpha
 - Canonical local receipt: `nix develop -c just ci-gate`
 
 ## How To Read This File
@@ -16,7 +15,7 @@
 - This roadmap tells you what we are trying to land next.
 - [../../ROADMAP.md](../../ROADMAP.md) and [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) are summaries, not the canonical plan.
 
-## Current Release Line: v0.11.0 Public Alpha
+## Current Release Line: v0.12.0 Public Alpha
 
 The current shipped line is still public alpha. The repo is usable today, but APIs, protocol details, and packaging can still change between minor releases.
 

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.11.0"
+version = "0.12.0"
 lsp_version = "3.18"
 compliance_percent = 99  # 96/97 features advertised, all GA
 


### PR DESCRIPTION
## Summary

- Bumps all 52 crate Cargo.toml versions from 0.11.0 to 0.12.0
- Updates root workspace version and all 119 workspace dependency version refs
- Updates features.toml version to 0.12.0
- Updates ROADMAP.md and CURRENT_STATUS.md to reflect v0.12.0 as the current release line
- Removes stale "active milestone: v0.12.0 hardening" references (0.12.0 IS the release now)

Supersedes #2035 which has merge conflicts.

**Release blocker**: `perl-lsp --version` was reporting 0.11.0

## Test plan

- [x] `cargo check --workspace` passes
- [ ] `cargo build -p perl-lsp --release` and verify `--version` outputs 0.12.0
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --lib` passes