### PR TITLE
fix(test): replace expect() with must() in workspace-symbols edge cases

### DIFF
--- a/crates/perl-lsp-workspace-symbols/tests/edge_cases.rs
+++ b/crates/perl-lsp-workspace-symbols/tests/edge_cases.rs
@@ -148,7 +148,7 @@ fn workspace_symbol_serializes_to_valid_json() {
         container_name: Some("MyPackage".to_string()),
     };
 
-    let json = serde_json::to_string(&sym).expect("should serialize");
+    let json = must(serde_json::to_string(&sym));
     assert!(json.contains("\"name\":\"test_fn\""));
     assert!(json.contains("\"kind\":12"));
     assert!(json.contains("\"containerName\":\"MyPackage\""));
@@ -166,7 +166,7 @@ fn workspace_symbol_without_container_omits_container_name_field() {
         container_name: None,
     };
 
-    let json = serde_json::to_string(&sym).expect("should serialize");
+    let json = must(serde_json::to_string(&sym));
     // skip_serializing_if = "Option::is_none" means absent when None
     assert!(!json.contains("containerName"), "containerName should be absent when None");
 }


### PR DESCRIPTION
## Summary

Two `serde_json::to_string()` calls in `crates/perl-lsp-workspace-symbols/tests/edge_cases.rs` used `.expect()` which is banned by the project coding standard (`-D clippy::expect-used`). This caused `clippy-no-unwrap-all` to fail for all PRs touching this crate.

The fix replaces both with `must(serde_json::to_string(...))` using the `perl_tdd_support::must` helper which was already imported in the same file. No behavior change — `must()` panics with the same effect as `expect()` in tests, but is the approved pattern.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-lsp-workspace-symbols/tests/edge_cases.rs` lines 151 and 169: replaced `.expect("should serialize")` with `must(...)`.

## How to review

Diff is 2 lines. Look at the two `workspace_symbol_serializes_to_valid_json` and `workspace_symbol_without_container_omits_container_name_field` tests. Both use `serde_json::to_string` which already returned `Ok` in every run — the only change is the error-handling style.

## Evidence

```
running 15 tests (edge_cases.rs)
test workspace_symbol_serializes_to_valid_json ... ok
test workspace_symbol_without_container_omits_container_name_field ... ok
... all 15 ok

cargo clippy -p perl-lsp-workspace-symbols --tests -- -D warnings
Finished `dev` profile — no errors
```

## Risk & rollback

Zero risk. Test-only file, no production code touched. Rollback: revert the 2-line change.

## Follow-ups

Note: `just ci-gate` has pre-existing failures in `perl-dap` (panic in test) and `xtask` (expect_err) that are unrelated to this PR and exist on master. These should be tracked separately.