### PR TITLE
chore: remove unused dependencies (serde, perl-ast, tracing-subscriber)

### DIFF
--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -46,7 +46,6 @@ tokio = { version = "1.49.0", features = ["full"] }
 
 # Logging
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 # Command-line argument parsing
 clap = { version = "4.5.60", features = ["derive"] }

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 lsp-types = { version = "0.97.0" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-qualified-name = { workspace = true }

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -76,7 +76,6 @@ ropey = { version = "1.6.1" }
 tokio = { version = "1.49.0", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
 once_cell = "1.21.3"
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 
 [build-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-tokenizer/Cargo.toml
+++ b/crates/perl-tokenizer/Cargo.toml
@@ -18,7 +18,6 @@ perl-lexer = { workspace = true }
 perl-token = { workspace = true }
 perl-error = { workspace = true }
 perl-position-tracking = { workspace = true }
-perl-ast = { workspace = true }
 perl-ast-v2 = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Removes 4 unused dependencies across 4 crates, as found by `cargo machete`:

| Crate | Removed dep | Reason |
|-------|------------|--------|
| `perl-lsp-navigation` | `serde` | `serde_json` is used directly; bare `serde` is not needed |
| `perl-tokenizer` | `perl-ast` | Superseded by `perl-ast-v2`; source uses `perl_ast_v2` only |
| `perl-lsp` | `tracing-subscriber` | Not imported in any source file |
| `perl-dap` | `tracing-subscriber` | Not imported in any source file |

## Verification

```
cargo machete  # reports zero unused deps in workspace
cargo build -p perl-lsp-navigation -p perl-tokenizer -p perl-lsp -p perl-dap  # clean build
cargo test -p perl-lsp-navigation -p perl-tokenizer -p perl-dap  # all pass
```

Closes #2217