### PR TITLE
docs: add getting-started guide for new users

### DIFF
--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -1,30 +1,35 @@
 # Getting Started with perl-lsp
 
-Get from zero to a working Perl language server in under 2 minutes.
+This guide gets you from zero to a working Perl language server in your editor.
+
+## What is a Language Server?
+
+A **language server** is a program that runs alongside your editor and gives it deep understanding of your code. Instead of each editor re-implementing features like "go to definition" or "show all references," the [Language Server Protocol (LSP)](https://microsoft.github.io/language-server-protocol/) defines a standard way for any editor to talk to a language-specific backend. perl-lsp is that backend for Perl 5: it parses your code, builds an index of symbols, and responds to editor requests over JSON-RPC -- so you get IDE-grade navigation, completion, diagnostics, and refactoring in VS Code, Neovim, Emacs, Helix, or any other LSP-capable editor. No Perl runtime is required; the server is a single native binary.
+
+## Prerequisites
+
+- **Rust 1.92+** (for building from source)
+- **A supported editor**: VS Code, Neovim, Emacs, Helix, or Sublime Text
 
 ## Installation
 
 Choose one method:
 
-### Option 1: VS Code Extension (Easiest)
-
-```bash
-code --install-extension effortlessmetrics.perl-lsp-rs
-```
-
-The extension auto-downloads the server binary. Open a `.pl` file and you are done.
-
-### Option 2: Pre-built Binary
-
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and place the binary on your `PATH`.
-
-### Option 3: From crates.io
+### Option 1: Install from crates.io (Recommended)
 
 ```bash
 cargo install perl-lsp
 ```
 
-### Option 4: Build from Source
+### Option 2: Install Script (Linux/macOS)
+
+Use the installer script (best-effort / non-canonical):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
+```
+
+### Option 3: Build from Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
@@ -35,19 +40,32 @@ cargo install --path crates/perl-lsp
 ## Verify Installation
 
 ```bash
+# Check binary is available
+perl-lsp --version
+
+# Quick health check
 perl-lsp --health
-# Output: ok 0.12.0
+# Should output: ok <installed-version>
+
+# Optional: show feature/profile information
+perl-lsp --info
+
+# Optional: validate a Perl file from the CLI
+perl-lsp --check script.pl
 ```
+
+If `--version` and `--health` work but your editor still cannot connect, jump to [Troubleshooting](../how-to/TROUBLESHOOTING.md).
 
 ## Quick Editor Setup
 
 ### VS Code
 
-Install the extension and open a Perl file -- everything works automatically:
+1. Install the extension:
+   ```bash
+   code --install-extension EffortlessMetrics.perl-lsp-rs
+   ```
 
-```bash
-code --install-extension effortlessmetrics.perl-lsp-rs
-```
+2. Open a `.pl` or `.pm` file - the server starts automatically.
 
 ### Neovim
 
@@ -57,6 +75,7 @@ Add to your `init.lua`:
 local lspconfig = require('lspconfig')
 local configs = require('lspconfig.configs')
 
+-- Register perl-lsp with nvim-lspconfig
 if not configs.perl_lsp then
   configs.perl_lsp = {
     default_config = {
@@ -64,12 +83,20 @@ if not configs.perl_lsp then
       filetypes = { 'perl' },
       root_dir = lspconfig.util.root_pattern('.git', 'Makefile.PL', 'cpanfile', 'dist.ini'),
       single_file_support = true,
+      settings = {
+        perl = {
+          workspace = {
+            includePaths = { 'lib', '.', 'local/lib/perl5' },
+          },
+        },
+      },
     },
   }
 end
 
 lspconfig.perl_lsp.setup({
   on_attach = function(client, bufnr)
+    -- Suggested keybindings (customize to taste)
     local opts = { buffer = bufnr, noremap = true, silent = true }
     vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
     vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
@@ -82,16 +109,16 @@ lspconfig.perl_lsp.setup({
 })
 ```
 
-Verify: open a `.pl` file and run `:LspInfo`.
+**Verify it works**: open a `.pl` file and run `:LspInfo` -- you should see `perl_lsp` attached.
 
-### Emacs (eglot, Emacs 29+)
+### Emacs (with eglot, Emacs 29+)
 
 ```elisp
 (add-to-list 'eglot-server-programs
              '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
 ```
 
-Run `M-x eglot` in a Perl buffer.
+Then run `M-x eglot` in a Perl buffer.
 
 ### Helix
 
@@ -107,34 +134,32 @@ command = "perl-lsp"
 args = ["--stdio"]
 ```
 
-### Other Editors
+## Your First 5 Minutes
 
-Any editor with LSP support works. Point it at `perl-lsp --stdio` as the language server command.
+Once installed, open any Perl file and try these features. Each heading describes what you will see in your editor.
 
-## What You Get
+### 1. Real-Time Diagnostics
 
-### Diagnostics
+As soon as you open a Perl file, the server parses it and reports errors. You will see **red or yellow squiggly underlines** directly on lines with problems, just like a spell-checker. A count badge appears in your editor's status bar or problems panel. Hover over a squiggle to read the error message inline.
 
-Parse errors appear as inline squiggly underlines the instant you open or edit a file. Hover over them for details.
+### 2. Hover for Documentation
 
-### Code Completion
+Move your cursor over a built-in function like `print`, `substr`, or `chomp`. After a brief pause, a **floating tooltip** appears with the function signature, a short description, and a usage example. This works for over 150 Perl built-ins, keywords, and special variables like `$_` and `@ARGV`.
 
-Start typing to see suggestions: variables in scope, 150+ built-in functions, module names, and your own subroutines.
+### 3. Code Completion
+
+Start typing and the server offers completions in a **dropdown list** that appears automatically. Type `$` to see variable names in scope, `use ` to see module names, or the first few letters of a function to see matching built-ins and your own subroutines. The list filters as you type.
 
 ```perl
 my $name = "Alice";
-print $na  # offers $name
-prin       # offers print, printf, ...
-use Fi     # offers File::Spec, File::Find, ...
+print $na  # Dropdown offers $name
+prin       # Dropdown offers print, printf, ...
+use Fi     # Dropdown offers File::Spec, File::Find, ...
 ```
 
-### Hover Documentation
+### 4. Go to Definition
 
-Hover over any built-in function (`print`, `substr`, `chomp`) or special variable (`$_`, `@ARGV`) for documentation, signatures, and examples.
-
-### Go to Definition
-
-Jump to where any symbol is defined -- variables go to `my`/`our`/`local`, subs go to `sub`, modules open the `.pm` file.
+Place your cursor on a variable, function call, or module name and jump to where it is defined.
 
 | Editor | Command |
 |--------|---------|
@@ -142,9 +167,11 @@ Jump to where any symbol is defined -- variables go to `my`/`our`/`local`, subs 
 | Neovim | `gd` |
 | Emacs | `M-.` |
 
-### Find All References
+The editor opens the target file and scrolls to the exact line. For variables, it jumps to the `my`, `our`, or `local` declaration. For subroutines, it jumps to the `sub` definition. For modules, it opens the `.pm` file.
 
-Find every use of a symbol across your project.
+### 5. Find All References
+
+Find every place a symbol is used across your project. Results appear in a **references panel** (VS Code) or a quickfix list (Neovim).
 
 | Editor | Command |
 |--------|---------|
@@ -152,9 +179,9 @@ Find every use of a symbol across your project.
 | Neovim | `gr` |
 | Emacs | `M-?` |
 
-### Rename Symbol
+### 6. Rename Symbol
 
-Rename a variable or subroutine across all files in one operation.
+Rename a variable or subroutine and the server updates **every reference** across files in a single operation. Your editor shows a preview of all changes before applying them.
 
 | Editor | Command |
 |--------|---------|
@@ -162,217 +189,174 @@ Rename a variable or subroutine across all files in one operation.
 | Neovim | `<leader>rn` |
 | Emacs | `M-x eglot-rename` |
 
-### Code Formatting
+### 7. Document Outline and Symbols
 
-Format code with [Perl::Tidy](https://metacpan.org/pod/Perl::Tidy). Requires `perltidy` to be installed on your system:
+Open your editor's symbol outline to see a **tree of subroutines, packages, and variables** in the current file. Use workspace symbol search (`Ctrl+T` in VS Code, `<leader>ws` in Neovim) to jump to any symbol across your project.
 
-```bash
-cpanm Perl::Tidy
-```
+### 8. Code Actions and Quick Fixes
 
-To configure, point to your `.perltidyrc` in VS Code settings:
+When the server detects a fixable issue, a **lightbulb icon** appears in the gutter (VS Code) or a hint appears in the diagnostic. Trigger the action to apply the fix automatically.
 
-```json
-{ "perl-lsp.perltidyConfig": "/path/to/.perltidyrc" }
-```
+| Editor | Command |
+|--------|---------|
+| VS Code | `Ctrl+.` |
+| Neovim | `<leader>ca` |
+| Emacs | `C-c l a` |
 
-### Signature Help
+## What You Get
 
-When calling a function, parameter hints appear as you type.
+perl-lsp provides:
 
-### Code Actions
+| Feature | What It Does |
+|---------|--------------|
+| **Diagnostics** | Real-time syntax error detection |
+| **Completion** | Variables, functions, keywords, file paths |
+| **Hover** | Documentation for 150+ Perl built-ins |
+| **Definition** | Jump to where symbols are defined |
+| **References** | Find all uses of a symbol |
+| **Rename** | Safely rename variables across files |
+| **Formatting** | Format code with Perl::Tidy |
+| **Folding** | Collapse functions, blocks, POD |
+| **Symbols** | Document outline and workspace search |
 
-Lightbulb icon appears when fixable issues are detected. Trigger with `Ctrl+.` (VS Code), `<leader>ca` (Neovim), or `C-c l a` (Emacs).
+## Project Configuration
 
-### Semantic Highlighting
+For project-specific settings, the server reads configuration from your editor's LSP settings.
 
-Enhanced syntax highlighting that understands context -- distinguishing variables, functions, packages, and special variables beyond what regex-based highlighting can do.
-
-### Code Lens
-
-Reference counts appear above subroutine definitions, showing how many places call each function.
-
-### Additional Features
-
-| Feature | Description |
-|---------|-------------|
-| Document symbols | Outline of subs, packages, and variables |
-| Workspace symbols | Search any symbol across your project (`Ctrl+T`) |
-| Inlay hints | Parameter names and type hints inline |
-| Call hierarchy | Navigate caller/callee chains |
-| Type hierarchy | Navigate class/role inheritance |
-| Folding | Collapse functions, blocks, POD sections |
-| Selection range | Smart expand/shrink selection |
-| Linked editing | Edit matching tokens simultaneously |
-| Document links | Clickable links to modules and documentation |
-| Color decorators | Color preview for color literals |
-
-## Configuration
-
-### VS Code Settings
-
-The extension exposes these settings (search "perl-lsp" in VS Code settings):
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `perl-lsp.serverPath` | _(auto)_ | Absolute path to `perl-lsp` binary |
-| `perl-lsp.autoDownload` | `true` | Auto-download binary if not found |
-| `perl-lsp.enableDiagnostics` | `true` | Real-time syntax diagnostics |
-| `perl-lsp.enableSemanticTokens` | `true` | Semantic syntax highlighting |
-| `perl-lsp.enableFormatting` | `true` | Document formatting (needs `perltidy`) |
-| `perl-lsp.formatOnSave` | `false` | Format on save |
-| `perl-lsp.enableRefactoring` | `true` | Refactoring code actions |
-| `perl-lsp.perltidyConfig` | _(auto)_ | Path to `.perltidyrc` |
-| `perl-lsp.includePaths` | `["lib", "local/lib/perl5"]` | Module search paths |
-| `perl-lsp.featureProfile` | `auto` | Feature profile (see below) |
-| `perl-lsp.trace.server` | `off` | LSP trace level (`off`, `messages`, `verbose`) |
-
-### Feature Profiles
-
-Feature profiles control which LSP capabilities are advertised:
-
-| Profile | Description |
-|---------|-------------|
-| `auto` | Follow binary build mode (default) |
-| `ga-lock` | Only GA-locked stable features |
-| `ga` | All GA features |
-| `prod` / `production` | Production-ready feature set |
-| `all` | Every implemented feature |
-
-Set via CLI (`--feature-profile prod`) or VS Code setting (`perl-lsp.featureProfile`).
-
-### Module Search Paths
-
-Configure where perl-lsp looks for modules:
+### Example: Configure Module Search Paths
 
 ```json
 {
-  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
+  "perl": {
+    "workspace": {
+      "includePaths": ["lib", ".", "local/lib/perl5"]
+    }
+  }
 }
 ```
 
-### Large Projects
-
-Tune resource limits for large codebases:
+### Example: Tune for Large Projects
 
 ```json
 {
   "perl": {
     "limits": {
       "maxIndexedFiles": 50000,
-      "referencesCap": 1000,
+      "referencesCap": 1000
+    }
+  }
+}
+```
+
+See [CONFIG.md](../reference/CONFIG.md) for all configuration options, including workspace paths, inlay hints, test-runner settings, and resource limits.
+
+## Troubleshooting
+
+Quick fixes for the most common first-run problems. For the full guide, see [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
+
+### "Binary not found" after install
+
+`cargo install` places the binary in `~/.cargo/bin/`. If your shell cannot find `perl-lsp`, that directory is not on your `PATH`.
+
+```bash
+# Check whether the binary exists
+ls ~/.cargo/bin/perl-lsp
+
+# Add Cargo's bin directory to your PATH (add to ~/.bashrc, ~/.zshrc, or equivalent)
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Reload your shell
+source ~/.bashrc   # or: source ~/.zshrc
+```
+
+After reloading, `perl-lsp --version` should print the version number.
+
+### Extension / editor not connecting to the server
+
+The editor must be able to find and launch the `perl-lsp` binary. Symptoms include "server failed to start" messages or LSP features simply not appearing.
+
+1. **Verify the binary path** -- run `which perl-lsp` in the same shell your editor uses. Some editors (VS Code, for instance) may not inherit your shell's `PATH` when launched from a desktop shortcut. Try launching the editor from the terminal (`code .`) so it inherits your environment.
+
+2. **Check editor logs** -- every LSP client has a log output:
+   - VS Code: View > Output > select "Perl Language Server"
+   - Neovim: `:LspLog`
+   - Emacs: `*eglot stderr*` buffer
+
+3. **Test JSON-RPC communication** manually:
+   ```bash
+   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
+   ```
+   You should see a JSON response. If you see an error, the binary itself has a problem -- try reinstalling.
+
+4. **VS Code specific**: ensure the extension is installed and enabled:
+   ```bash
+   code --list-extensions | grep perl
+   ```
+
+### Completion not working
+
+1. **Check file type registration** -- your editor must recognize the file as Perl. In VS Code, look at the language indicator in the bottom-right of the status bar (it should say "Perl"). In Neovim, run `:set filetype?` and confirm it says `filetype=perl`. Files without a `.pl`, `.pm`, or `.t` extension may not be detected automatically.
+
+2. **Trigger completion manually** to rule out trigger-character issues:
+   - VS Code: `Ctrl+Space`
+   - Neovim: `<C-x><C-o>` (omni-completion) or use a completion plugin like nvim-cmp
+   - Emacs: `M-TAB` or `C-M-i`
+
+3. **Ensure the server is actually running** -- check `:LspInfo` (Neovim) or the Output panel (VS Code). If no server is attached, see the "Extension not connecting" section above.
+
+### Tests are flaky when developing perl-lsp
+
+If you are building perl-lsp from source and encounter intermittent test failures (particularly in LSP integration tests), constrain the thread count:
+
+```bash
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
+```
+
+The LSP integration tests start real server instances that compete for ports and file handles. Limiting parallelism eliminates the race conditions. See [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md) for more details on test threading.
+
+### Server Not Starting
+
+```bash
+# Quick health check
+perl-lsp --health
+
+# Run with debug logging to see what's happening
+RUST_LOG=perl_lsp=debug perl-lsp --stdio 2>debug.log
+```
+
+### No Diagnostics Appearing
+
+1. Ensure your file has a Perl extension (`.pl`, `.pm`, `.t`)
+2. Check your editor's language mode is set to Perl
+3. Look at the LSP output log in your editor
+
+### Slow on Large Projects
+
+Reduce indexed files and result caps in your settings:
+
+```json
+{
+  "perl": {
+    "limits": {
+      "maxIndexedFiles": 5000,
       "workspaceSymbolCap": 100
     }
   }
 }
 ```
 
-## CLI Reference
-
-```
-perl-lsp [options]
-perl-lsp --check <file.pl> [file2.pm ...]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--stdio` | Use stdio for communication (default) |
-| `--socket` | Use TCP socket for communication |
-| `--port <N>` | Port for socket mode (default: 9257) |
-| `--log` | Enable logging to stderr |
-| `--health` | Quick health check: prints `ok <version>` |
-| `--info` | Show version, feature profile, LSP coverage |
-| `--check <files>` | Validate Perl files and report parse errors |
-| `--version` | Print version and git tag |
-| `--features-json` | Output feature catalog as JSON |
-| `--feature-profile <name>` | Set feature profile (`auto`, `ga-lock`, `ga`, `prod`, `all`) |
-| `--completion <shell>` | Generate shell completions (`bash`, `zsh`, `fish`, `powershell`) |
-| `--help` | Show help |
-
-### Examples
-
-```bash
-# Run as LSP server (default, what editors use)
-perl-lsp --stdio
-
-# Quick validation of Perl files
-perl-lsp --check lib/MyModule.pm script.pl
-
-# Show server capabilities
-perl-lsp --info
-
-# Run with logging for debugging
-perl-lsp --stdio --log
-
-# Run in socket mode
-perl-lsp --socket --port 9257
-
-# Install shell completions
-perl-lsp --completion bash >> ~/.bashrc
-perl-lsp --completion zsh >> ~/.zshrc
-perl-lsp --completion fish > ~/.config/fish/completions/perl-lsp.fish
-```
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `PERL_LSP_LOG` | Set log filter (e.g., `perl_lsp=debug`) |
-| `RUST_LOG` | Alternative log filter |
-| `NO_COLOR` | Disable colored output |
-
-## Troubleshooting
-
-### "Binary not found" after install
-
-`cargo install` places the binary in `~/.cargo/bin/`. If your shell cannot find `perl-lsp`:
-
-```bash
-# Add to ~/.bashrc or ~/.zshrc
-export PATH="$HOME/.cargo/bin:$PATH"
-source ~/.bashrc
-```
-
-### Editor not connecting
-
-1. Verify the binary: `which perl-lsp && perl-lsp --health`
-2. Launch your editor from the terminal so it inherits your `PATH`
-3. Check editor logs:
-   - VS Code: View > Output > "Perl Language Server"
-   - Neovim: `:LspLog`
-   - Emacs: `*eglot stderr*` buffer
-
-### Formatting not working
-
-Install perltidy: `cpanm Perl::Tidy`
-
-### No diagnostics
-
-1. Check file extension is `.pl`, `.pm`, or `.t`
-2. Verify editor language mode is set to Perl
-3. Check `perl-lsp.enableDiagnostics` is `true`
-
-### Debugging server issues
-
-```bash
-# Test JSON-RPC directly
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' \
-  | perl-lsp --stdio
-
-# Run with verbose logging
-RUST_LOG=perl_lsp=debug perl-lsp --stdio 2>debug.log
-```
+For the full troubleshooting guide including DAP debugging, parser edge cases, and editor-specific issues, see [TROUBLESHOOTING.md](../how-to/TROUBLESHOOTING.md).
 
 ## Next Steps
 
-- **[DAP User Guide](DAP_USER_GUIDE.md)** -- Set up the built-in debugger (breakpoints, stepping, watch expressions)
-- **[Editor Setup](../how-to/EDITOR_SETUP.md)** -- Detailed per-editor configurations
-- **[Configuration Reference](../reference/CONFIG.md)** -- All configuration options
-- **[LSP Features](../reference/LSP_FEATURES.md)** -- Complete feature documentation
-- **[FAQ](../reference/FAQ.md)** -- Frequently asked questions
-- **[Troubleshooting](../how-to/TROUBLESHOOTING.md)** -- Full troubleshooting guide
+- **[EDITOR_SETUP.md](../how-to/EDITOR_SETUP.md)** - Detailed editor configurations
+- **[INSTALLATION.md](../how-to/INSTALLATION.md)** - Platform-specific installation and verification steps
+- **[CONFIG.md](../reference/CONFIG.md)** - All configuration options
+- **[LSP_FEATURES.md](../reference/LSP_FEATURES.md)** - Complete feature documentation
+- **[FAQ.md](../reference/FAQ.md)** - Frequently asked questions
+- **[Documentation Index](../INDEX.md)** - Documentation front door and routing guide
 
 ## Getting Help
 
-- **Issues**: [github.com/EffortlessMetrics/perl-lsp/issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
-- **Documentation**: [docs/](../INDEX.md)
+- **Issues**: [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
+- **Documentation**: [docs/INDEX.md](../INDEX.md)


### PR DESCRIPTION
## Summary

- Rewrites `docs/tutorials/GETTING_STARTED.md` as a complete zero-to-working guide
- 4 installation methods: VS Code extension (easiest), pre-built binary, crates.io, from source
- Editor setup for VS Code, Neovim, Emacs, Helix, and generic LSP editors
- Feature tour covering diagnostics, completion, hover, go-to-definition, references, rename, formatting, signature help, code actions, semantic highlighting, code lens, and 10 additional features
- VS Code configuration reference table (all `perl-lsp.*` settings)
- Feature profiles documentation (`auto`, `ga-lock`, `ga`, `prod`, `all`)
- Full CLI reference with all flags, examples, and environment variables
- Troubleshooting quick fixes for common first-run problems

## Test plan

- [ ] Verify all editor config snippets are syntactically correct
- [ ] Confirm CLI flags match `perl-lsp --help` output
- [ ] Check all internal doc links resolve