### PR TITLE
fix(test): use AST walk instead of string matching in assert_clean_parse (#2553)

### DIFF
--- a/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
+++ b/crates/perl-parser-core/tests/cpan_test_helpers/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use perl_parser_core::{NodeKind, Parser};
+use perl_parser_core::{Node, NodeKind, Parser};
 use perl_tdd_support::must;
 
 /// Parse the given source and return the top-level AST node.
@@ -10,37 +10,40 @@ pub fn parse(source: &str) -> perl_parser_core::Node {
     must(parser.parse())
 }
 
-/// Assert that a parsed AST has no Error / Missing* nodes anywhere in the
-/// S-expression representation. This is a conservative "clean parse" check.
-pub fn assert_clean_parse(source: &str) {
-    let ast = parse(source);
-    let sexp = ast.to_sexp();
-
-    for marker in ERROR_MARKERS {
-        assert!(
-            !sexp.contains(marker),
-            "Clean-parse assertion failed: found '{}' in sexp for source:\n{}\n\nsexp:\n{}",
-            marker,
-            source,
-            sexp,
-        );
+/// Walk the AST recursively and return the kind_name of the first error or
+/// missing node found, or `None` if the tree is clean.
+fn find_first_error(node: &Node) -> Option<&'static str> {
+    match &node.kind {
+        NodeKind::Error { .. }
+        | NodeKind::MissingExpression
+        | NodeKind::MissingStatement
+        | NodeKind::MissingIdentifier
+        | NodeKind::MissingBlock => return Some(node.kind.kind_name()),
+        _ => {}
     }
+    for child in node.children() {
+        if let Some(name) = find_first_error(child) {
+            return Some(name);
+        }
+    }
+    None
 }
 
-/// Error markers used by both `assert_clean_parse` and `assert_has_error`.
-const ERROR_MARKERS: &[&str] = &[
-    "(error ",
-    "(Error ",
-    "(ERROR ",
-    "(missing_expression",
-    "(missing_statement",
-    "(missing_identifier",
-    "(missing_block",
-    "MissingExpression",
-    "MissingStatement",
-    "MissingIdentifier",
-    "MissingBlock",
-];
+/// Assert that a parsed AST has no Error / Missing* nodes anywhere in the
+/// tree. Uses AST node walking rather than sexp string matching to avoid
+/// false-positives on valid Perl that contains "ERROR" as an identifier.
+pub fn assert_clean_parse(source: &str) {
+    let ast = parse(source);
+    let error_kind = find_first_error(&ast);
+    let sexp = ast.to_sexp();
+    assert!(
+        error_kind.is_none(),
+        "Clean-parse assertion failed: found '{}' node in AST for source:\n{}\n\nsexp:\n{}",
+        error_kind.unwrap_or(""),
+        source,
+        sexp,
+    );
+}
 
 /// Assert that a parsed AST contains at least one Error or Missing* node
 /// whose sexp representation contains the given `needle` substring.
@@ -53,8 +56,8 @@ pub fn assert_has_error(source: &str, needle: &str) {
     let sexp_lower = sexp.to_lowercase();
     let needle_lower = needle.to_lowercase();
 
-    // First verify there IS an error node somewhere.
-    let has_any_error = ERROR_MARKERS.iter().any(|marker| sexp.contains(marker));
+    // First verify there IS an error node somewhere using AST walk.
+    let has_any_error = find_first_error(&ast).is_some();
     assert!(has_any_error, "Expected an error node for source:\n{}\n\nsexp:\n{}", source, sexp,);
 
     // Then verify the needle appears (case-insensitive) in the sexp.

--- a/crates/perl-parser-core/tests/fix_assert_clean_parse_error_false_positive.rs
+++ b/crates/perl-parser-core/tests/fix_assert_clean_parse_error_false_positive.rs
@@ -1,0 +1,32 @@
+//! Regression test: assert_clean_parse must not false-positive on valid Perl
+//! that contains the literal string "ERROR" in an identifier.
+//!
+//! Issue #2553: `use constant ERROR => 2;` was flagged as a parse error because
+//! assert_clean_parse string-matched "(ERROR " in the S-expression output.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+/// `use constant ERROR => 2;` is valid Perl -- the word ERROR is a constant name,
+/// not an AST error node. The old string-matching approach would see "(ERROR "
+/// in the sexp and incorrectly fail this assertion.
+#[test]
+fn test_constant_named_error_is_clean() {
+    let source = "use constant ERROR => 2;";
+    assert_clean_parse(source);
+}
+
+/// Also verify a constant named with an ERROR-prefixed name doesn't trip it.
+#[test]
+fn test_constant_error_prefix_name_is_clean() {
+    let source = "use constant ERROR_CODE => 42;";
+    assert_clean_parse(source);
+}
+
+/// Verify that assert_has_error still correctly identifies real parse errors.
+#[test]
+fn test_assert_has_error_still_catches_real_errors() {
+    // A bare semicolon where an expression is required is a real parse error.
+    let source = "my $x = ;";
+    assert_has_error(source, "expected expression");
+}


### PR DESCRIPTION
## Summary

`assert_clean_parse` in `crates/perl-parser-core/tests/cpan_test_helpers/mod.rs` used string-matching on the S-expression output to detect error nodes. It checked for substrings like `(ERROR `, `(error `, `(missing_expression`, etc. This false-positived on valid Perl that happens to contain `ERROR` (or any of the marker strings) as an identifier.

The concrete failing case: `use constant ERROR => 2;` — the S-expression renderer emits `(use constant (ERROR 2))` for constant declarations, causing the string match to fire even though there is no parse error in the AST.

This PR replaces the string-matching approach with a recursive AST node walk. `find_first_error` pattern-matches on `NodeKind::Error { .. }`, `NodeKind::MissingExpression`, `NodeKind::MissingStatement`, `NodeKind::MissingIdentifier`, and `NodeKind::MissingBlock` — the actual error variants. It cannot be confused by identifier names.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

These are test helpers — no public API is affected.

## What changed

- `find_first_error(node: &Node) -> Option<&'static str>` — new private helper in `cpan_test_helpers/mod.rs` that walks the AST recursively and returns the `kind_name` of the first error node, or `None` for a clean tree.
- `assert_clean_parse` — replaced `ERROR_MARKERS` string loop with `find_first_error` call.
- `assert_has_error` — replaced `ERROR_MARKERS.iter().any(...)` with `find_first_error(...).is_some()`. Kept the existing sexp needle check for the specific error message.
- `ERROR_MARKERS` const — removed entirely.
- New test file `fix_assert_clean_parse_error_false_positive.rs` with 3 tests covering the regression case.

## How to review

Start at `crates/perl-parser-core/tests/cpan_test_helpers/mod.rs`. The diff is self-contained: `find_first_error` is added, the two assert functions are updated, the const is removed. The new test file is the regression proof.

## Evidence

```
test test_assert_has_error_still_catches_real_errors ... ok
test test_constant_error_prefix_name_is_clean ... ok
test test_constant_named_error_is_clean ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo fmt -p perl-parser-core -- --check  → PASS
cargo clippy -p perl-parser-core --tests -- -D warnings  → PASS
cargo test -p perl-parser-core  → PASS (1 pre-existing failure in block_list_in_parens_tests::test_grep_block_file_test, confirmed pre-existing via git stash verification)
```

## Risk & rollback

Blast radius: test infrastructure only. No production code changes.

The new approach is strictly more correct — it walks the typed AST rather than pattern-matching rendered text. If any test was silently passing due to the false-positive (i.e., calling `assert_clean_parse` on code that had a real AST error node but the string happened not to match), it will now correctly fail. That would surface a real bug, not introduce one.

Rollback: revert `cpan_test_helpers/mod.rs` to the string-matching approach.

## Follow-ups

- `test_grep_block_file_test` in `block_list_in_parens_tests` is a pre-existing failure unrelated to this change. Recommend a follow-up scout/builder.
- `perl-lsp-workspace-symbols/tests/edge_cases.rs` has pre-existing `expect()` clippy violations that block `just ci-gate`. Separate issue.

Closes #2553