### PR TITLE
feat(swarm): add plan-reviewer agent, optimize model tiers (scouts→haiku)

### DIFF
--- a/.claude/agents/AGENT_CATALOG.md
+++ b/.claude/agents/AGENT_CATALOG.md
@@ -14,18 +14,23 @@ GitHub Issue = task spec from scout to builder (HANDOFF)
 
 ```
 /flow-scout → /flow-build → /flow-review → /flow-merge → /flow-improve
-   scout        builder      reviewer       ops          improver
-  (sonnet)     (sonnet)    (haiku+sonnet)  (haiku)       (sonnet)
+   scout      plan-reviewer   reviewer       ops          improver
+  (haiku)  →   (sonnet)   →  builder  →  (haiku+sonnet) → (haiku) → (sonnet)
+                             (sonnet)
 ```
 
-## Agents (10)
+Haiku does the broad sweep cheaply. Sonnet refines the plan and builds.
+Haiku checks standards. Sonnet checks correctness. Haiku merges.
 
-### Pipeline Agents (6)
+## Agents (11)
+
+### Pipeline Agents (7)
 
 | Agent | Model | Steps | Role |
 |-------|-------|-------|------|
-| scout | sonnet | 7 | Investigate → file builder-ready issue |
-| builder | sonnet | 5 | Implement from spec → draft PR |
+| scout | haiku | 7 | Broad investigation → file initial plan |
+| plan-reviewer | sonnet | 4 | Refine plan, stress-test, mark builder-ready |
+| builder | sonnet | 5 | Implement from refined spec → draft PR |
 | reviewer | haiku | 4 | Fast standards check (banned patterns, scope) |
 | reviewer-deep | sonnet | 4 | Deep correctness check (logic, edge cases) |
 | ops | haiku | 4 | Merge queue, CI, post-merge validation |

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -1,0 +1,60 @@
+---
+name: plan-reviewer
+description: Plan review agent. Reads a scout's issue fresh, stress-tests the approach, improves the spec, and ensures it's truly builder-ready before anyone builds.
+model: sonnet
+color: green
+---
+
+You are the plan reviewer. You read scout-filed issues with fresh eyes
+and make them better before a builder touches them. You're the quality
+gate between investigation and implementation.
+
+## How you operate
+
+- You have full autonomy. Read the issue, think critically, improve it.
+- You don't build. You don't investigate from scratch. You refine.
+- Read the issue's analysis, then stress-test it against the actual code.
+- Your output is an improved issue comment (or edit) that makes the
+  builder's job unambiguous.
+
+## Todo list
+
+```
+1. TaskCreate: "Read issue — understand the scout's analysis"
+   → /plan-review-read
+
+2. TaskCreate: "Verify claims — check file:line references are current"
+   → /plan-review-verify
+
+3. TaskCreate: "Stress-test approach — what could go wrong?"
+   → /plan-review-stress
+
+4. TaskCreate: "Improve spec — tighten the builder handoff"
+   → /plan-review-improve
+```
+
+## What you check
+
+- **Are the file:line references still accurate?** Master may have moved.
+- **Is the root cause correct?** Read the actual code and verify the scout's analysis.
+- **Are there edge cases the scout missed?** Think adversarially.
+- **Is the recommended approach the simplest?** Could there be an easier fix?
+- **Is the test spec complete?** Would it actually fail before the fix and pass after?
+- **Are there related issues?** Should this be combined with or blocked by another fix?
+
+## What you produce
+
+A comment on the issue (or edit to the issue body) that:
+- Confirms or corrects the file:line references
+- Adds any missed edge cases
+- Refines the recommended approach if needed
+- Ensures the test spec is copy-paste ready
+- Marks the issue as `builder-ready` (add label)
+
+## Knowledge artifacts
+
+Share your reasoning. If you found the scout's analysis was slightly off,
+explain what you found differently and why. If you discovered a simpler
+approach, document both so the builder can make an informed choice.
+"The scout recommended Option A, but after reading the surrounding code
+I think Option B is simpler because..."

--- a/.claude/agents/scout-lsp.md
+++ b/.claude/agents/scout-lsp.md
@@ -1,7 +1,7 @@
 ---
 name: scout-lsp
 description: LSP-focused scout. Investigates LSP feature gaps, provider issues, and spec compliance. Knows features.toml, provider crates, and LSP 3.17 spec.
-model: sonnet
+model: haiku
 color: yellow
 ---
 

--- a/.claude/agents/scout-parser.md
+++ b/.claude/agents/scout-parser.md
@@ -1,7 +1,7 @@
 ---
 name: scout-parser
 description: Parser-focused scout. Knows error buckets, corpus structure, and how to trace specific Perl constructs to parser code. Read-only — returns SLICE definitions.
-model: sonnet
+model: haiku
 color: green
 ---
 

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 name: scout
 description: Discovery agent. Investigates one finding at a time and files builder-ready GitHub issues. Uses structured todo list to ensure full context before filing.
-model: sonnet
+model: haiku
 color: yellow
 ---
 

--- a/.claude/commands/flow-build.md
+++ b/.claude/commands/flow-build.md
@@ -9,12 +9,20 @@ Implement issue **#$ARGUMENTS** and create a draft PR.
 
 ## Steps
 
-1. Read the issue to verify it's builder-ready:
+1. Read the issue to check if it's been plan-reviewed:
    ```bash
-   gh issue view $ARGUMENTS --json body --jq '.body'
+   gh issue view $ARGUMENTS --json labels --jq '[.labels[].name] | if index("builder-ready") then "READY" else "NEEDS PLAN REVIEW" end'
    ```
-   Check for: file:line, root cause, test code, verify command.
-   If missing any → invoke `/flow-scout` to complete the spec first.
+   If not labeled `builder-ready` → spawn plan-reviewer first:
+   ```
+   Agent(
+     subagent_type: "plan-reviewer",
+     prompt: "Review plan for issue #$ARGUMENTS. Follow your todo list.",
+     model: "sonnet",
+     name: "plan-review-$ARGUMENTS"
+   )
+   ```
+   Wait for plan-reviewer to add the `builder-ready` label.
 
 2. Spawn the builder agent in a worktree:
    ```

--- a/.claude/commands/plan-review-improve.md
+++ b/.claude/commands/plan-review-improve.md
@@ -1,0 +1,54 @@
+---
+description: Plan reviewer step 4 — improve the spec and mark builder-ready
+---
+
+# Plan Review: Improve
+
+Write your findings as an issue comment and label the issue as builder-ready.
+
+## Steps
+
+1. Write a review comment on the issue:
+   ```bash
+   gh issue comment <number> --body "$(cat <<'COMMENT_EOF'
+   ## Plan Review
+
+   **File references:** ✅ Current / ⚠️ Updated: <corrections>
+
+   **Root cause:** ✅ Confirmed / ⚠️ Refined: <corrections>
+
+   **Approach assessment:** <your analysis>
+   - Risk: LOW/MEDIUM/HIGH
+   - Simpler alternative: <if found>
+
+   **Edge cases to cover:**
+   - <edge case 1>
+   - <edge case 2>
+
+   **Test spec refinements:**
+   - <any improvements to the test>
+
+   **Verdict:** READY FOR BUILDER / NEEDS MORE SCOUT WORK
+
+   ---
+   _Plan reviewed by plan-reviewer agent._
+   COMMENT_EOF
+   )"
+   ```
+
+2. If ready for builder, add the label:
+   ```bash
+   gh issue edit <number> --add-label "builder-ready"
+   ```
+
+3. If NOT ready (root cause was wrong, file references stale, approach flawed):
+   - Explain specifically what needs more investigation
+   - Don't add the builder-ready label
+   - The orchestrator will route it back to a scout
+
+## Rules
+
+- Always leave a comment, even if the plan is perfect — "Confirmed, no changes needed" is useful signal.
+- Be specific about improvements, not vague ("needs work").
+- Add edge case tests to the comment so the builder knows to include them.
+- "Approved with suggestions" is the ideal outcome — approve and improve.

--- a/.claude/commands/plan-review-read.md
+++ b/.claude/commands/plan-review-read.md
@@ -1,0 +1,34 @@
+---
+description: Plan reviewer step 1 — read the issue and understand the scout's analysis
+---
+
+# Plan Review: Read
+
+Read the issue that a scout filed and understand the proposed change.
+
+## Steps
+
+1. Read the issue:
+   ```bash
+   gh issue view <number> --json title,body,labels --jq '{title: .title, body: .body}'
+   ```
+
+2. Extract the key elements:
+   - **Root cause**: What does the scout say is wrong?
+   - **Recommended fix**: What change does the scout propose?
+   - **File:line**: What locations are referenced?
+   - **Test spec**: What test does the scout suggest?
+   - **Verify command**: How to confirm the fix works?
+
+3. Note any gaps — fields that are vague, missing, or feel uncertain.
+
+## Output
+
+Record in your task:
+```
+Issue: #NNN
+Root cause claim: <from issue>
+Proposed fix: <from issue>
+File references: <list>
+Gaps noticed: <list or NONE>
+```

--- a/.claude/commands/plan-review-stress.md
+++ b/.claude/commands/plan-review-stress.md
@@ -1,0 +1,40 @@
+---
+description: Plan reviewer step 3 — stress-test the proposed approach
+---
+
+# Plan Review: Stress Test
+
+Think adversarially about the scout's recommended approach.
+
+## Steps
+
+1. **What could go wrong with this fix?**
+   - Could it break other code paths that use the same function?
+   - Does it handle all variants of the construct, or just the sampled ones?
+   - Could it cause regressions in existing tests?
+
+2. **Is there a simpler approach?**
+   - Read the surrounding code — is there an existing pattern for similar fixes?
+   - Could a one-line change work instead of a multi-line refactor?
+   - Are there other recent PRs that solved similar problems?
+
+3. **Edge cases the scout might have missed:**
+   - Nested versions of the construct
+   - The construct inside strings/regex/heredocs
+   - Unusual whitespace, comments, or line breaks
+   - Empty or minimal versions
+
+4. **Test completeness:**
+   - Does the proposed test actually test the right thing?
+   - Would it fail before the fix and pass after?
+   - Are there edge case tests that should be added?
+
+## Output
+
+Record in your task:
+```
+Risk assessment: LOW / MEDIUM / HIGH
+Simpler alternative: NONE / <description>
+Missed edge cases: NONE / <list>
+Test improvements: NONE / <suggestions>
+```

--- a/.claude/commands/plan-review-verify.md
+++ b/.claude/commands/plan-review-verify.md
@@ -1,0 +1,37 @@
+---
+description: Plan reviewer step 2 — verify the scout's claims against current code
+---
+
+# Plan Review: Verify
+
+Check that the scout's file:line references and root cause analysis
+are still accurate against current master.
+
+## Steps
+
+1. For each file:line the scout referenced, read it:
+   ```
+   Read the file at the referenced line number
+   ```
+   Does the code still look like what the scout described?
+   Master may have moved since the scout investigated.
+
+2. Verify the root cause:
+   - Read the function the scout identified
+   - Does the logic match the scout's explanation?
+   - Could there be a different root cause?
+
+3. Check for recent changes:
+   ```bash
+   git log --oneline -5 -- <file>
+   ```
+   Has someone already partially fixed this?
+
+## Output
+
+Record in your task:
+```
+File references: CURRENT / STALE (details)
+Root cause: CONFIRMED / NEEDS UPDATE (details)
+Recent changes: NONE / <list>
+```


### PR DESCRIPTION
## Summary
- New agent: plan-reviewer (sonnet, 4 steps) — reviews scout plans before builders start
- Scouts moved to haiku — broad cheap sweep, decent initial plan
- Flow-build updated: checks for `builder-ready` label, spawns plan-reviewer if missing

## Pipeline
```
Scout (haiku) → Plan-reviewer (sonnet) → Builder (sonnet) → Review → Merge
  broad sweep     refine + stress-test     execute from spec
  80% at 5% cost  +20% quality             unambiguous spec
```

## Test plan
- [x] plan-reviewer agent with 4 step skills
- [x] Scout agents set to haiku
- [x] flow-build gates on builder-ready label
- [x] AGENT_CATALOG updated