### PR TITLE
test(lsp): add integration test for FileWatcherDebouncer wired through LspServer

### DIFF
--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -436,7 +436,7 @@ impl LspServer {
     }
 
     /// Install the file watcher debouncer (called from Scheduler::new after Arc wrapping).
-    pub(crate) fn install_file_watcher_debouncer(
+    pub fn install_file_watcher_debouncer(
         &self,
         debouncer: file_watcher_debounce::FileWatcherDebouncer,
     ) {
@@ -447,7 +447,7 @@ impl LspServer {
     ///
     /// Returns `true` if a debouncer is installed (production runtime) and the
     /// URI was queued, `false` if no debouncer is present (unit-test path).
-    pub(crate) fn schedule_file_watcher_uri(&self, uri: &str) -> bool {
+    pub fn schedule_file_watcher_uri(&self, uri: &str) -> bool {
         let guard = self.file_watcher_debouncer.lock();
         if let Some(ref d) = *guard {
             d.schedule(uri);

--- a/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
@@ -20,7 +20,7 @@
 
 use perl_lsp::execute_command::{ExecuteCommandProvider, get_supported_commands};
 use perl_tdd_support::must;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs;
 use std::io::Write;
 use tempfile::NamedTempFile;

--- a/crates/perl-lsp/tests/lsp_async_perf_tests.rs
+++ b/crates/perl-lsp/tests/lsp_async_perf_tests.rs
@@ -163,6 +163,36 @@ fn test_file_watcher_debouncer_coalesces_50_rapid_events() {
     assert_eq!(uris, 50, "All 50 URIs should be delivered, got {uris}");
 }
 
+/// Verify that `FileWatcherDebouncer` is properly wired through `LspServer`.
+///
+/// Creates a bare `LspServer`, manually installs a debouncer with a short
+/// window, calls `schedule_file_watcher_uri()` for 10 distinct URIs rapidly,
+/// and asserts the batch callback fires after the debounce window expires.
+#[test]
+fn test_file_watcher_debouncer_wired_through_server() {
+    use perl_lsp::runtime::file_watcher_debounce::FileWatcherDebouncer;
+
+    let server = LspServer::new();
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&call_count);
+    let debouncer = FileWatcherDebouncer::with_interval(Duration::from_millis(80), move |_uris| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    server.install_file_watcher_debouncer(debouncer);
+
+    // 10 rapid CHANGED events — should queue, not fire immediately
+    for i in 0..10usize {
+        let queued = server.schedule_file_watcher_uri(&format!("file:///workspace/file{i}.pl"));
+        assert!(queued, "debouncer should be installed and return true");
+    }
+
+    thread::sleep(Duration::from_millis(250));
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 1,
+        "batch callback should have fired after debounce window"
+    );
+}
+
 /// Verify that duplicate URIs within the debounce window are deduplicated.
 #[test]
 fn test_file_watcher_debouncer_deduplicates_same_uri() {


### PR DESCRIPTION
## Summary

Closes #2627. Adds a single integration test — `test_file_watcher_debouncer_wired_through_server` — that exercises the production-wired path for `FileWatcherDebouncer` through `LspServer`. Prior to this PR, every integration test constructed `LspServer` directly without installing a debouncer, meaning `schedule_file_watcher_uri()` always fell through to `false` (no debouncer present). The wired path (debouncer installed, URIs batched, callback fires) had no integration coverage.

The test installs a debouncer with an 80ms window on a bare `LspServer`, fires 10 rapid URI events via `schedule_file_watcher_uri()`, asserts each call returns `true` (debouncer active), then waits 250ms and asserts the batch callback fired at least once.

Also fixes a pre-existing compile error in `execute_command_mutation_hardening_public_api_tests.rs` (missing `serde_json::json` import from PR #2617) so clippy is clean across all test binaries.

## Interface & compatibility

- `perl-lsp` API: additive — `install_file_watcher_debouncer` and `schedule_file_watcher_uri` promoted from `pub(crate)` to `pub` to allow access from integration tests (separate crate). No behavioral change.
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

- `crates/perl-lsp/src/runtime/mod.rs`: Two methods promoted `pub(crate)` → `pub` so integration tests in the same crate's `tests/` directory (compiled as separate crates) can call them.
- `crates/perl-lsp/tests/lsp_async_perf_tests.rs`: New test `test_file_watcher_debouncer_wired_through_server` added after the existing `#2458` debouncing tests.
- `crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs`: Added `json` to the `serde_json` import to fix pre-existing compile error.

The plan-reviewer's spec noted both methods were `pub(crate)` and accessible from integration tests — this was inaccurate. Integration tests are separate crates; `pub(crate)` is invisible to them. Fix-forward applied: promoted to `pub`.

## How to review

Start at `crates/perl-lsp/tests/lsp_async_perf_tests.rs:166` for the new test. Check `crates/perl-lsp/src/runtime/mod.rs:439` for the visibility change. The single-line import fix is at `execute_command_mutation_hardening_public_api_tests.rs:23`.

## Evidence

```
test test_file_watcher_debouncer_wired_through_server ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s

lib tests: 245 passed; 0 failed
clippy -p perl-lsp --tests: PASS
cargo fmt -p perl-lsp: PASS (auto-fixed closure formatting)
```

ci-gate fails on a pre-existing `panic!` in `perl-lsp-completion/src/completion/snippets.rs:512` (confirmed present on master before this branch).

## Risk & rollback

Minimal — the only production change is a visibility promotion (`pub(crate)` → `pub`) on two methods that were already callable from within the crate. No logic changes. Rollback by reverting the two `pub` keywords if needed.

## Follow-ups

- `cross_file_goto_definition_tests`: 3 tests fail on master already — pre-existing, unrelated.
- `perl-lsp-completion snippets.rs:512 panic!`: pre-existing `ci-gate` failure — recommend a separate builder to replace with `.unwrap_or_else()`.