### PR TITLE
fix(parser): resolve unclosed_brace errors in CPAN corpus

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1479,13 +1479,16 @@ impl<'a> PerlLexer<'a> {
                     let next_char = self.peek_char(1);
 
                     // Check if this is a dereference like @{$ref} or @{[...]}
-                    // If the next char suggests dereference, don't consume the brace
-                    if sigil != '*'
-                        && matches!(
+                    // If the next char suggests dereference, don't consume the brace.
+                    // For @ and % sigils, identifiers inside braces are also derefs
+                    // (e.g. @{Foo::Bar::baz} or %{Some::Hash}).
+                    let is_deref = sigil != '*'
+                        && (matches!(
                             next_char,
-                            Some('$' | '@' | '%' | '*' | '&' | '[' | ' ' | '\t' | '\n' | '\r')
-                        )
-                    {
+                            Some('$' | '@' | '%' | '*' | '&' | '[' | ' ' | '\t' | '\n' | '\r',)
+                        ) || (matches!(sigil, '@' | '%')
+                            && next_char.is_some_and(is_perl_identifier_start)));
+                    if is_deref {
                         // This is a dereference, don't consume the brace
                         let text = &self.input[start..self.position];
                         self.mode = LexerMode::ExpectOperator;

--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -404,6 +404,46 @@ impl<'a> Parser<'a> {
             module.push_str(&self.consume_token()?.text);
         }
 
+        // `use if CONDITION, MODULE [, ARGS]` and `use unless ...` are special:
+        // the condition is an arbitrary expression that may contain braces
+        // (e.g. `eval { ... }`), so we need brace-depth-aware token consumption.
+        if module == "if" || module == "unless" {
+            let mut cond_args = Vec::new();
+            let mut brace_depth: usize = 0;
+            while !self.tokens.is_eof() {
+                // At brace depth 0, stop at statement terminators
+                if brace_depth == 0 && Self::is_statement_terminator(self.peek_kind()) {
+                    break;
+                }
+                // At brace depth 0, commas separate arguments — consume the comma
+                // and continue to collect remaining args
+                if self.peek_kind() == Some(TokenKind::Comma) && brace_depth == 0 {
+                    self.consume_token()?; // consume ','
+                    continue;
+                }
+                match self.peek_kind() {
+                    Some(TokenKind::LeftBrace) => {
+                        brace_depth = brace_depth.saturating_add(1);
+                    }
+                    Some(TokenKind::RightBrace) => {
+                        brace_depth = brace_depth.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+                cond_args.push(self.consume_token()?.text.to_string());
+            }
+            let end = self.previous_position();
+            let has_filter_risk = Self::is_filter_module(&module);
+            return Ok(Node::new(
+                NodeKind::Use {
+                    module,
+                    args: cond_args,
+                    has_filter_risk,
+                },
+                SourceLocation { start, end },
+            ));
+        }
+
         // Parse optional import list
         let mut args = Vec::new();
 

--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -1,0 +1,84 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// --- @{Package::Name} dereference patterns ---
+
+#[test]
+fn test_array_deref_package_name() {
+    let source = r#"my @items = @{Foo::Bar::items};"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_array_deref_nested_package() {
+    let source = r#"my @list = @{Some::Deep::Package::list()};"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_hash_deref_package_name() {
+    let source = r#"my %data = %{Config::Data::hash};"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_array_deref_function_call() {
+    let source = r#"my @r = @{get_items()};"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_array_deref_simple_ident() {
+    let source = r#"my @r = @{arrayref};"#;
+    assert_clean_parse(source);
+}
+
+// --- use if / use unless with eval blocks ---
+
+#[test]
+fn test_use_if_eval_block() {
+    let source = r#"use if eval { require Foo; 1 }, 'Foo';"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_if_eval_block_complex() {
+    let source = r#"use if eval { require Some::Module; 1; }, 'Some::Module', qw(func1 func2);"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_if_simple_condition() {
+    let source = r#"use if $] >= 5.010, 'mro';"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_unless_condition() {
+    let source = r#"use unless $ENV{NO_FOO}, 'Foo::Bar';"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_if_negation() {
+    let source = r#"use if !$ENV{SKIP}, 'Module::Name';"#;
+    assert_clean_parse(source);
+}
+
+// --- Combined patterns from CPAN corpus ---
+
+#[test]
+fn test_mixed_deref_and_use_if() {
+    let source = r#"
+use if eval { require JSON::XS; 1 }, 'JSON::XS';
+my @keys = @{Some::Config::keys};
+my %opts = %{Default::Options::hash};
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_if_version_check() {
+    let source = r#"use if $] >= 5.008001, 'utf8';"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

Fixes two root causes of `unclosed_brace` errors in the CPAN corpus:

- **Lexer**: `@{Identifier}` and `%{Identifier}` were not recognized as dereferences when the character after `{` is a letter (identifier start). The lexer absorbed the brace into a combined token, causing downstream brace mismatch errors. Now correctly treats `@{Foo::Bar::baz}` and `%{Hash::name}` as dereference syntax.
- **Parser**: `use if eval { ... }, 'Module'` failed because semicolons inside eval blocks were treated as statement terminators, cutting off the `use` declaration prematurely. Added brace-depth-aware token consumption for `use if` and `use unless` pragmas.

## Changed files

- `crates/perl-lexer/src/lib.rs` — extend deref detection to recognize identifier-start chars after `{` for `@` and `%` sigils
- `crates/perl-parser-core/src/engine/parser/declarations.rs` — add early return path for `use if`/`use unless` with brace-depth tracking
- `crates/perl-parser-core/tests/unclosed_brace_tests.rs` — 12 new tests covering both fix categories

## Test plan

- [x] All 12 new tests pass (`cargo test -p perl-parser-core --test unclosed_brace_tests`)
- [x] `cargo clippy -p perl-lexer --tests` clean
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] `cargo test -p perl-lexer` all pass
- [x] `cargo test -p perl-parser-core` no regressions (1 pre-existing failure in `block_list_in_args_tests`)
- [ ] CI gate