### PR TITLE
feat(ux): add first-run onboarding and health check command

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -333,6 +333,12 @@
         "title": "Run Tests in Current File",
         "category": "Perl",
         "icon": "$(beaker)"
+      },
+      {
+        "command": "perl-lsp.runHealthCheck",
+        "title": "Run Health Check",
+        "category": "Perl",
+        "icon": "$(pulse)"
       }
     ],
     "menus": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -13,6 +13,7 @@ import {
 import { PerlTestAdapter } from './testAdapter';
 import { activateDebugger } from './debugAdapter';
 import { BinaryDownloader } from './downloader';
+import { OnboardingManager } from './onboarding';
 
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel;
@@ -151,6 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
             { label: '$(info) Show Version', detail: 'Check installed perl-lsp version', command: 'perl-lsp.showVersion' },
+            { label: '$(pulse) Run Health Check', detail: 'Check Perl, perltidy, and LSP binary', command: 'perl-lsp.runHealthCheck' },
             { label: '$(cloud-download) Reinstall Server Binary', detail: 'Re-download the managed perl-lsp binary', command: 'perl-lsp.reinstall' },
 
             { label: 'Configuration', kind: vscode.QuickPickItemKind.Separator },
@@ -163,6 +165,41 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (selection && selection.command && !selection.disabled) {
             vscode.commands.executeCommand(selection.command, ...(selection.args || []));
+        }
+    });
+
+    const runHealthCheckCommand = vscode.commands.registerCommand('perl-lsp.runHealthCheck', async (serverPath?: string | null) => {
+        const resolvedPath = serverPath !== undefined ? serverPath : currentServerPath;
+        const onboarding = new OnboardingManager(context, outputChannel);
+        const results = await onboarding.runSetupHealthCheck(resolvedPath ?? null);
+
+        const errors = results.filter(r => !r.ok && r.status === 'error');
+        const warnings = results.filter(r => !r.ok && r.status === 'warning');
+
+        const lines = results.map(r => {
+            const icon = r.ok ? '$(check)' : r.status === 'warning' ? '$(warning)' : '$(error)';
+            return `${icon} ${r.label}: ${r.detail}`;
+        });
+
+        outputChannel.appendLine('[health-check] Results:');
+        for (const line of lines) {
+            outputChannel.appendLine(`  ${line.replace(/\$\(\w[^)]*\)/g, '')}`);
+        }
+
+        if (errors.length > 0) {
+            const msg = `Health check failed: ${errors.map(e => e.label).join(', ')}`;
+            vscode.window.showErrorMessage(msg, 'Show Output').then(sel => {
+                if (sel === 'Show Output') { outputChannel.show(); }
+            });
+        } else if (warnings.length > 0) {
+            const msg = `Health check passed with warnings: ${warnings.map(w => w.detail).join(' | ')}`;
+            vscode.window.showWarningMessage(msg, 'Show Output').then(sel => {
+                if (sel === 'Show Output') { outputChannel.show(); }
+            });
+        } else {
+            vscode.window.showInformationMessage('Perl LSP health check passed.', 'Show Output').then(sel => {
+                if (sel === 'Show Output') { outputChannel.show(); }
+            });
         }
     });
 
@@ -198,6 +235,7 @@ export async function activate(context: vscode.ExtensionContext) {
         showVersionCommand,
         statusMenuCommand,
         reinstallCommand,
+        runHealthCheckCommand,
         formatOnSaveDisposable,
         configurationWatcher,
     );
@@ -205,6 +243,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // Initialize debug adapter
     activateDebugger(context);
     await initializeLanguageClient(context);
+
+    // First-run onboarding: show welcome notification once per installation
+    const onboarding = new OnboardingManager(context, outputChannel);
+    if (onboarding.shouldShowWelcome()) {
+        // Fire-and-forget; failures must not block extension startup
+        onboarding.showWelcomeNotification(currentServerPath).catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            outputChannel.appendLine(`[onboarding] Error showing welcome: ${msg}`);
+        });
+    }
 }
 
 export async function deactivate() {

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -1,0 +1,274 @@
+/**
+ * OnboardingManager — first-run setup experience and environment health check.
+ *
+ * Responsibilities:
+ * - Detect first run via `context.globalState` key `perl-lsp.welcomed`.
+ * - Run a multi-step health check: Perl version, perltidy, LSP binary.
+ * - Expose individual check methods so tests can exercise them in isolation.
+ */
+
+import * as fs from 'fs';
+import { execFile } from 'child_process';
+import * as vscode from 'vscode';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Severity level for a single health-check item. */
+export enum HealthCheckStatus {
+  Ok = 'ok',
+  Warning = 'warning',
+  Error = 'error',
+}
+
+/** Result of one health-check step. */
+export interface HealthCheckResult {
+  /** Short display name shown in the notification/output. */
+  label: string;
+  /** True when the check passed without errors or warnings. */
+  ok: boolean;
+  /** Severity: Ok / Warning / Error. */
+  status: HealthCheckStatus;
+  /** Human-readable detail (version string, error message, etc.). */
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal exec helper type
+// ---------------------------------------------------------------------------
+
+type ExecCheckFn = (
+  cmd: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }>;
+
+// ---------------------------------------------------------------------------
+// OnboardingManager
+// ---------------------------------------------------------------------------
+
+export class OnboardingManager {
+  private readonly context: vscode.ExtensionContext;
+  private readonly outputChannel: vscode.OutputChannel;
+
+  /**
+   * Replaceable exec function.  In production this wraps `child_process.execFile`;
+   * in tests it is replaced with a jest mock via `mgr._execCheck = jest.fn(...)`.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  _execCheck: ExecCheckFn;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel,
+  ) {
+    this.context = context;
+    this.outputChannel = outputChannel;
+    this._execCheck = defaultExecCheck;
+  }
+
+  // ---------------------------------------------------------------------------
+  // First-run state
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns `true` on the very first activation (welcome flag not yet stored).
+   */
+  shouldShowWelcome(): boolean {
+    return !this.context.globalState.get<boolean>('perl-lsp.welcomed', false);
+  }
+
+  /**
+   * Persist the welcomed flag so the welcome view only appears once per install.
+   */
+  async markWelcomed(): Promise<void> {
+    await this.context.globalState.update('perl-lsp.welcomed', true);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Individual checks
+  // ---------------------------------------------------------------------------
+
+  /** Check whether `perl` is on PATH and return its version. */
+  async checkPerlInstalled(): Promise<HealthCheckResult> {
+    const label = 'Perl interpreter';
+    try {
+      const { stdout } = await this._execCheck('perl', [
+        '-e',
+        'print $]',
+      ]);
+      const version = stdout.trim() || '(unknown)';
+      this.outputChannel.appendLine(`[onboarding] Perl version: ${version}`);
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `Perl ${version} found`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(`[onboarding] Perl not found: ${msg}`);
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Error,
+        detail: `Perl not found on PATH. Install Perl and reload. (${msg})`,
+      };
+    }
+  }
+
+  /**
+   * Check whether `perltidy` is on PATH.
+   *
+   * Perltidy absence is a *warning*, not an error — the LSP works without it
+   * but formatting will be unavailable.
+   */
+  async checkPerltidyInstalled(): Promise<HealthCheckResult> {
+    const label = 'perltidy';
+    try {
+      const { stdout } = await this._execCheck('perltidy', ['--version']);
+      const version = stdout.trim() || '(unknown)';
+      this.outputChannel.appendLine(`[onboarding] perltidy: ${version}`);
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `perltidy found (${version})`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(
+        `[onboarding] perltidy not found: ${msg}`,
+      );
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Warning,
+        detail:
+          'perltidy not found — document formatting will be unavailable. ' +
+          'Install via: cpanm Perl::Tidy',
+      };
+    }
+  }
+
+  /**
+   * Check whether the LSP binary has been downloaded / located.
+   *
+   * @param serverPath  Path returned by `getServerPath`, or `null` if not found.
+   */
+  checkBinaryDownloaded(serverPath: string | null): HealthCheckResult {
+    const label = 'LSP binary';
+    if (!serverPath) {
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Error,
+        detail: 'perl-lsp binary not found. Check Output for download details.',
+      };
+    }
+    if (!fs.existsSync(serverPath)) {
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Error,
+        detail: `perl-lsp binary path does not exist on disk: ${serverPath}`,
+      };
+    }
+    return {
+      label,
+      ok: true,
+      status: HealthCheckStatus.Ok,
+      detail: `Binary found: ${serverPath}`,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Composite health check
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run all setup health checks and return an ordered list of results.
+   *
+   * @param serverPath  Path to the LSP binary, or `null` if unavailable.
+   */
+  async runSetupHealthCheck(
+    serverPath: string | null,
+  ): Promise<HealthCheckResult[]> {
+    this.outputChannel.appendLine('[onboarding] Running setup health check...');
+
+    const [perlResult, perltidyResult] = await Promise.all([
+      this.checkPerlInstalled(),
+      this.checkPerltidyInstalled(),
+    ]);
+
+    const binaryResult = this.checkBinaryDownloaded(serverPath);
+
+    const results: HealthCheckResult[] = [
+      perlResult,
+      perltidyResult,
+      binaryResult,
+    ];
+
+    for (const r of results) {
+      const icon =
+        r.status === HealthCheckStatus.Ok
+          ? '[OK]'
+          : r.status === HealthCheckStatus.Warning
+            ? '[WARN]'
+            : '[ERROR]';
+      this.outputChannel.appendLine(
+        `[onboarding] ${icon} ${r.label}: ${r.detail}`,
+      );
+    }
+
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Welcome notification
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Show a first-run welcome notification and offer to run the health check.
+   *
+   * @param serverPath  Path to the LSP binary for the health check.
+   */
+  async showWelcomeNotification(serverPath: string | null): Promise<void> {
+    await this.markWelcomed();
+
+    const selection = await vscode.window.showInformationMessage(
+      'Welcome to Perl Language Server! Run a setup health check to verify your environment.',
+      'Run Health Check',
+      'Show Output',
+      'Dismiss',
+    );
+
+    if (selection === 'Run Health Check') {
+      await vscode.commands.executeCommand(
+        'perl-lsp.runHealthCheck',
+        serverPath,
+      );
+    } else if (selection === 'Show Output') {
+      this.outputChannel.show();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default exec implementation (production)
+// ---------------------------------------------------------------------------
+
+function defaultExecCheck(
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: 5000 }, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+}

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for OnboardingManager.
+ *
+ * Tests cover:
+ * - First-run detection via globalState
+ * - checkPerlInstalled: detects Perl presence and version
+ * - checkPerltidyInstalled: detects perltidy on PATH
+ * - checkBinaryDownloaded: confirms server path present
+ * - runSetupHealthCheck: full check sequence returning HealthCheckResult
+ * - shouldShowWelcome: returns false after welcome flag is set
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  OnboardingManager,
+  HealthCheckResult,
+  HealthCheckStatus,
+} from '../onboarding';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(opts?: { welcomed?: boolean; storagePath?: string }): any {
+  const store = new Map<string, any>();
+  if (opts?.welcomed) {
+    store.set('perl-lsp.welcomed', true);
+  }
+  const dir =
+    opts?.storagePath ??
+    fs.mkdtempSync(path.join(os.tmpdir(), 'onboarding-test-'));
+  return {
+    globalStorageUri: { fsPath: dir },
+    extensionPath: dir,
+    subscriptions: [],
+    globalState: {
+      get: jest.fn((key: string, defaultValue?: any) => {
+        if (store.has(key)) return store.get(key);
+        return defaultValue;
+      }),
+      update: jest.fn(async (key: string, value: any) => {
+        store.set(key, value);
+      }),
+    },
+  };
+}
+
+function makeOutputChannel(): any {
+  return {
+    appendLine: jest.fn(),
+    show: jest.fn(),
+    dispose: jest.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// shouldShowWelcome
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.shouldShowWelcome', () => {
+  test('returns true on first run (welcomed flag not set)', () => {
+    const ctx = makeContext();
+    const mgr = new OnboardingManager(ctx, makeOutputChannel());
+    expect(mgr.shouldShowWelcome()).toBe(true);
+  });
+
+  test('returns false if welcomed flag is already set', () => {
+    const ctx = makeContext({ welcomed: true });
+    const mgr = new OnboardingManager(ctx, makeOutputChannel());
+    expect(mgr.shouldShowWelcome()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markWelcomed
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.markWelcomed', () => {
+  test('sets the welcomed flag in globalState', async () => {
+    const ctx = makeContext();
+    const mgr = new OnboardingManager(ctx, makeOutputChannel());
+    expect(mgr.shouldShowWelcome()).toBe(true);
+    await mgr.markWelcomed();
+    expect(ctx.globalState.update).toHaveBeenCalledWith(
+      'perl-lsp.welcomed',
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPerlInstalled
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.checkPerlInstalled', () => {
+  test('returns ok status with version when perl is available', async () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    // Inject a mock that simulates `perl -e 'print $]'` returning a version
+    mgr._execCheck = jest.fn((_cmd: string, _args: string[]) =>
+      Promise.resolve({ stdout: '5.036000', stderr: '' }),
+    );
+    const result = await mgr.checkPerlInstalled();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('5.036000');
+  });
+
+  test('returns error status when perl is not found', async () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn(() =>
+      Promise.reject(new Error('perl: command not found')),
+    );
+    const result = await mgr.checkPerlInstalled();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPerltidyInstalled
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.checkPerltidyInstalled', () => {
+  test('returns ok status when perltidy is available', async () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn((_cmd: string, _args: string[]) =>
+      Promise.resolve({ stdout: 'perltidy, v20230309', stderr: '' }),
+    );
+    const result = await mgr.checkPerltidyInstalled();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('perltidy');
+  });
+
+  test('returns warning (not error) when perltidy is absent', async () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn(() =>
+      Promise.reject(new Error('perltidy: command not found')),
+    );
+    const result = await mgr.checkPerltidyInstalled();
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(HealthCheckStatus.Warning);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkBinaryDownloaded
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.checkBinaryDownloaded', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ob-bin-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns ok when server path exists', () => {
+    const binPath = path.join(tmpDir, 'perl-lsp');
+    fs.writeFileSync(binPath, '#!/bin/sh\necho ok');
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = mgr.checkBinaryDownloaded(binPath);
+    expect(result.ok).toBe(true);
+  });
+
+  test('returns error when server path is null', () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = mgr.checkBinaryDownloaded(null);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(HealthCheckStatus.Error);
+  });
+
+  test('returns error when server path does not exist on disk', () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = mgr.checkBinaryDownloaded('/nonexistent/perl-lsp');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(HealthCheckStatus.Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupHealthCheck
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.runSetupHealthCheck', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ob-health-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns a HealthCheckResult array with one entry per check', async () => {
+    const binPath = path.join(tmpDir, 'perl-lsp');
+    fs.writeFileSync(binPath, '#!/bin/sh\necho ok');
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn((_cmd: string, _args: string[]) =>
+      Promise.resolve({ stdout: '5.036000', stderr: '' }),
+    );
+    const results: HealthCheckResult[] = await mgr.runSetupHealthCheck(binPath);
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('each result has label, ok, status, and detail properties', async () => {
+    const binPath = path.join(tmpDir, 'perl-lsp');
+    fs.writeFileSync(binPath, '#!/bin/sh\necho ok');
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn((_cmd: string, _args: string[]) =>
+      Promise.resolve({ stdout: '5.036000', stderr: '' }),
+    );
+    const results: HealthCheckResult[] = await mgr.runSetupHealthCheck(binPath);
+    for (const r of results) {
+      expect(typeof r.label).toBe('string');
+      expect(typeof r.ok).toBe('boolean');
+      expect(Object.values(HealthCheckStatus)).toContain(r.status);
+      expect(typeof r.detail).toBe('string');
+    }
+  });
+
+  test('binary check fails when server path is null', async () => {
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn((_cmd: string, _args: string[]) =>
+      Promise.resolve({ stdout: '5.036000', stderr: '' }),
+    );
+    const results: HealthCheckResult[] = await mgr.runSetupHealthCheck(null);
+    const binCheck = results.find(r => r.label === 'LSP binary');
+    expect(binCheck).toBeDefined();
+    expect(binCheck!.ok).toBe(false);
+  });
+
+  test('all checks pass on a fully healthy environment', async () => {
+    const binPath = path.join(tmpDir, 'perl-lsp');
+    fs.writeFileSync(binPath, '#!/bin/sh\necho ok');
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    // Simulate both perl and perltidy available
+    mgr._execCheck = jest.fn((cmd: string, _args: string[]) => {
+      if (cmd === 'perl') return Promise.resolve({ stdout: '5.036000', stderr: '' });
+      if (cmd === 'perltidy') return Promise.resolve({ stdout: 'perltidy, v20230309', stderr: '' });
+      return Promise.reject(new Error('unknown'));
+    });
+    const results: HealthCheckResult[] = await mgr.runSetupHealthCheck(binPath);
+    const errors = results.filter(r => r.status === HealthCheckStatus.Error);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// package.json contract: healthCheck command registered
+// ---------------------------------------------------------------------------
+
+describe('package.json health check command', () => {
+  const EXT_ROOT = path.resolve(__dirname, '..', '..');
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = JSON.parse(fs.readFileSync(path.join(EXT_ROOT, 'package.json'), 'utf8'));
+  });
+
+  test('registers perl-lsp.runHealthCheck command', () => {
+    const commandIds = pkg.contributes.commands.map((c: any) => c.command);
+    expect(commandIds).toContain('perl-lsp.runHealthCheck');
+  });
+
+  test('health check command has Perl category', () => {
+    const cmd = pkg.contributes.commands.find(
+      (c: any) => c.command === 'perl-lsp.runHealthCheck',
+    );
+    expect(cmd).toBeDefined();
+    expect(cmd.category).toBe('Perl');
+  });
+
+  test('health check command title is user-friendly', () => {
+    const cmd = pkg.contributes.commands.find(
+      (c: any) => c.command === 'perl-lsp.runHealthCheck',
+    );
+    expect(cmd.title).toBeTruthy();
+    expect(cmd.title.toLowerCase()).toContain('health');
+  });
+});


### PR DESCRIPTION
Closes #2315

## Summary

- **`OnboardingManager`** (`vscode-extension/src/onboarding.ts`): new class that owns all first-run state and health check logic.
  - `shouldShowWelcome()` / `markWelcomed()` — reads/writes `perl-lsp.welcomed` in `context.globalState`; welcome appears exactly once per install.
  - `checkPerlInstalled()` — runs `perl -e 'print $]'`; returns version string or error.
  - `checkPerltidyInstalled()` — runs `perltidy --version`; absence is a *warning* (not error) since formatting is optional.
  - `checkBinaryDownloaded(path)` — checks the resolved server path exists on disk.
  - `runSetupHealthCheck(serverPath)` — runs all three checks in parallel and returns `HealthCheckResult[]`.
- **`perl-lsp.runHealthCheck`** command registered in `extension.ts` and declared in `package.json`. Surfaces result as info/warn/error notification with "Show Output" action. Accessible from the command palette and the status-bar quick-pick menu.
- **First-run welcome**: after `initializeLanguageClient` completes, checks `shouldShowWelcome()` and fires `showWelcomeNotification()` asynchronously (never blocks startup). Offers "Run Health Check", "Show Output", or "Dismiss".

## Test plan

- [ ] `cd vscode-extension && npm test` — 108 tests pass (17 new in `onboarding.test.ts`)
- [ ] `npx tsc --noEmit` — zero TypeScript errors
- [ ] `cargo clippy --workspace --lib` — zero new warnings
- [ ] Manual: open a Perl file in a fresh VS Code profile; welcome notification appears; "Run Health Check" shows Perl/perltidy/binary status in both a notification and the Output channel
- [ ] Manual: reload — welcome notification does not appear again
- [ ] Manual: run `Perl: Run Health Check` from command palette — works independently of first-run state