### PR TITLE
docs: clarify incremental parsing behavior and limitations

### DIFF
--- a/docs/how-to/INCREMENTAL_PARSING_GUIDE.md
+++ b/docs/how-to/INCREMENTAL_PARSING_GUIDE.md
@@ -1,309 +1,64 @@
 # Incremental Parsing Guide
 
-## Overview
+## Current State
 
-The native parser includes **incremental parsing** with **statistical validation framework** achieving 99.7% node reuse efficiency and 65µs average update times for efficient real-time LSP editing.
+The LSP server advertises `TextDocumentSyncKind::Incremental` (value 2) to clients. This refers to **how document text is transferred**, not whether parsing itself is incremental.
 
-## Architecture
+### What "Incremental" Means Here
 
-- **IncrementalDocument**: High-performance document state with intelligent subtree caching and Rope integration
-- **Rope-based Text Management**: Efficient UTF-16/UTF-8 position conversion using `ropey` crate
-- **Intelligent Subtree Reuse**: Container nodes reuse unchanged AST subtrees with symbol-priority-based eviction
-- **4-Tier Priority System**: Critical > High > Medium > Low symbol classification for cache management
-- **Metrics Tracking**: Detailed performance metrics (reused vs reparsed nodes)
-- **Content-based Caching**: Hash-based subtree matching for common patterns
-- **Position-based Caching**: Range-based subtree matching with precise Rope position tracking
-- **LSP-Aware Cache Eviction**: Preserves packages, use statements, and subroutines under memory pressure
+When a client sends `textDocument/didChange`, it uses LSP's incremental sync format: each change carries a `range` and replacement `text`, rather than the full document content. The server applies these range-based edits to its in-memory Rope buffer via [`apply_changes`](../../crates/perl-lsp/src/textdoc.rs).
+
+### What Happens After Each Edit
+
+After applying the text edits to the Rope, the LSP server does a **full reparse** of the document. There is no AST subtree reuse — `Parser::new(source).parse()` runs on the complete source text every time. This is correct and produces accurate diagnostics and symbol information, but it means every keystroke triggers a full parse regardless of edit size.
+
+See [`crates/perl-lsp/src/runtime/text_sync.rs`](../../crates/perl-lsp/src/runtime/text_sync.rs) for the implementation.
+
+## The `perl-incremental-parsing` Crate
+
+The `perl-incremental-parsing` crate exists and contains substantial incremental parsing infrastructure:
+
+- **`IncrementalState`** — Rope-backed document state with lexer checkpoints and token cache reuse
+- **`IncrementalDocument`** — `Arc<Node>`-based document with subtree cache and priority-aware eviction
+- **`IncrementalParserV2`** — Production-grade parser with AST subtree reuse metrics
+- **`DocumentParser`** — Enum wrapper (`Full` | `Incremental`) gated on `PERL_LSP_INCREMENTAL` env var
+
+This crate is a feature-gated optional dependency of `perl-parser` (behind the `incremental` feature flag). However, it is **not wired into the `perl-lsp` server** — `perl-lsp` does not depend on this crate and does not invoke it on `didChange` events.
+
+The infrastructure in `perl-incremental-parsing` represents real implementation work but is not connected to the running LSP. Wiring it in is tracked as future work.
+
+## Performance Characteristics (Current)
+
+The full-reparse approach is fast enough for typical Perl files in practice:
+
+- The v3 recursive-descent parser is written in Rust and generally handles small-to-medium files in under a millisecond on modern hardware
+- An AST content cache (`ast_cache`) avoids re-parsing when the same text is seen twice (e.g., on `didSave` after `didChange`)
+- Files larger than the configured size limit (`PERL_LSP_MAX_FILE_SIZE_KB`, default 512 KB) are skipped entirely with no AST
+
+No 65µs or 99.7% node-reuse benchmarks apply to the current LSP path — those numbers were measured against the `perl-incremental-parsing` crate's internal test suite, which is not connected to the server.
 
 ## Rope Integration
 
-The perl-parser crate includes comprehensive Rope support for document management:
+The server does use a Rope for efficient text management and UTF-16 position conversion. Key modules:
 
-**Core Rope Modules**:
-- **`textdoc.rs`**: UTF-16 aware text document handling with `ropey::Rope`
-- **`position_mapper.rs`**: Centralized position mapping (CRLF/LF/CR line endings, UTF-16 code units, byte offsets)
-- **`incremental_integration.rs`**: Bridge between LSP server and incremental parsing with Rope
-- **`incremental_handler_v2.rs`**: Enhanced incremental document updates using Rope
+- [`crates/perl-lsp/src/textdoc.rs`](../../crates/perl-lsp/src/textdoc.rs) — `Doc` struct, `apply_changes`, UTF-16 position conversion
+- [`crates/perl-lsp/src/state/document.rs`](../../crates/perl-lsp/src/state/document.rs) — `DocumentState` holding the Rope, AST, and `LineStartsCache`
 
-**Position Conversion Features**:
-```rust
-// UTF-16/UTF-8 position conversion
-use crate::textdoc::{Doc, PosEnc, lsp_pos_to_byte, byte_to_lsp_pos};
-use ropey::Rope;
+The Rope is used correctly for applying incremental text edits. It is not used to avoid reparsing.
 
-// Create document with Rope
-let mut doc = Doc { rope: Rope::from_str(content), version };
+## Roadmap
 
-// Convert LSP positions (UTF-16) to byte offsets 
-let byte_offset = lsp_pos_to_byte(&doc.rope, pos, PosEnc::Utf16);
-
-// Convert byte offsets to LSP positions
-let lsp_pos = byte_to_lsp_pos(&doc.rope, byte_offset, PosEnc::Utf16);
-```
-
-**Line Ending Support**:
-- **CRLF handling**: Proper Windows line ending support
-- **Mixed line endings**: Robust detection and handling of mixed CRLF/LF/CR
-- **UTF-16 emoji support**: Correct positioning with Unicode characters requiring surrogate pairs
-
-## Performance Targets ✅ **EXCEEDED**
-
-- **65µs average** for simple edits (target: <100µs) - ✅ **Excellent**
-- **205µs average** for moderate edits (target: <500µs) - ✅ **Very Good** 
-- **538µs average** for large documents (target: <1ms) - ✅ **Good**
-- **99.7% peak node reuse** (target: ≥70%) - ✅ **Exceptional**
-- **<0.6 coefficient of variation** for statistical consistency - ✅ **Excellent**
-- **100% incremental success rate** with comprehensive fallback mechanisms - ✅ **Perfect**
-
-## API Usage
-
-### Basic Incremental Parsing API
-```rust
-// Create incremental document with intelligent cache (default 1000 entries)
-let mut doc = IncrementalDocument::new(source)?;
-
-// Apply single edit (automatically preserves critical LSP symbols)
-let edit = IncrementalEdit::new(start_byte, end_byte, new_text);
-doc.apply_edit(edit)?;
-
-// Apply multiple edits in batch (cache respects symbol priorities)
-let mut edits = IncrementalEditSet::new();
-edits.add(edit1);
-edits.add(edit2);
-doc.apply_edits(&edits)?;
-
-// Performance metrics with intelligent cache management
-println!("Parse time: {:.2}ms", doc.metrics.last_parse_time_ms);
-println!("Nodes reused: {}", doc.metrics.nodes_reused);
-println!("Nodes reparsed: {}", doc.metrics.nodes_reparsed);
-println!("Cache hits: {}", doc.metrics.cache_hits);
-println!("Cache misses: {}", doc.metrics.cache_misses);
-
-// Configure cache size for different workloads
-doc.subtree_cache.set_max_size(2000); // Larger caches for complex codebases
-```
-
-### Advanced Incremental Parsing (IncrementalParserV2)
-
-**Features**:
-- **Smart Node Reuse**: Automatically detects which AST nodes can be preserved across edits with 99.7% peak efficiency
-- **Statistical Validation**: Comprehensive performance analysis with coefficient of variation tracking
-- **Sub-millisecond Performance**: 65µs average for simple edits with consistent performance
-- **Unicode-Safe Operations**: Proper handling of multibyte characters and international content
-- **Production Test Infrastructure**: 40+ comprehensive test cases with statistical validation
-- **Fallback Mechanisms**: Graceful degradation to full parsing when needed
-
-**Production Example**:
-```rust
-// Incremental parsing with statistical validation
-use perl_parser::{incremental_v2::IncrementalParserV2, edit::Edit, position::Position};
-
-let mut parser = IncrementalParserV2::new();
-
-// Initial parse
-let tree1 = parser.parse("my $x = 42;")?;
-println!("Initial: Reparsed={}, Reused={}", parser.reparsed_nodes, parser.reused_nodes);
-
-// Apply edit (change "42" to "4242")
-parser.edit(Edit::new(8, 10, 12, /* position data */));
-let tree2 = parser.parse("my $x = 4242;")?;
-println!("After edit: Reparsed={}, Reused={} (efficiency: {:.1}%)", 
-    parser.reparsed_nodes, parser.reused_nodes,
-    parser.reused_nodes as f64 / (parser.reused_nodes + parser.reparsed_nodes) as f64 * 100.0);
-// Typical output: Reparsed=1, Reused=3 (efficiency: 75.0%)
-// Production scenarios: Reused efficiency often reaches 96.8-99.7%
-```
-
-## Statistical Validation Framework (**Diataxis: Explanation**)
-
-The incremental parser includes a comprehensive statistical validation system for production reliability:
-
-### Performance Analysis Components
-- **Statistical Consistency**: Coefficient of variation tracking (target: <1.0, achieved: 0.6)
-- **Performance Categories**: Excellent (<100µs), Very Good (<500µs), Good (<1ms)
-- **Regression Detection**: Multi-batch testing to detect performance degradation
-- **Memory Stability**: 100-iteration stability testing for production reliability
-
-### Test Infrastructure
-```rust
-// Comprehensive statistical validation (40+ test cases)
-cargo test -p perl-parser incremental_statistical_validation_test --features incremental
-
-// Performance regression detection
-cargo test -p perl-parser incremental_performance_tests --features incremental
-
-// Edge case validation with Unicode support
-cargo test -p perl-parser incremental_edge_cases_test --features incremental
-```
-
-### Production Metrics Achieved
-- **Sub-millisecond consistency**: 65µs average with <0.6 coefficient of variation
-- **Exceptional node reuse**: 99.7% peak efficiency in production scenarios  
-- **Perfect reliability**: 100% incremental parsing success rate
-- **Unicode safety**: Proper multibyte character handling validated
-
-## LSP Integration
-
-- **Document Management**: LSP server uses Rope for all document state (`textdoc::Doc`)
-- **Position Conversion**: Automatic UTF-16 ↔ UTF-8 conversion via `position_mapper::PositionMapper`
-- **Incremental Updates**: Enable via `PERL_LSP_INCREMENTAL=1` environment variable
-- **Change Application**: Efficient change processing using `textdoc::apply_changes()`
-- **LSP-Aware Caching**: Critical LSP symbols (packages, use statements, subroutines) protected during cache pressure
-- **Symbol Resolution**: Cache preserves high-priority symbols (variables, function calls) for accurate completion
-- **Fallback Mechanisms**: Graceful degradation to full parsing when incremental parsing fails
-- **Testing**: Comprehensive integration tests with async LSP harness and Rope-based position validation
-
-## Development Guidelines
-
-**Where to Make Rope Improvements**:
-- **Production Code**: `/crates/perl-parser/src/` - All Rope enhancements should target this crate
-- **Key Modules**: `textdoc.rs`, `position_mapper.rs`, `incremental_*.rs` modules
-- **NOT Internal Test Harnesses**: Avoid modifying `/crates/tree-sitter-perl-rs/` or other internal test code
-
-## Intelligent Cache Management (*Diataxis: Explanation*)
-
-### Symbol Priority System
-
-The incremental parser uses a 4-tier priority system to intelligently manage cache eviction, ensuring critical LSP symbols remain available even under memory pressure:
-
-**Priority Levels** (Critical > High > Medium > Low):
-
-```rust
-pub enum SymbolPriority {
-    Critical = 3,  // LSP-essential symbols: packages, use statements, subroutines
-    High = 2,      // Navigation symbols: variables, function calls, declarations
-    Medium = 1,    // Structural elements: blocks, control flow, assignments
-    Low = 0,       // Simple elements: literals, binary/unary expressions
-}
-```
-
-### Symbol Classification (*Diataxis: Reference*)
-
-**Critical Priority** - Essential for LSP functionality:
-- `NodeKind::Package` - Package declarations for namespace resolution
-- `NodeKind::Use` / `NodeKind::No` - Import statements for symbol resolution
-- `NodeKind::Subroutine` - Function definitions for go-to-definition, completion
-
-**High Priority** - Important for code navigation:
-- `NodeKind::FunctionCall` - Function invocations for call hierarchy
-- `NodeKind::Variable` - Variable references for find-references
-- `NodeKind::VariableDeclaration` - Variable declarations for symbol tables
-
-**Medium Priority** - Structural elements:
-- `NodeKind::Block` - Code blocks for scope analysis
-- `NodeKind::If` / `NodeKind::While` / `NodeKind::For` - Control flow structures
-- `NodeKind::Assignment` - Assignment operations
-
-**Low Priority** - Simple expressions (first to be evicted):
-- `NodeKind::Number` / `NodeKind::String` - Literal values
-- `NodeKind::Binary` / `NodeKind::Unary` - Simple expressions
-
-### Cache Eviction Strategy (*Diataxis: Explanation*)
-
-When cache size exceeds the configured limit (`max_size`, default 1000 entries), the eviction algorithm follows these steps:
-
-1. **Priority-Based Selection**: Identifies candidates for eviction, prioritizing low-priority symbols
-2. **LRU Within Priority**: Among symbols of the same priority, removes least recently used entries
-3. **Graceful Fallback**: If no low-priority symbols exist, removes oldest entry regardless of priority
-4. **LSP Protection**: Critical symbols (packages, use statements, subroutines) are strongly protected
-
-**Eviction Algorithm**:
-```rust
-// Eviction prioritizes: Low -> Medium -> High -> Critical
-// Within same priority: Oldest (LRU) -> Newest
-fn find_least_important_entry(&self) -> Option<u64> {
-    // Sort by priority (ascending), then by LRU position (oldest first)
-    candidates.sort_by(|a, b| {
-        let priority_cmp = a.1.cmp(&b.1);
-        if priority_cmp != std::cmp::Ordering::Equal {
-            return priority_cmp;
-        }
-        // Same priority: prefer older entries
-        let a_pos = self.lru.iter().position(|&h| h == a.0).unwrap_or(usize::MAX);
-        let b_pos = self.lru.iter().position(|&h| h == b.0).unwrap_or(usize::MAX);
-        a_pos.cmp(&b_pos)
-    });
-}
-```
-
-### Cache Configuration (*Diataxis: How-to Guide*)
-
-**Workload-Specific Cache Sizing**:
-
-```rust
-// Small projects (< 1000 lines)
-doc.subtree_cache.set_max_size(500);
-
-// Medium projects (1000-5000 lines)  
-doc.subtree_cache.set_max_size(1000);  // Default
-
-// Large projects (5000-20000 lines)
-doc.subtree_cache.set_max_size(2000);
-
-// Enterprise codebases (> 20000 lines)
-doc.subtree_cache.set_max_size(5000);
-```
-
-**Memory Usage Estimation**:
-- **Small cache (500 entries)**: ~2-5 MB memory overhead
-- **Default cache (1000 entries)**: ~4-10 MB memory overhead  
-- **Large cache (2000 entries)**: ~8-20 MB memory overhead
-- **Enterprise cache (5000 entries)**: ~20-50 MB memory overhead
-
-*Memory usage varies based on AST complexity and symbol types cached*
-
-### Performance Impact (*Diataxis: Explanation*)
-
-The intelligent cache eviction provides these benefits:
-
-**LSP Reliability**: Critical symbols remain cached, ensuring consistent:
-- Package resolution for cross-file navigation
-- Import analysis for completion accuracy
-- Function definitions for go-to-definition features
-
-**Memory Efficiency**: Priority-based eviction prevents cache bloat while maintaining performance:
-- Low-priority literals evicted first (minimal LSP impact)
-- High-priority variables preserved for accurate completion
-- Critical symbols strongly protected
-
-**Performance Characteristics**:
-- **Cache hit rate**: 85-95% for critical/high priority symbols
-- **Eviction overhead**: <0.1ms per eviction cycle
-- **Memory efficiency**: 40-60% reduction in cache memory usage under pressure
-- **LSP feature reliability**: 99%+ accuracy maintained during cache pressure
+True incremental parsing (reusing AST subtrees across edits) requires wiring `perl-incremental-parsing` into `perl-lsp`'s `handle_did_change` path. The infrastructure exists; the integration does not. Contributions are welcome.
 
 ## Testing Commands
 
 ```bash
-# Test Rope-based position mapping
-cargo test -p perl-parser position_mapper
+# Run the LSP text-sync tests (exercises full-reparse path)
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 
-# Test incremental parsing with Rope integration  
-cargo test -p perl-parser incremental_integration_test
+# Run incremental-parsing crate unit tests (not connected to LSP server)
+cargo test -p perl-incremental-parsing
 
-# Test UTF-16 position conversion with multibyte characters
-cargo test -p perl-parser multibyte_edit_test
-
-# Test LSP document changes with Rope
-cargo test -p perl-lsp lsp_comprehensive_e2e_test
-
-# Test the example implementation
-cargo run -p perl-parser --example test_incremental_v2 --features incremental
-
-# Run comprehensive incremental tests
-cargo test -p perl-parser --test incremental_integration_test --features incremental
-
-# Run all incremental-related tests
-cargo test -p perl-parser incremental --features incremental
-
-# Test intelligent cache management and symbol priorities
-cargo test -p perl-parser test_symbol_priority_classification
-cargo test -p perl-parser test_cache_priority_preservation
-
-# Test cache eviction under memory pressure
-cargo test -p perl-parser test_cache_eviction_with_priorities
-cargo test -p perl-parser test_max_cache_size_enforcement
-
-# Validate LSP symbol protection during cache pressure
-cargo test -p perl-parser test_critical_symbol_preservation
+# Run perl-parser incremental tests (feature-gated)
+cargo test -p perl-parser --features incremental
 ```


### PR DESCRIPTION
Closes #2382

## Summary

- Rewrites `docs/how-to/INCREMENTAL_PARSING_GUIDE.md` to accurately reflect what the LSP server actually does
- Removes fabricated metrics (65µs, 99.7% node reuse) that were measured against the `perl-incremental-parsing` crate's internal tests, which are not connected to the running server
- Explains the critical distinction: `TextDocumentSyncKind::Incremental` (the value `2` advertised to clients) governs how *text is transferred* over the LSP wire, not whether parsing itself is incremental
- Documents the `perl-incremental-parsing` crate status: real infrastructure exists, but it is not wired into `perl-lsp`'s `handle_did_change` path
- Adds a clear Roadmap section pointing at the wiring work needed

## What was found

Three locations already had accurate inline comments explaining this (added previously):
- `crates/perl-lsp/src/runtime/text_sync.rs` lines 7-9
- `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs` lines 191-195

The public-facing How-To doc was the only place with misleading claims.

## Test plan

- [ ] `cargo fmt --all` passes (no Rust changes, just docs)
- [ ] `cargo clippy --workspace --lib` passes (confirmed clean)
- [ ] Docs accurately describe behavior verifiable by reading `crates/perl-lsp/src/runtime/text_sync.rs`