### PR TITLE
fix: remove unreachable patterns and unused imports across workspace

### DIFF
--- a/crates/perl-dap/tests/dap_security_validation_tests.rs
+++ b/crates/perl-dap/tests/dap_security_validation_tests.rs
@@ -7,8 +7,8 @@
 //! - Secure defaults
 
 use perl_dap::security::{
-    DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, SecurityError, validate_condition, validate_expression,
-    validate_path, validate_timeout,
+    DEFAULT_TIMEOUT_MS, SecurityError, validate_condition, validate_expression, validate_path,
+    validate_timeout,
 };
 use perl_tdd_support::must;
 use std::path::PathBuf;

--- a/crates/perl-token/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-token/tests/comprehensive_unit_tests.rs
@@ -284,8 +284,6 @@ fn all_token_kinds() -> Vec<TokenKind> {
         // Special
         TokenKind::Eof,
         TokenKind::Unknown,
-        // Class field keyword
-        TokenKind::Field,
     ]
 }
 
@@ -426,8 +424,7 @@ fn all_variants_are_listed() {
             | TokenKind::SubSigil
             | TokenKind::GlobSigil
             | TokenKind::Eof
-            | TokenKind::Unknown
-            | TokenKind::Field => {}
+            | TokenKind::Unknown => {}
         }
     }
 }


### PR DESCRIPTION
## Summary

Mechanical cleanup of compiler warnings — no logic changes.

- Removed duplicate `TokenKind::Field` from `all_token_kinds()` vec in `perl-token/tests/comprehensive_unit_tests.rs`. The variant was listed twice: once in the keyword block (line 188) and again at the bottom as "Class field keyword" (line 288). This caused the `all_variants_unique` test to panic.
- Removed the now-unreachable `TokenKind::Field` match arm from `all_variants_are_listed` in the same file (line 430), which was already covered by the arm at line 336.
- Removed unused `MAX_TIMEOUT_MS` import from `perl-dap/tests/dap_security_validation_tests.rs`. The constant was imported but never referenced in any test body.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Two test files, three lines removed net. The `all_variants_unique` test was failing silently due to the duplicate in `all_token_kinds()` — fixing the unreachable match arm revealed that companion bug, and both are fixed here.

## How to review

Start with `crates/perl-token/tests/comprehensive_unit_tests.rs` — the duplicate `TokenKind::Field` in `all_token_kinds()` (around line 288) and the unreachable match arm (around line 430). Then check `crates/perl-dap/tests/dap_security_validation_tests.rs` line 10 for the removed import.

## Evidence

```
cargo clippy --workspace --tests 2>&1 | grep -E "unreachable pattern|unused import"
# (no output — zero warnings)

cargo test -p perl-token --tests
# test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Risk & rollback

Zero risk — test-only files, no production code touched. Rollback is `git revert` if needed.

## Follow-ups

Pre-existing `panic!` in `crates/perl-dap/tests/dap_adapter_tests.rs:36` causes `clippy -p perl-dap --tests` to error — out of scope for this PR but worth a separate fix.