### PR TITLE
docs(status): regenerate metrics for current codebase state

### DIFF
--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -60,10 +60,10 @@ Key terms:
 | **Current release line** | `v0.11.0` public alpha | Truthful docs and receipts | Active |
 | **Active milestone** | `v0.12.0` public-alpha hardening sprint | Exit hardening sprint cleanly | In progress |
 | **Merge gate** | `nix develop -c just ci-gate` | Green before merge | Required |
-| **Tier A Tests** | 2673 lib tests (discovered), 6 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2733 lib tests (discovered), 5 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- BEGIN: STATUS_METRICS_TABLE -->
-| **LSP Coverage** | 100% (53/53 advertised features, `features.toml`) | 100% | PASS |
+| **LSP Coverage** | 100% (54/54 advertised features, `features.toml`) | 100% | PASS |
 <!-- END: STATUS_METRICS_TABLE -->
 | **Parser hardening** | CPAN baseline, repo corpus, and hang-risk receipts tracked below | 90%+ CPAN clean next | Active |
 | **DAP stance** | Native + Bridge preview | Harden preview flows | Active |
@@ -90,10 +90,10 @@ Key terms:
 ### Computed Metrics (auto-updated by `just status-update`)
 
 <!-- BEGIN: STATUS_METRICS_BULLETS -->
-- **LSP Coverage**: 100% user-visible feature coverage (53/53 advertised features from `features.toml`)
-- **Protocol Compliance**: 100% overall LSP protocol support (97/97 including plumbing)
+- **LSP Coverage**: 100% user-visible feature coverage (54/54 advertised features from `features.toml`)
+- **Protocol Compliance**: 100% overall LSP protocol support (98/98 including plumbing)
 - **Parser Coverage**: ~100% Perl 5 syntax via `tree-sitter-perl/test/corpus` (~611 sections) + `test_corpus/` (73 `.pl` files)
-- **Test Status**: 2673 lib tests (Tier A), 6 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2733 lib tests (Tier A), 5 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 - **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -112,10 +112,10 @@ The LSP compliance table is auto-generated from `features.toml`.
 | debug | 10 | 10 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
-| text_document | 41 | 41 | 100% |
+| text_document | 42 | 42 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **97** | **97** | **100%** |
+| **Overall** | **98** | **98** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->
 
 For live capability posture, run `just status-check` or read [CURRENT_STATUS.md](CURRENT_STATUS.md).


### PR DESCRIPTION
## Summary

- Ran `just status-update` to regenerate `CURRENT_STATUS.md` and `ROADMAP.md`
- Test count: 2673 -> 2733 lib tests, ignores: 6 -> 5
- LSP advertised features: 53/53 -> 54/54
- Protocol compliance: 97/97 -> 98/98 (new feature added to `features.toml`)
- ROADMAP.md compliance table updated to match

## Audit notes

- **`parser-corpus-baseline.json`**: Dated 2026-03-20, shows 85.7% system corpus clean rate (6081/7095). CPAN corpus is not installed in this worktree so `just cpan-corpus-ratchet` could not run. The baseline should be re-ratcheted from a full development environment after recent parser fixes are merged.
- **Stale "85.7%" references in articles**: Found in COMPETITIVE_ANALYSIS.md, COST_ROI.md, FLOW_STUDIO_PARALLELS.md, and others. These refer to the **system corpus clean-parse rate**, which the baseline still confirms at 85.7%. The "90.9%" figure is the **CPAN manifest coverage** (a different metric). The PUBLICATION_FACTS_LEDGER correctly distinguishes these two metrics. No article changes needed.
- **Stale "97 features" references**: ~30 docs still say "97 features" instead of "98". The PUBLICATION_FACTS_LEDGER already tracks this correction (line 72). A bulk article update could follow as a separate PR.

## Test plan

- [x] `just status-update` ran successfully
- [ ] `just ci-gate` (CI will verify)