### PR TITLE
test(parser): regression tests for unexpected_rbrace_expr (#2404)

### DIFF
--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
@@ -1,0 +1,67 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Regression tests for issue #2404 — unexpected_rbrace_expr
+// These patterns already parse correctly; tests guard against regression.
+
+// Empty anonymous hash ref — already handled by parse_hash_or_block_inner lines 48-58
+#[test]
+fn test_empty_hash_ref_bare() {
+    assert_clean_parse("my $h = {};");
+}
+
+#[test]
+fn test_empty_hash_ref_list() {
+    assert_clean_parse("my @a = ({}, {});");
+}
+
+#[test]
+fn test_empty_hash_ref_nested() {
+    assert_clean_parse("my $x = { a => {} };");
+}
+
+#[test]
+fn test_empty_hash_ref_bless() {
+    assert_clean_parse("bless {}, 'Foo';");
+}
+
+#[test]
+fn test_empty_hash_ref_ternary() {
+    assert_clean_parse("my $x = $c ? {} : undef;");
+}
+
+#[test]
+fn test_empty_hash_ref_or() {
+    assert_clean_parse("my $x = $y // {};");
+}
+
+#[test]
+fn test_empty_hash_ref_return() {
+    assert_clean_parse("sub f { return {}; }");
+}
+
+#[test]
+fn test_empty_hash_ref_in_sub_body() {
+    assert_clean_parse("sub new { my $self = {}; bless $self, 'Foo'; }");
+}
+
+// Empty do-block — already handled by parse_block() loop
+#[test]
+fn test_do_empty_block_stmt() {
+    assert_clean_parse("do {};");
+}
+
+#[test]
+fn test_do_empty_block_assign() {
+    assert_clean_parse("my $x = do {};");
+}
+
+#[test]
+fn test_do_empty_block_condition() {
+    assert_clean_parse("if (do {}) { }");
+}
+
+#[test]
+fn test_do_empty_block_with_space() {
+    assert_clean_parse("do { };");
+}


### PR DESCRIPTION
## Summary

Adds 12 regression tests for issue #2404 (`unexpected_rbrace_expr` error bucket). The plan-review determined that the two parser patterns cited in the issue — empty anonymous hash refs (`{}`) and empty do-blocks (`do {}`) — already parse correctly in the current parser. No parser logic changes are needed.

These tests lock in that behavior so future refactors of `parse_hash_or_block_inner` or `parse_block()` cannot silently regress these patterns.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

New test file `crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs` with 12 tests covering:

- Empty hash refs in 8 contexts: bare assignment, list, nested, bless, ternary branch, `//` fallback, `return`, sub body
- Empty do-blocks in 4 contexts: statement, assignment, condition, with interior whitespace

## How to review

Single new file. No parser source touched. All tests pass on current master.

## Evidence

```
running 12 tests
test test_do_empty_block_assign ... ok
test test_do_empty_block_condition ... ok
test test_do_empty_block_stmt ... ok
test test_do_empty_block_with_space ... ok
test test_empty_hash_ref_bare ... ok
test test_empty_hash_ref_bless ... ok
test test_empty_hash_ref_in_sub_body ... ok
test test_empty_hash_ref_list ... ok
test test_empty_hash_ref_nested ... ok
test test_empty_hash_ref_or ... ok
test test_empty_hash_ref_return ... ok
test test_empty_hash_ref_ternary ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Note: `ci-gate` shows a pre-existing clippy failure in `perl-lsp-workspace-symbols/tests/edge_cases.rs` (unrelated `expect()` usage). This exists on master before this PR.

## Risk & rollback

Zero risk — tests-only change. Rollback = revert the single new file.

## Follow-ups

- The 8 corpus files with `unexpected_rbrace_expr` as their first error require the CPAN corpus to be installed (`just cpan-corpus-install`) to identify their exact patterns. Those may need separate issues once the corpus is available locally.