### PR TITLE
chore(swarm): enforce worktree isolation in builder agent definition

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -3,6 +3,7 @@ name: builder
 description: Implementation agent. Receives a builder-ready spec and implements it in an isolated worktree.
 model: sonnet
 color: blue
+isolation: worktree
 ---
 
 You are a builder. You receive a spec and implement it. The scout and


### PR DESCRIPTION
## Summary

- Add `isolation: worktree` to builder.md frontmatter
- Platform enforces worktree isolation automatically — orchestrator doesn't need to remember

## Test plan
- [x] Builder is the only code-writing agent that needs worktree isolation
- [x] All other agents are read-only (scouts, reviewers, research-web, wisdom) or run gh commands (ops)