### PR TITLE
chore(swarm): universal worktree isolation + background for all agents

### DIFF
--- a/.claude/agents/AGENT_CATALOG.md
+++ b/.claude/agents/AGENT_CATALOG.md
@@ -82,7 +82,7 @@ security-scout, dap-scout, changelog
 
 1. **Agent = personality + todo list.** Skills = step mechanics. Context stays clean.
 2. **Scoped, short-lived agents** beat long-running team members. 20K context > 1M context.
-3. **Safety from architecture** (worktree + review + CI) enables full autonomy.
+3. **Every agent runs in its own worktree.** Full isolation = full freedom. Agents can't harm each other.
 4. **Every output is a knowledge artifact** — narrate thinking, leave breadcrumbs.
 5. **Crate CLAUDE.md files** carry domain context. Agents don't need domain specialization.
 6. **Issues carry task specs.** Scouts do 75% of the work; builders execute.

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -4,6 +4,7 @@ description: Implementation agent. Receives a builder-ready spec and implements 
 model: sonnet
 color: blue
 isolation: worktree
+background: true
 ---
 
 You are a builder. You receive a spec and implement it. The scout and

--- a/.claude/agents/ops.md
+++ b/.claude/agents/ops.md
@@ -3,6 +3,8 @@ name: ops
 description: Merge agent. Processes merge-ready PRs in safe batches. CI green → merge → validate.
 model: haiku
 color: purple
+isolation: worktree
+background: true
 ---
 
 You are ops. You merge reviewed, CI-green PRs. You don't review code —

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -3,6 +3,8 @@ name: plan-reviewer
 description: Plan review agent. Reads a scout's issue fresh, stress-tests the approach, and refines the spec before anyone builds.
 model: sonnet
 color: green
+isolation: worktree
+background: true
 ---
 
 You are the plan reviewer. You read scout-filed issues with fresh eyes

--- a/.claude/agents/research-web.md
+++ b/.claude/agents/research-web.md
@@ -6,6 +6,7 @@ color: green
 tools: WebSearch, WebFetch
 maxTurns: 6
 background: true
+isolation: worktree
 ---
 
 You are a web researcher. You take a specific question, find the answer online, and return a condensed result. The caller doesn't see your search context — only your answer.

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -3,6 +3,8 @@ name: reviewer-deep
 description: Correctness reviewer. Deep second pass — does the logic actually work? Edge cases? Regressions?
 model: sonnet
 color: green
+isolation: worktree
+background: true
 ---
 
 You are the correctness reviewer. The standards pass already cleared

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -3,6 +3,8 @@ name: reviewer
 description: Standards reviewer. Fast first pass on PRs — banned patterns, scope, formatting.
 model: haiku
 color: yellow
+isolation: worktree
+background: true
 ---
 
 You are the standards reviewer. Fast mechanical check on PRs.

--- a/.claude/agents/scout-dap.md
+++ b/.claude/agents/scout-dap.md
@@ -3,6 +3,8 @@ name: scout-dap
 description: "DAP-focused scout. Knows DAP crate test gaps, protocol compliance areas, and related issues (#420, #435). Read-only."
 model: sonnet
 color: green
+isolation: worktree
+background: true
 ---
 
 Use the local todo or task tool for the current slice. Start with 3-5 live items, keep them current, and make every item name the command or skill for that step.

--- a/.claude/agents/scout-lsp.md
+++ b/.claude/agents/scout-lsp.md
@@ -3,6 +3,8 @@ name: scout-lsp
 description: LSP-focused scout. Investigates LSP feature gaps, provider issues, and spec compliance. Knows features.toml, provider crates, and LSP 3.17 spec.
 model: haiku
 color: yellow
+isolation: worktree
+background: true
 ---
 
 You are an LSP scout. You investigate LSP features, provider quality,

--- a/.claude/agents/scout-parser.md
+++ b/.claude/agents/scout-parser.md
@@ -3,6 +3,8 @@ name: scout-parser
 description: Parser-focused scout. Knows error buckets, corpus structure, and how to trace specific Perl constructs to parser code. Read-only — returns SLICE definitions.
 model: haiku
 color: green
+isolation: worktree
+background: true
 ---
 
 Use the local todo or task tool for the current slice. Start with 3-5 live items, keep them current, and make every item name the command or skill for that step.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -3,6 +3,8 @@ name: scout
 description: Discovery agent. Investigates one finding and files a builder-ready GitHub issue.
 model: haiku
 color: yellow
+isolation: worktree
+background: true
 ---
 
 You are a scout. You investigate one finding at a time and produce a

--- a/.claude/agents/wisdom.md
+++ b/.claude/agents/wisdom.md
@@ -3,6 +3,8 @@ name: wisdom
 description: Synthesis agent. Reads the full trail of an issue→PR→merge cycle and surfaces patterns, learnings, and process improvements.
 model: sonnet
 color: purple
+isolation: worktree
+background: true
 ---
 
 You are the wisdom agent. You read the complete history of a change —


### PR DESCRIPTION
## Summary

- Add `isolation: worktree` to all 11 agents
- Add `background: true` to all 11 agents
- Update design principle in AGENT_CATALOG.md

Every agent gets its own worktree copy of the repo. They can't interfere with each other or the main workspace. Combined with background mode, the orchestrator can spawn all agents in parallel with zero conflict risk.

## Test plan
- [x] All 11 agents have `isolation: worktree` in frontmatter
- [x] All 11 agents have `background: true` in frontmatter
- [x] Catalog design principle updated