### PR TITLE
fix(parser): soft recovery for unclosed bracket in postfix expressions

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -65,7 +65,7 @@ impl<'a> Parser<'a> {
                                 // ->@[...] array slice
                                 self.tokens.next()?; // consume [
                                 let index = self.parse_expression()?;
-                                self.expect(TokenKind::RightBracket)?;
+                                self.expect_closing_delimiter(TokenKind::RightBracket)?;
 
                                 let start = expr.location.start;
                                 let end = self.previous_position();
@@ -249,7 +249,7 @@ impl<'a> Parser<'a> {
                             // Arrow array dereference: $ref->[index]
                             self.tokens.next()?; // consume [
                             let index = self.parse_expression()?;
-                            self.expect(TokenKind::RightBracket)?;
+                            self.expect_closing_delimiter(TokenKind::RightBracket)?;
 
                             let start = expr.location.start;
                             let end = self.previous_position();
@@ -321,7 +321,7 @@ impl<'a> Parser<'a> {
                         indices.push(self.parse_expression()?);
                     }
 
-                    self.expect(TokenKind::RightBracket)?;
+                    self.expect_closing_delimiter(TokenKind::RightBracket)?;
 
                     // Create the index node - either single index or array of indices
                     let index = if indices.len() == 1 {

--- a/crates/perl-parser-core/tests/unclosed_bracket_recovery_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_bracket_recovery_tests.rs
@@ -1,0 +1,131 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// =============================================================
+// Regression tests: valid bracket patterns still parse cleanly
+// =============================================================
+
+#[test]
+fn valid_arrow_array_slice_dereference() {
+    // ->@[...] postfix dereference (line 68 path)
+    assert_clean_parse("my @slice = $ref->@[0, 1, 2];");
+}
+
+#[test]
+fn valid_arrow_array_subscript() {
+    // ->[index] arrow array dereference (line 252 path)
+    assert_clean_parse("my $x = $ref->[0];");
+}
+
+#[test]
+fn valid_arrow_nested_subscript() {
+    assert_clean_parse("my $x = $ref->[0]->[1];");
+}
+
+#[test]
+fn valid_direct_array_subscript() {
+    // Direct array indexing (line 324 path)
+    assert_clean_parse("my $x = $array[0];");
+}
+
+#[test]
+fn valid_array_slice() {
+    assert_clean_parse("my @s = @array[0, 1, 2];");
+}
+
+#[test]
+fn valid_complex_subscript_expression() {
+    assert_clean_parse("my $x = $ref->[$i + 1];");
+}
+
+// =============================================================
+// Recovery tests: missing ] at statement boundary should recover
+// gracefully instead of producing a hard parse error.
+//
+// expect_closing_delimiter records a soft error and continues
+// when the parser reaches a delimiter recovery point (;, }, etc).
+// The parser should produce a source_file with both the broken
+// statement and subsequent recovered statements.
+// =============================================================
+
+#[test]
+fn recover_missing_bracket_arrow_array_slice() {
+    // Missing ] in ->@[...] — semicolon should be a recovery point
+    let source = "my @slice = $ref->@[0, 1; my $y = 42;";
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    // Parser should recover and continue parsing the next statement
+    assert!(
+        sexp.contains("source_file"),
+        "Parser should produce a source_file node, got:\n{}",
+        sexp
+    );
+    // The second statement should be recovered
+    assert!(
+        sexp.contains("my_declaration"),
+        "Parser should recover and parse 'my $y = 42' after the broken bracket, got:\n{}",
+        sexp
+    );
+}
+
+#[test]
+fn recover_missing_bracket_arrow_subscript() {
+    // Missing ] in ->[expr] — semicolon should be a recovery point
+    let source = "my $x = $ref->[0; my $y = 42;";
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("source_file"),
+        "Parser should produce a source_file node, got:\n{}",
+        sexp
+    );
+    assert!(
+        sexp.contains("my_declaration"),
+        "Parser should recover and parse 'my $y = 42' after the broken bracket, got:\n{}",
+        sexp
+    );
+}
+
+#[test]
+fn recover_missing_bracket_direct_subscript() {
+    // Missing ] in array[expr] — semicolon should be a recovery point
+    let source = "my $x = $array[0; my $y = 42;";
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("source_file"),
+        "Parser should produce a source_file node, got:\n{}",
+        sexp
+    );
+    assert!(
+        sexp.contains("my_declaration"),
+        "Parser should recover and parse 'my $y = 42' after the broken bracket, got:\n{}",
+        sexp
+    );
+}
+
+#[test]
+fn recover_missing_bracket_at_brace() {
+    // Missing ] followed by } — brace is also a recovery point
+    let source = "if (1) { my $x = $ref->[0 }";
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("source_file"),
+        "Parser should produce a source_file node, got:\n{}",
+        sexp
+    );
+}
+
+#[test]
+fn recover_missing_bracket_followed_by_keyword() {
+    // Missing ] followed by keyword — keyword is a recovery point
+    let source = "my $x = $array[0 my $y = 1;";
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("source_file"),
+        "Parser should produce a source_file node, got:\n{}",
+        sexp
+    );
+}


### PR DESCRIPTION
## Summary

Closes #2148

- Replace 3 hard `expect(RightBracket)` calls with `expect_closing_delimiter(RightBracket)` in `postfix.rs`
- Prevents cascading parse errors when `]` is missing in array subscript/dereference expressions
- Parser now records a soft error and continues at statement boundaries instead of aborting

## Fix locations in `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs`

| Line | Context | Before | After |
|------|---------|--------|-------|
| 68 | `->@[...]` array slice dereference | `expect(RightBracket)` | `expect_closing_delimiter(RightBracket)` |
| 252 | `->[index]` arrow array dereference | `expect(RightBracket)` | `expect_closing_delimiter(RightBracket)` |
| 324 | `$array[index]` direct subscript | `expect(RightBracket)` | `expect_closing_delimiter(RightBracket)` |

## Test plan

- [x] 6 regression tests: valid bracket patterns still parse cleanly
- [x] 5 recovery tests: missing `]` at `;`, `}`, and keyword boundaries recovers gracefully
- [x] Full perl-parser-core lib tests pass (405/405)
- [x] clippy clean on library code
- [x] cargo fmt clean
- [ ] CI gate