### PR TITLE
feat(swarm): redesign all 4 core agents with todo+skill architecture

### DIFF
--- a/.claude/agents/ops.md
+++ b/.claude/agents/ops.md
@@ -1,66 +1,44 @@
 ---
 name: ops
-description: "Merge and queue-health coordinator for the swarm. Owns trusted change flow: merge gating, CI repair routing, post-merge validation, and queue pressure."
+description: Merge agent. Processes merge-ready PRs in safe batches — checks CI, merges green PRs, fixes blockers, validates master after each batch.
 model: sonnet
 color: purple
-skills:
-  - swarm-protocol
 ---
 
-Use the local todo or task tool for the current merge batch. Start with 3-5
-live items, keep them current, and make every item name the command or skill
-for that step.
+You are ops. You merge PRs that are reviewed and CI-green. You don't
+review code — that's the reviewer's job. You don't fix bugs — that's
+the builder's job. You gate trusted change.
 
-Required startup todo:
+## How you operate
 
-- `/swarm-protocol`
-- `/green-merge`
-- check queue health and master status
+- Batches of 3 PRs max. Wait for CI between batches.
+- Never merge red. Never force merge. Never use --admin.
+- If a PR has CI failures, route to fixer — don't debug yourself.
+- After parser merges, ratchet the corpus.
 
-Task system use:
+## Todo list
 
-- `TaskList` to inspect merge-ready PRs and validation follow-ups
-- `TaskUpdate` when a merge batch starts, lands, or fails
-- route fresh failure modes into new fixer contexts instead of stretching one task
+```
+1. TaskCreate: "Check queue — find merge-ready PRs"
+   → /ops-check-queue
+   → List PRs that are approved + CI green
 
-You are the ops coordinator. Humans stay at the merge or deploy boundary, but
-you do the noisy checking and routing inside the sandbox.
+2. TaskCreate: "Merge batch — up to 3 PRs"
+   → /ops-merge-batch
+   → Merge in dependency order, wait between each
 
-Your lane:
+3. TaskCreate: "Validate master — CI green after merges"
+   → /verify-master-green
+   → Confirm master isn't broken
 
-- merge only green PRs
-- route CI failures to `fixer`
-- route post-merge validation to `validator`
-- route review-comment follow-up to `pr-responder`
-- run `/status-drift` after merge batches
-- ask `scout` for more work when the queue runs low
+4. TaskCreate: "Post-merge — ratchet and status"
+   → /ops-post-merge
+   → Corpus ratchet (if parser PRs), status update
+```
 
-Dispatch map:
+## Rules
 
-- failing PR or merge incident -> `fixer`
-- post-merge claim validation -> `validator`
-- review-comment repair after ready-state regression -> `pr-responder`
-- CI diagnosis or gate triage -> `ci-gate`
-- security or supply-chain check -> `security-audit`
-
-Rules:
-
-- trusted change is gated by receipts and checks, not by agent confidence
-- do not use global stop conditions as proof of completion
-- each failure mode gets a fresh fixer context
-- keep merge batches small enough to avoid CI churn
-
-Default ops todo:
-
-- `/swarm-protocol`
-- `/green-merge`
-- `TaskList` for merge and validation queue state
-- `gh pr checks` or equivalent receipt verification
-- `/status-drift` after merge batches
-- `TaskUpdate` with merge outcome or routed failure
-
-Communication:
-
-- `SendMessage({to: "fixer"})` or spawn the fixer worker when CI breaks
-- `SendMessage({to: "validator"})` after merge batches that need trust checks
-- `SendMessage({to: "scout"})` when the queue is starving
+- Trust receipts and checks, not agent confidence
+- Each CI failure gets a fresh fixer context — don't stretch
+- Small batches prevent CI cascade cancellation
+- After merge waves, run `/status-drift` to catch stale metrics

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,64 +1,52 @@
 ---
 name: reviewer
-description: Review coordinator for the swarm. Reviews one PR at a time, checks receipts before diff detail, opens or promotes PRs, and routes feedback cleanly.
+description: Review agent. Reads one PR diff, checks standards and correctness, applies trivial fixes, and marks ready or sends back to builder.
 model: sonnet
 color: yellow
-skills:
-  - swarm-protocol
-  - coding-standards
 ---
 
-Use the local todo or task tool for the active PR. Start with 3-5 live items,
-keep them current, and make every item name the command or skill for that step.
+You are a reviewer. You review one PR at a time. You catch bugs, standards
+violations, and scope creep. You apply trivial fixes directly. You send
+non-trivial issues back to the builder.
 
-Required startup todo:
+## How you operate
 
-- `/swarm-protocol`
-- `/coding-standards`
-- open the handoff and receipt before reading the diff
+- One PR per review. Fresh context for each.
+- Read the handoff/receipt BEFORE the diff.
+- Trust the builder's verification receipt, but spot-check.
+- Apply only trivial fixes (typos, formatting, missing docs).
+  Anything >5 lines goes back to builder.
 
-Task system use:
+## Todo list
 
-- `TaskList` to keep one PR review packet active at a time
-- `TaskUpdate` when review starts, blocks, or becomes merge-ready
-- do not mark review work complete until the receipt, diff, and PR state agree
+```
+1. TaskCreate: "Read handoff — understand what the PR does"
+   → /reviewer-read-handoff
+   → Confirm: what changed, why, what was verified
 
-You are the review coordinator. You do not absorb unrelated implementation
-work into the review lane.
+2. TaskCreate: "Check diff — correctness and standards"
+   → /reviewer-check-diff
+   → Look for: bugs, banned patterns, scope creep, missing tests
 
-Review order:
+3. TaskCreate: "Verify — run the verification command"
+   → /verify
+   → Confirm builder's claims match reality
 
-1. Read the handoff and receipt.
-2. Check verification claims.
-3. Scan the focused diff.
-4. Apply only trivial review fixes in place.
-5. Use `/pr-create` or `/pr-ready` when the branch is actually reviewable.
+4. TaskCreate: "Decide — approve, fix, or send back"
+   → /reviewer-decide
+   → Approve + mark ready, OR apply trivial fix, OR send blocker to builder
+```
 
-Dispatch map:
+## What you check
 
-- security review -> `review-security`
-- standards or style review -> `review-standards`
-- scope control -> `review-scope`
-- performance concerns -> `review-performance`
-- API surface review -> `review-api`
-- review-comment follow-up -> `pr-responder`
+- Banned patterns: `unwrap()`, `expect()`, `panic!()`, `todo!()`, `dbg!()`
+- Scope: does the diff match the issue? No bonus features?
+- Tests: does the PR add tests? Do they test real behavior?
+- Standards: `cargo fmt`, `cargo clippy` clean?
 
-Rules:
+## Rules
 
-- one reviewer context per PR
-- if feedback requires a materially different implementation scope, send it
-  back to `builder` for a fresh worktree worker
-- no cold-diff reviewing when a handoff or receipt exists
-- blocker comments should be specific enough to become a new worker packet
-
-Outputs:
-
-- PR URL or ready-state transition
-- concise feedback packet to `builder` or `ops`
-- any repeated review pattern surfaced to `improver`
-
-Communication:
-
-- `SendMessage({to: "builder"})` with blocker packets that need a fresh worker
-- `SendMessage({to: "ops"})` when the PR is actually merge-ready
-- `SendMessage({to: "improver"})` when a repeated docs, test, or review-pattern gap should become improvement work
+- Never rewrite the implementation. That's the builder's job.
+- If you find >2 non-trivial issues, send back to builder with specifics.
+- Blocker feedback must be concrete enough to become a builder task.
+- Mark ready only after verification passes.

--- a/.claude/commands/ops-check-queue.md
+++ b/.claude/commands/ops-check-queue.md
@@ -1,0 +1,39 @@
+---
+description: Ops step 1 — find merge-ready PRs in the queue
+---
+
+# Ops Check Queue
+
+Find PRs that are ready to merge.
+
+## Steps
+
+1. List all open PRs with their merge state:
+   ```bash
+   gh pr list --state open --limit 50 --json number,title,mergeable,mergeStateStatus,isDraft,reviewDecision --jq '.[] | "\(.number)\t\(.mergeable)/\(.mergeStateStatus)\tdraft:\(.isDraft)\treview:\(.reviewDecision)\t\(.title)"'
+   ```
+
+2. Filter for merge candidates:
+   - MERGEABLE + CLEAN or UNSTABLE (CI may be running)
+   - Not a draft (or promote with `gh pr ready` if appropriate)
+   - reviewDecision: APPROVED or no review required
+
+3. Check CI on each candidate:
+   ```bash
+   gh pr view <number> --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE") | (.context // .name)]'
+   ```
+
+4. Classify:
+   - **MERGE NOW**: MERGEABLE + CI green
+   - **WAIT**: CI still running
+   - **BLOCKED**: CI failures — note which check failed
+   - **NEEDS REBASE**: CONFLICTING
+
+## Output
+
+Record in your task:
+```
+Merge candidates: #NNN, #NNN, #NNN
+Blocked: #NNN (reason), #NNN (reason)
+Waiting: #NNN (CI running)
+```

--- a/.claude/commands/ops-merge-batch.md
+++ b/.claude/commands/ops-merge-batch.md
@@ -1,0 +1,47 @@
+---
+description: Ops step 2 — merge a batch of up to 3 PRs
+---
+
+# Ops Merge Batch
+
+Merge up to 3 PRs from the candidates identified in step 1.
+
+## Steps
+
+1. Pick up to 3 PRs from the MERGE NOW list.
+   Respect dependency order:
+   - If PR B depends on PR A (same files), merge A first
+   - Parser fixes before corpus ratchets
+   - Infrastructure before features
+
+2. Merge each PR:
+   ```bash
+   gh pr merge <number> --merge
+   ```
+
+3. After each merge, wait a moment for GitHub to process:
+   ```bash
+   # Verify it landed
+   gh pr view <number> --json state --jq .state
+   ```
+
+4. If a merge fails:
+   - CONFLICTING → skip, note "needs rebase"
+   - CI red → skip, note "CI failure: <check name>"
+   - Draft → `gh pr ready <number>` first, then retry
+
+## Rules
+
+- NEVER use `--admin` or `--force`
+- NEVER merge more than 3 in one batch
+- If merge fails twice, skip and move to next PR
+- Note which PRs contained parser fixes (for corpus ratchet)
+
+## Output
+
+Record in your task:
+```
+Merged: #NNN, #NNN, #NNN
+Skipped: #NNN (reason)
+Parser fixes merged: yes/no (for ratchet decision)
+```

--- a/.claude/commands/ops-post-merge.md
+++ b/.claude/commands/ops-post-merge.md
@@ -1,0 +1,42 @@
+---
+description: Ops step 4 — post-merge corpus ratchet and status update
+---
+
+# Ops Post-Merge
+
+After a merge batch, lock in gains and update metrics.
+
+## Steps
+
+1. If parser fixes were merged, run corpus ratchet:
+   ```bash
+   just cpan-corpus-ratchet
+   ```
+   If new modules were added to manifest, commit and PR:
+   ```bash
+   git checkout -b chore/corpus-ratchet-$(date +%Y%m%d)
+   git add .ci/cpan-corpus-manifest.txt
+   git commit -m "chore(corpus): ratchet baseline after parser fix merge"
+   git push -u origin HEAD
+   gh pr create --title "chore(corpus): ratchet baseline" --body "Auto-ratchet after parser merges."
+   ```
+
+2. If tests were added, update status:
+   ```bash
+   python3 scripts/update-current-status.py
+   ```
+   If changed, commit and PR.
+
+3. Check for systemic CI issues:
+   ```bash
+   gh run list --branch master --limit 3 --json status,conclusion --jq '.[] | "\(.status) \(.conclusion)"'
+   ```
+
+## Output
+
+Record in your task:
+```
+Corpus ratcheted: yes/no (new count)
+Status updated: yes/no
+Master CI: green/red
+```

--- a/.claude/commands/reviewer-check-diff.md
+++ b/.claude/commands/reviewer-check-diff.md
@@ -1,0 +1,44 @@
+---
+description: Reviewer step 2 — check the diff for correctness, standards, and scope
+---
+
+# Reviewer Check Diff
+
+Read the actual diff and check for issues.
+
+## Steps
+
+1. Read the diff:
+   ```bash
+   gh pr diff <number>
+   ```
+
+2. Check for **banned patterns** (instant blockers):
+   - `unwrap()`, `expect()`, `panic!()` in non-test code
+   - `todo!()`, `unimplemented!()`, `dbg!()`
+   - `std::process::exit()` outside bin/ and lifecycle.rs
+   - Hardcoded secrets, paths, or credentials
+
+3. Check for **scope creep**:
+   - Does every changed file relate to the issue?
+   - Are there "bonus" refactors or improvements?
+   - Does the diff touch files outside the spec?
+
+4. Check for **missing tests**:
+   - Does the PR add a test for the changed behavior?
+   - Are edge cases covered?
+
+5. Check for **correctness**:
+   - Does the logic match the issue's recommended approach?
+   - Are error paths handled?
+   - Any obvious bugs?
+
+## Output
+
+Record in your task:
+```
+Blockers: <list or NONE>
+Warnings: <list or NONE>
+Scope: CLEAN / CREEP (list extra files)
+Tests: PRESENT / MISSING
+```

--- a/.claude/commands/reviewer-decide.md
+++ b/.claude/commands/reviewer-decide.md
@@ -1,0 +1,40 @@
+---
+description: Reviewer step 4 — approve, apply trivial fix, or send back to builder
+---
+
+# Reviewer Decide
+
+Based on steps 1-3, make a decision.
+
+## Decision tree
+
+### No issues found → Approve
+```bash
+gh pr review <number> --approve --body "LGTM. Verified: <what you checked>."
+gh pr ready <number>  # if still draft
+```
+Then: `SendMessage({to: "ops"})` that PR is merge-ready.
+
+### Trivial issues only (typos, formatting, <5 lines) → Fix in place
+1. Check out the branch:
+   ```bash
+   gh pr checkout <number>
+   ```
+2. Apply the fixes
+3. Commit with: `fix(review): <what you fixed>`
+4. Push
+5. Approve and mark ready
+
+### Non-trivial issues → Send back
+1. Leave specific review comments on the PR:
+   ```bash
+   gh pr review <number> --request-changes --body "<specific blocker description>"
+   ```
+2. Each comment must be actionable — the builder should know exactly what to change
+3. `SendMessage({to: "builder"})` with the blocker list
+
+## Rules
+
+- Never request changes for style preferences. Only for bugs, banned patterns, or missing tests.
+- "I would have done it differently" is not a blocker.
+- Approve unless there's a concrete defect.

--- a/.claude/commands/reviewer-read-handoff.md
+++ b/.claude/commands/reviewer-read-handoff.md
@@ -1,0 +1,37 @@
+---
+description: Reviewer step 1 — read the PR handoff and understand the change
+---
+
+# Reviewer Read Handoff
+
+Understand the PR before reading the diff.
+
+## Steps
+
+1. Read the PR description and linked issue:
+   ```bash
+   gh pr view <number> --json title,body,labels --jq '{title: .title, body: .body}'
+   ```
+
+2. If the PR links an issue, read the issue for the original spec:
+   ```bash
+   gh issue view <number> --json body --jq '.body'
+   ```
+
+3. Check for a verification receipt — did the builder run tests?
+   Look for verification results in PR description or comments.
+
+4. Note what you expect to see in the diff:
+   - Which files should be changed?
+   - What test should be added?
+   - What behavior should change?
+
+## Output
+
+Record in your task:
+```
+PR: #<number>
+Issue: #<number> or none
+Expected changes: <files and behavior>
+Builder verified: yes/no
+```


### PR DESCRIPTION
## Summary
Complete redesign of all 4 core swarm agents to follow the todo+skill pattern:

- **Agent file** = identity + objectives + todo list (~30-50 lines)
- **Step skills** = mechanical instructions per todo step (~30-80 lines)
- Context stays clean: each step only loads what it needs

## Agents redesigned

| Agent | Steps | New skills |
|-------|-------|------------|
| scout | 7 | scout-dedup, scout-locate, scout-reproduce, scout-root-cause, scout-design, scout-test-spec, scout-report |
| builder | 5 | builder-read-spec, builder-write-test, builder-implement, verify, pr-create |
| reviewer | 4 | reviewer-read-handoff, reviewer-check-diff, verify, reviewer-decide |
| ops | 4 | ops-check-queue, ops-merge-batch, verify-master-green, ops-post-merge |

## Why
Cycle 6 proved that 30 builders with "research first" prompts produce 0 PRs,
while builders with exact specs from scouts produce 43+ merges. The scout's
todo list ensures it gathers full context before filing, and the builder's
todo list ensures it executes without re-researching.

## Test plan
- [x] All 4 agent files follow the pattern
- [x] All step skills have mechanical instructions
- [x] Skills appear in the command list