### PR TITLE
fix(dap): 5 DAP quality fixes — tests, dedup, feature gate, timeout Result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "winapi",
 ]
 
@@ -1680,6 +1679,9 @@ dependencies = [
 [[package]]
 name = "perl-dap-shell"
 version = "0.12.0"
+dependencies = [
+ "perl-dap-command-args",
+]
 
 [[package]]
 name = "perl-dap-stack"
@@ -1885,7 +1887,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber",
  "url",
  "uuid",
  "walkdir",
@@ -1963,6 +1964,7 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",
+ "serde_json",
  "url",
 ]
 
@@ -2198,7 +2200,6 @@ dependencies = [
  "perl-position-tracking",
  "perl-qualified-name",
  "perl-tdd-support",
- "serde",
  "serde_json",
 ]
 
@@ -2356,6 +2357,7 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2732,7 +2734,6 @@ version = "0.12.0"
 name = "perl-tokenizer"
 version = "0.12.0"
 dependencies = [
- "perl-ast",
  "perl-ast-v2",
  "perl-error",
  "perl-lexer",

--- a/crates/perl-dap-platform/src/lib.rs
+++ b/crates/perl-dap-platform/src/lib.rs
@@ -21,7 +21,7 @@ pub fn resolve_perl_path() -> Result<PathBuf> {
     resolve_perl_path_from_path_env(&path_env)
 }
 
-fn resolve_perl_path_from_path_env(path_env: &str) -> Result<PathBuf> {
+pub(crate) fn resolve_perl_path_from_path_env(path_env: &str) -> Result<PathBuf> {
     for path_dir in path_env.split(PATH_SEPARATOR) {
         let perl_path = PathBuf::from(path_dir).join(PERL_EXECUTABLE);
         if perl_path.exists() && perl_path.is_file() {
@@ -122,5 +122,66 @@ mod tests {
         let env =
             setup_environment(&[PathBuf::from("/workspace/lib"), PathBuf::from("/custom/lib")]);
         assert!(env.contains_key("PERL5LIB"));
+    }
+
+    #[test]
+    fn resolve_from_path_env_finds_perl_in_first_dir() {
+        use std::fs;
+        let tempdir = tempfile::tempdir().unwrap();
+        let bin = tempdir.path().join(PERL_EXECUTABLE);
+        fs::write(&bin, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&bin).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&bin, perms).unwrap();
+        }
+        let path_str = tempdir.path().to_string_lossy().to_string();
+        let result = resolve_perl_path_from_path_env(&path_str);
+        assert!(result.is_ok(), "expected perl found, got: {:?}", result);
+        assert_eq!(result.unwrap(), bin);
+    }
+
+    #[test]
+    fn resolve_from_path_env_empty_path_returns_error() {
+        let result = resolve_perl_path_from_path_env("");
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("perl") || msg.contains("PATH"),
+            "error should mention perl/PATH: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_from_path_env_no_perl_on_path_returns_error() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path_str = tempdir.path().to_string_lossy().to_string();
+        let result = resolve_perl_path_from_path_env(&path_str);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn normalize_path_wsl_mnt_translated_to_windows_style() {
+        let wsl_path = std::path::Path::new("/mnt/c/Users/user/script.pl");
+        let normalized = normalize_path(wsl_path);
+        let s = normalized.to_string_lossy();
+        assert!(
+            s.starts_with("C:\\") || s.starts_with("C:/"),
+            "expected Windows-style path, got: {s}"
+        );
+        assert!(s.contains("Users"), "path content preserved: {s}");
+    }
+
+    #[test]
+    fn normalize_path_non_wsl_unix_path_unchanged_on_linux() {
+        let path = std::path::Path::new("/usr/local/bin/perl");
+        let normalized = normalize_path(path);
+        assert!(
+            !normalized.to_string_lossy().contains('\\'),
+            "non-WSL path should not be Windows-escaped"
+        );
     }
 }

--- a/crates/perl-dap-security/src/lib.rs
+++ b/crates/perl-dap-security/src/lib.rs
@@ -17,7 +17,7 @@ use perl_path_security::{WorkspacePathError, validate_workspace_path};
 use std::path::{Path, PathBuf};
 
 /// Security validation errors
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum SecurityError {
     /// Path traversal attempt detected
     #[error("Path traversal attempt detected: {0}")]
@@ -78,10 +78,12 @@ pub fn validate_expression(expression: &str) -> Result<(), SecurityError> {
     Ok(())
 }
 
-/// Validate and cap a timeout value
-pub fn validate_timeout(timeout_ms: u32) -> u32 {
-    let timeout = timeout_ms.max(1);
-    timeout.min(MAX_TIMEOUT_MS)
+/// Validate a timeout value, returning an error if it exceeds the maximum allowed.
+pub fn validate_timeout(timeout_ms: u32) -> Result<u32, SecurityError> {
+    if timeout_ms > MAX_TIMEOUT_MS {
+        return Err(SecurityError::ExcessiveTimeout(timeout_ms));
+    }
+    Ok(timeout_ms.max(1))
 }
 
 /// Validate a breakpoint condition for security issues
@@ -236,20 +238,37 @@ mod tests {
 
     #[test]
     fn test_validate_timeout_within_bounds() {
-        assert_eq!(validate_timeout(1000), 1000);
-        assert_eq!(validate_timeout(5000), 5000);
-        assert_eq!(validate_timeout(100_000), 100_000);
+        assert_eq!(validate_timeout(1000).unwrap(), 1000);
+        assert_eq!(validate_timeout(5000).unwrap(), 5000);
+        assert_eq!(validate_timeout(100_000).unwrap(), 100_000);
     }
 
     #[test]
     fn test_validate_timeout_zero() {
-        assert_eq!(validate_timeout(0), 1, "Zero timeout should be capped to 1ms");
+        assert_eq!(validate_timeout(0).unwrap(), 1, "Zero timeout should be clamped to 1ms");
     }
 
     #[test]
     fn test_validate_timeout_excessive() {
-        assert_eq!(validate_timeout(500_000), MAX_TIMEOUT_MS, "Excessive timeout should be capped");
-        assert_eq!(validate_timeout(1_000_000), MAX_TIMEOUT_MS);
+        let result = validate_timeout(500_000);
+        assert!(result.is_err(), "Excessive timeout should be an error");
+        assert_eq!(result.unwrap_err(), SecurityError::ExcessiveTimeout(500_000));
+        assert!(validate_timeout(1_000_000).is_err());
+    }
+
+    #[test]
+    fn test_validate_timeout_boundary_at_max_is_ok() {
+        assert!(validate_timeout(MAX_TIMEOUT_MS).is_ok());
+        assert_eq!(validate_timeout(MAX_TIMEOUT_MS).unwrap(), MAX_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn test_validate_timeout_one_over_max_is_error() {
+        assert!(validate_timeout(MAX_TIMEOUT_MS + 1).is_err());
+        assert_eq!(
+            validate_timeout(MAX_TIMEOUT_MS + 1).unwrap_err(),
+            SecurityError::ExcessiveTimeout(MAX_TIMEOUT_MS + 1)
+        );
     }
 
     #[test]
@@ -291,9 +310,9 @@ mod tests {
 
     #[test]
     fn test_validate_timeout_boundary_values() {
-        assert_eq!(validate_timeout(1), 1);
-        assert_eq!(validate_timeout(MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
-        assert_eq!(validate_timeout(MAX_TIMEOUT_MS + 1), MAX_TIMEOUT_MS);
+        assert_eq!(validate_timeout(1).unwrap(), 1);
+        assert_eq!(validate_timeout(MAX_TIMEOUT_MS).unwrap(), MAX_TIMEOUT_MS);
+        assert!(validate_timeout(MAX_TIMEOUT_MS + 1).is_err());
     }
 
     #[test]

--- a/crates/perl-dap-security/tests/dap_path_traversal_hardened_tests.rs
+++ b/crates/perl-dap-security/tests/dap_path_traversal_hardened_tests.rs
@@ -515,36 +515,36 @@ fn dap_condition_rejects_cr() -> TestResult {
 
 #[test]
 fn dap_timeout_zero_capped_to_one() {
-    assert_eq!(validate_timeout(0), 1);
+    assert_eq!(validate_timeout(0).unwrap(), 1);
 }
 
 #[test]
 fn dap_timeout_one_is_minimum() {
-    assert_eq!(validate_timeout(1), 1);
+    assert_eq!(validate_timeout(1).unwrap(), 1);
 }
 
 #[test]
 fn dap_timeout_default_unchanged() {
-    assert_eq!(validate_timeout(DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+    assert_eq!(validate_timeout(DEFAULT_TIMEOUT_MS).unwrap(), DEFAULT_TIMEOUT_MS);
 }
 
 #[test]
 fn dap_timeout_max_unchanged() {
-    assert_eq!(validate_timeout(MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
+    assert_eq!(validate_timeout(MAX_TIMEOUT_MS).unwrap(), MAX_TIMEOUT_MS);
 }
 
 #[test]
-fn dap_timeout_over_max_capped() {
-    assert_eq!(validate_timeout(MAX_TIMEOUT_MS + 1), MAX_TIMEOUT_MS);
-    assert_eq!(validate_timeout(u32::MAX), MAX_TIMEOUT_MS);
+fn dap_timeout_over_max_returns_error() {
+    assert!(validate_timeout(MAX_TIMEOUT_MS + 1).is_err());
+    assert!(validate_timeout(u32::MAX).is_err());
 }
 
 #[test]
 fn dap_timeout_normal_values_unchanged() {
-    assert_eq!(validate_timeout(1000), 1000);
-    assert_eq!(validate_timeout(5000), 5000);
-    assert_eq!(validate_timeout(60_000), 60_000);
-    assert_eq!(validate_timeout(100_000), 100_000);
+    assert_eq!(validate_timeout(1000).unwrap(), 1000);
+    assert_eq!(validate_timeout(5000).unwrap(), 5000);
+    assert_eq!(validate_timeout(60_000).unwrap(), 60_000);
+    assert_eq!(validate_timeout(100_000).unwrap(), 100_000);
 }
 
 // ===========================================================================

--- a/crates/perl-dap-shell/Cargo.toml
+++ b/crates/perl-dap-shell/Cargo.toml
@@ -23,5 +23,8 @@ include = [
 name = "perl_dap_shell"
 path = "src/lib.rs"
 
+[dependencies]
+perl-dap-command-args = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/perl-dap-shell/src/lib.rs
+++ b/crates/perl-dap-shell/src/lib.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+pub use perl_dap_command_args::format_command_args;
+
 #[cfg(windows)]
 const PATH_SEPARATOR: char = ';';
 #[cfg(not(windows))]
@@ -23,30 +25,6 @@ pub fn setup_environment(include_paths: &[PathBuf]) -> HashMap<String, String> {
     }
 
     env
-}
-
-/// Format command-line arguments for platform-specific shells.
-pub fn format_command_args(args: &[String]) -> Vec<String> {
-    args.iter()
-        .map(|arg| {
-            if arg.contains(' ') {
-                #[cfg(windows)]
-                {
-                    format!("\"{}\"", arg.replace('"', "\\\""))
-                }
-                #[cfg(not(windows))]
-                {
-                    if arg.contains('\'') {
-                        format!("\"{}\"", arg.replace('"', "\\\""))
-                    } else {
-                        format!("'{}'", arg)
-                    }
-                }
-            } else {
-                arg.clone()
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/perl-dap-types/src/lib.rs
+++ b/crates/perl-dap-types/src/lib.rs
@@ -74,3 +74,102 @@ pub struct Variable {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indexed_variables: Option<i32>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stack_frame_new_defaults() {
+        let src = Source::new("/path/to/script.pl");
+        let frame = StackFrame::new(1, "main::foo", src, 42);
+        assert_eq!(frame.id, 1);
+        assert_eq!(frame.name, "main::foo");
+        assert_eq!(frame.line, 42);
+        assert_eq!(frame.column, 1);
+        assert!(frame.end_line.is_none());
+        assert!(frame.end_column.is_none());
+    }
+
+    #[test]
+    fn stack_frame_with_column_and_end() {
+        let src = Source::new("/a.pl");
+        let frame = StackFrame::new(2, "foo", src, 10).with_column(5).with_end(10, 20);
+        assert_eq!(frame.column, 5);
+        assert_eq!(frame.end_line, Some(10));
+        assert_eq!(frame.end_column, Some(20));
+    }
+
+    #[test]
+    fn source_new_extracts_filename() {
+        let src = Source::new("/path/to/Module.pm");
+        assert_eq!(src.path, "/path/to/Module.pm");
+        assert_eq!(src.name, Some("Module.pm".to_string()));
+        assert!(src.source_reference.is_none());
+    }
+
+    #[test]
+    fn stack_frame_serde_round_trip() {
+        let src = Source::new("/script.pl");
+        let frame = StackFrame::new(1, "run", src, 5);
+        let json = serde_json::to_string(&frame).unwrap();
+        let back: StackFrame = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, 1);
+        assert_eq!(back.line, 5);
+    }
+
+    #[test]
+    fn stack_frame_optional_fields_omitted_in_json() {
+        let src = Source::new("/a.pl");
+        let frame = StackFrame::new(1, "foo", src, 1);
+        let json = serde_json::to_string(&frame).unwrap();
+        assert!(!json.contains("endLine"), "endLine should be absent: {json}");
+        assert!(!json.contains("endColumn"), "endColumn should be absent: {json}");
+    }
+
+    #[test]
+    fn variable_type_field_serializes_as_type_not_type_underscore() {
+        let var = Variable {
+            name: "$x".to_string(),
+            value: "42".to_string(),
+            type_: Some("SCALAR".to_string()),
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+        };
+        let json = serde_json::to_string(&var).unwrap();
+        assert!(json.contains("\"type\":"), "must serialize as 'type' not 'type_': {json}");
+        assert!(!json.contains("type_"), "must not leak Rust field name: {json}");
+    }
+
+    #[test]
+    fn variable_optional_fields_omitted_when_none() {
+        let var = Variable {
+            name: "$x".to_string(),
+            value: "1".to_string(),
+            type_: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+        };
+        let json = serde_json::to_string(&var).unwrap();
+        assert!(!json.contains("namedVariables"), "absent: {json}");
+        assert!(!json.contains("indexedVariables"), "absent: {json}");
+    }
+
+    #[test]
+    fn variable_serde_round_trip() {
+        let var = Variable {
+            name: "@arr".to_string(),
+            value: "(3 elements)".to_string(),
+            type_: Some("ARRAY".to_string()),
+            variables_reference: 7,
+            named_variables: None,
+            indexed_variables: Some(3),
+        };
+        let json = serde_json::to_string(&var).unwrap();
+        let back: Variable = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.variables_reference, 7);
+        assert_eq!(back.indexed_variables, Some(3));
+    }
+}

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -89,7 +89,7 @@ nix = { version = "0.31.1", features = ["signal"] }  # For SIGINT handling (AC9)
 winapi = { version = "0.3.9", features = ["processthreadsapi"] }  # For Ctrl+C (AC9)
 
 [features]
-default = []
+default = ["dap-phase1", "dap-phase2"]
 # DAP implementation phases (TDD scaffold tests)
 dap-phase1 = []  # AC1-AC4: Bridge to Perl::LanguageServer
 dap-phase2 = []  # AC5-AC16: Native adapter, integration tests, performance, security

--- a/crates/perl-dap/tests/dap_security_validation_tests.rs
+++ b/crates/perl-dap/tests/dap_security_validation_tests.rs
@@ -188,21 +188,21 @@ fn test_condition_validation_protocol_injection() {
 
 #[test]
 fn test_timeout_validation_within_bounds() {
-    assert_eq!(validate_timeout(1000), 1000);
-    assert_eq!(validate_timeout(5000), 5000);
-    assert_eq!(validate_timeout(100_000), 100_000);
-    assert_eq!(validate_timeout(DEFAULT_TIMEOUT_MS), DEFAULT_TIMEOUT_MS);
+    assert_eq!(validate_timeout(1000).unwrap(), 1000);
+    assert_eq!(validate_timeout(5000).unwrap(), 5000);
+    assert_eq!(validate_timeout(100_000).unwrap(), 100_000);
+    assert_eq!(validate_timeout(DEFAULT_TIMEOUT_MS).unwrap(), DEFAULT_TIMEOUT_MS);
 }
 
 #[test]
 fn test_timeout_validation_zero_clamped() {
-    assert_eq!(validate_timeout(0), 1, "Zero timeout should be clamped to 1ms");
+    assert_eq!(validate_timeout(0).unwrap(), 1, "Zero timeout should be clamped to 1ms");
 }
 
 #[test]
-fn test_timeout_validation_excessive_capped() {
-    assert_eq!(validate_timeout(500_000), MAX_TIMEOUT_MS, "Excessive timeout should be capped");
-    assert_eq!(validate_timeout(1_000_000), MAX_TIMEOUT_MS, "Million ms timeout should be capped");
+fn test_timeout_validation_excessive_returns_error() {
+    assert!(validate_timeout(500_000).is_err(), "Excessive timeout should be an error");
+    assert!(validate_timeout(1_000_000).is_err(), "Million ms timeout should be an error");
 }
 
 // ===== Integration Tests =====


### PR DESCRIPTION
## Summary

Five easy DAP quality fixes from issues #2485, #2487, #2489, #2491, #2492:

- **#2485 perl-dap-types**: Add 8 serde round-trip tests for `StackFrame`, `Source`, `Variable`. Proves `type_` serializes as `"type"` and optional fields are absent from JSON when `None`.
- **#2487 perl-dap-platform**: Make `resolve_perl_path_from_path_env` `pub(crate)` and add 5 synthetic-PATH unit tests (found/empty/missing, plus WSL `/mnt/c/` normalization on Linux).
- **#2489 perl-dap-shell**: Remove duplicate `format_command_args` implementation; re-export from `perl-dap-command-args` (the canonical single-purpose crate). No behavior change.
- **#2491 perl-dap**: Promote `dap-phase2` to default feature so ~400 LOC of previously-invisible test scaffolding runs in CI by default.
- **#2492 perl-dap-security**: Change `validate_timeout` signature from `u32` to `Result<u32, SecurityError>`. Add `PartialEq` to `SecurityError`. Update all call sites in 3 test files. `ExcessiveTimeout` variant is no longer dead code.

## Files changed

- `crates/perl-dap-types/src/lib.rs` — 8 new tests
- `crates/perl-dap-platform/src/lib.rs` — `pub(crate)` visibility + 5 new tests
- `crates/perl-dap-shell/Cargo.toml` — add `perl-dap-command-args` dep
- `crates/perl-dap-shell/src/lib.rs` — remove duplicate impl, add re-export
- `crates/perl-dap/Cargo.toml` — `default = ["dap-phase1", "dap-phase2"]`
- `crates/perl-dap/tests/dap_security_validation_tests.rs` — update timeout tests
- `crates/perl-dap-security/src/lib.rs` — `PartialEq`, `Result` signature, 5 updated + 2 new tests
- `crates/perl-dap-security/tests/dap_path_traversal_hardened_tests.rs` — update 6 timeout tests

## Test plan

- [ ] `cargo test -p perl-dap-types` — 8 tests pass
- [ ] `cargo test -p perl-dap-platform` — 9 tests pass (4 pre-existing + 5 new)
- [ ] `cargo test -p perl-dap-shell` — all tests pass via re-export
- [ ] `cargo test -p perl-dap-security` — 57 integration tests + 20 unit tests pass
- [ ] `cargo clippy -p perl-dap-types -p perl-dap-platform -p perl-dap-shell -p perl-dap-security --lib` — clean

## Notes

- The `perl-lsp-perltidy` compile error visible in `--workspace --lib` is a pre-existing issue from another PR (unrelated to this change — confirmed by reverting and checking).
- `dap-phase2` tests that were previously hidden from CI now run by default; all pass.
- `ExcessiveTimeout` was previously only constructed in a Display-string test; it is now produced by real production logic.