### PR TITLE
ci: centralize CURRENT_STATUS.md rendering via post-merge regeneration

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -80,12 +80,12 @@ name = "Policy Compliance"
 type = "governance"
 blocking = true
 timeout_seconds = 60
-command = "bash ./.ci/scripts/check-from-raw.sh && python3 scripts/update-current-status.py --check"
+command = "bash ./.ci/scripts/check-from-raw.sh"
 evidence_pattern = "^✅"
 threshold = { type = "exit_code", pass = 0 }
 
 [gate.metadata]
-description = "Enforces ExitStatus policy and CURRENT_STATUS.md freshness"
+description = "Enforces ExitStatus policy (CURRENT_STATUS.md is regenerated post-merge via .github/workflows/post-merge-status.yml)"
 docs_url = "docs/ci/LOCAL_CI_PROTOCOL.md#ci-policy"
 cost_tier = "low"  # seconds
 failure_impact = "medium"

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -275,7 +275,6 @@ gates:
     required: true
     command: >-
       ./.ci/scripts/check-from-raw.sh &&
-      python3 scripts/update-current-status.py --check &&
       bash ci/check_missing_docs.sh &&
       bash ci/check_parse_errors.sh &&
       python3 scripts/check_features_invariants.py

--- a/.github/workflows/post-merge-status.yml
+++ b/.github/workflows/post-merge-status.yml
@@ -1,0 +1,59 @@
+name: Post-Merge Status Regeneration
+
+# Automatically regenerates docs/project/CURRENT_STATUS.md after every merge to master.
+# This eliminates the #1 merge friction point: PRs no longer need to edit CURRENT_STATUS.md
+# themselves, ending the cascade of merge conflicts on that hot shared file.
+# See issue #2296.
+
+on:
+  push:
+    branches:
+      - master
+
+# Only one regeneration at a time; cancel stale runs if a new push lands.
+concurrency:
+  group: post-merge-status-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate-status:
+    name: Regenerate CURRENT_STATUS.md
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Fetch full history so git can commit cleanly.
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: post-merge-status-${{ hashFiles('Cargo.lock') }}
+
+      - name: Regenerate CURRENT_STATUS.md and ROADMAP.md
+        run: cargo run -p xtask -- update-status --write
+
+      - name: Commit regenerated files if changed
+        run: |
+          if ! git diff --quiet -- docs/project/CURRENT_STATUS.md docs/project/ROADMAP.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add docs/project/CURRENT_STATUS.md docs/project/ROADMAP.md
+            git commit -m "chore(docs): regenerate CURRENT_STATUS.md post-merge [skip ci]"
+            git push
+            echo "::notice::Regenerated CURRENT_STATUS.md and pushed."
+          else
+            echo "::notice::CURRENT_STATUS.md already up to date -- nothing to commit."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The orchestrator routes work to agents, never writes code directly.
 - Don't rebase PRs unless merge conflicts exist
 - Merge in batches of 3 (CI cancellation cascade -- rapid merges cancel each other's CI runs)
 - Run `just cpan-corpus-ratchet` after parser fix merges
-- Run `python3 scripts/update-current-status.py` if tests were added
+- CURRENT_STATUS.md is regenerated automatically post-merge (no manual step needed)
 
 ## Quick Reference
 
@@ -172,7 +172,7 @@ Invoke `/coding-standards` for full detail.
 - **Prefer**: `.first()` over `.get(0)`, `.push(char)` over `.push_str("x")`, `or_default()` over `or_insert_with(Vec::new)`
 - **Avoid**: unnecessary `.clone()` on Copy types
 - **Regex**: `Option<Regex>` with `.ok()` for graceful degradation
-- After adding tests, run `python3 scripts/update-current-status.py` to prevent `policy_checks` CI failure
+- After adding tests, no manual status update needed — CURRENT_STATUS.md is auto-regenerated post-merge
 
 ## Documentation
 

--- a/justfile
+++ b/justfile
@@ -721,7 +721,6 @@ ci-policy:
     @echo "⚖️  Checking project policies..."
     just ci-check-todos
     @bash ./.ci/scripts/check-from-raw.sh
-    @cargo run -p xtask -- update-status --check
 
 # Check for machine-specific paths in documentation
 ci-doc-paths:

--- a/xtask/tests/post_merge_status_regen_tests.rs
+++ b/xtask/tests/post_merge_status_regen_tests.rs
@@ -1,0 +1,146 @@
+//! Post-merge CURRENT_STATUS.md regeneration validation tests.
+//!
+//! Tests for issue #2296: infra: centralize CURRENT_STATUS.md rendering (post-merge regeneration).
+//!
+//! Validates:
+//! - The `policy_checks` gate no longer blocks PRs with a `--check` on CURRENT_STATUS.md.
+//! - A post-merge workflow exists to auto-regenerate CURRENT_STATUS.md on push to master.
+//! - The GATE_REGISTRY.toml policy gate command does not require a freshness check either.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn project_root() -> PathBuf {
+    // Walk up from the manifest directory to the workspace root.
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // xtask is at <root>/xtask -- go up one level
+    dir.pop();
+    dir
+}
+
+/// The `policy_checks` gate in gate-policy.yaml must not run
+/// `update-current-status.py --check` as part of a PR merge gate.
+/// That check is now handled post-merge by the dedicated workflow.
+#[test]
+fn test_policy_checks_gate_does_not_block_on_stale_status() {
+    let root = project_root();
+    let gate_policy_path = root.join(".ci/gate-policy.yaml");
+    let content =
+        fs::read_to_string(&gate_policy_path).expect("should be able to read .ci/gate-policy.yaml");
+
+    // Find the policy_checks block
+    let policy_block_start = content
+        .find("name: policy_checks")
+        .expect("policy_checks gate must exist in gate-policy.yaml");
+
+    // Extract the policy_checks gate section (up to next gate entry or end of file)
+    let policy_section = &content[policy_block_start..];
+    let section_end =
+        policy_section[1..].find("\n  - name:").map(|i| i + 1).unwrap_or(policy_section.len());
+    let policy_section = &policy_section[..section_end];
+
+    // The --check on update-current-status.py must NOT appear in the policy_checks gate.
+    // Stale CURRENT_STATUS.md is regenerated post-merge, not blocked in PRs.
+    assert!(
+        !policy_section.contains("update-current-status.py --check"),
+        "policy_checks gate must not run `update-current-status.py --check`.\n\
+         This check causes PR merge conflicts. Regeneration is now post-merge.\n\
+         Found in gate-policy.yaml policy_checks section:\n{}",
+        policy_section
+    );
+}
+
+/// The GATE_REGISTRY.toml policy gate must not require CURRENT_STATUS.md freshness check.
+#[test]
+fn test_gate_registry_policy_does_not_require_status_check() {
+    let root = project_root();
+    let registry_path = root.join(".ci/GATE_REGISTRY.toml");
+    let content =
+        fs::read_to_string(&registry_path).expect("should be able to read .ci/GATE_REGISTRY.toml");
+
+    // Find the policy gate section
+    let policy_start =
+        content.find("id = \"policy\"").expect("policy gate must exist in GATE_REGISTRY.toml");
+
+    let policy_section = &content[policy_start..];
+    let section_end =
+        policy_section[1..].find("\n[[gate]]").map(|i| i + 1).unwrap_or(policy_section.len());
+    let policy_section = &policy_section[..section_end];
+
+    assert!(
+        !policy_section.contains("update-current-status.py --check"),
+        "GATE_REGISTRY.toml policy gate must not require CURRENT_STATUS.md freshness check.\n\
+         Regeneration is handled post-merge, not blocked in PRs.\n\
+         Found in GATE_REGISTRY.toml policy section:\n{}",
+        policy_section
+    );
+}
+
+/// A post-merge workflow must exist that regenerates CURRENT_STATUS.md on push to master.
+#[test]
+fn test_post_merge_status_workflow_exists() {
+    let root = project_root();
+    let workflow_path = root.join(".github/workflows/post-merge-status.yml");
+
+    assert!(
+        workflow_path.exists(),
+        "Missing post-merge status workflow at .github/workflows/post-merge-status.yml.\n\
+         This workflow is required to auto-regenerate CURRENT_STATUS.md after merges.\n\
+         See issue #2296."
+    );
+}
+
+/// The post-merge workflow must trigger on push to master.
+#[test]
+fn test_post_merge_workflow_triggers_on_push_to_master() {
+    let root = project_root();
+    let workflow_path = root.join(".github/workflows/post-merge-status.yml");
+
+    let content =
+        fs::read_to_string(&workflow_path).expect("post-merge-status.yml should be readable");
+
+    assert!(content.contains("push:"), "post-merge-status.yml must have a push trigger");
+    assert!(
+        content.contains("master"),
+        "post-merge-status.yml push trigger must include master branch"
+    );
+}
+
+/// The post-merge workflow must run the update-status write command.
+#[test]
+fn test_post_merge_workflow_runs_status_update() {
+    let root = project_root();
+    let workflow_path = root.join(".github/workflows/post-merge-status.yml");
+
+    let content =
+        fs::read_to_string(&workflow_path).expect("post-merge-status.yml should be readable");
+
+    // The workflow must invoke either the xtask command or the python script with --write
+    let runs_status_update = content.contains("update-status --write")
+        || content.contains("update-current-status.py --write");
+
+    assert!(
+        runs_status_update,
+        "post-merge-status.yml must run status update with --write flag.\n\
+         Expected one of: `update-status --write` or `update-current-status.py --write`.\n\
+         Workflow content:\n{}",
+        content
+    );
+}
+
+/// The post-merge workflow must auto-commit changed files.
+#[test]
+fn test_post_merge_workflow_auto_commits() {
+    let root = project_root();
+    let workflow_path = root.join(".github/workflows/post-merge-status.yml");
+
+    let content =
+        fs::read_to_string(&workflow_path).expect("post-merge-status.yml should be readable");
+
+    assert!(
+        content.contains("git commit") || content.contains("git push"),
+        "post-merge-status.yml must commit and push regenerated CURRENT_STATUS.md.\n\
+         Workflow content:\n{}",
+        content
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the #1 merge friction point identified across 5 development cycles: every PR that adds tests is forced to also edit `docs/project/CURRENT_STATUS.md`, causing cascading merge conflicts across concurrent agents.

The fix moves status regeneration from a PR-blocking gate check to a post-merge GitHub Actions workflow. The new workflow triggers on every push to master, runs `cargo run -p xtask -- update-status --write`, and auto-commits if anything changed. The `[skip ci]` tag on the commit prevents a CI loop.

Simultaneously, the `update-current-status.py --check` call is removed from three places where it blocked PRs: `gate-policy.yaml` (`policy_checks`), `GATE_REGISTRY.toml` (policy gate), and the `ci-policy` justfile recipe.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: `just ci-policy` no longer runs the status check (it now runs post-merge)

## What changed

| File | Change |
|------|--------|
| `.github/workflows/post-merge-status.yml` | New workflow: push to master → regenerate → auto-commit |
| `.ci/gate-policy.yaml` | Remove `update-current-status.py --check` from `policy_checks` gate |
| `.ci/GATE_REGISTRY.toml` | Same removal; description updated to reference new workflow |
| `justfile` | Remove `update-status --check` from `ci-policy` recipe |
| `CLAUDE.md` | Update two stale notes that told agents to run the script manually |
| `xtask/tests/post_merge_status_regen_tests.rs` | 6 tests enforcing all invariants |

## How to review

Start with `.github/workflows/post-merge-status.yml` — that is the core deliverable. Then check the three gate-config removals (gate-policy.yaml, GATE_REGISTRY.toml, justfile) are consistent. The test file validates all of this structurally.

The `git diff --quiet -- docs/project/CURRENT_STATUS.md docs/project/ROADMAP.md` scoping in the workflow is important: it only checks the two target files, not the entire working tree, so build artifacts can't accidentally get committed.

## Evidence

```
running 6 tests
test test_gate_registry_policy_does_not_require_status_check ... ok
test test_post_merge_status_workflow_exists ... ok
test test_policy_checks_gate_does_not_block_on_stale_status ... ok
test test_post_merge_workflow_triggers_on_push_to_master ... ok
test test_post_merge_workflow_runs_status_update ... ok
test test_post_merge_workflow_auto_commits ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

cargo clippy -p xtask --tests -- -D warnings: PASS
cargo fmt -p xtask -- --check: PASS

## Risk & rollback

**Blast radius**: Low. The worst case is that CURRENT_STATUS.md becomes stale after a merge. The post-merge workflow runs in isolation and cannot break any PR or test.

**Failure modes**:
- If the post-merge workflow fails (e.g. build error), CURRENT_STATUS.md stays at the pre-merge value — same as today but now explicitly expected
- The `[skip ci]` tag prevents the auto-commit from triggering a CI cascade

**Rollback**: Revert the three gate-config changes and disable/delete the workflow. Reverts are clean since nothing depends on the workflow having run.

## Follow-ups

- The `status-check` and `status-update` justfile targets remain for local developer use (`just status-check` still works)
- The `scripts/update-current-status.py` Python script is unchanged and can still be run manually for debugging

Closes #2296