### PR TITLE
fix(parser): resolve expected_module_name errors in CPAN corpus

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -323,8 +323,11 @@ impl<'a> Parser<'a> {
         self.consume_token()?; // consume 'use'
 
         // Parse module name, version, or identifier
-        let mut module = if self.peek_kind() == Some(TokenKind::Number) {
-            // Numeric version like 5.036
+        let mut module = if matches!(
+            self.peek_kind(),
+            Some(TokenKind::Number) | Some(TokenKind::VString)
+        ) {
+            // Numeric version like 5.036 or v-string like v5.14, v5.12.0
             self.consume_token()?.text.to_string()
         } else {
             let first_token = self.consume_token()?;

--- a/crates/perl-parser-core/tests/expected_module_name_tests.rs
+++ b/crates/perl-parser-core/tests/expected_module_name_tests.rs
@@ -1,0 +1,114 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// --- VString version directives in `use` ---
+
+#[test]
+fn test_use_vstring_v5_14() {
+    assert_clean_parse("use v5.14;");
+}
+
+#[test]
+fn test_use_vstring_v5_12_0() {
+    assert_clean_parse("use v5.12.0;");
+}
+
+#[test]
+fn test_use_vstring_v5_6_1() {
+    assert_clean_parse("use v5.6.1;");
+}
+
+#[test]
+fn test_use_vstring_v5_26_0() {
+    assert_clean_parse("use v5.26.0;");
+}
+
+#[test]
+fn test_use_vstring_v5_38() {
+    assert_clean_parse("use v5.38;");
+}
+
+// --- Numeric version directives in `use` ---
+
+#[test]
+fn test_use_numeric_version() {
+    assert_clean_parse("use 5.036;");
+}
+
+#[test]
+fn test_use_numeric_version_old_style() {
+    assert_clean_parse("use 5.008;");
+}
+
+// --- Standard module imports ---
+
+#[test]
+fn test_use_module_simple() {
+    assert_clean_parse("use strict;");
+}
+
+#[test]
+fn test_use_module_with_colons() {
+    assert_clean_parse("use File::Basename;");
+}
+
+#[test]
+fn test_use_module_with_empty_import() {
+    assert_clean_parse("use File::Basename ();");
+}
+
+#[test]
+fn test_use_overload() {
+    assert_clean_parse("use overload;");
+}
+
+#[test]
+fn test_use_no_warnings() {
+    assert_clean_parse("no warnings 'recursion';");
+}
+
+// --- VString in full program context (CPAN patterns) ---
+
+#[test]
+fn test_use_vstring_with_other_statements() {
+    assert_clean_parse(
+        r#"
+use v5.14;
+use warnings;
+use strict;
+my $x = 1;
+"#,
+    );
+}
+
+#[test]
+fn test_use_vstring_followed_by_module_import() {
+    assert_clean_parse(
+        r#"
+use v5.14;
+use Scalar::Util qw( blessed );
+"#,
+    );
+}
+
+#[test]
+fn test_use_vstring_three_part_in_program() {
+    assert_clean_parse(
+        r#"
+use v5.12.0;
+use warnings;
+1;
+"#,
+    );
+}
+
+#[test]
+fn test_use_eval_require() {
+    assert_clean_parse(
+        r#"
+if( !$ENV{PERL_FUTURE_NO_XS} and eval { require Future::XS } ) {
+    1;
+}
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

- The lexer tokenizes v-strings (`v5.14`, `v5.12.0`, `v5.6.1`) as `VString` tokens, but `parse_use` only accepted `Number` and `Identifier` token kinds
- Added `VString` to the accepted token kinds in `parse_use`, eliminating the `expected_module_name` error bucket entirely
- **Impact**: +17 clean corpus files, 27→0 expected_module_name errors

## Root Cause

`use v5.14;` — the lexer correctly produces a `VString` token for `v5.14`, but the parser's `parse_use` function only checked for `TokenKind::Number` (for `use 5.036;`) and `TokenKind::Identifier` (for `use strict;`). The `VString` case fell through to the error branch.

## Test plan

- [x] 16 new tests covering v-string versions, numeric versions, and module imports
- [x] `cargo test -p perl-parser-core --lib` — 404 tests pass
- [x] `cargo clippy -p perl-parser-core --lib` — clean
- [x] CPAN corpus sweep confirms 0 expected_module_name errors remaining