### PR TITLE
fix(parser): handle keywords as barewords and compound assignment in declarations

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -718,6 +718,8 @@ impl<'a> Parser<'a> {
             // Control-flow keywords — allowed as barewords in expression context
             // (e.g. `if => 1` or `(for => 2)`)
             | TokenKind::If
+            | TokenKind::Elsif
+            | TokenKind::Else
             | TokenKind::Unless
             | TokenKind::While
             | TokenKind::Until
@@ -773,5 +775,4 @@ impl<'a> Parser<'a> {
             }
         }
     }
-
 }

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -28,6 +28,28 @@ impl<'a> Parser<'a> {
         matches!(kind, Some(TokenKind::Increment) | Some(TokenKind::Decrement))
     }
 
+    fn peek_compound_assign_op(&mut self) -> Option<&'static str> {
+        match self.peek_kind()? {
+            TokenKind::Assign => Some("="),
+            TokenKind::PlusAssign => Some("+="),
+            TokenKind::MinusAssign => Some("-="),
+            TokenKind::StarAssign => Some("*="),
+            TokenKind::SlashAssign => Some("/="),
+            TokenKind::PercentAssign => Some("%="),
+            TokenKind::DotAssign => Some(".="),
+            TokenKind::AndAssign => Some("&="),
+            TokenKind::OrAssign => Some("|="),
+            TokenKind::XorAssign => Some("^="),
+            TokenKind::PowerAssign => Some("**="),
+            TokenKind::LeftShiftAssign => Some("<<="),
+            TokenKind::RightShiftAssign => Some(">>="),
+            TokenKind::LogicalAndAssign => Some("&&="),
+            TokenKind::LogicalOrAssign => Some("||="),
+            TokenKind::DefinedOrAssign => Some("//="),
+            _ => None,
+        }
+    }
+
     #[inline]
     fn is_variable_sigil(kind: Option<TokenKind>) -> bool {
         matches!(
@@ -414,7 +436,6 @@ impl<'a> Parser<'a> {
         &self.errors
     }
 
-
     /// Expect a closing delimiter, recovering gracefully if missing.
     /// Records error and returns Ok(()) at sync points instead of Err.
     fn expect_closing_delimiter(&mut self, kind: TokenKind) -> ParseResult<()> {
@@ -469,13 +490,16 @@ impl<'a> Parser<'a> {
         match self.peek_kind() {
             Some(TokenKind::Semicolon) => true,
             Some(TokenKind::RightBrace) => true,
-            Some(TokenKind::My) | Some(TokenKind::Our) | Some(TokenKind::Local) | Some(TokenKind::State) => true,
+            Some(TokenKind::My)
+            | Some(TokenKind::Our)
+            | Some(TokenKind::Local)
+            | Some(TokenKind::State) => true,
             Some(TokenKind::Sub) | Some(TokenKind::Package) | Some(TokenKind::Use) => true,
             Some(TokenKind::If) | Some(TokenKind::Unless) => true,
             Some(TokenKind::Elsif) | Some(TokenKind::Else) => true,
             Some(TokenKind::While) | Some(TokenKind::Until) => true,
             Some(TokenKind::For) | Some(TokenKind::Foreach) => true,
-            None => true,  // EOF is a sync point
+            None => true, // EOF is a sync point
             _ => false,
         }
     }
@@ -511,7 +535,13 @@ impl<'a> Parser<'a> {
     }
 
     /// Create an error node and record the error
-    fn recover_from_error(&mut self, message: String, expected: String, found: String, location: usize) -> Node {
+    fn recover_from_error(
+        &mut self,
+        message: String,
+        expected: String,
+        found: String,
+        location: usize,
+    ) -> Node {
         // Record the error
         let error = ParseError::unexpected(expected, found, location);
         self.record_error(error);
@@ -519,15 +549,10 @@ impl<'a> Parser<'a> {
         // Create error node
         let end = self.current_position();
         let found_token = self.tokens.peek().ok().cloned();
-        
+
         Node::new(
-            NodeKind::Error {
-                message,
-                expected: vec![],
-                found: found_token,
-                partial: None,
-            },
-            SourceLocation { start: location, end }
+            NodeKind::Error { message, expected: vec![], found: found_token, partial: None },
+            SourceLocation { start: location, end },
         )
     }
 
@@ -570,15 +595,10 @@ impl<'a> Parser<'a> {
     fn create_error_node(&mut self, message: String, expected: Vec<TokenKind>) -> Node {
         let start = self.current_position();
         let found = self.tokens.peek().ok().cloned();
-        
+
         Node::new(
-            NodeKind::Error {
-                message,
-                expected,
-                found,
-                partial: None,
-            },
-            SourceLocation { start, end: start }
+            NodeKind::Error { message, expected, found, partial: None },
+            SourceLocation { start, end: start },
         )
     }
 
@@ -640,9 +660,13 @@ impl<'a> Parser<'a> {
 
         match next.kind {
             // Sigiled variables: `func $x`, `func @arr`, `func %hash`
-            TokenKind::Identifier if next.text.starts_with('$')
-                || next.text.starts_with('@')
-                || next.text.starts_with('%') => true,
+            TokenKind::Identifier
+                if next.text.starts_with('$')
+                    || next.text.starts_with('@')
+                    || next.text.starts_with('%') =>
+            {
+                true
+            }
             TokenKind::ScalarSigil | TokenKind::ArraySigil | TokenKind::HashSigil => true,
 
             // `func other_func(args)` — identifier followed by `(`
@@ -718,8 +742,7 @@ impl<'a> Parser<'a> {
             | TokenKind::WordOr     // sub or { ... }
             | TokenKind::WordNot    // sub not { ... }
             | TokenKind::WordXor    // sub xor { ... }
-            | TokenKind::StringCompare  // sub cmp { ... }
+            | TokenKind::StringCompare // sub cmp { ... }
         )
     }
-
 }

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -105,9 +105,26 @@ impl<'a> Parser<'a> {
                 attributes.push(attr_token.text.to_string());
             }
 
-            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_expression()?))
+            // Accept both simple `=` and compound operators (`||=`, `//=`, `.=`, etc.)
+            // Perl allows `our $x ||= 0;` and `my $y .= "suffix";`
+            let assign_op = self.peek_compound_assign_op();
+            let initializer = if let Some(op) = assign_op {
+                self.tokens.next()?;
+                let rhs = self.parse_expression()?;
+                if op == "=" {
+                    Some(Box::new(rhs))
+                } else {
+                    let var_clone = variable.clone();
+                    let assign_end = rhs.location.end;
+                    Some(Box::new(Node::new(
+                        NodeKind::Assignment {
+                            op: op.to_string(),
+                            lhs: Box::new(var_clone),
+                            rhs: Box::new(rhs),
+                        },
+                        SourceLocation { start: variable.location.start, end: assign_end },
+                    )))
+                }
             } else {
                 None
             };
@@ -245,10 +262,7 @@ impl<'a> Parser<'a> {
             // Create an identifier node for the captured name
             let mut inner = Node::new(
                 NodeKind::Identifier { name: inner_name.to_string() },
-                SourceLocation {
-                    start: inner_start,
-                    end: inner_end,
-                },
+                SourceLocation { start: inner_start, end: inner_end },
             );
 
             // Parse postfix chain (handles function call parens, method calls, etc.)
@@ -271,21 +285,14 @@ impl<'a> Parser<'a> {
         // Handle $#$ref — last index of dereferenced array
         // The lexer sends `$#` as Identifier("$#"), so sigil="$" name="#"
         if sigil == "$" && full_name == "#" {
-            let next_is_var = self
-                .tokens
-                .peek()
-                .ok()
-                .is_some_and(|t| t.text.starts_with('$'));
+            let next_is_var = self.tokens.peek().ok().is_some_and(|t| t.text.starts_with('$'));
             let next_is_sigil = self.peek_kind() == Some(TokenKind::ScalarSigil);
             if next_is_var || next_is_sigil {
                 // $#$ref — parse the inner variable and wrap
                 let inner = self.parse_variable()?;
                 let inner_end = inner.location.end;
                 return Ok(Node::new(
-                    NodeKind::Unary {
-                        op: "$#".to_string(),
-                        operand: Box::new(inner),
-                    },
+                    NodeKind::Unary { op: "$#".to_string(), operand: Box::new(inner) },
                     SourceLocation { start: token.start, end: inner_end },
                 ));
             } else if self.peek_kind() == Some(TokenKind::LeftBrace) {
@@ -295,10 +302,7 @@ impl<'a> Parser<'a> {
                 self.expect(TokenKind::RightBrace)?;
                 let brace_end = self.previous_position();
                 return Ok(Node::new(
-                    NodeKind::Unary {
-                        op: "$#".to_string(),
-                        operand: Box::new(inner),
-                    },
+                    NodeKind::Unary { op: "$#".to_string(), operand: Box::new(inner) },
                     SourceLocation { start: token.start, end: brace_end },
                 ));
             }
@@ -466,14 +470,8 @@ impl<'a> Parser<'a> {
                                 }
 
                                 (format!("#{}", var_name), var_end)
-                            } else if matches!(
-                                self.peek_kind(),
-                                Some(TokenKind::ScalarSigil)
-                            ) || self
-                                .tokens
-                                .peek()
-                                .ok()
-                                .is_some_and(|t| t.text.starts_with('$'))
+                            } else if matches!(self.peek_kind(), Some(TokenKind::ScalarSigil))
+                                || self.tokens.peek().ok().is_some_and(|t| t.text.starts_with('$'))
                             {
                                 // $#$ref — last index of dereferenced array
                                 // Parse the inner variable expression
@@ -577,10 +575,7 @@ impl<'a> Parser<'a> {
         while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
             args.push(self.parse_expression()?);
             // Accept both comma and fat arrow as separators
-            if matches!(
-                self.peek_kind(),
-                Some(TokenKind::Comma | TokenKind::FatArrow)
-            ) {
+            if matches!(self.peek_kind(), Some(TokenKind::Comma | TokenKind::FatArrow)) {
                 self.consume_token()?;
             } else if self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
                 return Err(ParseError::syntax(
@@ -752,9 +747,7 @@ impl<'a> Parser<'a> {
                     | TokenKind::SubSigil
                     | TokenKind::GlobSigil => true,
                     // Sigils: peek past to distinguish prototype ($;@%) from signature ($x, @rest)
-                    TokenKind::ScalarSigil
-                    | TokenKind::ArraySigil
-                    | TokenKind::HashSigil => {
+                    TokenKind::ScalarSigil | TokenKind::ArraySigil | TokenKind::HashSigil => {
                         match self.tokens.peek_third() {
                             Ok(third) => !matches!(third.kind, TokenKind::Identifier),
                             Err(_) => true, // default to prototype on error
@@ -809,7 +802,6 @@ impl<'a> Parser<'a> {
 
         Ok(prototype)
     }
-
 }
 
 #[cfg(test)]
@@ -964,12 +956,7 @@ mod code_dereference_tests {
     fn assert_no_errors(code: &str) {
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
-        assert!(
-            !sexp.contains("ERROR"),
-            "Parse of `{}` produced ERROR nodes: {}",
-            code,
-            sexp,
-        );
+        assert!(!sexp.contains("ERROR"), "Parse of `{}` produced ERROR nodes: {}", code, sexp,);
     }
 
     #[test]
@@ -980,11 +967,7 @@ mod code_dereference_tests {
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
         // Should contain the &{} operator and a function call structure
-        assert!(
-            sexp.contains("&{}"),
-            "Expected &{{}} dereference in sexp, got: {}",
-            sexp,
-        );
+        assert!(sexp.contains("&{}"), "Expected &{{}} dereference in sexp, got: {}", sexp,);
     }
 
     #[test]
@@ -994,16 +977,8 @@ mod code_dereference_tests {
         assert_no_errors(code);
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
-        assert!(
-            sexp.contains("&{}"),
-            "Expected &{{}} dereference in sexp, got: {}",
-            sexp,
-        );
-        assert!(
-            sexp.contains("arg"),
-            "Expected argument in sexp, got: {}",
-            sexp,
-        );
+        assert!(sexp.contains("&{}"), "Expected &{{}} dereference in sexp, got: {}", sexp,);
+        assert!(sexp.contains("arg"), "Expected argument in sexp, got: {}", sexp,);
     }
 
     #[test]
@@ -1013,16 +988,8 @@ mod code_dereference_tests {
         assert_no_errors(code);
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
-        assert!(
-            sexp.contains("&{}"),
-            "Expected &{{}} dereference in sexp, got: {}",
-            sexp,
-        );
-        assert!(
-            sexp.contains("callback"),
-            "Expected 'callback' key in sexp, got: {}",
-            sexp,
-        );
+        assert!(sexp.contains("&{}"), "Expected &{{}} dereference in sexp, got: {}", sexp,);
+        assert!(sexp.contains("callback"), "Expected 'callback' key in sexp, got: {}", sexp,);
     }
 
     #[test]
@@ -1032,11 +999,7 @@ mod code_dereference_tests {
         assert_no_errors(code);
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
-        assert!(
-            sexp.contains("call"),
-            "Expected function call in sexp, got: {}",
-            sexp,
-        );
+        assert!(sexp.contains("call"), "Expected function call in sexp, got: {}", sexp,);
     }
 
     #[test]
@@ -1057,11 +1020,7 @@ mod code_dereference_tests {
         assert_no_errors(code);
         let ast = parse_program(code);
         let sexp = ast.to_sexp();
-        assert!(
-            sexp.contains("&{}"),
-            "Expected &{{}} dereference in sexp, got: {}",
-            sexp,
-        );
+        assert!(sexp.contains("&{}"), "Expected &{{}} dereference in sexp, got: {}", sexp,);
     }
 
     #[test]
@@ -1088,10 +1047,7 @@ mod code_dereference_tests {
                 // First arg is the Unary dereference node (&{$coderef}),
                 // remaining args are the actual arguments (may be combined into
                 // a single list node depending on comma parsing)
-                assert!(
-                    !args.is_empty(),
-                    "Expected at least 1 arg (the deref node)",
-                );
+                assert!(!args.is_empty(), "Expected at least 1 arg (the deref node)",);
                 // First arg should be the Unary &{} dereference
                 assert_eq!(
                     args.first().map(|a| a.kind.kind_name()),

--- a/crates/perl-parser-core/tests/keywords_as_barewords_tests.rs
+++ b/crates/perl-parser-core/tests/keywords_as_barewords_tests.rs
@@ -1,0 +1,42 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_else_as_hash_key() {
+    assert_clean_parse(r#"my %h = (else => 1);"#);
+}
+
+#[test]
+fn test_elsif_as_hash_key() {
+    assert_clean_parse(r#"my %h = (elsif => 1);"#);
+}
+
+#[test]
+fn test_do_as_hash_key() {
+    assert_clean_parse(r#"my %h = (do => 1);"#);
+}
+
+#[test]
+fn test_eval_as_hash_key() {
+    assert_clean_parse(r#"my %h = (eval => 1);"#);
+}
+
+#[test]
+fn test_require_as_hash_key() {
+    assert_clean_parse(r#"my %h = (require => "foo");"#);
+}
+
+#[test]
+fn test_glob_assignment_special_var() {
+    assert_clean_parse(r#"*ARG = *_ ;"#);
+}
+
+#[test]
+fn test_print_method_call() {
+    assert_clean_parse(r#"$fh->print("hello");"#);
+}
+
+#[test]
+fn test_postfix_if_after_increment() {
+    assert_clean_parse(r#"$count++ if $enabled;"#);
+}

--- a/crates/perl-parser-core/tests/scan_errors.rs
+++ b/crates/perl-parser-core/tests/scan_errors.rs
@@ -1,0 +1,27 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_our_or_assign() {
+    assert_clean_parse(r#"our $Verbose ||= 0;"#);
+}
+
+#[test]
+fn test_our_defined_or_assign() {
+    assert_clean_parse(r#"our $DYNAMIC_FILE_UPLOAD ||= 0;"#);
+}
+
+#[test]
+fn test_my_dotassign() {
+    assert_clean_parse(r#"my $result .= "hello";"#);
+}
+
+#[test]
+fn test_eval_block_and_operator() {
+    assert_clean_parse(r#"eval { 1 } && print("ok");"#);
+}
+
+#[test]
+fn test_do_block_or_die() {
+    assert_clean_parse(r#"do { require "config.pl" } || die "failed";"#);
+}


### PR DESCRIPTION
## Summary

- Add `else` and `elsif` to the barewords list in `parse_primary_inner` so they can be used as hash keys (e.g. `else => 1`, `elsif => "value"`)
- Add `peek_compound_assign_op()` helper method for recognizing all assignment operators (`=`, `+=`, `||=`, `//=`, `.=`, etc.)
- Modify `parse_variable_declaration()` to accept compound assignment operators, enabling `our $x ||= 0` and `my $y .= "suffix"`
- Add 13 regression tests covering both fixes

Addresses sub-categories from the `unexpected_token_in_expr` error bucket (#2189):
- Keywords as barewords (~10 files)
- Compound assignment in declarations (~14 files)

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo test -p perl-parser-core --test keywords_as_barewords_tests` (8 tests pass)
- [x] `cargo test -p perl-parser-core --test scan_errors` (5 tests pass)
- [x] No new clippy warnings introduced