### PR TITLE
test(parser): regression tests for and-after-call pattern (closes #2409)

### DIFF
--- a/crates/perl-parser-core/tests/fix_word_op_and_after_open_2409.rs
+++ b/crates/perl-parser-core/tests/fix_word_op_and_after_open_2409.rs
@@ -1,0 +1,59 @@
+//! Regression tests for issue #2409: `and` word operator after open(...) or
+//! similar 3-argument list-operator calls with explicit parentheses.
+//!
+//! Pattern: `open(my $fh, '<', $file) and do { ... }`
+//! Fixed as part of #2396 (word-op dispatch in parse_expression_statement).
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// === open() + and ===
+
+#[test]
+fn test_open_3arg_and_binmode() {
+    // Exact pattern from the issue description
+    assert_clean_parse("open(my $fh, '<', $f) and binmode($fh);");
+}
+
+#[test]
+fn test_open_3arg_and_do_block() {
+    // Pattern from Catalyst.pm: open(...) and do { ... }
+    assert_clean_parse(r#"open(my $fh, '<', $file) and do { print "ok\n" };"#);
+}
+
+#[test]
+fn test_open_2arg_and_die() {
+    // 2-argument open followed by and die
+    assert_clean_parse(r#"open(my $fh, $file) and die "unexpected";"#);
+}
+
+#[test]
+fn test_open_bareword_and_die() {
+    // open with bareword filehandle
+    assert_clean_parse(r#"open(FH, '<', $file) and print "opened";"#);
+}
+
+// === other list-ops + and ===
+
+#[test]
+fn test_close_fh_and_next() {
+    assert_clean_parse("close($fh) and next;");
+}
+
+#[test]
+fn test_function_call_and_expr() {
+    // Generic 3-arg function call followed by `and`
+    assert_clean_parse("foo($a, $b, $c) and bar();");
+}
+
+#[test]
+fn test_function_call_and_die() {
+    assert_clean_parse(r#"do_thing($x, $y) and die "unexpected success";"#);
+}
+
+// === and with complex RHS ===
+
+#[test]
+fn test_open_and_do_complex() {
+    assert_clean_parse(r#"open(my $fh, '<', $file) and do { local $/; <$fh> };"#);
+}


### PR DESCRIPTION
## Summary

Adds 8 regression tests for issue #2409 — the `and` word operator appearing after parenthesised function calls such as `open(my $fh, '<', $file) and binmode($fh)` and `open(...) and do { ... }`.

Investigation revealed the bug was already fixed as part of #2396 (PR #2451), which wired `parse_word_or_expr()` into `parse_expression_statement()`. The fix covers all call contexts including `open(...)`, generic 3-arg calls, and `close()`.

These tests serve as regression guards to ensure the pattern cannot silently regress in future parser changes.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

New test file `crates/perl-parser-core/tests/fix_word_op_and_after_open_2409.rs` with 8 tests:

- `test_open_3arg_and_binmode` — exact pattern from the issue spec
- `test_open_3arg_and_do_block` — Catalyst.pm pattern (`and do { ... }`)
- `test_open_2arg_and_die` — 2-arg open form
- `test_open_bareword_and_die` — bareword filehandle form
- `test_close_fh_and_next` — close() + and
- `test_function_call_and_expr` — generic 3-arg call + and
- `test_function_call_and_die` — generic call + and die
- `test_open_and_do_complex` — complex do-block RHS with local $/

## How to review

Single new test file. All tests call `assert_clean_parse()` — they pass if and only if the AST contains no `(error …)` / `(ERROR …)` / `missing_*` nodes. The tests document the expected behavior and will catch any future regression.

Pre-existing unrelated failure `test_grep_block_file_test` (grep with `-r` file-test operator inside a block, in `block_list_in_parens_tests.rs`) is not caused by this change — zero diff to that file.

## Evidence

```
running 8 tests
test test_close_fh_and_next ... ok
test test_function_call_and_die ... ok
test test_function_call_and_expr ... ok
test test_open_2arg_and_die ... ok
test test_open_3arg_and_binmode ... ok
test test_open_3arg_and_do_block ... ok
test test_open_and_do_complex ... ok
test test_open_bareword_and_die ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

fmt: PASS (auto-fixed one multiline call) | clippy: PASS | tests: PASS

## Risk & rollback

Test-only change. No production code modified. Rollback = revert the test file. Zero blast radius.

## Follow-ups

- `test_grep_block_file_test` failure (grep + `-r` file-test in block) is a separate issue, out of scope here.