### PR TITLE
feat(diagnostics): detect unused imports with grey-out hint

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lib.rs
+++ b/crates/perl-lsp-diagnostics/src/lib.rs
@@ -50,6 +50,7 @@ pub use perl_lsp_diagnostic_types::{
 pub use lints::common_mistakes;
 pub use lints::deprecated;
 pub use lints::strict_warnings;
+pub use lints::unused_imports;
 
 // Re-export dead code detection (when not targeting WASM)
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -88,3 +88,5 @@
 pub mod common_mistakes;
 pub mod deprecated;
 pub mod strict_warnings;
+/// Unused import detection
+pub mod unused_imports;

--- a/crates/perl-lsp-diagnostics/src/lints/unused_imports.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/unused_imports.rs
@@ -1,0 +1,216 @@
+//! Unused import detection lint
+//!
+//! Detects `use Module` statements where the module name does not appear
+//! elsewhere in the source text. Pragmas and known implicit-export modules
+//! are excluded to avoid false positives.
+//!
+//! # Diagnostic codes
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `unused-import` | Hint | Module appears to be unused |
+
+use perl_parser_core::ast::{Node, NodeKind};
+
+use super::super::walker::walk_node;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, RelatedInformation};
+
+/// Pragmas that should never be flagged as unused (they operate via side effects).
+const PRAGMA_SKIP_LIST: &[&str] = &[
+    "strict",
+    "warnings",
+    "utf8",
+    "feature",
+    "constant",
+    "lib",
+    "parent",
+    "base",
+    "Exporter",
+    "vars",
+    "subs",
+    "overload",
+    "overloading",
+    "integer",
+    "bigint",
+    "bignum",
+    "bigrat",
+    "bytes",
+    "charnames",
+    "encoding",
+    "locale",
+    "mro",
+    "open",
+    "ops",
+    "re",
+    "sigtrap",
+    "sort",
+    "threads",
+    "threads::shared",
+    "autodie",
+    "autouse",
+    "diagnostics",
+    "English",
+    "experimental",
+    "fields",
+    "filetest",
+    "if",
+    "less",
+    "POSIX",
+];
+
+/// Modules that implicitly export symbols into the caller's namespace.
+const IMPLICIT_EXPORT_SKIP_LIST: &[&str] = &[
+    "Moose",
+    "Moose::Role",
+    "Moose::Util::TypeConstraints",
+    "MooseX::StrictConstructor",
+    "MooseX::Types",
+    "Moo",
+    "Moo::Role",
+    "Mouse",
+    "Mouse::Role",
+    "Modern::Perl",
+    "Dancer",
+    "Dancer2",
+    "Catalyst",
+    "Mojolicious",
+    "Mojolicious::Lite",
+    "Mojo::Base",
+    "Test::More",
+    "Test::Most",
+    "Test::Simple",
+    "Test::Exception",
+    "Test::Fatal",
+    "Test::Warnings",
+    "Test::Deep",
+    "Test::Differences",
+    "Test::Class",
+    "Test::MockModule",
+    "Test::MockObject",
+    "Test::Spec",
+    "Test::Builder",
+    "Test2::V0",
+    "Test2::Bundle::More",
+    "Carp",
+    "Carp::Always",
+    "Scalar::Util",
+    "List::Util",
+    "List::MoreUtils",
+    "Data::Dumper",
+    "Try::Tiny",
+    "Getopt::Long",
+    "File::Basename",
+    "FindBin",
+    "Fcntl",
+    "UNIVERSAL",
+];
+
+/// Check for unused import statements.
+///
+/// Walks the AST to collect all `use Module` statements, then searches the
+/// source text for references to each module name. If no reference is found
+/// outside the `use` statement itself, a diagnostic hint is emitted.
+pub fn check_unused_imports(node: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
+    // Collect all use statements from the AST
+    let mut use_statements: Vec<(String, usize, usize)> = Vec::new();
+
+    walk_node(node, &mut |n| {
+        if let NodeKind::Use { module, .. } = &n.kind {
+            use_statements.push((module.clone(), n.location.start, n.location.end));
+        }
+    });
+
+    for (module, start, end) in &use_statements {
+        let module = module.as_str();
+        let start = *start;
+        let end = *end;
+
+        // Skip pragmas
+        if PRAGMA_SKIP_LIST.contains(&module) {
+            continue;
+        }
+
+        // Skip implicit exporters
+        if IMPLICIT_EXPORT_SKIP_LIST.contains(&module) {
+            continue;
+        }
+
+        // Skip version-like imports (e.g., `use 5.010;`)
+        if module.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            continue;
+        }
+
+        // Skip if the use statement has explicit import arguments
+        if has_use_args(node, module) {
+            continue;
+        }
+
+        // Check if the module name appears elsewhere in the source
+        if !is_module_referenced(source, module, start, end) {
+            diagnostics.push(Diagnostic {
+                range: (start, end),
+                severity: DiagnosticSeverity::Hint,
+                code: Some("unused-import".to_string()),
+                message: format!("Module '{}' appears to be unused", module),
+                related_information: vec![RelatedInformation {
+                    location: (start, end),
+                    message: format!(
+                        "If '{}' is imported for side effects, you can ignore this hint",
+                        module
+                    ),
+                }],
+                tags: vec![DiagnosticTag::Unnecessary],
+                suggestion: Some(format!("Remove 'use {};' if it is not needed", module)),
+            });
+        }
+    }
+}
+
+/// Returns true if the use statement for `target_module` has explicit import args.
+fn has_use_args(node: &Node, target_module: &str) -> bool {
+    let mut found = false;
+    walk_node(node, &mut |n| {
+        if let NodeKind::Use { module, args, .. } = &n.kind
+            && module == target_module
+            && !args.is_empty()
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Returns true if `module` appears in `source` outside the range `[use_start, use_end)`.
+///
+/// Uses word-boundary matching to avoid substring false positives (e.g.,
+/// `FooBar` should not match a reference to `Foo`).
+fn is_module_referenced(source: &str, module: &str, use_start: usize, use_end: usize) -> bool {
+    let mut search_start = 0;
+    while let Some(pos) = source[search_start..].find(module) {
+        let abs_pos = search_start + pos;
+        let match_end = abs_pos + module.len();
+
+        // Skip the use statement itself
+        if abs_pos >= use_start && abs_pos < use_end {
+            search_start = match_end;
+            continue;
+        }
+
+        // Check word boundaries
+        let before_ok = abs_pos == 0 || {
+            let ch = source.as_bytes()[abs_pos - 1];
+            !ch.is_ascii_alphanumeric() && ch != b'_'
+        };
+        let after_ok = match_end >= source.len() || {
+            let ch = source.as_bytes()[match_end];
+            !ch.is_ascii_alphanumeric() && ch != b'_'
+        };
+
+        if before_ok && after_ok {
+            return true;
+        }
+
+        search_start = match_end;
+    }
+    false
+}

--- a/crates/perl-lsp-diagnostics/tests/unused_imports_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unused_imports_tests.rs
@@ -1,0 +1,162 @@
+//! Tests for unused import detection lint
+
+use perl_lsp_diagnostics::unused_imports::check_unused_imports;
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticTag};
+use perl_parser_core::{Node, NodeKind, SourceLocation};
+
+fn loc(start: usize, end: usize) -> SourceLocation {
+    SourceLocation { start, end }
+}
+
+fn use_node(module: &str, start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::Use { module: module.to_string(), args: vec![], has_filter_risk: false },
+        loc(start, end),
+    )
+}
+
+fn use_node_with_args(module: &str, args: Vec<&str>, start: usize, end: usize) -> Node {
+    Node::new(
+        NodeKind::Use {
+            module: module.to_string(),
+            args: args.into_iter().map(|s| s.to_string()).collect(),
+            has_filter_risk: false,
+        },
+        loc(start, end),
+    )
+}
+
+fn program(stmts: Vec<Node>) -> Node {
+    Node::new(NodeKind::Program { statements: stmts }, loc(0, 500))
+}
+
+#[test]
+fn unused_module_is_flagged() {
+    let source = "use Foo::Bar;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("Foo::Bar", 0, 13)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].code.as_deref(), Some("unused-import"));
+    assert!(diags[0].message.contains("Foo::Bar"));
+}
+
+#[test]
+fn used_module_is_not_flagged() {
+    let source = "use Foo::Bar;\nFoo::Bar->new();\n";
+    let ast = program(vec![use_node("Foo::Bar", 0, 13)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn method_call_target_not_flagged() {
+    let source = "use Some::Module;\nSome::Module::do_thing();\n";
+    let ast = program(vec![use_node("Some::Module", 0, 17)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn pragma_strict_not_flagged() {
+    let source = "use strict;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("strict", 0, 11)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn pragma_warnings_not_flagged() {
+    let source = "use warnings;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("warnings", 0, 13)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn moose_not_flagged() {
+    let source = "use Moose;\nhas 'name' => (is => 'ro');\n";
+    let ast = program(vec![use_node("Moose", 0, 10)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn test_more_not_flagged() {
+    let source = "use Test::More;\nok(1, 'works');\n";
+    let ast = program(vec![use_node("Test::More", 0, 15)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn module_with_import_args_not_flagged() {
+    let source = "use Foo::Bar qw(baz);\nmy \$x = baz();\n";
+    let ast = program(vec![use_node_with_args("Foo::Bar", vec!["baz"], 0, 21)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn diagnostic_has_hint_severity_and_unnecessary_tag() {
+    let source = "use Unused::Mod;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("Unused::Mod", 0, 16)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, DiagnosticSeverity::Hint);
+    assert!(diags[0].tags.contains(&DiagnosticTag::Unnecessary));
+}
+
+#[test]
+fn multiple_unused_all_flagged() {
+    let source = "use Alpha;\nuse Beta;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("Alpha", 0, 10), use_node("Beta", 11, 20)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert_eq!(diags.len(), 2);
+}
+
+#[test]
+fn mixed_used_and_unused() {
+    let source = "use Alpha;\nuse Beta;\nAlpha->new();\n";
+    let ast = program(vec![use_node("Alpha", 0, 10), use_node("Beta", 11, 20)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].message.contains("Beta"));
+}
+
+#[test]
+fn empty_program_no_diagnostics() {
+    let source = "";
+    let ast = program(vec![]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn version_import_not_flagged() {
+    let source = "use 5.010;\nmy \$x = 1;\n";
+    let ast = program(vec![use_node("5.010", 0, 10)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn substring_match_does_not_count() {
+    let source = "use Foo;\nmy \$x = FooBar->new();\n";
+    let ast = program(vec![use_node("Foo", 0, 8)]);
+    let mut diags: Vec<Diagnostic> = Vec::new();
+    check_unused_imports(&ast, source, &mut diags);
+    assert_eq!(diags.len(), 1, "substring match should not suppress diagnostic");
+}


### PR DESCRIPTION
## Summary

- Adds `unused-import` lint to `perl-lsp-diagnostics` that detects `use Module` statements where the module name is not referenced elsewhere in the source text
- Emits `Hint`-severity diagnostics with `DiagnosticTag::Unnecessary` so editors grey out the line
- Conservative design: excludes pragmas (strict, warnings, utf8, etc.), implicit exporters (Moose, Test::More, Carp, etc.), modules with explicit import args, and version imports
- Word-boundary matching prevents substring false positives

## Files changed

- `crates/perl-lsp-diagnostics/src/lints/unused_imports.rs` — new lint implementation
- `crates/perl-lsp-diagnostics/src/lints/mod.rs` — register module
- `crates/perl-lsp-diagnostics/src/lib.rs` — re-export module
- `crates/perl-lsp-diagnostics/tests/unused_imports_tests.rs` — 14 tests

## Test plan

- [x] `cargo fmt -p perl-lsp-diagnostics` — clean
- [x] `cargo clippy -p perl-lsp-diagnostics --tests` — clean
- [x] `cargo test -p perl-lsp-diagnostics` — 134 tests pass (14 new)