### PR TITLE
feat(swarm): add vacuous-assertion check to reviewer pipelines

### DIFF
--- a/.claude/commands/reviewer-check-diff.md
+++ b/.claude/commands/reviewer-check-diff.md
@@ -29,14 +29,20 @@ Read the actual diff and check for issues.
    - Does the PR add a test for the changed behavior?
    - Are edge cases covered?
 
-5. Check for **correctness**:
+5. Check for **vacuous assertions** — tests that assert properties of locally-constructed data:
+   - Does the test still pass if you comment out the feature code? If yes, the test is not testing the feature.
+   - Watch for: `assert!(vec.len() > 0)` on a `Vec` built from hardcoded items, `assert!(!s.is_empty())` on string literals, `assert_eq!(result.len(), N)` when result was built from N hardcoded items, `assert!(result.is_some())` when result is `Some(hardcoded_value)`.
+   - The tell: the assertion proves a property of the test data, not the code under test.
+
+6. Check for **correctness**:
    - Does the logic match the issue's recommended approach?
    - Are error paths handled?
    - Any obvious bugs?
 
-6. **Fix forward** — for anything you find:
+7. **Fix forward** — for anything you find:
    - Banned pattern? Fix it and commit.
    - Missing test? Write it and commit.
+   - Vacuous assertion? Rewrite to test actual behavior of the code under test.
    - Naming could be better? Rename it and commit.
    - Push improvements directly to the PR branch rather than listing them as comments.
 

--- a/.claude/commands/reviewer-deep-analyze.md
+++ b/.claude/commands/reviewer-deep-analyze.md
@@ -24,14 +24,22 @@ Read the diff carefully and verify the logic matches the issue's intent.
    - Does it assert the right behavior (not just "no crash")?
    - Would the test have failed BEFORE the fix?
 
-4. Check for regressions:
+4. Check for **vacuous assertions** — assertions on hardcoded data that prove nothing about the code under test:
+   - `assert!(vec.len() > 0)` where the Vec was constructed from a hardcoded non-empty list
+   - `assert!(!s.is_empty())` on a string literal
+   - `assert_eq!(result.len(), N)` when result was built directly from N hardcoded items
+   - `assert!(result.is_some())` when result is `Some(hardcoded_value)`
+   - The litmus test: would this assertion still pass if the feature code were commented out? If yes, the test is vacuous.
+
+5. Check for regressions:
    - Does the change affect any other code paths?
    - Could existing callers break?
    - Are there related tests that might need updating?
 
-5. **Fix forward:**
+6. **Fix forward:**
    - Logic slightly off? Fix it on the branch.
    - Test only asserts "no crash" instead of behavior? Strengthen the assertion.
+   - Vacuous assertion? Rewrite to test actual behavior of the code under test.
    - Regression risk from an uncovered path? Add a test for it.
 
 ## Output


### PR DESCRIPTION
## Summary

- Adds vacuous-assertion detection as a checklist item in `reviewer-check-diff.md` (step 5) and `reviewer-deep-analyze.md` (step 4)
- Instructs reviewers to check whether test assertions would still pass if the feature code were commented out
- Adds "Vacuous assertion?" fix-forward action in both reviewer pipelines

## Motivation

Era 7 session 2 found 3 PRs with tests asserting properties of hardcoded data (#2597, #2604). These tests provide false confidence — they pass even when the feature is broken.

## Test plan

- [ ] Verify checklist items render correctly in both markdown files
- [ ] Step numbering is consistent (no gaps or duplicates)
- [ ] Next reviewer/deep-reviewer pass exercises the new checklist item

Closes #2666