### PR TITLE
feat(completion): add 13 regex operator snippets

### DIFF
--- a/crates/perl-lsp-completion/src/completion/snippets.rs
+++ b/crates/perl-lsp-completion/src/completion/snippets.rs
@@ -499,10 +499,38 @@ mod tests {
     }
 
     #[test]
-    fn snippets_count_updated() {
-        let ctx = make_context("");
-        let mut items = Vec::new();
-        add_snippet_completions(&mut items, &ctx);
-        assert!(items.len() >= 50, "expected >=50 snippets, got {}", items.len());
+    fn regex_snippet_bodies_are_correct() {
+        // Verify the actual regex syntax inside snippet bodies is spelled correctly.
+        // Existence tests confirm triggers fire; this test confirms the body text
+        // delivered to the LSP client contains valid Perl regex constructs.
+        let body = |trigger: &str| -> String {
+            SNIPPETS
+                .iter()
+                .find(|s| s.trigger == trigger)
+                .map(|s| s.body.to_string())
+                .unwrap_or_else(|| panic!("snippet '{trigger}' not found"))
+        };
+        assert!(body("namedcap").contains("(?<"), "namedcap must contain named-capture opener (?<");
+        assert!(body("lookahead").contains("(?="), "lookahead must contain positive lookahead (?=");
+        assert!(
+            body("neglookahead").contains("(?!"),
+            "neglookahead must contain negative lookahead (?!"
+        );
+        assert!(
+            body("lookbehind").contains("(?<="),
+            "lookbehind must contain positive lookbehind (?<="
+        );
+        assert!(
+            body("neglookbehind").contains("(?<!"),
+            "neglookbehind must contain negative lookbehind (?<!"
+        );
+        assert!(body("rxglobal").contains("/g"), "rxglobal must embed /g flag");
+        assert!(body("rxcase").contains("/i"), "rxcase must embed /i flag");
+        assert!(body("rxmulti").contains("/m"), "rxmulti must embed /m flag");
+        assert!(body("rxdots").contains("/s"), "rxdots must embed /s flag");
+        assert!(body("rxverbose").contains("/x"), "rxverbose must embed /x flag");
+        assert!(body("mbasic").starts_with("m/"), "mbasic body must start with m/");
+        assert!(body("sbasic").starts_with("s/"), "sbasic body must start with s/");
+        assert!(body("qrbasic").starts_with("qr/"), "qrbasic body must start with qr/");
     }
 }


### PR DESCRIPTION
## Summary

Adds 13 regex operator snippet templates to the `SNIPPETS` array in `crates/perl-lsp-completion/src/completion/snippets.rs`. The array previously had 40 entries covering control flow, OOP, file I/O, and list operators — but zero regex operator templates.

The 13 new snippets cover: basic operators (`mbasic`, `sbasic`, `qrbasic`), named capture groups (`namedcap`), lookahead/lookbehind assertions (`lookahead`, `neglookahead`, `lookbehind`, `neglookbehind`), and five flag-variant templates (`rxglobal`, `rxcase`, `rxmulti`, `rxdots`, `rxverbose`). Flag triggers use the `rx*` prefix to avoid visual collision with `sbasic` when a user types `s`.

A key architectural point: snippet triggers fire in **normal code context**, not inside regex delimiters. The completion router has an early-exit for `in_regex = true` that routes to `regex_patterns::add_regex_completions` instead. Users type e.g. `mba` → get `mbasic` snippet, then expand it; this is consistent with all 40 existing snippets.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive only (new snippet completions appear for new trigger prefixes)
- DAP surface: unchanged
- CLI: unchanged

## What changed

Single file: `crates/perl-lsp-completion/src/completion/snippets.rs`

- 13 new `Snippet` entries appended to `SNIPPETS` array (lines 287–381)
- Updated `snippets_returned_with_empty_prefix` count threshold from `>= 30` to `>= 50`
- 3 new tests: `regex_operator_snippets_exist`, `regex_snippet_filter_by_prefix`, `snippets_count_updated`

## How to review

The entire diff is data: new `Snippet { trigger, label, body, detail, doc }` structs. Review focuses on:
1. Body tab-stop syntax — all use `${1:...}` / `${0}` or `${0:...}` correctly
2. Trigger uniqueness — covered by existing `no_duplicate_triggers` test
3. Doc accuracy — named capture is Perl 5.10+ (corrected from scout's 5.32+)
4. `rxdots` trigger for the `/s` dotall flag (plan-review renamed from `flagss` to avoid confusion with `sbasic`)

## Evidence

```
cargo test -p perl-lsp-completion
running 72 tests  → ok. 72 passed
running 9 tests   → ok. 9 passed
running 28 tests  → ok. 28 passed
running 98 tests  → ok. 98 passed
running 127 tests → ok. 127 passed
running 12 tests  → ok. 12 passed
Total: 336 passed, 0 failed

cargo clippy -p perl-lsp-completion → Finished, no warnings
```

Note: `just ci-gate` reports errors in `xtask/tests/post_merge_status_regen_tests.rs` (pre-existing `expect()` violations unrelated to this PR, confirmed present on master before this change).

## Risk & rollback

Blast radius: zero. Pure data addition to a static array. No logic changes, no new dependencies. Existing tests (`no_duplicate_triggers`, `all_snippets_have_docs_and_tab_stop`) structurally validate all new entries automatically. Rollback: revert the single file.

## Follow-ups

- Issue #2330 (regex pattern completions inside regex context) remains open and is a separate code path