### PR TITLE
ci(hooks): hook reliability engineering — tests, drift fixes, executable-bit CI (#2297)

### DIFF
--- a/.ci/scripts/check-hook-executable.sh
+++ b/.ci/scripts/check-hook-executable.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# CI check: verify all registered hook scripts are executable
+#
+# Usage:
+#   ./.ci/scripts/check-hook-executable.sh
+#
+# Exit codes:
+#   0 — all hook scripts are executable
+#   1 — one or more hook scripts lack the executable bit
+
+set -euo pipefail
+
+FAILED=0
+
+for f in .claude/hooks/*.sh; do
+  if [[ ! -x "$f" ]]; then
+    echo "::error::Hook not executable: $f" >&2
+    FAILED=1
+  fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+  echo "Hook executable check passed"
+fi
+
+exit "$FAILED"

--- a/.ci/scripts/check-hook-registry.sh
+++ b/.ci/scripts/check-hook-registry.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# CI check: verify hook registry in settings.json matches files on disk
+#
+# Parses .claude/settings.json, extracts every .command that ends in .sh,
+# strips the "$CLAUDE_PROJECT_DIR"/ prefix, and verifies each file exists
+# and is executable.
+#
+# Usage:
+#   ./.ci/scripts/check-hook-registry.sh
+#
+# Exit codes:
+#   0 — all registered hook scripts exist and are executable
+#   1 — one or more registered scripts are missing or not executable
+
+set -euo pipefail
+
+SETTINGS=".claude/settings.json"
+FAILED=0
+
+if [[ ! -f "$SETTINGS" ]]; then
+  echo "::error::$SETTINGS not found" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "::error::jq is required but not installed" >&2
+  exit 1
+fi
+
+# Extract all .sh command paths from the hooks section
+# Strip the "$CLAUDE_PROJECT_DIR"/ prefix (with or without quotes around the variable)
+mapfile -t SCRIPT_PATHS < <(
+  jq -r '
+    .hooks
+    | to_entries[]
+    | .value[]
+    | .hooks[]?
+    | .command
+    | select(endswith(".sh"))
+  ' "$SETTINGS" \
+  | sed 's|"\$CLAUDE_PROJECT_DIR"/||g' \
+  | sed "s|\\\$CLAUDE_PROJECT_DIR/||g"
+)
+
+if [[ "${#SCRIPT_PATHS[@]}" -eq 0 ]]; then
+  echo "No .sh hook scripts registered in $SETTINGS — nothing to check"
+  exit 0
+fi
+
+for rel_path in "${SCRIPT_PATHS[@]}"; do
+  if [[ ! -f "$rel_path" ]]; then
+    echo "::error::Registered hook script missing: $rel_path" >&2
+    FAILED=1
+  elif [[ ! -x "$rel_path" ]]; then
+    echo "::error::Registered hook script not executable: $rel_path" >&2
+    FAILED=1
+  else
+    echo "  OK: $rel_path"
+  fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+  echo "Hook registry check passed (${#SCRIPT_PATHS[@]} scripts verified)"
+fi
+
+exit "$FAILED"

--- a/.ci/scripts/test-hooks.sh
+++ b/.ci/scripts/test-hooks.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Hook behavior tests — plain-bash unit tests, no bats required.
+# Modeled on .ci/scripts/check-from-raw.sh
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+assert_exit() {
+  local expected="$1"; shift
+  local desc="$1"; shift
+  local actual
+  actual=0
+  "$@" || actual=$?
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "  PASS: $desc (exit $actual)"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "  FAIL: $desc — expected exit $expected, got $actual" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  local desc="$2"
+  if [[ -f "$path" ]]; then
+    echo "  PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "  FAIL: $desc — file not found: $path" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+assert_executable() {
+  local path="$1"
+  local desc="$2"
+  if [[ -x "$path" ]]; then
+    echo "  PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "  FAIL: $desc — not executable: $path" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+assert_contains() {
+  local content="$1"
+  local pattern="$2"
+  local desc="$3"
+  if echo "$content" | grep -qE "$pattern"; then
+    echo "  PASS: $desc"
+    PASS=$(( PASS + 1 ))
+  else
+    echo "  FAIL: $desc — pattern '$pattern' not found in output" >&2
+    FAIL=$(( FAIL + 1 ))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test group: hook files exist and are executable
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Hook file existence and permissions ==="
+
+assert_file_exists "$HOOKS_DIR/task-completed.sh"     "task-completed.sh exists"
+assert_file_exists "$HOOKS_DIR/subagent-stop.sh"      "subagent-stop.sh exists"
+assert_file_exists "$HOOKS_DIR/pre-tool-use.sh"       "pre-tool-use.sh exists"
+assert_executable  "$HOOKS_DIR/task-completed.sh"     "task-completed.sh is executable"
+assert_executable  "$HOOKS_DIR/subagent-stop.sh"      "subagent-stop.sh is executable"
+assert_executable  "$HOOKS_DIR/pre-tool-use.sh"       "pre-tool-use.sh is executable"
+
+# ---------------------------------------------------------------------------
+# Test group: task-completed.sh
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== task-completed.sh behavior ==="
+
+# task-completed.sh should pass with no .rs changes staged (clean environment)
+assert_exit 0 "task-completed passes with no staged .rs files" \
+  bash "$HOOKS_DIR/task-completed.sh"
+
+# ---------------------------------------------------------------------------
+# Test group: subagent-stop.sh writes JSONL
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== subagent-stop.sh behavior ==="
+
+TMP_OPS="$(mktemp -d)"
+trap 'rm -rf "$TMP_OPS"' EXIT
+
+SAMPLE_PAYLOAD='{"subagent_name":"test-agent","subagent_type":"builder","session_id":"abc123"}'
+
+OUTPUT_FILE="$TMP_OPS/swarm-metrics.jsonl"
+echo "$SAMPLE_PAYLOAD" | OPS_DIR="$TMP_OPS" bash "$HOOKS_DIR/subagent-stop.sh"
+
+assert_file_exists "$OUTPUT_FILE" "subagent-stop.sh creates swarm-metrics.jsonl"
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  LINE="$(cat "$OUTPUT_FILE")"
+  assert_contains "$LINE" '"event":"subagent_stop"'  "JSONL contains event field"
+  assert_contains "$LINE" '"agent_name":"test-agent"' "JSONL contains agent_name"
+  assert_contains "$LINE" '"ts":"[0-9]{4}-'           "JSONL contains ts timestamp"
+fi
+
+# Custom OPS_DIR is respected
+TMP_CUSTOM="$(mktemp -d)"
+trap 'rm -rf "$TMP_OPS" "$TMP_CUSTOM"' EXIT
+echo "$SAMPLE_PAYLOAD" | OPS_DIR="$TMP_CUSTOM" bash "$HOOKS_DIR/subagent-stop.sh"
+assert_file_exists "$TMP_CUSTOM/swarm-metrics.jsonl" "subagent-stop.sh respects custom OPS_DIR"
+
+# ---------------------------------------------------------------------------
+# Test group: pre-tool-use.sh
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== pre-tool-use.sh behavior ==="
+
+SAFE_PAYLOAD='{"tool_input":{"command":"git status"}}'
+FORCE_PUSH_PAYLOAD='{"tool_input":{"command":"git push --force"}}'
+RESET_HARD_PAYLOAD='{"tool_input":{"command":"git reset --hard"}}'
+EMPTY_CMD_PAYLOAD='{"tool_input":{"command":""}}'
+
+assert_exit 0 "pre-tool-use allows safe commands (git status)" \
+  bash -c "echo '$SAFE_PAYLOAD' | bash '$HOOKS_DIR/pre-tool-use.sh'"
+
+assert_exit 2 "pre-tool-use blocks git push --force" \
+  bash -c "echo '$FORCE_PUSH_PAYLOAD' | bash '$HOOKS_DIR/pre-tool-use.sh'"
+
+assert_exit 2 "pre-tool-use blocks git reset --hard" \
+  bash -c "echo '$RESET_HARD_PAYLOAD' | bash '$HOOKS_DIR/pre-tool-use.sh'"
+
+assert_exit 0 "pre-tool-use allows empty command field" \
+  bash -c "echo '$EMPTY_CMD_PAYLOAD' | bash '$HOOKS_DIR/pre-tool-use.sh'"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block dangerous bash commands before execution
+# Exit 2 = block with feedback
+# Exit 0 = allow
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if echo "$CMD" | grep -qE 'git push --force|git push -f |git checkout \.|git reset --hard|rm -rf /|cargo publish|git clean -fd'; then
+  echo "Blocked: dangerous command '$CMD'. Use safer alternatives." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); if echo \"$CMD\" | grep -qE 'git push --force|git push -f |git checkout \\.|git reset --hard|rm -rf /|cargo publish|git clean -fd'; then echo \"Blocked: dangerous command '$CMD'. Use safer alternatives.\" >&2; exit 2; fi; exit 0"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-tool-use.sh"
           }
         ]
       }

--- a/docs/adr/0032-skill-scoping-and-hook-enforcement.md
+++ b/docs/adr/0032-skill-scoping-and-hook-enforcement.md
@@ -97,6 +97,20 @@ Instead of every agent prompt repeating "Invoke /coding-standards", context is i
 
 ---
 
+## Divergence from Original Design
+
+As of 2026-03-21, the following items described in this ADR were not implemented.
+Future agents should treat this section as the ground truth, not the decision tables above.
+
+| Hook | ADR Promise | Actual State |
+|------|------------|--------------|
+| `SubagentStart` | Auto-injects condensed coding standards and known pitfalls from `.claude/swarm-state/known-pitfalls.md` | Implemented as a bare `echo` command in `settings.json`; `.claude/swarm-state/` directory and `subagent-start.sh` do not exist |
+| `TaskCompleted` | Blocks completion unless a metrics entry exists in `swarm-metrics.jsonl` | Only checks `cargo fmt` and `CURRENT_STATUS.md`; no metrics gate implemented |
+| `TeammateIdle` | Registered in `settings.json` to block idle state if in-progress tasks exist | Hook script exists in `docs/handoff/swarm-pack/hooks/` but is **not registered** in live `settings.json` |
+| `PreToolUse` | (not in original ADR) | Inline in `settings.json` as of ADR write date; extracted to `.claude/hooks/pre-tool-use.sh` in PR #2297 |
+
+**Consequence for builders:** The metrics compliance guarantee (Decision 2) was never enforced. The original motivation — zero of 30 PRs contained a metrics entry — was not resolved by this ADR's implementation. A follow-up issue should implement the `TaskCompleted` metrics gate as a separate behavioral change requiring swarm-wide coordination.
+
 ## Files Changed
 
 | File | Change |

--- a/docs/handoff/swarm-pack/hooks/subagent-stop.sh
+++ b/docs/handoff/swarm-pack/hooks/subagent-stop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OPS_DIR="${OPS_DIR:-.ops}"
+OPS_DIR="${OPS_DIR:-.ops-perl-lsp}"
 METRICS_FILE="${OPS_DIR}/swarm-metrics.jsonl"
 
 mkdir -p "${OPS_DIR}"

--- a/docs/handoff/swarm-pack/hooks/task-completed.sh
+++ b/docs/handoff/swarm-pack/hooks/task-completed.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
-# TaskCompleted hook: quality gate before allowing task completion
-# Exit 2 = reject with feedback
-# Exit 0 = allow
+# TaskCompleted hook: verify quality before allowing task completion
+# Exit 2 = reject completion with feedback
+# Exit 0 = allow completion
 
-# Replace with your project's format check command
-FMT_CHECK_CMD="${FMT_CHECK_CMD:-cargo fmt --all -- --check}"
-
-if ! eval "$FMT_CHECK_CMD" 2>/dev/null; then
-  echo "Task completion blocked: format check failed. Fix formatting before marking complete."
+# Quick sanity check: is cargo fmt clean?
+if ! cargo fmt --all -- --check 2>/dev/null; then
+  echo "Task completion blocked: cargo fmt check failed. Run 'cargo fmt --all' before marking complete."
   exit 2
 fi
 
+# Check if test files were modified and CURRENT_STATUS.md needs updating
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+if git diff --cached --name-only 2>/dev/null | grep -qE '^crates/.*/tests/.*\.rs$' || \
+   git diff --name-only HEAD~1 2>/dev/null | grep -qE '^crates/.*/tests/.*\.rs$'; then
+  if command -v python3 &>/dev/null && [ -f "$REPO_ROOT/scripts/update-current-status.py" ]; then
+    python3 "$REPO_ROOT/scripts/update-current-status.py" 2>/dev/null || true
+    if ! git diff --quiet -- docs/project/CURRENT_STATUS.md 2>/dev/null; then
+      echo "Task completion blocked: test files changed but CURRENT_STATUS.md has stale counts."
+      echo "Run: python3 scripts/update-current-status.py && git add docs/project/CURRENT_STATUS.md"
+      exit 2
+    fi
+  fi
+fi
+
+# Allow completion
 exit 0

--- a/justfile
+++ b/justfile
@@ -440,7 +440,9 @@ ci-gate:
     just ci-semantic-frameworks && \
     just ci-dap-smoke-e2e && \
     just ci-parser-features-check && \
-    just ci-features-invariants
+    just ci-features-invariants && \
+    just hook-check && \
+    just hook-registry-check
     # @START=$$(date +%s); \
 
 # Gate runner with receipt output (Issue #210)
@@ -721,6 +723,18 @@ ci-policy:
     @echo "⚖️  Checking project policies..."
     just ci-check-todos
     @bash ./.ci/scripts/check-from-raw.sh
+
+# Check all registered hook scripts are executable
+hook-check:
+    @bash ./.ci/scripts/check-hook-executable.sh
+
+# Check hook registry in settings.json matches files on disk
+hook-registry-check:
+    @bash ./.ci/scripts/check-hook-registry.sh
+
+# Run all hook tests (behavior, registry, executable-bit)
+hook-tests:
+    @bash ./.ci/scripts/test-hooks.sh
 
 # Check for machine-specific paths in documentation
 ci-doc-paths:


### PR DESCRIPTION
## Summary

Fixes five concrete hook reliability gaps found during plan-review of #2297. Hooks were treated as "done once created" — no tests, no drift checks, no CI enforcement.

The PreToolUse guard was an untestable 200-character inline command in `settings.json`. Two swarm-pack documentation files had drifted from the live hooks (wrong `OPS_DIR`, generic template vs project-specific logic). No CI check existed to catch a future commit stripping the executable bit from a hook. No behavioral tests existed for any hook.

All five gaps addressed with shell-only changes (no Rust code touched).

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged
- Hook behavior: functionally identical — PreToolUse extraction is a pure refactor; same logic, now in a file

## What changed

| File | Change |
|------|--------|
| `.claude/hooks/pre-tool-use.sh` | New — extracted from inline `settings.json` command |
| `.claude/settings.json` | PreToolUse command updated to reference script file |
| `.ci/scripts/check-hook-executable.sh` | New — CI check: every `.claude/hooks/*.sh` must have `0755` |
| `.ci/scripts/check-hook-registry.sh` | New — CI check: every `.sh` in `settings.json` hooks must exist and be executable |
| `.ci/scripts/test-hooks.sh` | New — 16 behavioral tests (existence, permissions, JSONL output, OPS_DIR override, dangerous-command blocking) |
| `justfile` | Added `hook-check`, `hook-registry-check`, `hook-tests` targets; wired first two into `ci-gate` |
| `docs/handoff/swarm-pack/hooks/subagent-stop.sh` | Fixed `OPS_DIR` drift: `.ops` → `.ops-perl-lsp` |
| `docs/handoff/swarm-pack/hooks/task-completed.sh` | Replaced generic template with live project content |
| `docs/adr/0032-skill-scoping-and-hook-enforcement.md` | Added "Divergence from Original Design" section |

The ADR divergence section documents that SubagentStart (auto-inject coding standards), TaskCompleted (metrics gate), and TeammateIdle (block-on-in-progress-tasks) were promised in ADR-0032 but never implemented. Future agents reading the ADR now get accurate ground truth.

## How to review

Start with `.ci/scripts/test-hooks.sh` — it's the clearest statement of what each hook is supposed to do. Then check `check-hook-registry.sh` for the jq query logic. The `settings.json` diff is a single-line swap.

Hot spots:
- `check-hook-registry.sh` lines 32–43: jq extraction + sed prefix stripping. The two `sed` passes handle both `"$CLAUDE_PROJECT_DIR"/` (with quotes) and `$CLAUDE_PROJECT_DIR/` (without).
- `pre-tool-use.sh`: identical logic to the old inline command, just readable.

## Evidence

```
Hook executable check passed
  OK: .claude/hooks/task-completed.sh
  OK: .claude/hooks/subagent-stop.sh
  OK: .claude/hooks/pre-tool-use.sh
Hook registry check passed (3 scripts verified)

=== Results: 16 passed, 0 failed ===
```

## Risk & rollback

**Blast radius:** Shell scripts and docs only. No Rust compilation. No LSP/DAP behavior change.

**Failure modes:**
- `check-hook-registry.sh` requires `jq`. If `jq` is absent from a CI runner it will exit 1 with a clear error message (not silent failure).
- The `hook-check` and `hook-registry-check` steps are appended to `ci-gate` after `ci-features-invariants`. If they fail, CI blocks — intentional.

**Rollback:** Revert the commit. The PreToolUse behavior is identical (same regex, same exit codes); no swarm behavior changes.

## Follow-ups

- **TaskCompleted metrics gate** (ADR-0032 §Decision 2): metrics enforcement was never implemented. Needs a separate issue + swarm coordination. The ADR divergence section now documents this clearly.
- **TeammateIdle wiring**: `docs/handoff/swarm-pack/hooks/teammate-idle.sh` exists but is not registered in `settings.json`. Separate issue.
- **SubagentStart full implementation**: currently an echo stub. Separate issue.

Closes #2297