### PR TITLE
fix(lsp): prevent concurrent workspace indexing scans

### DIFF
--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -53,6 +53,8 @@ impl LspServer {
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
             pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(feature = "workspace")]
+            indexing_in_progress: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -145,6 +147,8 @@ impl LspServer {
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
             pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(feature = "workspace")]
+            indexing_in_progress: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -200,6 +204,8 @@ impl LspServer {
             pod_cache: Arc::new(Mutex::new(HashMap::new())),
             pending_index_task_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(feature = "workspace")]
+            indexing_in_progress: Arc::new(AtomicBool::new(false)),
         }
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -220,6 +220,13 @@ pub struct LspServer {
     /// setting the old flag to `true` interrupts the in-progress parse
     /// cooperatively (via `Parser::check_cancelled`).
     pub(crate) parse_cancel_flags: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    /// Guard that prevents concurrent workspace indexing scans.
+    ///
+    /// Set to `true` when `start_workspace_indexing` spawns a background thread,
+    /// cleared to `false` when that thread completes (via RAII drop guard in all
+    /// exit paths including panics).
+    #[cfg(feature = "workspace")]
+    indexing_in_progress: Arc<AtomicBool>,
 }
 
 // SAFETY: LspServer is not auto-Send/Sync because DocumentState contains

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -128,6 +128,19 @@ fn send_progress_end(outbound: &super::outbound::OutboundSender, message: &str) 
     }
 }
 
+/// RAII guard that clears the `indexing_in_progress` flag on drop.
+///
+/// Ensures the flag is always cleared, even if the indexing thread panics.
+#[cfg(feature = "workspace")]
+struct IndexingGuard(Arc<AtomicBool>);
+
+#[cfg(feature = "workspace")]
+impl Drop for IndexingGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
 impl LspServer {
     /// Handle workspace/symbol request (v2 implementation with lifecycle-aware dispatch)
     ///
@@ -1017,8 +1030,24 @@ impl LspServer {
     }
 
     /// Start a background workspace indexing scan
+    ///
+    /// Uses a compare-exchange guard on `indexing_in_progress` to ensure only
+    /// one scan runs at a time.  If a scan is already running the call is
+    /// silently skipped (logged via `eprintln!`).
     #[cfg(feature = "workspace")]
     pub(super) fn start_workspace_indexing(&self) {
+        // Guard: if already indexing, skip.  compare_exchange ensures only one
+        // thread wins the race.
+        if self
+            .indexing_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            eprintln!("Workspace indexing already in progress, skipping concurrent scan");
+            return;
+        }
+        let indexing_guard = IndexingGuard(Arc::clone(&self.indexing_in_progress));
+
         let Some(coordinator) = self.coordinator().map(Arc::clone) else {
             return;
         };
@@ -1036,6 +1065,7 @@ impl LspServer {
         let progress_create_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
 
         std::thread::spawn(move || {
+            let _guard = indexing_guard; // moved into closure, drops when closure exits
             let budget_start = Instant::now();
             coordinator.transition_to_scanning();
 

--- a/crates/perl-lsp/tests/workspace_indexing_progress_tests.rs
+++ b/crates/perl-lsp/tests/workspace_indexing_progress_tests.rs
@@ -203,3 +203,41 @@ fn work_done_progress_create_sent_to_client() -> TestResult {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Test 7: racing workspace folder change during initial indexing does not
+//         produce duplicate $/progress begin notifications (issue #2641).
+// ---------------------------------------------------------------------------
+#[test]
+fn no_duplicate_progress_begin_on_concurrent_reindex() -> TestResult {
+    let ws = make_workspace_with_files(5)?;
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, Some(caps_with_progress()))?;
+
+    // Immediately send workspace folder change to race with initial indexing.
+    harness.notify(
+        "workspace/didChangeWorkspaceFolders",
+        json!({ "event": { "added": [], "removed": [] } }),
+    );
+
+    // Wait for indexing to complete.
+    let _ = harness.wait_for_progress_kind("workspace-index", "end", progress_timeout());
+
+    // Collect all $/progress notifications.
+    let notifications = harness.drain_notifications(Some("$/progress"), 3_000);
+    let begins: Vec<_> = notifications
+        .iter()
+        .filter(|n| {
+            n.pointer("/params/token").and_then(|v| v.as_str()) == Some("workspace-index")
+                && n.pointer("/params/value/kind").and_then(|v| v.as_str()) == Some("begin")
+        })
+        .collect();
+
+    // Must have at most one begin for the workspace-index token.
+    assert!(
+        begins.len() <= 1,
+        "expected at most 1 progress begin, got {}: {begins:?}",
+        begins.len()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add `indexing_in_progress: Arc<AtomicBool>` field to `LspServer` (gated behind `#[cfg(feature = "workspace")]`)
- Use `compare_exchange` at the top of `start_workspace_indexing` to ensure only one scan runs at a time
- Add panic-safe `IndexingGuard` RAII struct that clears the flag on drop (moved into the spawned thread)
- Concurrent calls (e.g. `workspace/didChangeWorkspaceFolders` arriving during initial indexing) are safely skipped with an `eprintln!` log

Closes #2641

## Files Changed

| File | Change |
|------|--------|
| `crates/perl-lsp/src/runtime/mod.rs` | Add `indexing_in_progress` field to `LspServer` struct |
| `crates/perl-lsp/src/runtime/constructors.rs` | Initialize field in all 3 constructors |
| `crates/perl-lsp/src/runtime/workspace.rs` | Add `IndexingGuard` struct, add compare-exchange guard in `start_workspace_indexing` |
| `crates/perl-lsp/tests/workspace_indexing_progress_tests.rs` | Add test 7: racing folder change produces at most 1 progress begin |

## Test plan

- [x] New test `no_duplicate_progress_begin_on_concurrent_reindex` passes
- [x] All 7 workspace indexing progress tests pass
- [x] All 245 perl-lsp library tests pass
- [x] `cargo clippy -p perl-lsp --tests` clean (no new warnings)
- [x] `cargo fmt --all` clean