### PR TITLE
perf(parser): add cancellation token checks for responsive LSP

### DIFF
--- a/crates/perl-error/src/lib.rs
+++ b/crates/perl-error/src/lib.rs
@@ -427,6 +427,10 @@ pub enum ParseError {
         /// Maximum allowed depth
         max_depth: usize,
     },
+
+    /// Parsing was cancelled by an external cancellation token
+    #[error("Parsing cancelled")]
+    Cancelled,
 }
 
 /// Error classification and diagnostic generation for parsed Perl code.

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -234,5 +234,6 @@ fn build_parse_error_suggestion(error: &ParseError) -> Option<String> {
         ParseError::NestingTooDeep { .. } => Some(
             "Reduce nesting depth by extracting inner logic into named subroutines".to_string(),
         ),
+        ParseError::Cancelled => None,
     }
 }

--- a/crates/perl-lsp-diagnostics/src/parse_errors.rs
+++ b/crates/perl-lsp-diagnostics/src/parse_errors.rs
@@ -72,6 +72,7 @@ pub fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
             }
         }
         ParseError::SyntaxError { .. } => None,
+        ParseError::Cancelled => None,
     };
 
     Diagnostic {

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -63,6 +63,7 @@ use crate::{
 };
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 // Import enhanced recovery module
@@ -94,6 +95,10 @@ pub struct Parser<'a> {
     heredoc_start_time: Option<Instant>,
     /// Collection of parse errors encountered during parsing (for error recovery)
     errors: Vec<ParseError>,
+    /// Optional cancellation flag for cooperative cancellation from the LSP server.
+    cancellation_flag: Option<Arc<AtomicBool>>,
+    /// Counter to amortize cancellation checks (only check every N statements)
+    cancellation_check_counter: usize,
     // Enhanced error recovery state
     // pub enhanced_recovery: EnhancedRecovery,
 }
@@ -137,6 +142,30 @@ impl<'a> Parser<'a> {
             byte_cursor: 0,
             heredoc_start_time: None,
             errors: Vec::new(),
+            cancellation_flag: None,
+            cancellation_check_counter: 0,
+            // enhanced_recovery: EnhancedRecovery::new(RecoveryConfig::default()),
+        }
+    }
+
+    /// Create a new parser with a cancellation flag for cooperative cancellation.
+    ///
+    /// The parser periodically checks the atomic flag and returns
+    /// `ParseError::Cancelled` if it has been set to `true`.
+    pub fn new_with_cancellation(input: &'a str, cancellation_flag: Arc<AtomicBool>) -> Self {
+        Parser {
+            tokens: TokenStream::new(input),
+            recursion_depth: 0,
+            last_end_position: 0,
+            in_for_loop_init: false,
+            at_stmt_start: true,
+            pending_heredocs: VecDeque::new(),
+            src_bytes: input.as_bytes(),
+            byte_cursor: 0,
+            heredoc_start_time: None,
+            errors: Vec::new(),
+            cancellation_flag: Some(cancellation_flag),
+            cancellation_check_counter: 0,
             // enhanced_recovery: EnhancedRecovery::new(RecoveryConfig::default()),
         }
     }
@@ -175,8 +204,24 @@ impl<'a> Parser<'a> {
             byte_cursor: 0,
             heredoc_start_time: None,
             errors: Vec::new(),
+            cancellation_flag: None,
+            cancellation_check_counter: 0,
             // enhanced_recovery: EnhancedRecovery::new(config),
         }
+    }
+
+    /// Check if parsing has been cancelled.
+    #[inline]
+    fn check_cancelled(&mut self) -> ParseResult<()> {
+        self.cancellation_check_counter += 1;
+        if self.cancellation_check_counter & 63 == 0 {
+            if let Some(ref flag) = self.cancellation_flag {
+                if flag.load(Ordering::Relaxed) {
+                    return Err(ParseError::Cancelled);
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Parse the source and return the AST for the Parse stage.

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -5,6 +5,9 @@ impl<'a> Parser<'a> {
         let mut statements = Vec::new();
 
         while !self.tokens.is_eof() {
+            // Check for cancellation
+            self.check_cancelled()?;
+
             // Check for UnknownRest token (lexer budget exceeded)
             if matches!(self.peek_kind(), Some(TokenKind::UnknownRest)) {
                 let t = self.consume_token()?;
@@ -21,7 +24,7 @@ impl<'a> Parser<'a> {
                 Ok(stmt) => statements.push(stmt),
                 Err(e) => {
                     // Don't recover from recursion/nesting limits - propagate immediately
-                    if matches!(e, ParseError::RecursionLimit | ParseError::NestingTooDeep { .. }) {
+                    if matches!(e, ParseError::RecursionLimit | ParseError::NestingTooDeep { .. } | ParseError::Cancelled) {
                         return Err(e);
                     }
 
@@ -876,6 +879,9 @@ impl<'a> Parser<'a> {
             let mut statements = Vec::new();
 
             while s.peek_kind() != Some(TokenKind::RightBrace) && !s.tokens.is_eof() {
+                // Check for cancellation
+                s.check_cancelled()?;
+
                 // Parse statement with error recovery (AC3: Panic Mode Recovery inside blocks)
                 let stmt_result = s.parse_statement();
                 match stmt_result {
@@ -887,7 +893,7 @@ impl<'a> Parser<'a> {
                     }
                     Err(e) => {
                         // Don't recover from recursion/nesting limits - propagate immediately
-                        if matches!(e, ParseError::RecursionLimit | ParseError::NestingTooDeep { .. }) {
+                        if matches!(e, ParseError::RecursionLimit | ParseError::NestingTooDeep { .. } | ParseError::Cancelled) {
                             return Err(e);
                         }
 

--- a/crates/perl-parser-core/tests/cancellation_tests.rs
+++ b/crates/perl-parser-core/tests/cancellation_tests.rs
@@ -1,0 +1,62 @@
+mod cpan_test_helpers;
+
+use perl_parser_core::Parser;
+use perl_parser_core::error::ParseError;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[test]
+fn test_parse_without_cancellation_succeeds() {
+    let flag = Arc::new(AtomicBool::new(false));
+    let mut parser = Parser::new_with_cancellation("my $x = 1; my $y = 2;", flag);
+    let result = parser.parse();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_parse_with_immediate_cancellation() {
+    let flag = Arc::new(AtomicBool::new(true));
+    let statements: Vec<String> = (0..200).map(|i| format!("my $x{} = {};", i, i)).collect();
+    let source = statements.join("\n");
+    let mut parser = Parser::new_with_cancellation(&source, flag);
+    let result = parser.parse();
+    assert!(matches!(result, Err(ParseError::Cancelled)));
+}
+
+#[test]
+fn test_parse_with_delayed_cancellation() {
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_clone = Arc::clone(&flag);
+    let statements: Vec<String> = (0..200).map(|i| format!("my $x{} = {};", i, i)).collect();
+    let source = statements.join("\n");
+    flag_clone.store(true, Ordering::Relaxed);
+    let mut parser = Parser::new_with_cancellation(&source, flag);
+    let result = parser.parse();
+    assert!(matches!(result, Err(ParseError::Cancelled)));
+}
+
+#[test]
+fn test_parse_without_cancellation_flag_works() {
+    let mut parser = Parser::new("my $x = 1; my $y = 2;");
+    let result = parser.parse();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_cancelled_error_display() {
+    let err = ParseError::Cancelled;
+    assert_eq!(err.to_string(), "Parsing cancelled");
+}
+
+#[test]
+fn test_cancellation_in_nested_blocks() {
+    let flag = Arc::new(AtomicBool::new(true));
+    let mut source = String::from("{\n");
+    for i in 0..200 {
+        source.push_str(&format!("  my $x{} = {};\n", i, i));
+    }
+    source.push('}');
+    let mut parser = Parser::new_with_cancellation(&source, flag);
+    let result = parser.parse();
+    assert!(matches!(result, Err(ParseError::Cancelled)));
+}

--- a/crates/perl-parser/src/bin/perl-parse.rs
+++ b/crates/perl-parser/src/bin/perl-parse.rs
@@ -369,6 +369,9 @@ fn print_error(error: &ParseError, source: &str) {
         ParseError::NestingTooDeep { depth, max_depth } => {
             writeln!(stderr, "Parse error: Nesting too deep ({} > {})", depth, max_depth).ok();
         }
+        ParseError::Cancelled => {
+            writeln!(stderr, "Parse error: Parsing cancelled").ok();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds cooperative cancellation support to the recursive descent parser so the LSP can abort stale parse requests when the user types another character
- `Parser::new_with_cancellation(input, Arc<AtomicBool>)` accepts a shared flag; the parser checks it every 64 statements and returns `ParseError::Cancelled`
- Non-LSP usage is unaffected -- `Parser::new()` continues to work with no cancellation overhead

## Changes

- **perl-error**: New `ParseError::Cancelled` variant
- **perl-parser-core**: `cancellation_flag` field, `new_with_cancellation()` constructor, `check_cancelled()` method, checks in `parse_program` and `parse_block` loops
- **perl-lsp-diagnostics**, **perl-parser**: Updated exhaustive matches on `ParseError`
- 6 new tests covering cancellation behavior

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p perl-parser-core --lib` passes clean
- [x] All 404 existing lib tests pass
- [x] All 6 new cancellation tests pass
- [ ] Wire up to LSP text_sync.rs (separate PR)