### PR TITLE
docs(articles): update corpus numbers in INTERVIEW_QA and Q39 answer

### DIFF
--- a/docs/articles/INTERVIEW_QA.md
+++ b/docs/articles/INTERVIEW_QA.md
@@ -84,7 +84,9 @@ Larry Wall said "only perl can parse Perl," and he wasn't exaggerating. The char
 
 **Q: How do you measure "correct enough"?**
 
-We parse the CPAN corpus. 7,000+ real-world Perl files from published modules. The parse rate ratchets -- CI blocks any change that would lower it. We started at around 50%. We're above 85% now. Every session either improves the number or leaves it unchanged. Regressions are structurally impossible.
+We parse the CPAN corpus. 4,355 real-world Perl files from published modules. The parse rate ratchets -- CI blocks any change that would lower it. We started at around 50%. We're at 85.4% on the full corpus baseline, and 90.9% clean on the lib-file sweep after recent parser fixes. Every session either improves the number or leaves it unchanged. Regressions are structurally impossible.
+
+*Updated 2026-03-21: baseline 85.4% (3,717/4,355 files), manifest 2,052 clean modules. The March 21 session merged fat-arrow (#2613) and defined/ref (#2626) parser fixes — the lib-file sweep shows 90.9% clean (3,077/3,386). The baseline JSON will reset on next ratchet run.*
 
 ---
 

--- a/docs/articles/NEW_INTERVIEW_QUESTIONS.md
+++ b/docs/articles/NEW_INTERVIEW_QUESTIONS.md
@@ -63,11 +63,23 @@ Each question includes: the question itself, why it unlocks an interesting story
 
 **Evidence from codebase**:
 - INTERVIEW_QA.md: "I think we're already there, no? At this point it's about finding ways to make a better user experience."
-- CPAN corpus: 85%+ clean out of 4,355+ files
+- CPAN corpus baseline: 85.4% clean (3,717/4,355 files) as of 2026-03-20
+- Lib-file sweep after March 21 parser fixes: 90.9% clean (3,077/3,386 files)
+- Manifest: 2,052 clean modules explicitly verified
 - docs/issues/corpus/gaps/ lists specific gap categories including source filters and exotic syntax
 - Memory: `scout_unexpected_token_analysis.md` categorizes 146 failing files into 10 subcategories
 
+**Draft answer**:
+
+"There are two numbers. There's the baseline — 85.4% on 4,355 full corpus files — and there's the sweep, which is 90.9% on the lib-file subset after recent parser fixes. The gap between those two numbers is partly real and partly measurement artifact. The full corpus includes test files, scripts, and edge-case modules that nobody deploys. The lib-file sweep is closer to what you'd actually see in a production Perl codebase.
+
+The remaining ~10% breaks into categories. Source filters — code that rewrites itself before parsing — are structurally unfixable for any static parser. Exotic DSL syntax (some Moose patterns, some DBIx::Class query generation) needs semantic awareness, not just parsing. And then there's a long tail of real bugs we haven't fixed yet. The ratchet tracks all three: it just can't tell them apart.
+
+So when I said 'I think we're already there' — I meant for the IDE features that matter: go-to-definition, real-time diagnostics, hover. Those work. The 10% that doesn't parse cleanly mostly generates a degraded experience, not a broken one. The parser produces partial results, and the LSP does its best with what it has. That's different from saying we're done. We're not done. But 'not done' and 'not useful yet' are different claims."
+
 **Follow-up**: Have you profiled what percentage of Perl code in active production codebases falls in that 15%? Is the gap CPAN-specific or representative of what users actually write?
+
+*Updated 2026-03-21: baseline 85.4% (3,717/4,355), manifest 2,052 modules, 90.9% clean on lib-file sweep. Fat-arrow fix (#2613) and defined/ref fix (#2626) merged this session — estimated 80+ newly clean files not yet reflected in baseline JSON.*
 
 ---
 


### PR DESCRIPTION
## Summary

The interview article (`INTERVIEW_QA.md`) contained two stale corpus claims:

1. **"7,000+ real-world Perl files"** — the actual corpus is 4,355 files
2. **"We're above 85% now"** — precise numbers are now available: 85.4% baseline (full corpus) and 90.9% on the lib-file sweep after the March 21 parser fix session

The question-bank file (`NEW_INTERVIEW_QUESTIONS.md`) Q39 had an evidence section citing "85%+" without precision. This PR:
- Updates both numbers to cite the exact baseline (3,717/4,355 = 85.4%) and the post-fix sweep (3,077/3,386 = 90.9%)
- Adds a draft answer for Q39 that explains why there are two numbers and what the gap means
- Adds footnotes recording the session-2 parser fixes (#2613 fat-arrow, #2626 defined/ref) that account for ~80+ newly clean files not yet in the baseline JSON

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`docs/articles/INTERVIEW_QA.md` — "How do you measure correct enough?" answer updated with precise figures and a footnote explaining the measurement context (baseline JSON vs lib-file sweep).

`docs/articles/NEW_INTERVIEW_QUESTIONS.md` — Q39 evidence section updated with exact numbers; draft answer added explaining the baseline/sweep distinction, the three categories of remaining failures (source filters, exotic DSL, real bugs), and what "I think we're already there" means in context.

## How to review

Both files are pure prose. Verify:
- Numbers match the source files: `.ci/cpan-corpus-baseline.json` (3,717/4,355) and PR #2621 body (3,077/3,386 sweep)
- Manifest count: `wc -l .ci/cpan-corpus-manifest.txt` = 2,052
- The draft answer voice is consistent with the rest of INTERVIEW_QA.md

## Evidence

```
baseline.json:  clean=3717, total=4355, pct=85.4%
manifest:       2052 lines
PR #2621 body:  "3077/3386 clean (90.9%)"
PR #2613:       merged 2026-03-21T08:34:46Z (fat-arrow fix, 53-file bucket)
PR #2626:       merged 2026-03-21T10:13:50Z (defined/ref fix, ~29 word-op files)
Total estimated newly clean: 53 + 29 = 82 (cited as "80+" — conservative)
```

## Risk & rollback

Doc-only change. Zero risk to parser, LSP, or test correctness. Rollback = revert commit.

## Follow-ups

- Run `just cpan-corpus-ratchet` after #2626 to update baseline JSON (not in scope here)
- The "7,000+" figure may appear in other docs — a follow-up sweep scout could find and fix them