### PR TITLE
perf(lsp): add timeout to perldoc and external command invocations

### DIFF
--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -56,7 +56,7 @@ impl ExecuteCommandProvider {
     pub(crate) fn run_tests(&self, file_path: &Path) -> Result<Value, String> {
         let file_path_str = file_path.to_string_lossy();
         let is_test_file = self.is_test_file(&file_path_str);
-        let (command_name, mut cmd) = if is_test_file && self.command_exists("prove") {
+        let (command_name, cmd) = if is_test_file && self.command_exists("prove") {
             ("prove", {
                 let mut cmd = Command::new("prove");
                 cmd.arg("-v").arg("--").arg(file_path.as_os_str());
@@ -70,7 +70,8 @@ impl ExecuteCommandProvider {
             })
         };
 
-        let result = cmd.output().map_err(|e| format!("Failed to run {}: {}", command_name, e))?;
+        let result = crate::util::run_command_with_timeout(cmd, 30)
+            .map_err(|e| format!("Failed to run {}: {}", command_name, e))?;
         Ok(self.format_command_result(result, Some(("command", command_name.into()))))
     }
 
@@ -86,23 +87,18 @@ impl ExecuteCommandProvider {
             }
         "#;
 
-        let result = Command::new("perl")
-            .arg("-e")
-            .arg(perl_code)
-            .arg("--")
-            .arg(file_path.as_os_str())
-            .arg(sub_name)
-            .output()
+        let mut perl_cmd = Command::new("perl");
+        perl_cmd.arg("-e").arg(perl_code).arg("--").arg(file_path.as_os_str()).arg(sub_name);
+        let result = crate::util::run_command_with_timeout(perl_cmd, 30)
             .map_err(|e| format!("Failed to run test subroutine: {}", e))?;
 
         Ok(self.format_command_result(result, Some(("subroutine", sub_name.into()))))
     }
 
     pub(crate) fn run_file(&self, file_path: &Path) -> Result<Value, String> {
-        let result = Command::new("perl")
-            .arg("--")
-            .arg(file_path.as_os_str())
-            .output()
+        let mut perl_cmd = Command::new("perl");
+        perl_cmd.arg("--").arg(file_path.as_os_str());
+        let result = crate::util::run_command_with_timeout(perl_cmd, 30)
             .map_err(|e| format!("Failed to run file: {}", e))?;
 
         Ok(self.format_command_result(result, None))
@@ -440,9 +436,9 @@ impl ExecuteCommandProvider {
     }
 
     pub(crate) fn command_exists(&self, command: &str) -> bool {
-        Command::new("which")
-            .arg(command)
-            .output()
+        let mut cmd = Command::new("which");
+        cmd.arg(command);
+        crate::util::run_command_with_timeout(cmd, 2)
             .map(|output| output.status.success())
             .unwrap_or(false)
     }
@@ -450,9 +446,9 @@ impl ExecuteCommandProvider {
 
 /// Check whether a command exists in the current PATH.
 pub fn command_exists(command: &str) -> bool {
-    std::process::Command::new(command)
-        .arg("--version")
-        .output()
+    let mut cmd = std::process::Command::new(command);
+    cmd.arg("--version");
+    crate::util::run_command_with_timeout(cmd, 2)
         .map(|output| output.status.success())
         .unwrap_or(false)
 }

--- a/crates/perl-lsp/src/runtime/language/virtual_content.rs
+++ b/crates/perl-lsp/src/runtime/language/virtual_content.rs
@@ -54,14 +54,15 @@ fn fetch_virtual_content(uri: &str) -> Option<String> {
 fn fetch_perldoc(module: &str) -> Option<String> {
     // Run perldoc -T Module::Name to get plain text documentation
     // Use -- to prevent argument injection if module starts with -
-    let output =
-        match std::process::Command::new("perldoc").arg("-T").arg("--").arg(module).output() {
-            Ok(output) => output,
-            Err(e) => {
-                eprintln!("Failed to run perldoc for module {}: {}", module, e);
-                return None;
-            }
-        };
+    let mut cmd = std::process::Command::new("perldoc");
+    cmd.arg("-T").arg("--").arg(module);
+    let output = match crate::util::run_command_with_timeout(cmd, 10) {
+        Ok(output) => output,
+        Err(e) => {
+            eprintln!("Failed to run perldoc for module {}: {}", module, e);
+            return None;
+        }
+    };
 
     if output.status.success() {
         String::from_utf8(output.stdout)

--- a/crates/perl-lsp/src/security/sandbox.rs
+++ b/crates/perl-lsp/src/security/sandbox.rs
@@ -4,8 +4,9 @@
 //! of external processes and isolation from the host system.
 
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use anyhow::{Context, Result, anyhow};
+use crate::util::run_command_with_timeout;
 use serde::{Deserialize, Serialize};
 
 /// Sandbox configuration for process execution
@@ -82,8 +83,9 @@ impl Sandbox {
 
         // Execute and capture output
         let start = std::time::Instant::now();
-        let output = cmd
-            .output()
+        // Use the configured CPU time limit (or 30s as a fallback) as the wall-clock timeout.
+        let timeout_secs = self.config.max_cpu_time.unwrap_or(30);
+        let output = run_command_with_timeout(cmd, timeout_secs)
             .with_context(|| format!("failed to execute sandboxed command: {}", program))?;
         let execution_time = start.elapsed();
 
@@ -100,9 +102,8 @@ impl Sandbox {
     fn execute_unsandboxed(&self, program: &str, args: &[&str]) -> Result<SandboxResult> {
         let mut cmd = Command::new(program);
         cmd.args(args);
-        
-        let output = cmd
-            .output()
+        let timeout_secs = self.config.max_cpu_time.unwrap_or(30);
+        let output = run_command_with_timeout(cmd, timeout_secs)
             .with_context(|| format!("failed to execute command: {}", program))?;
         
         Ok(SandboxResult {
@@ -157,7 +158,9 @@ impl Sandbox {
     #[cfg(target_os = "linux")]
     fn apply_linux_sandbox(&self, cmd: &mut Command) -> Result<()> {
         // Use firejail if available
-        if Command::new("firejail").arg("--version").output().is_ok() {
+        let mut firejail_probe = Command::new("firejail");
+        firejail_probe.arg("--version");
+        if run_command_with_timeout(firejail_probe, 2).is_ok() {
             let mut firejail_cmd = Command::new("firejail");
             
             // Apply memory limits
@@ -206,7 +209,9 @@ impl Sandbox {
     #[cfg(target_os = "macos")]
     fn apply_macos_sandbox(&self, cmd: &mut Command) -> Result<()> {
         // Use sandbox-exec if available
-        if Command::new("sandbox-exec").arg("--version").output().is_ok() {
+        let mut sandbox_probe = Command::new("sandbox-exec");
+        sandbox_probe.arg("--version");
+        if run_command_with_timeout(sandbox_probe, 2).is_ok() {
             let sandbox_profile = self.generate_macos_sandbox_profile();
             
             let mut sandbox_cmd = Command::new("sandbox-exec");

--- a/crates/perl-lsp/src/util/command_timeout.rs
+++ b/crates/perl-lsp/src/util/command_timeout.rs
@@ -1,0 +1,76 @@
+//! Timeout-safe command execution wrapper.
+//!
+//! Provides a helper to run `std::process::Command` with a wall-clock
+//! timeout enforced via a background thread.  When the timeout expires
+//! the function returns an `Err`; the spawned process is left to the OS
+//! to clean up (it will be reaped when the thread eventually finishes or
+//! the LSP process exits).
+
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Execute `cmd` with a wall-clock `timeout_secs` limit.
+///
+/// Returns `Ok(Output)` if the command finishes within the timeout, or
+/// `Err(String)` with a human-readable message if it times out or fails
+/// to spawn.
+pub fn run_command_with_timeout(cmd: Command, timeout_secs: u64) -> Result<Output, String> {
+    let timeout = Duration::from_secs(timeout_secs);
+    let start = Instant::now();
+
+    // Move the command into a thread so we can poll without blocking.
+    let join_handle = thread::spawn(move || {
+        // cmd is moved here; the binding must be mut for .output()
+        let mut cmd = cmd;
+        cmd.output()
+    });
+
+    loop {
+        if start.elapsed() >= timeout {
+            // The background thread may still be running; we deliberately
+            // do not join it — the process will be reaped by the OS.
+            return Err(format!("command timed out after {} seconds", timeout_secs));
+        }
+
+        if join_handle.is_finished() {
+            return join_handle
+                .join()
+                .map_err(|_| "command thread panicked".to_string())?
+                .map_err(|e| format!("command failed to start: {}", e));
+        }
+
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn unit_timeout_fires_for_slow_command() {
+        let start = Instant::now();
+        let mut cmd = Command::new("sleep");
+        cmd.arg("10");
+        let result = run_command_with_timeout(cmd, 1);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "expected timeout error");
+        // Should take approximately 1s, allow up to 4s for slow CI
+        assert!(elapsed.as_secs() < 4, "timeout took too long: {}ms", elapsed.as_millis());
+    }
+
+    #[test]
+    fn unit_fast_command_succeeds() {
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello");
+        let result = run_command_with_timeout(cmd, 10);
+
+        assert!(result.is_ok(), "expected success, got: {:?}", result.err());
+        if let Ok(output) = result {
+            assert!(output.status.success());
+        }
+    }
+}

--- a/crates/perl-lsp/src/util/mod.rs
+++ b/crates/perl-lsp/src/util/mod.rs
@@ -3,7 +3,10 @@
 //! Common text processing helpers used across the LSP implementation.
 //! Includes panic-free accessors for safe string processing.
 
+pub mod command_timeout;
 pub mod uri;
+
+pub use command_timeout::run_command_with_timeout;
 
 use lsp_types::Position;
 use perl_module_reference::extract_module_reference as extract_module_reference_at_cursor;

--- a/crates/perl-lsp/tests/command_timeout_tests.rs
+++ b/crates/perl-lsp/tests/command_timeout_tests.rs
@@ -1,0 +1,36 @@
+//! Tests for the command timeout utility.
+//!
+//! Validates that `run_command_with_timeout` enforces timeouts and
+//! passes through successful command output correctly.
+
+use perl_lsp::util::run_command_with_timeout;
+use std::process::Command;
+use std::time::Instant;
+
+#[test]
+fn test_command_timeout_fires() {
+    let start = Instant::now();
+    let mut cmd = Command::new("sleep");
+    cmd.arg("5");
+    let result = run_command_with_timeout(cmd, 1);
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "Expected timeout error but got: {:?}", result.ok());
+    assert!(
+        elapsed.as_secs() >= 1 && elapsed.as_secs() <= 3,
+        "Expected ~1s timeout, got {}s",
+        elapsed.as_secs()
+    );
+}
+
+#[test]
+fn test_command_completes_before_timeout() {
+    let mut cmd = Command::new("echo");
+    cmd.arg("hello");
+    let result = run_command_with_timeout(cmd, 10);
+
+    assert!(result.is_ok(), "Expected success but got: {:?}", result.err());
+    if let Ok(output) = result {
+        assert!(output.status.success());
+    }
+}


### PR DESCRIPTION
## Summary

External `Command::output()` calls in the LSP server had no wall-clock
timeout, allowing a malformed `perldoc` request, a hung test runner, or a
slow tool-detection probe (`firejail --version`) to block the LSP process
indefinitely.

This PR introduces `crate::util::run_command_with_timeout(cmd, secs)` — a
lightweight thread-based polling helper — and applies it to every
`Command::output()` call site in `perl-lsp`:

- `perldoc` (virtual document content): **10 s**
- `prove` / `perl` execution (`runTests`, `runTestSub`, `runFile`): **30 s**
- Tool detection (`which`, `command --version`, `firejail`, `sandbox-exec`): **2 s**
- Sandboxed execution (`Sandbox::execute`, `execute_unsandboxed`): inherits `SandboxConfig::max_cpu_time` (default 30 s)

Closes #2460

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged — timeouts are internal; callers see `Err(String)` instead of blocking
- DAP surface: unchanged
- CLI: unchanged
- New public symbol: `perl_lsp::util::run_command_with_timeout` (additive)

## What changed

`crates/perl-lsp/src/util/command_timeout.rs` (new) — the timeout helper
spawns the command in a `std::thread`, polls `JoinHandle::is_finished()`
every 50 ms, and returns `Err` if the wall clock exceeds the limit.  The
background thread is not forcibly killed (that is not portable in std), but
the spawned OS process will be reaped by the OS when the LSP process exits or
the thread eventually unblocks.

All five modified call sites are in non-async code (`std::process::Command`),
so a thread-based approach matches the existing execution model without
pulling in `tokio::process`.

## How to review

Start at `crates/perl-lsp/src/util/command_timeout.rs` — that is the entire
new mechanism (45 lines of production code).  Then check each call site diff
in `provider.rs`, `virtual_content.rs`, and `sandbox.rs` to confirm timeout
values match the spec (10 s / 30 s / 2 s).

## Evidence

```
running 2 tests
test test_command_completes_before_timeout ... ok
test test_command_timeout_fires ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; finished in 1.01s

running 2 tests
test util::command_timeout::tests::unit_fast_command_succeeds ... ok
test util::command_timeout::tests::unit_timeout_fires_for_slow_command ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; finished in 4.71s

cargo fmt -p perl-lsp -- --check   → PASS
cargo clippy -p perl-lsp --lib -- -D warnings → PASS (0 warnings)
```

Pre-existing failures on base branch (not caused by this PR):
- `lsp_capabilities_snapshot` (5 tests): `"change": 2` vs `"change": 1` mismatch — confirmed present before this PR
- `cargo clippy --tests`: 7 `expect()` uses in `code_actions_provider/mod.rs` test code — pre-existing

## Risk & rollback

- **Blast radius**: small — new helper is isolated; only six call sites changed
- **Failure mode**: if `run_command_with_timeout` times out, the caller gets `Err(String)` with a human-readable message — same behaviour as an OS-level spawn failure
- **Background thread leak**: on timeout the thread keeps running until the OS process exits. This is acceptable for an LSP server; the thread count is bounded by the number of in-flight external commands
- **Rollback**: revert the six call sites to `.output()` — one-line change each

## Follow-ups

- Discovered: `Sandbox::execute` does not kill the child process on timeout (the `cmd` is moved into the thread). A proper `Child::kill()` approach would require restructuring to `Command::spawn()` + `Child::wait()`. Tracked as out-of-scope for this PR.