### PR TITLE
feat(logging): add file-based log rotation and migrate eprintln to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +2172,7 @@ dependencies = [
  "perl-lsp-feature-governance",
  "perl-tdd-support",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -3020,6 +3036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3818,6 +3840,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,6 +3993,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/perl-lsp-launcher/Cargo.toml
+++ b/crates/perl-lsp-launcher/Cargo.toml
@@ -19,6 +19,7 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 clap = { version = "4.5.60", features = ["derive"] }
 perl-lsp-feature-governance = { workspace = true }
 tracing = "0.1.44"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [features]

--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -11,7 +11,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::io::IsTerminal;
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 
 use clap::{Args, Parser};
 pub use perl_lsp_feature_governance::{
@@ -19,9 +19,12 @@ pub use perl_lsp_feature_governance::{
     to_json_for_profile, trackable_feature_count_for_grid,
 };
 use perl_lsp_feature_governance::{feature_profile_supported_tokens, parse_feature_profile_arg};
+use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt as tracing_fmt};
 
 static LOGGING_INIT: Once = Once::new();
+/// Keeps the non-blocking file writer alive for the process lifetime.
+static LOG_FILE_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
 
 /// Default port used by socket transport.
 pub const DEFAULT_LSP_PORT: u16 = 9257;
@@ -59,9 +62,11 @@ pub fn logging_filter(
     })
 }
 
-/// Initialize stderr-based tracing once for the current process.
+/// Initialize tracing once for the current process.
 ///
-/// Invalid `RUST_LOG` values fall back to `default_filter`.
+/// When `PERL_LSP_LOG_FILE` is set, logs are written to a daily-rotated file
+/// (max 5 files) **in addition to** stderr. Invalid `RUST_LOG` values fall
+/// back to `default_filter`.
 pub fn init_logging(default_filter: &str) {
     LOGGING_INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env()
@@ -69,6 +74,43 @@ pub fn init_logging(default_filter: &str) {
             .unwrap_or_else(|_| EnvFilter::new("info"));
 
         let use_ansi = std::env::var("NO_COLOR").is_err() && io::stderr().is_terminal();
+
+        // If PERL_LSP_LOG_FILE is set, add a rolling file appender alongside stderr.
+        if let Ok(log_path) = std::env::var("PERL_LSP_LOG_FILE") {
+            let path = std::path::Path::new(&log_path);
+            let log_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let log_file_prefix = path.file_name().and_then(|f| f.to_str()).unwrap_or("perl-lsp");
+
+            if let Ok(file_appender) = tracing_appender::rolling::RollingFileAppender::builder()
+                .rotation(tracing_appender::rolling::Rotation::DAILY)
+                .filename_prefix(log_file_prefix)
+                .max_log_files(5)
+                .build(log_dir)
+            {
+                let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+                let _ = LOG_FILE_GUARD.set(guard);
+
+                let stderr_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(io::stderr)
+                    .with_ansi(use_ansi)
+                    .with_target(true);
+
+                let file_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(non_blocking)
+                    .with_ansi(false)
+                    .with_target(true);
+
+                let _ = tracing_subscriber::registry()
+                    .with(filter)
+                    .with(stderr_layer)
+                    .with(file_layer)
+                    .try_init();
+
+                return;
+            }
+            // Fall through to stderr-only if file appender fails to build.
+        }
+
         let _ = tracing_fmt()
             .with_env_filter(filter)
             .with_writer(io::stderr)
@@ -527,6 +569,8 @@ pub fn help_text() -> String {
     out.push('\n');
     out.push_str("Environment:\n");
     out.push_str("  PERL_LSP_LOG=1       Enable logging (alternative to --log)\n");
+    out.push_str("  PERL_LSP_LOG_FILE=<path>\n");
+    out.push_str("                       Also log to a daily-rotated file (max 5 files)\n");
     out.push_str("  RUST_LOG=<filter>    Set tracing filter (e.g. perl_lsp=debug)\n");
     out.push_str("  NO_COLOR=1           Disable colored output\n");
     out
@@ -725,6 +769,43 @@ fn parse_feature_profile(raw_profile: &str) -> Result<FeatureProfile, LaunchPars
 mod tests {
     use super::{DEFAULT_LSP_PORT, LaunchAction, TransportMode, parse_args};
     use perl_tdd_support::must;
+
+    #[test]
+    fn init_logging_does_not_panic_without_log_file() {
+        // init_logging is guarded by Once, so calling it multiple times is safe.
+        // This test verifies the stderr-only path does not panic.
+        super::init_logging("warn");
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn init_logging_does_not_panic_with_log_file() {
+        let dir = std::env::temp_dir().join("perl-lsp-test-log-rotation");
+        let _ = std::fs::create_dir_all(&dir);
+        let log_path = dir.join("test.log");
+
+        // Set the env var for this test — init_logging is Once-guarded so the
+        // file path may not actually be used if another test already initialized,
+        // but this must not panic regardless.
+        // SAFETY: test-only, single-threaded access to this env var.
+        unsafe {
+            std::env::set_var("PERL_LSP_LOG_FILE", log_path.to_str().unwrap_or_default());
+        }
+        super::init_logging("debug");
+        // SAFETY: test-only cleanup.
+        unsafe {
+            std::env::remove_var("PERL_LSP_LOG_FILE");
+        }
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn help_mentions_log_file_env_var() {
+        let text = super::help_text();
+        assert!(text.contains("PERL_LSP_LOG_FILE"));
+    }
 
     #[test]
     fn parse_defaults_to_stdio_with_current_profile() {

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -30,15 +30,17 @@ impl LspServer {
                 params.pointer("/textDocument/version").and_then(|v| v.as_i64()).unwrap_or(0);
             let version = i32::try_from(version_i64).unwrap_or(0);
 
-            eprintln!("Document opened: {}", uri);
+            tracing::debug!("Document opened: {}", uri);
 
             // Large file guard: skip parsing for oversized files
             let file_size = text.len();
             let size_limit = crate::state::max_file_size_bytes();
             if file_size > size_limit {
-                eprintln!(
-                    "WARNING: Skipping parse for {} ({} bytes exceeds {} byte limit)",
-                    uri, file_size, size_limit
+                tracing::warn!(
+                    "Skipping parse for {} ({} bytes exceeds {} byte limit)",
+                    uri,
+                    file_size,
+                    size_limit
                 );
 
                 // Store document state without AST
@@ -67,7 +69,7 @@ impl LspServer {
                         "diagnostics": []
                     }),
                 ) {
-                    eprintln!("Failed to publish diagnostics for {}: {}", uri, e);
+                    tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                 }
 
                 return Ok(());
@@ -81,7 +83,7 @@ impl LspServer {
 
             // Check cache first
             let (ast, errors) = if let Some(cached_ast) = self.ast_cache.get(uri, text) {
-                eprintln!("Using cached AST for {}", uri);
+                tracing::debug!("Using cached AST for {}", uri);
                 (Some((*cached_ast).clone()), vec![])
             } else {
                 // Parse the document up to __DATA__ or __END__ marker
@@ -176,14 +178,14 @@ impl LspServer {
                                     let symbol_count = workspace_index.symbol_count();
                                     let file_count = workspace_index.file_count();
                                     coordinator.transition_to_ready(file_count, symbol_count);
-                                    eprintln!(
+                                    tracing::info!(
                                         "Index transitioned to Ready after first file (symbols: {})",
                                         symbol_count
                                     );
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Failed to index file {}: {}", uri, e);
+                                tracing::warn!("Failed to index file {}: {}", uri, e);
                             }
                         }
                     }
@@ -257,11 +259,13 @@ impl LspServer {
                     match serde_json::from_value::<TextDocumentContentChangeEvent>(c.clone()) {
                         Ok(change) => lsp_changes.push(change),
                         Err(e) => {
-                            eprintln!(
-                                "ERROR: Failed to deserialize change {} for {}: {}",
-                                i, uri, e
+                            tracing::error!(
+                                "Failed to deserialize change {} for {}: {}",
+                                i,
+                                uri,
+                                e
                             );
-                            eprintln!("Change JSON: {:?}", c);
+                            tracing::error!("Change JSON: {:?}", c);
                             // Continue processing other changes; LSP has no server-initiated
                             // full sync, so logging is critical for diagnosing state issues.
                         }
@@ -272,15 +276,17 @@ impl LspServer {
                 apply_changes(&mut doc, &lsp_changes, PosEnc::Utf16);
 
                 let text = doc.rope.to_string();
-                eprintln!("Document changed: {} (version {})", uri, version);
+                tracing::debug!("Document changed: {} (version {})", uri, version);
 
                 // Large file guard: skip parsing for oversized files
                 let file_size = text.len();
                 let size_limit = crate::state::max_file_size_bytes();
                 if file_size > size_limit {
-                    eprintln!(
-                        "WARNING: Skipping parse for {} ({} bytes exceeds {} byte limit)",
-                        uri, file_size, size_limit
+                    tracing::warn!(
+                        "Skipping parse for {} ({} bytes exceeds {} byte limit)",
+                        uri,
+                        file_size,
+                        size_limit
                     );
 
                     // Update document state without AST
@@ -307,7 +313,7 @@ impl LspServer {
                             "diagnostics": []
                         }),
                     ) {
-                        eprintln!("Failed to publish diagnostics for {}: {}", uri, e);
+                        tracing::warn!("Failed to publish diagnostics for {}: {}", uri, e);
                     }
 
                     return Ok(());
@@ -321,7 +327,7 @@ impl LspServer {
 
                 // Check cache first
                 let (ast, errors) = if let Some(cached_ast) = self.ast_cache.get(uri, &text) {
-                    eprintln!("Using cached AST for {}", uri);
+                    tracing::debug!("Using cached AST for {}", uri);
                     (Some((*cached_ast).clone()), vec![])
                 } else {
                     // Parse the document up to __DATA__ or __END__ marker
@@ -375,7 +381,7 @@ impl LspServer {
                     if existing_doc.generation.load(Ordering::SeqCst) != next_gen
                         || existing_doc.version > target_version
                     {
-                        eprintln!(
+                        tracing::debug!(
                             "Discarding stale parse result for {} (gen {} != {} or version {} > {})",
                             uri,
                             next_gen,
@@ -414,7 +420,7 @@ impl LspServer {
                                 .map(|d| d.text.clone())
                                 .unwrap_or_default();
                             if let Err(e) = workspace_index.index_file(url, doc_content) {
-                                eprintln!("Failed to index file {}: {}", uri, e);
+                                tracing::warn!("Failed to index file {}: {}", uri, e);
                             }
                         }
                     }
@@ -448,7 +454,7 @@ impl LspServer {
                 .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
             let normalized_uri = self.normalize_uri_key(uri);
 
-            eprintln!("Document closed: {}", uri);
+            tracing::debug!("Document closed: {}", uri);
 
             // Notify coordinator of pending change to track cleanup work
             #[cfg(feature = "workspace")]
@@ -481,7 +487,7 @@ impl LspServer {
                     "diagnostics": []
                 }),
             ) {
-                eprintln!("Failed to clear diagnostics for {}: {}", normalized_uri, e);
+                tracing::warn!("Failed to clear diagnostics for {}: {}", normalized_uri, e);
             }
         }
 
@@ -501,7 +507,7 @@ impl LspServer {
                 .and_then(|v| v.as_i64())
                 .and_then(|v| i32::try_from(v).ok());
 
-            eprintln!("Document saved: {}", uri);
+            tracing::debug!("Document saved: {}", uri);
 
             // Re-run diagnostics on save to catch any changes
             let documents = self.documents.lock();
@@ -543,7 +549,11 @@ impl LspServer {
                             "diagnostics": lsp_diagnostics
                         }),
                     ) {
-                        eprintln!("Failed to publish diagnostics for {}: {}", normalized_uri, e);
+                        tracing::warn!(
+                            "Failed to publish diagnostics for {}: {}",
+                            normalized_uri,
+                            e
+                        );
                     }
                 }
             }
@@ -561,7 +571,7 @@ impl LspServer {
             let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
             let reason = params["reason"].as_u64().unwrap_or(1); // 1 = Manual, 2 = AfterDelay, 3 = FocusOut
 
-            eprintln!("Document will save: {} (reason: {})", uri, reason);
+            tracing::debug!("Document will save: {} (reason: {})", uri, reason);
 
             // Pre-save validation or cleanup can be done here
             // For example: remove trailing whitespace, fix imports, etc.
@@ -579,7 +589,7 @@ impl LspServer {
             let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
             let _reason = params["reason"].as_u64().unwrap_or(1);
 
-            eprintln!("Document will save wait until: {}", uri);
+            tracing::debug!("Document will save wait until: {}", uri);
 
             let documents = self.documents.lock();
             if let Some(doc) = self.get_document(&documents, uri) {


### PR DESCRIPTION
## Summary
- Adds optional file-based log rotation via `PERL_LSP_LOG_FILE` env var
- Uses `tracing-appender` with daily rotation, max 5 files, non-blocking writes
- Dual output: logs go to both stderr and file when enabled
- Migrates all 20 `eprintln!()` calls in `text_sync.rs` to structured `tracing` macros
- Adds 3 tests covering init_logging paths and help text

## Usage
```bash
PERL_LSP_LOG_FILE=/tmp/perl-lsp.log perl-lsp --stdio --log
```

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy -p perl-lsp-launcher --tests` clean
- [x] `cargo clippy -p perl-lsp --lib` clean
- [x] `cargo test -p perl-lsp-launcher` — 72/72 pass
- [x] `cargo test -p perl-lsp --lib` — 189/189 pass

Closes #2175