### PR TITLE
fix(parser): recognise anonymous sub with attributes as expression

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -708,11 +708,16 @@ impl<'a> Parser<'a> {
 
             // Handle 'sub' specially - it might be an anonymous subroutine
             TokenKind::Sub => {
-                // Check if the token AFTER 'sub' is { or ( (anonymous subroutine)
+                // Check if the token AFTER 'sub' starts an anonymous subroutine:
+                //   sub { ... }          — block body
+                //   sub ( ... ) { ... }  — with prototype/signature
+                //   sub :attr { ... }    — with attribute(s), e.g. :lvalue, :shared
                 // We use peek_second() because peek() is still 'sub' (unconsumed)
                 let next = self.tokens.peek_second().ok().map(|t| t.kind);
-                if matches!(next, Some(k) if matches!(k, TokenKind::LeftBrace | TokenKind::LeftParen))
-                {
+                if matches!(
+                    next,
+                    Some(TokenKind::LeftBrace | TokenKind::LeftParen | TokenKind::Colon)
+                ) {
                     // It's an anonymous subroutine
                     self.parse_subroutine()
                 } else {

--- a/crates/perl-parser-core/tests/fix_variable_attributes_label_syntax.rs
+++ b/crates/perl-parser-core/tests/fix_variable_attributes_label_syntax.rs
@@ -1,0 +1,153 @@
+//! Tests for issue #2405: anonymous sub attribute syntax (`sub :lvalue { }`)
+//! and statement label syntax (`OUTER: for ...`).
+//!
+//! Root cause: In expression context, `sub` followed by `:` was not recognised
+//! as an anonymous subroutine — the parser only checked for `{` or `(` after
+//! `sub`, ignoring the `:attr` case.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// ---------------------------------------------------------------------------
+// Anonymous sub with attributes — the main failing patterns from CPAN
+// ---------------------------------------------------------------------------
+
+#[test]
+fn anon_sub_lvalue_attr_inline() {
+    // `my $f = sub :lvalue { $_[0] };`
+    let src = "my $f = sub :lvalue { $_[0] };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_lvalue_attr_with_space() {
+    // `my $f = sub : lvalue { $_[0] };`
+    let src = "my $f = sub : lvalue { $_[0] };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_lvalue_attr_typeglob_assign() {
+    // Core CPAN pattern: *foo = sub :lvalue { $_[0] };
+    let src = "*foo = sub :lvalue { $_[0] };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_lvalue_attr_multiline() {
+    // XML::Twig style — attribute on the next line
+    let src = "*{\"Foo::bar\"} = sub\n    :lvalue\n  { my $elt = shift; $elt->{x} };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_lvalue_attr_simple_multiline() {
+    // sub on one line, :lvalue on the next
+    let src = "my $f = sub\n    :lvalue\n{ $_[0] };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_method_and_lvalue_attrs() {
+    // Multiple attributes on anon sub
+    let src = "my $f = sub :lvalue :method { $_[0] };";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_attr_in_hash_value() {
+    // Anonymous sub with attribute as hash value
+    let src = "my %h = (foo => sub :lvalue { $_[0] });";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn anon_sub_attr_passed_as_arg() {
+    // Anonymous sub with attribute as function argument
+    let src = "install_method('foo', sub :lvalue { $_[0] });";
+    assert_clean_parse(src);
+}
+
+// ---------------------------------------------------------------------------
+// Named sub with attributes (already working but regression guard)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_sub_lvalue_attr() {
+    let src = "sub rbuf : lvalue { (tied *${$_[0]})->[3] }";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn named_sub_multiline_attr() {
+    let src = "sub foo\n    :lvalue\n{ return 1 }";
+    assert_clean_parse(src);
+}
+
+// ---------------------------------------------------------------------------
+// Variable attributes: my $var : attrname (regression guard — already working)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn my_scalar_lvalue_attr() {
+    let src = "my $x : lvalue;";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn my_array_shared_attr() {
+    let src = "my @arr : shared;";
+    assert_clean_parse(src);
+}
+
+#[test]
+fn my_scalar_lvalue_with_init() {
+    let src = "my $y : lvalue = 1;";
+    assert_clean_parse(src);
+}
+
+// ---------------------------------------------------------------------------
+// Statement labels — all-caps identifiers (regression guard — already working)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn outer_label_for_loop() {
+    let src = r#"OUTER: for my $i (1..10) { last OUTER; }"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn loop_label_while() {
+    let src = r#"LOOP: while (1) { last LOOP; }"#;
+    assert_clean_parse(src);
+}
+
+// ---------------------------------------------------------------------------
+// Real-world CPAN patterns from the issue
+// ---------------------------------------------------------------------------
+
+#[test]
+fn xml_twig_style_accessor_pattern() {
+    // From XML::Twig: typeglob = sub\n:lvalue\n{ ... }
+    let src = r#"
+*{"Foo::$att"} = sub
+    :lvalue
+  { my $elt = shift;
+    if (@_) { $elt->{att}->{$att} = $_[0]; }
+    $elt->{att}->{$att};
+  };
+"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn thread_queue_limit_lvalue() {
+    // From Thread::Queue: sub limit : lvalue { ... }
+    let src = r#"
+sub limit : lvalue {
+    my $self = shift;
+    $self->{LIMIT};
+}
+"#;
+    assert_clean_parse(src);
+}


### PR DESCRIPTION
## Summary

In expression context, `sub` followed by `:` (attribute introducer) was parsed as a bareword identifier rather than the start of an anonymous subroutine. The detection in `expressions/primary.rs` only checked for `{` or `(` after `sub`, missing the `:attr` form entirely.

Patterns like `my $f = sub :lvalue { $_[0] }` and `*foo = sub :lvalue { ... }` — common in CPAN modules that create lvalue accessors via typeglob assignment — produced parse errors: `expected expression, found ':' at position N`.

Fix: add `TokenKind::Colon` to the three-way detection condition so the parser routes to `parse_subroutine()` for the attribute case. `parse_subroutine()` already handles the no-name / anonymous case and calls `parse_declaration_attributes()` for the `:attr` list, so no further changes were needed.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged  
- DAP surface: unchanged
- CLI: unchanged

## What changed

Single condition change in `primary.rs` at the `TokenKind::Sub` arm of the primary expression parser. The `matches!` guard now includes `TokenKind::Colon` alongside `TokenKind::LeftBrace` and `TokenKind::LeftParen`.

## How to review

Start at `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` line ~709 — the `TokenKind::Sub` arm. The change is 3 lines. The test file `tests/fix_variable_attributes_label_syntax.rs` covers:
- Inline: `sub :lvalue { }` 
- With space: `sub : lvalue { }`
- Typeglob assign: `*foo = sub :lvalue { }`
- Multiline (XML::Twig style): attribute on the next line
- Multiple attributes: `sub :lvalue :method { }`
- As hash value / function argument
- Named sub regression guards
- Variable attribute and statement label regression guards (already worked)

## Evidence

```
test anon_sub_lvalue_attr_inline ... ok
test anon_sub_lvalue_attr_with_space ... ok
test anon_sub_lvalue_attr_typeglob_assign ... ok
test anon_sub_lvalue_attr_multiline ... ok
test anon_sub_lvalue_attr_simple_multiline ... ok
test anon_sub_method_and_lvalue_attrs ... ok
test anon_sub_attr_in_hash_value ... ok
test anon_sub_attr_passed_as_arg ... ok
test xml_twig_style_accessor_pattern ... ok
test named_sub_lvalue_attr ... ok
test named_sub_multiline_attr ... ok
test my_scalar_lvalue_attr ... ok
test my_array_shared_attr ... ok
test outer_label_for_loop ... ok
test loop_label_while ... ok
test thread_queue_limit_lvalue ... ok
test result: ok. 17 passed; 0 failed

fmt:    PASS
clippy: PASS  
tests:  PASS (one pre-existing unrelated failure in block_list_in_parens_tests::test_grep_block_file_test confirmed present on master before this change)
```

## Risk & rollback

Low risk — the change only adds `Colon` as a trigger for `parse_subroutine()`. The only way this could misfire is if `sub` legitimately appears as a bareword before `:` in expression context, which is not valid Perl syntax. `parse_subroutine()` already correctly handles anonymous subs (no name, no body) via the forward-declaration path.

Rollback: revert the single condition change in `primary.rs`.

## Follow-ups

- `test_grep_block_file_test` (`if grep {-r ...} @files { }`) is a pre-existing failure on master — out of scope for this PR.