### PR TITLE
test(lsp): add integration tests proving unused variable diagnostics (PL102) wire through pull diagnostics

### DIFF
--- a/crates/perl-lsp/tests/pull_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/pull_diagnostics_tests.rs
@@ -1,5 +1,107 @@
-use lsp_types::DocumentDiagnosticReport;
+use lsp_types::{DocumentDiagnosticReport, NumberOrString};
 use perl_lsp::features::diagnostics::PullDiagnosticsProvider;
+
+/// Extract items from a full diagnostic report, returning an error if it is Unchanged.
+fn items_from_report(
+    report: DocumentDiagnosticReport,
+) -> Result<Vec<lsp_types::Diagnostic>, Box<dyn std::error::Error>> {
+    match report {
+        DocumentDiagnosticReport::Full(full) => Ok(full.full_document_diagnostic_report.items),
+        DocumentDiagnosticReport::Unchanged(_) => {
+            Err("expected Full diagnostic report, got Unchanged".into())
+        }
+    }
+}
+
+/// Returns true when a diagnostic has the given code string (e.g. "PL102").
+fn has_code(diag: &lsp_types::Diagnostic, code: &str) -> bool {
+    matches!(&diag.code, Some(NumberOrString::String(s)) if s == code)
+}
+
+#[test]
+fn pull_diagnostics_unused_variable_emits_pl102() -> Result<(), Box<dyn std::error::Error>> {
+    let provider = PullDiagnosticsProvider::new();
+    let uri = "file:///test_unused.pl".parse()?;
+    // $used is referenced; $unused is not — should produce PL102 for $unused only.
+    let content = "use strict;\nuse warnings;\nsub foo {\n    my $used = 123;\n    my $unused = 456;\n    return $used;\n}\n";
+
+    let items = items_from_report(provider.get_document_diagnostics(&uri, content, None))?;
+
+    let pl102_diags: Vec<_> = items.iter().filter(|d| has_code(d, "PL102")).collect();
+    if pl102_diags.is_empty() {
+        return Err(format!(
+            "Expected at least one PL102 (unused variable) diagnostic, got none.\nAll diagnostics: {items:#?}"
+        )
+        .into());
+    }
+
+    // At least one PL102 must mention $unused
+    let mentions_unused =
+        pl102_diags.iter().any(|d| d.message.contains("$unused") || d.message.contains("unused"));
+    if !mentions_unused {
+        return Err(format!(
+            "Expected a PL102 diagnostic mentioning '$unused', got: {pl102_diags:#?}"
+        )
+        .into());
+    }
+
+    // No PL102 should mention $used (it is referenced)
+    let false_positive =
+        pl102_diags.iter().any(|d| d.message.contains("$used") && !d.message.contains("$unused"));
+    if false_positive {
+        return Err(format!(
+            "Unexpected PL102 diagnostic for '$used' (it is referenced): {pl102_diags:#?}"
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn pull_diagnostics_unused_variable_severity_is_warning() -> Result<(), Box<dyn std::error::Error>>
+{
+    let provider = PullDiagnosticsProvider::new();
+    let uri = "file:///test_unused_sev.pl".parse()?;
+    let content = "sub bar {\n    my $never_used = 1;\n}\n";
+
+    let items = items_from_report(provider.get_document_diagnostics(&uri, content, None))?;
+
+    let pl102 = items
+        .iter()
+        .find(|d| has_code(d, "PL102"))
+        .ok_or("Expected PL102 diagnostic for unused variable $never_used")?;
+
+    let severity = pl102.severity.ok_or("PL102 diagnostic must have a severity")?;
+    if severity != lsp_types::DiagnosticSeverity::WARNING {
+        return Err(format!("Expected WARNING severity for PL102, got {:?}", severity).into());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn pull_diagnostics_underscore_prefix_suppresses_unused_warning()
+-> Result<(), Box<dyn std::error::Error>> {
+    let provider = PullDiagnosticsProvider::new();
+    let uri = "file:///test_underscore.pl".parse()?;
+    // _intentionally_unused should NOT produce PL102 (underscore prefix = intentionally unused)
+    let content = "sub baz {\n    my $_intentionally_unused = 1;\n    return 42;\n}\n";
+
+    let items = items_from_report(provider.get_document_diagnostics(&uri, content, None))?;
+
+    let pl102_for_underscore =
+        items.iter().find(|d| has_code(d, "PL102") && d.message.contains("_intentionally_unused"));
+
+    if pl102_for_underscore.is_some() {
+        return Err(
+            "PL102 must NOT be emitted for underscore-prefixed variable $_intentionally_unused"
+                .into(),
+        );
+    }
+
+    Ok(())
+}
 
 #[test]
 fn pull_diagnostics_full_then_unchanged() -> Result<(), Box<dyn std::error::Error>> {

--- a/features.toml
+++ b/features.toml
@@ -208,6 +208,15 @@ tests = ["tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
 
 [[feature]]
+id = "lsp.diagnostic.unused_variable"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["tests/pull_diagnostics_tests.rs"]
+description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
+
+[[feature]]
 id = "lsp.inline_completion"
 spec = "LSP 3.18"
 area = "text_document"


### PR DESCRIPTION
## Summary

Issue #2632 claimed that unused variable detection in the `SemanticAnalyzer` was
disconnected from the diagnostics pipeline. Investigation found the wiring was already
complete: `ScopeAnalyzer` is invoked from `DiagnosticsProvider.get_diagnostics()`,
`ScopeIssue::UnusedVariable` maps to `DiagnosticCode::UnusedVariable` (`PL102`), and
the result flows through `PullDiagnosticsProvider` to the LSP client with `WARNING`
severity and the `Unnecessary` tag.

The actual gap was the absence of integration tests protecting this path. Without them,
a refactor could silently disconnect the wiring and no test would catch it.

This PR adds three integration tests via `PullDiagnosticsProvider` and registers the
capability in `features.toml`. It also corrects the spec's proposed diagnostic code:
`PL751` would fall in the Import range (PL700–PL799); the correct code is `PL102`
(StrictWarnings range, PL100–PL199), which is already live.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged (behavior was already present; no new capabilities advertised)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**`crates/perl-lsp/tests/pull_diagnostics_tests.rs`** — adds 3 new tests:
- `pull_diagnostics_unused_variable_emits_pl102`: verifies PL102 fires for `$unused`
  and not for `$used` (false positive guard)
- `pull_diagnostics_unused_variable_severity_is_warning`: verifies severity is `WARNING`
- `pull_diagnostics_underscore_prefix_suppresses_unused_warning`: verifies the
  `$_` prefix convention correctly suppresses the diagnostic

Adds two test helpers: `items_from_report` (returns `Result`, no panic) and `has_code`
(predicate on diagnostic code string).

**`features.toml`** — adds `lsp.diagnostic.unused_variable` entry documenting the
capability, its code (`PL102`), mechanism (scope analyzer), and suppression behavior.

## How to review

Start at `crates/perl-lsp/tests/pull_diagnostics_tests.rs:22`. The three new tests
exercise `PullDiagnosticsProvider::get_document_diagnostics` end-to-end — no mocking,
real parse + scope analysis + diagnostic mapping. The key regression risk was `panic!`
in a test helper; that path uses `Result` + `?` throughout.

## Evidence

```
running 4 tests
test pull_diagnostics_full_then_unchanged ... ok
test pull_diagnostics_underscore_prefix_suppresses_unused_warning ... ok
test pull_diagnostics_unused_variable_emits_pl102 ... ok
test pull_diagnostics_unused_variable_severity_is_warning ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p perl-lsp --tests -- -D warnings: PASS
cargo fmt -p perl-lsp -- --check: PASS
```

Note: `just ci-gate` reports failures in `perl-semantic-analyzer` (expect() in
`builtin_context_docs_tests.rs`, added in commit `6af0d20e8`) and `perl-lsp-completion`
(`panic!` in `snippets.rs`). These are pre-existing regressions from other recent
merges, not introduced here.

## Risk & rollback

- **Blast radius**: test file only (plus features.toml). No production code changed.
- **Failure modes**: none — tests pass, no new code paths added.
- **Rollback**: `git revert` on the single commit; no data migration needed.

## Follow-ups

- The pre-existing `ci-gate` failures in `perl-semantic-analyzer` and `perl-lsp-completion`
  should be fixed in separate PRs (recommend scout/builder for each).
- Issue #2632 should be closed: the wiring was already complete. The spec's root cause
  analysis was incorrect.