### PR TITLE
chore(swarm): remove background: true from worker agents

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -4,7 +4,6 @@ description: Implementation agent. Receives a builder-ready spec and implements 
 model: sonnet
 color: blue
 isolation: worktree
-background: true
 ---
 
 You are a builder. You receive a spec and implement it. The scout and

--- a/.claude/agents/ops.md
+++ b/.claude/agents/ops.md
@@ -4,7 +4,6 @@ description: Merge agent. Processes merge-ready PRs in safe batches. CI green â†
 model: haiku
 color: purple
 isolation: worktree
-background: true
 ---
 
 You are ops. You merge reviewed, CI-green PRs. You don't review code â€”

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -4,7 +4,6 @@ description: Plan review agent. Reads a scout's issue fresh, stress-tests the ap
 model: sonnet
 color: green
 isolation: worktree
-background: true
 ---
 
 You are the plan reviewer. You read scout-filed issues with fresh eyes

--- a/.claude/agents/research-web.md
+++ b/.claude/agents/research-web.md
@@ -5,7 +5,6 @@ model: sonnet
 color: green
 tools: WebSearch, WebFetch
 maxTurns: 6
-background: true
 isolation: worktree
 ---
 
@@ -51,7 +50,6 @@ From any agent:
 ```
 Agent(
   prompt: "Research: <specific question>. Return a RESEARCH RESULT with answer, confidence, and sources.",
-  run_in_background: true,
   name: "research-<topic>"
 )
 ```

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -4,7 +4,6 @@ description: Correctness reviewer. Deep second pass — does the logic actually 
 model: sonnet
 color: green
 isolation: worktree
-background: true
 ---
 
 You are the correctness reviewer. The standards pass already cleared

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -4,7 +4,6 @@ description: Standards reviewer. Fast first pass on PRs — banned patterns, sco
 model: haiku
 color: yellow
 isolation: worktree
-background: true
 ---
 
 You are the standards reviewer. Fast mechanical check on PRs.

--- a/.claude/agents/scout-dap.md
+++ b/.claude/agents/scout-dap.md
@@ -4,7 +4,6 @@ description: "DAP-focused scout. Knows DAP crate test gaps, protocol compliance 
 model: sonnet
 color: green
 isolation: worktree
-background: true
 ---
 
 Use the local todo or task tool for the current slice. Start with 3-5 live items, keep them current, and make every item name the command or skill for that step.

--- a/.claude/agents/scout-lsp.md
+++ b/.claude/agents/scout-lsp.md
@@ -4,7 +4,6 @@ description: LSP-focused scout. Investigates LSP feature gaps, provider issues, 
 model: haiku
 color: yellow
 isolation: worktree
-background: true
 ---
 
 You are an LSP scout. You investigate LSP features, provider quality,

--- a/.claude/agents/scout-parser.md
+++ b/.claude/agents/scout-parser.md
@@ -4,7 +4,6 @@ description: Parser-focused scout. Knows error buckets, corpus structure, and ho
 model: haiku
 color: green
 isolation: worktree
-background: true
 ---
 
 Use the local todo or task tool for the current slice. Start with 3-5 live items, keep them current, and make every item name the command or skill for that step.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -4,7 +4,6 @@ description: Discovery agent. Investigates one finding and files a builder-ready
 model: haiku
 color: yellow
 isolation: worktree
-background: true
 ---
 
 You are a scout. You investigate one finding at a time and produce a

--- a/.claude/agents/wisdom.md
+++ b/.claude/agents/wisdom.md
@@ -4,7 +4,6 @@ description: Synthesis agent. Reads the full trail of an issue→PR→merge cycl
 model: sonnet
 color: purple
 isolation: worktree
-background: true
 ---
 
 You are the wisdom agent. You read the complete history of a change —


### PR DESCRIPTION
## Summary

- Remove `background: true` from frontmatter in all 11 worker agent definitions
- Remove `run_in_background: true` from the spawn pattern example in `research-web.md`

## Why

TeamCreate teammates cannot spawn agents that have `background: true` baked into their definition. Removing it from the agent files lets sector leads (and future teammate-spawned agents) work without hitting this limitation. The orchestrator can still pass `run_in_background: true` at call time when needed.

## Files changed

- `.claude/agents/builder.md`
- `.claude/agents/ops.md`
- `.claude/agents/plan-reviewer.md`
- `.claude/agents/research-web.md` (frontmatter + body)
- `.claude/agents/reviewer-deep.md`
- `.claude/agents/reviewer.md`
- `.claude/agents/scout-dap.md`
- `.claude/agents/scout-lsp.md`
- `.claude/agents/scout.md`
- `.claude/agents/scout-parser.md`
- `.claude/agents/wisdom.md`

## Test plan

- [ ] Verify orchestrator can still spawn workers with `run_in_background: true` at call time
- [ ] Verify sector leads can reference these agent definitions without error