### PR TITLE
fix(parser): resolve unclosed_brace_semicolon errors for bare func blocks

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -351,9 +351,17 @@ impl<'a> Parser<'a> {
 
                 Some(TokenKind::LeftBrace) => {
                     // Check if this is a builtin function (or block-list func like first/any/all)
-                    // that needs special handling
+                    // or a user-defined function with a block argument that needs special handling
                     if let NodeKind::Identifier { name } = &expr.kind {
-                        if Self::is_builtin_function(name) || Self::is_block_list_func(name) {
+                        let is_builtin = Self::is_builtin_function(name);
+                        let is_block_list = Self::is_block_list_func(name);
+                        // In Perl, hash element access ALWAYS requires a sigil ($hash{key}).
+                        // A bare lowercase identifier followed by { is a function call with
+                        // a block argument: capture { ... }, where { ... }, etc.
+                        let is_bare_func =
+                            !is_builtin && !is_block_list && Self::looks_like_block_call_name(name);
+
+                        if is_builtin || is_block_list || is_bare_func {
                             // This is a builtin function with {} as argument
                             // Parse arguments without parentheses
                             let mut args = Vec::new();
@@ -370,7 +378,7 @@ impl<'a> Parser<'a> {
                                     }
                                     args.push(self.parse_comma()?);
                                 }
-                            } else if Self::is_block_list_func(name.as_str()) {
+                            } else if is_block_list || is_bare_func {
                                 // Parse block (may contain multiple statements) as first argument
                                 // for map/grep/sort/first/any/all/none/reduce/etc.
                                 args.push(self.parse_builtin_block()?);

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -611,6 +611,31 @@ impl<'a> Parser<'a> {
     /// - `func other_func(...)` (identifier followed by `(`)
     /// - `func other_func $arg` (chained bare calls)
     ///
+    /// Returns `true` when `name` looks like a user-defined function that
+    /// accepts a block argument: `capture { ... }`, `where { ... }`, etc.
+    ///
+    /// In Perl, hash element access ALWAYS requires a sigil (`\$hash{key}`).
+    /// A bare lowercase identifier followed by `{` is therefore a function
+    /// call with a block argument, not a hash subscript.
+    #[inline]
+    pub(crate) fn looks_like_block_call_name(name: &str) -> bool {
+        // Sigiled names are variables, not function calls
+        if name.starts_with('$')
+            || name.starts_with('@')
+            || name.starts_with('%')
+            || name.starts_with('&')
+            || name.starts_with('*')
+        {
+            return false;
+        }
+        // Qualified names like Tk::catch are always function calls
+        if name.contains("::") {
+            return true;
+        }
+        // Only lowercase/underscore-leading identifiers
+        name.starts_with(|c: char| c.is_ascii_lowercase() || c == '_')
+    }
+
     /// We are conservative: the identifier must be lowercase (uppercase bare
     /// identifiers are more likely to be constants or package names) and
     /// must NOT be a string comparison operator (`eq`, `ne`, `lt`, `gt`, etc.)

--- a/crates/perl-parser-core/tests/eval_brace_tests.rs
+++ b/crates/perl-parser-core/tests/eval_brace_tests.rs
@@ -1,0 +1,153 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Tests for the unclosed_brace_semicolon error bucket.
+// These patterns trigger "expected '}', found ';'" because the parser
+// treats `identifier { ... }` as hash element access instead of a
+// function call with a block argument.
+
+#[test]
+fn test_eval_block_in_list_context() {
+    let source = r#"
+my $result = eval { my $x = 1; $x + 2; };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_eval_block_in_if_condition() {
+    let source = r#"
+if (eval { require Some::Module; 1 }) {
+    print "loaded\n";
+}
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_eval_block_ternary() {
+    let source = r#"
+my $val = eval { dangerous(); 1 } ? "ok" : "fail";
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_capture_block_with_eval() {
+    let source = r#"
+my $output = capture { eval { die "oops"; }; print "hello"; };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_bare_func_block_simple() {
+    let source = r#"
+scope_guard { cleanup(); };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_bare_func_block_multiple_stmts() {
+    let source = r#"
+transaction { my $x = 1; do_work($x); commit(); };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_bare_func_block_with_trailing_args() {
+    let source = r#"
+my @results = filter { $_->is_valid; } @items;
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_qualified_func_block() {
+    let source = r#"
+Tk::catch { die "caught"; };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_moose_where_block() {
+    let source = r#"
+subtype 'PositiveInt', as 'Int', where { $_ > 0 };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_moose_inline_as_block() {
+    let source = r#"
+coerce 'MyType', from 'Str', via { MyType->new($_) };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_begin_eval_require() {
+    let source = r#"
+BEGIN { eval { require Some::Module; }; }
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_nested_eval_blocks() {
+    let source = r#"
+my $r = eval {
+    my $inner = eval { die "inner"; };
+    handle($inner);
+    1;
+};
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_eval_or_die() {
+    let source = r#"
+eval { require Foo::Bar; 1; } or die "Cannot load Foo::Bar: $@";
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_eval_and_check() {
+    let source = r#"
+my $ok = eval { $obj->method(); 1; } && $extra_check;
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_bare_func_block_in_sub() {
+    let source = r#"
+sub setup {
+    my $guard = scope_guard { cleanup(); };
+    do_work();
+}
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_bare_func_block_chained() {
+    let source = r#"
+before_each { setup(); };
+after_each { teardown(); };
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_declare_with_block() {
+    let source = r#"
+declare "MyType", where { defined($_) && length($_) > 0 };
+"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

- In Perl, hash element access ALWAYS requires a sigil (`$hash{key}`). A bare lowercase identifier followed by `{` is a function call with a block argument, not a hash subscript.
- The parser was treating user-defined functions like `capture { }`, `where { }`, `scope_guard { }`, `Tk::catch { }` as hash element access, causing "expected '}', found ';'" errors (the `unclosed_brace_semicolon` error bucket — 58 corpus files affected).
- Added `looks_like_block_call_name()` helper to identify bare identifiers and qualified names that should be parsed as function calls with block arguments.
- Extended the postfix chain's `LeftBrace` branch to use this helper alongside existing builtin/block-list-func checks.

## Changes

- `helpers.rs`: New `looks_like_block_call_name()` — returns true for lowercase/underscore-leading identifiers and qualified names (contains `::`)
- `postfix.rs`: Added `is_bare_func` condition to the `LeftBrace` branch, routing bare function+block patterns through `parse_builtin_block()` instead of hash element access
- `eval_brace_tests.rs`: 17 new tests covering eval blocks, capture/scope_guard, qualified calls, Moose DSL patterns, nested eval

## Test plan

- [x] All 17 new tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] No regressions in existing tests (426 total passing; 1 pre-existing failure in `block_list_in_args_tests`)