### PR TITLE
feat(completion): auto-import modules on completion selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "winapi",
 ]
 
@@ -1885,7 +1884,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber",
  "url",
  "uuid",
  "walkdir",
@@ -1963,6 +1961,7 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",
+ "serde_json",
  "url",
 ]
 
@@ -2198,7 +2197,6 @@ dependencies = [
  "perl-position-tracking",
  "perl-qualified-name",
  "perl-tdd-support",
- "serde",
  "serde_json",
 ]
 
@@ -2356,6 +2354,7 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2732,7 +2731,6 @@ version = "0.12.0"
 name = "perl-tokenizer"
 version = "0.12.0"
 dependencies = [
- "perl-ast",
  "perl-ast-v2",
  "perl-error",
  "perl-lexer",

--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -88,6 +88,7 @@
 //! - **Cancellation aware**: Respects LSP cancellation for responsiveness
 //! - **Memory efficient**: Uses streaming iteration without loading all results
 
+pub(crate) mod auto_import;
 mod builtins;
 mod context;
 mod file_path;
@@ -745,31 +746,34 @@ impl CompletionProvider {
     fn analyze_context(&self, source: &str, position: usize) -> CompletionContext {
         // Find the word being typed
         // Special handling for method calls: include the -> and the receiver
-        let (word_prefix, prefix_start) =
-            if position >= 2 && &source[position.saturating_sub(2)..position] == "->" {
-                // We're right after ->, find the receiver variable
-                let receiver_start = source[..position.saturating_sub(2)]
-                    .rfind(|c: char| {
-                        !c.is_alphanumeric() && c != '_' && c != '$' && c != '@' && c != '%'
-                    })
-                    .map(|p| p + 1)
-                    .unwrap_or(0);
-                (source[receiver_start..position].to_string(), receiver_start)
-            } else {
-                let word_start = source[..position]
-                    .rfind(|c: char| {
-                        !c.is_alphanumeric()
-                            && c != '_'
-                            && c != ':'
-                            && c != '$'
-                            && c != '@'
-                            && c != '%'
-                            && c != '&'
-                    })
-                    .map(|p| p + 1)
-                    .unwrap_or(0);
-                (source[word_start..position].to_string(), word_start)
-            };
+        let (word_prefix, prefix_start) = if position >= 2
+            && &source[position.saturating_sub(2)..position] == "->"
+        {
+            // We're right after ->, find the receiver variable or package name.
+            // Include ':' so that qualified package names like `My::Package->` are
+            // captured as a single receiver token rather than truncated at `::`.
+            let receiver_start = source[..position.saturating_sub(2)]
+                .rfind(|c: char| {
+                    !c.is_alphanumeric() && c != '_' && c != '$' && c != '@' && c != '%' && c != ':'
+                })
+                .map(|p| p + 1)
+                .unwrap_or(0);
+            (source[receiver_start..position].to_string(), receiver_start)
+        } else {
+            let word_start = source[..position]
+                .rfind(|c: char| {
+                    !c.is_alphanumeric()
+                        && c != '_'
+                        && c != ':'
+                        && c != '$'
+                        && c != '@'
+                        && c != '%'
+                        && c != '&'
+                })
+                .map(|p| p + 1)
+                .unwrap_or(0);
+            (source[word_start..position].to_string(), word_start)
+        };
 
         // Detect trigger character (trigger chars are ASCII, so byte access is safe)
         let trigger_character = if position > 0 {

--- a/crates/perl-lsp-completion/src/completion/auto_import.rs
+++ b/crates/perl-lsp-completion/src/completion/auto_import.rs
@@ -1,0 +1,219 @@
+//! Auto-import: generate `use Module;` edits for completion items.
+//!
+//! When a user completes a method or function from an unimported module, this
+//! module generates an `additionalTextEdits` entry that inserts the appropriate
+//! `use` statement at the top of the file, after any existing `use` block.
+//!
+//! # Rules
+//! - If `use ModuleName;` (or `use ModuleName qw(...)` or `use ModuleName ()`)
+//!   already appears in the file, no edit is produced.
+//! - The insertion point is the byte offset immediately after the last existing
+//!   `use` or `require` statement line, or line 0 if there are none.
+//! - The inserted text is `"use ModuleName;\n"`.
+
+use perl_parser_core::SourceLocation;
+
+/// Determine whether `module` is already imported in `source`.
+///
+/// Returns `true` if a `use <module>` or `require <module>` line already
+/// exists, so no duplicate edit is generated.
+pub fn module_already_imported(source: &str, module: &str) -> bool {
+    for line in source.lines() {
+        let trimmed = line.trim();
+        // Match `use Module;`, `use Module ();`, `use Module qw(...)`, etc.
+        if let Some(rest) = trimmed.strip_prefix("use ") {
+            let rest = rest.trim_start();
+            if let Some(after) = rest.strip_prefix(module) {
+                // Make sure the next char (if any) is a space, semicolon, or end-of-token.
+                if after.is_empty()
+                    || after.starts_with(';')
+                    || after.starts_with(' ')
+                    || after.starts_with('\t')
+                    || after.starts_with('(')
+                {
+                    return true;
+                }
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix("require ")
+            && let Some(after) = rest.trim_start().strip_prefix(module)
+            && (after.is_empty() || after.starts_with(';') || after.starts_with(' '))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Find the byte offset after the last `use`/`require` statement block.
+///
+/// Returns the byte offset at the start of the line immediately after the last
+/// `use` or `require` line.  If no such lines exist, returns `0` (insert at
+/// the very beginning of the file).
+pub fn find_use_block_end(source: &str) -> usize {
+    let mut last_use_line_end: Option<usize> = None;
+    let mut offset = 0usize;
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        let line_byte_len = line.len() + 1; // include the '\n'
+
+        let is_use_line = trimmed.starts_with("use ")
+            || trimmed.starts_with("require ")
+            || trimmed == "use strict"
+            || trimmed == "use warnings"
+            || trimmed == "use utf8"
+            || trimmed == "#!/usr/bin/perl"
+            || trimmed.starts_with('#')
+            || trimmed.is_empty();
+
+        if is_use_line {
+            // We keep tracking: the actual `use`/`require` lines advance the
+            // insertion candidate; blank lines and comments extend the "preamble"
+            // window but we only commit if a real use statement has been seen.
+            let is_real_use = trimmed.starts_with("use ") || trimmed.starts_with("require ");
+            if is_real_use {
+                last_use_line_end = Some(offset + line_byte_len);
+            }
+        }
+
+        offset += line_byte_len;
+    }
+
+    // Return the byte offset right after the last use/require line.
+    // If the file has no `use` block at all, insert at the top.
+    last_use_line_end.unwrap_or(0)
+}
+
+/// Build a `(SourceLocation, text)` edit that inserts `use ModuleName;\n`
+/// at the appropriate position in `source`.
+///
+/// Returns `None` if `module` is already imported.
+pub fn build_auto_import_edit(source: &str, module: &str) -> Option<(SourceLocation, String)> {
+    if module.is_empty() || module_already_imported(source, module) {
+        return None;
+    }
+
+    let insert_offset = find_use_block_end(source);
+    let insert_text = format!("use {module};\n");
+
+    Some((SourceLocation { start: insert_offset, end: insert_offset }, insert_text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // module_already_imported
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn already_imported_use_plain() {
+        let src = "use strict;\nuse DBI;\nmy $x = 1;\n";
+        assert!(module_already_imported(src, "DBI"));
+    }
+
+    #[test]
+    fn already_imported_use_qw() {
+        let src = "use List::Util qw(sum min max);\n";
+        assert!(module_already_imported(src, "List::Util"));
+    }
+
+    #[test]
+    fn already_imported_use_parens() {
+        let src = "use JSON ();\n";
+        assert!(module_already_imported(src, "JSON"));
+    }
+
+    #[test]
+    fn not_imported_when_absent() {
+        let src = "use strict;\nuse warnings;\nmy $x = 1;\n";
+        assert!(!module_already_imported(src, "DBI"));
+    }
+
+    #[test]
+    fn not_imported_prefix_match_only() {
+        // `use DBIx::Class` should NOT match a check for `DBI`
+        let src = "use DBIx::Class;\n";
+        assert!(!module_already_imported(src, "DBI"));
+    }
+
+    #[test]
+    fn already_imported_require() {
+        let src = "require LWP::UserAgent;\n";
+        assert!(module_already_imported(src, "LWP::UserAgent"));
+    }
+
+    // ------------------------------------------------------------------
+    // find_use_block_end
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn insert_offset_after_use_block() {
+        let src = "use strict;\nuse warnings;\n\nsub foo { }\n";
+        // After "use warnings;\n" — that is at byte 24 (12 + 12).
+        let offset = find_use_block_end(src);
+        assert_eq!(&src[offset..], "\nsub foo { }\n");
+    }
+
+    #[test]
+    fn insert_offset_zero_when_no_use() {
+        let src = "sub foo { }\n";
+        assert_eq!(find_use_block_end(src), 0);
+    }
+
+    #[test]
+    fn insert_offset_single_use() {
+        let src = "use strict;\nsub foo { }\n";
+        let offset = find_use_block_end(src);
+        assert_eq!(&src[offset..], "sub foo { }\n");
+    }
+
+    // ------------------------------------------------------------------
+    // build_auto_import_edit
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn edit_returned_when_not_imported() {
+        let src = "use strict;\n\nsub foo { DBI->connect(); }\n";
+        let edit = build_auto_import_edit(src, "DBI");
+        assert!(edit.is_some(), "should produce an edit");
+        let (loc, text) = edit.unwrap();
+        assert_eq!(text, "use DBI;\n");
+        // Insert point is after "use strict;\n" (12 bytes)
+        assert_eq!(loc.start, 12);
+        assert_eq!(loc.end, 12, "zero-width insertion");
+    }
+
+    #[test]
+    fn no_edit_when_already_imported() {
+        let src = "use strict;\nuse DBI;\n\nsub foo { }\n";
+        assert!(build_auto_import_edit(src, "DBI").is_none());
+    }
+
+    #[test]
+    fn no_edit_for_empty_module_name() {
+        let src = "use strict;\n";
+        assert!(build_auto_import_edit(src, "").is_none());
+    }
+
+    #[test]
+    fn edit_inserts_at_top_when_no_use_block() {
+        let src = "sub foo { LWP::UserAgent->new(); }\n";
+        let edit = build_auto_import_edit(src, "LWP::UserAgent");
+        assert!(edit.is_some());
+        let (loc, text) = edit.unwrap();
+        assert_eq!(loc.start, 0);
+        assert_eq!(text, "use LWP::UserAgent;\n");
+    }
+
+    #[test]
+    fn edit_for_submodule_name() {
+        let src = "use strict;\n";
+        let edit = build_auto_import_edit(src, "JSON::MaybeXS");
+        assert!(edit.is_some());
+        let (_, text) = edit.unwrap();
+        assert_eq!(text, "use JSON::MaybeXS;\n");
+    }
+}

--- a/crates/perl-lsp-completion/src/completion/methods.rs
+++ b/crates/perl-lsp-completion/src/completion/methods.rs
@@ -2,9 +2,29 @@
 //!
 //! Provides context-aware method completion including DBI methods.
 
-use super::{context::CompletionContext, items::CompletionItem};
+use super::{auto_import, context::CompletionContext, items::CompletionItem};
 use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
 use std::collections::HashSet;
+
+/// Extract the receiver module name from the completion prefix for static calls.
+///
+/// For `LWP::UserAgent->ge` the prefix is `LWP::UserAgent->ge` and we extract
+/// `LWP::UserAgent`.  Returns `None` when the receiver is a variable (`$obj->`)
+/// or when the prefix has no `->`.
+fn static_receiver_module(prefix: &str) -> Option<&str> {
+    let arrow = prefix.rfind("->")?;
+    let receiver = prefix[..arrow].trim();
+    // Static receivers start with an uppercase ASCII letter and contain no sigil.
+    if !receiver.starts_with('$')
+        && !receiver.starts_with('@')
+        && !receiver.starts_with('%')
+        && receiver.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+    {
+        Some(receiver)
+    } else {
+        None
+    }
+}
 
 /// DBI database handle methods
 pub const DBI_DB_METHODS: &[(&str, &str)] = &[
@@ -175,6 +195,19 @@ pub fn add_method_completions(
     // Try to infer the receiver type from context
     let receiver_type = infer_receiver_type(context, source);
 
+    // Determine module for auto-import:
+    // - For static calls like `LWP::UserAgent->` use the prefix receiver.
+    // - For DBI-inferred types use "DBI".
+    let import_module: Option<&str> =
+        static_receiver_module(&context.prefix).or(match receiver_type.as_deref() {
+            Some("DBI::db") | Some("DBI::st") => Some("DBI"),
+            _ => None,
+        });
+
+    // Build an auto-import edit once so all items in this batch share it.
+    let auto_import_edit =
+        import_module.and_then(|m| auto_import::build_auto_import_edit(source, m));
+
     // Choose methods based on inferred type
     let methods: Vec<(&str, &str)> = match receiver_type.as_deref() {
         Some("DBI::db") => DBI_DB_METHODS.to_vec(),
@@ -193,6 +226,8 @@ pub fn add_method_completions(
 
     for (method, desc) in methods {
         if seen.insert(method) {
+            let additional_edits =
+                auto_import_edit.as_ref().map(|e| vec![e.clone()]).unwrap_or_default();
             completions.push(CompletionItem {
                 label: method.to_string(),
                 kind: crate::completion::items::CompletionItemKind::Function,
@@ -201,7 +236,7 @@ pub fn add_method_completions(
                 insert_text: Some(format!("{}()", method)),
                 sort_text: Some(format!("2_{}", method)),
                 filter_text: Some(method.to_string()),
-                additional_edits: vec![],
+                additional_edits,
                 text_edit_range: Some((context.prefix_start, context.position)),
             });
         }
@@ -214,6 +249,8 @@ pub fn add_method_completions(
             ("can", "Check if object can call method"),
         ] {
             if seen.insert(method) {
+                let additional_edits =
+                    auto_import_edit.as_ref().map(|e| vec![e.clone()]).unwrap_or_default();
                 completions.push(CompletionItem {
                     label: method.to_string(),
                     kind: crate::completion::items::CompletionItemKind::Function,
@@ -222,7 +259,7 @@ pub fn add_method_completions(
                     insert_text: Some(format!("{}()", method)),
                     sort_text: Some(format!("9_{}", method)), // Lower priority
                     filter_text: Some(method.to_string()),
-                    additional_edits: vec![],
+                    additional_edits,
                     text_edit_range: Some((context.prefix_start, context.position)),
                 });
             }

--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -5,6 +5,7 @@
 //! completion for `->` expressions, and general cross-file symbol completion.
 
 use super::{
+    auto_import,
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
@@ -337,6 +338,8 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
 ///
 /// When the user types `$obj->` or `Package->`, queries the workspace index for
 /// methods defined in the receiver's package and suggests them.
+///
+/// Auto-import edits are attached when the receiver package is not yet imported.
 pub fn add_workspace_method_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -362,6 +365,9 @@ pub fn add_workspace_method_completions(
     let method_prefix = context.prefix.rsplit("->").next().unwrap_or("");
     let members = index.get_package_members(&package_name);
 
+    // Build an auto-import edit once for all methods from this package.
+    let auto_import_edit = auto_import::build_auto_import_edit(source, &package_name);
+
     for symbol in members {
         match symbol.kind {
             WsSymbolKind::Subroutine | WsSymbolKind::Method => {}
@@ -377,6 +383,9 @@ pub fn add_workspace_method_completions(
             continue;
         }
 
+        let additional_edits =
+            auto_import_edit.as_ref().map(|e| vec![e.clone()]).unwrap_or_default();
+
         completions.push(CompletionItem {
             label: symbol.name.clone(),
             kind: CompletionItemKind::Function,
@@ -387,7 +396,7 @@ pub fn add_workspace_method_completions(
             insert_text: Some(format!("{}()", symbol.name)),
             sort_text: Some(format!("2_{}", symbol.name)), // After local, before generic
             filter_text: Some(symbol.name.clone()),
-            additional_edits: vec![],
+            additional_edits,
             text_edit_range: Some((context.prefix_start, context.position)),
         });
     }

--- a/crates/perl-lsp-completion/tests/auto_import_tests.rs
+++ b/crates/perl-lsp-completion/tests/auto_import_tests.rs
@@ -1,0 +1,200 @@
+//! Integration tests for auto-import completion edits (issue #2322).
+//!
+//! These tests verify that when a user selects a completion item from a module
+//! method, an `additionalTextEdits` entry is produced to auto-insert the
+//! corresponding `use Module;` statement.
+
+use perl_lsp_completion::{CompletionItem, CompletionItemKind, CompletionProvider};
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+use perl_workspace_index::workspace_index::WorkspaceIndex;
+use std::sync::Arc;
+use url::Url;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_provider(code: &str) -> CompletionProvider {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    CompletionProvider::new_with_index_and_source(&ast, code, None)
+}
+
+fn parse_provider_with_index(code: &str, index: Arc<WorkspaceIndex>) -> CompletionProvider {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    CompletionProvider::new_with_index_and_source(&ast, code, Some(index))
+}
+
+fn completions_at_end(code: &str) -> Vec<CompletionItem> {
+    let provider = parse_provider(code);
+    provider.get_completions(code, code.len())
+}
+
+fn find_item<'a>(items: &'a [CompletionItem], label: &str) -> Option<&'a CompletionItem> {
+    items.iter().find(|i| i.label == label)
+}
+
+// ---------------------------------------------------------------------------
+// Static module call auto-import (e.g., DBI->connect)
+// ---------------------------------------------------------------------------
+
+/// Completing `DBI->` on a file with no existing `use DBI` should generate
+/// an auto-import edit that inserts `use DBI;\n` at the correct position.
+#[test]
+fn dbi_static_method_generates_auto_import_when_not_imported() {
+    let code = "use strict;\nuse warnings;\n\nmy $dbh = DBI->";
+    let items = completions_at_end(code);
+
+    // We expect some DBI method to have an additional_edit
+    let item_with_edit = items.iter().find(|i| !i.additional_edits.is_empty());
+    assert!(
+        item_with_edit.is_some(),
+        "Expected at least one DBI method completion with auto-import edit. \
+         Items: {:?}",
+        items.iter().map(|i| &i.label).collect::<Vec<_>>()
+    );
+
+    let item = item_with_edit.unwrap();
+    assert_eq!(item.additional_edits.len(), 1, "Should have exactly one auto-import edit");
+    let (loc, text) = &item.additional_edits[0];
+    assert_eq!(text, "use DBI;\n", "Auto-import text should be `use DBI;\\n`");
+    // Insertion is zero-width (start == end)
+    assert_eq!(loc.start, loc.end, "Auto-import is a zero-width insertion");
+}
+
+/// When `use DBI;` is already present, no auto-import edit is generated.
+#[test]
+fn dbi_static_method_no_auto_import_when_already_imported() {
+    let code = "use strict;\nuse DBI;\n\nmy $dbh = DBI->";
+    let items = completions_at_end(code);
+
+    let has_any_import_edit = items.iter().any(|i| !i.additional_edits.is_empty());
+    assert!(!has_any_import_edit, "Should produce no auto-import edits when DBI already imported");
+}
+
+/// The auto-import insertion point is after the last `use` block.
+#[test]
+fn dbi_auto_import_inserts_after_use_block() {
+    // "use strict;\n" = 12 bytes, "use warnings;\n" = 14 bytes => 26 bytes total for the use block
+    let code = "use strict;\nuse warnings;\n\nmy $dbh = DBI->";
+    let items = completions_at_end(code);
+
+    let item_with_edit = items.iter().find(|i| !i.additional_edits.is_empty());
+    assert!(item_with_edit.is_some(), "Expected a DBI method completion with import edit");
+    let (loc, _) = &item_with_edit.unwrap().additional_edits[0];
+    // "use strict;\n" = 12 + "use warnings;\n" = 14 => offset 26
+    assert_eq!(loc.start, 26, "Should insert after the last use statement line");
+}
+
+/// When there is no use block at all, insertion point is at offset 0.
+#[test]
+fn dbi_auto_import_inserts_at_top_when_no_use_block() {
+    let code = "my $dbh = DBI->";
+    let items = completions_at_end(code);
+
+    let item_with_edit = items.iter().find(|i| !i.additional_edits.is_empty());
+    assert!(item_with_edit.is_some(), "Expected a DBI method completion with import edit");
+    let (loc, _) = &item_with_edit.unwrap().additional_edits[0];
+    assert_eq!(loc.start, 0, "Should insert at offset 0 when no use block exists");
+}
+
+// ---------------------------------------------------------------------------
+// Static Module->new() auto-import for non-DBI modules
+// ---------------------------------------------------------------------------
+
+/// Completing `LWP::UserAgent->` should auto-import `LWP::UserAgent`.
+#[test]
+fn lwp_static_new_generates_auto_import() {
+    let code = "use strict;\n\nmy $ua = LWP::UserAgent->";
+    let items = completions_at_end(code);
+
+    // "new" should appear (generic Object methods) with an auto-import edit
+    let new_item = find_item(&items, "new");
+    assert!(new_item.is_some(), "Expected 'new' in completions for LWP::UserAgent->");
+    let new_item = new_item.unwrap();
+    assert!(
+        !new_item.additional_edits.is_empty(),
+        "Expected auto-import edit on 'new' for LWP::UserAgent"
+    );
+    let (_, text) = &new_item.additional_edits[0];
+    assert_eq!(text, "use LWP::UserAgent;\n");
+}
+
+/// Completing `LWP::UserAgent->` when already imported produces no edit.
+#[test]
+fn lwp_no_auto_import_when_already_imported() {
+    let code = "use strict;\nuse LWP::UserAgent;\n\nmy $ua = LWP::UserAgent->";
+    let items = completions_at_end(code);
+
+    let new_item = find_item(&items, "new");
+    if let Some(item) = new_item {
+        assert!(
+            item.additional_edits.is_empty(),
+            "Should have no auto-import edit when LWP::UserAgent already imported"
+        );
+    }
+    // If 'new' is not returned that's also acceptable — no crash is the requirement
+}
+
+// ---------------------------------------------------------------------------
+// Workspace-indexed method auto-import
+// ---------------------------------------------------------------------------
+
+/// A workspace-indexed method from a known package should carry an auto-import
+/// edit when the package is not yet imported.
+#[test]
+fn workspace_method_auto_import_when_not_imported() {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri = must(Url::parse("file:///workspace/MyApp/Client.pm"));
+    must(index.index_file(uri, "package MyApp::Client;\nsub fetch { }\n1;\n".to_string()));
+
+    let code = "use strict;\n\nmy $c = MyApp::Client->";
+    let provider = parse_provider_with_index(code, index);
+    let items = provider.get_completions(code, code.len());
+
+    let fetch_item = find_item(&items, "fetch");
+    assert!(fetch_item.is_some(), "Expected 'fetch' from workspace index");
+    let fetch_item = fetch_item.unwrap();
+    assert!(
+        !fetch_item.additional_edits.is_empty(),
+        "Expected auto-import edit on workspace-indexed method 'fetch'"
+    );
+    let (_, text) = &fetch_item.additional_edits[0];
+    assert_eq!(text, "use MyApp::Client;\n");
+}
+
+/// When the package is already imported, no auto-import edit for workspace methods.
+#[test]
+fn workspace_method_no_auto_import_when_already_imported() {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri = must(Url::parse("file:///workspace/MyApp/Client.pm"));
+    must(index.index_file(uri, "package MyApp::Client;\nsub fetch { }\n1;\n".to_string()));
+
+    let code = "use strict;\nuse MyApp::Client;\n\nmy $c = MyApp::Client->";
+    let provider = parse_provider_with_index(code, index);
+    let items = provider.get_completions(code, code.len());
+
+    let fetch_item = find_item(&items, "fetch");
+    if let Some(item) = fetch_item {
+        assert!(
+            item.additional_edits.is_empty(),
+            "Should produce no auto-import edit when package already imported"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompletionItemKind unused import suppression
+// ---------------------------------------------------------------------------
+
+// Ensure the CompletionItemKind import is used in an assertion
+#[test]
+fn method_completions_have_function_kind() {
+    let code = "DBI->";
+    let items = completions_at_end(code);
+    let method_items: Vec<_> =
+        items.iter().filter(|i| i.kind == CompletionItemKind::Function).collect();
+    assert!(!method_items.is_empty(), "Expected Function-kind items for DBI methods");
+}

--- a/crates/perl-lsp/src/runtime/language/completion.rs
+++ b/crates/perl-lsp/src/runtime/language/completion.rs
@@ -439,6 +439,26 @@ impl LspServer {
                             item["commitCharacters"] = json!([";", " ", ")", "]", "}"]);
                         }
 
+                        // Serialize additionalTextEdits (e.g. auto-import `use Module;`)
+                        if !c.additional_edits.is_empty() {
+                            let edits: Vec<Value> = c
+                                .additional_edits
+                                .iter()
+                                .map(|(loc, new_text)| {
+                                    let (sl, sc) = self.offset_to_pos16(doc, loc.start);
+                                    let (el, ec) = self.offset_to_pos16(doc, loc.end);
+                                    json!({
+                                        "range": {
+                                            "start": { "line": sl, "character": sc },
+                                            "end": { "line": el, "character": ec }
+                                        },
+                                        "newText": new_text
+                                    })
+                                })
+                                .collect();
+                            item["additionalTextEdits"] = json!(edits);
+                        }
+
                         item
                     })
                     .collect();
@@ -610,6 +630,26 @@ impl LspServer {
                                 "kind": "markdown",
                                 "value": documentation
                             });
+                        }
+
+                        // Serialize additionalTextEdits (e.g. auto-import `use Module;`)
+                        if !c.additional_edits.is_empty() {
+                            let edits: Vec<Value> = c
+                                .additional_edits
+                                .iter()
+                                .map(|(loc, new_text)| {
+                                    let (sl, sc) = self.offset_to_pos16(doc, loc.start);
+                                    let (el, ec) = self.offset_to_pos16(doc, loc.end);
+                                    json!({
+                                        "range": {
+                                            "start": { "line": sl, "character": sc },
+                                            "end": { "line": el, "character": ec }
+                                        },
+                                        "newText": new_text
+                                    })
+                                })
+                                .collect();
+                            item["additionalTextEdits"] = json!(edits);
                         }
 
                         Some(item)


### PR DESCRIPTION
## Summary

When a user selects a completion item from an unimported module's method (e.g. `DBI->connect`, `LWP::UserAgent->new`, or a workspace-indexed `MyApp::Client->fetch`), the LSP server now automatically inserts a `use Module;` statement at the correct location in the file via LSP `additionalTextEdits`.

- Adds a new `auto_import` module (`crates/perl-lsp-completion/src/completion/auto_import.rs`) with three focused functions: `module_already_imported`, `find_use_block_end`, and `build_auto_import_edit`. Zero external dependencies, all pure string logic.
- Wires auto-import edits into method completions for DBI types (`$dbh->`, `$sth->`) and static module calls (`Module->method`), and into workspace-indexed method completions.
- Serializes `additionalTextEdits` in both `handle_completion` and `handle_completion_cancellable` in the LSP runtime layer.
- Fixes a pre-existing bug in `analyze_context` where `::` was treated as a word boundary, causing `MyApp::Client->` to be truncated to `Client->` and preventing auto-import from capturing the full qualified module name.

Closes #2322.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive — `additionalTextEdits` field now populated on completion items when a module is not yet imported
- DAP surface: unchanged
- CLI: unchanged

## What changed

The `CompletionItem.additional_edits` field already existed but was always `vec![]`. This PR populates it for method completions where a receiver module can be identified, and serializes it through the LSP wire format.

The insertion logic inserts after the last `use`/`require` line (or at offset 0 if none exist), and suppresses the edit if the module is already imported via `use` or `require`.

## How to review

Start with `crates/perl-lsp-completion/src/completion/auto_import.rs` (the core logic), then `methods.rs` and `workspace.rs` (where it's wired in), then `crates/perl-lsp/src/runtime/language/completion.rs` (LSP serialization). Integration tests are in `crates/perl-lsp-completion/tests/auto_import_tests.rs`.

## Evidence

```
test result: ok. 9 passed; 0 failed; 0 ignored (auto_import_tests)
cargo clippy --workspace --lib  -- no warnings
cargo fmt --all                 -- no changes
```

All 321 workspace lib tests pass.

## Risk & rollback

- Blast radius: `perl-lsp-completion` and the completion handler in `perl-lsp`. No parser, tokenizer, or indexer changes.
- Failure modes: if `find_use_block_end` returns a wrong offset, the inserted `use` statement lands in the wrong place, but does not corrupt existing code (it is a zero-width insertion).
- Rollback: revert the `additionalTextEdits` serialization block in `completion.rs` to stop emitting the field; the auto-import logic is isolated in its own module.

## Follow-ups

- Auto-import for function completions (builtins from optional modules like `List::Util`)
- Workspace-aware import deduplication across multiple completion candidates in one batch