### PR TITLE
feat(lsp): wire inlayHint/resolve labelDetails.location for click-to-definition

### DIFF
--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -113,51 +113,103 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(mut hint) = params {
-            // If hint already has a tooltip, return as-is
-            if hint.get("tooltip").is_some() {
+            // If hint already has both tooltip and labelDetails, return as-is
+            if hint.get("tooltip").is_some() && hint.get("labelDetails").is_some() {
                 return Ok(Some(hint));
             }
 
-            // Extract hint properties for tooltip generation
-            let label = hint.get("label").and_then(|l| l.as_str()).unwrap_or("");
+            // Extract hint properties for tooltip and label location generation
+            let label = hint.get("label").and_then(|l| l.as_str()).unwrap_or("").to_string();
             let kind = hint.get("kind").and_then(|k| k.as_u64()).unwrap_or(0);
 
-            // Generate tooltip based on hint kind and label
-            let tooltip = match kind {
-                1 => {
-                    // Type hint
-                    if label.contains("Str") {
-                        "String value".to_string()
-                    } else if label.contains("Num") {
-                        "Numeric value".to_string()
-                    } else if label.contains("Array") || label.contains("ARRAY") {
-                        "Array reference".to_string()
-                    } else if label.contains("Hash") || label.contains("HASH") {
-                        "Hash reference".to_string()
-                    } else if label.contains("Regex") {
-                        "Regular expression".to_string()
-                    } else if label.contains("CodeRef") {
-                        "Code reference (anonymous subroutine)".to_string()
-                    } else {
-                        "Type annotation".to_string()
+            // Add tooltip if not already present
+            if hint.get("tooltip").is_none() {
+                let tooltip = match kind {
+                    1 => {
+                        // Type hint
+                        if label.contains("Str") {
+                            "String value".to_string()
+                        } else if label.contains("Num") {
+                            "Numeric value".to_string()
+                        } else if label.contains("Array") || label.contains("ARRAY") {
+                            "Array reference".to_string()
+                        } else if label.contains("Hash") || label.contains("HASH") {
+                            "Hash reference".to_string()
+                        } else if label.contains("Regex") {
+                            "Regular expression".to_string()
+                        } else if label.contains("CodeRef") {
+                            "Code reference (anonymous subroutine)".to_string()
+                        } else {
+                            "Type annotation".to_string()
+                        }
+                    }
+                    2 => {
+                        let param_name = label.trim_end_matches(':').trim();
+                        format!("Parameter: {}", param_name)
+                    }
+                    _ => "Inlay hint".to_string(),
+                };
+                if let Some(obj) = hint.as_object_mut() {
+                    obj.insert("tooltip".to_string(), json!(tooltip));
+                }
+            }
+
+            // Add labelDetails.location for parameter hints (kind=2) if not already present
+            if hint.get("labelDetails").is_none() && kind == 2 {
+                if let Some(label_location) = self.resolve_hint_label_location(&hint) {
+                    if let Some(obj) = hint.as_object_mut() {
+                        obj.insert(
+                            "labelDetails".to_string(),
+                            json!({ "location": label_location }),
+                        );
                     }
                 }
-                2 => {
-                    // Parameter hint
-                    let param_name = label.trim_end_matches(':').trim();
-                    format!("Parameter: {}", param_name)
-                }
-                _ => "Inlay hint".to_string(),
-            };
-
-            // Add tooltip to hint
-            if let Some(obj) = hint.as_object_mut() {
-                obj.insert("tooltip".to_string(), json!(tooltip));
             }
 
             Ok(Some(hint))
         } else {
             Err(invalid_params("Missing inlay hint parameter"))
+        }
+    }
+
+    /// Resolve the LSP Location for an inlay hint label, enabling click-to-definition.
+    ///
+    /// Extracts the document URI and function name from the hint's `data` field,
+    /// looks up the open document, walks the AST to find the subroutine definition,
+    /// and converts its byte-offset location to an LSP `{ uri, range }` object.
+    ///
+    /// Returns `None` when the document is not open, the function is not found,
+    /// or the hint data is missing required fields.
+    fn resolve_hint_label_location(&self, hint: &Value) -> Option<Value> {
+        let data = hint.get("data")?;
+        let uri = data.get("uri").and_then(|u| u.as_str())?;
+        let function_name = data.get("function").and_then(|f| f.as_str())?;
+
+        let documents = self.documents_guard();
+        let doc = self.get_document(&documents, uri)?;
+        let ast = doc.ast.as_ref()?;
+
+        let sub_node = Self::find_subroutine_node(ast, function_name)?;
+        let (start_line, start_char) = self.offset_to_pos16(doc, sub_node.location.start);
+        let (end_line, end_char) = self.offset_to_pos16(doc, sub_node.location.end);
+
+        Some(json!({
+            "uri": uri,
+            "range": {
+                "start": { "line": start_line, "character": start_char },
+                "end":   { "line": end_line,   "character": end_char   }
+            }
+        }))
+    }
+
+    /// Walk the AST to find a top-level subroutine node with the given name.
+    fn find_subroutine_node<'a>(node: &'a Node, name: &str) -> Option<&'a Node> {
+        match &node.kind {
+            NodeKind::Subroutine { name: Some(sub_name), .. } if sub_name == name => Some(node),
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                statements.iter().find_map(|s| Self::find_subroutine_node(s, name))
+            }
+            _ => None,
         }
     }
 

--- a/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
@@ -20,7 +20,7 @@
 
 use perl_lsp::execute_command::{ExecuteCommandProvider, get_supported_commands};
 use perl_tdd_support::must;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs;
 use std::io::Write;
 use tempfile::NamedTempFile;

--- a/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs
@@ -164,6 +164,101 @@ fn lsp_inlay_hint_resolve_no_op_when_complete() -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+/// Test that inlayHint/resolve adds labelDetails.location for click-to-definition
+///
+/// When a client advertises "label.location" in resolveSupport and the hint has
+/// a data.uri pointing to an open document with a matching subroutine, the resolved
+/// hint must include labelDetails.location with uri and range fields.
+#[test]
+fn lsp_inlay_hint_resolve_adds_label_location() -> Result<(), Box<dyn std::error::Error>> {
+    let srv = LspServer::new();
+
+    // Initialize with both tooltip and label.location in resolveSupport
+    let init = JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(1)),
+        method: "initialize".into(),
+        params: Some(json!({
+            "capabilities": {
+                "textDocument": {
+                    "inlayHint": {
+                        "resolveSupport": {
+                            "properties": ["tooltip", "label.location"]
+                        }
+                    }
+                }
+            }
+        })),
+    };
+    srv.handle_request(init);
+
+    let initialized = JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "initialized".into(),
+        params: Some(json!({})),
+    };
+    srv.handle_request(initialized);
+
+    // Open a document with a named subroutine definition
+    let doc_uri = "file:///test_label_location.pl";
+    let text = "sub my_func { my ($x) = @_; return $x; }";
+    let open = JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: None,
+        method: "textDocument/didOpen".into(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": doc_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": text
+            }
+        })),
+    };
+    srv.handle_request(open);
+
+    // Resolve a parameter hint referencing that subroutine
+    let hint = json!({
+        "position": {"line": 0, "character": 15},
+        "label": "x:",
+        "kind": 2,
+        "paddingLeft": false,
+        "paddingRight": true,
+        "data": {
+            "uri": doc_uri,
+            "function": "my_func",
+            "paramIndex": 0
+        }
+    });
+
+    let req = JsonRpcRequest {
+        _jsonrpc: "2.0".into(),
+        id: Some(json!(2)),
+        method: "inlayHint/resolve".into(),
+        params: Some(hint),
+    };
+
+    let res = srv.handle_request(req).ok_or("Failed to handle inlayHint/resolve request")?;
+    let result = res.result.ok_or("No result in inlayHint/resolve response")?;
+
+    // Must have labelDetails with a location field
+    let label_details = result.get("labelDetails").ok_or("labelDetails field missing")?;
+    let location = label_details.get("location").ok_or("labelDetails.location field missing")?;
+
+    // location must have uri and range
+    assert!(location.get("uri").is_some(), "labelDetails.location must have uri, got: {location}");
+    assert!(
+        location.get("range").is_some(),
+        "labelDetails.location must have range, got: {location}"
+    );
+
+    // Tooltip should still be present (no regression)
+    assert!(result.get("tooltip").is_some(), "tooltip should still be populated");
+
+    Ok(())
+}
+
 /// Test that resolve handles missing params gracefully
 #[test]
 fn lsp_inlay_hint_resolve_handles_invalid_params() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

The `inlayHint/resolve` handler was advertised as supporting `label.location` in `resolveSupport` (features.toml) but only ever populated `tooltip`. This made click-to-definition on parameter name hints impossible for VSCode/Neovim clients that check `labelDetails.location`.

This PR completes the handler by adding `labelDetails.location` for parameter hints (kind=2). When a hint's `data` field contains a `uri` and `function` name, the handler looks up the open document, walks the AST to find the subroutine definition node, and converts its byte-offset range into an LSP `{ uri, range }` location object.

Also fixes a pre-existing missing `use serde_json::json` import in `execute_command_mutation_hardening_public_api_tests.rs` that was blocking `clippy --tests`.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive — `labelDetails.location` now populated on `inlayHint/resolve` responses for parameter hints when the source document is open
- DAP surface: unchanged
- CLI: unchanged

## What changed

`handle_inlay_hint_resolve` (misc.rs):
- Early-return guard changed from "has tooltip" to "has both tooltip AND labelDetails" — so `labelDetails` can now be filled even when `tooltip` is already present
- Tooltip population wrapped in an `if hint.get("tooltip").is_none()` guard
- New conditional: when `kind == 2` and `labelDetails` not yet set, calls `resolve_hint_label_location`
- `resolve_hint_label_location`: extracts `data.uri` + `data.function`, acquires the document lock, walks AST with `find_subroutine_node`, converts node byte-offsets to LSP line/char positions, returns `{ uri, range }`
- `find_subroutine_node`: private static helper, same pattern as `find_subroutine_definition` in hover.rs

When the function is not found (document not open, function name missing, or subroutine not in AST), `resolve_hint_label_location` returns `None` and `labelDetails` is simply not added — graceful degradation, no error.

## How to review

Start at `misc.rs:111` — the `handle_inlay_hint_resolve` function. The structural change (early-return guard + two guarded blocks replacing one) is the core. Then review `resolve_hint_label_location` and `find_subroutine_node` below it.

The test `lsp_inlay_hint_resolve_adds_label_location` in `lsp_inlay_hint_resolve_tests.rs` exercises the full path: initialize with `label.location` in resolveSupport, open a document with `sub my_func`, resolve a parameter hint referencing it, assert `labelDetails.location` has both `uri` and `range`.

## Evidence

```
test lsp_inlay_hint_resolve_adds_tooltip ... ok
test lsp_inlay_hint_resolve_preserves_data ... ok
test lsp_inlay_hint_resolve_no_op_when_complete ... ok
test lsp_inlay_hint_resolve_handles_invalid_params ... ok
test lsp_inlay_hint_resolve_adds_label_location ... ok
test result: ok. 5 passed; 0 failed

cargo clippy -p perl-lsp --lib -- -D warnings: Finished (clean)
cargo fmt -p perl-lsp -- --check: PASS
cargo test -p perl-lsp --lib: 245 passed; 0 failed
```

Note: `ci-gate` fails on `perl-lsp-completion/snippets.rs:512` (`panic!` in production code) — pre-existing on master, not caused by this PR.

## Risk & rollback

Blast radius: only `handle_inlay_hint_resolve`. The `labelDetails` block has a guard that skips silently when resolution fails. The tooltip path is unchanged in behavior (just wrapped in a guard). Rollback: revert the three changed lines in the early-return guard and the `labelDetails` block.

## Follow-ups

- `find_subroutine_node` (misc.rs) and `find_subroutine_definition` (hover.rs) are near-duplicates. A future refactor could extract a shared utility, but that's a separate concern.
- `labelDetails.location` currently spans the entire subroutine node. A tighter range (name token only) would be more precise for large subs — Phase 2 improvement.