### PR TITLE
fix(parser): resolve unexpected_comma_expr for builtin-comma patterns

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -520,7 +520,16 @@ impl<'a> Parser<'a> {
                             let is_nullary_without_args = Self::is_nullary_builtin(name)
                                 && self.peek_kind().is_some_and(Self::is_binary_operator);
 
-                            if self.is_at_statement_end() || is_nullary_without_args {
+                            // When a builtin is followed by a comma, it should be treated
+                            // as having no arguments.  The comma belongs to an enclosing
+                            // list context (e.g. `grep defined, @list`).
+                            let is_comma_terminated =
+                                self.peek_kind() == Some(TokenKind::Comma);
+
+                            if self.is_at_statement_end()
+                                || is_nullary_without_args
+                                || is_comma_terminated
+                            {
                                 // Bare builtin with no arguments
                                 expr = Node::new(
                                     NodeKind::FunctionCall { name: name.clone(), args: vec![] },


### PR DESCRIPTION
## Summary

- When a builtin function (`defined`, `length`, `ord`, `chomp`, etc.) is followed by a comma in expression context, treat it as having no arguments
- The comma belongs to the enclosing list context (e.g. `grep defined, @list` -- `defined` operates on `$_`, the comma separates grep's EXPR from the LIST)
- Fixes the most common sub-pattern in the `unexpected_comma_expr` error bucket (~113 corpus files)

## Changes

Single change in `postfix.rs`: add `is_comma_terminated` check alongside the existing `is_nullary_without_args` and `is_at_statement_end()` checks. When a builtin is followed by a comma, it produces a zero-argument function call node, allowing the comma to be consumed by the enclosing list/expression context.

## Test Results

Fixes 15 previously-failing tests in `fix_unexpected_comma_expr.rs`:
- Before: 24/45 passing
- After: 39/45 passing
- No regressions in the full `perl-parser-core` test suite

Remaining 6 failures are different sub-patterns (CORE:: prefix, file test ops in grep, `no warnings` multi-arg) that need separate fixes.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -p perl-parser-core --lib` passes clean
- [x] `cargo test -p perl-parser-core --test fix_unexpected_comma_expr` -- 39/45 pass (15 newly fixed)
- [x] Full `cargo test -p perl-parser-core` -- no regressions