### PR TITLE
docs: add canonical corpus program for path to 95-98% coverage

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -153,6 +153,10 @@ pub struct LspArgs {
     #[arg(long)]
     pub check: bool,
 
+    /// Scan a project directory and report parsability summary
+    #[arg(long, conflicts_with = "check")]
+    pub check_project: Option<Option<String>>,
+
     /// Generate shell completions (bash, zsh, fish, powershell)
     #[arg(long)]
     pub completion: Option<String>,
@@ -216,6 +220,11 @@ pub enum LaunchAction {
     Info,
     /// Validate Perl files in batch mode.
     Check,
+    /// Scan a project directory and report parsability summary.
+    CheckProject {
+        /// Directory to scan (defaults to ".").
+        dir: String,
+    },
     /// Generate shell completions for a given shell.
     Completion {
         /// Target shell (bash, zsh, fish, powershell).
@@ -351,6 +360,9 @@ where
                 LaunchAction::Info
             } else if parsed_args.check {
                 LaunchAction::Check
+            } else if let Some(maybe_dir) = parsed_args.check_project {
+                let dir = maybe_dir.unwrap_or_else(|| ".".to_string());
+                LaunchAction::CheckProject { dir }
             } else if let Some(shell) = parsed_args.completion {
                 LaunchAction::Completion { shell }
             } else if parsed_args.features_json {
@@ -479,6 +491,7 @@ pub fn help_text() -> String {
     out.push('\n');
     out.push_str("Usage: perl-lsp [options]\n");
     out.push_str("       perl-lsp --check <file.pl> [file2.pm ...]\n");
+    out.push_str("       perl-lsp --check-project [dir]\n");
     out.push('\n');
     out.push_str("Server options:\n");
     out.push_str("  --stdio              Use stdio for communication (default)\n");
@@ -498,6 +511,7 @@ pub fn help_text() -> String {
     out.push('\n');
     out.push_str("Tool options:\n");
     out.push_str("  --check <files...>   Validate Perl files and report parse errors\n");
+    out.push_str("  --check-project [dir] Scan project directory for parsability report\n");
     out.push_str("  --completion <shell> Generate shell completions (bash, zsh, fish)\n");
     out.push_str("  --help               Show this help message\n");
     out.push('\n');
@@ -507,6 +521,7 @@ pub fn help_text() -> String {
     out.push_str("  perl-lsp --socket --port 9257            # TCP socket mode\n");
     out.push_str("  perl-lsp --stdio --feature-profile=prod  # production profile\n");
     out.push_str("  perl-lsp --check lib/MyModule.pm         # syntax check\n");
+    out.push_str("  perl-lsp --check-project lib/             # project scan\n");
     out.push_str("  perl-lsp --info                          # server information\n");
     out.push_str("  perl-lsp --completion bash >> ~/.bashrc   # install completions\n");
     out.push('\n');
@@ -535,7 +550,7 @@ const BASH_COMPLETION: &str = r#"_perl_lsp() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--stdio --socket --port --log --health --info --check --version --features-json --feature-profile --completion --help"
+    opts="--stdio --socket --port --log --health --info --check --check-project --version --features-json --feature-profile --completion --help"
 
     case "${prev}" in
         --port)
@@ -574,6 +589,7 @@ _perl-lsp() {
         '--health[Quick health check]' \
         '--info[Show server info]' \
         '--check[Validate Perl files]:file:_files -g "*.{pl,pm,t}"' \
+        '--check-project[Scan project directory for parsability report]:dir:_directories' \
         '--version[Show version information]' \
         '--features-json[Output features catalog as JSON]' \
         '--feature-profile[Set feature profile]:profile:(ga-lock ga prod production all auto)' \
@@ -592,6 +608,7 @@ complete -c perl-lsp -l log -d 'Enable logging to stderr'
 complete -c perl-lsp -l health -d 'Quick health check'
 complete -c perl-lsp -l info -d 'Show server info'
 complete -c perl-lsp -l check -F -d 'Validate Perl files'
+complete -c perl-lsp -l check-project -d 'Scan project directory for parsability report'
 complete -c perl-lsp -l version -d 'Show version information'
 complete -c perl-lsp -l features-json -d 'Output features catalog as JSON'
 complete -c perl-lsp -l feature-profile -x -a 'ga-lock ga prod production all auto' -d 'Set feature profile'
@@ -610,6 +627,7 @@ const POWERSHELL_COMPLETION: &str = r#"Register-ArgumentCompleter -Native -Comma
         [CompletionResult]::new('--health', '--health', 'ParameterName', 'Quick health check')
         [CompletionResult]::new('--info', '--info', 'ParameterName', 'Show server info')
         [CompletionResult]::new('--check', '--check', 'ParameterName', 'Validate Perl files')
+        [CompletionResult]::new('--check-project', '--check-project', 'ParameterName', 'Scan project directory for parsability report')
         [CompletionResult]::new('--version', '--version', 'ParameterName', 'Show version information')
         [CompletionResult]::new('--features-json', '--features-json', 'ParameterName', 'Output features catalog as JSON')
         [CompletionResult]::new('--feature-profile', '--feature-profile', 'ParameterName', 'Set feature profile')
@@ -907,6 +925,26 @@ mod tests {
     fn help_mentions_completion_flag() {
         let text = super::help_text();
         assert!(text.contains("--completion"));
+    }
+
+    // -- --check-project flag -----------------------------------------
+
+    #[test]
+    fn parse_check_project_no_dir_defaults_to_dot() {
+        let plan = must(parse_args(["perl-lsp", "--check-project"]));
+        assert_eq!(plan.action, LaunchAction::CheckProject { dir: ".".to_string() });
+    }
+
+    #[test]
+    fn parse_check_project_with_dir() {
+        let plan = must(parse_args(["perl-lsp", "--check-project", "lib/"]));
+        assert_eq!(plan.action, LaunchAction::CheckProject { dir: "lib/".to_string() });
+    }
+
+    #[test]
+    fn help_mentions_check_project_flag() {
+        let text = super::help_text();
+        assert!(text.contains("--check-project"));
     }
 
     // ── InvalidShell error ────────────────────────────────────────

--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -87,6 +87,10 @@ fn main() {
             let exit_code = run_check(&launch_plan.files);
             process::exit(exit_code);
         }
+        LaunchAction::CheckProject { ref dir } => {
+            let exit_code = run_check_project(dir);
+            process::exit(exit_code);
+        }
         LaunchAction::Completion { ref shell } => {
             if let Some(script) = shell_completion(shell) {
                 print!("{script}");
@@ -160,6 +164,145 @@ fn run_check(files: &[String]) -> i32 {
 fn is_terminal_stdout() -> bool {
     use std::io::IsTerminal;
     env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
+}
+
+/// Error details for a single file that failed to parse cleanly.
+struct FileError {
+    path: String,
+    errors: Vec<String>,
+}
+
+/// Run the `--check-project` mode: scan a directory and report parsability.
+fn run_check_project(dir: &str) -> i32 {
+    let extensions: &[&str] = &["pm", "pl", "t"];
+
+    let walker = walkdir::WalkDir::new(dir).follow_links(true).into_iter();
+
+    let mut total = 0usize;
+    let mut clean = 0usize;
+    let mut file_errors: Vec<FileError> = Vec::new();
+    let mut category_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    for entry in walker.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let ext_match = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| extensions.contains(&e))
+            .unwrap_or(false);
+        if !ext_match {
+            continue;
+        }
+
+        total += 1;
+        let path_str = path.display().to_string();
+
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                file_errors
+                    .push(FileError { path: path_str, errors: vec![format!("read error: {e}")] });
+                category_counts.entry("IO error".to_string()).and_modify(|c| *c += 1).or_insert(1);
+                continue;
+            }
+        };
+
+        let mut parser = perl_parser::Parser::new(&source);
+        let parse_result = parser.parse();
+        let recovered_errors = parser.errors();
+
+        let mut errors_for_file: Vec<String> = Vec::new();
+
+        // Collect recovered errors (parser returned Ok but had issues)
+        for err in recovered_errors {
+            let cat = categorize_error(&format!("{err}"));
+            category_counts.entry(cat).and_modify(|c| *c += 1).or_insert(1);
+            errors_for_file.push(format!("{err}"));
+        }
+
+        // Collect catastrophic parse failure
+        if let Err(ref e) = parse_result {
+            let cat = categorize_error(&format!("{e}"));
+            category_counts.entry(cat).and_modify(|c| *c += 1).or_insert(1);
+            errors_for_file.push(format!("{e}"));
+        }
+
+        if errors_for_file.is_empty() {
+            clean += 1;
+        } else {
+            file_errors.push(FileError { path: path_str, errors: errors_for_file });
+        }
+    }
+
+    // Print report
+    println!("Perl Project Parsability Report");
+    println!("===============================");
+    println!();
+    println!("Directory: {dir}");
+    println!("Files scanned: {total}");
+
+    if total == 0 {
+        println!();
+        println!("No Perl files (.pm, .pl, .t) found.");
+        return 0;
+    }
+
+    let pct = if total > 0 { (clean as f64 / total as f64) * 100.0 } else { 0.0 };
+
+    println!("Clean parses: {clean}/{total} ({pct:.1}%)");
+    println!();
+
+    if !file_errors.is_empty() {
+        println!("Parse errors:");
+        for fe in &file_errors {
+            for err in &fe.errors {
+                println!("  {}: {err}", fe.path);
+            }
+        }
+        println!();
+    }
+
+    if !category_counts.is_empty() {
+        let mut cats: Vec<_> = category_counts.into_iter().collect();
+        cats.sort_by(|a, b| b.1.cmp(&a.1));
+        println!("Top issue categories:");
+        for (cat, count) in &cats {
+            println!("  {cat}: {count}");
+        }
+        println!();
+    }
+
+    if pct >= 80.0 {
+        println!("Assessment: PASS ({pct:.1}% parsable)");
+        0
+    } else {
+        println!("Assessment: FAIL ({pct:.1}% parsable, threshold 80%)");
+        1
+    }
+}
+
+/// Categorize an error message into a broad bucket.
+fn categorize_error(msg: &str) -> String {
+    if msg.contains("Unexpected end of input") {
+        "Unexpected EOF".to_string()
+    } else if msg.contains("expected") && msg.contains("found") {
+        "Unexpected token".to_string()
+    } else if msg.contains("Invalid syntax") {
+        "Syntax error".to_string()
+    } else if msg.contains("Lexer error") {
+        "Lexer error".to_string()
+    } else if msg.contains("recursion") || msg.contains("Recursion") {
+        "Recursion limit".to_string()
+    } else if msg.contains("read error") {
+        "IO error".to_string()
+    } else {
+        "Other".to_string()
+    }
 }
 
 fn run_server(launch_config: LaunchConfig) {


### PR DESCRIPTION
## Summary

- Adds `docs/project/CORPUS_PROGRAM.md` — the canonical document for the CPAN corpus coverage program
- Consolidates scattered coverage targets, error bucket analysis, phase plans, and success criteria into ONE document
- Based on the committed baseline: 3,139/4,355 clean (72.1%) from `.ci/cpan-corpus-baseline.json`

## Contents

1. **Current Baseline** — exact numbers from the 2026-03-18 sweep
2. **Target: 95%** — primary target with timeline (7-9 weeks)
3. **Stretch: 98%** — secondary target with caveats (11-15 weeks)
4. **Unfixable Floor: 2-3%** — source filters, BEGIN blocks, XS, generated code
5. **Error Bucket Breakdown** — all 29 buckets with file counts, root causes, fix status, effort estimates (Tier 1/2/3)
6. **Expansion Plan** — CPAN manifest gaps (918/1000 missing roots), framework coverage, modern Perl features
7. **Test Locking Strategy** — ratchet mechanism, per-bucket tests, module snapshots
8. **Phase Plan** — Phase A (90%), Phase B (95%), Phase C (98%) with week-by-week breakdown
9. **Success Criteria** — 10 concrete completion gates
10. **Metrics Dashboard** — what to track, how often, where to report

## Test plan

- [ ] Document renders correctly in GitHub markdown preview
- [ ] All referenced files (`.ci/cpan-corpus-baseline.json`, `.ci/cpan-corpus-manifest.txt`) exist
- [ ] All referenced PRs and issues exist
- [ ] Numbers are consistent with baseline JSON