### PR TITLE
fix(parser): sigil-peek heuristic for imported unary functions (fixes #1943)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -511,6 +511,26 @@ impl<'a> Parser<'a> {
                                 NodeKind::FunctionCall { name: name.clone(), args },
                                 SourceLocation { start, end },
                             );
+                        } else if !Self::is_builtin_function(name)
+                            && !self.is_at_statement_end()
+                            && self.peek_kind() != Some(TokenKind::FatArrow)
+                            && self.tokens.peek().ok().is_some_and(|t| {
+                                t.text.starts_with('$')
+                                    || t.text.starts_with('@')
+                                    || t.text.starts_with('%')
+                            })
+                        {
+                            // Sigil-peek heuristic: non-builtin identifier followed by a
+                            // sigil-starting argument is a bare function call.
+                            // Handles `blessed $self`, `reftype $x`, `weaken $ref`, etc.
+                            // (imported unary functions that look like builtins at the call site)
+                            let arg = self.parse_ternary()?;
+                            let start = expr.location.start;
+                            let end = arg.location.end;
+                            expr = Node::new(
+                                NodeKind::FunctionCall { name: name.clone(), args: vec![arg] },
+                                SourceLocation { start, end },
+                            );
                         } else if Self::is_builtin_function(name) || self.looks_like_bare_call(name) {
                             // In call argument lists, `builtin => value` should keep the lhs as a
                             // bareword key so parse_args can auto-quote it for fat-comma pairs.

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -518,3 +518,39 @@ fn unless_null_in_paren() {
     // unless (null $root)
     assert_clean_parse(r#"unless (null $root) { print "not null" }"#);
 }
+
+// === Sigil-peek heuristic: imported unary functions without parens (#1943) ===
+// These all fail with "expected ')', found identifier" before the fix because
+// `blessed`, `reftype`, etc. are not in the builtin table. The fix adds a
+// sigil-peek heuristic in postfix.rs: if an unknown identifier is immediately
+// followed by a sigil-starting token, treat it as a unary function call.
+
+#[test]
+fn blessed_self_in_if() {
+    // From Moose::Util::TypeConstraints and many CPAN modules
+    assert_clean_parse(r#"if (blessed $self) { $self->foo() }"#);
+}
+
+#[test]
+fn blessed_in_unless() {
+    // unless (blessed $obj)
+    assert_clean_parse(r#"unless (blessed $obj) { die "not an object" }"#);
+}
+
+#[test]
+fn blessed_with_and_chain() {
+    // if (blessed $err and $err->isa("Foo"))
+    assert_clean_parse(r#"if (blessed $err and $err->isa("Foo")) { 1 }"#);
+}
+
+#[test]
+fn reftype_scalar_comparison() {
+    // if (reftype $x eq 'ARRAY')
+    assert_clean_parse(r#"if (reftype $x eq 'ARRAY') { 1 }"#);
+}
+
+#[test]
+fn looks_like_number_sigil() {
+    // looks_like_number $val — common in Type::Tiny and Params::Util
+    assert_clean_parse(r#"return 0 unless looks_like_number $val;"#);
+}


### PR DESCRIPTION
## Problem

`blessed $self`, `reftype $x`, `looks_like_number $val` and other imported unary functions called without parens inside parenthesized contexts (like `if (blessed $self)`) trigger `unclosed_paren_identifier` errors.

Root cause traced in #1943: the parser returns the bare identifier without consuming the argument, then `expect(RightParen)` finds the argument variable instead of `)`.

## Fix

Added a sigil-peek heuristic in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` (the `_ =>` fallthrough branch at line ~514):

> If an identifier not in the builtin table is followed by a sigil-starting token (`$`, `@`, `%`) and NOT followed by `=>`, parse one `parse_ternary()` as its argument.

This mirrors the existing `is_nullary_builtin` sigil-peek logic at lines 495-504 and generalizes it to ALL imported unary functions (not just a curated list).

## Impact

- `unclosed_paren_identifier` bucket: **78 → 62** (16 fewer errors)
- Corpus clean rate: **89.6% → 89.8%** (+16 files)

## Test coverage

New tests in `crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs`:
- `blessed_self_in_if` — `if (blessed $self) { ... }`
- `blessed_in_unless` — `unless (blessed $obj) { ... }`
- `blessed_with_and_chain` — `if (blessed $err and $err->isa("Foo")) { ... }`
- `reftype_scalar_comparison` — `if (reftype $x eq 'ARRAY') { ... }`
- `looks_like_number_sigil` — `return 0 unless looks_like_number $val;`

## Pre-existing failures (not introduced by this PR)

- `test_split_regex_complex_paren_list` — already failing on master
- `test_grep_block_file_test` — already failing on master
- Clippy `panic` in test code — pre-existing on master

Closes #1943