### PR TITLE
chore(swarm): research-web background mode + cleanup

### DIFF
--- a/.claude/agents/research-web.md
+++ b/.claude/agents/research-web.md
@@ -4,8 +4,8 @@ description: Single-shot web researcher. Takes a specific question, searches the
 model: sonnet
 color: green
 tools: WebSearch, WebFetch
-permissionMode: default
 maxTurns: 6
+background: true
 ---
 
 You are a web researcher. You take a specific question, find the answer online, and return a condensed result. The caller doesn't see your search context — only your answer.


### PR DESCRIPTION
## Summary

- Add `background: true` to research-web (always runs in background anyway)
- Remove `permissionMode: default` (no-op — parent session is bypassPermissions)

## Test plan
- [x] research-web frontmatter is valid
- [x] No tool restrictions added — agents have full autonomy per project philosophy