### PR TITLE
fix(parser): relex slash as regex at statement start after closing brace (#2401)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -80,6 +80,14 @@ impl<'a> Parser<'a> {
         // Every new statement begins here
         self.at_stmt_start = true;
 
+        // A `/` at statement start is always a regex delimiter, never division.
+        // The lexer may be in ExpectOperator mode after a preceding block's `}`,
+        // causing it to emit Division (Slash) instead of RegexMatch.  Roll back
+        // and re-lex in ExpectTerm mode to get the correct token.
+        if self.tokens.peek()?.kind == TokenKind::Slash {
+            self.tokens.relex_as_term();
+        }
+
         let kind = self.tokens.peek()?.kind;
 
         // Don't check for labels here - it breaks regular identifier parsing

--- a/crates/perl-parser-core/tests/fix_unexpected_slash_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_slash_expr.rs
@@ -1,0 +1,64 @@
+/// Tests for issue #2401: unexpected_slash_expr — regex after complex LHS
+///
+/// Covers cases where `/pattern/` appears:
+///   1. After a block statement (e.g. `if (...) { } /re/`)
+///   2. After `=~` binding operator on complex LHS (method call result)
+///   3. Bare regex at statement start immediately after `{ }` ends a block
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// ── After =~ with simple variable (baseline — must stay passing) ────────────
+
+#[test]
+fn regex_after_binding_op_simple_var() {
+    assert_clean_parse("$str =~ /pattern/;");
+}
+
+// ── After =~ with method call result ─────────────────────────────────────────
+
+#[test]
+fn regex_after_binding_op_method_call() {
+    assert_clean_parse("if ($obj->method() =~ /pattern/) { 1; }");
+}
+
+// ── Bare /re/ at statement start following a block statement ─────────────────
+
+#[test]
+fn bare_regex_at_stmt_start_after_block() {
+    assert_clean_parse("if ($x) { 1; }\n/^prefix/ and do_thing();");
+}
+
+// ── Bare /re/ at statement start following a bare brace block ────────────────
+
+#[test]
+fn bare_regex_at_stmt_start_after_bare_block() {
+    assert_clean_parse("{ 1; }\n/^prefix/ and do_thing();");
+}
+
+// ── Full CPAN-style pattern: conditional with binding op ─────────────────────
+
+#[test]
+fn regex_in_if_with_binding_op() {
+    assert_clean_parse("if ($x =~ /re/) { }");
+}
+
+// ── Chained: multiple block stmts followed by bare regex ─────────────────────
+
+#[test]
+fn bare_regex_after_multiple_blocks() {
+    assert_clean_parse("if ($a) { 1; }\nwhile ($b) { 2; }\n/^prefix/ and do_thing();");
+}
+
+// ── Bare /re/ at file start (baseline — must stay passing) ───────────────────
+
+#[test]
+fn bare_regex_at_file_start() {
+    assert_clean_parse("/^prefix/ and do_thing();");
+}
+
+// ── !~ binding operator should also produce clean parse ──────────────────────
+
+#[test]
+fn regex_after_not_binding_op() {
+    assert_clean_parse("if ($str !~ /bad/) { 1; }");
+}


### PR DESCRIPTION
## Summary

Fixes #2401. After a block statement ends with `}`, the lexer is left in
`ExpectOperator` mode. When the next statement starts with `/pattern/`, the
lexer incorrectly emits `Division` (`Slash`) instead of `RegexMatch`, producing a
spurious parse error: *"expected expression, found '/' at position N"*.

The fix adds a guard at the top of `parse_statement_inner()`: if the first
peeked token is `Slash`, call `relex_as_term()` to roll the lexer back to that
token's start position in `ExpectTerm` mode and clear the peek cache. The next
`peek()` then correctly re-lexes `/` as `RegexMatch`.

This follows the existing `relex_as_term()` pattern already used in the codebase
for `split /regex/` and `grep /regex/` disambiguation (see `statements.rs:787`
and `postfix.rs:638`).

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-parser-core/src/engine/parser/statements.rs` — 8 lines added to
`parse_statement_inner()`. The guard only fires when the peeked token is
`TokenKind::Slash` (the division token), so it does not affect `//` (defined-or),
`/=` (division-assign), or any non-slash statement starts.

`crates/perl-parser-core/tests/fix_unexpected_slash_expr.rs` — 8 new tests covering:
- bare `/re/` after `if { }` block
- bare `/re/` after bare `{ }` block
- bare `/re/` after multiple chained blocks
- bare `/re/` at file start (baseline)
- `$str =~ /pattern/` (baseline)
- `$obj->method() =~ /pattern/` (method call LHS)
- `if ($x =~ /re/) { }` (binding op inside condition)
- `if ($str !~ /bad/) { }` (`!~` form)

## How to review

Start at `statements.rs`, the `parse_statement_inner()` function, around line 80.
The 8-line addition is the entire production change. The test file is self-contained
and uses the existing `assert_clean_parse` helper.

## Evidence

```
running 8 tests
test bare_regex_after_multiple_blocks ... ok
test bare_regex_at_file_start ... ok
test bare_regex_at_stmt_start_after_block ... ok
test bare_regex_at_stmt_start_after_bare_block ... ok
test regex_after_binding_op_method_call ... ok
test regex_after_binding_op_simple_var ... ok
test regex_after_not_binding_op ... ok
test regex_in_if_with_binding_op ... ok
test result: ok. 8 passed; 0 failed

fmt: PASS
clippy: PASS (no warnings)
perl-parser-core tests: 450 passed, 0 new failures
(pre-existing: test_grep_block_file_test — unrelated, fails on master too)
```

## Risk & rollback

**Blast radius**: `perl-parser-core` only. The guard is a single `if` branch at
statement start that only activates for `TokenKind::Slash`. All 450 existing
passing tests continue to pass. Rollback: revert the 8-line addition to
`parse_statement_inner()`.

**Failure mode**: If `relex_as_term()` were called on a token that is legitimately
a `Slash` in operator position at statement start (theoretically impossible in
valid Perl — division cannot appear as the first token of a statement), the relexed
token would become `Regex`, which the parser would attempt to parse as an expression
— a tolerable degradation with error recovery rather than a crash.

## Follow-ups

- `test_grep_block_file_test` (`if grep { BLOCK } @list { }`) is a pre-existing
  failure unrelated to this PR. Filed separately.
- Corpus ratchet (`just cpan-corpus-ratchet`) should be run after merge to capture
  the ~4 newly clean CPAN files.