### PR TITLE
fix(parser): allow if/unless conditions without parentheses (#2187)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -4,7 +4,12 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'if'
 
-        self.expect(TokenKind::LeftParen)?;
+        let has_parens = self.peek_kind() == Some(TokenKind::LeftParen);
+        if has_parens {
+            self.tokens.next()?; // consume (
+        } else {
+            self.stop_before_bare_brace = true;
+        }
 
         // Check if this is a variable declaration in the condition
         let condition = if matches!(
@@ -20,7 +25,10 @@ impl<'a> Parser<'a> {
             self.parse_expression()?
         };
 
-        self.expect_closing_delimiter(TokenKind::RightParen)?;
+        self.stop_before_bare_brace = false;
+        if has_parens {
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
+        }
 
         let then_branch = self.parse_block()?;
 
@@ -77,10 +85,18 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'unless'
 
-        self.expect(TokenKind::LeftParen)?;
+        let has_parens = self.peek_kind() == Some(TokenKind::LeftParen);
+        if has_parens {
+            self.tokens.next()?; // consume (
+        } else {
+            self.stop_before_bare_brace = true;
+        }
         self.mark_not_stmt_start();
         let condition = self.parse_expression()?;
-        self.expect_closing_delimiter(TokenKind::RightParen)?;
+        self.stop_before_bare_brace = false;
+        if has_parens {
+            self.expect_closing_delimiter(TokenKind::RightParen)?;
+        }
 
         // Negate the condition
         let negated_condition = Node::new(

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -488,7 +488,11 @@ impl<'a> Parser<'a> {
                         }
                     }
 
-                    // Hash element access
+                    // Hash element access — but NOT when we're parsing a paren-less condition
+                    // (the { is the if/unless body, not a subscript).
+                    if self.stop_before_bare_brace {
+                        break;
+                    }
                     self.tokens.next()?; // consume {
                     let key = self.parse_expression()?;
                     self.expect(TokenKind::RightBrace)?;

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -83,6 +83,9 @@ pub struct Parser<'a> {
     last_end_position: usize,
     /// Context flag for disambiguating for-loop initialization syntax
     in_for_loop_init: bool,
+    /// When true, parse_postfix_chain stops before consuming a bare { that would
+    /// be the body block of an if/unless with a no-paren condition.
+    stop_before_bare_brace: bool,
     /// Statement boundary tracking for indirect object syntax detection
     at_stmt_start: bool,
     /// FIFO queue of pending heredoc declarations awaiting content collection
@@ -132,6 +135,7 @@ impl<'a> Parser<'a> {
             recursion_depth: 0,
             last_end_position: 0,
             in_for_loop_init: false,
+            stop_before_bare_brace: false,
             at_stmt_start: true,
             pending_heredocs: VecDeque::new(),
             src_bytes: input.as_bytes(),

--- a/crates/perl-parser-core/tests/block_list_in_parens_tests.rs
+++ b/crates/perl-parser-core/tests/block_list_in_parens_tests.rs
@@ -147,12 +147,9 @@ fn test_return_grep_block_ref_check() {
 }
 
 #[test]
-#[ignore = "parser requires parens after `if`; `if EXPR { }` without parens not yet supported (see issue #2187)"]
 fn test_grep_block_file_test() {
     // From Catmandu::Env
     // Valid Perl: `if grep { ... } @list { }` — `if` condition without parens.
-    // The parser unconditionally requires `(` after `if` (control_flow.rs:7).
-    // Fixing this requires reworking if-condition parsing to handle bare expressions.
     let source = r#"if grep {-r File::Spec->catfile($path, $_)} @files { }"#;
     assert_clean_parse(source);
 }

--- a/crates/perl-parser-core/tests/fix_expected_left_paren.rs
+++ b/crates/perl-parser-core/tests/fix_expected_left_paren.rs
@@ -1,0 +1,53 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// fix for issue #2187: if/unless accept paren-less conditions.
+// Primary acceptance criterion: test_grep_block_file_test in block_list_in_parens_tests.rs.
+
+#[test]
+fn if_grep_block_no_parens() {
+    // Basic no-paren if with grep block — primary corpus pattern
+    assert_clean_parse(r#"if grep {-r $_} @files { print "found"; }"#);
+}
+
+#[test]
+fn if_grep_block_method_call_no_parens() {
+    // Exact Catmandu::Env pattern that triggered the corpus failure
+    assert_clean_parse(r#"if grep {-r File::Spec->catfile($path, $_)} @files { }"#);
+}
+
+#[test]
+fn unless_grep_block_no_parens() {
+    // unless should get the same fix
+    assert_clean_parse(r#"unless grep { defined $_ } @list { die "empty"; }"#);
+}
+
+#[test]
+fn if_with_parens_still_works() {
+    // Regression: paren form must still parse correctly
+    assert_clean_parse(r#"if (grep { $_ eq $target } @items) { }"#);
+}
+
+#[test]
+fn if_simple_scalar_no_parens() {
+    // Simple scalar condition without parens
+    assert_clean_parse(r#"if $ok { print "yes"; }"#);
+}
+
+#[test]
+fn if_any_block_no_parens() {
+    // List::Util's any() — also is_block_list_func
+    assert_clean_parse(r#"if any { $_ > 0 } @values { return 1; }"#);
+}
+
+#[test]
+fn if_no_parens_with_else() {
+    // else branch must still parse after no-paren condition
+    assert_clean_parse(r#"if grep { /pattern/ } @lines { found(); } else { not_found(); }"#);
+}
+
+#[test]
+fn nested_if_grep_no_parens() {
+    // Nested no-paren ifs — stop_before_bare_brace must reset correctly
+    assert_clean_parse(r#"if grep { $_ } @a { if grep { $_ } @b { } }"#);
+}


### PR DESCRIPTION
## Summary

Perl allows `if EXPR { }` and `unless EXPR { }` without wrapping the condition in parentheses. The parser unconditionally called `expect(LeftParen)` after `if`/`unless`, which meant any no-paren form — most critically `if grep { BLOCK } @list { }` from Catmandu::Env — failed immediately with "expected '(' found identifier".

This was a two-part fix. The surface fix (make `(` optional) alone is not sufficient: `parse_postfix_chain` loops after any non-Identifier expression and falls through to the "hash element access" branch at the bare `{`, consuming the if-body brace as a phantom hash subscript. A new `stop_before_bare_brace` flag (modeled exactly on the existing `in_for_loop_init` flag) signals `parse_postfix_chain` to break before consuming a bare `{` when inside a no-paren condition.

Scope is `if`/`unless` only — no CPAN evidence that `while`/`until` need the same fix. `elsif` still requires parens (no observed no-paren `elsif` in CPAN).

## Interface & compatibility

- perl-parser API: unchanged (no public types added or modified)
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

- `mod.rs`: added `stop_before_bare_brace: bool` field to `Parser` struct, initialized `false` in `Parser::new`. Placed after `in_for_loop_init` following the same pattern.
- `control_flow.rs`: `parse_if_statement` and `parse_unless_statement` now check `peek_kind() == LeftParen`; if present, consume it and require the closing `)` after the condition; if absent, set `stop_before_bare_brace = true`. Flag is cleared (`= false`) immediately after the condition is parsed, before `parse_block()` for the then-branch.
- `postfix.rs`: added a `if self.stop_before_bare_brace { break; }` guard in `parse_postfix_chain` just before the "Hash element access" fallthrough at the `LeftBrace` arm.
- `block_list_in_parens_tests.rs`: removed `#[ignore]` from `test_grep_block_file_test` (the primary acceptance criterion test).
- `fix_expected_left_paren.rs`: new test file with 8 tests covering the no-paren `if`/`unless` cases and regression for the paren form.

## How to review

Start in `control_flow.rs` at the two `has_parens` blocks (lines 7-12 and 88-97). The critical invariant: `stop_before_bare_brace` is always reset to `false` before `parse_block()` is called for the then-branch. Nested `if`s work because each outer `if` resets the flag after parsing its condition; inner expressions inside the body parse with `false`.

Then check `postfix.rs` at the guard (~line 491): it's a 3-line break that only fires in the narrow no-paren-condition window.

Regression risk: `test_grep_in_if_condition` (paren form with grep block) and `test_any_block_in_if` both pass — paren path is unchanged.

## Evidence

```
test test_grep_block_file_test ... ok    # was #[ignore] before this fix
test test_grep_in_if_condition ... ok    # regression: paren form unchanged
test test_any_block_in_if ... ok         # regression: any() block in if unchanged
test test_grep_block_in_if_qw ... ok     # regression

fix_expected_left_paren tests:
  if_grep_block_no_parens .............. ok
  if_grep_block_method_call_no_parens .. ok
  unless_grep_block_no_parens .......... ok
  if_with_parens_still_works ........... ok
  if_simple_scalar_no_parens ........... ok
  if_any_block_no_parens ............... ok
  if_no_parens_with_else ............... ok
  nested_if_grep_no_parens ............. ok

fmt: PASS | clippy: PASS | test: PASS (7 pre-existing failures in complex_paren_args_tests unchanged)
```

## Risk & rollback

- Blast radius: `perl-parser-core` only. No downstream crates changed.
- Failure mode: if `stop_before_bare_brace` leaks on a parse-error path (same risk as `in_for_loop_init`), subsequent hash subscripts on the next statement could be skipped. Only affects already-broken input.
- Rollback: revert commit `c2636338f` — single commit, no deps.

## Follow-ups

- Issue #2391 (`unclosed_paren_identifier`, 15 files) may benefit from related `postfix.rs` treatment — flagged for a follow-up scout.
- `while`/`until` no-paren forms not addressed — no CPAN evidence but theoretically possible.