### PR TITLE
fix(swarm): remove disable-model-invocation from orchestrator entry point

### DIFF
--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -1,7 +1,6 @@
 ---
 description: Start a continuous swarm with agent teams for parallel codebase improvement
 argument-hint: "[focus] e.g. 'all', 'parser', 'dap', 'tests', 'cleanup', 'improve'"
-disable-model-invocation: true
 ---
 
 # Swarm: Continuous Agent Team


### PR DESCRIPTION
## Summary
- Remove `disable-model-invocation: true` from `/swarm` command frontmatter
- `/swarm` is the orchestrator's own entry point — it says "You are the lead" which addresses the model directly
- Having `disable-model-invocation` blocks the exact workflow it's designed for

## Context
When the user types `/swarm all`, the model tries to invoke the skill. But `disable-model-invocation` prevents this, forcing a manual bootstrap fallback. This is self-contradictory since the orchestrator IS the model.

## Test plan
- [x] Verified `/swarm` now appears in model-invocable skill list
- [x] No code changes — only `.claude/commands/swarm.md` frontmatter