### PR TITLE
feat(code-actions): add quick-fix for bareword-filehandle and two-arg-open (#2324)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -145,6 +145,12 @@ impl CodeActionsProvider {
                     "variable-shadowing" => {
                         actions.extend(quick_fixes::fix_variable_shadowing(&qf_diag));
                     }
+                    "bareword-filehandle" => {
+                        actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
+                    }
+                    "two-arg-open" => {
+                        actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
+                    }
                     _ => {}
                 }
             }

--- a/crates/perl-lsp-code-actions/src/quick_fixes.rs
+++ b/crates/perl-lsp-code-actions/src/quick_fixes.rs
@@ -561,3 +561,47 @@ pub fn fix_variable_shadowing(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction
 
     actions
 }
+
+/// Fix bareword filehandle by replacing with lexical filehandle
+///
+/// Bareword filehandles (e.g., `open FILE, ...`) are a common Perl anti-pattern.
+/// This fix suggests replacing the bareword with a lexical variable (`my $fh`).
+pub fn fix_bareword_filehandle(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    // Extract filehandle name from message, e.g. "Bareword filehandle 'FILE'"
+    let fh_name = diagnostic.message.split('\'').nth(1).unwrap_or("FH");
+    // Derive a lowercase lexical name: FILE -> $file_fh, LOGFILE -> $logfile_fh
+    let lexical_name = format!("${}_fh", fh_name.to_lowercase());
+
+    vec![CodeAction {
+        title: format!("Replace bareword filehandle '{}' with lexical '{}'", fh_name, lexical_name),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec!["bareword-filehandle".to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: format!("my {}", lexical_name),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Suggest upgrading two-argument open() to three-argument form
+///
+/// Two-argument `open($fh, $filename)` is unsafe because `$filename` can
+/// contain shell metacharacters. The three-argument form separates the mode
+/// from the filename, e.g. `open(my $fh, '<', $filename)`.
+pub fn fix_two_arg_open(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    vec![CodeAction {
+        title: "Convert to three-argument open() for safety".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec!["two-arg-open".to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: "open(my $fh, '<', $filename)".to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-code-actions/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-code-actions/tests/comprehensive_unit_tests.rs
@@ -818,3 +818,102 @@ fn missing_semicolon_at_end_of_file_no_newline() {
 
     assert!(has_action_matching(&actions, |a| a.title.contains("semicolon")));
 }
+
+// ===========================================================================
+// Quick-fix: bareword-filehandle (PL400)
+// ===========================================================================
+
+#[test]
+fn bareword_filehandle_offers_lexical_replacement() {
+    // "open FILE, ..." uses a bareword filehandle (FILE)
+    let src = "open FILE, '<', 'data.txt';";
+    // The bareword filehandle "FILE" spans bytes 5..9
+    let diags = [make_diag(5, 9, "bareword-filehandle", "Bareword filehandle 'FILE'")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_matching(&actions, |a| a.title.contains("lexical")
+            || a.title.contains("my $")
+            || a.title.contains("$fh")),
+        "Expected action to replace bareword filehandle with lexical, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn bareword_filehandle_action_is_quickfix_kind() {
+    let src = "open FILE, '<', 'data.txt';";
+    let diags = [make_diag(5, 9, "bareword-filehandle", "Bareword filehandle 'FILE'")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let fh_actions: Vec<_> = actions
+        .iter()
+        .filter(|a| a.diagnostics.contains(&"bareword-filehandle".to_string()))
+        .collect();
+    assert!(!fh_actions.is_empty(), "Expected at least one bareword-filehandle action");
+    assert!(
+        fh_actions.iter().all(|a| a.kind == CodeActionKind::QuickFix),
+        "bareword-filehandle actions should be QuickFix kind"
+    );
+}
+
+#[test]
+fn bareword_filehandle_action_is_preferred() {
+    let src = "open LOGFILE, '<', 'log.txt';";
+    let diags = [make_diag(5, 12, "bareword-filehandle", "Bareword filehandle 'LOGFILE'")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let preferred: Vec<_> = actions
+        .iter()
+        .filter(|a| a.diagnostics.contains(&"bareword-filehandle".to_string()) && a.is_preferred)
+        .collect();
+    assert!(!preferred.is_empty(), "At least one bareword-filehandle action should be preferred");
+}
+
+// ===========================================================================
+// Quick-fix: two-arg-open (PL401)
+// ===========================================================================
+
+#[test]
+fn two_arg_open_offers_three_arg_upgrade() {
+    // "open $fh, $filename" is the two-arg form; should suggest three-arg
+    let src = "open my $fh, $filename;";
+    let diags = [make_diag(0, 22, "two-arg-open", "Two-argument open() is unsafe")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_matching(&actions, |a| a.title.contains("three")
+            || a.title.contains("3-arg")
+            || a.title.contains("three-argument")),
+        "Expected action to convert to three-arg open, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn two_arg_open_action_is_quickfix_kind() {
+    let src = "open my $fh, $filename;";
+    let diags = [make_diag(0, 22, "two-arg-open", "Two-argument open() is unsafe")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let open_actions: Vec<_> =
+        actions.iter().filter(|a| a.diagnostics.contains(&"two-arg-open".to_string())).collect();
+    assert!(!open_actions.is_empty(), "Expected at least one two-arg-open action");
+    assert!(
+        open_actions.iter().all(|a| a.kind == CodeActionKind::QuickFix),
+        "two-arg-open actions should be QuickFix kind"
+    );
+}
+
+#[test]
+fn two_arg_open_action_is_preferred() {
+    let src = "open my $fh, $filename;";
+    let diags = [make_diag(0, 22, "two-arg-open", "Two-argument open() is unsafe")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let preferred: Vec<_> = actions
+        .iter()
+        .filter(|a| a.diagnostics.contains(&"two-arg-open".to_string()) && a.is_preferred)
+        .collect();
+    assert!(!preferred.is_empty(), "At least one two-arg-open action should be preferred");
+}


### PR DESCRIPTION
## Summary

Implements the diagnostic-driven quick-fix handlers requested in #2324 for two common Perl anti-patterns that already have stable diagnostic codes in the catalog but had no corresponding code actions:

- **`bareword-filehandle` (PL400)**: Suggests replacing a bareword filehandle (`FILE`) with a lexical filehandle (`my $file_fh`). This is the most common beginner mistake with `open()`.
- **`two-arg-open` (PL401)**: Suggests upgrading `open($fh, $filename)` to the safer three-argument form `open(my $fh, '<', $filename)`, which separates mode from filename and avoids shell metacharacter injection.

Both actions are `is_preferred: true` and `CodeActionKind::QuickFix`, consistent with the existing quick-fix pattern in this crate.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged (code actions were already advertised; this adds two new handled diagnostic codes)
- DAP surface: unchanged
- CLI: unchanged
- `perl-lsp-code-actions` public API: additive only (`fix_bareword_filehandle`, `fix_two_arg_open` are `pub` but internal to the crate dispatch)

## What changed

**`src/quick_fixes.rs`** — two new functions appended:
- `fix_bareword_filehandle(&QuickFixDiagnostic)` extracts the filehandle name from the diagnostic message and replaces the bareword range with `my $<name>_fh`.
- `fix_two_arg_open(&QuickFixDiagnostic)` replaces the full two-arg `open` range with the idiomatic three-arg form as a template the user can adjust.

**`src/code_actions.rs`** — two new match arms in `get_code_actions` dispatch the new handlers for `"bareword-filehandle"` and `"two-arg-open"` diagnostic codes.

**`tests/comprehensive_unit_tests.rs`** — six new tests covering: lexical-replacement title presence, `QuickFix` kind, and `is_preferred` flag for both new handlers.

## How to review

Start at `src/quick_fixes.rs` lines 564–609 (the two new functions), then verify wiring at `src/code_actions.rs` (the two new match arms). The tests in `tests/comprehensive_unit_tests.rs` (bottom of file) show the exact expected behavior.

## Evidence

```
test bareword_filehandle_action_is_quickfix_kind ... ok
test bareword_filehandle_action_is_preferred ... ok
test bareword_filehandle_offers_lexical_replacement ... ok
test two_arg_open_action_is_preferred ... ok
test two_arg_open_action_is_quickfix_kind ... ok
test two_arg_open_offers_three_arg_upgrade ... ok

test result: ok. 63 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

fmt: PASS | clippy -D warnings: PASS | tests: 74 passed, 0 failed
```

## Risk & rollback

- Blast radius: confined to `perl-lsp-code-actions`. No other crate is changed.
- Failure mode: a diagnostic with code `"bareword-filehandle"` or `"two-arg-open"` that previously silently fell through the `_ => {}` arm now returns a quick-fix action. This is additive.
- Rollback: revert the two match arms in `code_actions.rs` to restore prior behavior.

## Follow-ups

- The `fix_two_arg_open` template uses a hardcoded `'<'` mode and `$filename` placeholder. A smarter implementation could parse the actual `open` call to extract the existing filehandle/mode — deferred as a separate issue.
- The `fix_bareword_filehandle` name derivation (`FILE` → `$file_fh`) is heuristic; a full rename-aware fix would use the workspace index — also deferred.