### PR TITLE
fix(parser): x operator RHS uses parse_power() for correct ** precedence

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -981,7 +981,9 @@ impl<'a> Parser<'a> {
                         break;
                     }
                     let op_token = self.tokens.next()?;
-                    let right = self.parse_unary()?;
+                    // Use parse_power() so that `a x b**c` parses as `a x (b**c)`.
+                    // Exponentiation binds more tightly than repetition in Perl.
+                    let right = self.parse_power()?;
                     let start = expr.location.start;
                     let end = right.location.end;
 

--- a/crates/perl-parser-core/tests/fix_x_operator_power_precedence.rs
+++ b/crates/perl-parser-core/tests/fix_x_operator_power_precedence.rs
@@ -1,0 +1,36 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// === x operator with ** on RHS ===
+
+#[test]
+fn x_operator_power_rhs_variable() {
+    // ("x") x $n**2 should parse as ("x") x ($n**2)
+    assert_clean_parse(r#"my @a = ("x") x $n**2;"#);
+}
+
+#[test]
+fn x_operator_power_rhs_literal() {
+    // "a" x 2**3 should parse as "a" x (2**3) = "a" x 8
+    assert_clean_parse(r#"my $s = "a" x 2**3;"#);
+}
+
+#[test]
+fn x_operator_power_rhs_complex() {
+    // $s x ($a**$b) — variable power expression
+    assert_clean_parse(r#"$format .= "0" x 2**$bits;"#);
+}
+
+// === Regression guards ===
+
+#[test]
+fn x_operator_simple_still_works() {
+    // Basic x operator must still work
+    assert_clean_parse(r#"my $line = "-" x 80;"#);
+}
+
+#[test]
+fn x_operator_additive_rhs() {
+    // x with additive expression on RHS
+    assert_clean_parse(r#"my $s = "ab" x $count;"#);
+}


### PR DESCRIPTION
## Summary

- Fixes #2625 — the `x` string repetition operator consumed its RHS via `parse_unary()`, leaving `**` (exponentiation) unconsumed as an ERROR node
- Changed `self.parse_unary()` to `self.parse_power()` on line 984 of `precedence.rs`, identical to the fix applied to `*`/`/`/`%` in PR #2550
- Adds 5 tests: 3 for x-with-power combinations and 2 regression guards

## Root cause

`parse_multiplicative_with()` had two RHS-consumption branches:
1. `*`/`/`/`%` — fixed in PR #2550 to use `parse_power()`
2. `x` — still using `parse_unary()` (this PR fixes it)

Without the fix, `"a" x $n**2` parsed as `("a" x $n) ERROR(**2)`.

## Test plan

- [x] 5 new tests in `fix_x_operator_power_precedence.rs` — all pass
- [x] Full `perl-parser-core` suite — no regressions (1 pre-existing failure `find_with_no_chdir` unrelated)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p perl-parser-core --tests` clean