### PR TITLE
fix(tests): eliminate unwrap/expect in tree-sitter-perl-rs tests

### DIFF
--- a/crates/tree-sitter-perl-rs/tests/all_features_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/all_features_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "pure-rust")]
 mod tests {
+    use perl_tdd_support::must;
     use tree_sitter_perl::pure_rust_parser::PureRustPerlParser;
     use tree_sitter_perl::stateful_parser::StatefulPerlParser;
 
@@ -114,7 +115,7 @@ mod tests {
         ];
 
         for code in q_tests {
-            let ast = parser.parse(code).unwrap();
+            let ast = must(parser.parse(code));
             let sexp = parser.to_sexp(&ast);
             assert!(sexp.contains("string"), "Failed to parse: {}", code);
         }
@@ -128,14 +129,14 @@ mod tests {
         ];
 
         for code in nested_tests {
-            let ast = parser.parse(code).unwrap();
+            let ast = must(parser.parse(code));
             let sexp = parser.to_sexp(&ast);
             assert!(sexp.contains("string"), "Failed to parse nested: {}", code);
         }
 
         // Test qw (word list)
         let code = "qw(one two three)";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("qw_list"));
 
@@ -143,7 +144,7 @@ mod tests {
         let qr_tests = vec!["qr/pattern/", "qr{pattern}", "qr(pattern)i", "qr[pattern]x"];
 
         for code in qr_tests {
-            let ast = parser.parse(code).unwrap();
+            let ast = must(parser.parse(code));
             let sexp = parser.to_sexp(&ast);
             assert!(
                 sexp.contains("qr_regex") || sexp.contains("regex"),
@@ -164,7 +165,7 @@ $name, $age, $city
 .
 print "done";"#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = PureRustPerlParser::node_to_sexp(&ast);
         assert!(sexp.contains("format_declaration"));
 
@@ -175,7 +176,7 @@ Name: @<<<<<<<<<<<
 .
 write;"#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = PureRustPerlParser::node_to_sexp(&ast);
         assert!(sexp.contains("format_declaration"));
     }
@@ -186,25 +187,25 @@ write;"#;
 
         // Test tie
         let code = "tie %hash, 'Tie::Hash::Indexed'";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("tie_statement"));
 
         // Test tie with args
         let code = "tie @array, 'Tie::File', $filename, O_RDWR";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("tie_statement"));
 
         // Test untie
         let code = "untie %hash";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("untie_statement"));
 
         // Test tied
         let code = "tied(%hash)";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("tied"));
     }
@@ -220,7 +221,7 @@ with multiple lines
 END
 print $text;"#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = PureRustPerlParser::node_to_sexp(&ast);
         assert!(sexp.contains("heredoc"));
 
@@ -231,7 +232,7 @@ No interpolation: $var @array
 EOF
 "#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = PureRustPerlParser::node_to_sexp(&ast);
         assert!(sexp.contains("heredoc"));
 
@@ -242,7 +243,7 @@ EOF
     END
 "#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = PureRustPerlParser::node_to_sexp(&ast);
         assert!(sexp.contains("heredoc"));
     }
@@ -278,7 +279,7 @@ EOF
         ];
 
         for (code, expected) in blocks {
-            let ast = parser.parse(code).unwrap();
+            let ast = must(parser.parse(code));
             let sexp = parser.to_sexp(&ast);
             assert!(
                 sexp.contains(expected),
@@ -318,7 +319,7 @@ EOF
 
         // Test smartmatch
         let code = "$a ~~ @array";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("~~"));
     }

--- a/crates/tree-sitter-perl-rs/tests/enhanced_parser_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/enhanced_parser_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(all(test, feature = "pure-rust"))]
 mod enhanced_parser_tests {
+    use perl_tdd_support::must;
     use tree_sitter_perl::EnhancedFullParser;
 
     #[test]
@@ -340,7 +341,7 @@ EOF
         assert!(result.is_ok());
 
         // The content should be preserved with original formatting
-        let ast = result.unwrap();
+        let ast = must(result);
         // Just verify the AST was created successfully
         // Content preservation is handled internally
         assert!(!format!("{:?}", ast).is_empty());

--- a/crates/tree-sitter-perl-rs/tests/heredoc_integration_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/heredoc_integration_tests.rs
@@ -19,7 +19,7 @@ print $text;"#;
         }
         assert!(result.is_ok(), "Failed to parse basic heredoc");
 
-        let ast = result.unwrap();
+        let ast = must(result);
         eprintln!("Parse succeeded, AST type: {:?}", std::mem::discriminant(&ast));
 
         eprintln!("Calling parse_to_sexp...");
@@ -27,7 +27,7 @@ print $text;"#;
         if let Err(ref e) = sexp_result {
             eprintln!("S-expression generation failed: {:?}", e);
         }
-        let sexp = sexp_result.unwrap();
+        let sexp = must(sexp_result);
         eprintln!("S-expression generated:\n{}", sexp);
         assert!(sexp.contains("Hello, World"));
     }

--- a/crates/tree-sitter-perl-rs/tests/integration_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/integration_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "pure-rust")]
 mod tests {
+    use perl_tdd_support::must;
     use tree_sitter_perl::pure_rust_parser::PureRustPerlParser;
     use tree_sitter_perl::stateful_parser::StatefulPerlParser;
 
@@ -118,7 +119,7 @@ print <<~EOF;
 print "Done\n";
 "#;
 
-        let _ast = parser.parse(code).unwrap();
+        let _ast = must(parser.parse(code));
         // The stateful parser should properly handle both heredocs and format
     }
 
@@ -187,7 +188,7 @@ my $status = do {
 };
 "#;
 
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
 
         // Verify parsing succeeded with complex real-world patterns

--- a/crates/tree-sitter-perl-rs/tests/new_features_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/new_features_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "pure-rust")]
 mod tests {
+    use perl_tdd_support::must;
     use tree_sitter_perl::pure_rust_parser::PureRustPerlParser;
 
     fn parse_to_sexp(code: &str) -> Result<String, String> {
@@ -75,7 +76,7 @@ mod tests {
 $x,   $y
 .
 "#;
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("format_declaration"));
 
@@ -85,7 +86,7 @@ Name: @<<<<<<<<<<<<
       $name
 .
 "#;
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("format_declaration"));
     }
@@ -96,13 +97,13 @@ Name: @<<<<<<<<<<<<
 
         // Test tie statement
         let code = "tie $scalar, 'Tie::Scalar', $arg1, $arg2;";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("tie_statement"));
 
         // Test untie statement
         let code = "untie @array;";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("untie_statement"));
 
@@ -159,7 +160,7 @@ Name: @<<<<<<<<<<<<
     when (2) { say "two"; }
     default { say "other"; }
 }"#;
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("given_statement"));
         assert!(sexp.contains("when_clause"));
@@ -172,13 +173,13 @@ Name: @<<<<<<<<<<<<
 
         // Test basic signature
         let code = "sub add ($x, $y) { return $x + $y; }";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("subroutine"));
 
         // Test signature with defaults
         let code = "sub greet ($name = 'World') { say \"Hello, $name!\"; }";
-        let ast = parser.parse(code).unwrap();
+        let ast = must(parser.parse(code));
         let sexp = parser.to_sexp(&ast);
         assert!(sexp.contains("subroutine"));
     }

--- a/crates/tree-sitter-perl-rs/tests/special_context_heredoc_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/special_context_heredoc_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "pure-rust")]
 mod tests {
+    use perl_tdd_support::must_some;
     use tree_sitter_perl::context_aware_parser::{
         ContextAwareFullParser, ContextAwareHeredocParser,
     };
@@ -46,11 +47,9 @@ CODE
         assert!(declarations.iter().any(|d| d.terminator == "CODE"));
 
         // The inner heredoc should be detected when eval content is parsed
-        let eval_content = declarations
-            .iter()
-            .find(|d| d.terminator == "CODE")
-            .and_then(|d| d.content.as_ref())
-            .unwrap();
+        let eval_content = must_some(
+            declarations.iter().find(|d| d.terminator == "CODE").and_then(|d| d.content.as_ref()),
+        );
 
         assert!(eval_content.contains("<<'DATA'"));
     }

--- a/crates/tree-sitter-perl-rs/tests/test_additional_edge_cases.rs
+++ b/crates/tree-sitter-perl-rs/tests/test_additional_edge_cases.rs
@@ -1,4 +1,5 @@
 //! Test additional edge cases mentioned in the audit
+use perl_tdd_support::must_some;
 use tree_sitter_perl::perl_lexer::{PerlLexer, TokenType};
 
 #[test]
@@ -15,7 +16,7 @@ fn test_number_formats() {
         println!("\n=== Testing {} ===", desc);
         let mut lexer = PerlLexer::new(input);
 
-        let token = lexer.next_token().unwrap();
+        let token = must_some(lexer.next_token());
         println!("Token: {:?}", token);
         assert!(matches!(token.token_type, TokenType::Number(_)));
     }
@@ -78,7 +79,7 @@ fn test_transliteration_operators() {
         println!("\n=== Testing {} ===", desc);
         let mut lexer = PerlLexer::new(input);
 
-        let token = lexer.next_token().unwrap();
+        let token = must_some(lexer.next_token());
         println!("Token: {:?}", token);
 
         // Check if it's recognized as a transliteration

--- a/crates/tree-sitter-perl-rs/tests/test_reference_operator.rs
+++ b/crates/tree-sitter-perl-rs/tests/test_reference_operator.rs
@@ -1,5 +1,5 @@
 //! Test reference operator
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 use tree_sitter_perl::perl_lexer::{PerlLexer, TokenType};
 
 #[test]
@@ -17,20 +17,20 @@ fn test_reference_operator_basic() {
         let mut lexer = PerlLexer::new(input);
 
         // Should get backslash as operator
-        let token1 = lexer.next_token().unwrap();
+        let token1 = must_some(lexer.next_token());
         println!("Token 1: {:?}", token1);
         assert!(matches!(token1.token_type, TokenType::Operator(_)));
         assert_eq!(token1.text.as_ref(), "\\");
 
         // Should get the variable or operator
-        let token2 = lexer.next_token().unwrap();
+        let token2 = must_some(lexer.next_token());
         println!("Token 2: {:?}", token2);
 
         // For &sub, it's tokenized as & operator
         if input.contains("&") {
             assert!(matches!(token2.token_type, TokenType::Operator(_)));
             // Get the subroutine name
-            let token3 = lexer.next_token().unwrap();
+            let token3 = must_some(lexer.next_token());
             println!("Token 3: {:?}", token3);
             assert!(matches!(token3.token_type, TokenType::Identifier(_)));
         } else {


### PR DESCRIPTION
## Summary

- Eliminates all 33 `unwrap()` violations in `crates/tree-sitter-perl-rs/tests/` per coding standards (#2649)
- Replaces `.unwrap()` on `Result` with `must(expr)` and `.unwrap()` on `Option` with `must_some(expr)` from `perl_tdd_support`
- 8 test files changed, zero new dependencies (perl-tdd-support already in Cargo.toml)

## Files changed

| File | Violations fixed | Type |
|------|-----------------|------|
| all_features_tests.rs | 16 | Result -> must |
| new_features_tests.rs | 7 | Result -> must |
| test_reference_operator.rs | 3 | Option -> must_some |
| heredoc_integration_tests.rs | 2 | Result -> must |
| integration_tests.rs | 2 | Result -> must |
| test_additional_edge_cases.rs | 2 | Option -> must_some |
| enhanced_parser_tests.rs | 1 | Result -> must |
| special_context_heredoc_tests.rs | 1 | Option -> must_some |

## Test plan

- [x] `cargo test -p tree-sitter-perl` -- all tests pass
- [x] `cargo clippy -p tree-sitter-perl --tests` -- clean
- [x] `cargo fmt --package tree-sitter-perl -- --check` -- clean
- [x] Zero remaining `.unwrap()` or `.expect()` in tests/ (verified via rg)