### PR TITLE
fix(parser): accept keyword tokens as package names (#2150)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -1,6 +1,12 @@
 impl<'a> Parser<'a> {
     fn parse_qualified_name(&mut self, allow_trailing_separator: bool) -> ParseResult<(String, SourceLocation)> {
-        let first = self.expect(TokenKind::Identifier)?;
+        // Accept keywords as package names (e.g., `package if;`, `package next;`)
+        // Same pattern as parse_subroutine — keywords are valid barewords in Perl
+        let first = if self.peek_kind().is_some_and(Self::can_be_sub_name) {
+            self.consume_token()?
+        } else {
+            self.expect(TokenKind::Identifier)?
+        };
         let mut name = first.text.to_string();
         let name_start = first.start;
         let mut name_end = first.end;
@@ -28,8 +34,8 @@ impl<'a> Parser<'a> {
 
             name.push_str("::");
 
-            if self.peek_kind() == Some(TokenKind::Identifier) {
-                let next = self.tokens.next()?;
+            if self.peek_kind().is_some_and(Self::can_be_sub_name) {
+                let next = self.consume_token()?;
                 name_end = next.end;
                 name.push_str(&next.text);
             } else if allow_trailing_separator {

--- a/crates/perl-parser-core/tests/fix_expected_identifier_package_keywords_tests.rs
+++ b/crates/perl-parser-core/tests/fix_expected_identifier_package_keywords_tests.rs
@@ -1,0 +1,157 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Tests for issue #2150: expected_identifier — keyword tokens as package names
+// Corpus files: if.pm, mro.pm, Class/C3/next.pm
+
+// === Core bug: keyword as first token in package name ===
+
+#[test]
+fn test_package_keyword_if() {
+    // Source: /usr/share/perl/5.38/if.pm line 1
+    let source = r#"package if;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_keyword_next() {
+    // Source: mro.pm line 24-25
+    let source = r#"package next;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_keyword_next_after_comment() {
+    // Source: mro.pm — package name on next line after comment
+    let source = "package # hide me from PAUSE\n    next;";
+    assert_clean_parse(source);
+}
+
+// === Additional keyword-as-package-name patterns ===
+
+#[test]
+fn test_package_keyword_unless() {
+    let source = r#"package unless;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_keyword_while() {
+    let source = r#"package while;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_keyword_for() {
+    let source = r#"package for;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_keyword_do() {
+    let source = r#"package do;"#;
+    assert_clean_parse(source);
+}
+
+// === Keyword after :: separator ===
+
+#[test]
+fn test_package_compound_keyword_suffix() {
+    // e.g., Foo::if — keyword after ::
+    let source = r#"package Foo::if;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_compound_keyword_prefix() {
+    // e.g., next::Foo — keyword before ::
+    let source = r#"package next::Foo;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_maybe_next() {
+    // Source: mro.pm — maybe::next with comment
+    let source = "package # hide me from PAUSE\n    maybe::next;";
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_maybe_next_simple() {
+    // maybe::next without comment
+    let source = r#"package maybe::next;"#;
+    assert_clean_parse(source);
+}
+
+// === Regression: normal packages still work ===
+
+#[test]
+fn test_package_normal_still_works() {
+    let source = r#"package Normal::Package;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_package_simple_identifier() {
+    let source = r#"package Foo;"#;
+    assert_clean_parse(source);
+}
+
+// === Full file patterns from corpus ===
+
+#[test]
+fn test_if_pm_full() {
+    let source = r#"package if;
+use strict;
+our $VERSION = '0.0610';
+
+sub work {
+  my $method = shift() ? 'import' : 'unimport';
+  return unless shift;
+  my $p = $_[0];
+  require $p;
+}
+
+sub import   { shift; unshift @_, 1; goto &work }
+sub unimport { shift; unshift @_, 0; goto &work }
+
+1;
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_mro_pm_packages() {
+    let source = r#"package mro;
+use strict;
+use warnings;
+
+our $VERSION = '1.28';
+
+sub import {
+    mro::set_mro(scalar(caller), $_[1]) if $_[1];
+}
+
+package # hide me from PAUSE
+    next;
+
+sub can { mro::_nextcan($_[0], 0) }
+
+sub method {
+    my $method = mro::_nextcan($_[0], 1);
+    goto &$method;
+}
+
+package # hide me from PAUSE
+    maybe::next;
+
+sub method {
+    my $method = mro::_nextcan($_[0], 0);
+    goto &$method if defined $method;
+    return;
+}
+
+1;
+"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
## Summary

- Fix `parse_qualified_name()` to accept keyword tokens (`if`, `next`, `unless`, `while`, `for`, `do`, etc.) as valid package names using the existing `can_be_sub_name()` helper
- Fix applies to both the first token position and after `::` separators, enabling `package if;`, `package next;`, and `package maybe::next;`
- Adds 15 tests covering keyword-as-package-name, compound names with keyword segments, and full-file patterns from corpus (if.pm, mro.pm)

## Root Cause

`parse_qualified_name()` called `self.expect(TokenKind::Identifier)` which rejected keyword tokens. The tokenizer emits `TokenKind::If` for `if`, `TokenKind::Next` for `next`, etc. -- but in Perl these are valid package names. The fix reuses the `can_be_sub_name()` pattern already established by `parse_subroutine()`.

## Changes

- `crates/perl-parser-core/src/engine/parser/declarations.rs` -- 2 sites changed (~6 lines)
- `crates/perl-parser-core/tests/fix_expected_identifier_package_keywords_tests.rs` -- 15 new tests

## Corpus Impact

~24 files become clean (10 system + 14 CPAN): `if.pm`, `mro.pm` (next/maybe::next), `Class/C3/next.pm`

## Test Plan

- [x] 15 new tests pass (keyword packages, compound names, full-file patterns)
- [x] 12 existing `fix_expected_identifier_tests.rs` tests pass (regression check)
- [x] All 405 perl-parser-core lib tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy -p perl-parser-core --tests` clean

Closes #2150