### PR TITLE
test: add unit tests for perl-ast-v2 and perl-workspace-index-monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,6 +2855,7 @@ name = "perl-workspace-index-monitoring"
 version = "0.12.0"
 dependencies = [
  "parking_lot",
+ "perl-tdd-support",
 ]
 
 [[package]]

--- a/crates/perl-ast-v2/tests/node_kinds.rs
+++ b/crates/perl-ast-v2/tests/node_kinds.rs
@@ -97,6 +97,7 @@ fn test_missing_kind_variant_sexp() {
     let node = make_node(&mut id_gen, NodeKind::Missing(MissingKind::Semicolon));
     let sexp = node.to_sexp();
     assert!(sexp.contains("MISSING"), "expected MISSING in {sexp}");
+    assert!(sexp.contains("Semicolon"), "expected Semicolon variant in {sexp}");
 }
 
 #[test]
@@ -138,9 +139,11 @@ fn test_binary_sexp() {
 fn test_node_equality() {
     let mut id_gen = NodeIdGenerator::new();
     let r = zero_range();
-    let a = Node::new(id_gen.next_id(), NodeKind::Number { value: "5".into() }, r.clone());
+    let a = Node::new(id_gen.next_id(), NodeKind::Number { value: "5".into() }, r);
     let b = Node::new(id_gen.next_id(), NodeKind::Number { value: "5".into() }, r);
     // Same kind/range but different ids — kinds are equal even if ids differ
     assert_eq!(a.kind, b.kind);
     assert_ne!(a.id, b.id);
+    // Full node equality considers id — nodes with different ids are not equal
+    assert_ne!(a, b);
 }

--- a/crates/perl-workspace-index-monitoring/Cargo.toml
+++ b/crates/perl-workspace-index-monitoring/Cargo.toml
@@ -17,5 +17,8 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 parking_lot = "0.12.5"
 
+[dev-dependencies]
+perl-tdd-support = { path = "../../crates/perl-tdd-support" }
+
 [lints]
 workspace = true

--- a/crates/perl-workspace-index-monitoring/tests/monitoring_behaviour.rs
+++ b/crates/perl-workspace-index-monitoring/tests/monitoring_behaviour.rs
@@ -1,3 +1,4 @@
+use perl_tdd_support::must_some;
 use perl_workspace_index_monitoring::{
     EarlyExitReason, EarlyExitRecord, IndexInstrumentation, IndexMetrics, IndexPerformanceCaps,
     IndexPhase, IndexPhaseTransition, IndexResourceLimits, IndexStateKind, IndexStateTransition,
@@ -153,7 +154,7 @@ fn test_instrumentation_multiple_early_exits_accumulate() {
     let snap = inst.snapshot();
     assert_eq!(snap.early_exit_counts.get(&EarlyExitReason::FileLimit), Some(&2));
     // last_early_exit should be the most recent one
-    let last = snap.last_early_exit.unwrap();
+    let last = must_some(snap.last_early_exit);
     assert_eq!(last.elapsed_ms, 200);
 }
 
@@ -162,8 +163,12 @@ fn test_instrumentation_snapshot_contains_current_state_duration() {
     let inst = IndexInstrumentation::new();
     // Even without any transitions, the snapshot should include time in Building state
     let snap = inst.snapshot();
-    let building_ms = snap.state_durations_ms.get(&IndexStateKind::Building).copied().unwrap_or(0);
-    // We can't assert an exact value, but it should be non-negative
+    assert!(
+        snap.state_durations_ms.contains_key(&IndexStateKind::Building),
+        "snapshot must contain Building key in state_durations_ms"
+    );
+    let building_ms = must_some(snap.state_durations_ms.get(&IndexStateKind::Building).copied());
+    // We can't assert an exact value, but it should be small in a unit test
     assert!(building_ms < 10_000, "duration should be small in a unit test: {building_ms}ms");
 }
 


### PR DESCRIPTION
## Summary

Adds tests to two foundational crates that were severely undertested relative to their LOC.

### perl-ast-v2 (2 → 19 tests)

New file `tests/node_kinds.rs` with 17 integration tests covering:
- `NodeIdGenerator` sequential ID generation and `Default` impl
- `to_sexp()` output for: `Variable`, `Number`, `String` (interpolated/plain), `Binary`, `Block`, `Program`, `ErrorRef`, `MissingExpression/Statement/Identifier/Block`, `Missing(kind)`
- Nested node sexp (program with child, binary expression)
- `Node` equality — same kind, different IDs

### perl-workspace-index-monitoring (2 → 13 tests)

Extended `tests/monitoring_behaviour.rs` with 11 additional tests covering:
- `IndexMetrics` default threshold (10), default pending count (0), storm detection at/above threshold
- `EarlyExitRecord` field construction for all 3 `EarlyExitReason` variants
- `IndexResourceLimits` and `IndexPerformanceCaps` default values
- `IndexInstrumentation` phase transition counting, early-exit accumulation (last record is most recent), snapshot includes current state duration, state transitions across Degraded state

## Test plan

- [x] `cargo test -p perl-ast-v2` — 19 tests pass (2 unit + 17 integration)
- [x] `cargo test -p perl-workspace-index-monitoring` — 13 tests pass

Closes #2213