### PR TITLE
fix(parser): handle expected_identifier for no-if, method-as-function

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -887,8 +887,25 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'no'
 
-        // Parse module name (can include ::)
-        let mut module = self.expect(TokenKind::Identifier)?.text.to_string();
+        // Parse module name — accepts bare identifiers or keyword-named pragmas
+        // (e.g. `no if COND, warnings`, `no feature`).
+        let first_token = self.consume_token()?;
+        let mut module = if first_token.kind == TokenKind::Identifier {
+            first_token.text.to_string()
+        } else if first_token.text.chars().all(|c| c.is_alphanumeric() || c == '_')
+            && !first_token.text.is_empty()
+        {
+            // Keyword-named pragmas: `no if COND, MODULE`, etc.
+            first_token.text.to_string()
+        } else {
+            return Err(ParseError::syntax(
+                format!(
+                    "Expected module name after 'no', found {}",
+                    first_token.kind.display_name()
+                ),
+                first_token.start,
+            ));
+        };
 
         // Handle :: in module names
         // Handle both DoubleColon tokens and separate Colon tokens (in case lexer sends :: as separate colons)
@@ -918,6 +935,39 @@ impl<'a> Parser<'a> {
         if self.peek_kind() == Some(TokenKind::Number) {
             module.push(' ');
             module.push_str(&self.consume_token()?.text);
+        }
+
+        // `no if CONDITION, MODULE [, ARGS]` and `no unless ...` are special:
+        // the condition is an arbitrary expression that may contain braces
+        // (e.g. `eval { ... }`), so we need brace-depth-aware token consumption.
+        if module == "if" || module == "unless" {
+            let mut cond_args = Vec::new();
+            let mut brace_depth: usize = 0;
+            while !self.tokens.is_eof() {
+                if brace_depth == 0 && Self::is_statement_terminator(self.peek_kind()) {
+                    break;
+                }
+                if self.peek_kind() == Some(TokenKind::Comma) && brace_depth == 0 {
+                    self.consume_token()?;
+                    continue;
+                }
+                match self.peek_kind() {
+                    Some(TokenKind::LeftBrace) => {
+                        brace_depth = brace_depth.saturating_add(1);
+                    }
+                    Some(TokenKind::RightBrace) => {
+                        brace_depth = brace_depth.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+                cond_args.push(self.consume_token()?.text.to_string());
+            }
+            let end = self.previous_position();
+            let has_filter_risk = Self::is_filter_module(&module);
+            return Ok(Node::new(
+                NodeKind::No { module, args: cond_args, has_filter_risk },
+                SourceLocation { start, end },
+            ));
         }
 
         // Parse optional arguments list

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -208,7 +208,17 @@ impl<'a> Parser<'a> {
                 })
             }
             TokenKind::Class => self.parse_class(),
-            TokenKind::Method => self.parse_method(),
+            // `method NAME SIGNATURE BLOCK` is a Perl 5.38+ declaration.
+            // Legacy code uses `method` as a function name; disambiguate by
+            // checking the next token is an Identifier (the method name).
+            TokenKind::Method
+                if matches!(
+                    self.tokens.peek_second().map(|t| t.kind),
+                    Ok(TokenKind::Identifier)
+                ) =>
+            {
+                self.parse_method()
+            }
 
             // Package management
             TokenKind::Package => self.parse_package(),

--- a/crates/perl-parser-core/tests/fix_expected_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/fix_expected_identifier_tests.rs
@@ -1,0 +1,90 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Tests for issue #2397: expected_identifier — version literals, sigil edge cases
+
+#[test]
+fn test_use_version_numeric() {
+    // use 5.010; — numeric version literal
+    let source = r#"use 5.010;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_use_version_vstring() {
+    // use v5.10; — v-string version
+    let source = r#"use v5.10;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_our_version_vstring() {
+    // our $VERSION = v1.2.3;
+    let source = r#"our $VERSION = v1.2.3;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_version_vstring() {
+    // package Foo v1.0; — package with v-string version
+    let source = r#"package Foo v1.0;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_version_dotted() {
+    // package Foo 1.0; — package with dotted numeric version
+    let source = r#"package Foo 1.0;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_local_dollar_underscore() {
+    // local $_; — bare special variable
+    let source = r#"local $_;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_local_input_record_separator() {
+    // local $/; — input record separator
+    let source = r#"local $/;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_local_dollar_bang() {
+    // local $!; — errno variable
+    let source = r#"local $!;"#;
+    assert_clean_parse(source);
+}
+
+// Actual corpus failures: no if CONDITION, MODULE
+#[test]
+fn test_no_if_condition_module() {
+    // no if $] >= 5.014, warnings => 'Imager::channelmask';
+    let source = r#"no if $] >= 5.014, warnings => 'Imager::channelmask';"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_no_if_feature_variant() {
+    // no if $^V ge v5.10.0, 'feature', 'switch';
+    let source = r#"no if $^V ge v5.10.0, 'feature', 'switch';"#;
+    assert_clean_parse(source);
+}
+
+// Actual corpus failures: method keyword used as function call
+#[test]
+fn test_method_as_function_call() {
+    // sub request_method { method(@_) }
+    let source = r#"sub request_method { method(@_) }"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_method_call_bare() {
+    // method(@_) — method as a bareword function call
+    let source = r#"method(@_);"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary
- `no if COND, MODULE` now parses correctly — `parse_no()` accepts keyword-named pragmas matching `parse_use()` behavior
- `method(@_)` as a function call no longer errors — disambiguates `method` keyword vs bareword by peeking at the next token
- Adds `no if`/`no unless` brace-depth-aware condition parsing in `parse_no()`

## Test plan
- [x] 12 new tests in `fix_expected_identifier_tests.rs` all pass
- [x] Existing method declaration tests pass (29 method-related tests)
- [x] Full `perl-parser-core` test suite: no regressions introduced

Closes #2397