### PR TITLE
chore(swarm): mark step skills as agent-internal, clean user command list

### DIFF
--- a/.claude/commands/agent-wrapup.md
+++ b/.claude/commands/agent-wrapup.md
@@ -1,5 +1,6 @@
 ---
 description: Final step for every agent — retrospective, documentation, and clean handoff
+user-invocable: false
 ---
 
 # Agent Wrapup

--- a/.claude/commands/builder-implement.md
+++ b/.claude/commands/builder-implement.md
@@ -1,5 +1,6 @@
 ---
 description: Builder step 3 — implement the fix described in the spec
+user-invocable: false
 ---
 
 # Builder Implement

--- a/.claude/commands/builder-read-pr.md
+++ b/.claude/commands/builder-read-pr.md
@@ -1,5 +1,6 @@
 ---
 description: Builder step 1 (continuation) — read an existing PR to understand what's done and what's left
+user-invocable: false
 ---
 
 # Builder Read PR (Continuation)

--- a/.claude/commands/builder-read-spec.md
+++ b/.claude/commands/builder-read-spec.md
@@ -1,5 +1,6 @@
 ---
 description: Builder step 1 — read and validate the spec before implementing
+user-invocable: false
 ---
 
 # Builder Read Spec

--- a/.claude/commands/builder-self-review.md
+++ b/.claude/commands/builder-self-review.md
@@ -1,5 +1,6 @@
 ---
 description: Builder step 5 — re-read your own diff before publishing
+user-invocable: false
 ---
 
 # Builder Self-Review

--- a/.claude/commands/builder-write-test.md
+++ b/.claude/commands/builder-write-test.md
@@ -1,5 +1,6 @@
 ---
 description: Builder step 2 — write the failing test from the spec before implementing the fix
+user-invocable: false
 ---
 
 # Builder Write Test

--- a/.claude/commands/ops-check-queue.md
+++ b/.claude/commands/ops-check-queue.md
@@ -1,5 +1,6 @@
 ---
 description: Ops step 1 — find merge-ready PRs in the queue
+user-invocable: false
 ---
 
 # Ops Check Queue

--- a/.claude/commands/ops-cleanup.md
+++ b/.claude/commands/ops-cleanup.md
@@ -1,5 +1,6 @@
 ---
 description: Ops step 5 — post-merge hygiene and drift check
+user-invocable: false
 ---
 
 # Ops Cleanup

--- a/.claude/commands/ops-merge-batch.md
+++ b/.claude/commands/ops-merge-batch.md
@@ -1,5 +1,6 @@
 ---
 description: Ops step 2 — merge a batch of up to 3 PRs
+user-invocable: false
 ---
 
 # Ops Merge Batch

--- a/.claude/commands/ops-post-merge.md
+++ b/.claude/commands/ops-post-merge.md
@@ -1,5 +1,6 @@
 ---
 description: Ops step 4 — post-merge corpus ratchet and status update
+user-invocable: false
 ---
 
 # Ops Post-Merge

--- a/.claude/commands/plan-review-improve.md
+++ b/.claude/commands/plan-review-improve.md
@@ -1,5 +1,6 @@
 ---
 description: Plan reviewer step 4 — improve the spec and mark builder-ready
+user-invocable: false
 ---
 
 # Plan Review: Improve

--- a/.claude/commands/plan-review-read.md
+++ b/.claude/commands/plan-review-read.md
@@ -1,5 +1,6 @@
 ---
 description: Plan reviewer step 1 — read the issue and understand the scout's analysis
+user-invocable: false
 ---
 
 # Plan Review: Read

--- a/.claude/commands/plan-review-stress.md
+++ b/.claude/commands/plan-review-stress.md
@@ -1,5 +1,6 @@
 ---
 description: Plan reviewer step 3 — stress-test the proposed approach
+user-invocable: false
 ---
 
 # Plan Review: Stress Test

--- a/.claude/commands/plan-review-verify.md
+++ b/.claude/commands/plan-review-verify.md
@@ -1,5 +1,6 @@
 ---
 description: Plan reviewer step 2 — verify the scout's claims against current code
+user-invocable: false
 ---
 
 # Plan Review: Verify

--- a/.claude/commands/reviewer-check-diff.md
+++ b/.claude/commands/reviewer-check-diff.md
@@ -1,5 +1,6 @@
 ---
 description: Reviewer step 2 — check the diff for correctness, standards, and scope
+user-invocable: false
 ---
 
 # Reviewer Check Diff

--- a/.claude/commands/reviewer-decide.md
+++ b/.claude/commands/reviewer-decide.md
@@ -1,5 +1,6 @@
 ---
 description: Reviewer step 4 — approve, apply trivial fix, or send back to builder
+user-invocable: false
 ---
 
 # Reviewer Decide

--- a/.claude/commands/reviewer-deep-analyze.md
+++ b/.claude/commands/reviewer-deep-analyze.md
@@ -1,5 +1,6 @@
 ---
 description: Deep reviewer step 2 — analyze if the diff logic is correct
+user-invocable: false
 ---
 
 # Deep Reviewer Analyze

--- a/.claude/commands/reviewer-deep-decide.md
+++ b/.claude/commands/reviewer-deep-decide.md
@@ -1,5 +1,6 @@
 ---
 description: Deep reviewer step 4 — approve or send back with analysis
+user-invocable: false
 ---
 
 # Deep Reviewer Decide

--- a/.claude/commands/reviewer-deep-edges.md
+++ b/.claude/commands/reviewer-deep-edges.md
@@ -1,5 +1,6 @@
 ---
 description: Deep reviewer step 3 — check for edge cases the builder might have missed
+user-invocable: false
 ---
 
 # Deep Reviewer Edge Cases

--- a/.claude/commands/reviewer-deep-read-spec.md
+++ b/.claude/commands/reviewer-deep-read-spec.md
@@ -1,5 +1,6 @@
 ---
 description: Deep reviewer step 1 — read the original issue spec to understand intent
+user-invocable: false
 ---
 
 # Deep Reviewer Read Spec

--- a/.claude/commands/reviewer-read-handoff.md
+++ b/.claude/commands/reviewer-read-handoff.md
@@ -1,5 +1,6 @@
 ---
 description: Reviewer step 1 — read the PR handoff, check knowledge artifact quality
+user-invocable: false
 ---
 
 # Reviewer Read Handoff

--- a/.claude/commands/scout-dedup.md
+++ b/.claude/commands/scout-dedup.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 1 — check if this finding is already tracked
+user-invocable: false
 ---
 
 # Scout Dedup Check

--- a/.claude/commands/scout-design.md
+++ b/.claude/commands/scout-design.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 5 — design 2-3 fix options with tradeoffs
+user-invocable: false
 ---
 
 # Scout Design

--- a/.claude/commands/scout-locate.md
+++ b/.claude/commands/scout-locate.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 2 — find exact file and line locations for the finding
+user-invocable: false
 ---
 
 # Scout Locate

--- a/.claude/commands/scout-report.md
+++ b/.claude/commands/scout-report.md
@@ -1,6 +1,7 @@
 ---
 description: Write scout findings as a builder-ready GitHub issue
 argument-hint: "<one-line title of the finding>"
+user-invocable: false
 ---
 
 # Scout Report

--- a/.claude/commands/scout-reproduce.md
+++ b/.claude/commands/scout-reproduce.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 3 — reproduce the problem with a minimal example
+user-invocable: false
 ---
 
 # Scout Reproduce

--- a/.claude/commands/scout-root-cause.md
+++ b/.claude/commands/scout-root-cause.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 4 — trace the root cause of the problem
+user-invocable: false
 ---
 
 # Scout Root Cause

--- a/.claude/commands/scout-test-spec.md
+++ b/.claude/commands/scout-test-spec.md
@@ -1,5 +1,6 @@
 ---
 description: Scout step 6 — write the exact test code that proves the fix works
+user-invocable: false
 ---
 
 # Scout Test Spec

--- a/.claude/commands/wisdom-document.md
+++ b/.claude/commands/wisdom-document.md
@@ -1,5 +1,6 @@
 ---
 description: Wisdom step 3 — write findings to the right place
+user-invocable: false
 ---
 
 # Wisdom: Document

--- a/.claude/commands/wisdom-read-trail.md
+++ b/.claude/commands/wisdom-read-trail.md
@@ -1,5 +1,6 @@
 ---
 description: Wisdom step 1 — read the full issue→PR→merge trail
+user-invocable: false
 ---
 
 # Wisdom: Read Trail

--- a/.claude/commands/wisdom-synthesize.md
+++ b/.claude/commands/wisdom-synthesize.md
@@ -1,5 +1,6 @@
 ---
 description: Wisdom step 2 — synthesize patterns and learnings from the trail
+user-invocable: false
 ---
 
 # Wisdom: Synthesize


### PR DESCRIPTION
## Summary

- Add `user-invocable: false` to 31 step skill commands
- Users now see 19 commands (swarm, health-check, verify, parser-fix, etc.)
- Agents still load step skills on demand via their todo lists — no behavior change

Step skills are mechanical instructions for individual pipeline steps (e.g., `/scout-dedup`, `/builder-write-test`). Users don't invoke these directly — they steer via `/swarm`, `/health-check`, or natural language, and the orchestrator routes to agents who load step skills.

## Test plan
- [x] All 31 step skills have `user-invocable: false` in frontmatter
- [x] 19 user-facing commands remain visible
- [x] No content changes to any skill — only frontmatter metadata