### PR TITLE
feat(ux): add Perl boilerplate snippet library

### DIFF
--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -33,6 +33,7 @@ criterion = "0.8.1"
 perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-workspace-index = { workspace = true }
+serde_json = "1.0"
 url = "2.5.8"
 
 [lints]

--- a/crates/perl-lsp-completion/tests/vscode_snippet_library_tests.rs
+++ b/crates/perl-lsp-completion/tests/vscode_snippet_library_tests.rs
@@ -1,0 +1,209 @@
+//! Validation tests for the VSCode Perl snippet library.
+//!
+//! These tests verify that `vscode-extension/snippets/perl.json` is:
+//!   1. Valid JSON
+//!   2. Contains all required snippet prefix categories
+//!   3. Meets the minimum count threshold
+//!   4. Each snippet has required fields (prefix, body, description)
+
+use std::collections::HashSet;
+
+/// Resolve the path to the snippets file from the repo root.
+/// Walks up from CARGO_MANIFEST_DIR to find the directory containing
+/// `vscode-extension/snippets/perl.json`.
+fn snippet_file_path() -> Result<std::path::PathBuf, String> {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut dir = manifest_dir.as_path();
+    loop {
+        let candidate = dir.join("vscode-extension").join("snippets").join("perl.json");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return Err(
+                "walked past filesystem root without finding vscode-extension/snippets/perl.json"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Parse the snippet file and return a serde_json Value.
+fn load_snippets() -> Result<serde_json::Value, String> {
+    let path = snippet_file_path()?;
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&content).map_err(|e| format!("invalid JSON in {}: {e}", path.display()))
+}
+
+/// Collect all prefix values (string or array-of-strings) from the snippet map.
+fn all_prefixes(snippets: &serde_json::Value) -> HashSet<String> {
+    let mut prefixes = HashSet::new();
+    if let Some(map) = snippets.as_object() {
+        for (_name, snippet) in map {
+            match &snippet["prefix"] {
+                serde_json::Value::String(s) => {
+                    prefixes.insert(s.clone());
+                }
+                serde_json::Value::Array(arr) => {
+                    for v in arr {
+                        if let serde_json::Value::String(s) = v {
+                            prefixes.insert(s.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    prefixes
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_snippet_file_is_valid_json() -> Result<(), String> {
+    load_snippets().map(|_| ())
+}
+
+#[test]
+fn test_snippet_count_meets_minimum() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let count = snippets.as_object().map(|m| m.len()).unwrap_or(0);
+    assert!(count >= 50, "expected at least 50 snippets, found {count}");
+    Ok(())
+}
+
+#[test]
+fn test_snippet_control_flow_coverage() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    let required = ["if", "unless", "while", "until", "for", "foreach"];
+    for p in required {
+        assert!(prefixes.contains(p), "missing control-flow snippet prefix: '{p}'");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_snippet_do_while_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("do-while") || prefixes.contains("dowhile"),
+        "missing do-while/dowhile snippet prefix"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_anonymous_sub_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("anon-sub")
+            || prefixes.contains("anonsub")
+            || prefixes.contains("sub-anon"),
+        "missing anonymous sub snippet prefix (anon-sub / anonsub / sub-anon)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_moose_class_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("moose-class") || prefixes.contains("mooseclass"),
+        "missing Moose class snippet prefix (moose-class / mooseclass)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_moo_class_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("moo-class") || prefixes.contains("mooclass"),
+        "missing Moo class snippet prefix (moo-class / mooclass)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_moose_has_attribute_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("has") || prefixes.contains("moose-has") || prefixes.contains("moo-has"),
+        "missing Moose/Moo 'has' attribute snippet"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_qr_regex_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("qr") || prefixes.contains("qr//"),
+        "missing qr// compiled regex snippet"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_snippet_deref_patterns_present() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let prefixes = all_prefixes(&snippets);
+    assert!(
+        prefixes.contains("deref-array")
+            || prefixes.contains("derefarray")
+            || prefixes.contains("deref-hash")
+            || prefixes.contains("derefhash")
+            || prefixes.contains("deref"),
+        "missing dereference snippet (deref-array / deref-hash / deref)"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_each_snippet_has_required_fields() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let map =
+        snippets.as_object().ok_or_else(|| "snippets root is not a JSON object".to_string())?;
+    for (name, snippet) in map {
+        assert!(!snippet["prefix"].is_null(), "snippet '{name}' is missing 'prefix' field");
+        assert!(!snippet["body"].is_null(), "snippet '{name}' is missing 'body' field");
+        assert!(
+            !snippet["description"].is_null(),
+            "snippet '{name}' is missing 'description' field"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_snippet_body_non_empty() -> Result<(), String> {
+    let snippets = load_snippets()?;
+    let map =
+        snippets.as_object().ok_or_else(|| "snippets root is not a JSON object".to_string())?;
+    for (name, snippet) in map {
+        match &snippet["body"] {
+            serde_json::Value::Array(lines) => {
+                assert!(!lines.is_empty(), "snippet '{name}' has an empty body array");
+            }
+            serde_json::Value::String(s) => {
+                assert!(!s.is_empty(), "snippet '{name}' has an empty body string");
+            }
+            other => {
+                return Err(format!("snippet '{name}' has unexpected body type: {other:?}"));
+            }
+        }
+    }
+    Ok(())
+}

--- a/vscode-extension/snippets/perl.json
+++ b/vscode-extension/snippets/perl.json
@@ -425,5 +425,104 @@
             "done_testing();"
         ],
         "description": "End test file (Test::More)"
+    },
+    "Until Loop": {
+        "prefix": "until",
+        "body": [
+            "until (${1:condition}) {",
+            "    ${0}",
+            "}"
+        ],
+        "description": "Until loop (runs while condition is false)"
+    },
+    "Do-While Loop": {
+        "prefix": "do-while",
+        "body": [
+            "do {",
+            "    ${1}",
+            "} while (${0:condition});"
+        ],
+        "description": "Do-while loop (always runs at least once)"
+    },
+    "Anonymous Subroutine": {
+        "prefix": "anon-sub",
+        "body": [
+            "my \\$${1:code_ref} = sub {",
+            "    my (${2:\\$arg}) = @_;",
+            "    ${0}",
+            "};"
+        ],
+        "description": "Anonymous subroutine assigned to a variable"
+    },
+    "Moose Class": {
+        "prefix": "moose-class",
+        "body": [
+            "package ${1:My::Class};",
+            "",
+            "use strict;",
+            "use warnings;",
+            "use Moose;",
+            "",
+            "has '${2:attribute}' => (",
+            "    is  => '${3:ro}',",
+            "    isa => '${4:Str}',",
+            ");",
+            "",
+            "no Moose;",
+            "__PACKAGE__->meta->make_immutable;",
+            "",
+            "1;"
+        ],
+        "description": "Moose class boilerplate"
+    },
+    "Moo Class": {
+        "prefix": "moo-class",
+        "body": [
+            "package ${1:My::Class};",
+            "",
+            "use strict;",
+            "use warnings;",
+            "use Moo;",
+            "",
+            "has '${2:attribute}' => (",
+            "    is      => '${3:ro}',",
+            "    default => sub { ${4:'default_value'} },",
+            ");",
+            "",
+            "1;"
+        ],
+        "description": "Moo class boilerplate"
+    },
+    "Moose/Moo Attribute": {
+        "prefix": "has",
+        "body": [
+            "has '${1:attribute}' => (",
+            "    is  => '${2|ro,rw,rwp|}',",
+            "    isa => '${3:Str}',",
+            "    ${0}",
+            ");"
+        ],
+        "description": "Moose/Moo attribute declaration"
+    },
+    "Compiled Regex": {
+        "prefix": "qr",
+        "body": [
+            "my \\$${1:pattern} = qr/${2:regex}/${3:flags};"
+        ],
+        "description": "Compiled regex with qr//"
+    },
+    "Dereference Array": {
+        "prefix": "deref-array",
+        "body": [
+            "my @${1:array} = @{\\$${2:array_ref}};"
+        ],
+        "description": "Dereference an array reference"
+    },
+    "Dereference Hash": {
+        "prefix": "deref-hash",
+        "body": [
+            "my %${1:hash} = %{\\$${2:hash_ref}};"
+        ],
+        "description": "Dereference a hash reference"
     }
 }


### PR DESCRIPTION
Closes #2314

## Summary

Expands `vscode-extension/snippets/perl.json` from 49 to 58 snippets by adding 9 commonly-needed Perl boilerplate patterns that were missing: `until` loop, `do-while`, anonymous subroutine, Moose class, Moo class, Moose/Moo `has` attribute, compiled regex (`qr//`), and array/hash dereference patterns.

Adds a Rust integration test file (`vscode_snippet_library_tests.rs`) in `perl-lsp-completion` that validates the JSON file's structure on every CI run — catching future regressions in snippet count, required fields, and category coverage.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged
- VSCode extension: additive only (new snippet prefixes, no removals)

## What changed

- `vscode-extension/snippets/perl.json`: +9 snippets. Each follows the existing style (VSCode snippet format with `${N:placeholder}` and `${N|choice|}` syntax, backslash-escaped sigils).
- `crates/perl-lsp-completion/Cargo.toml`: added `serde_json = "1.0"` to `[dev-dependencies]` for test parsing.
- `crates/perl-lsp-completion/tests/vscode_snippet_library_tests.rs`: new file with 12 tests covering JSON validity, minimum count (≥50), control-flow coverage, and presence of each new snippet category.

## How to review

Start with `vscode-extension/snippets/perl.json` — the 9 new entries begin after the existing "Done Testing" snippet. Then check `vscode_snippet_library_tests.rs` to confirm the tests are structural (not brittle).

Hotspots to verify:
- Moose class uses `no Moose; __PACKAGE__->meta->make_immutable;` — correct Perl idiom
- Moo class omits `make_immutable` (Moo handles this automatically) — also correct
- `has` prefix collision: standard in all Perl snippet libraries, scoped to `.pl`/`.pm` files only

## Evidence

```
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured (vscode_snippet_library_tests)
test result: ok. 116 passed; 0 failed; 0 ignored; 0 measured (existing completion tests)
fmt: PASS
clippy -D warnings: PASS (0 warnings)
```

## Risk & rollback

Blast radius: VSCode extension snippets only — no runtime code path changes. If a snippet has a syntax error in its body, VSCode silently ignores it (no crash). Rollback: revert the JSON additions.

## Follow-ups

- The `keywords.rs` LSP server-side snippet map (in-editor as-you-type completions) could be extended to match these new prefixes — tracked separately, out of scope for this PR.
- `until` and `do-while` are not yet in the LSP keyword snippet map; that is a separate `perl-lsp-completion` change.