### PR TITLE
feat(semantic): die/warn exception context and Carp hover docs

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -341,11 +341,11 @@ pub fn get_builtin_documentation(name: &str) -> Option<BuiltinDoc> {
         // Control flow
         "die" => Some(BuiltinDoc {
             signature: "die LIST",
-            description: "Raises an exception. If the last element of LIST does not end in a newline, the current script line number and input line number are appended.",
+            description: "Raises an exception. The error is stored in $@ and can be caught with eval {}. If LIST does not end in a newline, the current script file and line number are appended. In modules, prefer Carp::croak to report the error from the caller's perspective.",
         }),
         "warn" => Some(BuiltinDoc {
             signature: "warn LIST",
-            description: "Produces a message on STDERR, like die but does not exit or throw an exception.",
+            description: "Prints a warning message to STDERR without throwing an exception. In modules, prefer Carp::carp to report the warning from the caller's perspective.",
         }),
         "eval" => Some(BuiltinDoc {
             signature: "eval BLOCK\neval EXPR",
@@ -586,6 +586,69 @@ pub fn get_builtin_documentation(name: &str) -> Option<BuiltinDoc> {
             description: "Declares lexically scoped variables that persist across calls to the enclosing subroutine (like C static variables).",
         }),
 
+        // Carp — stack-aware exception helpers (use Carp)
+        "croak" => Some(BuiltinDoc {
+            signature: "croak LIST",
+            description: "Like die but reports the error from the caller's perspective (one stack level up). Use in modules so the error points at the calling code, not the module internals.",
+        }),
+        "carp" => Some(BuiltinDoc {
+            signature: "carp LIST",
+            description: "Like warn but reports the warning from the caller's perspective (one stack level up). Use in modules so the warning points at the calling code.",
+        }),
+        "confess" => Some(BuiltinDoc {
+            signature: "confess LIST",
+            description: "Like die but includes a full stack trace. Use when deep call chains make croak's single-level context insufficient.",
+        }),
+        "cluck" => Some(BuiltinDoc {
+            signature: "cluck LIST",
+            description: "Like warn but includes a full stack trace. Use when you need a warning with complete call context.",
+        }),
+
+        _ => None,
+    }
+}
+
+/// Structured exception context for die/warn and Carp functions.
+///
+/// Provides IDE guidance about exception semantics: which variable captures the
+/// error and whether a stack-aware alternative is preferred.
+pub struct ExceptionContext {
+    /// The variable that captures the thrown exception, if applicable.
+    /// For `die` this is `$@`; Carp functions do not set a distinct variable.
+    pub error_variable: Option<String>,
+    /// A preferred alternative (e.g. `Carp::croak` instead of `die`).
+    /// `None` when the function is already the preferred form.
+    pub preferred_alternative: Option<String>,
+}
+
+/// Check if a function name belongs to Perl's exception-handling family.
+///
+/// Returns `true` for `die`, `warn`, and all four Carp functions
+/// (`croak`, `carp`, `confess`, `cluck`).
+pub fn is_exception_function(name: &str) -> bool {
+    matches!(name, "die" | "warn" | "croak" | "carp" | "confess" | "cluck")
+}
+
+/// Return exception context for a die/warn/Carp function.
+///
+/// Returns `None` for any function that is not part of the exception family.
+pub fn get_exception_context(name: &str) -> Option<ExceptionContext> {
+    match name {
+        "die" => Some(ExceptionContext {
+            error_variable: Some("$@".to_string()),
+            preferred_alternative: Some("Carp::croak".to_string()),
+        }),
+        "warn" => Some(ExceptionContext {
+            error_variable: None,
+            preferred_alternative: Some("Carp::carp".to_string()),
+        }),
+        "croak" | "confess" => Some(ExceptionContext {
+            error_variable: Some("$@".to_string()),
+            preferred_alternative: None,
+        }),
+        "carp" | "cluck" => {
+            Some(ExceptionContext { error_variable: None, preferred_alternative: None })
+        }
         _ => None,
     }
 }

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -23,7 +23,10 @@ mod references;
 mod tokens;
 
 // Public re-exports — downstream consumers see exactly the same surface.
-pub use builtins::{BuiltinDoc, get_builtin_documentation};
+pub use builtins::{
+    BuiltinDoc, ExceptionContext, get_builtin_documentation, get_exception_context,
+    is_exception_function,
+};
 pub use hover::HoverInfo;
 pub use model::SemanticModel;
 pub use tokens::{SemanticToken, SemanticTokenModifier, SemanticTokenType};

--- a/crates/perl-semantic-analyzer/tests/die_warn_exception_context_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/die_warn_exception_context_tests.rs
@@ -1,0 +1,186 @@
+//! Tests for die/warn exception context — issue #2359.
+//!
+//! Verifies that:
+//! - die and warn hover docs include exception semantics ($@ context).
+//! - Carp functions (croak, carp, confess, cluck) are documented.
+//! - `is_exception_function` classifies the full exception family.
+//! - `get_exception_context` returns structured upgrade advice for die.
+
+use perl_semantic_analyzer::analysis::semantic::{
+    get_builtin_documentation, get_exception_context, is_exception_function,
+};
+use perl_tdd_support::must_some;
+
+// ---------------------------------------------------------------------------
+// die / warn enhanced hover docs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_die_doc_mentions_exception_variable() {
+    let doc = must_some(get_builtin_documentation("die"));
+    // The description must tell the developer that $@ captures the error.
+    assert!(
+        doc.description.contains("$@"),
+        "die description should mention $@ variable, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn test_die_doc_mentions_croak_alternative() {
+    let doc = must_some(get_builtin_documentation("die"));
+    assert!(
+        doc.description.contains("croak") || doc.description.contains("Carp"),
+        "die description should suggest Carp::croak as a module-safe alternative, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn test_warn_doc_mentions_stderr() {
+    let doc = must_some(get_builtin_documentation("warn"));
+    assert!(
+        doc.description.contains("STDERR"),
+        "warn description should mention STDERR, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn test_warn_doc_mentions_carp_alternative() {
+    let doc = must_some(get_builtin_documentation("warn"));
+    assert!(
+        doc.description.contains("carp") || doc.description.contains("Carp"),
+        "warn description should suggest Carp::carp as a module-safe alternative, got: {}",
+        doc.description
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Carp functions are documented
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_croak_has_docs() {
+    let doc = get_builtin_documentation("croak");
+    assert!(doc.is_some(), "croak (Carp) should have hover documentation");
+}
+
+#[test]
+fn test_croak_doc_mentions_caller() {
+    let doc = must_some(get_builtin_documentation("croak"));
+    assert!(
+        doc.description.contains("caller") || doc.description.contains("stack"),
+        "croak description should explain caller-perspective errors, got: {}",
+        doc.description
+    );
+}
+
+#[test]
+fn test_carp_has_docs() {
+    let doc = get_builtin_documentation("carp");
+    assert!(doc.is_some(), "carp (Carp) should have hover documentation");
+}
+
+#[test]
+fn test_confess_has_docs() {
+    let doc = get_builtin_documentation("confess");
+    assert!(doc.is_some(), "confess (Carp) should have hover documentation");
+}
+
+#[test]
+fn test_cluck_has_docs() {
+    let doc = get_builtin_documentation("cluck");
+    assert!(doc.is_some(), "cluck (Carp) should have hover documentation");
+}
+
+// ---------------------------------------------------------------------------
+// is_exception_function
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_is_exception_function_die() {
+    assert!(is_exception_function("die"), "die must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_warn() {
+    assert!(is_exception_function("warn"), "warn must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_croak() {
+    assert!(is_exception_function("croak"), "croak must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_carp() {
+    assert!(is_exception_function("carp"), "carp must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_confess() {
+    assert!(is_exception_function("confess"), "confess must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_cluck() {
+    assert!(is_exception_function("cluck"), "cluck must be an exception function");
+}
+
+#[test]
+fn test_is_exception_function_rejects_print() {
+    assert!(!is_exception_function("print"), "print must not be an exception function");
+}
+
+// ---------------------------------------------------------------------------
+// get_exception_context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_exception_context_die_suggests_croak() {
+    let ctx = must_some(get_exception_context("die"));
+    assert!(
+        ctx.preferred_alternative.is_some(),
+        "die context should suggest a preferred alternative"
+    );
+    let alt = must_some(ctx.preferred_alternative);
+    assert_eq!(alt, "Carp::croak", "die preferred alternative should be Carp::croak, got: {}", alt);
+}
+
+#[test]
+fn test_get_exception_context_warn_suggests_carp() {
+    let ctx = must_some(get_exception_context("warn"));
+    assert!(
+        ctx.preferred_alternative.is_some(),
+        "warn context should suggest a preferred alternative"
+    );
+    let alt = must_some(ctx.preferred_alternative);
+    assert_eq!(alt, "Carp::carp", "warn preferred alternative should be Carp::carp, got: {}", alt);
+}
+
+#[test]
+fn test_get_exception_context_die_sets_error_var() {
+    let ctx = must_some(get_exception_context("die"));
+    assert_eq!(
+        ctx.error_variable,
+        Some("$@".to_string()),
+        "die context should identify $@ as the error variable"
+    );
+}
+
+#[test]
+fn test_get_exception_context_croak_no_alternative() {
+    // croak is already the preferred form — no further upgrade needed
+    let ctx = must_some(get_exception_context("croak"));
+    assert!(
+        ctx.preferred_alternative.is_none(),
+        "croak should have no preferred alternative (it is already preferred)"
+    );
+}
+
+#[test]
+fn test_get_exception_context_unknown_returns_none() {
+    let ctx = get_exception_context("print");
+    assert!(ctx.is_none(), "non-exception function should return None from get_exception_context");
+}


### PR DESCRIPTION
## Summary

Closes #2359.

Enriches the semantic analyzer's hover documentation for Perl's exception-handling functions with IDE-useful context:

- `die` description now mentions `$@` capture, `eval {}` catching, and recommends `Carp::croak` for module code
- `warn` description clarifies STDERR output and recommends `Carp::carp` for module code
- Adds complete hover docs for the four Carp functions: `croak`, `carp`, `confess`, `cluck`
- Adds `ExceptionContext` struct with `error_variable` and `preferred_alternative` fields
- Adds `is_exception_function()` to classify the full exception family (die, warn, croak, carp, confess, cluck)
- Adds `get_exception_context()` returning structured IDE guidance (which error variable is set, what the preferred alternative is)

All new items are exported from `perl_semantic_analyzer::analysis::semantic`.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive only (richer hover text for die/warn; new Carp hover entries)
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs` — two description strings updated, four Carp arms added to `get_builtin_documentation`, three new public items (`ExceptionContext`, `is_exception_function`, `get_exception_context`) appended.

`crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs` — re-export line expanded to include the three new public items.

`crates/perl-semantic-analyzer/tests/die_warn_exception_context_tests.rs` — 21 new tests covering: enhanced die/warn descriptions, Carp function docs, `is_exception_function` classification, and `get_exception_context` structured output.

## How to review

Start at `builtins.rs` lines 341-354 (die/warn description changes), then jump to the Carp block starting at ~line 590, then the three new functions at the end of the file. The mod.rs change is a single `pub use` expansion.

## Evidence

```
running 21 tests
test test_carp_has_docs ... ok
test test_cluck_has_docs ... ok
test test_confess_has_docs ... ok
test test_croak_doc_mentions_caller ... ok
test test_croak_has_docs ... ok
test test_die_doc_mentions_croak_alternative ... ok
test test_die_doc_mentions_exception_variable ... ok
test test_get_exception_context_croak_no_alternative ... ok
test test_get_exception_context_die_sets_error_var ... ok
test test_get_exception_context_die_suggests_croak ... ok
test test_get_exception_context_unknown_returns_none ... ok
test test_get_exception_context_warn_suggests_carp ... ok
test test_is_exception_function_carp ... ok
test test_is_exception_function_cluck ... ok
test test_is_exception_function_confess ... ok
test test_is_exception_function_croak ... ok
test test_is_exception_function_die ... ok
test test_is_exception_function_rejects_print ... ok
test test_is_exception_function_warn ... ok
test test_warn_doc_mentions_carp_alternative ... ok
test test_warn_doc_mentions_stderr ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p perl-semantic-analyzer --lib -- -D warnings: PASS (51 lib tests pass, 0 regressions)
```

## Risk & rollback

Blast radius: zero functional change to existing behavior. Only documentation strings are enriched and new query functions added. The new `ExceptionContext` struct and helper functions are additive-only exports. Rollback: revert the three files in this commit.

## Follow-ups

- Code action to convert `die` → `Carp::croak` in module context (requires LSP code-action provider work, out of scope here)
- `$@` variable tracking through try/catch patterns (requires scope analyzer work)
- Debugger exception breakpoint integration (DAP scope)