### PR TITLE
feat(hover): explain regex patterns in human-readable format

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -1275,13 +1275,15 @@ impl LspServer {
         while i < len {
             // --- bare /pattern/ ---
             if bytes[i] == b'/' {
-                // Reject division: preceded by alphanumeric, `_`, `)`, `]`, `'`, `"`
+                // Reject division: preceded by alphanumeric, `_`, `)`, `]`, `}`, `'`, `"`
+                // e.g. `$x / 2` or `$hash{key}/2` should not trigger regex detection.
                 let is_division = i > 0 && {
                     let prev = bytes[i - 1];
                     prev.is_ascii_alphanumeric()
                         || prev == b'_'
                         || prev == b')'
                         || prev == b']'
+                        || prev == b'}'
                         || prev == b'\''
                         || prev == b'"'
                 };
@@ -1397,21 +1399,101 @@ impl LspServer {
             match b {
                 b'\\' if i + 1 < len => {
                     let next = bytes[i + 1];
+                    // Handle \p{...} and \P{...} Unicode property escapes.
+                    if (next == b'p' || next == b'P') && i + 2 < len && bytes[i + 2] == b'{' {
+                        let prop_start = i + 3;
+                        let mut k = prop_start;
+                        while k < len && bytes[k] != b'}' {
+                            k += 1;
+                        }
+                        let prop_end = if k < len { k + 1 } else { k };
+                        let prop_str = pattern.get(i..prop_end).unwrap_or(if next == b'p' {
+                            r"\p{}"
+                        } else {
+                            r"\P{}"
+                        });
+                        let desc = if next == b'p' {
+                            "Unicode property — matches characters with this property"
+                        } else {
+                            "Unicode property complement — matches characters WITHOUT this property"
+                        };
+                        i = prop_end;
+                        let prop_owned = prop_str.to_string();
+                        let (final_tok, final_desc) =
+                            Self::apply_quantifier(prop_owned, desc.to_string(), bytes, &mut i);
+                        entries.push((final_tok, final_desc));
+                        continue;
+                    }
+                    // Handle \N{name} — named Unicode character.
+                    if next == b'N' && i + 2 < len && bytes[i + 2] == b'{' {
+                        let name_start = i + 3;
+                        let mut k = name_start;
+                        while k < len && bytes[k] != b'}' {
+                            k += 1;
+                        }
+                        let name_end = if k < len { k + 1 } else { k };
+                        let name_str = pattern.get(i..name_end).unwrap_or(r"\N{}");
+                        i = name_end;
+                        let name_owned = name_str.to_string();
+                        entries.push((name_owned, "Named Unicode character".to_string()));
+                        continue;
+                    }
+                    // Handle \g{name} and \g{n} — named/numbered backreference.
+                    if next == b'g' && i + 2 < len && bytes[i + 2] == b'{' {
+                        let ref_start = i + 3;
+                        let mut k = ref_start;
+                        while k < len && bytes[k] != b'}' {
+                            k += 1;
+                        }
+                        let ref_end = if k < len { k + 1 } else { k };
+                        let ref_str = pattern.get(i..ref_end).unwrap_or(r"\g{}");
+                        i = ref_end;
+                        let ref_owned = ref_str.to_string();
+                        entries.push((ref_owned, "Named or numbered backreference".to_string()));
+                        continue;
+                    }
+                    // Handle \k<name> — named backreference (angle-bracket form).
+                    if next == b'k' && i + 2 < len && bytes[i + 2] == b'<' {
+                        let name_start = i + 3;
+                        let mut k = name_start;
+                        while k < len && bytes[k] != b'>' {
+                            k += 1;
+                        }
+                        let name_end = if k < len { k + 1 } else { k };
+                        let ref_str = pattern.get(i..name_end).unwrap_or(r"\k<>");
+                        i = name_end;
+                        let ref_owned = ref_str.to_string();
+                        entries.push((
+                            ref_owned,
+                            "Named backreference (angle-bracket form)".to_string(),
+                        ));
+                        continue;
+                    }
                     let (tok, desc) = match next {
                         b'd' => (r"\d", "Any decimal digit (0-9)"),
                         b'D' => (r"\D", "Any non-digit character"),
                         b'w' => (r"\w", "Any word character (alphanumeric + underscore)"),
                         b'W' => (r"\W", "Any non-word character"),
-                        b's' => (r"\s", "Any whitespace character"),
+                        b's' => (r"\s", "Any whitespace character (space, tab, newline, etc.)"),
                         b'S' => (r"\S", "Any non-whitespace character"),
                         b'b' => (r"\b", "Word boundary"),
                         b'B' => (r"\B", "Non-word boundary"),
-                        b'A' => (r"\A", "Start of string"),
-                        b'Z' => (r"\Z", "End of string (before optional newline)"),
+                        b'A' => (r"\A", "Start of string (unaffected by multiline mode)"),
+                        b'Z' => (r"\Z", "End of string (allows optional trailing newline)"),
                         b'z' => (r"\z", "Absolute end of string"),
-                        b'n' => (r"\n", "Newline"),
-                        b't' => (r"\t", "Tab"),
-                        b'r' => (r"\r", "Carriage return"),
+                        b'G' => (r"\G", "Where the previous match left off (pos())"),
+                        b'n' => (r"\n", "Newline character"),
+                        b't' => (r"\t", "Tab character"),
+                        b'r' => (r"\r", "Carriage return character"),
+                        b'f' => (r"\f", "Form feed character"),
+                        b'e' => (r"\e", "Escape character"),
+                        b'a' => (r"\a", "Alarm (bell) character"),
+                        b'0' => (r"\0", "Null character"),
+                        b'h' => (r"\h", "Horizontal whitespace (space or tab)"),
+                        b'H' => (r"\H", "Non-horizontal-whitespace character"),
+                        b'v' => (r"\v", "Vertical whitespace character"),
+                        b'V' => (r"\V", "Non-vertical-whitespace character"),
+                        b'X' => (r"\X", "Extended Unicode grapheme cluster"),
                         b'1'..=b'9' => {
                             let n = (next - b'0') as usize;
                             let tok_s = format!("\\{}", n);
@@ -1423,6 +1505,7 @@ impl LspServer {
                             continue;
                         }
                         _ => {
+                            // Escaped literal or unrecognised — skip silently.
                             i += 2;
                             continue;
                         }
@@ -1435,13 +1518,12 @@ impl LspServer {
                     entries.push((final_tok, final_desc));
                 }
                 b'^' => {
-                    let desc = if i == 0 {
-                        "Start of string/line anchor"
-                    } else {
-                        "Negation (inside character class) or literal ^"
-                    };
+                    // Outside a character class (handled separately by `[`), `^`
+                    // is always an anchor — at position 0 it anchors to the start
+                    // of the string/line, and after `(?` it can appear inside
+                    // alternatives such as `(?:^foo|^bar)`.
                     i += 1;
-                    entries.push((r"^".to_string(), desc.to_string()));
+                    entries.push((r"^".to_string(), "Start of string/line anchor".to_string()));
                 }
                 b'$' => {
                     i += 1;
@@ -1456,21 +1538,34 @@ impl LspServer {
                     entries.push((final_tok, final_desc));
                 }
                 b'(' => {
-                    // Check for non-capturing or named group
+                    // Check for non-capturing group, lookaround, or named capture.
                     if i + 2 < len && bytes[i + 1] == b'?' {
                         let kind = bytes[i + 2];
-                        let desc = match kind {
-                            b':' => "Non-capturing group",
-                            b'=' => "Positive lookahead",
-                            b'!' => "Negative lookahead",
-                            b'<' if i + 3 < len && bytes[i + 3] == b'=' => "Positive lookbehind",
-                            b'<' if i + 3 < len && bytes[i + 3] == b'!' => "Negative lookbehind",
-                            b'<' => "Named capture group",
-                            b'\'' => "Named capture group (single-quote form)",
-                            _ => "Special group",
+                        let (prefix, desc, advance) = match kind {
+                            b':' => ("(?:", "Non-capturing group", 3),
+                            b'=' => ("(?=", "Positive lookahead assertion", 3),
+                            b'!' => ("(?!", "Negative lookahead assertion", 3),
+                            b'<' if i + 3 < len && bytes[i + 3] == b'=' => {
+                                ("(?<=", "Positive lookbehind assertion", 4)
+                            }
+                            b'<' if i + 3 < len && bytes[i + 3] == b'!' => {
+                                ("(?<!", "Negative lookbehind assertion", 4)
+                            }
+                            b'<' => ("(?<name>", "Named capture group (angle-bracket form)", 3),
+                            b'\'' => ("(?'name'", "Named capture group (single-quote form)", 3),
+                            b'#' => ("(?#", "Comment — ignored by the regex engine", 3),
+                            b'|' => (
+                                "(?|",
+                                "Branch reset group — resets capture numbering per branch",
+                                3,
+                            ),
+                            b'>' => ("(?>", "Atomic group (no backtracking into this group)", 3),
+                            _ => ("(?", "Special group (inline modifier or other extension)", 2),
                         };
-                        i += 1; // advance past '('
-                        entries.push(("(?)".to_string(), desc.to_string()));
+                        // Advance past the full group-open prefix so we don't
+                        // re-process `?`, `:`, `=`, etc. as standalone tokens.
+                        i += advance;
+                        entries.push((prefix.to_string(), desc.to_string()));
                     } else {
                         i += 1;
                         entries.push((
@@ -1545,34 +1640,66 @@ impl LspServer {
         let suffix = match bytes[*pos] {
             b'+' => {
                 *pos += 1;
-                // possessive? `++`
                 if *pos < len && bytes[*pos] == b'+' {
+                    // `++` possessive quantifier — no backtracking
                     *pos += 1;
-                    ", one or more (possessive)"
+                    ", one or more (possessive — no backtracking)"
+                } else if *pos < len && bytes[*pos] == b'?' {
+                    // `+?` lazy quantifier — matches as few as possible
+                    *pos += 1;
+                    ", one or more (lazy — matches as few as possible)"
                 } else {
-                    ", one or more"
+                    ", one or more (greedy)"
                 }
             }
             b'*' => {
                 *pos += 1;
-                ", zero or more"
+                if *pos < len && bytes[*pos] == b'?' {
+                    // `*?` lazy quantifier
+                    *pos += 1;
+                    ", zero or more (lazy — matches as few as possible)"
+                } else if *pos < len && bytes[*pos] == b'+' {
+                    // `*+` possessive quantifier
+                    *pos += 1;
+                    ", zero or more (possessive — no backtracking)"
+                } else {
+                    ", zero or more (greedy)"
+                }
             }
             b'?' => {
                 *pos += 1;
-                ", zero or one (optional)"
+                if *pos < len && bytes[*pos] == b'?' {
+                    // `??` lazy optional
+                    *pos += 1;
+                    ", zero or one (lazy — prefers zero)"
+                } else {
+                    ", zero or one (optional, greedy)"
+                }
             }
             b'{' => {
-                // {n} or {n,m} — just skip, no suffix in description
-                let start = *pos;
+                // {n} or {n,m} — collect the quantifier text and fold it in.
+                let brace_start = *pos;
                 *pos += 1;
                 while *pos < len && bytes[*pos] != b'}' {
                     *pos += 1;
                 }
                 if *pos < len {
-                    *pos += 1;
+                    *pos += 1; // consume '}'
                 }
-                let range = std::str::from_utf8(&bytes[start..*pos]).unwrap_or("");
-                return (format!("{}{}", tok, range), format!("{}, counted repetition", desc));
+                let brace_end = *pos;
+                // Check for lazy ({n,m}?) or possessive ({n,m}+) suffix.
+                let counted_suffix = if *pos < len && bytes[*pos] == b'?' {
+                    *pos += 1;
+                    ", counted repetition (lazy)"
+                } else if *pos < len && bytes[*pos] == b'+' {
+                    *pos += 1;
+                    ", counted repetition (possessive)"
+                } else {
+                    ", counted repetition"
+                };
+                // All bytes in {…} are ASCII so from_utf8 is infallible here.
+                let range = std::str::from_utf8(&bytes[brace_start..brace_end]).unwrap_or("{n}");
+                return (format!("{}{}", tok, range), format!("{}{}", desc, counted_suffix));
             }
             _ => return (tok, desc),
         };

--- a/crates/perl-lsp/tests/regex_hover_tests.rs
+++ b/crates/perl-lsp/tests/regex_hover_tests.rs
@@ -82,7 +82,8 @@ fn test_hover_regex_fat_arrow_pattern() -> TestResult {
 /// Hover on a regex explains capture groups.
 #[test]
 fn test_hover_regex_capture_group_explanation() -> TestResult {
-    let doc = "my @m = ($str =~ /(\\w+)/);\\n";
+    // Use a real newline at the end, not a literal backslash-n.
+    let doc = "my @m = ($str =~ /(\\w+)/);\n";
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
     harness.open_document("file:///regex_capture.pl", doc)?;
@@ -155,5 +156,176 @@ fn test_hover_regex_returns_markdown_kind() -> TestResult {
         let kind = result.get("contents").and_then(|c| c.get("kind")).and_then(|k| k.as_str());
         assert_eq!(kind, Some("markdown"), "Hover kind should be 'markdown'; got: {kind:?}");
     }
+    Ok(())
+}
+
+/// Hover on a non-capturing group `(?:...)` shows correct description without
+/// spurious `?` quantifier entries bleeding from the `(?` prefix.
+#[test]
+fn test_hover_regex_non_capturing_group() -> TestResult {
+    // `/(?:\d+)/` — position 2 is inside the `(?:` prefix
+    let doc = "my $x = /(?:\\d+)/;\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///regex_non_capturing.pl", doc)?;
+
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///regex_non_capturing.pl"},
+                "position": {"line": 0, "character": 10}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover contents")?;
+    assert!(
+        val.contains("Non-capturing") || val.contains("non-capturing"),
+        "Hover should explain (?:...) as non-capturing group; got: {val}"
+    );
+    // The `?` from the `(?` prefix must NOT appear as a standalone "optional" entry.
+    assert!(
+        !val.contains("zero or one (optional"),
+        "Hover must not have spurious standalone ? quantifier entry; got: {val}"
+    );
+    Ok(())
+}
+
+/// Hover on a positive lookahead `(?=...)` shows the correct description.
+#[test]
+fn test_hover_regex_positive_lookahead() -> TestResult {
+    let doc = "if ($x =~ /\\w+(?=\\s)/) {\n}\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///regex_lookahead.pl", doc)?;
+
+    // Position 15 is inside `(?=\s)` (on the `(`)
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///regex_lookahead.pl"},
+                "position": {"line": 0, "character": 15}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover contents for lookahead")?;
+    assert!(
+        val.contains("lookahead") || val.contains("Lookahead"),
+        "Hover should explain (?=...) as lookahead; got: {val}"
+    );
+    Ok(())
+}
+
+/// `$hash{key}/2` must NOT be detected as a regex.
+/// The `/` after `}` is division, not a regex delimiter.
+#[test]
+fn test_hover_no_false_positive_division_after_brace() -> TestResult {
+    let doc = "my $x = $h{key}/2;\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///no_regex_division.pl", doc)?;
+
+    // Position 15 is on the `/` between `}` and `2`
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///no_regex_division.pl"},
+                "position": {"line": 0, "character": 15}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    // The hover result should NOT contain "Regex Pattern" — this is division.
+    if let Some(val) = hover_value(&result) {
+        assert!(
+            !val.contains("Regex Pattern"),
+            "Should not treat division as regex; got hover: {val}"
+        );
+    }
+    Ok(())
+}
+
+/// Hover on `\b` shows word boundary, not "backspace".
+#[test]
+fn test_hover_regex_word_boundary() -> TestResult {
+    let doc = "if ($x =~ /\\bfoo\\b/) {\n}\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///regex_boundary.pl", doc)?;
+
+    // Position 11 is on `\b` inside `/\bfoo\b/`
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///regex_boundary.pl"},
+                "position": {"line": 0, "character": 11}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover contents for word boundary")?;
+    assert!(
+        val.contains("boundary") || val.contains("Boundary"),
+        "Hover should explain \\b as word boundary; got: {val}"
+    );
+    Ok(())
+}
+
+/// Hover on a negated character class `[^a-z]` shows correct description.
+#[test]
+fn test_hover_regex_negated_char_class() -> TestResult {
+    let doc = "my $x = /[^a-z]+/;\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///regex_negated_class.pl", doc)?;
+
+    // Position 9 is inside `[^a-z]`
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///regex_negated_class.pl"},
+                "position": {"line": 0, "character": 9}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover contents for char class")?;
+    assert!(
+        val.contains("Negated") || val.contains("negated"),
+        "Hover should explain [^...] as negated character class; got: {val}"
+    );
+    Ok(())
+}
+
+/// Hover on `qr/pattern/` operator form shows regex explanation.
+#[test]
+fn test_hover_qr_operator() -> TestResult {
+    let doc = "my $re = qr/\\d{2,4}/;\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///regex_qr.pl", doc)?;
+
+    // Position 12 is inside `qr/\d{2,4}/` (on the `\d`)
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///regex_qr.pl"},
+                "position": {"line": 0, "character": 12}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover contents for qr//")?;
+    assert!(
+        val.contains("digit") || val.contains("Digit"),
+        "Hover should explain \\d inside qr//; got: {val}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

When hovering over a Perl regex literal in the editor, the LSP now returns a Markdown table explaining each metacharacter in the pattern rather than falling through to generic token hover.

Supported operator forms: `/pattern/`, `m/pattern/`, `s/pattern/replacement/`, `qr/pattern/` — including all paired-delimiter variants (`{}`, `()`, `[]`, `<>`).

Metacharacters covered: `\d`, `\D`, `\w`, `\W`, `\s`, `\S`, `\b`, `\B`, `\A`, `\Z`, `\z`, `\n`, `\t`, `\r`, anchors `^` and `$`, `.` (dot), capture groups `()`, character classes `[]`, alternation `|`, backreferences `\1`–`\9`, quantifiers `+`/`*`/`?`/`{n,m}`, and non-capturing/lookaround groups `(?:…)`, `(?=…)`, `(?!…)`, `(?<=…)`, `(?<!…)`.

Quantifiers are folded into the preceding token's description rather than emitting a redundant row.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive — hover responses gain a new `Regex Pattern` heading when cursor is inside a regex literal
- DAP surface: unchanged
- CLI: unchanged

## What changed

- `crates/perl-lsp/src/runtime/language/hover.rs`: added 7 private methods (`extract_regex_hover`, `find_regex_at_offset`, `find_regex_in_line`, `matching_close`, `explain_regex`, `apply_quantifier`, `skip_quantifier`) and a 4-line call site in `extract_symbol_hover` (before the special-variable check).
- `crates/perl-lsp/tests/regex_hover_tests.rs`: 5 new integration tests covering `\d+`, `^(…)` anchors, capture groups, `s///` substitution, and the markdown `kind` field.

## How to review

Start at `extract_symbol_hover` (~line 176) to see the call site, then jump to `extract_regex_hover` (near line 1225) and read down through `find_regex_in_line` for the detection logic and `explain_regex` for the metacharacter table.

## Evidence

```
running 5 tests
test test_hover_regex_fat_arrow_pattern ... ok
test test_hover_regex_capture_group_explanation ... ok
test test_hover_regex_returns_markdown_kind ... ok
test test_hover_regex_simple_digit_plus ... ok
test test_hover_substitution_regex_explanation ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Risk & rollback

- Blast radius: hover only, no parser or LSP protocol changes.
- Failure mode: `find_regex_in_line` returns `None` for ambiguous input → falls through to existing hover logic unchanged.
- Rollback: revert the 4-line call site in `extract_symbol_hover`; the detection methods are dead code and can be removed separately.

## Follow-ups

- Recognised metacharacters do not cover POSIX classes (`[:alpha:]`) or Unicode properties (`\p{Letter}`) — future PR.
- The regex detector is line-scoped; multi-line heredoc-style regex patterns are not detected (acceptable for initial implementation).