### PR TITLE
feat(semantic-analyzer): add phase-aware hover docs for BEGIN/END/CHECK/INIT/UNITCHECK blocks

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs
@@ -498,13 +498,19 @@ impl SemanticAnalyzer {
                 }
             }
 
-            NodeKind::PhaseBlock { phase: _, phase_span: _, block } => {
+            NodeKind::PhaseBlock { phase, phase_span: _, block } => {
                 // Handle BEGIN/END/INIT/CHECK/UNITCHECK blocks
                 self.semantic_tokens.push(SemanticToken {
                     location: node.location,
                     token_type: SemanticTokenType::Keyword,
                     modifiers: vec![],
                 });
+
+                let (signature, documentation) = phase_block_hover(phase);
+                self.hover_info.insert(
+                    node.location,
+                    HoverInfo { signature, documentation: Some(documentation), details: vec![] },
+                );
 
                 self.analyze_node(block, scope_id);
             }
@@ -1138,5 +1144,50 @@ impl SemanticAnalyzer {
 
             _ => None,
         }
+    }
+}
+
+/// Return `(signature, documentation)` for each Perl execution phase block.
+fn phase_block_hover(phase: &str) -> (String, String) {
+    match phase {
+        "BEGIN" => (
+            "BEGIN { ... }".to_string(),
+            "Executed at compile time, immediately when the block is fully compiled. \
+             Use for module loading, constant definition, and compile-time configuration. \
+             Runs before any runtime code in the file."
+                .to_string(),
+        ),
+        "END" => (
+            "END { ... }".to_string(),
+            "Executed during interpreter shutdown, after all runtime code has finished. \
+             Multiple END blocks run in reverse order of definition (LIFO). \
+             Use for cleanup, resource release, and shutdown logging."
+                .to_string(),
+        ),
+        "INIT" => (
+            "INIT { ... }".to_string(),
+            "Executed after compilation is complete but before the main program runs. \
+             Multiple INIT blocks run in order of definition (FIFO). \
+             Use for runtime initialization that must happen after all BEGIN blocks."
+                .to_string(),
+        ),
+        "CHECK" => (
+            "CHECK { ... }".to_string(),
+            "Executed at the end of the compilation phase, before INIT blocks. \
+             Multiple CHECK blocks run in reverse order of definition (LIFO). \
+             Use for compile-time validation and code checks."
+                .to_string(),
+        ),
+        "UNITCHECK" => (
+            "UNITCHECK { ... }".to_string(),
+            "Executed immediately after the compilation unit (file or string eval) finishes compiling. \
+             Runs before CHECK and INIT blocks. \
+             Use for per-unit initialization that depends on that unit being fully compiled."
+                .to_string(),
+        ),
+        other => (
+            format!("{other} {{ ... }}"),
+            format!("Perl execution phase block: {other}"),
+        ),
     }
 }

--- a/crates/perl-semantic-analyzer/tests/phase_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/phase_hover_tests.rs
@@ -1,0 +1,158 @@
+//! Tests for BEGIN/END/CHECK/INIT/UNITCHECK phase block hover documentation.
+//!
+//! Phase blocks have distinct execution semantics in Perl:
+//! - BEGIN: compile-time execution
+//! - END: interpreter shutdown
+//! - INIT: post-compile, pre-runtime
+//! - CHECK: end of compilation, before INIT
+//! - UNITCHECK: after each compilation unit compiles
+//!
+//! Each phase block should produce hover info explaining when it runs.
+
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::analysis::semantic::SemanticAnalyzer;
+use perl_semantic_analyzer::{Node, NodeKind, SourceLocation};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Find the first PhaseBlock node in the AST, returning its location.
+fn find_phase_block_location(node: &Node) -> Option<SourceLocation> {
+    match &node.kind {
+        NodeKind::PhaseBlock { .. } => Some(node.location),
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            for stmt in statements {
+                if let Some(loc) = find_phase_block_location(stmt) {
+                    return Some(loc);
+                }
+            }
+            None
+        }
+        NodeKind::ExpressionStatement { expression } => find_phase_block_location(expression),
+        _ => None,
+    }
+}
+
+fn parse_and_analyze(code: &str) -> Result<(Node, SemanticAnalyzer), Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+    Ok((ast, analyzer))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_begin_phase_block_hover_contains_compile_time() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "BEGIN { my $x = 1; }";
+    let (ast, analyzer) = parse_and_analyze(code)?;
+
+    let loc = find_phase_block_location(&ast).ok_or("no PhaseBlock node found")?;
+    let hover = analyzer.hover_at(loc).ok_or("no hover info for BEGIN block")?;
+
+    assert!(
+        hover.signature.to_lowercase().contains("begin")
+            || hover.signature.to_lowercase().contains("compile"),
+        "BEGIN hover signature should mention 'begin' or 'compile', got: {}",
+        hover.signature
+    );
+    Ok(())
+}
+
+#[test]
+fn test_end_phase_block_hover_contains_cleanup() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "END { print 'done'; }";
+    let (ast, analyzer) = parse_and_analyze(code)?;
+
+    let loc = find_phase_block_location(&ast).ok_or("no PhaseBlock node found")?;
+    let hover = analyzer.hover_at(loc).ok_or("no hover info for END block")?;
+
+    assert!(
+        hover.signature.to_lowercase().contains("end")
+            || hover.signature.to_lowercase().contains("shutdown")
+            || hover.signature.to_lowercase().contains("cleanup"),
+        "END hover signature should mention 'end', 'shutdown', or 'cleanup', got: {}",
+        hover.signature
+    );
+    Ok(())
+}
+
+#[test]
+fn test_init_phase_block_hover_contains_post_compile() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "INIT { my $y = 2; }";
+    let (ast, analyzer) = parse_and_analyze(code)?;
+
+    let loc = find_phase_block_location(&ast).ok_or("no PhaseBlock node found")?;
+    let hover = analyzer.hover_at(loc).ok_or("no hover info for INIT block")?;
+
+    assert!(
+        hover.signature.to_lowercase().contains("init")
+            || hover.signature.to_lowercase().contains("post-compile")
+            || hover.signature.to_lowercase().contains("runtime"),
+        "INIT hover signature should mention 'init', 'post-compile', or 'runtime', got: {}",
+        hover.signature
+    );
+    Ok(())
+}
+
+#[test]
+fn test_check_phase_block_hover_present() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "CHECK { my $z = 3; }";
+    let (ast, analyzer) = parse_and_analyze(code)?;
+
+    let loc = find_phase_block_location(&ast).ok_or("no PhaseBlock node found")?;
+    let hover = analyzer.hover_at(loc).ok_or("no hover info for CHECK block")?;
+
+    assert!(
+        hover.signature.to_lowercase().contains("check"),
+        "CHECK hover signature should mention 'check', got: {}",
+        hover.signature
+    );
+    Ok(())
+}
+
+#[test]
+fn test_unitcheck_phase_block_hover_present() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "UNITCHECK { my $u = 4; }";
+    let (ast, analyzer) = parse_and_analyze(code)?;
+
+    let loc = find_phase_block_location(&ast).ok_or("no PhaseBlock node found")?;
+    let hover = analyzer.hover_at(loc).ok_or("no hover info for UNITCHECK block")?;
+
+    assert!(
+        hover.signature.to_lowercase().contains("unitcheck")
+            || hover.signature.to_lowercase().contains("unit"),
+        "UNITCHECK hover signature should mention 'unitcheck' or 'unit', got: {}",
+        hover.signature
+    );
+    Ok(())
+}
+
+#[test]
+fn test_phase_block_hover_has_documentation() -> Result<(), Box<dyn std::error::Error>> {
+    // All phase blocks should provide documentation explaining execution semantics
+    let cases = [
+        ("BEGIN { 1 }", "BEGIN"),
+        ("END { 1 }", "END"),
+        ("INIT { 1 }", "INIT"),
+        ("CHECK { 1 }", "CHECK"),
+        ("UNITCHECK { 1 }", "UNITCHECK"),
+    ];
+
+    for (code, phase) in cases {
+        let (ast, analyzer) = parse_and_analyze(code)?;
+        let loc = find_phase_block_location(&ast)
+            .ok_or_else(|| format!("no PhaseBlock node found for {phase}"))?;
+        let hover =
+            analyzer.hover_at(loc).ok_or_else(|| format!("no hover info for {phase} block"))?;
+
+        assert!(
+            hover.documentation.is_some(),
+            "{phase} hover should include documentation describing execution semantics"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Perl's five execution phase blocks (BEGIN, END, INIT, CHECK, UNITCHECK) previously produced semantic highlight tokens but no hover information. Hovering over a phase block keyword in an IDE returned nothing.

This change adds `HoverInfo` (signature + documentation) for each phase in the `PhaseBlock` arm of `SemanticAnalyzer::analyze_node`. Each phase gets a concise description of when it runs, its ordering behavior (FIFO vs LIFO for multiples), and its idiomatic use.

The `phase_block_hover` helper is a pure `fn` with no side effects — it matches on the phase name string and returns `(signature, documentation)`. An `other` fallback arm handles any unexpected phase name gracefully without panicking.

## Interface & compatibility

- `perl-parser` API: unchanged
- `perl-semantic-analyzer` API: unchanged (adds hover entries to existing `hover_info` map)
- LSP surface: additive — hover responses now populated for phase blocks that previously returned nothing
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-semantic-analyzer/src/analysis/semantic/node_analysis.rs`:
- `NodeKind::PhaseBlock` arm now binds `phase` (was `phase: _`) and inserts a `HoverInfo` entry keyed by `node.location`
- New free function `phase_block_hover(phase: &str) -> (String, String)` returns signature and documentation for each of the five phases

`crates/perl-semantic-analyzer/tests/phase_hover_tests.rs` (new):
- 6 tests covering all five phases plus a parametric documentation-presence check
- TDD: written before the fix, all 6 failed (confirmed), then all 6 pass after

## How to review

Start at `node_analysis.rs` line ~501 — the `PhaseBlock` arm is a 6-line addition followed by the new `phase_block_hover` function at the bottom of the file. The test file exercises each phase independently.

## Evidence

```
running 6 tests
test test_end_phase_block_hover_contains_cleanup ... ok
test test_phase_block_hover_has_documentation ... ok
test test_check_phase_block_hover_present ... ok
test test_begin_phase_block_hover_contains_compile_time ... ok
test test_init_phase_block_hover_contains_post_compile ... ok
test test_unitcheck_phase_block_hover_present ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo fmt -p perl-semantic-analyzer -- --check  → PASS
cargo clippy -p perl-semantic-analyzer --lib -- -D warnings  → PASS (clean)
cargo clippy -p perl-semantic-analyzer --test phase_hover_tests -- -D warnings  → PASS (clean)
```

Pre-existing failures NOT caused by this PR:
- `attribute_introspection_tests.rs`: imports `get_attribute_documentation` which has never existed in source (pre-existing broken test)
- `perl-lsp-perltidy`: trait method arity mismatch in lib.rs (pre-existing)

## Risk & rollback

Blast radius is minimal — this is an additive change to the hover info map. If hover is not queried for a phase block, nothing changes at runtime. The `HoverInfo` struct has no side effects. Rollback: revert the 6-line insertion in the `PhaseBlock` arm and remove the helper function.

## Follow-ups

- The diagnostic for "file I/O in BEGIN block" mentioned in the issue is out of scope for this PR (would require a separate analysis pass)
- Phase ordering validation (BEGIN must come before END) is similarly out of scope