### PR TITLE
fix(parser): treat print STDERR => as list call not indirect object (#2392)

### DIFF
--- a/crates/perl-parser-core/tests/fix_unclosed_brace_2392.rs
+++ b/crates/perl-parser-core/tests/fix_unclosed_brace_2392.rs
@@ -1,0 +1,38 @@
+//! Tests for issue #2392 — print/say/printf with uppercase bareword filehandle
+//! followed by fat-arrow (=>) were incorrectly treated as indirect call syntax.
+//!
+//! Root cause: `is_indirect_call_pattern()` in calls.rs checked for Comma and Arrow
+//! but not FatArrow when deciding whether `print STDERR => ...` is a list call.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn print_stderr_fat_arrow() {
+    assert_clean_parse(r#"print STDERR => "error message\n";"#);
+}
+
+#[test]
+fn warn_stderr_fat_arrow() {
+    assert_clean_parse(r#"warn STDERR => "something wrong\n";"#);
+}
+
+#[test]
+fn say_stdout_fat_arrow() {
+    assert_clean_parse(r#"say STDOUT => "line\n";"#);
+}
+
+#[test]
+fn printf_stderr_fat_arrow() {
+    assert_clean_parse(r#"printf STDERR => "%s\n", $msg;"#);
+}
+
+#[test]
+fn print_stdout_fat_arrow_multi_args() {
+    assert_clean_parse(r#"print STDOUT => $scalar, "\n";"#);
+}
+
+#[test]
+fn print_custom_fh_fat_arrow() {
+    assert_clean_parse(r#"print FILE => "data";"#);
+}


### PR DESCRIPTION
## Summary

When `print`, `say`, or `printf` is followed by an uppercase bareword (e.g. `STDERR`, `STDOUT`, `FILE`) and then a fat-arrow (`=>`), the parser incorrectly classified the statement as indirect-object call syntax. This produced `(ERROR "expected expression, found '=>' at position N")` instead of parsing the fat-arrow as a list separator.

The fix is one line in `is_indirect_call_pattern()` in `calls.rs`: the guard that bails out of indirect-object detection when the third token is a `Comma` or `Arrow` (`->`) now also bails out on `FatArrow` (`=>`).

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-parser-core/src/engine/parser/expressions/calls.rs` — at the uppercase-bareword filehandle branch in `is_indirect_call_pattern()`, extended the guard condition from:

```rust
if third.kind == TokenKind::Comma || third.kind == TokenKind::Arrow {
    return false;
}
```

to:

```rust
if matches!(third.kind, TokenKind::Comma | TokenKind::Arrow | TokenKind::FatArrow) {
    return false;
}
```

The `warn` builtin was already unaffected (it is not in the `indirect_builtins` list), so `warn STDERR => "msg"` already parsed correctly.

## How to review

Start at `calls.rs` line ~155 — the `is_indirect_call_pattern()` function, uppercase-bareword branch. The diff is a single condition change. The new test file `tests/fix_unclosed_brace_2392.rs` has 6 cases covering all affected builtins and edge cases from the plan-reviewer spec.

## Evidence

```
running 6 tests
test print_stderr_fat_arrow ... ok
test print_custom_fh_fat_arrow ... ok
test say_stdout_fat_arrow ... ok
test print_stdout_fat_arrow_multi_args ... ok
test printf_stderr_fat_arrow ... ok
test warn_stderr_fat_arrow ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured
```

Note: `test_grep_block_file_test` in `block_list_in_parens_tests.rs` fails — this is a pre-existing failure on master before this change (`if grep { ... } @list { }` — separate bug where `parse_if_statement()` requires `(` after `if`). Also `perl-lsp-workspace-symbols/tests/edge_cases.rs` has pre-existing `expect()` calls that fail the `clippy-no-unwrap-all` gate — neither is introduced by this PR.

## Risk & rollback

Blast radius is narrow: only the branch in `is_indirect_call_pattern()` that handles `print/say/printf UPPERCASE_WORD ...`. Rollback: revert the one-line condition change. No other files touched.

## Follow-ups

- File new issue for `if grep { ... } @list { }` parsing failure (separate bug: `parse_if_statement()` requires `(` after `if`, tracked via pre-existing `test_grep_block_file_test` failure)
- File new issue for pre-existing `expect()` calls in `perl-lsp-workspace-symbols/tests/edge_cases.rs` blocking `ci-gate`

Closes #2392