### PR TITLE
feat(hover): show subroutine complexity indicator

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -104,41 +104,35 @@ impl LspServer {
                 _ => "Symbol",
             };
 
-            let (display_name, complexity_info) =
-                if symbol_info.kind == crate::symbol::SymbolKind::Subroutine {
-                    let mut params = Vec::new();
-                    let mut complexity = String::new();
-                    if let Some(sub_node) =
-                        self.find_subroutine_definition(ast, &symbol_info.name)
-                    {
-                        if let NodeKind::Subroutine {
-                            signature: sub_sig,
-                            body,
-                            ..
-                        } = &sub_node.kind
-                        {
-                            if let Some(sig) = sub_sig {
-                                if let NodeKind::Signature { parameters } = &sig.kind {
-                                    for param in parameters {
-                                        self.extract_signature_params(param, &mut params);
-                                    }
+            let (display_name, complexity_info) = if symbol_info.kind
+                == crate::symbol::SymbolKind::Subroutine
+            {
+                let mut params = Vec::new();
+                let mut complexity = String::new();
+                if let Some(sub_node) = self.find_subroutine_definition(ast, &symbol_info.name) {
+                    if let NodeKind::Subroutine { signature: sub_sig, body, .. } = &sub_node.kind {
+                        if let Some(sig) = sub_sig {
+                            if let NodeKind::Signature { parameters } = &sig.kind {
+                                for param in parameters {
+                                    self.extract_signature_params(param, &mut params);
                                 }
-                            } else {
-                                self.extract_params_from_body(body, &mut params);
                             }
+                        } else {
+                            self.extract_params_from_body(body, &mut params);
                         }
-                        complexity = Self::build_complexity_info(sub_node, text);
                     }
-                    let name = if params.is_empty() {
-                        format!("sub {}", symbol_info.name)
-                    } else {
-                        format!("sub {}({})", symbol_info.name, params.join(", "))
-                    };
-                    (name, complexity)
+                    complexity = Self::build_complexity_info(sub_node, text);
+                }
+                let name = if params.is_empty() {
+                    format!("sub {}", symbol_info.name)
                 } else {
-                    let sigil = symbol_info.kind.sigil().unwrap_or("");
-                    (format!("{}{}", sigil, symbol_info.name), String::new())
+                    format!("sub {}({})", symbol_info.name, params.join(", "))
                 };
+                (name, complexity)
+            } else {
+                let sigil = symbol_info.kind.sigil().unwrap_or("");
+                (format!("{}{}", sigil, symbol_info.name), String::new())
+            };
 
             let decl_info = symbol_info
                 .declaration


### PR DESCRIPTION
## Summary

- When hovering over a subroutine definition, the hover now shows a complexity summary:
  `Lines: 42 | Branches: 8 | Complexity: Medium`
- Counts branch points by walking the AST: if/elsif/else, ternary operators, when clauses, and statement modifier if/unless
- Classifies as Low (0-3 branches), Medium (4-8), or High (9+)
- This is a unique AST-dependent feature only a native parser can provide

## Test plan

- [x] `cargo check -p perl-lsp` passes
- [x] `cargo clippy -p perl-lsp --lib` clean
- [x] `cargo test -p perl-lsp --lib` passes (185 tests)
- [ ] Manual hover test over a subroutine in VS Code