### PR TITLE
perf(lsp): make workspace indexing asynchronous and non-blocking

### DIFF
--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -50,6 +50,7 @@ impl LspServer {
             trace_level: Arc::new(Mutex::new("off".to_string())),
             feature_profile,
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
+            pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -139,6 +140,7 @@ impl LspServer {
             trace_level: Arc::new(Mutex::new("off".to_string())),
             feature_profile,
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
+            pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -191,6 +193,7 @@ impl LspServer {
             trace_level: Arc::new(Mutex::new("off".to_string())),
             feature_profile,
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
+            pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -204,6 +204,12 @@ pub struct LspServer {
     feature_profile: FeatureProfile,
     /// Cache of extracted POD documentation keyed by resolved file path.
     pod_cache: Arc<Mutex<HashMap<PathBuf, perl_pod::PodDoc>>>,
+    /// Count of background workspace indexing tasks currently in flight.
+    ///
+    /// Incremented before spawning a background `index_file` task, decremented
+    /// when it completes.  Used by tests to observe that indexing was detached
+    /// from the synchronous handler (issue #2352).
+    pub(crate) pending_index_task_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 // SAFETY: LspServer is not auto-Send/Sync because DocumentState contains
@@ -370,6 +376,15 @@ impl LspServer {
     //   symbol_extraction - AST symbol extraction and reference counting
     //   test_runners      - run_test, run_test_file
     //   test_api          - #[cfg(test)] public wrappers
+
+    /// Number of background workspace-indexing tasks currently in flight.
+    ///
+    /// Returns 0 when all background `index_file` tasks have completed.
+    /// Intended for tests that need to observe the async-indexing behaviour
+    /// introduced by issue #2352.
+    pub fn pending_index_tasks(&self) -> usize {
+        self.pending_index_task_count.load(std::sync::atomic::Ordering::SeqCst)
+    }
 
     /// Install the diagnostic debouncer (called from Scheduler::new after Arc wrapping).
     pub(crate) fn install_diagnostic_debouncer(

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -163,37 +163,69 @@ impl LspServer {
                     // Just ensure the index exists even without workspace feature
                 }
 
-                // Update the workspace-wide index for cross-file features
+                // Update the workspace-wide index for cross-file features.
+                // Indexing runs in a background task so the handler returns
+                // immediately without blocking on file I/O or symbol extraction.
+                // `notify_parse_complete` is called inside the background task.
                 #[cfg(feature = "workspace")]
                 if let Some(coordinator) = self.coordinator() {
-                    let workspace_index = coordinator.index();
                     if let Ok(url) = url::Url::parse(uri) {
-                        match workspace_index.index_file(url, text.to_string()) {
-                            Ok(()) => {
-                                // Transition to Ready on first successful index if still Building
-                                if matches!(
-                                    coordinator.state(),
-                                    IndexState::Building { phase: IndexPhase::Idle, .. }
-                                ) {
-                                    let symbol_count = workspace_index.symbol_count();
-                                    let file_count = workspace_index.file_count();
-                                    coordinator.transition_to_ready(file_count, symbol_count);
-                                    tracing::info!(
-                                        "Index transitioned to Ready after first file (symbols: {})",
-                                        symbol_count
-                                    );
+                        let workspace_index = Arc::clone(coordinator.index());
+                        let coordinator_clone = Arc::clone(coordinator);
+                        let text_owned = text.to_string();
+                        let uri_owned = uri.to_string();
+                        let task_counter = Arc::clone(&self.pending_index_task_count);
+                        task_counter.fetch_add(1, Ordering::SeqCst);
+
+                        let task = move || {
+                            match workspace_index.index_file(url, text_owned) {
+                                Ok(()) => {
+                                    if matches!(
+                                        coordinator_clone.state(),
+                                        IndexState::Building { phase: IndexPhase::Idle, .. }
+                                    ) {
+                                        let symbol_count = workspace_index.symbol_count();
+                                        let file_count = workspace_index.file_count();
+                                        coordinator_clone
+                                            .transition_to_ready(file_count, symbol_count);
+                                        tracing::info!(
+                                            "Index transitioned to Ready after first file \
+                                             (symbols: {})",
+                                            symbol_count
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Failed to index file {}: {}", uri_owned, e);
                                 }
                             }
-                            Err(e) => {
-                                tracing::warn!("Failed to index file {}: {}", uri, e);
+                            coordinator_clone.notify_parse_complete(&uri_owned);
+                            task_counter.fetch_sub(1, Ordering::SeqCst);
+                        };
+
+                        // Spawn on the tokio blocking pool when a runtime is available
+                        // (production path via Scheduler).  Fall back to synchronous
+                        // execution in unit tests that construct LspServer directly.
+                        match tokio::runtime::Handle::try_current() {
+                            Ok(handle) => {
+                                handle.spawn_blocking(task);
+                                // Diagnostics are published below; coordinator completion
+                                // happens asynchronously in the background task.
+                            }
+                            Err(_) => {
+                                task();
                             }
                         }
+                        // Skip the synchronous notify_parse_complete below — it was
+                        // moved into the background task (or run inline on fallback).
+                        self.publish_diagnostics(uri);
+                        return Ok(());
                     }
                 }
             }
 
             // Notify coordinator that all work (parse + index) is complete (may trigger recovery)
-            // This must come AFTER indexing to keep mutation work inside the tracking window
+            // Reached only when: no coordinator, URL parse fails, or workspace feature is off.
             #[cfg(feature = "workspace")]
             if let Some(coordinator) = self.coordinator() {
                 coordinator.notify_parse_complete(uri);
@@ -403,31 +435,50 @@ impl LspServer {
                 // Must drop the lock before calling publish_diagnostics
                 drop(documents);
 
-                // Index symbols for workspace search
-                // Note: Indexing is a MUTATION operation - use coordinator.index() directly
-                // This must happen BEFORE notify_parse_complete to keep work inside the tracking window
+                // Index symbols for workspace search.
+                // Indexing runs in a background task so the handler returns
+                // immediately; `notify_parse_complete` is called inside the task.
                 if let Some(ref _ast) = ast_arc {
-                    // Update the workspace-wide index for cross-file features
-                    // Note: version is maintained by the document state
                     #[cfg(feature = "workspace")]
                     if let Some(coordinator) = self.coordinator() {
-                        let workspace_index = coordinator.index();
                         if let Ok(url) = url::Url::parse(uri) {
+                            let workspace_index = Arc::clone(coordinator.index());
+                            let coordinator_clone = Arc::clone(coordinator);
                             let doc_content = self
                                 .documents
                                 .lock()
                                 .get(uri)
                                 .map(|d| d.text.clone())
                                 .unwrap_or_default();
-                            if let Err(e) = workspace_index.index_file(url, doc_content) {
-                                tracing::warn!("Failed to index file {}: {}", uri, e);
+                            let uri_owned = uri.to_string();
+                            let task_counter = Arc::clone(&self.pending_index_task_count);
+                            task_counter.fetch_add(1, Ordering::SeqCst);
+
+                            let task = move || {
+                                if let Err(e) = workspace_index.index_file(url, doc_content) {
+                                    tracing::warn!("Failed to index file {}: {}", uri_owned, e);
+                                }
+                                coordinator_clone.notify_parse_complete(&uri_owned);
+                                task_counter.fetch_sub(1, Ordering::SeqCst);
+                            };
+
+                            match tokio::runtime::Handle::try_current() {
+                                Ok(handle) => {
+                                    handle.spawn_blocking(task);
+                                }
+                                Err(_) => {
+                                    task();
+                                }
                             }
+
+                            // Send diagnostics (debounced); coordinator completion is async.
+                            self.publish_diagnostics_debounced(uri);
+                            return Ok(());
                         }
                     }
                 }
 
-                // Notify coordinator that all work (parse + index) is complete (may trigger recovery)
-                // This must come AFTER indexing to keep mutation work inside the tracking window
+                // Notify coordinator synchronously when no coordinator/URL/workspace feature.
                 #[cfg(feature = "workspace")]
                 if let Some(coordinator) = self.coordinator() {
                     coordinator.notify_parse_complete(uri);
@@ -654,5 +705,52 @@ impl LspServer {
             "line": last_line,
             "character": last_char
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Verify that `did_open` and `did_change` return with the document stored
+    /// and that the `pending_index_tasks()` counter is accessible (issue #2352).
+    ///
+    /// Without a tokio runtime the sync fallback path runs, so the counter
+    /// returns to zero before the assertions.  This test exercises the public
+    /// API surface introduced by the async-indexing refactor.
+    #[test]
+    fn test_indexing_does_not_block_did_change() -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///test_async_index.pl";
+        let text = "package Foo;\nsub bar { 1 }\n1;\n";
+
+        // Open document — handler must return Ok even when indexing is async.
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": text
+            }
+        }))?;
+
+        // Document must be stored in the in-memory map after did_open returns.
+        assert!(server.documents.lock().contains_key(uri));
+
+        // The counter is accessible; in the sync fallback path (no tokio runtime
+        // in unit tests) it settles to 0 once the handler returns.
+        assert_eq!(server.pending_index_tasks(), 0);
+
+        // A subsequent did_change must also succeed.
+        server.handle_did_change(Some(json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{ "text": "package Foo;\nsub baz { 2 }\n1;\n" }]
+        })))?;
+
+        assert!(server.documents.lock().contains_key(uri));
+        assert_eq!(server.pending_index_tasks(), 0);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #2352

## Summary

Workspace indexing (`index_file()`) previously ran synchronously on the LSP
mutation worker during `did_open` and `did_change` notifications.  On large
files this blocked diagnostics publication and all other LSP requests for
100–200 ms.

This PR detaches `index_file()` onto `tokio::task::spawn_blocking()` so the
handler returns as soon as the document is stored in memory.
`notify_parse_complete` is moved into the background task to keep
`IndexCoordinator` state consistent.  A sync-execution fallback runs the task
inline when no tokio runtime is available (unit tests, embedded use).

A lightweight `pending_index_task_count: Arc<AtomicUsize>` counter is added to
`LspServer` with a public `pending_index_tasks()` accessor.  This lets tests
assert on in-flight work and gives future monitoring/progress-reporting code a
hook to observe indexing activity.

## Interface & compatibility

- **perl-parser API**: unchanged
- **LSP surface**: unchanged — same notifications handled, same diagnostics published
- **DAP surface**: unchanged
- **CLI**: unchanged
- **LspServer public API**: additive — `pending_index_tasks() -> usize` added

## What changed

`crates/perl-lsp/src/runtime/text_sync.rs`
- Both `handle_did_open` and `handle_did_change` now build a closure that clones
  the `Arc<WorkspaceIndex>` and `Arc<IndexCoordinator>` before spawning, then
  call `notify_parse_complete` and decrement the counter inside the closure.
- `tokio::runtime::Handle::try_current()` chooses between async spawn and
  synchronous inline execution.
- `publish_diagnostics` / `publish_diagnostics_debounced` still fires on the
  handler thread immediately after spawning.

`crates/perl-lsp/src/runtime/mod.rs`
- `pending_index_task_count: Arc<AtomicUsize>` field added to `LspServer`.
- `pending_index_tasks() -> usize` public accessor.

`crates/perl-lsp/src/runtime/constructors.rs`
- All three constructors initialise `pending_index_task_count` to 0.

## How to review

Start with `text_sync.rs`: the two `#[cfg(feature = "workspace")]` blocks
inside `handle_did_open` (around line 166) and `handle_did_change` (around
line 441) are the core change.  The surrounding control flow (stale-parse
guard, `publish_diagnostics`) is untouched.

Check that `notify_parse_complete` is called exactly once per indexing path
(either in the background task or in the sync fallback — not both).

## Evidence

```
cargo fmt -p perl-lsp -- --check   → EXIT 0
cargo clippy -p perl-lsp --lib -- -D warnings → EXIT 0
RUST_TEST_THREADS=2 cargo test -p perl-lsp --lib -- --test-threads=2
  test result: ok. 206 passed; 0 failed
test runtime::text_sync::tests::test_indexing_does_not_block_did_change ... ok
```

Pre-existing failure unrelated to this PR:
- `lsp_capabilities_snapshot` tests fail on master (snapshot JSON is stale
  since commit 83cdf69c9, predates this branch).
- `clippy --tests` on `special_variable_hover_tests.rs` uses `expect()` (commit
  83cdf69c9, also predates this branch).

## Risk & rollback

**Blast radius**: `did_open` and `did_change` handlers only.  Diagnostics path
is unchanged.  Symbol-query handlers read from the coordinator with existing
lifecycle semantics.

**Failure modes**:
- If the background task panics, the `pending_index_task_count` will not be
  decremented.  The counter is advisory; no code gates on it being zero.
- `notify_parse_complete` is now called slightly later (after `index_file`
  returns), which matches the original intent of the comment "must come AFTER
  indexing".

**Rollback**: revert this single commit; no schema or protocol changes.

## Follow-ups

- `$/progress` notifications during workspace scan (mentioned in issue) — deferred.
- `$/cancelRequest` abort of in-flight indexing — deferred (requires per-task
  cancellation token).
- Fast-symbol-index `find_symbols("")` call in `did_open` still reads pre-index
  state; separate issue.