### PR TITLE
feat(tooling): add files_by_bucket to corpus sweep baseline (schema 1.2.0)

### DIFF
--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -129,6 +129,8 @@ pub struct SweepReport {
     pub files_with_errors: usize,
     pub total_error_nodes: usize,
     pub first_error_buckets: BTreeMap<String, usize>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub files_by_bucket: BTreeMap<String, Vec<String>>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub file_results: Vec<FileResult>,
     pub elapsed_secs: f64,
@@ -423,6 +425,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
     let mut files_with_errors = 0usize;
     let mut total_error_nodes = 0usize;
     let mut first_error_buckets: BTreeMap<String, usize> = BTreeMap::new();
+    let mut files_by_bucket: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut file_results: Vec<FileResult> = Vec::new();
 
     for path in &pm_files {
@@ -458,6 +461,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
                 total_error_nodes += 1;
                 let bucket = "catastrophic_parse_failure".to_string();
                 *first_error_buckets.entry(bucket.clone()).or_default() += 1;
+                files_by_bucket.entry(bucket.clone()).or_default().push(path.display().to_string());
                 if config.verbose {
                     file_results.push(FileResult {
                         path: path.display().to_string(),
@@ -490,6 +494,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
             let first = summary.first_message.as_deref().unwrap_or("unknown");
             let bucket = normalize_error_bucket(first);
             *first_error_buckets.entry(bucket.clone()).or_default() += 1;
+            files_by_bucket.entry(bucket.clone()).or_default().push(path.display().to_string());
             if config.verbose {
                 file_results.push(FileResult {
                     path: path.display().to_string(),
@@ -509,7 +514,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
     let commit = get_git_commit();
 
     let report = SweepReport {
-        schema_version: "1.1.0".to_string(),
+        schema_version: "1.2.0".to_string(),
         commit,
         timestamp: chrono::Utc::now().to_rfc3339(),
         corpus_profile: corpus_profile.clone(),
@@ -526,6 +531,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
         files_with_errors,
         total_error_nodes,
         first_error_buckets,
+        files_by_bucket,
         file_results: if config.verbose { file_results } else { Vec::new() },
         elapsed_secs: elapsed.as_secs_f64(),
     };
@@ -786,7 +792,7 @@ mod tests {
         first_error_buckets: BTreeMap<String, usize>,
     ) -> SweepReport {
         SweepReport {
-            schema_version: "1.1.0".to_string(),
+            schema_version: "1.2.0".to_string(),
             commit: "abc".to_string(),
             timestamp: "now".to_string(),
             corpus_profile: "system".to_string(),
@@ -799,6 +805,7 @@ mod tests {
             files_with_errors,
             total_error_nodes,
             first_error_buckets,
+            files_by_bucket: BTreeMap::new(),
             file_results: vec![],
             elapsed_secs: 1.0,
         }
@@ -1370,5 +1377,72 @@ mod tests {
         let report = baseline.clone();
         let violations = enforce_ratchet(&report, &baseline);
         assert!(violations.is_empty(), "Empty baselines should have no violations");
+    }
+
+    // ── files_by_bucket tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_files_by_bucket_populated_for_error_files() {
+        // A report where files_by_bucket has known content
+        let mut fbb = BTreeMap::new();
+        fbb.insert("unclosed_brace".to_string(), vec!["Foo.pm".to_string(), "Bar.pm".to_string()]);
+        let report = SweepReport {
+            files_by_bucket: fbb,
+            ..test_report(8, 2, 3, 0, BTreeMap::from([("unclosed_brace".to_string(), 2)]))
+        };
+        let files = report.files_by_bucket.get("unclosed_brace").expect("bucket should exist");
+        assert_eq!(files.len(), 2);
+        assert!(files.contains(&"Foo.pm".to_string()));
+    }
+
+    #[test]
+    fn test_files_by_bucket_serde_roundtrip() {
+        let mut fbb = BTreeMap::new();
+        fbb.insert("expected_semicolon".to_string(), vec!["Some/Module.pm".to_string()]);
+        let report = SweepReport {
+            files_by_bucket: fbb,
+            ..test_report(9, 1, 1, 0, BTreeMap::from([("expected_semicolon".to_string(), 1)]))
+        };
+        let json = serde_json::to_string(&report).expect("serialize");
+        let back: SweepReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.files_by_bucket, report.files_by_bucket);
+    }
+
+    #[test]
+    fn test_files_by_bucket_absent_in_old_schema_deserializes_empty() {
+        // The existing backward-compat JSON (schema 1.0.0) has no files_by_bucket
+        // field — must deserialize as empty BTreeMap.
+        let old_json = r#"{
+            "schema_version": "1.0.0",
+            "commit": "abc",
+            "timestamp": "now",
+            "corpus_roots": ["/usr/share/perl"],
+            "total_files": 100,
+            "files_unreadable": 0,
+            "clean_files": 80,
+            "files_with_errors": 20,
+            "total_error_nodes": 30,
+            "first_error_buckets": {},
+            "elapsed_secs": 1.0
+        }"#;
+        let report: SweepReport = serde_json::from_str(old_json).expect("deserialize old schema");
+        assert!(report.files_by_bucket.is_empty(), "files_by_bucket should default to empty");
+    }
+
+    #[test]
+    fn test_files_by_bucket_not_examined_by_ratchet() {
+        // Different file lists in files_by_bucket with identical counts should not trigger
+        // violations — files_by_bucket is informational only, not part of the ratchet.
+        let mut fbb_a = BTreeMap::new();
+        fbb_a.insert("unclosed_brace".to_string(), vec!["A.pm".to_string()]);
+        let mut fbb_b = BTreeMap::new();
+        fbb_b.insert("unclosed_brace".to_string(), vec!["B.pm".to_string()]);
+        let baseline = SweepReport {
+            files_by_bucket: fbb_a,
+            ..test_report(9, 1, 1, 0, BTreeMap::from([("unclosed_brace".to_string(), 1)]))
+        };
+        let report = SweepReport { files_by_bucket: fbb_b, ..baseline.clone() };
+        let violations = enforce_ratchet(&report, &baseline);
+        assert!(violations.is_empty(), "files_by_bucket changes should not affect ratchet");
     }
 }


### PR DESCRIPTION
## Summary

Adds `files_by_bucket: BTreeMap<String, Vec<String>>` to `SweepReport` as a separate, additive field alongside the existing `first_error_buckets` count map. The field is populated unconditionally in both error-file branches of the sweep loop (catastrophic parse failure and normal error), so it appears in the baseline JSON produced by `just cpan-corpus-ratchet` without requiring `--verbose`.

Schema version bumped from `1.1.0` to `1.2.0`. Old JSON without `files_by_bucket` deserializes cleanly via `#[serde(default)]`.

The motivation is precision: scouts currently guess file-to-bucket attribution when filing issues, and 4/4 plan-reviews in Era 7 session 1 had to correct those guesses. With this field in the baseline, reviewers can verify claims in seconds.

## Interface & compatibility

- `perl-parser` API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged — `just cpan-corpus-ratchet` output grows from ~1KB to ~50KB; no behavioral change
- Baseline JSON: additive new field, old readers ignore it; old baselines deserialize as empty map

## What changed

`xtask/src/tasks/parser_corpus_sweep.rs` only:

1. New field on `SweepReport`: `files_by_bucket: BTreeMap<String, Vec<String>>` with `#[serde(skip_serializing_if = "BTreeMap::is_empty", default)]`
2. Initialization: `let mut files_by_bucket: BTreeMap<String, Vec<String>> = BTreeMap::new();` in `run()`
3. Population (catastrophic branch, line ~463): `files_by_bucket.entry(bucket.clone()).or_default().push(path.display().to_string());`
4. Population (normal error branch, line ~496): same pattern
5. Included in `SweepReport` construction in `run()`
6. Schema version bumped to `"1.2.0"` in `run()` and `test_report()` helper
7. `test_report()` helper updated with `files_by_bucket: BTreeMap::new()`
8. 4 new tests: content check, serde round-trip, backward-compat deserialization, ratchet isolation

## How to review

Start at the `SweepReport` struct (~line 131) then follow the sweep loop changes at lines ~464 and ~497. The test block is at the end of the file.

Hotspots: the two `files_by_bucket.entry(...).or_default().push(...)` lines — confirm they mirror the existing `first_error_buckets` increment pattern exactly.

## Evidence

```
running 4 tests
test tasks::parser_corpus_sweep::tests::test_files_by_bucket_absent_in_old_schema_deserializes_empty ... ok
test tasks::parser_corpus_sweep::tests::test_files_by_bucket_not_examined_by_ratchet ... ok
test tasks::parser_corpus_sweep::tests::test_files_by_bucket_populated_for_error_files ... ok
test tasks::parser_corpus_sweep::tests::test_files_by_bucket_serde_roundtrip ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 157 filtered out; finished in 0.00s

cargo clippy -p xtask --tests -- -D warnings: PASS
cargo fmt -p xtask -- --check: PASS
```

Pre-existing failures (6 `test_normalize_error_bucket_*` / `test_semantic_bucket_mapping`) exist on master before this PR — not introduced here.

## Risk & rollback

Blast radius: `xtask` only, no published crate, no runtime code path. The field is additive — consumers reading old baselines get an empty map, new baselines just have more data.

Rollback: revert this commit. The baseline JSON at `.ci/cpan-corpus-baseline.json` should be regenerated with `just cpan-corpus-ratchet` after merge.

## Follow-ups

- Regenerate `.ci/cpan-corpus-baseline.json` after merge: `just cpan-corpus-ratchet`
- Pre-existing `test_normalize_error_bucket_*` failures (6 tests on master) warrant a separate scout/builder — out of scope here