### PR TITLE
test(parser): regression tests for qr<...> angle-bracket delimiter (#2406)

### DIFF
--- a/crates/perl-parser-core/tests/fix_qr_angle_delimiter.rs
+++ b/crates/perl-parser-core/tests/fix_qr_angle_delimiter.rs
@@ -1,0 +1,95 @@
+//! Regression tests: qr<> angle-bracket delimiter (corpus: Template-Toolkit)
+//! Issue #2406: Template/Parser.pm was filed under unclosed_angle error bucket (stale sweep data).
+//! Plan-review confirmed the parser already handles qr<...> correctly at all layers.
+//! Template/Parser.pm line 391: my $tags_dir = $self->{ANYCASE} ? qr<TAGS>i : qr<TAGS>;
+//! These tests lock in the correct behaviour and prevent future regressions.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// --- qr<...> basic patterns ---
+
+#[test]
+fn qr_angle_basic() {
+    assert_clean_parse(r#"my $re = qr<TAGS>;"#);
+}
+
+#[test]
+fn qr_angle_with_i_modifier() {
+    assert_clean_parse(r#"my $re = qr<TAGS>i;"#);
+}
+
+#[test]
+fn qr_angle_multiple_modifiers() {
+    assert_clean_parse(r#"my $re = qr<foo\s+bar>xi;"#);
+}
+
+#[test]
+fn qr_angle_in_ternary() {
+    // The exact pattern from Template::Parser line 391
+    assert_clean_parse(r#"my $tags_dir = $self->{ANYCASE} ? qr<TAGS>i : qr<TAGS>;"#);
+}
+
+#[test]
+fn qr_angle_nested_delimiters() {
+    // Nested angle brackets — depth counter must handle these
+    assert_clean_parse(r#"my $re = qr<a<b>c>;"#);
+}
+
+#[test]
+fn qr_angle_special_chars() {
+    assert_clean_parse(r#"my $re = qr<\d+\s*>;"#);
+}
+
+#[test]
+fn qr_angle_empty() {
+    assert_clean_parse(r#"my $re = qr<>;"#);
+}
+
+// --- Other quote-like operators with angle brackets ---
+
+#[test]
+fn m_angle_delimiter() {
+    // m<> uses the same delimiter path as qr<>
+    assert_clean_parse(r#"if ($x =~ m<pattern>i) { }"#);
+}
+
+#[test]
+fn s_angle_angle() {
+    assert_clean_parse(r#"$x =~ s<foo><bar>;"#);
+}
+
+#[test]
+fn tr_angle_angle() {
+    assert_clean_parse(r#"$x =~ tr<a-z><A-Z>;"#);
+}
+
+#[test]
+fn y_angle_angle() {
+    assert_clean_parse(r#"$x =~ y<abc><def>;"#);
+}
+
+// --- qr with other paired delimiters (regression guard) ---
+
+#[test]
+fn qr_parens() {
+    assert_clean_parse(r#"my $re = qr(foo)i;"#);
+}
+
+#[test]
+fn qr_brackets() {
+    assert_clean_parse(r#"my $re = qr[foo]i;"#);
+}
+
+#[test]
+fn qr_braces() {
+    assert_clean_parse(r#"my $re = qr{foo}i;"#);
+}
+
+// --- Real-world patterns from CPAN ---
+
+#[test]
+fn qr_angle_complex_pattern() {
+    // Complex nested angle-bracket pattern
+    assert_clean_parse(r#"my $re = qr<(?:foo|bar)<baz>>xi;"#);
+}


### PR DESCRIPTION
## Summary

Issue #2406 filed \`Template/Parser.pm\` under the \`unclosed_angle\` error bucket. Plan-review investigated all five parsing layers (lexer, tokenizer bridge, quote parser, parser expressions) and confirmed the parser already handles \`qr<...>\` correctly — the corpus sweep data was stale. No parser code fix is needed.

This PR adds 15 regression tests to lock in the correct behaviour and prevent future breakage.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

New test file: \`crates/perl-parser-core/tests/fix_qr_angle_delimiter.rs\`

Tests cover:
- \`qr<>\` basic, with \`i\`, \`xi\` modifiers, empty, special chars (\`\d+\s*\`)
- Nested angle brackets: \`qr<a<b>c>\` (exercises the lexer depth counter)
- Exact pattern from \`Template::Parser\` line 391: ternary with \`qr<TAGS>i : qr<TAGS>\`
- All other quote-like operators with angle brackets: \`m<>\`, \`s<><>\`, \`tr<><>\`, \`y<><>\`
- Other paired delimiters as regression guard: \`qr()\`, \`qr[]\`, \`qr{}\`
- Complex nested pattern: \`qr<(?:foo|bar)<baz>>xi\`

## How to review

Single new file, no production code changed. Read \`crates/perl-parser-core/tests/fix_qr_angle_delimiter.rs\` — all 15 tests are self-explanatory. The module doc comment explains the issue context.

## Evidence

\`\`\`
running 15 tests
test m_angle_delimiter ... ok
test qr_angle_complex_pattern ... ok
test qr_angle_in_ternary ... ok
test qr_angle_nested_delimiters ... ok
test qr_angle_basic ... ok
test qr_angle_multiple_modifiers ... ok
test qr_angle_empty ... ok
test qr_angle_special_chars ... ok
test qr_angle_with_i_modifier ... ok
test qr_braces ... ok
test qr_brackets ... ok
test qr_parens ... ok
test s_angle_angle ... ok
test tr_angle_angle ... ok
test y_angle_angle ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\`\`\`

Note: \`just ci-gate\` fails with a pre-existing \`expect()\` clippy error in \`perl-lsp-workspace-symbols/tests/edge_cases.rs\` — confirmed present on master before this branch.

## Risk & rollback

Zero risk — tests only, no production code touched. Rollback = revert the single file.

## Follow-ups

- Pre-existing CI gate failure in \`perl-lsp-workspace-symbols/tests/edge_cases.rs\` (two \`expect()\` calls) should be filed as a separate issue.
- Plan-review noted \`assert_clean_parse\` false-positives on files containing \`use constant ERROR => 2\` — worth a separate enhancement to use \`NodeKind::Error\` AST walk instead of string matching. Not in scope for this PR.

Closes #2406

## What's next (builder retrospective)

The plan-review spec was precise — all 15 tests passed on the first run with no iteration. The main friction was distinguishing pre-existing CI failures from regressions; the \`git stash\` check pattern (stash, re-run failing test, observe same failure) confirmed both \`test_grep_block_file_test\` and the \`perl-lsp-workspace-symbols\` \`expect()\` errors predate this branch.

Surprising latent hazard: \`assert_clean_parse\` string-matches \`(ERROR \` in the sexp, which false-positives on any Perl file defining \`use constant ERROR => 2\`. The corpus sweep correctly uses \`NodeKind::Error\` AST walk and does not have this bug. A follow-up enhancement to align the test helper with the corpus sweep would eliminate future confusion.

For agents picking up other \`unclosed_angle\` bucket work: verify bucket data against current master before assuming the file still fails — this bucket had at least one stale entry.