### PR TITLE
feat(perl-module-import): add dispatch semantics and require file-path awareness (#2355)

### DIFF
--- a/crates/perl-module-import/src/lib.rs
+++ b/crates/perl-module-import/src/lib.rs
@@ -9,12 +9,65 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+/// When a module is loaded relative to program execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadTiming {
+    /// Module is loaded at compile time (e.g. `use`).
+    CompileTime,
+    /// Module is loaded at runtime (e.g. `require`).
+    Runtime,
+}
+
+/// Whether the module's `import` method is called after loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportBehavior {
+    /// The module's `import` method is called (as with `use`).
+    CallsImport,
+    /// No `import` call is made (as with `require`).
+    NoImport,
+}
+
+/// Semantic description of a `use`/`require` dispatch form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DispatchSemantics {
+    /// When the module load happens.
+    pub load_timing: LoadTiming,
+    /// Whether `import` is called on the loaded module.
+    pub import_behavior: ImportBehavior,
+}
+
+impl DispatchSemantics {
+    /// A short human-readable description suitable for hover text.
+    #[must_use]
+    pub fn hover_description(&self) -> &'static str {
+        match (self.load_timing, self.import_behavior) {
+            (LoadTiming::CompileTime, ImportBehavior::CallsImport) => {
+                "compile-time load; calls import()"
+            }
+            (LoadTiming::Runtime, ImportBehavior::NoImport) => "runtime load; no import() call",
+            (LoadTiming::CompileTime, ImportBehavior::NoImport) => {
+                "compile-time load; no import() call"
+            }
+            (LoadTiming::Runtime, ImportBehavior::CallsImport) => "runtime load; calls import()",
+        }
+    }
+}
+
+/// Distinguishes the two syntactic forms of `require`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequireForm {
+    /// `require Module::Name` — bare module name.
+    ModuleName,
+    /// `require "path/to/file.pm"` or `require 'path/to/file.pm'` — quoted file path.
+    FilePath,
+}
+
 /// Classifies the import statement form for a parsed line.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModuleImportKind {
     /// `use Module::Name;`
     Use,
-    /// `require Module::Name;`
+    /// `require Module::Name;` or `require "file.pm";`
     Require,
     /// `use parent ...`
     UseParent,
@@ -22,23 +75,56 @@ pub enum ModuleImportKind {
     UseBase,
 }
 
+impl ModuleImportKind {
+    /// Returns the dispatch semantics for this import kind.
+    #[must_use]
+    pub fn dispatch_semantics(self) -> DispatchSemantics {
+        match self {
+            ModuleImportKind::Use | ModuleImportKind::UseParent | ModuleImportKind::UseBase => {
+                DispatchSemantics {
+                    load_timing: LoadTiming::CompileTime,
+                    import_behavior: ImportBehavior::CallsImport,
+                }
+            }
+            ModuleImportKind::Require => DispatchSemantics {
+                load_timing: LoadTiming::Runtime,
+                import_behavior: ImportBehavior::NoImport,
+            },
+        }
+    }
+}
+
 /// Parsed leading import token from a `use`/`require` line.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ModuleImportHead<'a> {
     /// Parsed statement kind.
     pub kind: ModuleImportKind,
-    /// First token after `use` or `require`.
+    /// First token after `use` or `require` (quotes stripped for file-path forms).
     pub token: &'a str,
     /// Inclusive byte start offset of `token` in the full line.
     pub token_start: usize,
     /// Exclusive byte end offset of `token` in the full line.
     pub token_end: usize,
+    /// For `require`, whether the argument was a quoted file path or a bare module name.
+    /// Always `None` for `use` forms.
+    require_form: Option<RequireForm>,
+}
+
+impl<'a> ModuleImportHead<'a> {
+    /// Returns the [`RequireForm`] for `require` statements, or `None` for `use` forms.
+    #[must_use]
+    pub fn require_form(&self) -> Option<RequireForm> {
+        self.require_form
+    }
 }
 
 /// Parse the leading import token of a single Perl source line.
 ///
 /// Returns [`None`] when the line does not start with `use` or `require`
 /// (after leading whitespace) or when no token is present after the keyword.
+///
+/// For `require "file.pm"` and `require 'file.pm'` forms, the surrounding
+/// quotes are stripped and the inner path is returned as `token`.
 ///
 /// # Examples
 ///
@@ -61,19 +147,66 @@ pub fn parse_module_import_head(line: &str) -> Option<ModuleImportHead<'_>> {
             "base" => ModuleImportKind::UseBase,
             _ => ModuleImportKind::Use,
         };
-        return Some(ModuleImportHead { kind, token, token_start, token_end });
+        return Some(ModuleImportHead { kind, token, token_start, token_end, require_form: None });
     }
 
-    if let Some((token, token_start, token_end)) = parse_statement_head(line, "require") {
-        return Some(ModuleImportHead {
-            kind: ModuleImportKind::Require,
-            token,
-            token_start,
-            token_end,
-        });
+    if let Some(result) = parse_require_head(line) {
+        return Some(result);
     }
 
     None
+}
+
+/// Parse a `require` statement, handling both bare module names and quoted file paths.
+fn parse_require_head(line: &str) -> Option<ModuleImportHead<'_>> {
+    let trimmed = line.trim_start();
+    let leading = line.len().saturating_sub(trimmed.len());
+
+    let rest = trimmed.strip_prefix("require")?;
+    if !rest.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+
+    let after_keyword = leading + "require".len();
+
+    // Check for quoted file-path form: require "..." or require '...'
+    let rest_trimmed = rest.trim_start();
+    let quote_offset = rest.len() - rest_trimmed.len();
+
+    if let Some(inner) = rest_trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"').or_else(|| s.split('"').next()))
+        .or_else(|| {
+            rest_trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\'').or_else(|| s.split('\'').next()))
+        })
+    {
+        // Quoted form: token is the content inside the quotes, offsets point inside them
+        let quote_char_len = 1usize; // single byte for ' or "
+        let token_start = after_keyword + quote_offset + quote_char_len;
+        let token_end = token_start + inner.len();
+        return Some(ModuleImportHead {
+            kind: ModuleImportKind::Require,
+            token: inner,
+            token_start,
+            token_end,
+            require_form: Some(RequireForm::FilePath),
+        });
+    }
+
+    // Bare module name form
+    let (token, token_rel_start, token_rel_end) = first_token_with_range(rest)?;
+    let token_start = after_keyword + token_rel_start;
+    let token_end = after_keyword + token_rel_end;
+
+    Some(ModuleImportHead {
+        kind: ModuleImportKind::Require,
+        token,
+        token_start,
+        token_end,
+        require_form: Some(RequireForm::ModuleName),
+    })
 }
 
 fn parse_statement_head<'a>(line: &'a str, keyword: &str) -> Option<(&'a str, usize, usize)> {

--- a/crates/perl-module-import/tests/dispatch_semantics.rs
+++ b/crates/perl-module-import/tests/dispatch_semantics.rs
@@ -1,0 +1,235 @@
+//! Tests for dispatch semantics and lazy loading awareness.
+//!
+//! Covers the distinction between compile-time `use` and runtime `require`,
+//! including import call behaviour, load timing, and file-path `require` syntax.
+
+use perl_module_import::{
+    ImportBehavior, LoadTiming, ModuleImportKind, RequireForm, parse_module_import_head,
+};
+
+// ===========================================================================
+// LoadTiming — use is compile-time, require is runtime
+// ===========================================================================
+
+#[test]
+fn test_use_has_compile_time_load_timing() -> Result<(), String> {
+    let timing = ModuleImportKind::Use.dispatch_semantics().load_timing;
+    if timing != LoadTiming::CompileTime {
+        return Err(format!("expected CompileTime, got {timing:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_has_runtime_load_timing() -> Result<(), String> {
+    let timing = ModuleImportKind::Require.dispatch_semantics().load_timing;
+    if timing != LoadTiming::Runtime {
+        return Err(format!("expected Runtime, got {timing:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_parent_has_compile_time_load_timing() -> Result<(), String> {
+    let timing = ModuleImportKind::UseParent.dispatch_semantics().load_timing;
+    if timing != LoadTiming::CompileTime {
+        return Err(format!("expected CompileTime, got {timing:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_base_has_compile_time_load_timing() -> Result<(), String> {
+    let timing = ModuleImportKind::UseBase.dispatch_semantics().load_timing;
+    if timing != LoadTiming::CompileTime {
+        return Err(format!("expected CompileTime, got {timing:?}"));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// ImportBehavior — use calls import(), require does not
+// ===========================================================================
+
+#[test]
+fn test_use_calls_import() -> Result<(), String> {
+    let behavior = ModuleImportKind::Use.dispatch_semantics().import_behavior;
+    if behavior != ImportBehavior::CallsImport {
+        return Err(format!("expected CallsImport, got {behavior:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_does_not_call_import() -> Result<(), String> {
+    let behavior = ModuleImportKind::Require.dispatch_semantics().import_behavior;
+    if behavior != ImportBehavior::NoImport {
+        return Err(format!("expected NoImport, got {behavior:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_parent_calls_import() -> Result<(), String> {
+    let behavior = ModuleImportKind::UseParent.dispatch_semantics().import_behavior;
+    if behavior != ImportBehavior::CallsImport {
+        return Err(format!("expected CallsImport, got {behavior:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_base_calls_import() -> Result<(), String> {
+    let behavior = ModuleImportKind::UseBase.dispatch_semantics().import_behavior;
+    if behavior != ImportBehavior::CallsImport {
+        return Err(format!("expected CallsImport, got {behavior:?}"));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// DispatchSemantics struct — derived traits
+// ===========================================================================
+
+#[test]
+fn test_dispatch_semantics_debug_contains_load_timing() -> Result<(), String> {
+    let sem = ModuleImportKind::Use.dispatch_semantics();
+    let dbg = format!("{sem:?}");
+    if !dbg.contains("CompileTime") {
+        return Err(format!("Debug missing CompileTime: {dbg}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_dispatch_semantics_equality() -> Result<(), String> {
+    let a = ModuleImportKind::Use.dispatch_semantics();
+    let b = ModuleImportKind::Use.dispatch_semantics();
+    if a != b {
+        return Err("expected equal DispatchSemantics for same kind".into());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_dispatch_semantics_inequality_across_kinds() -> Result<(), String> {
+    let use_sem = ModuleImportKind::Use.dispatch_semantics();
+    let req_sem = ModuleImportKind::Require.dispatch_semantics();
+    if use_sem == req_sem {
+        return Err("expected Use and Require semantics to differ".into());
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// require "File.pm" — file-path syntax
+// ===========================================================================
+
+#[test]
+fn test_require_file_path_double_quote_parses() -> Result<(), String> {
+    let head = parse_module_import_head(r#"require "Module/File.pm";"#)
+        .ok_or("expected Some for quoted require")?;
+    if head.kind != ModuleImportKind::Require {
+        return Err(format!("expected Require kind, got {:?}", head.kind));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_file_path_single_quote_parses() -> Result<(), String> {
+    let head = parse_module_import_head("require 'Module/File.pm';")
+        .ok_or("expected Some for single-quoted require")?;
+    if head.kind != ModuleImportKind::Require {
+        return Err(format!("expected Require kind, got {:?}", head.kind));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_file_path_is_file_form() -> Result<(), String> {
+    let head = parse_module_import_head(r#"require "Module/File.pm";"#)
+        .ok_or("expected Some for quoted require")?;
+    if head.require_form() != Some(RequireForm::FilePath) {
+        return Err(format!("expected FilePath form, got {:?}", head.require_form()));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_bare_module_is_module_name_form() -> Result<(), String> {
+    let head = parse_module_import_head("require Foo::Bar;")
+        .ok_or("expected Some for bare module require")?;
+    if head.require_form() != Some(RequireForm::ModuleName) {
+        return Err(format!("expected ModuleName form, got {:?}", head.require_form()));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_has_no_require_form() -> Result<(), String> {
+    let head =
+        parse_module_import_head("use Foo::Bar;").ok_or("expected Some for use statement")?;
+    if head.require_form().is_some() {
+        return Err(format!("expected None require_form for use, got {:?}", head.require_form()));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_file_path_token_strips_quotes() -> Result<(), String> {
+    let head = parse_module_import_head(r#"require "Module/File.pm";"#)
+        .ok_or("expected Some for quoted require")?;
+    // The token should be the content without the surrounding quotes
+    if head.token == r#""Module/File.pm""# {
+        return Err(format!(
+            "token should strip quotes, got {:?} — quotes still present",
+            head.token
+        ));
+    }
+    if head.token != "Module/File.pm" {
+        return Err(format!("expected 'Module/File.pm' token, got {:?}", head.token));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_file_path_single_quote_token_strips_quotes() -> Result<(), String> {
+    let head = parse_module_import_head("require 'Module/File.pm';")
+        .ok_or("expected Some for single-quoted require")?;
+    if head.token != "Module/File.pm" {
+        return Err(format!("expected 'Module/File.pm' token, got {:?}", head.token));
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// hover_description — human-readable semantic label
+// ===========================================================================
+
+#[test]
+fn test_use_hover_description_mentions_compile_time() -> Result<(), String> {
+    let desc = ModuleImportKind::Use.dispatch_semantics().hover_description();
+    if !desc.to_lowercase().contains("compile") {
+        return Err(format!("hover description for Use should mention compile-time: {desc}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_hover_description_mentions_runtime() -> Result<(), String> {
+    let desc = ModuleImportKind::Require.dispatch_semantics().hover_description();
+    if !desc.to_lowercase().contains("runtime") {
+        return Err(format!("hover description for Require should mention runtime: {desc}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_require_hover_description_mentions_no_import() -> Result<(), String> {
+    let desc = ModuleImportKind::Require.dispatch_semantics().hover_description();
+    let lower = desc.to_lowercase();
+    if !lower.contains("import") {
+        return Err(format!("hover description for Require should mention import: {desc}"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the core semantic layer requested in issue #2355: distinguishing
`require` (runtime, no import) from `use` (compile-time, with import) at the
type level in `perl-module-import`.

Three new public types are added to `ModuleImportKind`:
- `LoadTiming` — `CompileTime` for `use`, `Runtime` for `require`
- `ImportBehavior` — `CallsImport` for `use`, `NoImport` for `require`
- `DispatchSemantics` — bundles both, returned by `ModuleImportKind::dispatch_semantics()`

A `hover_description()` method on `DispatchSemantics` returns a short
human-readable string suitable for IDE hover text (e.g. `"compile-time load;
calls import()"`).

Additionally, `RequireForm` is added to distinguish `require "file.pm"`
(quoted file-path syntax) from `require Module::Name` (bare module name).
The parser now handles both forms, stripping quotes and returning the inner
path as the token. `ModuleImportHead::require_form()` exposes this distinction.

## Interface & compatibility

- `perl-module-import` API: **additive only** — new types and methods, existing
  `ModuleImportHead` struct gains a private `require_form` field (no breakage
  since struct construction is not public). `parse_module_import_head` return
  type is unchanged.
- LSP surface: unchanged (this crate is not directly wired to LSP yet)
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-module-import/src/lib.rs` — added `LoadTiming`, `ImportBehavior`,
`DispatchSemantics`, `RequireForm` enums/structs; added `dispatch_semantics()`
on `ModuleImportKind`; added `require_form()` accessor on `ModuleImportHead`;
split `require` parsing into `parse_require_head()` to handle both quoted and
bare forms.

`crates/perl-module-import/tests/dispatch_semantics.rs` — 21 new tests
covering all four `ModuleImportKind` variants for `LoadTiming` and
`ImportBehavior`, both quoted require forms (single and double), token
quote-stripping, `require_form()` accessor, and `hover_description()` content.

## How to review

Start with `crates/perl-module-import/src/lib.rs` lines 12–99 (new types),
then `parse_require_head()` (~line 160) for the quoted-form parser logic.
The test file is the fastest way to understand the intended API surface.

## Evidence

```
test result: ok. 5 passed   (lib unit tests)
test result: ok. 80 passed  (comprehensive_unit_tests)
test result: ok. 21 passed  (dispatch_semantics — new)
test result: ok. 5 passed   (bdd)
test result: ok. 1 passed   (fuzz)
test result: ok. 3 passed   (integration)
test result: ok. 3 passed   (prop)
test result: ok. 1 passed   (doc-tests)
fmt: PASS, clippy: PASS (zero warnings)
```

## Risk & rollback

Blast radius is limited to `perl-module-import`. The new `require_form` field
is private; struct construction is only done inside `parse_module_import_head`
and `parse_require_head`, so no downstream breakage. Rollback is a single
revert commit.

The `parse_require_head` quoted-form detection uses `strip_prefix`/
`strip_suffix` with a `split` fallback (handles `require "file.pm";` where
the trailing `;` prevents `strip_suffix` from matching). All 80 existing
comprehensive unit tests continue to pass.

## Follow-ups

- Wire `dispatch_semantics()` into the hover provider (separate issue/PR)
- Expose `require_form()` in the diagnostic layer for lazy-load warnings
- Code action to convert `require` to `use` (separate issue/PR)

Closes #2355