### PR TITLE
test(parser): add regression tests for typeglob = sub assignment patterns

### DIFF
--- a/crates/perl-parser-core/tests/fix_typeglob_sub_assignment_tests.rs
+++ b/crates/perl-parser-core/tests/fix_typeglob_sub_assignment_tests.rs
@@ -1,0 +1,67 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Issue #2394: typeglob assignment with sub bodies fail to parse cleanly.
+// Patterns from MOOSE, CLASS-ACCESSOR, CATALYST corpus files.
+
+#[test]
+fn test_typeglob_assign_sub_simple() {
+    // *method = sub { ... };  — from Moose::Meta::Class
+    let source = r#"*foo = sub { 1 };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_reference() {
+    // *foo = \&other;  — glob aliasing via reference
+    let source = r#"*foo = \&other;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_prototype() {
+    // *GLOB = sub () { ... };  — with empty prototype, from Catalyst
+    let source = r#"*GLOB = sub () { 1 };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_dynamic_simple() {
+    // *{$name} = sub { ... };  — dynamic name
+    let source = r#"*{$name} = sub { return $_[0] };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_dynamic_concat() {
+    // *{$pkg . '::' . $name} = sub { ... };  — from Class::Accessor
+    let source = r#"*{$pkg . '::' . $name} = sub { $_[0] };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_qualified() {
+    // *{'UNIVERSAL::isa'} = sub () { ... };  — string key, from Catalyst
+    let source = r#"*{'UNIVERSAL::isa'} = sub () { ... };"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_body_multiline() {
+    // Multi-statement sub body
+    let source = r#"
+*install = sub {
+    my ($self, $name) = @_;
+    $self->{$name} = 1;
+    return $self;
+};
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_typeglob_assign_sub_qualified_name() {
+    // *Foo::bar = sub { ... };  — qualified typeglob
+    let source = r#"*Foo::bar = sub { my $x = 1; $x };"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

Issue #2394 identified 8 corpus files failing to parse due to typeglob assignment with sub bodies (`*foo = sub { ... }`). On investigation, the parser already handles these patterns correctly — the bug had been fixed by prior work. This PR adds the missing regression test suite to lock in the behaviour and prevent future regressions.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Added `crates/perl-parser-core/tests/fix_typeglob_sub_assignment_tests.rs` with 8 tests covering:

- `*foo = sub { 1 };` — simple named typeglob with sub body
- `*foo = \&other;` — glob aliasing via reference
- `*GLOB = sub () { 1 };` — empty prototype (Catalyst pattern)
- `*{$name} = sub { ... };` — dynamic typeglob with simple expression
- `*{$pkg . '::' . $name} = sub { ... };` — dynamic typeglob with concat (Class::Accessor pattern)
- `*{'UNIVERSAL::isa'} = sub () { ... };` — string-key dynamic typeglob (Catalyst pattern)
- Multi-statement sub body
- `*Foo::bar = sub { ... };` — qualified typeglob name

## How to review

Single new test file at:
`crates/perl-parser-core/tests/fix_typeglob_sub_assignment_tests.rs`

All 8 tests pass. No implementation changes.

## Evidence

```
running 8 tests
test test_typeglob_assign_sub_dynamic_concat ... ok
test test_typeglob_assign_sub_body_multiline ... ok
test test_typeglob_assign_sub_dynamic_simple ... ok
test test_typeglob_assign_sub_prototype ... ok
test test_typeglob_assign_sub_qualified ... ok
test test_typeglob_assign_sub_qualified_name ... ok
test test_typeglob_assign_sub_reference ... ok
test test_typeglob_assign_sub_simple ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Risk & rollback

Zero risk — test-only change, no production code modified. Rollback = revert the one file.

## Follow-ups

None. Issue #2394 can be closed as the underlying parser behaviour is already correct.