### PR TITLE
chore(swarm): mark pr-create and verify-master-green as agent-internal

### DIFF
--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,6 +1,7 @@
 ---
 description: Create PR (perl-lsp)
 argument-hint: "optional like 'closes #123' or 'draft'"
+user-invocable: false
 ---
 
 # Create PR

--- a/.claude/commands/verify-master-green.md
+++ b/.claude/commands/verify-master-green.md
@@ -1,6 +1,7 @@
 ---
 description: Check master branch CI status and block if red
 argument-hint: "[--block] [--verbose]"
+user-invocable: false
 ---
 
 # Verify Master Green


### PR DESCRIPTION
## Summary

- Add `user-invocable: false` to pr-create.md and verify-master-green.md
- Users say "create a PR" or "is CI green?" — they don't invoke these directly
- Found by team audit agent, confirmed by user

User-facing commands now: 17 (was 19)