### PR TITLE
feat(diagnostics): add context_hint() to DiagnosticCode for human-readable error messages

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -231,6 +231,79 @@ impl DiagnosticCode {
         }
     }
 
+    /// Return a human-readable context hint for this diagnostic code.
+    ///
+    /// Hints are short, actionable explanations that help users understand
+    /// what the diagnostic means and how to resolve it.  Perl::Critic codes
+    /// return `None` because their per-policy descriptions already serve this
+    /// purpose.
+    pub fn context_hint(&self) -> Option<&'static str> {
+        match self {
+            DiagnosticCode::ParseError => Some(
+                "The parser could not understand this code. \
+                Check for missing semicolons, unmatched brackets, or incorrect syntax.",
+            ),
+            DiagnosticCode::SyntaxError => Some(
+                "Perl syntax error. Check for typos, missing operators, \
+                or unbalanced parentheses near this location.",
+            ),
+            DiagnosticCode::UnexpectedEof => Some(
+                "The file ended unexpectedly. Check for unclosed blocks `{}`, \
+                heredocs, or multi-line strings.",
+            ),
+            DiagnosticCode::MissingStrict => Some(
+                "Add `use strict;` at the top of your file. \
+                Strict mode catches common variable mistakes at compile time.",
+            ),
+            DiagnosticCode::MissingWarnings => Some(
+                "Add `use warnings;` at the top of your file. \
+                Warnings highlight many common programming mistakes.",
+            ),
+            DiagnosticCode::UnusedVariable => Some(
+                "This variable is declared but never used. \
+                Remove it, or prefix with `_` (e.g., `$_unused`) to suppress.",
+            ),
+            DiagnosticCode::UndefinedVariable => Some(
+                "This variable was not declared with `my`, `our`, or `local`. \
+                Add `use strict;` and declare all variables before use.",
+            ),
+            DiagnosticCode::MissingPackageDeclaration => Some(
+                "This file has no `package` declaration. \
+                Add `package MyModule;` at the top for module files.",
+            ),
+            DiagnosticCode::DuplicatePackage => Some(
+                "This package name is declared more than once in the same file. \
+                Each package should appear once, or split into separate files.",
+            ),
+            DiagnosticCode::DuplicateSubroutine => Some(
+                "A subroutine with this name is defined more than once. \
+                The later definition silently replaces the earlier one.",
+            ),
+            DiagnosticCode::MissingReturn => Some(
+                "This subroutine has no explicit `return` statement. \
+                Add `return $value;` to make the return value clear.",
+            ),
+            DiagnosticCode::BarewordFilehandle => Some(
+                "Bareword filehandles (e.g., `open FH, ...`) are global and unsafe. \
+                Use a lexical filehandle instead: `open my $fh, '<', $file or die $!;`",
+            ),
+            DiagnosticCode::TwoArgOpen => Some(
+                "Two-argument `open()` is vulnerable to injection. \
+                Use three-argument form: `open my $fh, '<', $filename or die $!;`",
+            ),
+            DiagnosticCode::ImplicitReturn => Some(
+                "The return value of this expression is used implicitly. \
+                Make it explicit with `return` or assign it to a variable.",
+            ),
+            // Perl::Critic codes carry per-policy descriptions; no generic hint needed.
+            DiagnosticCode::CriticSeverity1
+            | DiagnosticCode::CriticSeverity2
+            | DiagnosticCode::CriticSeverity3
+            | DiagnosticCode::CriticSeverity4
+            | DiagnosticCode::CriticSeverity5 => None,
+        }
+    }
+
     /// Try to infer a diagnostic code from a message.
     pub fn from_message(msg: &str) -> Option<DiagnosticCode> {
         let msg_lower = msg.to_lowercase();

--- a/crates/perl-diagnostics-codes/tests/context_hint_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/context_hint_tests.rs
@@ -1,0 +1,200 @@
+//! Tests for DiagnosticCode::context_hint() — human-readable error hints.
+//!
+//! Issue #2316: users see cryptic codes like `unexpected_rbrace_expr` and
+//! disable diagnostics thinking the LSP is broken. Each code should return
+//! an actionable hint string.
+
+use perl_diagnostics_codes::DiagnosticCode;
+
+// ---------------------------------------------------------------------------
+// Parser codes — hints required (PL001-PL003)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_error_has_context_hint() {
+    let hint = DiagnosticCode::ParseError.context_hint();
+    assert!(hint.is_some(), "ParseError (PL001) must have a context hint");
+    if let Some(text) = hint {
+        assert!(!text.is_empty(), "context hint must not be empty");
+    }
+}
+
+#[test]
+fn syntax_error_has_context_hint() {
+    let hint = DiagnosticCode::SyntaxError.context_hint();
+    assert!(hint.is_some(), "SyntaxError (PL002) must have a context hint");
+}
+
+#[test]
+fn unexpected_eof_has_context_hint() {
+    let hint = DiagnosticCode::UnexpectedEof.context_hint();
+    assert!(hint.is_some(), "UnexpectedEof (PL003) must have a context hint");
+}
+
+// ---------------------------------------------------------------------------
+// Pragma codes — hints required (PL100-PL101)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_strict_has_context_hint() {
+    let hint = DiagnosticCode::MissingStrict.context_hint();
+    assert!(hint.is_some(), "MissingStrict (PL100) must have a context hint");
+    if let Some(text) = hint {
+        assert!(
+            text.to_lowercase().contains("strict"),
+            "MissingStrict hint should mention strict, got: {text}"
+        );
+    }
+}
+
+#[test]
+fn missing_warnings_has_context_hint() {
+    let hint = DiagnosticCode::MissingWarnings.context_hint();
+    assert!(hint.is_some(), "MissingWarnings (PL101) must have a context hint");
+    if let Some(text) = hint {
+        assert!(
+            text.to_lowercase().contains("warn"),
+            "MissingWarnings hint should mention warnings, got: {text}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Variable codes — hints required (PL102-PL103)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unused_variable_has_context_hint() {
+    let hint = DiagnosticCode::UnusedVariable.context_hint();
+    assert!(hint.is_some(), "UnusedVariable (PL102) must have a context hint");
+}
+
+#[test]
+fn undefined_variable_has_context_hint() {
+    let hint = DiagnosticCode::UndefinedVariable.context_hint();
+    assert!(hint.is_some(), "UndefinedVariable (PL103) must have a context hint");
+}
+
+// ---------------------------------------------------------------------------
+// Package codes — hints required (PL200-PL201)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_package_declaration_has_context_hint() {
+    let hint = DiagnosticCode::MissingPackageDeclaration.context_hint();
+    assert!(hint.is_some(), "MissingPackageDeclaration (PL200) must have a context hint");
+}
+
+#[test]
+fn duplicate_package_has_context_hint() {
+    let hint = DiagnosticCode::DuplicatePackage.context_hint();
+    assert!(hint.is_some(), "DuplicatePackage (PL201) must have a context hint");
+}
+
+// ---------------------------------------------------------------------------
+// Subroutine codes — hints required (PL300-PL301)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn duplicate_subroutine_has_context_hint() {
+    let hint = DiagnosticCode::DuplicateSubroutine.context_hint();
+    assert!(hint.is_some(), "DuplicateSubroutine (PL300) must have a context hint");
+}
+
+#[test]
+fn missing_return_has_context_hint() {
+    let hint = DiagnosticCode::MissingReturn.context_hint();
+    assert!(hint.is_some(), "MissingReturn (PL301) must have a context hint");
+}
+
+// ---------------------------------------------------------------------------
+// Best-practice codes — hints required (PL400-PL402)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bareword_filehandle_has_context_hint() {
+    let hint = DiagnosticCode::BarewordFilehandle.context_hint();
+    assert!(hint.is_some(), "BarewordFilehandle (PL400) must have a context hint");
+}
+
+#[test]
+fn two_arg_open_has_context_hint() {
+    let hint = DiagnosticCode::TwoArgOpen.context_hint();
+    assert!(hint.is_some(), "TwoArgOpen (PL401) must have a context hint");
+}
+
+#[test]
+fn implicit_return_has_context_hint() {
+    let hint = DiagnosticCode::ImplicitReturn.context_hint();
+    assert!(hint.is_some(), "ImplicitReturn (PL402) must have a context hint");
+}
+
+// ---------------------------------------------------------------------------
+// Perl::Critic codes — hints intentionally absent (PC001-PC005)
+//
+// Critic violations already carry per-policy descriptions from perlcritic
+// itself; adding generic hints would be redundant and misleading.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn critic_severity_1_has_no_context_hint() {
+    assert!(
+        DiagnosticCode::CriticSeverity1.context_hint().is_none(),
+        "CriticSeverity1 (PC001) must NOT have a generic context hint"
+    );
+}
+
+#[test]
+fn critic_severity_2_has_no_context_hint() {
+    assert!(DiagnosticCode::CriticSeverity2.context_hint().is_none());
+}
+
+#[test]
+fn critic_severity_3_has_no_context_hint() {
+    assert!(DiagnosticCode::CriticSeverity3.context_hint().is_none());
+}
+
+#[test]
+fn critic_severity_4_has_no_context_hint() {
+    assert!(DiagnosticCode::CriticSeverity4.context_hint().is_none());
+}
+
+#[test]
+fn critic_severity_5_has_no_context_hint() {
+    assert!(DiagnosticCode::CriticSeverity5.context_hint().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Hint quality: must be actionable (not just a label)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_pl_hints_are_at_least_20_chars() {
+    let pl_codes = [
+        DiagnosticCode::ParseError,
+        DiagnosticCode::SyntaxError,
+        DiagnosticCode::UnexpectedEof,
+        DiagnosticCode::MissingStrict,
+        DiagnosticCode::MissingWarnings,
+        DiagnosticCode::UnusedVariable,
+        DiagnosticCode::UndefinedVariable,
+        DiagnosticCode::MissingPackageDeclaration,
+        DiagnosticCode::DuplicatePackage,
+        DiagnosticCode::DuplicateSubroutine,
+        DiagnosticCode::MissingReturn,
+        DiagnosticCode::BarewordFilehandle,
+        DiagnosticCode::TwoArgOpen,
+        DiagnosticCode::ImplicitReturn,
+    ];
+    for code in pl_codes {
+        let hint = code.context_hint();
+        assert!(hint.is_some(), "PL code {code:?} must have a context hint");
+        if let Some(text) = hint {
+            assert!(
+                text.len() >= 20,
+                "context hint for {code:?} is too short ({} chars): {text:?}",
+                text.len()
+            );
+        }
+    }
+}

--- a/crates/perl-lsp-diagnostic-catalog/src/lib.rs
+++ b/crates/perl-lsp-diagnostic-catalog/src/lib.rs
@@ -17,6 +17,10 @@ pub struct DiagnosticMeta {
     pub code: Value,
     /// Optional code description object containing a docs URL.
     pub desc: Option<Value>,
+    /// Optional human-readable context hint explaining what the diagnostic
+    /// means and how to resolve it.  `None` for codes (e.g. Perl::Critic)
+    /// whose per-policy descriptions already serve this purpose.
+    pub hint: Option<&'static str>,
 }
 
 impl DiagnosticMeta {
@@ -24,6 +28,7 @@ impl DiagnosticMeta {
         Self {
             code: json!(code.as_str()),
             desc: code.documentation_url().map(|url| json!({ "href": url })),
+            hint: code.context_hint(),
         }
     }
 }

--- a/crates/perl-lsp-diagnostic-catalog/tests/context_hint_catalog_tests.rs
+++ b/crates/perl-lsp-diagnostic-catalog/tests/context_hint_catalog_tests.rs
@@ -1,0 +1,81 @@
+//! Tests that DiagnosticMeta exposes context hints from DiagnosticCode.
+//!
+//! Issue #2316: the catalog layer must surface the `context_hint` so that
+//! consumers (LSP providers, formatters) can attach it to error messages
+//! without pulling in `perl-diagnostics-codes` directly.
+
+use perl_lsp_diagnostic_catalog as catalog;
+
+#[test]
+fn parse_error_meta_has_hint() {
+    let meta = catalog::parse_error();
+    assert!(meta.hint.is_some(), "parse_error DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn syntax_error_meta_has_hint() {
+    let meta = catalog::syntax_error();
+    assert!(meta.hint.is_some(), "syntax_error DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn unexpected_eof_meta_has_hint() {
+    let meta = catalog::unexpected_eof();
+    assert!(meta.hint.is_some(), "unexpected_eof DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn missing_strict_meta_has_hint() {
+    let meta = catalog::missing_strict();
+    assert!(meta.hint.is_some(), "missing_strict DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn missing_warnings_meta_has_hint() {
+    let meta = catalog::missing_warnings();
+    assert!(meta.hint.is_some(), "missing_warnings DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn unused_var_meta_has_hint() {
+    let meta = catalog::unused_var();
+    assert!(meta.hint.is_some(), "unused_var DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn undefined_var_meta_has_hint() {
+    let meta = catalog::undefined_var();
+    assert!(meta.hint.is_some(), "undefined_var DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn bareword_filehandle_meta_has_hint() {
+    let meta = catalog::bareword_filehandle();
+    assert!(meta.hint.is_some(), "bareword_filehandle DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn two_arg_open_meta_has_hint() {
+    let meta = catalog::two_arg_open();
+    assert!(meta.hint.is_some(), "two_arg_open DiagnosticMeta must expose a context hint");
+}
+
+#[test]
+fn critic_codes_have_no_hint_in_meta() {
+    // Critic codes intentionally have no generic hint — the policy description is the hint
+    let meta = catalog::critic_severity_1();
+    assert!(
+        meta.hint.is_none(),
+        "critic_severity_1 DiagnosticMeta must NOT expose a generic context hint"
+    );
+    let meta = catalog::critic_severity_5();
+    assert!(meta.hint.is_none(), "critic_severity_5 must also have no hint");
+}
+
+#[test]
+fn hint_content_is_non_empty_string_when_present() {
+    let meta = catalog::parse_error();
+    if let Some(hint) = meta.hint {
+        assert!(!hint.is_empty(), "DiagnosticMeta hint must not be an empty string");
+    }
+}


### PR DESCRIPTION
Fixes #2316.

## Summary

Users encountering parser diagnostics like `PL001` or `PL002` had no idea what action to take. The error code alone was enough to make them disable diagnostics entirely, thinking the LSP was broken.

This adds a `context_hint() -> Option<&'static str>` method to `DiagnosticCode` (in `perl-diagnostics-codes`) returning a concise, actionable explanation for every PL-range code. The `DiagnosticMeta` struct in `perl-lsp-diagnostic-catalog` gains a `hint: Option<&'static str>` field that surfaces this text to LSP provider consumers without requiring a direct `perl-diagnostics-codes` dependency.

Perl::Critic codes (PC001–PC005) intentionally return `None` — their per-policy descriptions already serve this purpose and a generic hint would be redundant.

## Interface & compatibility

- `perl-diagnostics-codes` API: **additive** — new public method `DiagnosticCode::context_hint()`
- `perl-lsp-diagnostic-catalog` API: **additive** — new public field `DiagnosticMeta::hint`
- LSP surface: unchanged (hint is opt-in; no existing consumer is modified)
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-diagnostics-codes/src/lib.rs` — added `context_hint()` impl block matching all 19 variants. Returns `Some(&'static str)` for 14 PL codes, `None` for 5 PC codes.

`crates/perl-lsp-diagnostic-catalog/src/lib.rs` — added `hint` field to `DiagnosticMeta` struct; `from_code()` populates it by calling `code.context_hint()`.

## How to review

Start at `crates/perl-diagnostics-codes/src/lib.rs` line 234 — the new `context_hint()` match block. Then check `crates/perl-lsp-diagnostic-catalog/src/lib.rs` lines 17–31 for the `hint` field addition.

Test coverage is in the two new test files under `tests/`.

## Evidence

```
test result: ok. 20 passed; 0 failed in perl-diagnostics-codes context_hint_tests
test result: ok. 11 passed; 0 failed in perl-lsp-diagnostic-catalog context_hint_catalog_tests
test result: ok. 102 passed; 0 failed in perl-diagnostics-codes comprehensive_unit_tests
test result: ok. 24 passed; 0 failed in perl-lsp-diagnostic-catalog catalog_coverage
cargo clippy --workspace --lib — zero warnings
cargo fmt --all — clean
```

## Risk & rollback

Blast radius is minimal: `context_hint()` is a pure read-only method returning `&'static str` data. No existing behavior changes. No unsafe code. Rollback: revert the two source files.

## Follow-ups

- Wire `DiagnosticMeta::hint` into the LSP diagnostic emission (`crates/perl-lsp/src/runtime/diagnostics.rs`) so hints appear in the `message` or `data` field sent to the editor — tracked separately as that touches the LSP server directly and warrants its own PR.