### PR TITLE
ux(community): improve GitHub issue templates for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,17 +74,27 @@ body:
     attributes:
       label: LSP Logs / Error Output
       description: |
-        Paste any relevant LSP log output. You can capture logs by starting the server with `perl-lsp --stdio 2>lsp.log`.
+        Paste any relevant LSP log output.
+        - **VS Code**: run the `Perl: Show Output Channel` command (Ctrl+Shift+P → "Perl: Show Output Channel") and paste the contents.
+        - **Other editors**: start the server with `perl-lsp --stdio 2>lsp.log` and paste `lsp.log`.
       render: text
 
   - type: input
     id: version
     attributes:
       label: perl-lsp Version
-      description: Output of `perl-lsp --version`
-      placeholder: "0.10.0"
+      description: |
+        Run `perl-lsp --version` in your terminal, or in VS Code run the `Perl: Show Server Version` command (Ctrl+Shift+P → "Perl: Show Server Version").
+      placeholder: "0.12.0"
     validations:
       required: true
+
+  - type: input
+    id: perl-version
+    attributes:
+      label: Perl Version
+      description: Output of `perl --version` (the first line, e.g. "This is perl 5, version 38...").
+      placeholder: "perl 5.38.2"
 
   - type: input
     id: editor
@@ -94,6 +104,13 @@ body:
       placeholder: "VS Code 1.96, Neovim 0.10, Helix 24.07, etc."
     validations:
       required: true
+
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VS Code Version (if applicable)
+      description: Help > About in VS Code — only needed if using the VS Code extension.
+      placeholder: "1.96.2"
 
   - type: input
     id: os

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -49,6 +49,27 @@ body:
       render: perl
 
   - type: textarea
+    id: competitor-reference
+    attributes:
+      label: Competitor or Prior Art Reference
+      description: |
+        Does another tool already implement this? Describing how it works there helps us understand the expected behavior and set a quality bar.
+      placeholder: |
+        - rust-analyzer shows type hints inline (inlay hints); it works by ...
+        - PerlNavigator supports goto-definition for @INC modules; example: ...
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: |
+        How will we know this feature is done? List specific, observable outcomes.
+      placeholder: |
+        - [ ] `go to definition` on a `use`d module name navigates to the correct `.pm` file
+        - [ ] Works for both installed modules and local project modules
+        - [ ] Responds in <100ms on a 200-module workspace
+
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ See [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) for details
 | [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) | Debugger setup and usage |
 | [Contributing](CONTRIBUTING.md) | Development guidelines and workflow |
 | [Changelog](CHANGELOG.md) | Release history and notable changes |
+| **[Report an Issue](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose)** | Bug reports, feature requests, parser issues |
 
 ## History
 


### PR DESCRIPTION
Closes #2342

## Summary

- `bug_report.yml`: Add links to `Perl: Show Output Channel` and `Perl: Show Server Version` VS Code commands in the relevant fields; add separate Perl runtime version field; add optional VS Code version field; update placeholder from `0.10.0` to `0.12.0`.
- `feature_request.yml`: Add "Competitor or Prior Art Reference" field (optional) and "Acceptance Criteria" field (optional).
- `README.md`: Add a "Report an Issue" row at the bottom of the Documentation table pointing to `/issues/new/choose`.

## What changed and why

The existing templates were functional but missing context that reduces back-and-forth on issues:

1. Users didn't know how to get LSP logs in VS Code — the `Perl: Show Output Channel` command is non-obvious.
2. Users didn't know how to find the version in VS Code — the `Perl: Show Server Version` command is the right path, not just `perl-lsp --version` in a terminal.
3. Perl runtime version was missing entirely, but is sometimes relevant (Perl version-specific syntax bugs).
4. VS Code version was bundled with "Editor/Client" — separating it makes it easier to capture for VS Code-specific bugs.
5. Feature requests had no way to reference prior art from competitors or express acceptance criteria.
6. The README had no dedicated "Report an Issue" entry in the documentation table.

## Test plan

- [ ] Open a new issue on GitHub and verify each template renders correctly with the new fields
- [ ] Verify `bug_report.yml` YAML is valid (no parse errors on GitHub)
- [ ] Verify `feature_request.yml` YAML is valid
- [ ] Verify README table renders correctly on GitHub