### PR TITLE
feat(vscode): show perl-lsp version in status bar

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -144,6 +144,23 @@ export async function activate(context: vscode.ExtensionContext) {
     });
 
     const showVersionCommand = vscode.commands.registerCommand('perl-lsp.showVersion', async () => {
+        // Prefer the version already obtained from the initialize handshake —
+        // no subprocess needed and the result is instant.
+        const cachedVersion = healthWidget?.version;
+        if (cachedVersion) {
+            const binaryPath = currentServerPath ?? '<unknown>';
+            vscode.window.showInformationMessage(
+                `perl-lsp v${cachedVersion} (${binaryPath})`,
+                'Copy'
+            ).then(selection => {
+                if (selection === 'Copy') {
+                    void vscode.env.clipboard.writeText(`perl-lsp v${cachedVersion}`);
+                }
+            });
+            return;
+        }
+
+        // Fall back to running --version when the server has not yet started.
         if (!currentServerPath) {
             vscode.window.showErrorMessage('Perl LSP server path is unavailable.');
             return;
@@ -427,6 +444,11 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
     bindClientState(client);
     await client.start();
     registerProgressHandler(client);
+    const version = client.initializeResult?.serverInfo?.version;
+    if (version && healthWidget) {
+        outputChannel.appendLine(`Perl Language Server version: ${version}`);
+        healthWidget.setVersion(version);
+    }
     await refreshTestAdapter(context);
     outputChannel.appendLine('Perl Language Server started successfully');
     return true;

--- a/vscode-extension/src/healthWidget.ts
+++ b/vscode-extension/src/healthWidget.ts
@@ -74,6 +74,7 @@ export class HealthWidget {
     private _errorCount = 0;
     private _indexingMessage: string | undefined = undefined;
     private _activeTokens = new Set<ProgressToken>();
+    private _version: string | undefined = undefined;
 
     constructor(private readonly item: vscode.StatusBarItem) {
         this._render();
@@ -137,6 +138,12 @@ export class HealthWidget {
         this._render();
     }
 
+    /** Set the server version string from the initialize handshake. */
+    setVersion(version: string): void {
+        this._version = version;
+        this._render();
+    }
+
     /** Current display mode (useful for testing). */
     get mode(): WidgetMode {
         return this._mode;
@@ -150,6 +157,11 @@ export class HealthWidget {
     /** Current error count. */
     get errorCount(): number {
         return this._errorCount;
+    }
+
+    /** Server version from the initialize handshake (undefined until set). */
+    get version(): string | undefined {
+        return this._version;
     }
 
     // -----------------------------------------------------------------------
@@ -178,6 +190,7 @@ export class HealthWidget {
             }
 
             case 'running': {
+                const label = this._version ? `perl-lsp v${this._version}` : 'perl-lsp';
                 const parts: string[] = [];
                 if (this._fileCount !== undefined) {
                     parts.push(`${this._fileCount} files`);
@@ -186,9 +199,10 @@ export class HealthWidget {
                     parts.push(`${this._errorCount} error${this._errorCount === 1 ? '' : 's'}`);
                 }
                 const detail = parts.length > 0 ? `: ${parts.join(' | ')}` : '';
-                this.item.text = `$(check) perl-lsp${detail}`;
+                this.item.text = `$(check) ${label}${detail}`;
+                const versionNote = this._version ? ` v${this._version}` : '';
                 this.item.tooltip =
-                    'Perl Language Server is running (click for options)';
+                    `Perl Language Server${versionNote} is running (click for options)`;
                 this.item.backgroundColor = undefined;
                 break;
             }

--- a/vscode-extension/src/test/healthWidget.test.ts
+++ b/vscode-extension/src/test/healthWidget.test.ts
@@ -252,3 +252,101 @@ describe('HealthWidget — counts', () => {
         expect(widget.errorCount).toBe(7);
     });
 });
+
+// ---------------------------------------------------------------------------
+// Version display (issue #2340)
+// ---------------------------------------------------------------------------
+
+describe('HealthWidget — version display', () => {
+    test('version accessor is undefined before setVersion', () => {
+        const { widget } = makeWidget();
+        expect(widget.version).toBeUndefined();
+    });
+
+    test('setVersion updates the accessor', () => {
+        const { widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        expect(widget.version).toBe('0.12.0');
+    });
+
+    test('running state without version shows plain "perl-lsp"', () => {
+        const { item, widget } = makeWidget();
+        widget.onStateChange(ClientState.Running);
+        expect(item.text).toBe('$(check) perl-lsp');
+    });
+
+    test('running state with version shows "perl-lsp v{version}"', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.onStateChange(ClientState.Running);
+        expect(item.text).toBe('$(check) perl-lsp v0.12.0');
+    });
+
+    test('setVersion while running updates text immediately', () => {
+        const { item, widget } = makeWidget();
+        widget.onStateChange(ClientState.Running);
+        widget.setVersion('0.13.0');
+        expect(item.text).toBe('$(check) perl-lsp v0.13.0');
+    });
+
+    test('version is shown with file count', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.setFileCount(100);
+        widget.onStateChange(ClientState.Running);
+        expect(item.text).toBe('$(check) perl-lsp v0.12.0: 100 files');
+    });
+
+    test('version is shown with error count', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.setErrorCount(3);
+        widget.onStateChange(ClientState.Running);
+        expect(item.text).toBe('$(check) perl-lsp v0.12.0: 3 errors');
+    });
+
+    test('tooltip includes version when set', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.onStateChange(ClientState.Running);
+        expect(item.tooltip).toContain('v0.12.0');
+    });
+
+    test('tooltip does not include version string when not set', () => {
+        const { item, widget } = makeWidget();
+        widget.onStateChange(ClientState.Running);
+        // The tooltip should not contain a version like "v0.12.0"
+        expect(item.tooltip).not.toMatch(/v\d+\.\d+/);
+    });
+
+    test('version does not affect stopped display', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.onStateChange(ClientState.Stopped);
+        expect(item.text).toBe('$(error) perl-lsp: stopped');
+    });
+
+    test('version does not affect starting display', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        // widget is already in starting mode
+        expect(item.text).toBe('$(sync~spin) Perl LSP');
+    });
+
+    test('version does not affect indexing display', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.onProgress('t', { kind: 'begin', title: 'Indexing' });
+        expect(item.text).not.toContain('v0.12.0');
+    });
+
+    test('after progress ends, running shows version again', () => {
+        const { item, widget } = makeWidget();
+        widget.setVersion('0.12.0');
+        widget.onStateChange(ClientState.Running);
+        widget.onProgress('t', { kind: 'begin', title: 'Indexing' });
+        widget.onProgress('t', { kind: 'end' });
+        expect(widget.mode).toBe('running');
+        expect(item.text).toBe('$(check) perl-lsp v0.12.0');
+    });
+});


### PR DESCRIPTION
## Summary

Closes #2340.

- `HealthWidget.setVersion(version)` stores the server version and immediately re-renders the running state as `$(check) perl-lsp v{version}` (tooltip also includes the version)
- `extension.ts` reads `client.initializeResult?.serverInfo?.version` after `client.start()` and calls `healthWidget.setVersion(version)` — the version comes directly from the LSP `initialize` handshake, requiring no extra subprocess
- `perl-lsp.showVersion` command now uses the cached version for an instant response, with fallback to `--version` subprocess if the server hasn't started yet

## What it looks like

**Before**: `$(check) perl-lsp`
**After**: `$(check) perl-lsp v0.12.0`

The version is available within the same round-trip as server startup (no added latency). The tooltip becomes `Perl Language Server v0.12.0 is running (click for options)`.

## Test plan

- [x] 13 new `HealthWidget` unit tests in `healthWidget.test.ts` covering:
  - `version` getter undefined before `setVersion`
  - Running state text and tooltip with/without version
  - `setVersion` while already running updates text immediately
  - Version shown alongside file count and error count
  - Version not shown during starting, indexing, or stopped states
  - After indexing ends, version reappears in running display
- [x] All 167 existing extension tests pass
- [x] TypeScript compilation clean (`npm run compile`)

## Notes

- The server already returns `serverInfo.version = env!("CARGO_PKG_VERSION")` in the `initialize` response (in `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs`); no Rust changes needed
- Version is cleared when `disposeLanguageClient` sets `healthWidget` to undefined on deactivation (the widget itself is disposed via the extension context subscription)