### PR TITLE
fix(docs): remove intra-doc links to private items in perl-lsp and perl-dap

### DIFF
--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -479,7 +479,7 @@ impl DapServer {
     /// Run the DAP server
     ///
     /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
-    /// - [`DapMode::Native`]: Starts the stdio transport loop via [`DebugAdapter::run`]
+    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
     /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
     ///   via [`BridgeAdapter`] using a tokio async runtime
     pub fn run(&mut self) -> anyhow::Result<()> {

--- a/crates/perl-lsp/src/runtime/serving.rs
+++ b/crates/perl-lsp/src/runtime/serving.rs
@@ -48,7 +48,7 @@ impl LspServer {
     /// Serve LSP requests with worker-queue dispatch.
     ///
     /// The ingress loop reads messages from `rx`, classifies them via
-    /// [`scheduler::classify`], and routes them to dedicated worker queues.
+    /// `scheduler::classify`, and routes them to dedicated worker queues.
     /// No heavy work runs inline — only classification and channel sends.
     ///
     /// Architecture:


### PR DESCRIPTION
## Summary

- Removes broken intra-doc links to `pub(crate)` items in public doc comments
- `perl-lsp`: `serve_async` doc linked to `scheduler::classify` (private) - replaced with plain backtick
- `perl-dap`: `DapServer::run` doc linked to `DebugAdapter::run` (private) - replaced with plain backtick

## Verification

`cargo doc -p perl-lsp -p perl-dap --no-deps 2>&1 | grep -c warning` returns 0 (was 2).

Closes #2376

## Test plan

- [ ] `cargo doc -p perl-lsp -p perl-dap --no-deps` produces 0 warnings
- [ ] `cargo fmt --all` passes clean
- [ ] No behavior change - doc comment text meaning is preserved