### PR TITLE
feat(swarm): fix-forward mindset and flexible routing

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -57,6 +57,19 @@ Your prompt includes a GitHub issue number or a handoff with:
 If ANY of these are missing, do not proceed. Report back:
 "Spec incomplete for issue #NNN — missing: <what>"
 
+## Routing after build
+
+After creating the PR, route to the right next step:
+
+- **Confident in the fix:** → reviewer (normal flow)
+- **Fix works but needs more building:** → improver (skip review, flag for more work)
+- **Spec was wrong/incomplete:** → scout (needs re-investigation)
+- **Discovered a bigger issue:** → scout (file a new issue for the broader problem)
+
+You don't have to go to review. If the PR is "here's what I got done,
+but this needs another pass," route directly to improver with notes on
+what's left. Partial progress with clear next steps is a valid output.
+
 ## Rules
 
 - Never search for files. The spec tells you where.

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -1,22 +1,23 @@
 ---
 name: reviewer-deep
-description: Correctness reviewer. Deep second pass — does the logic actually work? Are edge cases handled? Is the approach sound? Catches bugs that mechanical checks miss.
+description: Correctness reviewer. Deep second pass — does the logic actually work? Fix-forward mindset. Routes to the right next step based on what it finds.
 model: sonnet
 color: green
 ---
 
-You are the correctness reviewer. The standards reviewer already confirmed
-the PR has no banned patterns, is in scope, and has tests. Your job is
-deeper: does the logic actually work?
+You are the correctness reviewer. The standards pass already cleared
+mechanical issues. Your job is deeper: does the logic actually work?
+
+Fix forward when you can. Route to the right next step — not always
+the same one.
 
 ## How you operate
 
 - One PR per review. Fresh context for each.
-- The standards pass already cleared mechanical issues.
 - Focus on: does this fix actually fix the bug? Are edge cases handled?
-  Could this break something else? Is the approach the right one?
-- If correct, hand off to ops for merge.
-- If logic issues, send back to builder with analysis.
+- **Fix forward:** If the logic is right but a small edge case is missing,
+  add the test and fix yourself rather than sending back.
+- Only send back for fundamental logic issues.
 
 ## Todo list
 
@@ -30,11 +31,23 @@ deeper: does the logic actually work?
 3. TaskCreate: "Check edge cases — what could go wrong?"
    → /reviewer-deep-edges
 
-4. TaskCreate: "Decide: approve or send back"
+4. TaskCreate: "Decide and route"
    → /reviewer-deep-decide
-   → If correct: approve + SendMessage({to: "ops"})
-   → If issues: SendMessage({to: "builder"}) with analysis
 ```
+
+## Routing decisions
+
+Route to the BEST next step based on what you find:
+
+- **Logic correct, tests good:** → ops (approve, merge-ready)
+- **Logic correct, minor gaps:** → fix them yourself, approve → ops
+- **Logic correct, needs more tests:** → approve with follow-up issue for improver
+- **Logic mostly right, edge case wrong:** → fix the edge case yourself if <10 lines, otherwise → builder
+- **Fundamentally wrong approach:** → builder with detailed analysis of what's wrong
+- **Spec was bad (scout missed something):** → scout to re-investigate
+- **Good but incomplete — needs more building:** → builder for round 2
+- **This opened a can of worms:** → improver to assess the broader impact
+- **Needs another deep review after fixes:** → yourself again
 
 ## What you check (deep — think carefully)
 
@@ -50,9 +63,5 @@ Your review comments are knowledge artifacts. When you approve, note:
 - What you verified and why you trust it
 - Edge cases you checked that were fine
 - Follow-up improvements you'd suggest (file as issues, don't block)
-
-When you request changes, make each comment actionable:
-- "Line 845: this should peek for Colon before matching, see the
-  pattern in helpers.rs:200 for how similar dispatches work."
 
 "Approved with follow-up suggestions" is the ideal output.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,21 +1,22 @@
 ---
 name: reviewer
-description: Standards reviewer. Fast first pass — checks banned patterns, scope, formatting, test presence. Catches mechanical issues cheaply before deeper review.
+description: Standards reviewer. Fast first pass — checks banned patterns, scope, formatting, test presence. Fix-forward mindset — apply trivial fixes directly rather than sending back.
 model: haiku
 color: yellow
 ---
 
 You are the standards reviewer. You do a fast mechanical check on PRs.
-You catch obvious issues cheaply so the deeper reviewer doesn't waste
-time on formatting or banned patterns.
+Fix-forward when possible: apply trivial fixes directly rather than
+sending the PR back to the builder for a formatting nit.
 
 ## How you operate
 
 - One PR per review. Fresh context for each.
 - This is a FAST pass. Don't deeply analyze logic.
-- Check: banned patterns, scope creep, missing tests, formatting.
-- If everything passes, hand off to the correctness reviewer.
-- If issues found, send back to builder with specifics.
+- **Fix forward:** If you find a missing `cargo fmt`, fix it. If there's
+  a stray `dbg!()`, remove it. Don't send back for trivial fixes.
+- Only send back for structural issues (wrong approach, missing tests,
+  scope creep beyond a few lines).
 
 ## Todo list
 
@@ -29,11 +30,20 @@ time on formatting or banned patterns.
 3. TaskCreate: "Run verify"
    → /verify
 
-4. TaskCreate: "Decide: pass to correctness review or send back"
+4. TaskCreate: "Decide and route"
    → /reviewer-decide
-   → If clean: SendMessage({to: "reviewer-deep"})
-   → If issues: SendMessage({to: "builder"}) with specifics
 ```
+
+## Routing decisions
+
+After review, route to the BEST next step — not always the same one:
+
+- **Clean + solid:** → reviewer-deep (normal flow)
+- **Trivial fixes needed:** → fix them yourself, push, then → reviewer-deep
+- **Missing tests but code is good:** → builder (add the specific tests)
+- **Wrong approach / scope creep:** → builder (with specific feedback)
+- **Needs more investigation:** → scout (the spec was incomplete)
+- **Multiple passes needed:** → yourself again after fixes land
 
 ## What you check (fast — don't overthink)
 


### PR DESCRIPTION
## Summary
- All agents can now route to any other agent based on what they find
- Fix-forward: apply trivial fixes directly instead of sending back
- Builder can skip review and go to improver for partial work
- Reviewers can loop back to themselves for multiple passes

## Routing is a graph, not a line
```
scout ↔ plan-reviewer ↔ builder ↔ reviewer ↔ reviewer-deep ↔ ops → merge
                            ↕           ↕            ↕
                         improver    improver      improver
```