### PR TITLE
fix(lsp): advertise TextDocumentSyncKind::Full instead of Incremental

### DIFF
--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -23,10 +23,13 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
     let mut caps = ServerCapabilities::default();
 
     // Always-on capabilities
-    // Use Options instead of Kind to comply with LSP 3.18 shape requirements
+    // Use Options instead of Kind to comply with LSP 3.18 shape requirements.
+    // TextDocumentSyncKind::FULL (1): the server always reparses the full document
+    // on every didChange notification.  INCREMENTAL (2) would be inaccurate — no
+    // incremental AST state is maintained between edits.
     caps.text_document_sync = Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
         open_close: Some(true),
-        change: Some(TextDocumentSyncKind::INCREMENTAL),
+        change: Some(TextDocumentSyncKind::FULL),
         will_save: None,
         will_save_wait_until: None,
         save: None,

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -188,12 +188,11 @@ impl LspServer {
 
         eprintln!("Tool availability: perltidy={}, perlcritic={}", has_perltidy, has_perlcritic);
 
-        // TextDocumentSyncKind::Incremental (2): the client sends incremental
-        // text edits (range + replacement) and the server applies them to its
-        // in-memory Rope.  This is correct even though we do a full reparse
-        // after each edit — the sync kind governs how *text* is transferred,
-        // not whether parsing is incremental.  Incremental parsing is future work.
-        let sync_kind = 2;
+        // TextDocumentSyncKind::Full (1): the server always reparses the full
+        // document on every didChange notification.  Advertising Incremental (2)
+        // would be inaccurate — we do not maintain incremental AST state between
+        // edits; we rebuild the entire AST from the complete document text each time.
+        let sync_kind = 1;
 
         // Build capabilities using catalog-driven approach
         let profile = self.feature_profile();

--- a/crates/perl-lsp/tests/lsp_api_contracts.rs
+++ b/crates/perl-lsp/tests/lsp_api_contracts.rs
@@ -66,19 +66,19 @@ fn test_initialization_contract() -> TestResult {
     assert!(!trigger_set.contains("-"), "Must not have '-' as separate trigger");
     assert!(!trigger_set.contains(">"), "Must not have '>' as separate trigger");
 
-    // Text document sync must support incremental sync
+    // Text document sync must be Full (1) — the server fully reparses on every edit
     let sync = caps.get("textDocumentSync");
     if let Some(sync_obj) = sync {
         if let Some(obj) = sync_obj.as_object() {
             // If it's an object, check the change field
             assert_eq!(
                 obj.get("change").and_then(|v| v.as_u64()),
-                Some(2),
-                "textDocumentSync.change must be 2 (incremental sync)"
+                Some(1),
+                "textDocumentSync.change must be 1 (Full sync — server reparses entire document)"
             );
         } else if let Some(num) = sync_obj.as_u64() {
             // If it's a number directly
-            assert_eq!(num, 2, "textDocumentSync must be 2 (incremental sync)");
+            assert_eq!(num, 1, "textDocumentSync must be 1 (Full sync)");
         }
     }
 

--- a/crates/perl-lsp/tests/lsp_text_sync_kind_test.rs
+++ b/crates/perl-lsp/tests/lsp_text_sync_kind_test.rs
@@ -1,0 +1,31 @@
+//! TextDocumentSyncKind accuracy test — issue #2349
+//!
+//! The server does full reparsing on every keystroke. The advertised sync
+//! kind must match actual behaviour: Full (1), not Incremental (2).
+
+mod support;
+use support::lsp_harness::LspHarness;
+
+/// TextDocumentSyncKind::Full = 1, Incremental = 2.
+/// The server always reparses the full document text after each
+/// didChange, so it must advertise Full (1).
+#[test]
+fn test_text_document_sync_kind_is_full() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = LspHarness::new();
+    let response = harness.initialize(None)?;
+    let caps = response.get("capabilities").ok_or("missing capabilities")?;
+
+    let sync_change = caps
+        .pointer("/textDocumentSync/change")
+        .and_then(|v| v.as_u64())
+        .ok_or("textDocumentSync.change must be a number")?;
+
+    assert_eq!(
+        sync_change, 1,
+        "textDocumentSync.change must be 1 (Full) because the server does full \
+         reparse on every edit, not incremental AST updates. Got: {}",
+        sync_change
+    );
+
+    Ok(())
+}

--- a/crates/perl-lsp/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/all_capabilities.json
@@ -132,7 +132,7 @@
     ]
   },
   "textDocumentSync": {
-    "change": 2,
+    "change": 1,
     "openClose": true
   },
   "typeDefinitionProvider": true,

--- a/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
@@ -131,7 +131,7 @@
     ]
   },
   "textDocumentSync": {
-    "change": 2,
+    "change": 1,
     "openClose": true
   },
   "typeDefinitionProvider": true,

--- a/crates/perl-lsp/tests/snapshots/production_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/production_capabilities.json
@@ -130,7 +130,7 @@
     ]
   },
   "textDocumentSync": {
-    "change": 2,
+    "change": 1,
     "openClose": true
   },
   "typeDefinitionProvider": true,


### PR DESCRIPTION
## Summary

The LSP server was advertising `TextDocumentSyncKind::Incremental` (value 2) in its `initialize` response, but the implementation always performs a full AST reparse via `Parser::new(code_text).parse()` on every `didChange` notification. This was inaccurate: no incremental AST state is maintained between edits.

This PR corrects the advertised capability to `TextDocumentSyncKind::Full` (value 1) in both the base capability builder (`perl-lsp-protocol`) and the `handle_initialize` override (`perl-lsp`). Snapshot files and the API contract test are updated to match.

Closes #2349.

## Interface & compatibility

- **perl-parser API**: unchanged
- **LSP surface**: changed — `initialize` response now returns `textDocumentSync.change: 1` instead of `2`
- **DAP surface**: unchanged
- **CLI**: unchanged

This is a truthfulness fix, not a behavioral change. The server already behaved as Full; clients that honored the Incremental advertisement may have been sending range-only change events, but `apply_changes()` in `text_sync.rs` handles both full and range events correctly regardless of this advertisement.

## What changed

Two source locations set the sync kind:

1. `crates/perl-lsp-protocol/src/capabilities.rs:29` — `capabilities_for()` builds the base `ServerCapabilities` struct used by snapshot tests and protocol-layer consumers. Changed from `TextDocumentSyncKind::INCREMENTAL` to `FULL`.

2. `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs:195` — `handle_initialize` assembles the JSON response and overrides `textDocumentSync`. Changed `sync_kind = 2` to `sync_kind = 1` and replaced the old comment (which incorrectly justified `Incremental`) with an accurate one.

Snapshot JSON files (`production_capabilities.json`, `all_capabilities.json`, `ga_lock_capabilities.json`) updated from `"change": 2` to `"change": 1`.

Existing contract test `test_initialization_contract` in `lsp_api_contracts.rs` updated from asserting `Some(2)` to `Some(1)`.

New regression test `test_text_document_sync_kind_is_full` added (TDD: was written to fail before the fix).

## How to review

- Start at `crates/perl-lsp-protocol/src/capabilities.rs` line ~29 (the `INCREMENTAL` → `FULL` change)
- Then `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs` line ~195 (the `sync_kind` constant)
- Snapshot and test changes are mechanical

## Evidence

```
test test_text_document_sync_kind_is_full ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s

test test_production_capabilities_snapshot ... ok
```

Pre-existing failures (present on master before this PR, unrelated to sync kind):
- 4 snapshot tests about `documentRangesFormattingProvider` — pre-existing divergence
- 7 clippy `expect()` errors in `code_actions_provider/mod.rs` — pre-existing

## Risk & rollback

**Blast radius**: LSP clients that send incremental (range-based) change events. The server's `apply_changes()` function handles both full-text and range-based events via the `TextDocumentContentChangeEvent` enum, so changing the advertisement does not break existing clients that send ranges.

**Failure mode**: If a client strictly requires Incremental advertisement before sending range-based diffs and falls back to full-document sends when Full is advertised, there is a slight increase in network traffic per keystroke. This is preferable to false capability advertising.

**Rollback**: Revert the two `sync_kind`/`FULL` changes to restore the original values.

## Follow-ups

- Implement true incremental parsing via `perl-incremental-parsing` crate (Option B from issue) — tracked in #2349