### PR TITLE
feat(swarm): add sector-lead agent and two-tier architecture

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -10,26 +10,18 @@ The canonical runtime surfaces are:
 
 Legacy directories archived to `docs/reference/archive/` during architecture transition.
 
-## Canonical Roster
+## Agent Roster
 
 See [agents/AGENT_CATALOG.md](./agents/AGENT_CATALOG.md) for the full inventory.
 
-### Pipeline Agents
-- `scout` (haiku) — investigate, file issues
-- `plan-reviewer` (sonnet) — stress-test plans, mark builder-ready
-- `builder` (sonnet) — implement from spec
-- `reviewer` (haiku) — fast standards check
-- `reviewer-deep` (sonnet) — deep correctness check
-- `ops` (haiku) — merge queue, CI, post-merge
+### Team Agents (TeamCreate — long-running coordinators)
+- `sector-lead` (sonnet) — manages a sector, spawns workers, tracks progress
 
-### Specialized Scouts
-- `scout-parser` (haiku) — error buckets, corpus, parser
-- `scout-lsp` (haiku) — features.toml, providers, LSP spec
-- `scout-dap` (sonnet) — DAP protocol, bridge mode
-
-### Utility
-- `research-web` (sonnet) — web search, doc lookup
-- `wisdom` (sonnet) — synthesize learnings from issue→PR→merge cycles
+### Worker Agents (Agent() — worktree-isolated, one task, exit)
+- `scout` (haiku), `scout-parser` (haiku), `scout-lsp` (haiku), `scout-dap` (sonnet)
+- `plan-reviewer` (sonnet), `builder` (sonnet)
+- `reviewer` (haiku), `reviewer-deep` (sonnet)
+- `ops` (haiku), `research-web` (sonnet), `wisdom` (sonnet)
 
 ## Operating Doctrine
 
@@ -39,12 +31,11 @@ See [agents/AGENT_CATALOG.md](./agents/AGENT_CATALOG.md) for the full inventory.
 - hooks and settings = deterministic enforcement
 - GitHub issues and PRs = persistent work state
 
-Every agent should use the local todo or task tool and name the slash
-entrypoint for each item. The orchestrator reads the agent catalog and
-agent files to route work — no separate flow commands needed. Step skills
-provide mechanical instructions for each todo step. Domain ops
-(`/parser-fix`, `/verify`, `/corpus-ratchet`, etc.) handle specialized
-procedures.
+Two interfaces for two scales: Agent() spawns worktree-isolated workers
+for individual tasks. TeamCreate with sector leads coordinates workers at
+scale (10+ tasks). Step skills provide mechanical instructions for each
+todo step. Domain ops (`/parser-fix`, `/verify`, `/corpus-ratchet`, etc.)
+handle specialized procedures.
 
 The roster mapping lives in
 [agents/AGENT_CATALOG.md](./agents/AGENT_CATALOG.md). It records agent models,

--- a/.claude/agents/AGENT_CATALOG.md
+++ b/.claude/agents/AGENT_CATALOG.md
@@ -3,11 +3,18 @@
 ## Architecture
 
 ```
+Two interfaces, two agent types:
+
+  Agent()     → Worker agents (11) — worktree-isolated, background, one task, exit
+  TeamCreate  → Sector leads (1+) — long-running, shared task list, spawn workers
+
 Agent file = identity + objectives + todo list (WHAT to do)
 Step skill = mechanical instructions per todo step (HOW to do it)
 Crate CLAUDE.md = domain context carried by the codebase (CONTEXT)
 GitHub Issue = task spec from scout to builder (HANDOFF)
-Orchestrator = reads catalog + agent files to route work (ROUTING)
+
+At scale:  User → Orchestrator → Sector leads (TeamCreate) → Workers (Agent())
+At small:  User → Orchestrator → Workers (Agent()) directly
 ```
 
 ## Core Pipeline
@@ -24,7 +31,15 @@ Post-merge: wisdom (sonnet) synthesizes learnings
 Haiku does the broad sweep cheaply. Sonnet refines the plan and builds.
 Haiku checks standards. Sonnet checks correctness. Haiku merges.
 
-## Agents (11)
+## Team Agents (TeamCreate)
+
+| Agent | Model | Role |
+|-------|-------|------|
+| sector-lead | sonnet | Long-running coordinator. Manages a sector by spawning workers, tracking progress, messaging other leads. |
+
+Instantiated per sector at scale. Common sectors: parser, LSP, quality (review+merge), infra.
+
+## Worker Agents (Agent()) — 11
 
 ### Pipeline Agents (6)
 
@@ -80,11 +95,11 @@ security-scout, dap-scout, changelog
 
 ## Design Principles
 
-1. **Agent = personality + todo list.** Skills = step mechanics. Context stays clean.
-2. **Scoped, short-lived agents** beat long-running team members. 20K context > 1M context.
-3. **Every agent runs in its own worktree.** Full isolation = full freedom. Agents can't harm each other.
-4. **Every output is a knowledge artifact** — narrate thinking, leave breadcrumbs.
-5. **Crate CLAUDE.md files** carry domain context. Agents don't need domain specialization.
+1. **Two interfaces, two agent types.** Workers via Agent() (worktree-isolated, one task, exit). Sector leads via TeamCreate (long-running, manage workers).
+2. **Workers are scoped and short-lived.** One issue, one PR, one task per agent. 20K context > 1M context.
+3. **Every worker runs in its own worktree.** Full isolation = full freedom. Agents can't harm each other.
+4. **Sector leads manage, workers execute.** Leads spawn workers, track progress, coordinate. They never write code.
+5. **Scale by adding sector leads, not by the orchestrator tracking more workers.** Small sessions: direct Agent() calls. Large sessions: TeamCreate with sector leads.
 6. **Issues carry task specs.** Scouts do 75% of the work; builders execute.
-7. **"Not done, but here's what's next"** is a valid success state.
-8. **Model tiering:** haiku for mechanical checks, sonnet for creative analysis.
+7. **Every output is a knowledge artifact** — narrate thinking, leave breadcrumbs.
+8. **Model tiering:** haiku for mechanical checks, sonnet for creative analysis and coordination.

--- a/.claude/agents/sector-lead.md
+++ b/.claude/agents/sector-lead.md
@@ -1,0 +1,65 @@
+---
+name: sector-lead
+description: Long-running team coordinator. Manages a sector by spawning worker agents, tracking progress, and coordinating with other sector leads. Used via TeamCreate, not Agent().
+model: sonnet
+color: cyan
+---
+
+You are a sector lead. You coordinate work in your assigned sector by
+spawning worker agents, tracking their progress, and reporting to the
+orchestrator. You never write production code yourself.
+
+## How you work
+
+1. You are spawned as a **TeamCreate teammate**, not a one-shot subagent
+2. You own a shared task list for your sector
+3. You spawn **worker agents** (our 11 worktree-isolated agents) for the actual work
+4. You track what's in flight, what's blocked, what's done
+5. You message other sector leads when work crosses boundaries
+6. You message the orchestrator with summaries, not raw details
+
+## Lifecycle
+
+- You persist for the duration of the session
+- You go idle between tasks — this is normal
+- When the orchestrator sends you work, you wake up and route it
+- You shut down when the orchestrator sends a shutdown request
+
+## Spawning workers
+
+Use Agent() to spawn workers. Their agent definitions handle isolation and
+background mode — don't override frontmatter settings.
+
+```
+# Scout for work
+Agent(subagent_type: "scout-parser", prompt: "Investigate: <topic>. Follow your todo list.", name: "scout-<topic>")
+
+# Build from spec
+Agent(subagent_type: "builder", prompt: "Implement issue #NNN. Follow your todo list.", name: "builder-NNN")
+
+# Review a PR
+Agent(subagent_type: "reviewer", prompt: "Review PR #NNN. Follow your todo list.", name: "reviewer-NNN")
+```
+
+## Task management
+
+- Create tasks for work items in your sector via TaskCreate
+- Update task status as workers report back via TaskUpdate
+- Check TaskList after each worker completes to find next work
+- When all tasks are done, notify the orchestrator
+
+## Communication
+
+- **To orchestrator**: progress summaries, blockers, completion reports
+- **To other sector leads**: cross-boundary handoffs (e.g., "3 parser PRs ready for review")
+- **To workers**: spawned via Agent(), they report back when done
+
+## What you DON'T do
+
+- Write code
+- Create PRs
+- Merge PRs
+- Edit files
+- Work in a worktree
+
+You are the coordination layer between the orchestrator and the workers.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -41,8 +41,30 @@ Check what needs work:
 
 ## Phase 3: Route Work
 
-Spawn short-lived, scoped agents directly. Each agent file has its model,
-todo list, and step skills. Read the agent file if you need a reminder.
+Choose routing mode based on session scale:
+
+### Small scale (1-10 tasks): Direct Agent() calls
+
+Spawn workers directly. Each agent file has its model, todo list, and
+step skills — read the agent file if you need a reminder.
+
+### Large scale (10+ tasks): TeamCreate with sector leads
+
+Create a team and spawn sector leads to manage workers:
+```
+TeamCreate(team_name: "swarm-<focus>", description: "...")
+
+Agent(subagent_type: "sector-lead", team_name: "swarm-<focus>",
+  prompt: "You lead the parser sector. Spawn scout-parser and builder agents for parser corpus work. Track issues and PRs in your sector.",
+  name: "parser-lead")
+
+Agent(subagent_type: "sector-lead", team_name: "swarm-<focus>",
+  prompt: "You lead quality. Spawn reviewer, reviewer-deep, and ops agents. Manage the review and merge pipeline.",
+  name: "quality-lead")
+```
+
+Sector leads spawn workers via Agent(). Workers don't know they're part of
+a team — they just follow their todo list in their worktree.
 
 ### Scouting (find work)
 ```
@@ -88,14 +110,14 @@ Agent(subagent_type: "wisdom", prompt: "Read the trail for issue #NNN. Follow yo
 
 ## Orchestrator Principles
 
-- **Spawn scoped, short-lived agents.** One issue, one PR, one task per agent.
-  Don't create long-running teams. Each agent follows its todo list and exits.
+- **Scale with sector leads, not with more direct workers.** At 10+ tasks,
+  create a team with sector leads instead of tracking 30 agents yourself.
 - **Route by label.** `needs-plan-review` → plan-reviewer. `builder-ready` → builder.
   `in-review` → already being reviewed. `merge-ready` → ops.
-- **Don't micromanage.** Agents have autonomy within their scope. The pipeline
-  and guardrails ensure quality. You just route work.
-- **Parallel lanes.** Run scouts, builders, reviewers, and ops simultaneously
-  on different issues/PRs. They don't conflict because of worktree isolation.
+- **Don't micromanage.** Workers have autonomy within their scope. Sector leads
+  have autonomy within their sector. You set direction and monitor.
+- **Parallel lanes.** Workers don't conflict because of worktree isolation.
+  Sector leads don't conflict because they own different sectors.
 - **Can't skip validation.** Every PR goes through review. Every issue goes
   through plan review before building. The pipeline can loop but not skip.
 


### PR DESCRIPTION
## Summary

Introduces two-tier agent architecture:

- **Worker agents** (11, via Agent()) — worktree-isolated, background, one task, exit
- **Sector lead** (1, via TeamCreate) — long-running coordinator, manages workers in a sector

At small scale (1-10 tasks): orchestrator spawns workers directly.
At large scale (10+ tasks): orchestrator creates team with sector leads that manage workers.

- New file: `.claude/agents/sector-lead.md`
- Updated: AGENT_CATALOG.md, swarm.md, .claude/README.md

## Test plan
- [x] sector-lead.md has valid frontmatter (no isolation, no background — it's a team agent)
- [x] AGENT_CATALOG documents both tiers
- [x] swarm.md documents both routing modes
- [x] TeamCreate test validated the pattern earlier in this session