### PR TITLE
feat(vscode): show What's New page on extension update

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -356,6 +356,12 @@
         "title": "Show Refactoring Options",
         "category": "Perl",
         "icon": "$(wrench)"
+      },
+      {
+        "command": "perl-lsp.showWhatsNew",
+        "title": "Show What's New",
+        "category": "Perl",
+        "icon": "$(star-empty)"
       }
     ],
     "menus": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,7 @@ import { PerlTestAdapter } from './testAdapter';
 import { activateDebugger } from './debugAdapter';
 import { BinaryDownloader } from './downloader';
 import { OnboardingManager } from './onboarding';
+import { WhatsNewManager } from './whatsNew';
 import { generateBoilerplate } from './fileCreation';
 
 let client: LanguageClient | undefined;
@@ -204,6 +205,11 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    const whatsNewManager = new WhatsNewManager(context, outputChannel);
+    const showWhatsNewCommand = vscode.commands.registerCommand('perl-lsp.showWhatsNew', async () => {
+        await whatsNewManager.showWhatsNew();
+    });
+
     const formatOnSaveDisposable = vscode.workspace.onWillSaveTextDocument((event) => {
         if (!shouldFormatOnSave(event.document)) {
             return;
@@ -261,6 +267,7 @@ export async function activate(context: vscode.ExtensionContext) {
         statusMenuCommand,
         reinstallCommand,
         runHealthCheckCommand,
+        showWhatsNewCommand,
         formatOnSaveDisposable,
         configurationWatcher,
         fileCreationWatcher,
@@ -277,6 +284,21 @@ export async function activate(context: vscode.ExtensionContext) {
         onboarding.showWelcomeNotification(currentServerPath).catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             outputChannel.appendLine(`[onboarding] Error showing welcome: ${msg}`);
+        });
+        // Mark the version seen on first install so the next activation
+        // (after an update) triggers the What's New panel instead of welcome.
+        whatsNewManager.markVersionSeen().catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            outputChannel.appendLine(`[whats-new] Error marking version seen: ${msg}`);
+        });
+    } else if (whatsNewManager.shouldShowWhatsNew()) {
+        // Extension was updated — show What's New panel.
+        // Fire-and-forget; failures must not block extension startup.
+        whatsNewManager.markVersionSeen().then(() => {
+            return whatsNewManager.showWhatsNew();
+        }).catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            outputChannel.appendLine(`[whats-new] Error showing What's New: ${msg}`);
         });
     }
 }

--- a/vscode-extension/src/test/whatsNew.test.ts
+++ b/vscode-extension/src/test/whatsNew.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for WhatsNewManager.
+ *
+ * Tests cover:
+ * - shouldShowWhatsNew: version-change detection via globalState
+ * - markVersionSeen: persists the current version
+ * - extractChangelogSection: parses CHANGELOG.md sections
+ * - markdownToHtml: converts Markdown subset to HTML
+ * - buildHtml: generates a valid HTML document
+ * - package.json contract: showWhatsNew command declared
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { WhatsNewManager, extractVersionSection, markdownToHtml } from '../whatsNew';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const SAMPLE_CHANGELOG = `# Change Log
+
+## [0.13.0] - 2026-04-01
+
+### Added
+- New feature A
+- New feature B
+
+### Fixed
+- Bug fix C
+
+## [0.12.0] - 2026-03-19
+
+### Changed
+- Something changed
+
+## [0.11.0] - 2026-03-11
+
+### Fixed
+- Old fix
+`;
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'whats-new-test-'));
+    // Write a package.json with a known version
+    fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ version: '0.13.0' }),
+    );
+    // Write a CHANGELOG.md
+    fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), SAMPLE_CHANGELOG);
+    return dir;
+}
+
+function makeContext(opts?: {
+    lastVersion?: string;
+    extensionPath?: string;
+}): any {
+    const store = new Map<string, any>();
+    if (opts?.lastVersion !== undefined) {
+        store.set('perl-lsp.lastVersion', opts.lastVersion);
+    }
+    const dir = opts?.extensionPath ?? makeTmpDir();
+    return {
+        extensionPath: dir,
+        globalState: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+                if (store.has(key)) return store.get(key);
+                return defaultValue;
+            }),
+            update: jest.fn(async (key: string, value: any) => {
+                store.set(key, value);
+            }),
+        },
+    };
+}
+
+function makeOutputChannel(): any {
+    return {
+        appendLine: jest.fn(),
+        show: jest.fn(),
+        dispose: jest.fn(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// shouldShowWhatsNew
+// ---------------------------------------------------------------------------
+
+describe('WhatsNewManager.shouldShowWhatsNew', () => {
+    test('returns true when no version has been stored (first install)', () => {
+        const ctx = makeContext(); // no lastVersion stored
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        expect(mgr.shouldShowWhatsNew()).toBe(true);
+    });
+
+    test('returns true when stored version differs from current version', () => {
+        const ctx = makeContext({ lastVersion: '0.12.0' }); // old version stored
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        // extensionPath has package.json with version 0.13.0
+        expect(mgr.shouldShowWhatsNew()).toBe(true);
+    });
+
+    test('returns false when stored version matches current version', () => {
+        const ctx = makeContext({ lastVersion: '0.13.0' }); // same as package.json
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        expect(mgr.shouldShowWhatsNew()).toBe(false);
+    });
+
+    test('returns false when package.json cannot be read', () => {
+        const ctx = makeContext({ extensionPath: '/nonexistent/path' });
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        expect(mgr.shouldShowWhatsNew()).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// markVersionSeen
+// ---------------------------------------------------------------------------
+
+describe('WhatsNewManager.markVersionSeen', () => {
+    test('stores the current version in globalState', async () => {
+        const ctx = makeContext();
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        await mgr.markVersionSeen();
+        expect(ctx.globalState.update).toHaveBeenCalledWith(
+            'perl-lsp.lastVersion',
+            '0.13.0',
+        );
+    });
+
+    test('after markVersionSeen, shouldShowWhatsNew returns false', async () => {
+        const ctx = makeContext();
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        expect(mgr.shouldShowWhatsNew()).toBe(true);
+        await mgr.markVersionSeen();
+        // Now the stored version equals the current version
+        expect(mgr.shouldShowWhatsNew()).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// currentVersion
+// ---------------------------------------------------------------------------
+
+describe('WhatsNewManager.currentVersion', () => {
+    test('reads version from package.json in extensionPath', () => {
+        const ctx = makeContext();
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        expect(mgr.currentVersion()).toBe('0.13.0');
+    });
+
+    test('returns undefined when extensionPath has no package.json', () => {
+        const ctx = makeContext({ extensionPath: os.tmpdir() });
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        // os.tmpdir() is unlikely to have a package.json with a version field
+        // We just test it doesn't throw
+        const version = mgr.currentVersion();
+        expect(typeof version === 'string' || version === undefined).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractChangelogSection (pure function)
+// ---------------------------------------------------------------------------
+
+describe('extractVersionSection', () => {
+    test('extracts the section for the requested version', () => {
+        const section = extractVersionSection(SAMPLE_CHANGELOG, '0.13.0');
+        expect(section).toContain('0.13.0');
+        expect(section).toContain('New feature A');
+        expect(section).toContain('New feature B');
+        expect(section).toContain('Bug fix C');
+    });
+
+    test('does not include content from adjacent version sections', () => {
+        const section = extractVersionSection(SAMPLE_CHANGELOG, '0.13.0');
+        expect(section).not.toContain('0.12.0');
+        expect(section).not.toContain('Something changed');
+    });
+
+    test('extracts a middle version correctly', () => {
+        const section = extractVersionSection(SAMPLE_CHANGELOG, '0.12.0');
+        expect(section).toContain('0.12.0');
+        expect(section).toContain('Something changed');
+        expect(section).not.toContain('0.11.0');
+        expect(section).not.toContain('New feature A');
+    });
+
+    test('extracts the last version (no following section)', () => {
+        const section = extractVersionSection(SAMPLE_CHANGELOG, '0.11.0');
+        expect(section).toContain('0.11.0');
+        expect(section).toContain('Old fix');
+    });
+
+    test('returns empty string when version is not found', () => {
+        const section = extractVersionSection(SAMPLE_CHANGELOG, '9.99.0');
+        expect(section).toBe('');
+    });
+
+    test('handles CHANGELOG without bracket notation', () => {
+        const changelog = `## 1.0.0\n\n- Something\n\n## 0.9.0\n\n- Older\n`;
+        const section = extractVersionSection(changelog, '1.0.0');
+        expect(section).toContain('Something');
+        expect(section).not.toContain('Older');
+    });
+});
+
+describe('WhatsNewManager.extractChangelogSection', () => {
+    test('delegates to extractVersionSection with the CHANGELOG from extensionPath', () => {
+        const ctx = makeContext();
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        const section = mgr.extractChangelogSection('0.13.0');
+        expect(section).toContain('New feature A');
+    });
+
+    test('returns empty string when CHANGELOG is not found', () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wn-no-cl-'));
+        fs.writeFileSync(
+            path.join(tmpDir, 'package.json'),
+            JSON.stringify({ version: '0.13.0' }),
+        );
+        const ctx = makeContext({ extensionPath: tmpDir });
+        const mgr = new WhatsNewManager(ctx, makeOutputChannel());
+        const section = mgr.extractChangelogSection('0.13.0');
+        expect(section).toBe('');
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// markdownToHtml (pure function)
+// ---------------------------------------------------------------------------
+
+describe('markdownToHtml', () => {
+    test('converts ## heading to <h2>', () => {
+        const html = markdownToHtml('## My Heading');
+        expect(html).toContain('<h2>');
+        expect(html).toContain('My Heading');
+    });
+
+    test('converts ### heading to <h3>', () => {
+        const html = markdownToHtml('### Sub Heading');
+        expect(html).toContain('<h3>');
+        expect(html).toContain('Sub Heading');
+    });
+
+    test('converts - list items to <ul><li>', () => {
+        const html = markdownToHtml('- Item one\n- Item two');
+        expect(html).toContain('<ul>');
+        expect(html).toContain('<li>');
+        expect(html).toContain('Item one');
+        expect(html).toContain('Item two');
+        expect(html).toContain('</ul>');
+    });
+
+    test('converts **bold** to <strong>', () => {
+        const html = markdownToHtml('**bold text**');
+        expect(html).toContain('<strong>bold text</strong>');
+    });
+
+    test('converts `code` to <code>', () => {
+        const html = markdownToHtml('Use `perltidy` to format');
+        expect(html).toContain('<code>perltidy</code>');
+    });
+
+    test('escapes HTML special characters', () => {
+        const html = markdownToHtml('Use <br> & "quotes"');
+        expect(html).not.toContain('<br>');
+        expect(html).toContain('&lt;br&gt;');
+        expect(html).toContain('&amp;');
+    });
+
+    test('closes list before next heading', () => {
+        const md = '- item\n## Next Section';
+        const html = markdownToHtml(md);
+        const ulClose = html.indexOf('</ul>');
+        const h2Open = html.indexOf('<h2>');
+        expect(ulClose).toBeGreaterThanOrEqual(0);
+        expect(h2Open).toBeGreaterThan(ulClose);
+    });
+
+    test('blank lines do not create orphaned tags', () => {
+        const html = markdownToHtml('Line one\n\nLine two');
+        expect(html).toContain('<p>Line one</p>');
+        expect(html).toContain('<p>Line two</p>');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildHtml
+// ---------------------------------------------------------------------------
+
+describe('WhatsNewManager.buildHtml', () => {
+    function makeMgr() {
+        const ctx = makeContext();
+        return new WhatsNewManager(ctx, makeOutputChannel());
+    }
+
+    test('returns a valid HTML document with DOCTYPE', () => {
+        const html = makeMgr().buildHtml('0.13.0', '## [0.13.0]\n- Feature X');
+        expect(html).toContain('<!DOCTYPE html>');
+        expect(html).toContain('<html');
+        expect(html).toContain('</html>');
+    });
+
+    test('includes the version number in the title', () => {
+        const html = makeMgr().buildHtml('0.13.0', '');
+        expect(html).toContain('0.13.0');
+        expect(html).toContain('<title>');
+    });
+
+    test('includes changelog content in the body', () => {
+        const html = makeMgr().buildHtml('0.13.0', '## [0.13.0]\n- Feature X');
+        expect(html).toContain('Feature X');
+    });
+
+    test('shows fallback link when markdown content is empty', () => {
+        const html = makeMgr().buildHtml('0.13.0', '');
+        expect(html).toContain('CHANGELOG');
+        expect(html).toContain('href=');
+    });
+
+    test('escapes HTML in version string', () => {
+        const html = makeMgr().buildHtml('<script>', '');
+        expect(html).not.toContain('<script>');
+        expect(html).toContain('&lt;script&gt;');
+    });
+
+    test('includes Content-Security-Policy meta tag', () => {
+        const html = makeMgr().buildHtml('0.13.0', '');
+        expect(html).toContain('Content-Security-Policy');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// package.json contract: showWhatsNew command declared
+// ---------------------------------------------------------------------------
+
+describe('package.json showWhatsNew command', () => {
+    const EXT_ROOT = path.resolve(__dirname, '..', '..');
+    let pkg: any;
+
+    beforeAll(() => {
+        pkg = JSON.parse(
+            fs.readFileSync(path.join(EXT_ROOT, 'package.json'), 'utf8'),
+        );
+    });
+
+    test('registers perl-lsp.showWhatsNew command', () => {
+        const commandIds = pkg.contributes.commands.map((c: any) => c.command);
+        expect(commandIds).toContain('perl-lsp.showWhatsNew');
+    });
+
+    test('showWhatsNew command has Perl category', () => {
+        const cmd = pkg.contributes.commands.find(
+            (c: any) => c.command === 'perl-lsp.showWhatsNew',
+        );
+        expect(cmd).toBeDefined();
+        expect(cmd.category).toBe('Perl');
+    });
+
+    test('showWhatsNew command title is user-friendly', () => {
+        const cmd = pkg.contributes.commands.find(
+            (c: any) => c.command === 'perl-lsp.showWhatsNew',
+        );
+        expect(cmd).toBeDefined();
+        expect(cmd.title).toBeTruthy();
+        expect(cmd.title.toLowerCase()).toMatch(/what'?s new|release notes|changelog/i);
+    });
+});

--- a/vscode-extension/src/whatsNew.ts
+++ b/vscode-extension/src/whatsNew.ts
@@ -1,0 +1,327 @@
+/**
+ * WhatsNewManager — show a "What's New" webview panel on extension update.
+ *
+ * Responsibilities:
+ * - Detect extension version changes by comparing the stored version in
+ *   `context.globalState` (`perl-lsp.lastVersion`) against the version
+ *   declared in `package.json`.
+ * - Render a styled HTML webview panel from the CHANGELOG entries for the
+ *   current version.
+ * - Expose `showWhatsNew()` so the command `perl-lsp.showWhatsNew` can open
+ *   the panel at any time.
+ * - Never block extension startup; the panel is shown fire-and-forget.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export class WhatsNewManager {
+    private readonly context: vscode.ExtensionContext;
+    private readonly outputChannel: vscode.OutputChannel;
+
+    constructor(
+        context: vscode.ExtensionContext,
+        outputChannel: vscode.OutputChannel,
+    ) {
+        this.context = context;
+        this.outputChannel = outputChannel;
+    }
+
+    // -----------------------------------------------------------------------
+    // Version tracking
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns `true` when the extension version stored in global state differs
+     * from the currently installed extension version.
+     *
+     * On a fresh install there is no stored version, so this returns `true` to
+     * trigger the panel — but `OnboardingManager.shouldShowWelcome()` handles
+     * the truly first-run case.  The caller is responsible for coordinating
+     * which panel to show.
+     */
+    shouldShowWhatsNew(): boolean {
+        const currentVersion = this.currentVersion();
+        if (!currentVersion) {
+            return false;
+        }
+        const storedVersion = this.context.globalState.get<string>(
+            'perl-lsp.lastVersion',
+        );
+        return storedVersion !== currentVersion;
+    }
+
+    /**
+     * Persist the current version so `shouldShowWhatsNew()` returns `false`
+     * until the next update.
+     */
+    async markVersionSeen(): Promise<void> {
+        const currentVersion = this.currentVersion();
+        if (currentVersion) {
+            await this.context.globalState.update(
+                'perl-lsp.lastVersion',
+                currentVersion,
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Webview panel
+    // -----------------------------------------------------------------------
+
+    /**
+     * Open (or reveal) the "What's New" webview panel.
+     *
+     * Reads CHANGELOG.md from the extension root and extracts the section for
+     * the current version.  Falls back to showing the full CHANGELOG on
+     * parse failure so the user always sees something useful.
+     */
+    async showWhatsNew(): Promise<void> {
+        const version = this.currentVersion() ?? 'Unknown';
+        const changelogSection = this.extractChangelogSection(version);
+
+        const panel = vscode.window.createWebviewPanel(
+            'perlLspWhatsNew',
+            `What's New in Perl LSP v${version}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: false,
+                localResourceRoots: [],
+            },
+        );
+
+        panel.webview.html = this.buildHtml(version, changelogSection);
+        this.outputChannel.appendLine(
+            `[whats-new] Opened What's New panel for v${version}`,
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Read the version from the extension's `package.json`.
+     *
+     * Returns `undefined` when the extension cannot be located (e.g., in
+     * unit tests that do not supply a real extension context).
+     */
+    currentVersion(): string | undefined {
+        try {
+            const pkgPath = path.join(
+                this.context.extensionPath,
+                'package.json',
+            );
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+                version?: string;
+            };
+            return pkg.version ?? undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Extract the changelog section for the given version from CHANGELOG.md.
+     *
+     * Returns the raw Markdown text for that version heading and its content,
+     * or an empty string when the version is not found.
+     */
+    extractChangelogSection(version: string): string {
+        try {
+            const changelogPath = path.join(
+                this.context.extensionPath,
+                'CHANGELOG.md',
+            );
+            const full = fs.readFileSync(changelogPath, 'utf8');
+            return extractVersionSection(full, version);
+        } catch {
+            return '';
+        }
+    }
+
+    /**
+     * Build the HTML page for the webview.
+     *
+     * The content is static — no scripts are loaded.  Markdown is converted
+     * to HTML via a minimal inline renderer so the webview does not need an
+     * external Markdown library.
+     */
+    buildHtml(version: string, markdownContent: string): string {
+        const htmlBody =
+            markdownContent.trim().length > 0
+                ? markdownToHtml(markdownContent)
+                : `<p>See the full <a href="https://github.com/EffortlessMetrics/perl-lsp/blob/master/vscode-extension/CHANGELOG.md">CHANGELOG</a> for details.</p>`;
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+<title>What's New in Perl LSP v${escapeHtml(version)}</title>
+<style>
+  body {
+    font-family: var(--vscode-font-family, sans-serif);
+    font-size: var(--vscode-font-size, 13px);
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+    padding: 24px 32px;
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.6em; margin-bottom: 0.25em; }
+  h2 { font-size: 1.2em; margin-top: 1.5em; border-bottom: 1px solid var(--vscode-panel-border, #444); padding-bottom: 4px; }
+  h3 { font-size: 1em; margin-top: 1.2em; }
+  ul { padding-left: 1.4em; }
+  li { margin-bottom: 0.3em; }
+  code { font-family: var(--vscode-editor-font-family, monospace); background: var(--vscode-textCodeBlock-background, #1e1e1e); padding: 1px 4px; border-radius: 3px; }
+  strong { font-weight: 600; }
+  a { color: var(--vscode-textLink-foreground, #4daafc); }
+  .version-badge {
+    display: inline-block;
+    background: var(--vscode-badge-background, #4d4d4d);
+    color: var(--vscode-badge-foreground, #fff);
+    border-radius: 10px;
+    padding: 2px 10px;
+    font-size: 0.85em;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+</style>
+</head>
+<body>
+<h1>What's New <span class="version-badge">v${escapeHtml(version)}</span></h1>
+${htmlBody}
+</body>
+</html>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the changelog section for a given version from the full CHANGELOG.md
+ * text.
+ *
+ * Looks for a heading of the form `## [x.y.z]` or `## x.y.z` and returns
+ * everything up to (but not including) the next `##`-level heading.
+ *
+ * Returns an empty string when the version is not found.
+ */
+export function extractVersionSection(
+    changelog: string,
+    version: string,
+): string {
+    // Match headings like: ## [0.12.0] - 2026-03-19  or  ## 0.12.0
+    const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const headingRe = new RegExp(
+        `^##\\s+(?:\\[${escaped}\\]|${escaped})(?:\\s+[^\\n]*)?$`,
+        'm',
+    );
+    const match = headingRe.exec(changelog);
+    if (!match) {
+        return '';
+    }
+
+    const start = match.index;
+    // Find the next ## heading after this one
+    const rest = changelog.slice(start + match[0].length);
+    const nextHeading = /^## /m.exec(rest);
+    const end =
+        nextHeading !== null
+            ? start + match[0].length + nextHeading.index
+            : changelog.length;
+
+    return changelog.slice(start, end).trim();
+}
+
+/**
+ * Minimal Markdown-to-HTML converter for CHANGELOG content.
+ *
+ * Handles the subset used in CHANGELOG.md:
+ *   - `##` and `###` headings
+ *   - Unordered list items (`- `)
+ *   - `**bold**` inline
+ *   - `` `code` `` inline
+ *   - Blank-line paragraph breaks
+ *
+ * External libraries are intentionally avoided to keep the extension
+ * dependency-free.
+ */
+export function markdownToHtml(md: string): string {
+    const lines = md.split('\n');
+    const out: string[] = [];
+    let inList = false;
+
+    for (const rawLine of lines) {
+        const line = rawLine.trimEnd();
+
+        // Headings
+        if (line.startsWith('### ')) {
+            if (inList) { out.push('</ul>'); inList = false; }
+            out.push(`<h3>${inlineMarkdown(line.slice(4))}</h3>`);
+            continue;
+        }
+        if (line.startsWith('## ')) {
+            if (inList) { out.push('</ul>'); inList = false; }
+            out.push(`<h2>${inlineMarkdown(line.slice(3))}</h2>`);
+            continue;
+        }
+        if (line.startsWith('# ')) {
+            if (inList) { out.push('</ul>'); inList = false; }
+            out.push(`<h1>${inlineMarkdown(line.slice(2))}</h1>`);
+            continue;
+        }
+
+        // Unordered list items
+        if (/^[-*] /.test(line)) {
+            if (!inList) { out.push('<ul>'); inList = true; }
+            out.push(`<li>${inlineMarkdown(line.slice(2))}</li>`);
+            continue;
+        }
+
+        // Blank line — paragraph break
+        if (line.trim() === '') {
+            if (inList) { out.push('</ul>'); inList = false; }
+            out.push('');
+            continue;
+        }
+
+        // Plain paragraph text
+        if (inList) { out.push('</ul>'); inList = false; }
+        out.push(`<p>${inlineMarkdown(line)}</p>`);
+    }
+
+    if (inList) { out.push('</ul>'); }
+    return out.join('\n');
+}
+
+/**
+ * Process inline Markdown: bold, code, and HTML escaping.
+ */
+function inlineMarkdown(text: string): string {
+    // Escape HTML first, then apply Markdown inline rules.
+    let s = escapeHtml(text);
+    // `code`
+    s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+    // **bold**
+    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    return s;
+}
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
## Summary

- Adds `WhatsNewManager` in `vscode-extension/src/whatsNew.ts` that detects version bumps via `globalState` key `perl-lsp.lastVersion` and automatically opens a styled HTML webview panel after each extension update
- Registers `perl-lsp.showWhatsNew` command so users can reopen the panel at any time from the command palette
- Integrates with the existing first-run onboarding flow: welcome panel shows on install, What's New panel shows on subsequent updates (mutually exclusive)
- 33 unit tests in `src/test/whatsNew.test.ts` covering version detection, CHANGELOG parsing, Markdown rendering, HTML generation, and the `package.json` contract

## Implementation details

- `WhatsNewManager.shouldShowWhatsNew()` compares stored version against current `package.json` version
- `extractVersionSection()` pure function parses `## [x.y.z]` headings from CHANGELOG.md
- `markdownToHtml()` pure function converts the CHANGELOG subset (headings, lists, bold, inline code) without external dependencies
- The webview uses `enableScripts: false` and a strict CSP (`default-src 'none'`)
- All panel open calls are fire-and-forget and log errors to the output channel so startup is never blocked

## Test plan

- [x] `WhatsNewManager.shouldShowWhatsNew()` returns true on version change, false on same version
- [x] `markVersionSeen()` persists current version; subsequent `shouldShowWhatsNew()` returns false
- [x] `extractVersionSection()` correctly isolates a version's changelog section
- [x] `markdownToHtml()` produces valid HTML from CHANGELOG subset
- [x] `buildHtml()` includes version badge, CSP header, fallback link when section is empty
- [x] HTML escaping prevents XSS in version string
- [x] `package.json` contract: `perl-lsp.showWhatsNew` command with Perl category declared