### PR TITLE
feat(lsp): add workspace indexing progress reporting (#2317, #2356)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -53,6 +53,81 @@ fn send_index_ready_notification(outbound: &super::outbound::OutboundSender, rea
     }
 }
 
+/// Token used for workspace indexing progress notifications.
+#[cfg(feature = "workspace")]
+const WORKSPACE_INDEX_PROGRESS_TOKEN: &str = "workspace-index";
+
+/// Send `window/workDoneProgress/create` to register the indexing token.
+///
+/// This is a fire-and-forget request — the client response is not awaited.
+/// Per LSP 3.15+ the server must create the token before sending `$/progress`.
+#[cfg(feature = "workspace")]
+fn send_progress_create(outbound: &super::outbound::OutboundSender, request_id: i64) {
+    if let Err(e) = outbound.send_request(
+        request_id,
+        "window/workDoneProgress/create",
+        json!({ "token": WORKSPACE_INDEX_PROGRESS_TOKEN }),
+    ) {
+        eprintln!("Failed to send workDoneProgress/create: {}", e);
+    }
+}
+
+/// Send a `$/progress` begin notification for workspace indexing.
+#[cfg(feature = "workspace")]
+fn send_progress_begin(outbound: &super::outbound::OutboundSender) {
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "begin",
+                "title": "Indexing workspace",
+                "cancellable": false,
+                "percentage": 0
+            }
+        }),
+    ) {
+        eprintln!("Failed to send progress begin: {}", e);
+    }
+}
+
+/// Send a `$/progress` report notification for workspace indexing.
+#[cfg(feature = "workspace")]
+fn send_progress_report(outbound: &super::outbound::OutboundSender, indexed: usize, total: usize) {
+    let percentage = if total > 0 { (indexed * 100 / total).min(99) as u32 } else { 0 };
+    let message = format!("Indexed {} of {} files", indexed, total);
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "report",
+                "message": message,
+                "percentage": percentage
+            }
+        }),
+    ) {
+        eprintln!("Failed to send progress report: {}", e);
+    }
+}
+
+/// Send a `$/progress` end notification for workspace indexing.
+#[cfg(feature = "workspace")]
+fn send_progress_end(outbound: &super::outbound::OutboundSender, message: &str) {
+    if let Err(e) = outbound.send_notification(
+        "$/progress",
+        json!({
+            "token": WORKSPACE_INDEX_PROGRESS_TOKEN,
+            "value": {
+                "kind": "end",
+                "message": message
+            }
+        }),
+    ) {
+        eprintln!("Failed to send progress end: {}", e);
+    }
+}
+
 impl LspServer {
     /// Handle workspace/symbol request (v2 implementation with lifecycle-aware dispatch)
     ///
@@ -968,10 +1043,20 @@ impl LspServer {
         let outbound = self.outbound.clone();
         let limits = coordinator.limits().clone();
         let caps = coordinator.performance_caps().clone();
+        let work_done_progress = self.client_capabilities.lock().work_done_progress_support;
+        // Generate a request ID for the workDoneProgress/create call. Atomically
+        // increment so it doesn't collide with IDs from other server-to-client requests.
+        let progress_create_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
 
         std::thread::spawn(move || {
             let budget_start = Instant::now();
             coordinator.transition_to_scanning();
+
+            // Send progress begin if client supports work done progress.
+            if work_done_progress {
+                send_progress_create(&outbound, progress_create_id);
+                send_progress_begin(&outbound);
+            }
 
             let mut files: Vec<std::path::PathBuf> = Vec::new();
             let mut early_exit: Option<(EarlyExitReason, u64, usize, usize)> = None;
@@ -1010,6 +1095,9 @@ impl LspServer {
 
             let mut indexed_files = 0usize;
             let total_files = files.len();
+            // Track the last file count at which a progress report was sent so we
+            // can batch updates every 50 files (avoid flooding small workspaces).
+            let mut last_reported = 0usize;
 
             for path in files {
                 let elapsed_ms = budget_start.elapsed().as_millis() as u64;
@@ -1032,6 +1120,12 @@ impl LspServer {
                 if coordinator.index().index_file(url, content).is_ok() {
                     indexed_files += 1;
                     coordinator.update_building_progress(indexed_files);
+
+                    // Send a progress report every 50 files.
+                    if work_done_progress && indexed_files - last_reported >= 50 {
+                        send_progress_report(&outbound, indexed_files, total_files);
+                        last_reported = indexed_files;
+                    }
                 }
             }
 
@@ -1048,11 +1142,17 @@ impl LspServer {
                             .transition_to_degraded(DegradationReason::ScanTimeout { elapsed_ms });
                     }
                 }
+                if work_done_progress {
+                    send_progress_end(&outbound, "Indexing stopped early");
+                }
                 send_index_ready_notification(&outbound, false);
             } else {
                 let file_count = coordinator.index().file_count();
                 let symbol_count = coordinator.index().symbol_count();
                 coordinator.transition_to_ready(file_count, symbol_count);
+                if work_done_progress {
+                    send_progress_end(&outbound, "Indexing complete");
+                }
                 send_index_ready_notification(&outbound, true);
             }
         });

--- a/crates/perl-lsp/tests/support/lsp_harness.rs
+++ b/crates/perl-lsp/tests/support/lsp_harness.rs
@@ -544,6 +544,106 @@ impl LspHarness {
         result
     }
 
+    /// Wait for a `$/progress` notification whose token and kind match.
+    ///
+    /// Actively polls the notification buffer until a `$/progress` message
+    /// matching `token` and `kind` ("begin" | "report" | "end") is found, or
+    /// the timeout expires.  Non-matching messages are left in the buffer.
+    ///
+    /// Returns the full notification value on success, or an error message.
+    pub fn wait_for_progress_kind(
+        &mut self,
+        token: &str,
+        kind: &str,
+        timeout: Duration,
+    ) -> Result<Value, String> {
+        let start = Instant::now();
+
+        loop {
+            // Pump any pending output into the framer and stash parsed messages.
+            {
+                let mut guard = self.output_buffer.lock();
+                if !guard.is_empty() {
+                    let chunk = std::mem::take(&mut *guard);
+                    self.output_framer.push(&chunk);
+                }
+                drop(guard);
+            }
+            while let Some(msg_bytes) = self.try_take_one_framed_message() {
+                if let Ok(msg) = serde_json::from_slice::<Value>(&msg_bytes) {
+                    self.stash_non_matching_message(msg);
+                }
+            }
+
+            {
+                let mut notifications = self.notification_buffer.lock();
+                if let Some(pos) = notifications.iter().position(|n| {
+                    n.get("method").and_then(|m| m.as_str()) == Some("$/progress")
+                        && n.pointer("/params/token").and_then(|v| v.as_str()) == Some(token)
+                        && n.pointer("/params/value/kind").and_then(|v| v.as_str()) == Some(kind)
+                }) {
+                    let found = notifications.remove(pos).unwrap_or(json!(null));
+                    return Ok(found);
+                }
+            }
+
+            let remaining = timeout.saturating_sub(start.elapsed());
+            if remaining.is_zero() {
+                return Err(format!(
+                    "$/progress {kind} for token '{token}' not received within {timeout:?}"
+                ));
+            }
+
+            // Wait for the TestWriter to signal new data.
+            let mut guard = self.output_buffer.lock();
+            self.output_signal.wait_for(&mut guard, remaining.min(Duration::from_millis(50)));
+        }
+    }
+
+    /// Drain server-initiated requests from the buffer.
+    ///
+    /// Server-to-client requests (e.g., `window/workDoneProgress/create`) are
+    /// buffered in `server_requests` by `stash_non_matching_message`.  This
+    /// method waits up to `timeout_ms` for at least one request to arrive, then
+    /// drains and returns all of them.
+    pub fn drain_server_requests(&mut self, timeout_ms: u64) -> Vec<Value> {
+        let start = Instant::now();
+        let timeout = Duration::from_millis(timeout_ms);
+
+        // Pump the output buffer so any queued bytes are parsed first.
+        while start.elapsed() < timeout {
+            {
+                let mut guard = self.output_buffer.lock();
+                if !guard.is_empty() {
+                    let chunk = std::mem::take(&mut *guard);
+                    self.output_framer.push(&chunk);
+                }
+                drop(guard);
+            }
+
+            while let Some(msg_bytes) = self.try_take_one_framed_message() {
+                if let Ok(msg) = serde_json::from_slice::<Value>(&msg_bytes) {
+                    self.stash_non_matching_message(msg);
+                }
+            }
+
+            {
+                let reqs = self.server_requests.lock();
+                if !reqs.is_empty() {
+                    break;
+                }
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut reqs = self.server_requests.lock();
+        let mut result = Vec::new();
+        while let Some(req) = reqs.pop_front() {
+            result.push(req);
+        }
+        result
+    }
+
     /// Get performance timing for a request
     pub fn timed_request(
         &mut self,

--- a/crates/perl-lsp/tests/workspace_indexing_progress_tests.rs
+++ b/crates/perl-lsp/tests/workspace_indexing_progress_tests.rs
@@ -1,0 +1,205 @@
+//! Workspace indexing progress reporting tests.
+//!
+//! Covers issues #2317 and #2356: the LSP server must send `$/progress`
+//! notifications (begin -> report* -> end) during workspace indexing when the
+//! client advertises `window.workDoneProgress = true`.
+
+mod support;
+
+use serde_json::json;
+use std::time::Duration;
+use support::lsp_harness::LspHarness;
+use support::test_workspace::TempWorkspace;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Capability set that enables work-done progress.
+fn caps_with_progress() -> serde_json::Value {
+    json!({
+        "window": {
+            "workDoneProgress": true
+        }
+    })
+}
+
+/// Capability set without work-done progress.
+fn caps_without_progress() -> serde_json::Value {
+    json!({
+        "window": {
+            "workDoneProgress": false
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a workspace with N Perl files.
+// ---------------------------------------------------------------------------
+fn make_workspace_with_files(n: usize) -> Result<TempWorkspace, String> {
+    let ws = TempWorkspace::new()?;
+    for i in 0..n {
+        ws.write(
+            &format!("lib/Module{i}.pm"),
+            &format!("package Module{i};\nsub new {{ return bless {{}} }}\n1;\n"),
+        )?;
+    }
+    Ok(ws)
+}
+
+/// Adaptive timeout: longer in CI or constrained environments.
+fn progress_timeout() -> Duration {
+    let is_ci = std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok();
+    if is_ci { Duration::from_secs(10) } else { Duration::from_secs(5) }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: progress begin is sent when client supports workDoneProgress.
+// ---------------------------------------------------------------------------
+#[test]
+fn progress_begin_sent_on_indexing_start() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    harness
+        .wait_for_progress_kind("workspace-index", "begin", progress_timeout())
+        .map_err(|e| format!("expected $/progress begin: {e}"))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: progress end is sent when indexing completes.
+// ---------------------------------------------------------------------------
+#[test]
+fn progress_end_sent_when_indexing_completes() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    // Wait for both begin and end.
+    harness
+        .wait_for_progress_kind("workspace-index", "begin", progress_timeout())
+        .map_err(|e| format!("expected $/progress begin: {e}"))?;
+    harness
+        .wait_for_progress_kind("workspace-index", "end", progress_timeout())
+        .map_err(|e| format!("expected $/progress end: {e}"))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: no $/progress sent when client does not support workDoneProgress.
+// ---------------------------------------------------------------------------
+#[test]
+fn no_progress_sent_when_capability_absent() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_without_progress()))?;
+
+    // Give the background thread time to finish indexing.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let progress_notifications = harness.drain_notifications(Some("$/progress"), 200);
+
+    // Filter to workspace-index token specifically.
+    let ws_progress: Vec<_> = progress_notifications
+        .iter()
+        .filter(|n| n.pointer("/params/token").and_then(|v| v.as_str()) == Some("workspace-index"))
+        .collect();
+
+    assert!(
+        ws_progress.is_empty(),
+        "expected no $/progress for workspace-index when capability is absent; \
+         got: {ws_progress:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: progress sequence is well-formed (begin before end).
+// ---------------------------------------------------------------------------
+#[test]
+fn progress_sequence_is_ordered() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    let timeout = progress_timeout();
+
+    let begin = harness.wait_for_progress_kind("workspace-index", "begin", timeout);
+    let end = harness.wait_for_progress_kind("workspace-index", "end", timeout);
+
+    // Both begin and end must arrive.
+    assert!(begin.is_ok(), "expected begin: {begin:?}");
+    assert!(end.is_ok(), "expected end: {end:?}");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: percentage in report notifications is in 0..=100.
+// ---------------------------------------------------------------------------
+#[test]
+fn progress_report_percentage_is_valid() -> TestResult {
+    // Use a larger workspace to increase the chance of report notifications.
+    let ws = make_workspace_with_files(60)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    let timeout = Duration::from_secs(8);
+
+    // Wait for begin first.
+    let _ = harness.wait_for_progress_kind("workspace-index", "begin", timeout);
+
+    // Collect any report notifications that arrived within the timeout.
+    let notifications = harness.drain_notifications(Some("$/progress"), timeout.as_millis() as u64);
+
+    let report_notifications: Vec<_> = notifications
+        .iter()
+        .filter(|n| {
+            n.pointer("/params/token").and_then(|v| v.as_str()) == Some("workspace-index")
+                && n.pointer("/params/value/kind").and_then(|v| v.as_str()) == Some("report")
+        })
+        .collect();
+
+    for report in &report_notifications {
+        if let Some(pct) = report.pointer("/params/value/percentage").and_then(|v| v.as_u64()) {
+            assert!(pct <= 100, "progress percentage must be <= 100, got {pct} in {report}");
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: window/workDoneProgress/create is sent as a server-to-client
+//         request when the client supports workDoneProgress.
+// ---------------------------------------------------------------------------
+#[test]
+fn work_done_progress_create_sent_to_client() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    // Wait for begin (which implies create was sent first).
+    harness
+        .wait_for_progress_kind("workspace-index", "begin", progress_timeout())
+        .map_err(|e| format!("expected $/progress begin (after create): {e}"))?;
+
+    // Now drain server-initiated requests.
+    let server_requests = harness.drain_server_requests(1_000);
+
+    let create_found = server_requests.iter().any(|req| {
+        req.get("method").and_then(|m| m.as_str()) == Some("window/workDoneProgress/create")
+            && req.pointer("/params/token").and_then(|v| v.as_str()) == Some("workspace-index")
+    });
+
+    assert!(
+        create_found,
+        "expected window/workDoneProgress/create for token 'workspace-index'; \
+         got server_requests: {server_requests:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Implements LSP 3.15+ `$/progress` protocol for workspace indexing
- Sends `window/workDoneProgress/create` (server-to-client request) to register the token before sending notifications
- Sends `begin` when indexing starts, `report` with percentage every 50 files, and `end` on completion
- Capability-gated: no notifications sent when `window.workDoneProgress` is absent or false

## Implementation

Modified `crates/perl-lsp/src/runtime/workspace.rs`:
- Added `WORKSPACE_INDEX_PROGRESS_TOKEN` constant and four standalone helper functions (`send_progress_create`, `send_progress_begin`, `send_progress_report`, `send_progress_end`) that use the existing `outbound` channel
- Modified `start_workspace_indexing` to clone `work_done_progress_support` bool before spawning the background thread and call the helpers at the right points

Modified `crates/perl-lsp/tests/support/lsp_harness.rs`:
- Added `wait_for_progress_kind(token, kind, timeout)`: condvar-based polling for a specific `$/progress` token+kind combination; does not exit early on unrelated notifications
- Added `drain_server_requests(timeout_ms)`: pumps the output buffer and returns buffered server-initiated requests (e.g. `window/workDoneProgress/create`)

## Tests

New test file `crates/perl-lsp/tests/workspace_indexing_progress_tests.rs` (6 tests):

1. `progress_begin_sent_on_indexing_start` — begin arrives when capability is present
2. `progress_end_sent_when_indexing_completes` — end arrives after begin
3. `no_progress_sent_when_capability_absent` — no notifications when `workDoneProgress: false`
4. `progress_sequence_is_ordered` — both begin and end arrive
5. `progress_report_percentage_is_valid` — any report percentages are 0..=100
6. `work_done_progress_create_sent_to_client` — `window/workDoneProgress/create` is sent as server request

All 6 tests pass.

## Notes

- Pre-existing `clippy::expect_used` failures in `code_actions_provider/mod.rs` and `special_variable_hover_tests.rs` (test code only, unchanged from master) are not caused by this PR
- The `window/workDoneProgress/create` is sent as fire-and-forget (no response waiting) per LSP 3.15+ spec since the server initiates it

Closes #2317, #2356

## Test plan

- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp --test workspace_indexing_progress_tests -- --test-threads=2` — all 6 pass
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy -p perl-lsp` — zero errors in production code