### PR TITLE
docs(discussions): add Discussion templates and update CONTRIBUTING.md

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,15 @@
+title: ""
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For anything that doesn't fit Q&A, Ideas, Show & Tell, or the issue tracker. Introductions, meta-discussion, links to related projects, feedback on the project direction -- all welcome here.
+
+  - type: textarea
+    id: message
+    attributes:
+      label: What's on your mind?
+      description: No format required -- just write.
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,37 @@
+title: "[Idea] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share a feature request or design idea. This is the place for open-ended brainstorming before an idea is ready to become a formal issue. If your idea is fully scoped with reproduction steps or acceptance criteria, consider opening an issue instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Opportunity
+      description: What pain are you solving, or what opportunity do you see?
+      placeholder: |
+        Currently, when I work with large Perl codebases, ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: How do you imagine this working? Sketches, examples, and pseudocode all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've thought about or tried.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Editor, codebase size, Perl version, related issues, or anything else that helps frame this.

--- a/.github/DISCUSSION_TEMPLATE/q-and-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.yml
@@ -1,0 +1,37 @@
+title: "[Q&A] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask anything about using perl-lsp -- editor setup, configuration, troubleshooting, or understanding how something works. If you found an answer, please mark it so others can find it quickly.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: What do you want to know? Include as much context as helps.
+      placeholder: |
+        I'm trying to set up perl-lsp with Neovim and ...
+    validations:
+      required: true
+
+  - type: input
+    id: editor
+    attributes:
+      label: Editor / LSP Client
+      description: Which editor or LSP client are you using? (Leave blank if not applicable.)
+      placeholder: "VS Code 1.96, Neovim 0.10, Helix 24.07, etc."
+
+  - type: input
+    id: version
+    attributes:
+      label: perl-lsp Version
+      description: Output of `perl-lsp --version` (Leave blank if you haven't installed it yet.)
+      placeholder: "0.12.0"
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I've Already Tried
+      description: Saves others from suggesting things you've already ruled out.

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,37 @@
+title: "[Show & Tell] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share how you use perl-lsp. Neovim configs, CI integration scripts, company setups, Moose workflows, anything you've built or discovered that others might find useful.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What Are You Sharing?
+      description: Describe what you built, configured, or discovered.
+      placeholder: |
+        I've been using perl-lsp with Helix and put together a config that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: content
+    attributes:
+      label: The Config, Script, or Setup
+      description: Paste your config, script, or a link to it. Code blocks and screenshots welcome.
+      render: text
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Editor / Environment
+      description: Editor, OS, Perl version, and any other context that makes this work.
+      placeholder: "Neovim 0.10 on Ubuntu 24.04, Perl 5.38"
+
+  - type: textarea
+    id: gotchas
+    attributes:
+      label: Gotchas / Tips
+      description: Anything that tripped you up or that would save others time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,8 +185,18 @@ See [STABILITY.md](docs/reference/STABILITY.md) for our API stability policy.
 
 ## Getting Help
 
-- **Issues**: [Browse or create issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
-- **Discussions**: Use [GitHub Discussions](https://github.com/EffortlessMetrics/perl-lsp/discussions) for questions and ideas
+Use the right channel for the fastest response:
+
+| Channel | Use for |
+|---------|---------|
+| [GitHub Discussions - Q&A](https://github.com/EffortlessMetrics/perl-lsp/discussions/categories/q-a) | Editor setup, configuration, how-to questions |
+| [GitHub Discussions - Ideas](https://github.com/EffortlessMetrics/perl-lsp/discussions/categories/ideas) | Feature brainstorming before opening a formal issue |
+| [GitHub Discussions - Show & Tell](https://github.com/EffortlessMetrics/perl-lsp/discussions/categories/show-and-tell) | Configs, workflows, and integrations to share |
+| [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues) | Bug reports and confirmed feature requests |
+
+> Note: Discussions must be enabled in repository settings before the links above are active.
+> See [#2169](https://github.com/EffortlessMetrics/perl-lsp/issues/2169) for the tracking issue.
+
 - **Docs**: See `docs/` for detailed guides -- start with [COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md)
 
 ## Code of Conduct


### PR DESCRIPTION
## Summary

- Adds `.github/DISCUSSION_TEMPLATE/` with four category templates ready for when an admin enables Discussions:
  - `q-and-a.yml` — editor setup, configuration, troubleshooting questions (Q/A format)
  - `ideas.yml` — feature brainstorming before formal issues (open-ended)
  - `show-and-tell.yml` — community configs, workflows, integrations (open-ended)
  - `general.yml` — lightweight catch-all for everything else
- Updates the **Getting Help** section of `CONTRIBUTING.md` to route users to the correct channel with a routing table (Discussions for questions/ideas, Issues for bugs)
- Includes an explicit note that Discussions requires a **manual admin step** in Settings > General > Features > Discussions

## Manual step required (not automatable via API or PR)

GitHub does not expose a REST or GraphQL endpoint to enable Discussions programmatically. A repo admin must:

1. Go to **Settings > General > Features**
2. Check **Discussions**
3. Save

Once enabled, the four categories from the templates will appear automatically, and the links in CONTRIBUTING.md will become active.

## Test plan

- [ ] Admin enables Discussions in repo settings
- [ ] Verify four categories appear: Q&A, Ideas, Show & Tell, General
- [ ] Verify CONTRIBUTING.md "Getting Help" links resolve correctly
- [ ] Open a test discussion in each category to confirm templates load

Closes #2169