### PR TITLE
feat(hover): add educational tooltips for Perl special variables

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -977,10 +977,7 @@ impl LspServer {
         // Single punctuation character after $ (e.g. $!, $/, $\, $$, $;, etc.)
         if sigil == '$' && !next_ch.is_ascii_alphanumeric() && next_ch != b'_' {
             let punct = next_ch as char;
-            if matches!(
-                punct,
-                '!' | '@' | '/' | '\\' | '$' | ';' | ',' | '.' | '&' | '\'' | '`'
-            ) {
+            if matches!(punct, '!' | '@' | '/' | '\\' | '$' | ';' | ',' | '.' | '&' | '\'' | '`') {
                 return Some(format!("${}", punct));
             }
         }
@@ -1133,5 +1130,4 @@ impl LspServer {
             },
         }))
     }
-
 }

--- a/crates/perl-lsp/tests/special_variable_hover_tests.rs
+++ b/crates/perl-lsp/tests/special_variable_hover_tests.rs
@@ -1,4 +1,3 @@
-
 mod support;
 
 use serde_json::json;


### PR DESCRIPTION
## Summary

- Add get_special_variable_hover() with markdown documentation for 20 common Perl special variables
- Add extract_special_variable() to handle punctuation variables the normal tokenizer misses
- Two-tier check in hover pipeline: punctuation vars before tokenizer, named vars after tokenizer but before builtin docs
- 6 integration tests verifying hover content and markdown format

## Test plan

- [x] cargo fmt -p perl-lsp passes
- [x] cargo clippy -p perl-lsp --lib passes clean
- [x] All 6 new tests pass (special_variable_hover_tests)
- [x] All 6 existing hover tests pass (lsp_hover_tests)