### PR TITLE
fix(parser): resolve multiple small CPAN corpus error buckets

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -547,6 +547,31 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
+        // Handle anonymous sub as use argument: use Filter::Simple sub { ... };
+        else if self.peek_kind() == Some(TokenKind::Sub) {
+            args.push(self.consume_token()?.text.to_string()); // consume 'sub'
+            if self.peek_kind() == Some(TokenKind::LeftBrace) {
+                let mut depth: u32 = 0;
+                while !self.tokens.is_eof() {
+                    match self.peek_kind() {
+                        Some(TokenKind::LeftBrace) => {
+                            depth = depth.saturating_add(1);
+                            args.push(self.consume_token()?.text.to_string());
+                        }
+                        Some(TokenKind::RightBrace) => {
+                            args.push(self.consume_token()?.text.to_string());
+                            depth = depth.saturating_sub(1);
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        _ => {
+                            args.push(self.consume_token()?.text.to_string());
+                        }
+                    }
+                }
+            }
+        }
         // Handle bare arguments (no parentheses)
         else if matches!(self.peek_kind(), Some(k) if matches!(k, TokenKind::String | TokenKind::Identifier | TokenKind::Minus | TokenKind::QuoteWords))
             && !Self::is_statement_terminator(self.peek_kind())

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -650,6 +650,10 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::Until)
                 | Some(TokenKind::For)
                 | Some(TokenKind::Foreach)
+                | Some(TokenKind::WordAnd)
+                | Some(TokenKind::WordOr)
+                | Some(TokenKind::WordXor)
+                | Some(TokenKind::WordNot)
                 | Some(TokenKind::Eof)
                 | None
         )

--- a/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
@@ -89,6 +89,37 @@ impl<'a> Parser<'a> {
                         SourceLocation { start, end },
                     ));
                 }
+                // Handle 'not' keyword as a unary prefix at expression level.
+                // This lets `$a && not $b` parse correctly.
+                TokenKind::WordNot => {
+                    let op_token = self.tokens.next()?;
+                    let start = op_token.start;
+
+                    if self.tokens.is_eof() || self.is_at_statement_end() {
+                        let end = op_token.end;
+                        return Ok(Node::new(
+                            NodeKind::Unary {
+                                op: op_token.text.to_string(),
+                                operand: Box::new(Node::new(
+                                    NodeKind::Undef,
+                                    SourceLocation { start: end, end },
+                                )),
+                            },
+                            SourceLocation { start, end },
+                        ));
+                    }
+
+                    let operand = self.parse_unary()?;
+                    let end = operand.location.end;
+
+                    return Ok(Node::new(
+                        NodeKind::Unary {
+                            op: op_token.text.to_string(),
+                            operand: Box::new(operand),
+                        },
+                        SourceLocation { start, end },
+                    ));
+                }
                 TokenKind::Not | TokenKind::Backslash | TokenKind::BitwiseNot | TokenKind::Star => {
                     let op_token = self.tokens.next()?;
                     let start = op_token.start;

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -140,7 +140,8 @@ impl<'a> Parser<'a> {
 
             // Variable declarations
             TokenKind::My | TokenKind::Our | TokenKind::State => {
-                self.parse_variable_declaration()
+                let decl = self.parse_variable_declaration()?;
+                Ok(self.parse_word_or_expr(decl)?)
             }
             // `field` is a variable declarator only in Perl 5.38+ class bodies.
             // In legacy code it is commonly a regular identifier (function call,
@@ -149,7 +150,8 @@ impl<'a> Parser<'a> {
             // identifier), treat it as a declaration; otherwise fall through
             // to expression parsing.
             TokenKind::Field if self.is_field_declaration_context() => {
-                self.parse_variable_declaration()
+                let decl = self.parse_variable_declaration()?;
+                Ok(self.parse_word_or_expr(decl)?)
             }
             TokenKind::Local => self.parse_local_statement(),
 

--- a/crates/perl-parser-core/tests/small_bucket_fixes_tests.rs
+++ b/crates/perl-parser-core/tests/small_bucket_fixes_tests.rs
@@ -1,0 +1,82 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn not_after_logical_and() {
+    assert_clean_parse(r#"my $x = $a && not $b;"#);
+}
+
+#[test]
+fn not_after_method_logical_and() {
+    assert_clean_parse(r#"my $x = $obj->flag && not $disabled;"#);
+}
+
+#[test]
+fn not_after_word_and() {
+    assert_clean_parse(r#"$x and not $y;"#);
+}
+
+#[test]
+fn not_in_parenthesized_expr() {
+    assert_clean_parse(r#"my $x = (not $flag);"#);
+}
+
+#[test]
+fn not_in_complex_expr() {
+    assert_clean_parse(r#"if ($a && not $b || $c) { 1; }"#);
+}
+
+#[test]
+fn not_with_if_modifier() {
+    assert_clean_parse(r#"die "error" if not $ok;"#);
+}
+
+#[test]
+fn filetest_and_return() {
+    assert_clean_parse(r#"sub f { -r and return $_; }"#);
+}
+
+#[test]
+fn our_var_and_warn() {
+    assert_clean_parse(r#"our $DEBUG and warn "debugging";"#);
+}
+
+#[test]
+fn my_var_and_expr() {
+    assert_clean_parse(r#"my $ok = 1 and warn "assigned";"#);
+}
+
+#[test]
+fn method_and_return_in_sub() {
+    assert_clean_parse(r#"sub check { $self->valid or return; }"#);
+}
+
+#[test]
+fn use_filter_simple_sub() {
+    assert_clean_parse(r#"use Filter::Simple sub { $_ = lc $_; };"#);
+}
+
+#[test]
+fn use_module_sub_block() {
+    assert_clean_parse(r#"use My::Module sub { my $x = 1; return $x; };"#);
+}
+
+#[test]
+fn subst_after_or() {
+    assert_clean_parse(r#"$x or s/foo/bar/;"#);
+}
+
+#[test]
+fn subst_after_and() {
+    assert_clean_parse(r#"$x and s/foo/bar/;"#);
+}
+
+#[test]
+fn basic_or_and_not() {
+    assert_clean_parse(r#"$a or $b and not $c;"#);
+}
+
+#[test]
+fn open_or_die() {
+    assert_clean_parse(r#"open my $fh, '<', $file or die "Cannot open: $!";"#);
+}


### PR DESCRIPTION
## Summary

Fix 4 root causes across 5 CPAN error buckets:

- **unexpected_word_op_not**: Add `WordNot` to `parse_unary()` so `not` works as a prefix in higher-precedence contexts like `$a && not $b`
- **unexpected_word_op_or/and**: Add `WordAnd`/`WordOr`/`WordXor`/`WordNot` to `is_at_statement_end()` so file test operators and named unaries stop consuming at word operators (e.g., `-r and return $_`)
- **Variable declarations + word ops**: Wrap `my`/`our`/`state`/`field` declaration parsing with `parse_word_or_expr()` so `our $DEBUG and warn "msg"` parses correctly
- **unexpected_rbrace_expr (use + sub block)**: Handle `use Module sub { ... };` by consuming anonymous sub blocks in `parse_use()`

## Test plan

- [x] 16 new tests in `small_bucket_fixes_tests.rs` covering all fixed patterns
- [x] 404 lib tests pass (no regressions)
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [ ] CI gate