### PR TITLE
perf(vscode): defer health check from activation to error handler

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -402,6 +402,10 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
     } catch (startError: unknown) {
         const msg = startError instanceof Error ? startError.message : String(startError);
         outputChannel.appendLine(`[startup] Language client failed to start: ${msg}`);
+        stateChangeDisposable?.dispose();
+        stateChangeDisposable = undefined;
+        try { client.dispose(); } catch { /* already dead */ }
+        client = undefined;
         setStatusBarState(State.Stopped);
         const choice = await vscode.window.showErrorMessage(
             `Perl Language Server failed to start. The binary at '${currentServerPath}' may be corrupted or incompatible.`,


### PR DESCRIPTION
## Summary

- Removes the pre-flight `runHealthCheck()` call from `initializeLanguageClient()`, which spawned a separate process with a 5-second timeout on every activation (50-2000ms overhead)
- Wraps `client.start()` in try-catch with equivalent failure UX: error message offering "Show Output", "Reinstall", and "Run Health Check" buttons
- Preserves the health check in `reinstallServerBinary()` to validate freshly-downloaded binaries

Closes #2177

## Rationale

The language client itself will fail naturally if the binary is broken -- the pre-flight health check was redundant. Moving error handling to the `client.start()` catch block removes the startup penalty while preserving all failure recovery options.

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit` -- verified)
- [ ] Jest test suite: 218 pass, 29 fail (all pre-existing on master -- verified)
- [ ] Manual: extension activates without pre-flight delay
- [ ] Manual: corrupt binary triggers error dialog with correct buttons
- [ ] `perl-lsp.runHealthCheck` command still works from status menu
- [ ] `reinstallServerBinary` still validates the downloaded binary with health check