### PR TITLE
fix(lsp): eliminate reentrant deadlock in publish_diagnostics

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -71,132 +71,156 @@ impl LspServer {
     /// Only publishes if client doesn't support pull diagnostics to avoid
     /// double-flow for modern LSP 3.17+ clients.
     pub(crate) fn publish_diagnostics(&self, uri: &str) {
-        let documents = self.documents.lock();
         let normalized_uri = self.normalize_uri_key(uri);
-        if let Some(doc) = documents.get(&normalized_uri).or_else(|| documents.get(uri)) {
-            let lsp_diagnostics: Vec<Value> = if let Some(ast) = &doc.ast {
-                // Get diagnostics (already includes unused variable detection)
-                let provider = DiagnosticsProvider::new(ast, doc.text.clone());
-                let resolver = |module: &str| self.resolve_module_to_path(module).is_some();
-                let mut diagnostics =
-                    provider.get_diagnostics(ast, &doc.parse_errors, &doc.text, Some(&resolver));
 
-                // Add Perl::Critic built-in analysis
-                let built_in_analyzer = BuiltInAnalyzer::new();
-                let violations = built_in_analyzer.analyze(ast, &doc.text);
-                for violation in violations {
-                    diagnostics.push(builtin_violation_to_diagnostic(&violation));
+        // Snapshot all fields needed from DocumentState while holding the lock briefly,
+        // then drop the lock before calling resolve_module_to_path which also acquires
+        // documents.lock().  Holding the lock across that call causes a reentrant deadlock
+        // because parking_lot::Mutex is not reentrant.
+        let snapshot = {
+            let documents = self.documents.lock();
+            documents.get(&normalized_uri).or_else(|| documents.get(uri)).map(|doc| {
+                (
+                    doc.ast.clone(),
+                    doc.text.clone(),
+                    doc.parse_errors.clone(),
+                    doc.version,
+                    doc.degradation_tier,
+                    doc.line_starts.clone(),
+                    doc.rope.clone(),
+                )
+            })
+            // lock is released here
+        };
+
+        let Some((ast_opt, text, parse_errors, version, degradation_tier, line_starts, rope)) =
+            snapshot
+        else {
+            return;
+        };
+
+        // Position helper that works on the snapshotted line_starts + rope.
+        let pos16 = |offset: usize| line_starts.offset_to_position_rope(&rope, offset);
+
+        let lsp_diagnostics: Vec<Value> = if let Some(ast) = &ast_opt {
+            // Get diagnostics (already includes unused variable detection).
+            // resolver is called with the documents lock *released* — no reentrant deadlock.
+            let provider = DiagnosticsProvider::new(ast, text.clone());
+            let resolver = |module: &str| self.resolve_module_to_path(module).is_some();
+            let mut diagnostics =
+                provider.get_diagnostics(ast, &parse_errors, &text, Some(&resolver));
+
+            // Add Perl::Critic built-in analysis
+            let built_in_analyzer = BuiltInAnalyzer::new();
+            let violations = built_in_analyzer.analyze(ast, &text);
+            for violation in violations {
+                diagnostics.push(builtin_violation_to_diagnostic(&violation));
+            }
+
+            // Add external perlcritic diagnostics (opt-in)
+            self.collect_external_perlcritic_diagnostics(uri, &text, &mut diagnostics);
+
+            // Add dead code diagnostics from workspace-wide symbol analysis
+            #[cfg(all(feature = "workspace", not(target_arch = "wasm32")))]
+            {
+                if let Some(workspace_index) = self.workspace_index() {
+                    let dead_code_diags = perl_lsp_diagnostics::detect_dead_code(
+                        &workspace_index,
+                        uri,
+                        &text,
+                        &line_starts,
+                    );
+                    diagnostics.extend(dead_code_diags);
                 }
+            }
 
-                // Add external perlcritic diagnostics (opt-in)
-                self.collect_external_perlcritic_diagnostics(uri, &doc.text, &mut diagnostics);
+            // Convert to LSP diagnostics
+            diagnostics
+                .into_iter()
+                .map(|d| {
+                    let (start_line, start_char) = pos16(d.range.0);
+                    let (end_line, end_char) = pos16(d.range.1);
 
-                // Add dead code diagnostics from workspace-wide symbol analysis
-                #[cfg(all(feature = "workspace", not(target_arch = "wasm32")))]
-                {
-                    if let Some(workspace_index) = self.workspace_index() {
-                        let dead_code_diags = perl_lsp_diagnostics::detect_dead_code(
-                            &workspace_index,
-                            uri,
-                            &doc.text,
-                            &doc.line_starts,
-                        );
-                        diagnostics.extend(dead_code_diags);
+                    let mut diag = json!({
+                        "range": {
+                            "start": {"line": start_line, "character": start_char},
+                            "end": {"line": end_line, "character": end_char},
+                        },
+                        "severity": match d.severity {
+                            InternalDiagnosticSeverity::Error => 1,
+                            InternalDiagnosticSeverity::Warning => 2,
+                            InternalDiagnosticSeverity::Information => 3,
+                            InternalDiagnosticSeverity::Hint => 4,
+                        },
+                        "code": d.code,
+                        "source": "perl-parser",
+                        "message": d.message,
+                    });
+                    if !d.tags.is_empty() {
+                        diag["tags"] = json!(Self::diagnostic_tags_to_lsp(&d.tags));
                     }
-                }
-
-                // Convert to LSP diagnostics
-                diagnostics
-                    .into_iter()
-                    .map(|d| {
-                        let (start_line, start_char) = self.offset_to_pos16(doc, d.range.0);
-                        let (end_line, end_char) = self.offset_to_pos16(doc, d.range.1);
-
-                        let mut diag = json!({
-                            "range": {
-                                "start": {"line": start_line, "character": start_char},
-                                "end": {"line": end_line, "character": end_char},
-                            },
-                            "severity": match d.severity {
-                                InternalDiagnosticSeverity::Error => 1,
-                                InternalDiagnosticSeverity::Warning => 2,
-                                InternalDiagnosticSeverity::Information => 3,
-                                InternalDiagnosticSeverity::Hint => 4,
-                            },
-                            "code": d.code,
-                            "source": "perl-parser",
-                            "message": d.message,
-                        });
-                        if !d.tags.is_empty() {
-                            diag["tags"] = json!(Self::diagnostic_tags_to_lsp(&d.tags));
+                    diag
+                })
+                .collect()
+        } else {
+            // No AST available (parse failed completely), just report parse errors
+            parse_errors
+                .iter()
+                .map(|e| {
+                    // Extract location and message from error enum
+                    let (location, message) = match e {
+                        crate::error::ParseError::UnexpectedToken { location, expected, found } => {
+                            (*location, format!("Expected {}, found {}", expected, found))
                         }
-                        diag
-                    })
-                    .collect()
-            } else {
-                // No AST available (parse failed completely), just report parse errors
-                doc.parse_errors
-                    .iter()
-                    .map(|e| {
-                        // Extract location and message from error enum
-                        let (location, message) = match e {
-                            crate::error::ParseError::UnexpectedToken {
-                                location,
-                                expected,
-                                found,
-                            } => (*location, format!("Expected {}, found {}", expected, found)),
-                            crate::error::ParseError::SyntaxError { location, message } => {
-                                (*location, message.clone())
-                            }
-                            crate::error::ParseError::UnexpectedEof => {
-                                (doc.text.len(), "Unexpected end of input".to_string())
-                            }
-                            crate::error::ParseError::LexerError { message } => {
-                                (0, message.clone())
-                            }
-                            _ => (0, e.to_string()),
-                        };
+                        crate::error::ParseError::SyntaxError { location, message } => {
+                            (*location, message.clone())
+                        }
+                        crate::error::ParseError::UnexpectedEof => {
+                            (text.len(), "Unexpected end of input".to_string())
+                        }
+                        crate::error::ParseError::LexerError { message } => (0, message.clone()),
+                        _ => (0, e.to_string()),
+                    };
 
-                        // Convert byte offset to line/column
-                        let (line, character) = self.offset_to_pos16(doc, location);
+                    // Convert byte offset to line/column
+                    let (line, character) = pos16(location);
 
-                        json!({
-                            "range": {
-                                "start": {"line": line, "character": character},
-                                "end": {"line": line, "character": character + 1},
-                            },
-                            "severity": 1, // Error
-                            "code": DiagnosticCode::ParseError.as_str(),
-                            "source": "perl-parser",
-                            "message": message,
-                        })
-                    })
-                    .collect()
-            };
-
-            eprintln!(
-                "Publishing {} diagnostics for {} (version {}, tier: {})",
-                lsp_diagnostics.len(),
-                normalized_uri,
-                doc.version,
-                doc.degradation_tier
-            );
-
-            // Only publish if client doesn't support pull diagnostics
-            // This avoids double-flow for modern clients
-            if !self.client_supports_pull_diags.load(Ordering::Relaxed) {
-                // Send diagnostics notification with version
-                // This ensures diagnostics are cleared when all errors are fixed
-                if let Err(e) = self.notify(
-                    "textDocument/publishDiagnostics",
                     json!({
-                        "uri": uri,
-                        "version": doc.version,
-                        "diagnostics": lsp_diagnostics
-                    }),
-                ) {
-                    eprintln!("Failed to publish diagnostics for {}: {}", uri, e);
-                }
+                        "range": {
+                            "start": {"line": line, "character": character},
+                            "end": {"line": line, "character": character + 1},
+                        },
+                        "severity": 1, // Error
+                        "code": DiagnosticCode::ParseError.as_str(),
+                        "source": "perl-parser",
+                        "message": message,
+                    })
+                })
+                .collect()
+        };
+
+        eprintln!(
+            "Publishing {} diagnostics for {} (version {}, tier: {})",
+            lsp_diagnostics.len(),
+            normalized_uri,
+            version,
+            degradation_tier
+        );
+
+        // Only publish if client doesn't support pull diagnostics
+        // This avoids double-flow for modern clients
+        if !self.client_supports_pull_diags.load(Ordering::Relaxed) {
+            // Send diagnostics notification with version
+            // This ensures diagnostics are cleared when all errors are fixed
+            if let Err(e) = self.notify(
+                "textDocument/publishDiagnostics",
+                json!({
+                    "uri": uri,
+                    "version": version,
+                    "diagnostics": lsp_diagnostics
+                }),
+            ) {
+                eprintln!("Failed to publish diagnostics for {}: {}", uri, e);
             }
         }
     }
@@ -233,8 +257,14 @@ impl LspServer {
             let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
             let previous_result_id = params["previousResultId"].as_str().map(|s| s.to_string());
 
-            let documents = self.documents.lock();
-            if let Some(doc) = self.get_document(&documents, uri) {
+            // Snapshot the document while holding the lock briefly, then release before
+            // calling resolve_module_to_path which also acquires documents.lock().
+            let doc_snapshot = {
+                let documents = self.documents.lock();
+                self.get_document(&documents, uri).cloned()
+                // lock released here
+            };
+            if let Some(doc) = doc_snapshot {
                 // Get diagnostics from the existing provider
                 if let Some(ast) = &doc.ast {
                     let provider = DiagnosticsProvider::new(ast, doc.text.clone());

--- a/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
+++ b/crates/perl-lsp/tests/execute_command_mutation_hardening_public_api_tests.rs
@@ -20,7 +20,7 @@
 
 use perl_lsp::execute_command::{ExecuteCommandProvider, get_supported_commands};
 use perl_tdd_support::must;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs;
 use std::io::Write;
 use tempfile::NamedTempFile;


### PR DESCRIPTION
## Summary

`publish_diagnostics` held `documents.lock()` for its entire body, then called `resolve_module_to_path()` which acquires the same mutex a second time. `parking_lot::Mutex` is not reentrant — the server thread deadlocked indefinitely on any `didOpen` notification containing a `use Module;` statement. Since the test harness uses a single server thread with a synchronous fallback path (no Tokio runtime in tests), every request after the stuck `didOpen` timed out.

This caused all 10 `lsp_behavioral_tests` to fail with `"Request timed out after 500ms"`, blocking the `lsp_tier_b` CI gate on every branch. The same latent deadlock existed in `handle_document_diagnostic`.

The fix snapshots all needed `DocumentState` fields (ast, text, parse_errors, version, degradation_tier, line_starts, rope) inside a scoped block, releases the lock, then runs diagnostics computation with the `resolver` closure holding no lock.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged — same push/pull diagnostics semantics
- DAP surface: unchanged
- CLI: unchanged

## What changed

- `publish_diagnostics`: replaced the long-held lock with a snapshot pattern. The lock is acquired briefly to clone the fields, released, then `resolve_module_to_path` is called lock-free. A local `pos16` closure replaces `self.offset_to_pos16(doc, ...)` using the snapshotted `line_starts`+`rope`.
- `handle_document_diagnostic`: same snapshot pattern applied to remove its identical latent deadlock.
- `execute_command_mutation_hardening_public_api_tests.rs`: added missing `json` to the `serde_json` import (pre-existing compilation failure, unrelated to the deadlock).

## How to review

Start at `crates/perl-lsp/src/runtime/diagnostics.rs` `publish_diagnostics`. The key change is the scoped `{ let documents = self.documents.lock(); ... }` block that clones fields and releases before the `let resolver = ...` line. Everything else is the same logic using the cloned values instead of `doc.*`.

Verify `crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs:157` — that is the second `documents.lock()` that was causing the deadlock.

## Evidence

```
running 10 tests
test test_folding_ranges_work ... ok
test test_completion_detail_formatting ... ok
test test_cross_file_references ... ok
test test_workspace_symbol_search ... ok
test test_hover_enriched_information ... ok
test test_extract_variable_returns_edits ... ok
test test_utf16_definition_with_non_ascii_on_same_line ... ok
test test_word_boundary_references ... ok
test test_cross_file_definition ... ok
test test_critic_violations_emit_diagnostics ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s

lsp_tier_b: 10/10 suites pass, 0 failures
```

## Risk & rollback

Low risk. The snapshot approach clones all needed fields (all `Clone`) with the lock held for a few microseconds, then proceeds lock-free. Diagnostics content is unchanged — only the locking discipline changed. Rollback: revert this commit.

One known pre-existing issue in `execute_command_mutation_hardening_public_api_tests`: 3 tests fail due to uninitialized server state and a command-list sync gap (`perl.debugTest` missing from the provider list). These were already failing before this PR (the file didn't even compile on master). They are not in the `lsp_tier_b` gate. Recommend a follow-up scout/builder for the command list sync.

## Follow-ups

- `execute_command_mutation_hardening_public_api_tests`: 3 tests still fail after fixing the compilation error — command list sync (`perl.debugTest`) and uninitialized server state. Separate issue.