### PR TITLE
fix(parser): batch parser fixes for comma_expr, paren_ident, colon, subst (#2388, #2391, #2393, #2395)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -10,7 +10,50 @@ impl<'a> Parser<'a> {
     fn is_indirect_call_pattern(&mut self, name: &str) -> bool {
         // Only check for indirect objects at statement start to avoid false positives
         // in contexts like: my $x = 1; if (1) { print $x; }
-        if !self.at_stmt_start && name != "new" {
+        //
+        // Exception: print/say/printf/exec/system with a block filehandle `{ $fh }`
+        // or a `$var VAR` (two consecutive sigiled tokens, no comma) are unambiguous
+        // enough to allow outside statement-start context.
+        let is_filehandle_builtin = matches!(name, "print" | "say" | "printf" | "exec" | "system");
+        if !self.at_stmt_start && !is_filehandle_builtin && name != "new" {
+            return false;
+        }
+        // In non-stmt-start context for print/etc., only allow the unambiguous forms:
+        // 1. `{ $fh }` block-form filehandle
+        // 2. `$var $something` (two sigiled tokens, no comma) — indirect $fh
+        if !self.at_stmt_start && is_filehandle_builtin {
+            // Clone the needed info to avoid multiple borrows of self.tokens.
+            let next_kind = self.tokens.peek_second().ok().map(|t| t.kind);
+            let next_text = self.tokens.peek_second().ok().map(|t| t.text.to_string());
+            let third_kind = self.tokens.peek_third().ok().map(|t| t.kind);
+            let third_text = self.tokens.peek_third().ok().map(|t| t.text.to_string());
+
+            if let Some(nk) = next_kind {
+                // Form 1: block filehandle `print { $fh } ...`
+                if nk == TokenKind::LeftBrace {
+                    if let Some(ref txt) = third_text {
+                        if txt.starts_with('$') || txt.starts_with('*') {
+                            return true;
+                        }
+                    }
+                }
+                // Form 2: variable filehandle `print $fh $msg` (no comma after $fh)
+                if next_text.as_deref().unwrap_or("").starts_with('$') {
+                    // If next-next starts with $ or @ or is a string, it's likely
+                    // `print $fh $msg` — no comma between filehandle and message.
+                    // A comma means it's a regular `print $var, $other` list.
+                    if third_kind != Some(TokenKind::Comma) {
+                        if let Some(ref txt) = third_text {
+                            if txt.starts_with('$')
+                                || txt.starts_with('@')
+                                || third_kind == Some(TokenKind::String)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
             return false;
         }
 
@@ -480,7 +523,23 @@ impl<'a> Parser<'a> {
 
                 args.push(arg);
 
-                // Accept both comma and fat arrow as separators
+                // Accept both comma and fat arrow as separators.
+                // Special case: a Block or HashLiteral argument (from `exec({ ... } @args)`,
+                // `map({ ... } @list)`, or `map({k => v} keys ...)`) may be followed by the
+                // list without a comma. If we just pushed a Block or HashLiteral and next is
+                // not `)` or a separator, treat the rest as implicit comma-separated arguments.
+                let last_is_block = matches!(
+                    args.last(),
+                    Some(n) if matches!(n.kind, NodeKind::Block { .. } | NodeKind::HashLiteral { .. })
+                );
+                if last_is_block
+                    && s.peek_kind() != Some(TokenKind::RightParen)
+                    && !matches!(s.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow))
+                {
+                    // Continue the while loop to parse more args (implicit comma after block)
+                    continue;
+                }
+
                 match s.peek_kind() {
                     Some(TokenKind::Comma) | Some(TokenKind::FatArrow) => {
                         s.tokens.next()?;

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -418,16 +418,57 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_ternary()?);
                                 }
                             } else {
-                                // Other builtins - parse {} as first argument
+                                // Other builtins - parse {} as first argument (filehandle or hash)
                                 args.push(self.parse_hash_or_block()?);
 
-                                // Parse remaining arguments separated by commas or fat arrows
-                                while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
-                                    self.consume_token()?; // consume comma or fat arrow
-                                    if self.is_at_statement_end() {
-                                        break;
+                                // For print/say/printf/exec/system, `{ $fh } $args` uses
+                                // the block as a filehandle and args follow without a comma.
+                                // Collect trailing args without requiring commas first.
+                                let is_fh_builtin = matches!(
+                                    name.as_str(),
+                                    "print" | "say" | "printf" | "exec" | "system"
+                                );
+                                if is_fh_builtin && !self.is_at_statement_end()
+                                    && !matches!(
+                                        self.peek_kind(),
+                                        Some(TokenKind::Comma | TokenKind::FatArrow)
+                                    )
+                                {
+                                    // No comma — treat the block as a filehandle and parse the list.
+                                    while !self.is_at_statement_end()
+                                        && !matches!(
+                                            self.peek_kind(),
+                                            Some(
+                                                TokenKind::WordOr
+                                                    | TokenKind::WordAnd
+                                                    | TokenKind::WordXor
+                                                    | TokenKind::WordNot
+                                            )
+                                        )
+                                    {
+                                        if matches!(
+                                            self.peek_kind(),
+                                            Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                        ) {
+                                            self.consume_token()?;
+                                        }
+                                        if self.is_at_statement_end() {
+                                            break;
+                                        }
+                                        args.push(self.parse_ternary()?);
                                     }
-                                    args.push(self.parse_comma()?);
+                                } else {
+                                    // Parse remaining arguments separated by commas or fat arrows
+                                    while matches!(
+                                        self.peek_kind(),
+                                        Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                    ) {
+                                        self.consume_token()?; // consume comma or fat arrow
+                                        if self.is_at_statement_end() {
+                                            break;
+                                        }
+                                        args.push(self.parse_comma()?);
+                                    }
                                 }
                             }
 
@@ -616,6 +657,55 @@ impl<'a> Parser<'a> {
                                         }
                                         args.push(self.parse_ternary()?);
                                     }
+                                } else if name == "sort"
+                                    && matches!(self.peek_kind(), Some(TokenKind::Identifier))
+                                    && self.tokens.peek().ok().is_some_and(|t| {
+                                        // Named comparator: lowercase identifier that's not a
+                                        // binary string op. e.g. `sort cmp_events @list`
+                                        let txt: &str = &t.text;
+                                        !txt.is_empty()
+                                            && txt.starts_with(|c: char| {
+                                                c.is_ascii_lowercase() || c == '_'
+                                            })
+                                            && !matches!(
+                                                txt,
+                                                "eq" | "ne"
+                                                    | "lt"
+                                                    | "le"
+                                                    | "gt"
+                                                    | "ge"
+                                                    | "cmp"
+                                                    | "x"
+                                            )
+                                    })
+                                {
+                                    // sort FUNCNAME LIST — `sort by_name @list`
+                                    // Parse the comparator function name as the first arg,
+                                    // then collect the list to sort.
+                                    args.push(self.parse_ternary()?);
+
+                                    while !self.is_at_statement_end()
+                                        && !matches!(
+                                            self.peek_kind(),
+                                            Some(
+                                                TokenKind::WordOr
+                                                    | TokenKind::WordAnd
+                                                    | TokenKind::WordXor
+                                                    | TokenKind::WordNot
+                                            )
+                                        )
+                                    {
+                                        if matches!(
+                                            self.peek_kind(),
+                                            Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                        ) {
+                                            self.consume_token()?;
+                                        }
+                                        if self.is_at_statement_end() {
+                                            break;
+                                        }
+                                        args.push(self.parse_ternary()?);
+                                    }
                                 } else if name == "bless"
                                     && self.peek_kind() == Some(TokenKind::LeftBrace)
                                 {
@@ -629,6 +719,34 @@ impl<'a> Parser<'a> {
                                             break;
                                         }
                                         args.push(self.parse_assignment()?);
+                                    }
+                                } else if matches!(name.as_str(), "print" | "say" | "printf" | "exec" | "system")
+                                    && self.peek_kind() == Some(TokenKind::LeftBrace)
+                                {
+                                    // print { $fh } ARGS — block-form filehandle in expr context
+                                    // Parse the block as the filehandle, then the remaining args.
+                                    args.push(self.parse_hash_or_block()?);
+                                    while !self.is_at_statement_end()
+                                        && !matches!(
+                                            self.peek_kind(),
+                                            Some(
+                                                TokenKind::WordOr
+                                                    | TokenKind::WordAnd
+                                                    | TokenKind::WordXor
+                                                    | TokenKind::WordNot
+                                            )
+                                        )
+                                    {
+                                        if matches!(
+                                            self.peek_kind(),
+                                            Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                        ) {
+                                            self.consume_token()?;
+                                        }
+                                        if self.is_at_statement_end() {
+                                            break;
+                                        }
+                                        args.push(self.parse_ternary()?);
                                     }
                                 } else if matches!(name.as_str(), "split" | "grep" | "map" | "sort")
                                     && self.peek_kind() == Some(TokenKind::Slash)
@@ -649,6 +767,52 @@ impl<'a> Parser<'a> {
                                 } else {
                                     // Parse the first argument
                                     args.push(self.parse_ternary()?);
+
+                                    // Special case: print/say/printf/exec with indirect filehandle.
+                                    // `print $fh $msg` — $fh is the filehandle (no comma before $msg).
+                                    // After the first arg, if next is a sigil/string without comma,
+                                    // treat first arg as filehandle and continue parsing the list.
+                                    if matches!(
+                                        name.as_str(),
+                                        "print" | "say" | "printf" | "exec" | "system"
+                                    ) && !self.is_at_statement_end()
+                                        && !matches!(
+                                            self.peek_kind(),
+                                            Some(
+                                                TokenKind::Comma
+                                                    | TokenKind::FatArrow
+                                                    | TokenKind::WordOr
+                                                    | TokenKind::WordAnd
+                                                    | TokenKind::WordXor
+                                                    | TokenKind::WordNot
+                                            )
+                                        )
+                                    {
+                                        // No comma after first arg — it's an indirect filehandle.
+                                        // Parse the remaining args (the actual list to print).
+                                        while !self.is_at_statement_end()
+                                            && !matches!(
+                                                self.peek_kind(),
+                                                Some(
+                                                    TokenKind::WordOr
+                                                        | TokenKind::WordAnd
+                                                        | TokenKind::WordXor
+                                                        | TokenKind::WordNot
+                                                )
+                                            )
+                                        {
+                                            if matches!(
+                                                self.peek_kind(),
+                                                Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                                            ) {
+                                                self.consume_token()?;
+                                            }
+                                            if self.is_at_statement_end() {
+                                                break;
+                                            }
+                                            args.push(self.parse_ternary()?);
+                                        }
+                                    }
 
                                     // Parse remaining arguments separated by commas or fat arrows
                                     // Perl allows `push @array => $value` as well as commas

--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -174,6 +174,11 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // After processing all or/xor operators, apply any trailing 'and' operators.
+        // This handles patterns like `($a or $b, $c and $d)` where comma collection
+        // inside `or` absorbs `$c` but leaves `and $d` for this level.
+        expr = self.parse_word_and_expr_with(expr)?;
+
         Ok(expr)
     }
 

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -695,9 +695,35 @@ impl<'a> Parser<'a> {
             TokenKind::ScalarSigil | TokenKind::ArraySigil | TokenKind::HashSigil => true,
 
             // `func other_func(args)` — identifier followed by `(`
+            // `func bareword => value` — identifier followed by fat arrow (auto-quoted arg)
             TokenKind::Identifier if !next.text.starts_with(|c: char| c.is_ascii_uppercase()) => {
+                let next_text = next.text.clone();
+                // Block-list functions (map/grep/sort/etc.) as argument: `uniq map { ... } @list`
+                if Self::is_block_list_func(&next_text) {
+                    if let Ok(third) = self.tokens.peek_second() {
+                        return third.kind == TokenKind::LeftBrace
+                            || third.kind == TokenKind::LeftParen;
+                    }
+                }
+                // Builtin functions that take a single sigiled argument as argument:
+                // `max values %hash`, `func keys %h`, `func reverse @list`
+                // These are builtins whose first/only argument is a sigiled expression.
+                if Self::is_builtin_function(&next_text) {
+                    if let Ok(third) = self.tokens.peek_second() {
+                        let third_text: &str = &third.text;
+                        return third_text.starts_with('$')
+                            || third_text.starts_with('@')
+                            || third_text.starts_with('%')
+                            || third.kind == TokenKind::ScalarSigil
+                            || third.kind == TokenKind::ArraySigil
+                            || third.kind == TokenKind::HashSigil;
+                    }
+                }
                 // Check if the next-next token is `(` — that signals a function call
-                self.tokens.peek_second().ok().is_some_and(|t| t.kind == TokenKind::LeftParen)
+                // or `=>` (fat arrow after bareword) — that signals an auto-quoted arg
+                self.tokens.peek_second().ok().is_some_and(|t| {
+                    t.kind == TokenKind::LeftParen || t.kind == TokenKind::FatArrow
+                })
             }
 
             _ => false,

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -786,6 +786,19 @@ impl<'a> Parser<'a> {
                                 // ExpectTerm mode so it becomes a regex.
                                 self.tokens.relex_as_term();
                                 args.push(self.parse_assignment()?);
+                            } else if self.peek_kind() == Some(TokenKind::LeftParen)
+                                && (Self::is_block_list_func(func_name.as_ref())
+                                    || matches!(
+                                        func_name.as_ref(),
+                                        "exec" | "system" | "print" | "say" | "printf"
+                                    ))
+                            {
+                                // block-list and filehandle builtins followed by (...) use
+                                // parse_args() so that `map({...} keys ...)` and
+                                // `exec({...} @prog)` work: the block/hash inside the parens
+                                // may be followed by the list without a separating comma.
+                                let paren_args = self.parse_args()?;
+                                args.extend(paren_args);
                             } else {
                                 // For builtins, use parse_assignment_or_declaration to handle
                                 // my/our/local/state declarations inside argument lists


### PR DESCRIPTION
## Summary

- Fixes unclosed-paren-identifier parse errors for CPAN patterns involving block/hash args followed by implicit comma in `map`, `exec`, and `print` builtins
- Adds `sort FUNCNAME LIST` support (named comparator) in bare-call context
- Fixes `($x or $y, $z and $w)` word operator precedence in paren lists  
- Extends `looks_like_bare_call` heuristic for block-list funcs, builtins with sigiled args, and fat-arrow after bareword
- Extends `is_indirect_call_pattern` to allow filehandle builtins outside stmt-start context

## Root Causes Fixed

**exec({ $prog[0] } @prog)** and **map({$cache{$_} => $_} keys %cache)**:
Statement-level builtin dispatch called `parse_assignment_or_declaration()` for these builtins followed by `(`, which parsed `(` as a paren expression and couldn't handle `{block} rest` without a comma. Fixed by routing through `parse_args()` in `parse_simple_statement`.

**print { $self->{gui} } $mode** in expression context:
The `LeftBrace` arm's else branch in `parse_postfix_chain` didn't parse trailing args after a filehandle block without a comma. Fixed by adding filehandle-builtin awareness to that arm.

**parse_args last_is_block** extended to also cover `HashLiteral` nodes (from `{key => val}` blocks).

## Test Plan

- [x] `cargo test -p perl-parser-core` passes (82/82 unclosed_paren_identifier tests, 404 total parser tests)
- [x] `cargo clippy -p perl-parser-core --tests` clean
- [x] `cargo fmt --all` applied
- [x] Pre-existing failure `test_grep_block_file_test` (invalid Perl `if grep {...} @files { }` without parens) unchanged

## Issues Addressed

Closes #2388, #2391, #2393, #2395