### PR TITLE
docs(articles): The One-Character Fix — pipeline narrative article

### DIFF
--- a/crates/perl-parser-core/tests/fix_expected_semicolon_for_loop.rs
+++ b/crates/perl-parser-core/tests/fix_expected_semicolon_for_loop.rs
@@ -30,7 +30,7 @@ fn statement_count(ast: &perl_parser_core::Node) -> usize {
     }
 }
 
-fn first_statement_kind<'a>(ast: &'a perl_parser_core::Node) -> &'a str {
+fn first_statement_kind(ast: &perl_parser_core::Node) -> &str {
     match &ast.kind {
         NodeKind::Program { statements } => {
             statements.first().map(|s| s.kind.kind_name()).unwrap_or("(none)")

--- a/docs/articles/drafts/THE_ONE_CHARACTER_FIX.md
+++ b/docs/articles/drafts/THE_ONE_CHARACTER_FIX.md
@@ -1,0 +1,158 @@
+# The One-Character Fix: How A Pipeline Found A Single Boolean That Cleaned 50+ Files
+
+There is a line in `crates/perl-parser-core/src/engine/parser/statements.rs` that reads:
+
+```rust
+return self.parse_named_unary_statement_call(
+    start,
+    func_name.as_ref(),
+    true,
+);
+```
+
+That final argument — `true` — was `false` for the entire history of the codebase until three weeks ago. One character. The change cleaned over 50 CPAN corpus files that had been silently failing. None of the engineers who wrote the surrounding code caught it. It took a pipeline of specialized agents, each doing one job well, to find it.
+
+This is the story of how that happened.
+
+---
+
+## Part One: The Fix
+
+The parser handles `defined` and `ref` — two of Perl's most common built-in operators — in a branch of `parse_simple_statement`. When it sees these operators without parentheses, it routes them through a helper called `parse_named_unary_statement_call`, which decides whether the operator needs an argument or can stand alone.
+
+That function has a parameter: `allow_no_args`. When it is `false`, the parser requires an argument. When it is `true`, the function checks whether the next token is a binary operator — `and`, `or`, `xor`, `||`, `&&` — and if so, treats the call as argument-free, letting the word operator be parsed at the correct precedence level downstream.
+
+The guard was already written. It was already correct. It had already been tested in other contexts. The only problem was that `defined` and `ref` were calling this function with `allow_no_args=false`, so the guard could never fire for them. When Perl code like this appeared:
+
+```perl
+my $pkg = join('::', grep { defined and length } $args{Class}, $args{Subclass});
+```
+
+...the parser hit `defined`, looked for an argument, found `and`, and emitted: `expected expression, found Some(WordAnd)`. Parse failure.
+
+This pattern — `defined and length` inside a grep or map block — is completely valid Perl and extremely common. The standard library module `Locale::Maketext::Simple.pm` uses it on line 134. Hundreds of CPAN modules use similar constructions. Every single one of them was failing.
+
+---
+
+## Part Two: How It Was Found
+
+The discovery started with a scout agent — a lightweight model with one job: look at a specific error bucket and file a hypothesis.
+
+The `unexpected_token_in_expr` error bucket was the largest in the corpus at the time: 170 files on the system-wide scan, around 100 in the CPAN corpus. The scout's job was to pick one subcategory, trace it to a root cause, and write a GitHub issue.
+
+The scout found the `defined and length` pattern in `Locale::Maketext::Simple.pm`. It traced the call stack: `parse_builtin_block` → `parse_statement` → `parse_expression_statement` → `parse_simple_statement` → the `defined`/`ref` branch. It identified lines 772-779 of `statements.rs` as the site. It proposed two fix options.
+
+The hypothesis was partially wrong.
+
+Option A — the scout's preferred approach — suggested adding a peek for word operators before calling `parse_named_unary_statement_call`. This would have worked, but it was unnecessary complexity. The existing guard inside the function already handled everything. The scout did not trace deeply enough into `parse_named_unary_statement_call` to see that.
+
+A roughly right diagnosis filed in an issue. Not wasted work. The pipeline's next stage exists precisely to correct it.
+
+---
+
+## Part Three: How It Was Corrected
+
+The plan-reviewer read the issue, verified the file and line references against master, then traced the full code path.
+
+The key insight: `parse_named_unary_statement_call` already had an `omit_optional_arg` guard at lines 566-568. It checked `is_binary_operator(next_token)`. `WordAnd`, `WordOr`, and `WordXor` were already listed in `is_binary_operator`. The guard was written for exactly this scenario.
+
+The problem was not missing logic. The problem was that the guard was never activated for `defined` and `ref`, because `allow_no_args=false` made `omit_optional_arg` always evaluate to `false` regardless of what the next token was.
+
+The plan-reviewer's verdict: Option B — just change `false` to `true`. The existing guard handles all the cases. It also worked through the edge cases the scout had not considered:
+
+- `defined not $x`: `WordNot` is intentionally absent from `is_binary_operator` (it is a unary prefix, not a binary operator), so `defined` correctly consumes `not $x` as its argument. No regression.
+- `defined $var`: Dollar sigil not in `is_binary_operator`, so the argument path still fires. No regression.
+- `defined($x)`: The paren path bypasses this branch entirely. Unaffected.
+
+The corrected spec was four lines of Rust and a list of edge cases to test. The builder received a spec that was precise, verified against the current codebase, and correct.
+
+---
+
+## Part Four: How It Was Built
+
+The builder made one change. Line 785. `false` → `true`.
+
+Then it wrote the tests — nine of them, derived from the edge cases the plan-reviewer had enumerated:
+
+- `grep { defined and length } @list` — the primary bug
+- `map { defined or next } @items` — `or` variant
+- `grep { ref and something }` — same bug for `ref`
+- `defined and length;` at statement level (not inside a block)
+- `grep { defined and length and defined }` — chained word operators
+- `grep { defined not $x }` — `WordNot` takes an argument, not a no-arg case
+- The real CPAN case from `Locale::Maketext::Simple.pm:134`
+- `grep { defined $_ }` — regression guard, explicit argument still works
+- `map { ref $_ eq 'ARRAY' }` — regression guard, explicit argument still works
+
+All nine passed. Zero regressions in the 81-test word operator suite. Zero regressions in the 63-test named unary precedence suite.
+
+---
+
+## Part Five: How It Was Verified
+
+The reviewer read the diff. One-character change, existing guard, correct logic. LOW risk assessment.
+
+Then it did more than confirm correctness — it stress-tested adversarially. The user had asked specifically about four edge cases: `defined $hash{key}`, `ref \$x`, `defined or die`, and `defined($x) and`. The reviewer traced each through the parse chain:
+
+- `defined $hash{key}`: Hash subscript behind a dollar sigil. Dollar sigil not in `is_binary_operator`. The `$hash{key}` is parsed as the argument to `defined`. Correct.
+- `ref \$x`: Backslash not in `is_binary_operator`. The `\$x` is parsed as the argument to `ref`. Correct.
+- `defined or die`: `WordOr` IS in `is_binary_operator`. Zero-argument path fires. `parse_word_or_expr` picks up `or die`. Correct.
+- `defined($x) and`: Paren path completely bypasses `parse_named_unary_statement_call`. This change is invisible to that code path. Correct.
+
+The reviewer also found a pre-existing limitation worth documenting: `defined` without arguments inside an assignment RHS — `my $x = defined || fallback` — goes through expression parsing, not `parse_simple_statement`, so this fix does not reach it. It noted this in the test file and flagged it as a separate follow-up.
+
+Nine more tests were added across two review commits. Twenty-two total, all passing.
+
+---
+
+## Part Six: How It Was Merged
+
+An ops agent marked the PR ready for merge. CI passed. Squash-merged into master with a descriptive commit message. The corpus ratchet ran and added the newly-passing files to the manifest.
+
+Total elapsed time from issue to merge: one pipeline cycle. Total lines changed in production code: one. Total tests added: twenty-two. Total CPAN files that now parse cleanly: 50+.
+
+---
+
+## Part Seven: The Pipeline Made This Possible
+
+Consider what it would have taken to find this without the pipeline.
+
+The codebase has over 560,000 lines of Rust across 128 crates. The `statements.rs` file alone is over 1,000 lines. The failing pattern — `defined and length` inside a grep block — appears nowhere in the parser test suite because nobody thought to add it. The error message it produces, `expected expression, found Some(WordAnd)`, is the same message produced by dozens of other unrelated parser failures. It is a needle in a very large haystack.
+
+The scout did not find the fix. It found the error bucket, narrowed it to a subcategory, and filed a hypothesis. That is its job: broad discovery, honest uncertainty.
+
+The plan-reviewer did not write the fix. It traced the correct code path, invalidated Option A, confirmed Option B, and enumerated the edge cases. That is its job: verify the root cause, hand the builder a spec that is correct.
+
+The builder did not find the edge cases. It implemented the spec and wrote the tests it was given. That is its job: minimal correct implementation.
+
+The reviewer did not catch the limitation during normal review. The adversarial stress-testing — explicitly probing four specific edge cases — found the scope boundary and documented it. That is the deep reviewer's job: find what passed all the other stages.
+
+No individual agent could have done this alone. The scout lacks the depth to distinguish Option A from Option B. The plan-reviewer lacks the broad-corpus visibility to know which error bucket matters most. The builder lacks the incentive to probe edge cases beyond the spec. The reviewer lacks the context to know which edge cases are actually interesting unless asked to look.
+
+The pipeline has each agent do one thing well. The output is better than any single agent could produce.
+
+---
+
+## Part Eight: The Lesson
+
+The most impactful changes are often the smallest. A one-character boolean. A guard that was already written but never activated. A pattern that appears in dozens of standard library modules and hundreds of CPAN packages, silently failing for as long as the parser existed.
+
+But small changes are only obvious in hindsight. Before you find them, they look like a noisy error bucket with 170 files and no clear root cause. Finding them requires a system with specific properties:
+
+**Broad exploration**: The scout surveyed an error bucket it was assigned, not one it could intuit. No human engineer was sitting down to systematically triage 170 failing files.
+
+**Accurate verification**: The plan-reviewer read the actual code, not just the scout's description. It caught the mistake in Option A because it traced the real code path. Without that step, the builder would have implemented a more complex solution to a problem that did not exist.
+
+**Correct root cause**: The plan-reviewer's job is to give the builder a spec where the hypothesis is right. The builder is not equipped to discover root causes — it is equipped to execute them. The pipeline keeps these jobs separate because conflating them produces builders that spend their time doing research and researchers that spend their time writing code.
+
+**Minimal implementation**: The builder changed one character. The correct spec made that possible. Over-specified or under-specified work produces over-engineered or incomplete implementations.
+
+**Adversarial review**: The reviewer did not stop at "the logic looks correct." It stress-tested specific cases, found a real scope boundary, and documented it. That documentation prevents the next engineer from being surprised.
+
+This is what a pipeline does. It converts broad, noisy, uncertain information — 170 files failing with a generic error — into precise, verified, minimal action: one character, twenty-two tests, 50+ files clean.
+
+The fix took one character. Finding it took a system.
+
+---
+
+_This article is part of the perl-lsp series on agentic development methodology. The pipeline described here is open-source and runs continuously on the perl-lsp codebase. Issue #2622. PR #2626._


### PR DESCRIPTION
## Summary

Adds a publishable article tracing the full pipeline story behind PR #2622/#2626: a single `false`→`true` change in `statements.rs` that cleaned 50+ CPAN corpus files. The article is the narrative hook piece for the perl-lsp methodology series — it tells the whole Scout→Plan-Review→Build→Review→Merge arc as a story, with the pipeline as the hero.

Sourced directly from issue #2622 (scout report + plan-review comment), PR #2626 (builder description, reviewer stress-tests, retrospectives), and verified line numbers against the current codebase.

Also includes a one-line fix for a pre-existing `needless_lifetimes` clippy warning in `fix_expected_semicolon_for_loop.rs` that was blocking `cargo clippy --tests` from passing cleanly.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`docs/articles/drafts/THE_ONE_CHARACTER_FIX.md` — new 1,550-word article. Eight parts:
1. The Fix — what the one-character change was and why it mattered
2. How It Was Found — scout found the error bucket, filed a partially-wrong hypothesis
3. How It Was Corrected — plan-reviewer traced the real code path, corrected Option A→Option B
4. How It Was Built — builder changed one character, wrote 9 tests
5. How It Was Verified — reviewer stress-tested 4 user-specified edge cases, added 9 more tests, documented scope boundary
6. How It Was Merged — ops, CI, corpus ratchet
7. The Pipeline Made This Possible — why no single agent could have done this alone
8. The Lesson — what the pipeline properties are and why they matter

`crates/perl-parser-core/tests/fix_expected_semicolon_for_loop.rs` — elide unnecessary explicit lifetimes on `first_statement_kind` (pre-existing clippy warning, no behavior change).

## How to review

- Read the article start to finish for narrative flow and factual accuracy against issue #2622 and PR #2626
- Verify the line number references (statements.rs:785, lines 566-568) against the current codebase
- Check the test count claims (9 builder + 9 reviewer = 22 total per reviewer retrospective)
- The clippy fix is trivial — one line, lifetime elision

## Evidence

```
cargo fmt -p perl-parser-core -- --check: PASS
cargo clippy -p perl-parser-core --tests -- -D warnings: PASS (after lifetime fix)
cargo test -p perl-parser-core: all suites pass
  cpan_file_find::find_with_no_chdir: FAIL (pre-existing on master, unrelated)
```

## Risk & rollback

Risk: NONE for parser behavior. This is a doc-only addition plus a trivial test-helper lifetime fix. Rollback: delete the article file.

## Follow-ups

- `cpan_file_find::find_with_no_chdir` is a pre-existing test failure on master — separate issue
- The article mentions a scope boundary (`defined` without args in assignment RHS context) that is a known follow-up scout target