### PR TITLE
fix(parser): treat print STDERR => as list call not indirect object (#2392)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -149,10 +149,15 @@ impl<'a> Parser<'a> {
             // But NOT if followed by comma — that's a regular call: open FILE, "..."
             // And NOT if followed by arrow — that's a class method chain:
             //   print Data::Dumper->new([$self])->Dump()
+            // And NOT if followed by fat arrow — that's a hash-style list, NOT indirect:
+            //   print STDERR => "msg"  means  print(STDERR => "msg"), not print to STDERR
             if next_kind == TokenKind::Identifier {
                 if next_text.chars().next().is_some_and(|c| c.is_uppercase()) {
                     if let Ok(third) = self.tokens.peek_third() {
-                        if third.kind == TokenKind::Comma || third.kind == TokenKind::Arrow {
+                        if matches!(
+                            third.kind,
+                            TokenKind::Comma | TokenKind::Arrow | TokenKind::FatArrow
+                        ) {
                             return false;
                         }
                     }
@@ -348,6 +353,14 @@ impl<'a> Parser<'a> {
         // Parse remaining arguments
         let mut args = vec![];
 
+        // In Perl, `=>` (fat arrow) is equivalent to `,` everywhere, including
+        // in indirect-call argument lists.  Consume any leading `=>` that
+        // separates the filehandle/object from the first argument:
+        //   print STDERR => "msg";  — STDERR is object, "msg" is first arg
+        if self.peek_kind() == Some(TokenKind::FatArrow) {
+            self.tokens.next()?; // consume =>
+        }
+
         // Continue parsing arguments until we hit a statement terminator
         // Word operators (or, and, not, xor) bind less tightly than list operators,
         // so they terminate argument collection for indirect calls.
@@ -367,9 +380,12 @@ impl<'a> Parser<'a> {
             // Use parse_assignment instead of parse_expression to avoid grouping by comma operator
             args.push(self.parse_assignment()?);
 
-            // Check if we should continue (comma is optional in indirect syntax)
-            if self.peek_kind() == Some(TokenKind::Comma) {
-                self.tokens.next()?; // consume comma
+            // Check if we should continue (comma or fat arrow as separator in indirect syntax)
+            if matches!(
+                self.peek_kind(),
+                Some(TokenKind::Comma | TokenKind::FatArrow)
+            ) {
+                self.tokens.next()?; // consume , or =>
             } else if Self::is_statement_terminator(self.peek_kind())
                 || self.is_statement_modifier_keyword()
             {

--- a/crates/perl-parser-core/tests/fix_fat_arrow_filehandle_tests.rs
+++ b/crates/perl-parser-core/tests/fix_fat_arrow_filehandle_tests.rs
@@ -1,0 +1,67 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Issue #2392: print STDERR => "msg" was misclassified as indirect-call syntax
+// because the is_indirect_call_pattern() guard checked for Comma and Arrow but
+// not FatArrow. Adding FatArrow to the short-circuit guard fixes this.
+
+#[test]
+fn test_print_stderr_fat_arrow() {
+    let source = r#"print STDERR => "error message\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_say_stdout_fat_arrow() {
+    let source = r#"say STDOUT => "hello\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_printf_stderr_fat_arrow() {
+    let source = r#"printf STDERR => "%s\n", $msg;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_filehandle_fat_arrow_in_sub() {
+    let source = r#"
+sub log_error {
+    my ($msg) = @_;
+    print STDERR => $msg;
+}
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_stderr_fat_arrow_with_concat() {
+    let source = r#"print STDERR => "Error: " . $err . "\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_stdout_fat_arrow() {
+    let source = r#"print STDOUT => "message\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_comma_still_works() {
+    // Ensure comma separator still treated as regular call (not indirect)
+    let source = r#"print STDERR, "message\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_indirect_object_still_works() {
+    // print STDERR "msg" (no fat arrow, no comma) should still work as indirect object
+    let source = r#"print STDERR "direct message\n";"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_print_fat_arrow_multiple_args() {
+    let source = r#"print STDERR => "val=%s\n", $val;"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

`print STDERR => "msg"` was producing an unclosed-brace parse error (issue #2392). The root cause was in `is_indirect_call_pattern()` in `crates/perl-parser-core/src/engine/parser/expressions/calls.rs`: the guard that short-circuits uppercase-bareword filehandle detection checked for `Comma` and `Arrow` after the bareword, but not `FatArrow`. So `STDERR =>` was classified as an indirect filehandle, causing the parser to consume `STDERR` as the object and then choke on `=>`.

The fix adds `TokenKind::FatArrow` to the `matches!()` guard in `is_indirect_call_pattern()`. When an uppercase bareword is followed by `=>`, the pattern returns `false` so the call goes through the regular list-call path where `=>` auto-quotes `STDERR` as a bareword string key — which is the correct Perl semantic.

A secondary hardening in `parse_indirect_call()` also makes the argument-list loop accept `FatArrow` as a separator alongside `Comma`, covering any residual cases where indirect-call syntax legitimately contains `=>` separators.

## Interface & compatibility

- perl-parser API: unchanged (behavior fix only, no public API change)
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Single guard change in `is_indirect_call_pattern()` (~line 112 of `calls.rs`):

```rust
// Before
if third.kind == TokenKind::Comma || third.kind == TokenKind::Arrow {

// After
if matches!(third.kind, TokenKind::Comma | TokenKind::Arrow | TokenKind::FatArrow) {
```

Plus a comment update explaining the fat-arrow case, and two small improvements in `parse_indirect_call()` to consume a leading `=>` and accept `=>` as an argument separator.

## How to review

Start at `crates/perl-parser-core/src/engine/parser/expressions/calls.rs`:
- Lines ~105–118: the guard fix in `is_indirect_call_pattern()`
- Lines ~308–346: the `parse_indirect_call()` robustness changes

Then `crates/perl-parser-core/tests/fix_fat_arrow_filehandle_tests.rs` for the 9 regression tests covering all three builtins (`print`/`say`/`printf`) with `STDERR`/`STDOUT` and `=>`.

## Evidence

```
cargo clippy -p perl-parser-core --tests  →  Finished (no warnings)
cargo test -p perl-parser-core            →  404 passed, 0 failed (lib)
cargo test -p perl-parser-core --test fix_fat_arrow_filehandle_tests
    →  9 passed; 0 failed
```

Pre-existing unrelated failure in `test_grep_block_file_test` (block_list_in_parens_tests) exists on master independently of this change.

## Risk & rollback

- Blast radius: `perl-parser-core` only. No API surface changes.
- Regression risk: low — the change only makes the guard more restrictive (adds one more token kind that triggers the short-circuit return `false`). Any code that was correctly parsed before continues to parse correctly.
- `print STDERR "msg"` (no fat arrow) is unaffected — the guard only fires when the third token is `FatArrow`.
- Rollback: revert the `matches!()` change in `is_indirect_call_pattern()`.

## Follow-ups

- The 9 corpus files mentioned in issue #2392 should be re-swept with `just cpan-corpus-ratchet` after merge to capture the newly clean parses.