### PR TITLE
feat(diagnostics): add auto-quote suggestion for bareword warnings

### DIFF
--- a/crates/perl-lsp-diagnostics/src/scope.rs
+++ b/crates/perl-lsp-diagnostics/src/scope.rs
@@ -180,6 +180,12 @@ fn build_enhanced_scope_message(issue: &ScopeIssue) -> String {
                 name
             )
         }
+        IssueKind::UnquotedBareword => {
+            format!(
+                "Bareword '{}' is not allowed under 'use strict' -- quote it as '{}' or use it as a subroutine call",
+                name, name
+            )
+        }
         // Fall back to the analyzer's original description for other kinds
         _ => issue.description.clone(),
     }
@@ -196,6 +202,9 @@ fn build_scope_suggestion(issue: &ScopeIssue) -> Option<String> {
         }
         IssueKind::VariableRedeclaration => Some("Remove the duplicate 'my' keyword".to_string()),
         IssueKind::UninitializedVariable => Some(format!("Initialize: my {} = ...;", name)),
+        IssueKind::UnquotedBareword => {
+            Some(format!("Quote as '{}' or use qw({}) for lists", name, name))
+        }
         _ => None,
     }
 }

--- a/crates/perl-lsp-diagnostics/tests/bareword_diagnostics_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/bareword_diagnostics_tests.rs
@@ -1,0 +1,215 @@
+//! Tests for bareword-as-string coercion warnings (issue #2365).
+//!
+//! Covers:
+//! - Bareword under `use strict` is flagged with `unquoted-bareword` code
+//! - The diagnostic has a concrete auto-quote suggestion (not None)
+//! - The message explains the problem and names the bareword
+//! - Severity is Error under strict
+//! - Hash-key barewords are NOT flagged (they are auto-quoted by Perl)
+//! - Related information includes quoting guidance
+
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticsProvider};
+use perl_parser::Parser;
+
+// ---------------------------------------------------------------------------
+// Helper: parse Perl source and return all diagnostics
+// ---------------------------------------------------------------------------
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source)
+}
+
+fn bareword_diags(source: &str) -> Vec<Diagnostic> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("unquoted-bareword"))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Bareword under use strict is flagged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_under_strict_is_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "expected at least one unquoted-bareword diagnostic");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 2. Diagnostic code is 'unquoted-bareword'
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_diagnostic_has_correct_code() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(
+        diags.iter().all(|d| d.code.as_deref() == Some("unquoted-bareword")),
+        "all bareword diagnostics should have code 'unquoted-bareword'"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3. Severity is Error under strict
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_under_strict_severity_is_error() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    assert!(
+        diags.iter().all(|d| d.severity == DiagnosticSeverity::Error),
+        "bareword under strict should have Error severity"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 4. Message mentions the bareword name
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_diagnostic_message_names_the_bareword() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    let msg = &diags[0].message;
+    assert!(msg.contains("FOO"), "message should name the bareword 'FOO', got: {msg}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 5. Message explains strict context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_diagnostic_message_explains_strict() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    let msg = &diags[0].message;
+    assert!(
+        msg.to_lowercase().contains("strict") || msg.to_lowercase().contains("bare"),
+        "message should mention strict or bareword context, got: {msg}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 6. Diagnostic has a suggestion for quoting the bareword
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_diagnostic_has_auto_quote_suggestion() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    let suggestion = diags[0].suggestion.as_deref();
+    assert!(suggestion.is_some(), "bareword diagnostic should have a suggestion");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 7. Suggestion text mentions quoting with single quotes or double quotes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_suggestion_mentions_quoting() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    let suggestion = diags[0].suggestion.as_deref().unwrap_or("");
+    assert!(
+        suggestion.contains('\'')
+            || suggestion.contains('"')
+            || suggestion.to_lowercase().contains("quot"),
+        "suggestion should mention quoting (e.g., 'FOO' or \"FOO\"), got: {suggestion}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 8. Related information includes quoting guidance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_diagnostic_has_related_info() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    assert!(
+        !diags[0].related_information.is_empty(),
+        "bareword diagnostic should have related information with quoting guidance"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 9. Hash key barewords are NOT flagged (Perl auto-quotes them)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hash_key_bareword_is_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy %h = ();\nmy $v = $h{foo};\n";
+    let diags = bareword_diags(source);
+    assert!(
+        diags.is_empty(),
+        "hash key bareword should not be flagged (Perl auto-quotes hash keys), got: {diags:?}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 10. Multiple barewords in one file each get their own diagnostic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_barewords_each_get_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = FOO;\nmy $y = BAR;\n";
+    let diags = bareword_diags(source);
+    assert!(
+        diags.len() >= 2,
+        "expected at least 2 bareword diagnostics for FOO and BAR, got: {}",
+        diags.len()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 11. Suggestion text includes the bareword name for easy replacement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_suggestion_includes_bareword_name() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use strict;\nuse warnings;\nmy $x = MYCONST;\n";
+    let diags = bareword_diags(source);
+    assert!(!diags.is_empty(), "should have a bareword diagnostic");
+    let suggestion = diags[0].suggestion.as_deref().unwrap_or("");
+    assert!(
+        suggestion.contains("MYCONST"),
+        "suggestion should include the bareword name 'MYCONST' for easy copy-paste, got: {suggestion}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 12. No bareword diagnostic when not under strict
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_without_strict_is_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Without use strict, barewords should not generate unquoted-bareword diagnostics
+    let source = "my $x = FOO;\n";
+    let diags = bareword_diags(source);
+    assert!(diags.is_empty(), "bareword should not be flagged without use strict, got: {diags:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Bareword diagnostics under `use strict` previously had `suggestion: None`, meaning IDEs received no actionable fix hint. This PR adds a concrete suggestion and an enhanced diagnostic message for every `UnquotedBareword` issue.

The suggestion reads: `"Quote as 'FOO' or use qw(FOO) for lists"` — it includes the bareword name verbatim for easy copy-paste. The enhanced message reads: `"Bareword 'FOO' is not allowed under 'use strict' -- quote it as 'FOO' or use it as a subroutine call"` which explains both the problem and the two valid resolutions.

Closes #2365.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (diagnostics now carry a non-None suggestion field for `unquoted-bareword` codes)
- DAP surface: unchanged
- CLI: unchanged

## What changed

Two private functions in `crates/perl-lsp-diagnostics/src/scope.rs`:

- `build_enhanced_scope_message`: added `IssueKind::UnquotedBareword` arm — previously fell through to `_ => issue.description.clone()` which returned the raw analyzer text
- `build_scope_suggestion`: added `IssueKind::UnquotedBareword` arm — previously fell through to `_ => None`

The underlying detection (scope analyzer), severity (Error), code (`unquoted-bareword`), and related information were already correct and are untouched.

## How to review

Start at `crates/perl-lsp-diagnostics/src/scope.rs` lines ~183 and ~205. Both new arms are one-liners. Then check `crates/perl-lsp-diagnostics/tests/bareword_diagnostics_tests.rs` for the 12 tests added.

## Evidence

```
running 12 tests
test bareword_under_strict_is_flagged ... ok
test bareword_diagnostic_has_correct_code ... ok
test bareword_under_strict_severity_is_error ... ok
test bareword_diagnostic_message_names_the_bareword ... ok
test bareword_diagnostic_message_explains_strict ... ok
test bareword_diagnostic_has_auto_quote_suggestion ... ok
test bareword_suggestion_mentions_quoting ... ok
test bareword_diagnostic_has_related_info ... ok
test hash_key_bareword_is_not_flagged ... ok
test multiple_barewords_each_get_diagnostic ... ok
test bareword_suggestion_includes_bareword_name ... ok
test bareword_without_strict_is_not_flagged ... ok

test result: ok. 12 passed; 0 failed

fmt: PASS | clippy: PASS (0 warnings) | tests: PASS (162 total, 0 failures)
```

## Risk & rollback

Blast radius: only the `suggestion` and `message` fields of `UnquotedBareword` diagnostics change. No logic, no severity, no detection changes. The only observable difference to callers is a non-None `suggestion` string and a more specific message string. Rollback: revert the two new match arms.

## Follow-ups

- The issue also mentions a code action for auto-quoting via LSP `textDocument/codeAction` — that requires a separate `perl-lsp-code-actions` change and is out of scope for this PR.
- `qw()` expansion in completion (also mentioned in the issue) is a separate feature.