### PR TITLE
fix(parser): support C-style foreach loops (#2149 Pattern A)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/control_flow.rs
+++ b/crates/perl-parser-core/src/engine/parser/control_flow.rs
@@ -241,6 +241,21 @@ impl<'a> Parser<'a> {
             return self.parse_foreach_style_for();
         }
 
+        // Parenthesized: could be C-style `for (init; cond; update)` or
+        // implicit-$_ foreach `for (LIST)`. Delegate to shared helper.
+        self.parse_c_style_or_implicit_foreach(start)
+    }
+
+    /// Shared parser for C-style `for/foreach (init; cond; update) BLOCK` and
+    /// implicit-$_ foreach `for/foreach (LIST) BLOCK`.
+    ///
+    /// Called after the keyword (`for` or `foreach`) has been consumed and we
+    /// know the next token is `(`. Handles both syntaxes because in Perl `for`
+    /// and `foreach` are fully interchangeable.
+    fn parse_c_style_or_implicit_foreach(
+        &mut self,
+        start: usize,
+    ) -> ParseResult<Node> {
         self.expect(TokenKind::LeftParen)?;
 
         // Parse init (or check if it's a foreach)
@@ -351,6 +366,15 @@ impl<'a> Parser<'a> {
         let start = self.current_position();
         self.tokens.next()?; // consume 'foreach'
 
+        // In Perl, `for` and `foreach` are fully interchangeable. When the
+        // next token is `(`, it could be either:
+        //   - C-style:  foreach (my $i=0; $i<10; $i++) { ... }
+        //   - List:     foreach (@list) { ... }
+        // Delegate to the shared helper that disambiguates via semicolons.
+        if self.peek_kind() == Some(TokenKind::LeftParen) {
+            return self.parse_c_style_or_implicit_foreach(start);
+        }
+
         // Set flag to prevent semicolon consumption in variable declaration
         self.in_for_loop_init = true;
         let variable = if matches!(
@@ -361,12 +385,6 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::State)
         ) {
             self.parse_variable_declaration()?
-        } else if self.peek_kind() == Some(TokenKind::LeftParen) {
-            // foreach (LIST) — implicit $_ topic variable
-            Node::new(
-                NodeKind::Variable { sigil: "$".to_string(), name: "_".to_string() },
-                SourceLocation { start, end: start },
-            )
         } else {
             // foreach $var (LIST) — bare scalar without my
             self.parse_variable()?

--- a/crates/perl-parser-core/tests/fix_foreach_c_style_loop.rs
+++ b/crates/perl-parser-core/tests/fix_foreach_c_style_loop.rs
@@ -1,0 +1,96 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Pattern A from #2149: C-style foreach loop
+//
+// In Perl, `for` and `foreach` are fully interchangeable.
+// `foreach (my $i=0; $i<10; $i++) { ... }` is valid C-style syntax.
+// The parser's parse_foreach_statement() only handled list-style foreach,
+// not C-style. This fix delegates to C-style for loop parsing when
+// semicolons are detected inside the parens.
+
+#[test]
+fn test_foreach_c_style_basic() {
+    // Basic C-style foreach loop
+    assert_clean_parse(r#"foreach (my $i=0; $i<10; $i++) { print $i; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_array_length() {
+    // C-style foreach with array-length condition
+    assert_clean_parse(r#"foreach (my $i=0; $i<@arr; $i+=2) { push @out, $arr[$i]; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_decrement() {
+    // C-style foreach decrementing
+    assert_clean_parse(r#"foreach (my $i = $n-1; $i >= 0; $i--) { next; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_complex_condition() {
+    // C-style foreach with complex condition (from CPAN: Biber/Entry/Names.pm)
+    assert_clean_parse(r#"foreach (my $x=0; $x <= $#choices; $x++) { push @ret, $choices[$x]; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_expression_init() {
+    // C-style foreach where init is a plain expression (no my)
+    assert_clean_parse(r#"foreach ($i = 0; $i < 10; $i++) { print $i; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_empty_parts() {
+    // C-style foreach with empty init
+    assert_clean_parse(r#"foreach (; $i < 10; $i++) { print $i; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_all_empty() {
+    // C-style foreach with all parts empty (infinite loop)
+    assert_clean_parse(r#"foreach (;;) { last; }"#);
+}
+
+#[test]
+fn test_foreach_c_style_nested() {
+    // Nested C-style foreach loops
+    assert_clean_parse(
+        r#"foreach (my $i = 0; $i < 10; $i++) {
+        foreach (my $j = 0; $j < 10; $j++) {
+            print "$i $j\n";
+        }
+    }"#,
+    );
+}
+
+// Regression tests — list-style foreach must still work
+
+#[test]
+fn test_foreach_list_style_regression() {
+    // Standard list-style foreach
+    assert_clean_parse(r#"foreach my $x (@list) { print $x; }"#);
+}
+
+#[test]
+fn test_foreach_list_style_bare_var_regression() {
+    // Bare variable in list-style foreach
+    assert_clean_parse(r#"foreach $item (@items) { print $item; }"#);
+}
+
+#[test]
+fn test_foreach_list_style_implicit_topic_regression() {
+    // Implicit $_ topic variable
+    assert_clean_parse(r#"foreach (@list) { print; }"#);
+}
+
+#[test]
+fn test_for_c_style_still_works_regression() {
+    // C-style `for` must still work (not just `foreach`)
+    assert_clean_parse(r#"for (my $i=0; $i<10; $i++) { print $i; }"#);
+}
+
+#[test]
+fn test_for_list_style_still_works_regression() {
+    // List-style `for` must still work
+    assert_clean_parse(r#"for my $x (@list) { print $x; }"#);
+}


### PR DESCRIPTION
## Summary

- Extract C-style/implicit-foreach disambiguation logic from `parse_for_statement()` into shared `parse_c_style_or_implicit_foreach()` helper
- Call the shared helper from both `parse_for_statement` and `parse_foreach_statement` when the next token is `(`
- In Perl, `for` and `foreach` are fully interchangeable -- `foreach (my $i=0; $i<10; $i++)` is valid C-style syntax that previously failed with `expected_left_brace`

## Test plan

- [x] 8 new C-style foreach tests (basic, array length, decrement, complex condition, expression init, empty parts, all empty, nested)
- [x] 5 regression tests (list-style foreach with my, bare var, implicit topic; C-style for; list-style for)
- [x] All 31 existing `fix_expected_left_brace` tests pass
- [x] All 19 existing `fix_c_style_for_loop` tests pass
- [x] All 9 `fix_foreach_bare_variable` tests pass
- [x] All 10 `fix_foreach_no_variable_tests` pass
- [x] Full `perl-parser-core` test suite passes (only pre-existing `find_with_no_chdir` failure)
- [x] `cargo clippy -p perl-parser-core --tests` clean
- [x] `cargo fmt --all` clean

Fixes Pattern A of #2149 (5 CPAN files, ~50% of expected_left_brace bucket).