### PR TITLE
fix(parser): add missing special variables $>, $<, $) and empty while() condition (fixes #2400)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1674,6 +1674,9 @@ impl<'a> PerlLexer<'a> {
                                 | ','
                                 | '"'
                                 | ';'
+                                | '>'
+                                | '<'
+                                | ')'
                         )
                     {
                         self.advance(); // consume the special character

--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -143,7 +143,14 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::LeftParen)?;
 
         // Check if this is a variable declaration in the condition
-        let condition = if matches!(
+        let condition = if self.peek_kind() == Some(TokenKind::RightParen) {
+            // while () { } — empty condition is the infinite-loop idiom, equivalent to while (1)
+            let loc = self.current_position();
+            Node::new(
+                NodeKind::Number { value: "1".to_string() },
+                SourceLocation { start: loc, end: loc },
+            )
+        } else if matches!(
             self.peek_kind(),
             Some(TokenKind::My)
                 | Some(TokenKind::Our)

--- a/crates/perl-parser-core/tests/special_punct_variables_tests.rs
+++ b/crates/perl-parser-core/tests/special_punct_variables_tests.rs
@@ -84,3 +84,47 @@ write;
 fn prototype_semicolon_not_confused_with_special_var() {
     parse_ok("sub foo($;@) {}");
 }
+
+// ===== $>, $<, $) — process UID/GID special variables =====
+
+#[test]
+fn dollar_gt_effective_uid() {
+    parse_ok("my $uid = $>;");
+}
+
+#[test]
+fn dollar_lt_real_uid() {
+    parse_ok("my $uid = $<;");
+}
+
+#[test]
+fn dollar_rparen_effective_gid() {
+    parse_ok(r#"my ($egid, @supp) = split " ", $);"#);
+}
+
+#[test]
+fn dollar_rparen_in_constant() {
+    parse_ok(r#"use constant GID => (split ' ', $) )[0];"#);
+}
+
+#[test]
+fn dollar_gt_in_getpwuid() {
+    parse_ok(r#"my $user = (getpwuid($>))[0];"#);
+}
+
+#[test]
+fn dollar_rparen_in_grep() {
+    parse_ok(r#"$ok = grep { $_ == $x } split /\s+/, $);"#);
+}
+
+// ===== while () { } — empty condition (infinite loop idiom) =====
+
+#[test]
+fn while_empty_condition() {
+    parse_ok("while () { last; }");
+}
+
+#[test]
+fn while_empty_condition_with_body() {
+    parse_ok("while () { my $line = <STDIN>; last unless defined $line; }");
+}


### PR DESCRIPTION
## Problem

The `unexpected_rparen_expr` error bucket has **92 corpus files** (6th largest). Two distinct root causes:

1. **Missing special variables in lexer**: `$>` (effective UID), `$<` (real UID), `$)` (effective GID) were not listed in the lexer's special punctuation variable table. The lexer emitted a bare `$` sigil token, causing the parser to see `)`, `>`, or `<` as unexpected tokens.

2. **Empty `while ()` condition**: `while () { }` is a valid Perl infinite-loop idiom but the parser tried to call `parse_expression()` and immediately hit `)`.

## Fix

### Lexer (`crates/perl-lexer/src/lib.rs`)
Added `'>' | '<' | ')'` to the `matches!()` list at line 1656 in `try_variable()`.

### Parser (`crates/perl-parser-core/src/engine/parser/control_flow.rs`)
In `parse_while_statement()`, added a guard: if the next token after `(` is `)`, emit a synthetic `NumberLiteral("1")` as the condition instead of calling `parse_expression()`.

## Corpus Impact

Fixes 46 unique files (92 sweep entries due to dual 5.38/5.38.2 paths):
- `Net/hostent.pm`, `Net/netent.pm`, `Net/protoent.pm`, `Net/servent.pm`, `User/grent.pm`, `User/pwent.pm` — `$)` in split
- `Archive/Tar/Constant.pm` — `(split ' ', $) )[0]`
- `File/stat.pm` — `$)` and `new()`
- `Benchmark.pm`, `CPAN/Debug.pm`, `HTTP/Tiny.pm`, `CPAN/Distribution.pm`, `CPAN/Shell.pm`, `CPAN.pm` — `while () {}`
- `Net/FTP.pm` — `$>` in getpwuid
- And their 5.38.2 counterparts + CPAN corpus files

## Tests

8 new tests in `crates/perl-parser-core/tests/special_punct_variables_tests.rs`:
- `dollar_gt_effective_uid`, `dollar_lt_real_uid`, `dollar_rparen_effective_gid`
- `dollar_rparen_in_constant`, `dollar_gt_in_getpwuid`, `dollar_rparen_in_grep`
- `while_empty_condition`, `while_empty_condition_with_body`

All 21 tests in the file pass. Pre-existing failure `test_split_regex_complex_paren_list` is unrelated and existed before this PR.

## Verify

```bash
cargo test -p perl-lexer && cargo test -p perl-parser-core --test special_punct_variables_tests
```