### PR TITLE
fix(parser): handle 'my $var->{key} = ...' lvalue declaration

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -94,7 +94,14 @@ impl<'a> Parser<'a> {
                 self.parse_assignment()?
             } else {
                 // For my/our/state, parse a simple variable
-                self.parse_variable()?
+                let var = self.parse_variable()?;
+                // If -> follows the declared variable, treat it as an lvalue subscript chain
+                // e.g. my $cache->{key} = expr  or  my $foo->method()
+                if self.peek_kind() == Some(TokenKind::Arrow) {
+                    self.parse_postfix_chain(var)?
+                } else {
+                    var
+                }
             };
 
             // Parse optional attributes

--- a/crates/perl-parser-core/tests/fix_my_var_arrow_lvalue.rs
+++ b/crates/perl-parser-core/tests/fix_my_var_arrow_lvalue.rs
@@ -1,0 +1,18 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn my_scalar_arrow_hash_subscript() {
+    assert_clean_parse(r#"my $cache->{key} = [1,2,3];"#);
+}
+
+#[test]
+fn my_scalar_arrow_nested_subscript() {
+    assert_clean_parse(r#"my $obj->{a}{b} = 'val';"#);
+}
+
+#[test]
+fn my_scalar_arrow_method_call() {
+    // my $foo->method() is unusual but syntactically valid Perl
+    assert_clean_parse(r#"my $foo->init();"#);
+}


### PR DESCRIPTION
## Summary

`my $cache->{key} = [1,2,3]` is a valid Perl idiom — declare `$cache` and immediately assign to a dereferenced slot. The parser was stopping after `my $cache`, leaving `->` at the expression level where no primary expression is expected, producing a spurious `(ERROR "expected expression, found '->' at position 9")` node.

The fix is a 7-line addition in `parse_variable_declaration`: after `parse_variable()` returns for `my`/`our`/`state` declarations, peek for `TokenKind::Arrow` and if present, call `parse_postfix_chain()` on the variable node to consume the subscript or method chain as the lvalue. The resulting node then flows into the existing initializer path unchanged.

## Interface & compatibility
- perl-parser API: unchanged — `VariableDeclaration` node shape is preserved; the `variable` field may now be a postfix chain node rather than a bare `Variable`, which is already the case for `local` declarations
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-parser-core/src/engine/parser/variables.rs` — in the single-variable declaration path (the `else` branch of the `declarator == "local"` check), replaced the bare `self.parse_variable()?` with a two-step: parse the variable, then if `->` follows, call `parse_postfix_chain()` on it. `local` already handled this pattern by calling `parse_assignment()`.

## How to review

- `variables.rs` diff: 8 lines, one `if/else` added after `parse_variable()` on line 97.
- `tests/fix_my_var_arrow_lvalue.rs`: 3 tests covering hash subscript, nested subscript, and method call.

## Evidence

```
test my_scalar_arrow_method_call ... ok
test my_scalar_arrow_hash_subscript ... ok
test my_scalar_arrow_nested_subscript ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

fmt: PASS
clippy -D warnings: PASS
```

Pre-existing failures (7) in `complex_paren_args_tests` are unrelated (`(caller 0)[8]` pattern) and present on master before this change.

## Risk & rollback

- Blast radius: small — only affects `my`/`our`/`state` declarations followed by `->`. The `local` path is unchanged. Compound assign operators (`||=`, `.=`, etc.) work correctly on the postfix chain node.
- Rollback: revert `variables.rs` 8-line addition.

## Follow-ups

None — this is a self-contained RC2 from issue #2188's original scope, fully addressed here.

Closes #2581