### PR TITLE
feat(hover): tied variable class display and tie magic method docs

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -140,6 +140,16 @@ impl LspServer {
                 .map(|d| format!("\n**Declaration**: `{}`", d))
                 .unwrap_or_default();
 
+            // Check if this variable is tied — scan AST for a matching Tie node.
+            let tied_info = if symbol_info.kind.is_variable() {
+                let sigil = symbol_info.kind.sigil().unwrap_or("");
+                Self::find_tied_class(ast, sigil, &symbol_info.name)
+                    .map(|cls| format!("\n**Tied to**: `{}`", cls))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
             let attrs_info = if symbol_info.attributes.is_empty() {
                 String::new()
             } else {
@@ -161,10 +171,11 @@ impl LspServer {
             return HoverExtracted::Complete(json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": format!("**{}**\n\n`{}`{}{}{}{}",
+                    "value": format!("**{}**\n\n`{}`{}{}{}{}{}",
                         kind_str,
                         display_name,
                         decl_info,
+                        tied_info,
                         attrs_info,
                         complexity_section,
                         doc_info
@@ -738,6 +749,36 @@ impl LspServer {
             _ => {}
         }
         None
+    }
+
+    /// Walk the AST to find a `tie` statement whose variable matches `sigil` and `var_name`.
+    /// Returns the class string if the package argument is a string literal, `None` otherwise.
+    /// Handles the first tie encountered for the given name; retie sequences are a known limitation.
+    fn find_tied_class(node: &Node, sigil: &str, var_name: &str) -> Option<String> {
+        match &node.kind {
+            NodeKind::Tie { variable, package, .. } => {
+                let matched = match &variable.kind {
+                    NodeKind::Variable { sigil: s, name: n } => s == sigil && n == var_name,
+                    NodeKind::VariableDeclaration { variable: inner, .. } => {
+                        matches!(&inner.kind, NodeKind::Variable { sigil: s, name: n } if s == sigil && n == var_name)
+                    }
+                    _ => false,
+                };
+                if matched {
+                    if let NodeKind::String { value, .. } = &package.kind {
+                        return Some(value.trim_matches(|c| c == '\'' || c == '"').to_string());
+                    }
+                }
+                None
+            }
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                statements.iter().find_map(|s| Self::find_tied_class(s, sigil, var_name))
+            }
+            NodeKind::ExpressionStatement { expression } => {
+                Self::find_tied_class(expression, sigil, var_name)
+            }
+            _ => None,
+        }
     }
 
     /// Extract parameter names from a params node (for signature help)

--- a/crates/perl-lsp/tests/semantic_hover.rs
+++ b/crates/perl-lsp/tests/semantic_hover.rs
@@ -463,6 +463,81 @@ my $circumference = 2 * PI * $radius;
 }
 
 #[cfg(test)]
+mod tied_variable_hover_tests {
+    use crate::common::test_utils::TestServerBuilder;
+    use serde_json::Value;
+
+    fn hover_content(resp: &Value) -> Option<String> {
+        let result = resp.get("result")?;
+        if result.is_null() {
+            return None;
+        }
+        let contents = result.get("contents")?;
+        let value = contents.get("value")?.as_str()?;
+        Some(value.to_string())
+    }
+
+    fn find_pos(
+        code: &str,
+        needle: &str,
+        target_line: usize,
+    ) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+        let line = code
+            .lines()
+            .nth(target_line)
+            .ok_or_else(|| format!("no line {} in test code", target_line))?;
+        let col = line
+            .find(needle)
+            .ok_or_else(|| format!("could not find `{needle}` on line {target_line}"))?;
+        Ok((target_line as u32, col as u32))
+    }
+
+    /// Hover on a tied scalar variable at usage site should mention the tied class.
+    #[test]
+    fn test_hover_on_tied_variable_shows_class() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "tie my $counter, 'Tie::Counter';\nmy $x = $counter;\n";
+        let uri = "file:///test_tied.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Hover over $counter on line 1 (the usage site)
+        let (line, character) = find_pos(code, "$counter", 1)?;
+        let response = server.get_hover(uri, line, character);
+        println!("TIED SCALAR HOVER RESPONSE: {response:#}");
+
+        let content = hover_content(&response).ok_or("expected hover content for tied $counter")?;
+
+        assert!(
+            content.contains("Tie::Counter"),
+            "hover should mention tied class 'Tie::Counter', got: {content}"
+        );
+        Ok(())
+    }
+
+    /// Hover on a tied variable when the class is given as a runtime variable should
+    /// not panic and should gracefully degrade (no class shown is acceptable).
+    #[test]
+    fn test_hover_on_tied_variable_unknown_class_does_not_panic()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = "my $cls = 'Tie::Counter';\ntie my $x, $cls;\nmy $y = $x;\n";
+        let uri = "file:///test_tied_dynamic.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Hover over $x on line 2 (the usage site) — must not panic
+        let (line, character) = find_pos(code, "$x", 2)?;
+        let response = server.get_hover(uri, line, character);
+        println!("TIED DYNAMIC CLASS HOVER RESPONSE: {response:#}");
+
+        // Must not panic; result may be null or generic — both acceptable
+        let _ = hover_content(&response);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
 mod module_hover_tests {
     use crate::common::test_utils::TestServerBuilder;
     use serde_json::Value;

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -338,6 +338,44 @@ pub fn get_builtin_documentation(name: &str) -> Option<BuiltinDoc> {
             description: "Returns a reference to the object underlying VARIABLE if it is tied, or undef if not.",
         }),
 
+        // Tie magic methods
+        "TIESCALAR" => Some(BuiltinDoc {
+            signature: "TIESCALAR CLASSNAME, LIST",
+            description: "Constructor called when `tie $scalar, CLASSNAME, LIST` is used. Must return a blessed reference.",
+        }),
+        "TIEARRAY" => Some(BuiltinDoc {
+            signature: "TIEARRAY CLASSNAME, LIST",
+            description: "Constructor called when `tie @array, CLASSNAME, LIST` is used. Must return a blessed reference.",
+        }),
+        "TIEHASH" => Some(BuiltinDoc {
+            signature: "TIEHASH CLASSNAME, LIST",
+            description: "Constructor called when `tie %hash, CLASSNAME, LIST` is used. Must return a blessed reference.",
+        }),
+        "TIEHANDLE" => Some(BuiltinDoc {
+            signature: "TIEHANDLE CLASSNAME, LIST",
+            description: "Constructor called when `tie *FH, CLASSNAME, LIST` is used. Must return a blessed reference.",
+        }),
+        "FETCH" => Some(BuiltinDoc {
+            signature: "FETCH this",
+            description: "Called on every access of a tied scalar or array/hash element. Returns the value.",
+        }),
+        "STORE" => Some(BuiltinDoc {
+            signature: "STORE this, value",
+            description: "Called on every assignment to a tied scalar or array/hash element.",
+        }),
+        "FIRSTKEY" => Some(BuiltinDoc {
+            signature: "FIRSTKEY this",
+            description: "Called when `keys` or `each` is first invoked on a tied hash.",
+        }),
+        "NEXTKEY" => Some(BuiltinDoc {
+            signature: "NEXTKEY this, lastkey",
+            description: "Called during iteration of a tied hash with `each` or `keys`.",
+        }),
+        "DESTROY" => Some(BuiltinDoc {
+            signature: "DESTROY this",
+            description: "Called when the tied object goes out of scope or is explicitly untied.",
+        }),
+
         // Control flow
         "die" => Some(BuiltinDoc {
             signature: "die LIST",

--- a/crates/perl-semantic-analyzer/tests/tied_variable_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/tied_variable_hover_tests.rs
@@ -1,0 +1,52 @@
+//! Tests for tied variable magic method builtin documentation.
+//!
+//! Verifies that `get_builtin_documentation` returns entries for all
+//! standard Perl tie magic methods (TIESCALAR, TIEARRAY, TIEHASH,
+//! TIEHANDLE, FETCH, STORE, FIRSTKEY, NEXTKEY, DESTROY).
+
+use perl_semantic_analyzer::analysis::semantic::get_builtin_documentation;
+
+/// All tie magic methods must have documentation entries.
+#[test]
+fn test_tie_magic_methods_have_docs() {
+    let magic_methods = [
+        "TIESCALAR",
+        "TIEARRAY",
+        "TIEHASH",
+        "TIEHANDLE",
+        "FETCH",
+        "STORE",
+        "FIRSTKEY",
+        "NEXTKEY",
+        "DESTROY",
+    ];
+    for method in &magic_methods {
+        assert!(
+            get_builtin_documentation(method).is_some(),
+            "Missing builtin docs for tie magic method: {method}"
+        );
+    }
+}
+
+/// Each documented magic method must have a non-empty signature and description.
+#[test]
+fn test_tie_magic_method_docs_are_non_empty() -> Result<(), Box<dyn std::error::Error>> {
+    let magic_methods = [
+        "TIESCALAR",
+        "TIEARRAY",
+        "TIEHASH",
+        "TIEHANDLE",
+        "FETCH",
+        "STORE",
+        "FIRSTKEY",
+        "NEXTKEY",
+        "DESTROY",
+    ];
+    for method in &magic_methods {
+        let doc = get_builtin_documentation(method)
+            .ok_or_else(|| format!("Missing docs for {method}"))?;
+        assert!(!doc.signature.is_empty(), "signature should be non-empty for {method}");
+        assert!(!doc.description.is_empty(), "description should be non-empty for {method}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements two targeted hover improvements for Perl's `tie` mechanism, closing #2367.

1. **Tied variable class display**: When hovering over a variable that has been tied (e.g. `tie my $counter, 'Tie::Counter'`), the hover now shows `**Tied to**: \`Tie::Counter\`` beneath the declaration info. A new `find_tied_class` AST-walk helper in `hover.rs` scans for a matching `NodeKind::Tie` node, following the existing `find_subroutine_definition` pattern. When the class is given as a runtime expression (not a string literal), the hover degrades gracefully — no class shown, no panic.

2. **Magic method documentation**: Nine tie magic methods (`TIESCALAR`, `TIEARRAY`, `TIEHASH`, `TIEHANDLE`, `FETCH`, `STORE`, `FIRSTKEY`, `NEXTKEY`, `DESTROY`) are added to `builtins.rs`. Developers writing a tied class stub can now hover on these method names to see their signatures and purpose.

The code action for generating tied class stubs (part of the original issue) is explicitly deferred — it requires in-document edit architecture work beyond this PR's scope.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (hover response gains optional `Tied to` line)
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-lsp/src/runtime/language/hover.rs`:
- Added `find_tied_class(node, sigil, var_name) -> Option<String>` static method (mirrors `find_subroutine_definition` structure)
- Added `tied_info` computation in `extract_symbol_hover`, inserted between `decl_info` and `attrs_info` in the format string

`crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs`:
- Added 9 magic method entries after the existing `tied` builtin entry

`crates/perl-lsp/tests/semantic_hover.rs`:
- New `tied_variable_hover_tests` module with 2 integration tests

`crates/perl-semantic-analyzer/tests/tied_variable_hover_tests.rs` (new):
- 2 unit tests verifying all 9 magic methods have non-empty docs

## How to review

Start with `find_tied_class` in `hover.rs` (~line 754) — the core logic. Then check its call site in `extract_symbol_hover` (~line 143). The `builtins.rs` addition is mechanical (9 match arms after `"tied"`). Tests are in the two test files.

The `ExpressionStatement` arm in `find_tied_class` is necessary because `NodeKind::Tie` is produced as an expression node and wrapped in `ExpressionStatement` by the parser — confirmed by `tie_tests.rs`.

## Evidence

```
cargo fmt -p perl-lsp -p perl-semantic-analyzer -- --check
→ FMT: PASS

cargo clippy -p perl-lsp --lib -- -D warnings
→ Finished (0 errors, 0 warnings)

cargo clippy -p perl-semantic-analyzer --tests -- -D warnings
→ Finished (0 errors, 0 warnings)

RUST_TEST_THREADS=2 cargo test -p perl-lsp --test semantic_hover -- tied_variable
→ test tied_variable_hover_tests::test_hover_on_tied_variable_shows_class ... ok
→ test tied_variable_hover_tests::test_hover_on_tied_variable_unknown_class_does_not_panic ... ok
→ test result: ok. 2 passed; 0 failed

RUST_TEST_THREADS=2 cargo test -p perl-semantic-analyzer --test tied_variable_hover_tests
→ test test_tie_magic_methods_have_docs ... ok
→ test test_tie_magic_method_docs_are_non_empty ... ok
→ test result: ok. 2 passed; 0 failed

perl-semantic-analyzer full suite: 12 test binaries, 0 failures
```

Note: `just ci-gate` fails on `xtask` clippy (`expect()` in `xtask/tests/` and `xtask/src/tasks/features.rs`) — pre-existing on this worktree base, not introduced by this PR. `perl-lsp --tests` clippy fails on a missing `commit_characters` field in `completion.rs` — also pre-existing.

## Risk & rollback

- **Blast radius**: hover only. The `find_tied_class` scan is O(n) over AST statements; for any realistic file this is negligible.
- **Failure modes**: if `find_tied_class` returns `None` (dynamic class, no tie found, or parse failure), the hover is unchanged — graceful degradation.
- **Rollback**: revert the 4 files in this commit. No schema migrations, no cross-crate API changes.

## Follow-ups

- Code action "Generate tied class stub" — deferred, needs in-document CodeActionEdit architecture work (separate issue recommended)
- Retie sequences (`untie %x; tie %x, 'NewClass'`) — `find_tied_class` returns the first match. Known limitation documented in code comment.