### PR TITLE
fix(parser): parse phase-block keywords as statement labels when followed by colon (#2389)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -229,7 +229,23 @@ impl<'a> Parser<'a> {
             // Format declarations
             TokenKind::Format => self.parse_format(),
 
-            // Phase blocks
+            // Phase blocks — but first check for label syntax (CHECK: ..., BEGIN: ..., etc.)
+            // In Perl, phase-block keywords are valid statement labels when followed by `:`.
+            // e.g. `CHECK: for (my $i = 0; ...)` uses CHECK as a loop label, not a phase block.
+            TokenKind::Begin
+            | TokenKind::End
+            | TokenKind::Check
+            | TokenKind::Init
+            | TokenKind::Unitcheck
+                if self
+                    .tokens
+                    .peek_second()
+                    .ok()
+                    .map(|t| t.kind == TokenKind::Colon)
+                    .unwrap_or(false) =>
+            {
+                self.parse_keyword_as_label()
+            }
             TokenKind::Begin
             | TokenKind::End
             | TokenKind::Check
@@ -1046,6 +1062,34 @@ impl<'a> Parser<'a> {
         let end = self.previous_position();
         Ok(Node::new(
             NodeKind::LoopControl { op, label },
+            SourceLocation { start, end },
+        ))
+    }
+
+    /// Parse a phase-block keyword token used as a statement label.
+    ///
+    /// Perl allows phase-block keywords (BEGIN, END, CHECK, INIT, UNITCHECK) as
+    /// statement labels when followed by `:`.  Because these tokenise as their own
+    /// `TokenKind` variants rather than `TokenKind::Identifier`, the standard
+    /// `parse_labeled_statement` (which calls `expect(TokenKind::Identifier)`)
+    /// cannot handle them.  This function consumes the keyword token, then the
+    /// `:`, then the subordinate statement, producing a `LabeledStatement` node.
+    fn parse_keyword_as_label(&mut self) -> ParseResult<Node> {
+        let start = self.current_position();
+
+        // Consume the phase-keyword token (BEGIN / END / CHECK / INIT / UNITCHECK)
+        let label_token = self.consume_token()?;
+        let label = label_token.text.to_string();
+
+        // Consume the `:`
+        self.expect(TokenKind::Colon)?;
+
+        // Parse the statement that follows the label
+        let statement = Box::new(self.parse_statement()?);
+
+        let end = self.previous_position();
+        Ok(Node::new(
+            NodeKind::LabeledStatement { label, statement },
             SourceLocation { start, end },
         ))
     }

--- a/crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs
+++ b/crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs
@@ -1,0 +1,67 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Issue #2389 — Phase-block keywords used as statement labels
+//
+// In Perl, BEGIN / END / CHECK / INIT / UNITCHECK are valid statement labels
+// when followed by `:`.  The parser previously dispatched these tokens to
+// `parse_phase_block` before reaching the label-detection path, so
+// `CHECK: for (...)` produced a parse error instead of a LabeledStatement.
+//
+// Sample from Mojo::Exception:
+//   CHECK: for (my $i = 0; $i < @$spec; $i += 2) { ... }
+
+#[test]
+fn test_check_as_label_c_style_for() {
+    assert_clean_parse("CHECK: for (my $i = 0; $i < @$spec; $i += 2) { }");
+}
+
+#[test]
+fn test_check_as_label_foreach() {
+    assert_clean_parse("CHECK: for my $x (@items) { }");
+}
+
+#[test]
+fn test_init_as_label() {
+    assert_clean_parse("INIT: for my $x (@items) { }");
+}
+
+#[test]
+fn test_begin_as_label() {
+    assert_clean_parse("BEGIN: for my $x (@items) { }");
+}
+
+#[test]
+fn test_end_as_label() {
+    assert_clean_parse("END: for my $x (@items) { }");
+}
+
+#[test]
+fn test_unitcheck_as_label() {
+    assert_clean_parse("UNITCHECK: for my $x (@items) { }");
+}
+
+#[test]
+fn test_check_label_with_last() {
+    // Labels are commonly used with `last LABEL` / `next LABEL`.
+    // Note: `last CHECK` would require loop-control to also accept keyword
+    // tokens as label names (a separate issue); test with `next` on a regular
+    // flow to verify the label statement itself parses correctly.
+    assert_clean_parse("CHECK: while (1) { last; }");
+}
+
+#[test]
+fn test_phase_block_without_colon_still_works() {
+    // Regression: actual phase blocks must still parse correctly
+    assert_clean_parse("CHECK { print 'check phase'; }");
+}
+
+#[test]
+fn test_begin_block_still_works() {
+    assert_clean_parse("BEGIN { my $x = 1; }");
+}
+
+#[test]
+fn test_end_block_still_works() {
+    assert_clean_parse("END { cleanup(); }");
+}


### PR DESCRIPTION
## Summary

Fixes #2389. In Perl, `BEGIN`, `END`, `CHECK`, `INIT`, and `UNITCHECK` are
valid statement labels when followed by `:`. The real-world trigger is
`Mojo::Exception` line 25:

```perl
CHECK: for (my $i = 0; $i < @$spec; $i += 2) { ... }
```

The parser previously dispatched all five phase-block token kinds directly
to `parse_phase_block`, which errored with `CHECK must be followed by a block`
before reaching the label-detection path in the `_` catch-all arm.

The fix adds a guard to the phase-block match arm that peeks at the second
token. When it is `:`, dispatch goes to a new `parse_keyword_as_label` helper
that consumes the keyword as the label name, consumes the `:`, then parses the
subordinate statement — producing a `LabeledStatement` node identical to what
`parse_labeled_statement` emits for ordinary identifier labels.

`parse_phase_block` is unchanged; it continues to fire for the unambiguous form
`KEYWORD {`.

## Interface & compatibility
- perl-parser API: unchanged (no new node kinds; uses existing `LabeledStatement`)
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-parser-core/src/engine/parser/statements.rs`:
- Split the single phase-block match arm into two: a guarded arm (second token is `:`) that calls `parse_keyword_as_label`, followed by the original arm that calls `parse_phase_block`.
- Added `parse_keyword_as_label` — a 10-line helper that consumes any token as a label name, then delegates to `parse_statement`.

`crates/perl-parser-core/tests/fix_phase_keyword_as_label_2389.rs`:
- 10 tests: 7 covering the new label behavior for all five phase keywords, plus 3 regression tests confirming actual phase blocks (`BEGIN {}`, `END {}`, `CHECK {}`) still parse correctly.

## How to review

Start at the two-arm split in `statements.rs` around the comment `Phase blocks`.
Then read `parse_keyword_as_label` at the bottom of the impl block — it is a
near-copy of `parse_labeled_statement` minus the `expect(Identifier)` call.

## Evidence

```
test test_begin_as_label ... ok
test test_begin_block_still_works ... ok
test test_check_as_label_c_style_for ... ok
test test_check_as_label_foreach ... ok
test test_check_label_with_last ... ok
test test_end_as_label ... ok
test test_end_block_still_works ... ok
test test_init_as_label ... ok
test test_phase_block_without_colon_still_works ... ok
test test_unitcheck_as_label ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured
```

fmt: PASS | clippy: PASS (no warnings) | test: PASS

## Risk & rollback

Blast radius: `parse_statement_inner` dispatch only. The guard is a cheap
`peek_second()` call identical to the one already used on line 217 for `Method`
disambiguation. Failure mode: if `peek_second()` errors, `unwrap_or(false)`
falls through to `parse_phase_block` (safe degradation). Rollback: revert
the two match-arm split; one-line change.

## Follow-ups

- `last CHECK` / `next CHECK` (referring back to a phase-keyword label) would
  also fail because `parse_loop_control` only accepts `TokenKind::Identifier`
  as an optional label target. This is a separate, lower-priority issue not
  covered here.
- Issues #2398, #2399, #2401, #2403-#2409 were probed and found already
  implemented in the current codebase; no additional fixes needed.