### PR TITLE
fix(parser): accept keyword-named variables with any sigil (#2149 Pattern B)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -371,8 +371,9 @@ impl<'a> Parser<'a> {
         let next_kind = self.peek_kind();
 
         let (name, end) = if next_kind == Some(TokenKind::Identifier) ||
-                             // Keywords that can be used as subroutine names with & sigil
-                             (sigil == "&" && matches!(next_kind, Some(k) if Self::can_be_sub_name(k)))
+                             // Keywords can be used as variable names with any sigil
+                             // e.g., %try, $default, @for, &try are all valid Perl
+                             matches!(next_kind, Some(k) if Self::can_be_sub_name(k))
         {
             let name_token = self.tokens.next()?;
             let mut name = name_token.text.to_string();

--- a/crates/perl-parser-core/tests/fix_hash_keyword_variable.rs
+++ b/crates/perl-parser-core/tests/fix_hash_keyword_variable.rs
@@ -1,0 +1,81 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Pattern B from issue #2149: Hash variable with keyword name after block close
+//
+// After `}`, the lexer is in ExpectOperator mode. `%` becomes a Percent (modulo)
+// token, and `try` becomes TokenKind::Try. The parser's `parse_variable_from_sigil()`
+// only accepted keyword tokens as variable names after `&` sigil, not `%` or others.
+// The fix removes the `sigil == "&"` guard so ALL sigils accept keyword-named variables.
+
+#[test]
+fn hash_keyword_name_try_after_block() {
+    // %try after block close was parsed as modulo + try keyword
+    assert_clean_parse(r#"if (1) { 1; } %try = ();"#);
+}
+
+#[test]
+fn hash_keyword_name_default_after_block() {
+    assert_clean_parse(r#"if (1) { 1; } %default = ();"#);
+}
+
+#[test]
+fn my_hash_keyword_name_for() {
+    // my %for should work as a hash variable declaration
+    assert_clean_parse(r#"my %for = (a => 1);"#);
+}
+
+#[test]
+fn my_hash_keyword_name_if_with_access() {
+    // my %if; then access with $if{key}
+    assert_clean_parse(r#"my %if; $if{key} = 1;"#);
+}
+
+#[test]
+fn hash_keyword_name_given_after_unless() {
+    assert_clean_parse(r#"unless ($x) { 1; } %given = ();"#);
+}
+
+#[test]
+fn hash_keyword_name_try_in_block() {
+    // %try after bare block
+    assert_clean_parse(r#"{ 1 } %try = ();"#);
+}
+
+#[test]
+fn my_hash_keyword_name_try() {
+    assert_clean_parse(r#"if (1) { 1; } my %try = ();"#);
+}
+
+#[test]
+fn my_hash_keyword_name_default() {
+    assert_clean_parse(r#"if (1) { 1; } my %default = ();"#);
+}
+
+// Regression: regular hash variables must still work
+#[test]
+fn regular_hash_still_works() {
+    assert_clean_parse(r#"%regular_hash = (a => 1, b => 2);"#);
+}
+
+#[test]
+fn regular_hash_after_block() {
+    assert_clean_parse(r#"if (1) { 1; } %regular_hash = ();"#);
+}
+
+// Regression: scalar/array keyword names should also work with the fix
+#[test]
+fn scalar_keyword_name_try() {
+    assert_clean_parse(r#"my $try = 1;"#);
+}
+
+#[test]
+fn array_keyword_name_try() {
+    assert_clean_parse(r#"my @try = (1, 2);"#);
+}
+
+// Regression: & sigil with keyword name still works
+#[test]
+fn ampersand_keyword_name_still_works() {
+    assert_clean_parse(r#"&try();"#);
+}


### PR DESCRIPTION
## Summary

- Removes the `sigil == "&"` guard in `parse_variable_from_sigil()` so that keyword-named variables like `%try`, `%default`, `@for`, `$if` are accepted with any sigil, not just `&`
- Fixes Pattern B from #2149: hash variable with keyword name after block close (e.g., `if (1) { } %try = ();`)
- Affected CPAN files: Encode/Guess.pm (`%try`), CPAN/Meta/Merge.pm (`%default`)

## Changes

**One-line fix** in `crates/perl-parser-core/src/engine/parser/variables.rs:373`:

```rust
// BEFORE: only & sigil accepted keyword names
(sigil == "&" && matches!(next_kind, Some(k) if Self::can_be_sub_name(k)))

// AFTER: all sigils accept keyword names (matches Perl semantics)
matches!(next_kind, Some(k) if Self::can_be_sub_name(k))
```

**13 new tests** in `crates/perl-parser-core/tests/fix_hash_keyword_variable.rs`:
- `%try` / `%default` after block close
- `my %for`, `my %if` declarations
- `%given` after `unless` block
- `%try` after bare block
- Regression: regular hashes, `$try`, `@try`, `&try()` all still work

## Test plan

- [x] 13 new tests pass
- [x] 31 existing `fix_expected_left_brace` tests pass (no regression)
- [x] Full `perl-parser-core` suite passes (629 tests; 1 pre-existing failure in `cpan_file_find::find_with_no_chdir` unrelated)
- [x] `cargo clippy -p perl-parser-core --tests` clean (no new warnings)
- [x] `cargo fmt --all -- --check` clean

Closes Pattern B of #2149.