### PR TITLE
feat(semantic): add Moose/Moo type constraint and attribute documentation on hover

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -589,3 +589,178 @@ pub fn get_builtin_documentation(name: &str) -> Option<BuiltinDoc> {
         _ => None,
     }
 }
+
+/// Get documentation for a Moose/Moo/Mouse built-in type constraint.
+///
+/// Accepts both bare types (`Str`, `ArrayRef`) and parametrized forms
+/// (`ArrayRef[Int]`, `Maybe[Str]`).  For parametrized forms the base
+/// type is extracted and used for the lookup.
+///
+/// Returns signature and description suitable for LSP hover display,
+/// or `None` if the type is not a known Moose built-in.
+pub fn get_moose_type_documentation(type_str: &str) -> Option<BuiltinDoc> {
+    // Strip optional parametrization: "ArrayRef[Int]" -> "ArrayRef"
+    let base = type_str.split('[').next().unwrap_or(type_str).trim();
+
+    match base {
+        // Moose::Util::TypeConstraints — Any / Item
+        "Any" => Some(BuiltinDoc {
+            signature: "Any",
+            description: "The root type. Every value passes this constraint.",
+        }),
+        "Item" => Some(BuiltinDoc {
+            signature: "Item",
+            description: "Synonym for Any. Used as a base for the type hierarchy.",
+        }),
+        // Undef / Defined
+        "Undef" => Some(BuiltinDoc { signature: "Undef", description: "Accepts only undef." }),
+        "Defined" => Some(BuiltinDoc {
+            signature: "Defined",
+            description: "Accepts any defined value (anything that is not undef).",
+        }),
+        // Value / Bool
+        "Value" => Some(BuiltinDoc {
+            signature: "Value",
+            description: "Accepts any defined, non-reference value (scalars and strings).",
+        }),
+        "Bool" => Some(BuiltinDoc {
+            signature: "Bool",
+            description: "Accepts 1, 0, the empty string '', or undef — Perl's boolean-ish values.",
+        }),
+        // Strings
+        "Str" => Some(BuiltinDoc {
+            signature: "Str",
+            description: "Accepts any defined, non-reference scalar value (a string or number).",
+        }),
+        "Num" => Some(BuiltinDoc {
+            signature: "Num",
+            description: "Accepts any value that looks like a number (integer or float).",
+        }),
+        "Int" => Some(BuiltinDoc {
+            signature: "Int",
+            description: "Accepts only integer values (no decimal point).",
+        }),
+        "ClassName" => Some(BuiltinDoc {
+            signature: "ClassName",
+            description: "Accepts a string that is the name of a loaded Perl package/class.",
+        }),
+        "RoleName" => Some(BuiltinDoc {
+            signature: "RoleName",
+            description: "Accepts a string that is the name of a loaded Moose role.",
+        }),
+        // References
+        "Ref" => Some(BuiltinDoc { signature: "Ref", description: "Accepts any reference." }),
+        "ScalarRef" => Some(BuiltinDoc {
+            signature: "ScalarRef[TYPE]",
+            description: "Accepts a scalar reference. Optionally parametrized: ScalarRef[Int] requires the referent to satisfy Int.",
+        }),
+        "ArrayRef" => Some(BuiltinDoc {
+            signature: "ArrayRef[TYPE]",
+            description: "Accepts an array reference. Optionally parametrized: ArrayRef[Int] requires all elements to satisfy Int.",
+        }),
+        "HashRef" => Some(BuiltinDoc {
+            signature: "HashRef[TYPE]",
+            description: "Accepts a hash reference. Optionally parametrized: HashRef[Str] requires all values to satisfy Str.",
+        }),
+        "CodeRef" => Some(BuiltinDoc {
+            signature: "CodeRef",
+            description: "Accepts a code reference (subroutine reference).",
+        }),
+        "RegexpRef" => Some(BuiltinDoc {
+            signature: "RegexpRef",
+            description: "Accepts a compiled regular expression reference (qr//).",
+        }),
+        "GlobRef" => {
+            Some(BuiltinDoc { signature: "GlobRef", description: "Accepts a glob reference." })
+        }
+        "FileHandle" => Some(BuiltinDoc {
+            signature: "FileHandle",
+            description: "Accepts an IO object or a glob reference that can be used as a filehandle.",
+        }),
+        // Object / Role
+        "Object" => Some(BuiltinDoc {
+            signature: "Object",
+            description: "Accepts any blessed reference (an object).",
+        }),
+        // Maybe
+        "Maybe" => Some(BuiltinDoc {
+            signature: "Maybe[TYPE]",
+            description: "Accepts undef or any value satisfying TYPE. Useful for optional attributes: Maybe[Str] accepts either a string or undef.",
+        }),
+        // Type::Tiny extras commonly used with Moo
+        "InstanceOf" => Some(BuiltinDoc {
+            signature: "InstanceOf[CLASSNAME]",
+            description: "Accepts a blessed object that is an instance of CLASSNAME.",
+        }),
+        "ConsumerOf" => Some(BuiltinDoc {
+            signature: "ConsumerOf[ROLENAME]",
+            description: "Accepts a blessed object that consumes ROLENAME.",
+        }),
+        "HasMethods" => Some(BuiltinDoc {
+            signature: "HasMethods[METHOD, ...]",
+            description: "Accepts a blessed object that has all the listed methods.",
+        }),
+        "Dict" => Some(BuiltinDoc {
+            signature: "Dict[KEY => TYPE, ...]",
+            description: "Accepts a hash reference matching a specific key/type schema (Type::Tiny).",
+        }),
+        "Tuple" => Some(BuiltinDoc {
+            signature: "Tuple[TYPE, ...]",
+            description: "Accepts an array reference matching a specific positional type schema (Type::Tiny).",
+        }),
+        "Map" => Some(BuiltinDoc {
+            signature: "Map[KEYTYPE, VALUETYPE]",
+            description: "Accepts a hash reference where keys satisfy KEYTYPE and values satisfy VALUETYPE (Type::Tiny).",
+        }),
+        "Enum" => Some(BuiltinDoc {
+            signature: "Enum[VALUE, ...]",
+            description: "Accepts a string that is one of the listed values (Type::Tiny).",
+        }),
+
+        _ => None,
+    }
+}
+
+/// Get documentation for a Perl subroutine or variable attribute.
+///
+/// Attributes are declared with `:name` syntax, e.g. `sub foo :lvalue { ... }`.
+/// Pass the attribute name without the leading colon.
+///
+/// Returns signature and description suitable for LSP hover display,
+/// or `None` if the attribute is not a known built-in.
+pub fn get_attribute_documentation(attr: &str) -> Option<BuiltinDoc> {
+    // Strip leading colon if present
+    let name = attr.trim_start_matches(':');
+
+    match name {
+        "lvalue" => Some(BuiltinDoc {
+            signature: ":lvalue",
+            description: "Marks a subroutine as an lvalue subroutine. The return value can be assigned to, enabling constructs like `foo() = 42;`.",
+        }),
+        "method" => Some(BuiltinDoc {
+            signature: ":method",
+            description: "Marks a subroutine as a method. Used by some attribute handlers to modify dispatch or prototype checking.",
+        }),
+        "prototype" => Some(BuiltinDoc {
+            signature: ":prototype(PROTO)",
+            description: "Sets the prototype of a subroutine. Controls how Perl parses calls to the sub (e.g. `prototype($$)` for two scalar args).",
+        }),
+        "const" => Some(BuiltinDoc {
+            signature: ":const",
+            description: "Marks a subroutine as a constant. The value is computed once and cached; subsequent calls return the cached value immutably.",
+        }),
+        "shared" => Some(BuiltinDoc {
+            signature: ":shared",
+            description: "Marks a variable or subroutine as shared across threads (requires `threads::shared`). The variable is accessible from all threads.",
+        }),
+        "weak_ref" => Some(BuiltinDoc {
+            signature: ":weak_ref",
+            description: "Marks a Moose/Moo attribute as a weak reference. The stored reference will not prevent the referent from being garbage-collected.",
+        }),
+        "overload" => Some(BuiltinDoc {
+            signature: ":overload(OP)",
+            description: "Declares that a subroutine implements an operator overload for OP.",
+        }),
+        _ => None,
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -23,7 +23,10 @@ mod references;
 mod tokens;
 
 // Public re-exports — downstream consumers see exactly the same surface.
-pub use builtins::{BuiltinDoc, get_builtin_documentation};
+pub use builtins::{
+    BuiltinDoc, get_attribute_documentation, get_builtin_documentation,
+    get_moose_type_documentation,
+};
 pub use hover::HoverInfo;
 pub use model::SemanticModel;
 pub use tokens::{SemanticToken, SemanticTokenModifier, SemanticTokenType};

--- a/crates/perl-semantic-analyzer/tests/moose_type_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/moose_type_hover_tests.rs
@@ -1,0 +1,229 @@
+//! Tests for Moose/Moo type constraint documentation on hover.
+//!
+//! Covers `get_moose_type_documentation` for built-in Moose types:
+//! simple types (Str, Int, Bool, etc.), parametrized types (ArrayRef[Int]),
+//! and Maybe types.  Also covers `get_attribute_documentation` which is
+//! exercised by the sibling `attribute_introspection_tests` file.
+
+use perl_semantic_analyzer::analysis::semantic::{
+    get_attribute_documentation, get_moose_type_documentation,
+};
+
+// ---------------------------------------------------------------------------
+// get_moose_type_documentation — simple base types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn moose_type_doc_str_has_description() {
+    let doc = get_moose_type_documentation("Str");
+    assert!(doc.is_some(), "Str should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("string")
+            || doc.description.to_lowercase().contains("str"),
+        "Str description should mention string, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_int_has_description() {
+    let doc = get_moose_type_documentation("Int");
+    assert!(doc.is_some(), "Int should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("integer")
+            || doc.description.to_lowercase().contains("int"),
+        "Int description should mention integer, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_bool_has_description() {
+    let doc = get_moose_type_documentation("Bool");
+    assert!(doc.is_some(), "Bool should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("bool")
+            || doc.description.to_lowercase().contains("true")
+            || doc.description.to_lowercase().contains("false"),
+        "Bool description should mention boolean values, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_arrayref_has_description() {
+    let doc = get_moose_type_documentation("ArrayRef");
+    assert!(doc.is_some(), "ArrayRef should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("array")
+            || doc.description.to_lowercase().contains("ref"),
+        "ArrayRef description should mention array reference, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_hashref_has_description() {
+    let doc = get_moose_type_documentation("HashRef");
+    assert!(doc.is_some(), "HashRef should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("hash")
+            || doc.description.to_lowercase().contains("ref"),
+        "HashRef description should mention hash reference, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_maybe_has_description() {
+    let doc = get_moose_type_documentation("Maybe");
+    assert!(doc.is_some(), "Maybe should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("undef")
+            || doc.description.to_lowercase().contains("maybe")
+            || doc.description.to_lowercase().contains("optional"),
+        "Maybe description should mention undef/optional, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_num_has_description() {
+    let doc = get_moose_type_documentation("Num");
+    assert!(doc.is_some(), "Num should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("num")
+            || doc.description.to_lowercase().contains("float")
+            || doc.description.to_lowercase().contains("number"),
+        "Num description should mention number, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_coderef_has_description() {
+    let doc = get_moose_type_documentation("CodeRef");
+    assert!(doc.is_some(), "CodeRef should have documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("code")
+            || doc.description.to_lowercase().contains("subroutine")
+            || doc.description.to_lowercase().contains("sub"),
+        "CodeRef description should mention code/subroutine, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_unknown_returns_none() {
+    let doc = get_moose_type_documentation("NonExistentTypeXyz");
+    assert!(doc.is_none(), "unknown Moose type should return None");
+}
+
+// ---------------------------------------------------------------------------
+// Parametrized type lookup — strip parameter and resolve base type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn moose_type_doc_arrayref_int_resolves_base() {
+    // "ArrayRef[Int]" should resolve to the ArrayRef documentation
+    let doc = get_moose_type_documentation("ArrayRef[Int]");
+    assert!(doc.is_some(), "ArrayRef[Int] should resolve to ArrayRef documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("array")
+            || doc.description.to_lowercase().contains("ref"),
+        "ArrayRef[Int] description should describe array reference, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_maybe_str_resolves_base() {
+    // "Maybe[Str]" should resolve to Maybe documentation
+    let doc = get_moose_type_documentation("Maybe[Str]");
+    assert!(doc.is_some(), "Maybe[Str] should resolve to Maybe documentation");
+    let doc = doc.unwrap();
+    assert!(
+        doc.description.to_lowercase().contains("undef")
+            || doc.description.to_lowercase().contains("maybe")
+            || doc.description.to_lowercase().contains("optional"),
+        "Maybe[Str] description should mention undef/optional, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn moose_type_doc_hashref_str_str_resolves_base() {
+    // "HashRef[Str]" should resolve to HashRef documentation
+    let doc = get_moose_type_documentation("HashRef[Str]");
+    assert!(doc.is_some(), "HashRef[Str] should resolve to HashRef documentation");
+}
+
+// ---------------------------------------------------------------------------
+// Signature format validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn moose_type_doc_str_signature_not_empty() {
+    let doc = get_moose_type_documentation("Str");
+    let doc = doc.unwrap();
+    assert!(!doc.signature.is_empty(), "Str signature should not be empty");
+}
+
+#[test]
+fn moose_type_doc_covers_core_types() {
+    let core_types = [
+        "Str",
+        "Int",
+        "Num",
+        "Bool",
+        "ArrayRef",
+        "HashRef",
+        "CodeRef",
+        "RegexpRef",
+        "ScalarRef",
+        "Object",
+        "Defined",
+        "Value",
+        "Ref",
+        "Maybe",
+        "Undef",
+        "Any",
+        "Item",
+    ];
+    for type_name in &core_types {
+        let doc = get_moose_type_documentation(type_name);
+        assert!(
+            doc.is_some(),
+            "Expected documentation for Moose type '{}' but got None",
+            type_name
+        );
+        let doc = doc.unwrap();
+        assert!(
+            !doc.description.is_empty(),
+            "Documentation for Moose type '{}' has empty description",
+            type_name
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// get_attribute_documentation — these tests duplicate the existing
+// attribute_introspection_tests but keep them here for completeness
+// and to confirm the function is exported correctly from the same path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn attribute_doc_exported_lvalue() {
+    // Confirm get_attribute_documentation is exported from analysis::semantic
+    let doc = get_attribute_documentation("lvalue");
+    assert!(doc.is_some(), "lvalue attribute should have documentation");
+}


### PR DESCRIPTION
## Summary

Adds two new public functions to `perl-semantic-analyzer::analysis::semantic`:

- `get_moose_type_documentation(type_str)` — returns `BuiltinDoc` for all
  core Moose/Moo/Mouse type constraints (Str, Int, Num, Bool, ArrayRef,
  HashRef, CodeRef, Maybe, Undef, Any, Item, etc.) plus common Type::Tiny
  types (Dict, Tuple, Map, Enum, InstanceOf, ConsumerOf, HasMethods).
  Parametrized forms like `ArrayRef[Int]` and `Maybe[Str]` are handled by
  stripping the `[...]` parameter and resolving the base type name.

- `get_attribute_documentation(attr)` — returns `BuiltinDoc` for Perl
  subroutine and variable attributes (:lvalue, :method, :prototype, :const,
  :shared, :weak_ref, :overload). Accepts names with or without leading colon.

Both functions are pure static lookups (zero allocation, no regex), consistent
with the existing `get_builtin_documentation` pattern. The `BuiltinDoc` struct
provides both a `signature` and a `description` field suitable for LSP hover
rendering.

This also fixes a pre-existing compile failure in `attribute_introspection_tests.rs`,
which imported `get_attribute_documentation` before the function existed. That
test file has been uncompilable since it was added; this PR makes all 14 of its
tests pass.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (new public functions in `analysis::semantic`)
- DAP surface: unchanged
- CLI: unchanged
- `BuiltinDoc` type is already public — no new public types introduced

## What changed

`crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs` — two new
`pub fn` functions appended after `get_builtin_documentation`. The parametrized
type stripping uses `str::split('[').next().unwrap_or(type_str)`, which is
infallible (no panic path).

`crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs` — the `pub use
builtins::{...}` line extended to re-export both new functions alongside the
existing `get_builtin_documentation` and `BuiltinDoc`.

`crates/perl-semantic-analyzer/tests/moose_type_hover_tests.rs` — new test
file with 15 tests covering simple types, parametrized type resolution, the
negative case, signature non-emptiness, and a table-driven coverage test for
all 17 core Moose types.

## How to review

Start with `builtins.rs` at the two new functions (lines 601+ and 731+). The
parametrized stripping logic is at line 603. Check that all types listed in the
test's `core_types` array have a corresponding match arm. The `mod.rs` change
is a 3-line pub use extension.

## Evidence

```
cargo fmt -p perl-semantic-analyzer -- --check    PASS
cargo clippy -p perl-semantic-analyzer --tests    PASS (no warnings)
cargo test -p perl-semantic-analyzer
  lib tests:                    62 passed
  attribute_introspection_tests: 14 passed  (was failing to compile before)
  comprehensive_unit_tests:      76 passed
  extended_unit_tests:          102 passed
  frameworks_moo:                20 passed
  frameworks_web:                13 passed
  moose_type_hover_tests:        15 passed  (new)
  real_world_patterns:           69 passed
  scope_and_symbol_tests:        63 passed
  symbol_perf_test:               3 passed
  Total: 437 passed, 0 failed
```

## Risk & rollback

- Zero risk to existing behavior: additive-only changes, no existing code paths modified.
- The only risk is incorrect documentation text — factual errors in type descriptions.
- Rollback: revert the commit. No state changes, no migrations.

## Follow-ups

- Wire `get_moose_type_documentation` into the LSP hover provider so callers
  can query it when the cursor is on a `has` attribute's `isa` value string
  (out of scope for this PR — requires changes to `perl-lsp-hover` or similar).
- Add Type::Tiny's `Defined[TYPE]` coercion variant.

Closes #2334