### PR TITLE
docs(research): add 2026 competitive and agentic dev landscape research

### DIFF
--- a/docs/articles/research/AGENTIC_DEV_LANDSCAPE_2026.md
+++ b/docs/articles/research/AGENTIC_DEV_LANDSCAPE_2026.md
@@ -1,0 +1,110 @@
+# Agentic Development Landscape (2026)
+
+*Explore agent research report. Data current as of March 2026.*
+
+---
+
+## Summary
+
+The agentic coding tool market consolidated significantly in 2025. Every major AI lab and IDE vendor now ships an agent mode. Cost-per-PR benchmarks are not publicly available from any vendor — perl-lsp would be the first project to publish them.
+
+---
+
+## Tool Inventory
+
+### Claude Agent SDK (Anthropic)
+
+- **Default model**: Sonnet 4.5
+- **Key capabilities**: Subagents, hooks, checkpoints, worktree isolation
+- **Architecture**: Agents can spawn subagents; hooks enforce pipeline gates; checkpoints enable resumable long tasks
+- **Relevance to perl-lsp**: Current swarm infrastructure — the SDK powering this development model
+
+### Codex CLI (OpenAI)
+
+- **Models**: o3, o4-mini
+- **Pricing**: $1.50 / $6.00 per million tokens (input/output, approximate)
+- **Positioning**: Lightweight CLI agent; no IDE dependency
+- **Architecture**: Terminal-native; designed for scripted, non-interactive workflows
+- **Status**: GA as of 2025
+
+### Copilot Coding Agent (GitHub/Microsoft)
+
+- **GA date**: September 2025
+- **Key feature**: Mission Control dashboard for managing parallel agent tasks
+- **Architecture**: GitHub-native; integrates directly with Issues and PRs
+- **Positioning**: Developer workflow integration over raw coding capability
+- **Status**: Generally available
+
+### Windsurf (Codeium)
+
+- **Agent**: Cascade
+- **Model**: SWE-1.5 (proprietary)
+- **Performance**: 950 tokens/sec inference
+- **Pricing**: $15/seat/month
+- **Architecture**: IDE-native agent with context-aware file editing
+- **Positioning**: Speed-focused; targets developers who find Cursor/Copilot too slow
+
+### Cursor
+
+- **Agent**: Agent mode
+- **Model**: Claude 3.5 Sonnet (default as of research date)
+- **Pricing**: $20/seat/month
+- **Architecture**: IDE fork; deep editor integration
+- **Positioning**: Power-user focused; most complete context window usage of IDE tools
+
+---
+
+## Market Observations
+
+### Cost-per-PR Benchmarks
+
+No vendor publishes cost-per-PR data. This is a significant gap:
+
+- Vendors optimize for capability claims, not efficiency metrics
+- "Agentic" is used as a marketing term without standardized measurement
+- perl-lsp's swarm model tracks cost-per-PR internally and would be the first to publish verified numbers
+
+### Architectural Patterns
+
+| Pattern | Tools Using It |
+|---------|---------------|
+| IDE-native agent | Cursor, Windsurf, Copilot |
+| CLI agent | Codex CLI, Claude Agent SDK |
+| Worktree isolation | Claude Agent SDK (perl-lsp swarm) |
+| Subagent spawning | Claude Agent SDK |
+| Mission Control / dashboard | Copilot Coding Agent |
+
+### Pricing Landscape
+
+| Tool | Price |
+|------|-------|
+| Copilot Coding Agent | Included in GitHub Copilot subscription |
+| Cursor | $20/seat/month |
+| Windsurf | $15/seat/month |
+| Codex CLI | Pay-per-token ($1.50–$6.00/M) |
+| Claude Agent SDK | Pay-per-token (API pricing) |
+
+---
+
+## Differentiation of perl-lsp Swarm Model
+
+The perl-lsp swarm does not map neatly to any single product:
+
+- **vs. Copilot/Cursor/Windsurf**: Those are single-agent IDE tools. perl-lsp runs 50-100 parallel agents with worktree isolation and a pipeline (Scout → Plan-Review → Build → Review → Green → Merge).
+- **vs. Codex CLI**: Codex is single-task CLI. perl-lsp uses multi-stage quality gates with plan-reviewers improving scout specs before builders execute.
+- **vs. Claude Agent SDK alone**: perl-lsp adds the swarm operating model on top — agent definitions, catalog routing, corpus ratchets, and CI integration.
+
+The perl-lsp swarm is closer to an agentic CI/CD system than an IDE assistant.
+
+---
+
+## What Does Not Exist (as of March 2026)
+
+- No vendor publishes cost-per-PR benchmarks
+- No tool demonstrates 90%+ CPAN corpus coverage with a native parser
+- No open-source project has documented a 100-agent parallel swarm development model with full receipts
+- No Perl-specific agentic tooling from any vendor
+
+---
+
+*Source: Explore agent findings, March 2026.*

--- a/docs/articles/research/COMPETITIVE_LANDSCAPE_2026.md
+++ b/docs/articles/research/COMPETITIVE_LANDSCAPE_2026.md
@@ -1,0 +1,76 @@
+# Competitive Landscape: Perl LSP Tools (2026)
+
+*Explore agent research report. Data current as of March 2026.*
+
+---
+
+## Summary
+
+The Perl LSP ecosystem has three meaningful players, all in different states of activity. Zero new competitors entered the market in 2025-2026. perl-lsp is the only Rust-based alternative.
+
+---
+
+## Player Analysis
+
+### PerlNavigator
+
+- **Installs**: 53,314 (VS Code Marketplace)
+- **Version**: v0.8.20
+- **Status**: Actively maintained — last release February 2026
+- **Stack**: TypeScript/Node.js wrapper around `perlcritic`, `perltidy`, and external tools
+- **Approach**: Delegates to existing CPAN tools rather than implementing a native parser
+
+### Perl::LanguageServer
+
+- **Installs**: 293,154 (VS Code Marketplace — highest install count in the ecosystem)
+- **Version**: Last known release December 2023
+- **Status**: STALE — no releases in 27+ months as of March 2026
+- **Stack**: Perl-based LSP server
+- **Approach**: Full LSP server written in Perl; stagnation suggests maintenance burden
+
+### PLS (Perl Language Server)
+
+- **Installs**: 9,709 (VS Code Marketplace)
+- **Version**: Last release August 2021
+- **Status**: Server inactive — over four years without a release
+- **Stack**: Perl-based
+- **Approach**: Largely abandoned; install count reflects historical adoption
+
+### coc-perl
+
+- **Status**: Wrapper only — not a standalone LSP server
+- **Approach**: Delegates to one of the above servers; no independent implementation
+
+---
+
+## Market Gaps
+
+| Gap | Evidence |
+|-----|----------|
+| No rename support | None of the active tools advertise cross-file rename |
+| No inlay hints | Not present in PerlNavigator feature list |
+| No code actions | None of the tools implement code action providers |
+| No native parser | All tools wrap external processes; none parse Perl natively |
+| Stagnant leader | Perl::LanguageServer has 5.5x more installs than PerlNavigator but is unmaintained |
+
+---
+
+## perl-lsp Differentiation
+
+- Only Rust-based Perl LSP implementation
+- Native recursive-descent parser (v3) — no subprocess delegation
+- Zero CPAN runtime dependencies for the LSP server itself
+- Active swarm development model: 100+ agents, 90%+ CPAN corpus coverage
+- Features none of the incumbents have: rename, inlay hints, code actions, DAP
+
+---
+
+## Competitive Opportunity
+
+The high install count of the stale Perl::LanguageServer (293K) represents a large user base with no upgrade path from their current server. PerlNavigator is actively maintained but architecturally limited to what `perlcritic` and `perltidy` expose. The market has an open lane for a native, feature-complete alternative.
+
+No new Perl LSP competitors emerged in 2025 or early 2026.
+
+---
+
+*Source: Explore agent findings, March 2026. VS Code Marketplace install counts captured at time of research.*

--- a/docs/articles/research/PERL_COMMUNITY_SENTIMENT_2026.md
+++ b/docs/articles/research/PERL_COMMUNITY_SENTIMENT_2026.md
@@ -1,0 +1,107 @@
+# Perl Community Sentiment: LSP Adoption (2026)
+
+*Explore agent research report. Data current as of March 2026.*
+
+*Source: Perl IDE Survey 2025, https://survey.perlide.org/results/2025 — 602 respondents*
+
+---
+
+## Headline Finding
+
+Despite six years of Perl LSP implementations, 78% of Perl developers use no language server at all.
+
+---
+
+## Survey Data (n=602)
+
+### LSP Adoption
+
+| Status | Share |
+|--------|-------|
+| No LSP | 78% |
+| Use LSP | 22% |
+
+### LSP Tool Usage (among the 22% who use one)
+
+| Tool | Approximate Users (of 602) |
+|------|---------------------------|
+| PerlNavigator | ~66 |
+| Perl::LanguageServer | ~44 |
+| PLS | ~8 |
+
+Note: These are derived counts from 22% of 602. Rounding applies.
+
+### IDE Distribution
+
+| IDE | Share |
+|-----|-------|
+| Vim | 28.4% |
+| VS Code | 21.6% |
+| Emacs | 14.1% |
+| Neovim | 7.0% |
+| Other | ~29% |
+
+---
+
+## Interpretation
+
+### The Adoption Gap
+
+The 78% non-adoption rate is striking given that PerlNavigator has been available since 2022 and Perl::LanguageServer since 2018. This is not a supply problem — tools exist. The gap suggests:
+
+1. **Awareness**: Many Perl developers may not know LSP tooling is available or mature enough
+2. **Editor fragmentation**: Vim (28.4%) and Emacs (14.1%) users have different LSP integration workflows than VS Code users; combined they represent 42.5% of the respondent base
+3. **Tool quality**: The leading tool by installs (Perl::LanguageServer, 293K) has been stale since December 2023, which may suppress adoption among developers who tried it
+4. **Community norms**: Perl's culture of "editor as personal environment" may reduce uptake of opinionated tooling
+
+### The Neovim Gap
+
+Neovim at 7% has native LSP support built in (since v0.5, 2021). Yet LSP adoption among this segment is not separable from the 22% overall figure. This is a segment that should be early adopters of LSP.
+
+### IDE Mix Implications
+
+VS Code at 21.6% is the strongest target for LSP distribution — VS Code's extension model is the most accessible path for new users. But Vim (28.4%) being the top editor means any LSP strategy must account for `coc.nvim` and similar setups.
+
+---
+
+## Conference Landscape
+
+### TPRC 2026
+
+- **When**: June 25-29, 2026
+- **Where**: Greenville, SC
+- **Status**: Soliciting tooling talks
+- **Gap**: No dedicated LSP track despite 6+ years of availability
+
+### PTS 2026 (Perl Toolchain Summit)
+
+- **Attendees**: 33 maintainers
+- **Focus**: CPAN infrastructure
+- **Gap**: LSP tooling not in current agenda despite direct relevance to developer workflows
+
+---
+
+## Narrative Frame
+
+"Despite six years of Perl LSP implementations, 78% still don't use them."
+
+This is the key story. The market is not saturated — it is underpenetrated. The audience that would benefit most (the 78%) has not been reached by any of the existing tools. The stale leader (Perl::LanguageServer) may be actively suppressing trust in the category.
+
+perl-lsp's position: the first actively maintained, native-parser-backed Perl LSP with full CPAN corpus coverage — entering a market where adoption is low not because users rejected LSP, but because no tool has successfully converted them.
+
+---
+
+## Strategic Implications
+
+| Observation | Action |
+|-------------|--------|
+| 78% non-adoption | Messaging should explain the category, not just differentiate perl-lsp |
+| Vim is #1 editor | Ensure Vim/Neovim integration is documented and tested |
+| TPRC soliciting talks | Submit a tooling talk with survey data and live demo |
+| No LSP track at conferences | Opportunity to be first; propose a BOF or session |
+| PLS stale | Target PLS users (9,709 installs) with direct migration path |
+| Perl::LanguageServer stale | Large user base (293K installs) with no maintained upgrade path |
+
+---
+
+*Source: Perl IDE Survey 2025 (https://survey.perlide.org/results/2025), 602 respondents. Explore agent findings, March 2026.*


### PR DESCRIPTION
## Summary

Three explore-agent research documents capturing market intelligence as of March 2026, for use as article source material and strategic planning:

1. **COMPETITIVE_LANDSCAPE_2026.md** — State of the Perl LSP ecosystem: PerlNavigator (53K installs, active), Perl::LanguageServer (293K installs, stale 27+ months), PLS (inactive since 2021), and zero new competitors in 2025-2026. perl-lsp is the only Rust-based alternative.

2. **AGENTIC_DEV_LANDSCAPE_2026.md** — The broader agentic coding tool market: Claude Agent SDK, Codex CLI, Copilot Coding Agent, Windsurf, and Cursor. Key finding: no vendor publishes cost-per-PR benchmarks — perl-lsp would be the first. Includes pricing table and architectural pattern comparison.

3. **PERL_COMMUNITY_SENTIMENT_2026.md** — Perl IDE Survey 2025 data (n=602): 78% of Perl devs use no LSP despite 6+ years of tool availability. IDE breakdown: Vim 28.4%, VS Code 21.6%, Emacs 14.1%, Neovim 7%. Includes conference landscape (TPRC 2026, PTS 2026) and strategic implications.

The headline narrative hook: "Despite six years of Perl LSP implementations, 78% still don't use them." The market is underpenetrated, not saturated.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Three new markdown files added to `docs/articles/research/`. No code changes. No existing files modified.

## How to review

All three files are self-contained. Start with PERL_COMMUNITY_SENTIMENT_2026.md for the survey data, then COMPETITIVE_LANDSCAPE_2026.md for the player analysis, then AGENTIC_DEV_LANDSCAPE_2026.md for the broader tool market context.

Check:
- Data matches the explore agent findings provided in the task
- Narrative framing is accurate and not overreaching
- Strategic implications table in PERL_COMMUNITY_SENTIMENT_2026.md is actionable

## Evidence

Documentation-only change. No cargo gate needed.

```
3 files changed, 293 insertions(+)
docs/articles/research/AGENTIC_DEV_LANDSCAPE_2026.md    (110 lines)
docs/articles/research/COMPETITIVE_LANDSCAPE_2026.md    (76 lines)
docs/articles/research/PERL_COMMUNITY_SENTIMENT_2026.md (107 lines)
```

## Risk & rollback

Blast radius: zero. Documentation files only, no build dependencies. Rollback by reverting the commit.

## Follow-ups

- Scout opportunity: verify Perl IDE Survey URL (https://survey.perlide.org/results/2025) is publicly accessible and data is accurately transcribed
- Article draft agent could use these three files as source material for a launch post
- TPRC 2026 talk submission opportunity flagged in PERL_COMMUNITY_SENTIMENT_2026.md