### PR TITLE
fix(lsp): eliminate ABBA lock ordering deadlock + reduce lock contention

### DIFF
--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -306,6 +306,11 @@ impl LspServer {
                         }
                     }
 
+                    // Snapshot capability flag once before the loop to avoid
+                    // acquiring client_capabilities lock per diagnostic item
+                    let markup_message_support =
+                        self.client_capabilities.lock().markup_message_support;
+
                     // Convert to LSP diagnostics
                     let lsp_diagnostics: Vec<Value> = diagnostics
                         .into_iter()
@@ -347,7 +352,7 @@ impl LspServer {
                             }
 
                             // Add markdown content if client supports it (LSP 3.18)
-                            if self.client_capabilities.lock().markup_message_support {
+                            if markup_message_support {
                                 let markdown = self
                                     .generate_diagnostic_markdown(d.code.as_deref(), &d.message);
                                 diag["data"] = json!({

--- a/crates/perl-lsp/src/runtime/language/completion.rs
+++ b/crates/perl-lsp/src/runtime/language/completion.rs
@@ -396,17 +396,20 @@ impl LspServer {
                 let is_incomplete = completions.len() > cap;
                 completions.truncate(cap);
 
+                // Snapshot capability flag once before the loop to avoid
+                // acquiring client_capabilities lock per completion item
+                let snippet_support = self.client_capabilities.lock().snippet_support;
+
                 let items: Vec<Value> = completions
                     .into_iter()
                     .map(|c| {
                         // Determine insertTextFormat based on client capability and completion kind
                         let is_snippet = c.kind == CompletionItemKind::Snippet;
-                        let insert_text_format =
-                            if is_snippet && self.client_capabilities.lock().snippet_support {
-                                2 // Snippet format
-                            } else {
-                                1 // PlainText format
-                            };
+                        let insert_text_format = if is_snippet && snippet_support {
+                            2 // Snippet format
+                        } else {
+                            1 // PlainText format
+                        };
 
                         let mut item = json!({
                             "label": c.label,
@@ -431,7 +434,7 @@ impl LspServer {
                         // Only include insertText if it has a value
                         if let Some(mut insert_text) = c.insert_text {
                             // Degrade snippets to plaintext if client doesn't support snippets
-                            if is_snippet && !self.client_capabilities.lock().snippet_support {
+                            if is_snippet && !snippet_support {
                                 // Remove snippet syntax: $1, $0, ${1:placeholder}, etc.
                                 insert_text = Self::degrade_snippet_to_plaintext(&insert_text);
                             }

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -224,16 +224,23 @@ impl LspServer {
                 message: "Missing textDocument.uri".into(),
                 data: None,
             })?;
-            let documents = self.documents_guard();
-            let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
-                code: INVALID_REQUEST,
-                message: format!("Document not open: {}", uri),
-                data: None,
-            })?;
+            // Snapshot document text under lock, then release before acquiring
+            // workspace_folders via workspace_roots() to prevent ABBA deadlock.
+            // Path A (here): documents -> workspace_folders
+            // Path B (workspace.rs): workspace_folders -> documents
+            let doc_text = {
+                let documents = self.documents_guard();
+                let doc = self.get_document(&documents, uri).ok_or_else(|| JsonRpcError {
+                    code: INVALID_REQUEST,
+                    message: format!("Document not open: {}", uri),
+                    data: None,
+                })?;
+                doc.text.clone()
+            };
+            // documents lock released here
 
-            // Get workspace roots from initialization params
             let roots = self.workspace_roots();
-            let links = crate::document_links::compute_links(uri, &doc.text, &roots);
+            let links = crate::document_links::compute_links(uri, &doc_text, &roots);
             Ok(Some(json!(links)))
         } else {
             Ok(Some(json!([])))

--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -750,7 +750,7 @@ impl LspServer {
 
         for (uri, doc) in documents.iter() {
             if let Some(ref ast) = doc.ast {
-                self.find_subclasses_in_ast(ast, base_class, uri, &mut results);
+                self.find_subclasses_in_ast(ast, base_class, uri, &mut results, &doc.text);
             }
         }
 
@@ -758,6 +758,9 @@ impl LspServer {
     }
 
     /// Find subclasses in an AST
+    ///
+    /// Takes `source_text` from the caller instead of acquiring `documents_guard()`
+    /// internally, which would deadlock if the caller already holds the documents lock.
     #[allow(dead_code)]
     fn find_subclasses_in_ast(
         &self,
@@ -765,26 +768,22 @@ impl LspServer {
         base_class: &str,
         uri: &str,
         results: &mut Vec<Location>,
+        source_text: &str,
     ) {
         if let NodeKind::Package { name: _name, .. } = &node.kind {
             // Check if this package extends the base class
             // Look for @ISA assignment or 'use base' or 'use parent'
             // This would need proper traversal - simplified for now
             if self.check_inheritance_in_package(node, base_class) {
-                // Get source text for position conversion
-                let documents = self.documents_guard();
-                if let Some(doc) = documents.get(uri) {
-                    let source_text = &doc.text;
-                    // Convert byte offsets to wire range using conversion waist
-                    let wire_range = crate::convert::WireRange::from_byte_offsets(
-                        source_text,
-                        node.location.start,
-                        node.location.end,
-                    );
+                // Convert byte offsets to wire range using caller-provided source text
+                let wire_range = crate::convert::WireRange::from_byte_offsets(
+                    source_text,
+                    node.location.start,
+                    node.location.end,
+                );
 
-                    // Create typed Location
-                    results.push(Location { uri: parse_uri(uri), range: wire_range.into() });
-                }
+                // Create typed Location
+                results.push(Location { uri: parse_uri(uri), range: wire_range.into() });
             }
         }
 
@@ -792,12 +791,12 @@ impl LspServer {
         match &node.kind {
             NodeKind::Program { statements } | NodeKind::Block { statements } => {
                 for stmt in statements {
-                    self.find_subclasses_in_ast(stmt, base_class, uri, results);
+                    self.find_subclasses_in_ast(stmt, base_class, uri, results, source_text);
                 }
             }
             NodeKind::Package { block, .. } => {
                 if let Some(b) = block {
-                    self.find_subclasses_in_ast(b, base_class, uri, results);
+                    self.find_subclasses_in_ast(b, base_class, uri, results, source_text);
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary

- **ABBA deadlock fix (HIGH)**: Reorder lock acquisition in `handle_document_links` — snapshot document text under `documents` lock, release it, then call `workspace_roots()` (which acquires `workspace_folders`). This eliminates a production-triggerable deadlock where Path A (documents -> workspace_folders) conflicted with Path B in `didChangeWorkspaceFolders` (workspace_folders -> documents).
- **Dead code reentrant lock fix (LOW)**: Thread `source_text` through `find_subclasses_in_ast` from the caller instead of acquiring `documents_guard()` internally, preventing future deadlock if this dead code path is ever activated.
- **Lock contention reduction (LOW)**: Snapshot `client_capabilities.markup_message_support` and `snippet_support` once before their respective loops in diagnostics and completion handlers, avoiding per-item lock acquisitions on hot paths.

4 files changed, ~30 lines net. All changes are independent and mechanical.

Closes #2661

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p perl-lsp --tests` — no new warnings
- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2` — all tests pass (2 pre-existing failures on master confirmed unrelated)
- [x] `cargo test -p perl-lsp-navigation` — all 45 tests pass