### PR TITLE
feat(swarm): add /agent-wrapup retrospective for all agents

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -14,7 +14,7 @@ plan-reviewer already did the research — you just need to write the code.
 - If the spec is incomplete, STOP and report what's missing.
 - One PR, one issue, one crate. Stay in your lane.
 - Every PR goes to review. No skipping validation gates.
-- Document what you found along the way in the PR description.
+- Note what you learn — surprises, gotchas, context that would have helped.
 
 ## Todo list
 
@@ -24,4 +24,5 @@ plan-reviewer already did the research — you just need to write the code.
 3. /builder-implement — make the change, minimal diff
 4. /verify — cargo test, fmt, clippy
 5. /pr-create — draft PR with knowledge artifacts
+6. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/improver.md
+++ b/.claude/agents/improver.md
@@ -24,4 +24,5 @@ you create follow-up work.
 2. /improver-classify — triage: fix now vs file issue
 3. /improver-act — apply fixes or file issues
 4. /health-check — overall codebase health
+5. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/ops.md
+++ b/.claude/agents/ops.md
@@ -22,4 +22,5 @@ that's the reviewers' job. You gate trusted change.
 2. /ops-merge-batch — merge up to 3
 3. /verify-master-green — confirm master CI
 4. /ops-post-merge — ratchet corpus, update status
+5. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -24,4 +24,5 @@ implementation.
 2. /plan-review-verify — check file:line refs against current code
 3. /plan-review-stress — what could go wrong?
 4. /plan-review-improve — refine spec, add label
+5. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -22,4 +22,5 @@ mechanical issues. Your job is deeper: does the logic actually work?
 2. /reviewer-deep-analyze — does the diff logic match the intent?
 3. /reviewer-deep-edges — what could go wrong?
 4. /reviewer-deep-decide — approve, fix, or send back
+5. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -22,4 +22,5 @@ than sending back for a formatting nit.
 2. /reviewer-check-diff — banned patterns, scope, tests
 3. /verify — run the verification command
 4. /reviewer-decide — route: reviewer-deep, builder, or self again
+5. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -15,7 +15,7 @@ re-researching the codebase.
 - Evidence over opinion: file paths, line numbers, commands, failures.
 - Narrate your thinking. Share what you explored and what you ruled out.
 - One sector or error bucket per investigation.
-- Leave breadcrumbs for whoever picks this up next.
+- Learn as you go. Note what surprised you, what was harder than expected.
 
 ## Todo list
 
@@ -27,4 +27,5 @@ re-researching the codebase.
 5. /scout-design — 2-3 fix approaches
 6. /scout-test-spec — write actual test code
 7. /scout-report — file the issue
+8. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/commands/agent-wrapup.md
+++ b/.claude/commands/agent-wrapup.md
@@ -1,0 +1,53 @@
+---
+description: Final step for every agent — retrospective, documentation, and clean handoff
+---
+
+# Agent Wrapup
+
+Every agent invokes this as their last action before stopping.
+Captures what was learned, documents the ending state, and ensures
+clean handoff to whoever picks up next.
+
+## Steps
+
+1. **Summarize what you did.** One paragraph. What changed, what was created,
+   what was decided.
+
+2. **Document the ending state.** Where did things land?
+   - For scouts: issue URL, what's ready, what needs plan review
+   - For builders: PR URL, what passes, what doesn't yet
+   - For reviewers: approval status, follow-up issues filed
+   - For ops: what merged, what's still in queue, master status
+
+3. **Retrospective — what did you learn?** This is the most valuable part.
+   Write 2-3 sentences about:
+   - What was harder or easier than expected?
+   - What would you do differently next time?
+   - What surprised you about the code or the problem?
+   - What context would have helped you work faster?
+
+4. **Breadcrumbs for the next agent.** What should whoever picks this up
+   next know?
+   - What's the logical next step?
+   - Are there related issues that should be tackled together?
+   - Any gotchas or traps to watch out for?
+
+5. **Update task status.** Mark your tasks as completed with the summary
+   from step 1.
+
+## Where to write this
+
+- **Scouts:** Add retrospective to the issue as a closing comment
+- **Builders:** Add retrospective to the PR description under "What's next"
+- **Reviewers:** Add retrospective to the review comment
+- **Ops:** Add retrospective to a brief merge summary comment
+- **Improver:** Add retrospective to follow-up issues
+
+## Why this matters
+
+Each agent's retrospective makes the NEXT agent faster. If a scout notes
+"the dispatch table in statements.rs is ordered by token kind, not by
+frequency — check this first next time," the next scout saves 10 minutes.
+
+These observations compound across cycles. They're the swarm's learning
+mechanism.


### PR DESCRIPTION
## Summary
- New shared skill: /agent-wrapup — retrospective, documentation, clean handoff
- All 7 pipeline agents + plan-reviewer now have /agent-wrapup as final step
- Agents capture what they learned, what surprised them, what to do differently

## Why
Each agent's retrospective makes the next agent faster. A scout noting
"the dispatch table is ordered by token kind" saves the next scout 10 minutes.
These observations compound across cycles.