### PR TITLE
fix(parser): handle v-strings in expression and comparison contexts

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -59,6 +59,14 @@ impl<'a> Parser<'a> {
                 ))
             }
 
+            TokenKind::VString => {
+                let token = self.tokens.next()?;
+                Ok(Node::new(
+                    NodeKind::String { value: token.text.to_string(), interpolated: false },
+                    SourceLocation { start: token.start, end: token.end },
+                ))
+            }
+
             TokenKind::String => {
                 let token = self.tokens.next()?;
                 // Check if it's a double-quoted string (interpolated)

--- a/crates/perl-parser-core/tests/vstring_tests.rs
+++ b/crates/perl-parser-core/tests/vstring_tests.rs
@@ -1,0 +1,20 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_use_vstring() {
+    let source = r#"use v5.38.0;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_vstring_in_expression() {
+    let source = r#"my $v = v1.2.3;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_vstring_comparison() {
+    let source = r#"$^V ge v5.10.0"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

- Add `TokenKind::VString` as a primary expression in the parser, producing a `String` node
- Fixes parse errors for v-string literals used outside of `use` declarations (e.g., `my $v = v1.2.3;`, `$^V ge v5.10.0`)
- The lexer already tokenizes v-strings correctly; only the expression parser needed the new case

Closes #2269

## Test plan

- [x] `test_use_vstring` — `use v5.38.0;` parses cleanly
- [x] `test_vstring_in_expression` — `my $v = v1.2.3;` parses cleanly
- [x] `test_vstring_comparison` — `$^V ge v5.10.0` parses cleanly
- [x] All 404 existing perl-parser-core lib tests pass