### PR TITLE
fix(parser): handle keyword hash keys and q{} in use imports

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -613,7 +613,7 @@ impl<'a> Parser<'a> {
             }
         }
         // Handle bare arguments (no parentheses)
-        else if matches!(self.peek_kind(), Some(k) if matches!(k, TokenKind::String | TokenKind::Identifier | TokenKind::Minus | TokenKind::QuoteWords))
+        else if matches!(self.peek_kind(), Some(k) if matches!(k, TokenKind::String | TokenKind::Identifier | TokenKind::Minus | TokenKind::QuoteWords | TokenKind::QuoteSingle | TokenKind::QuoteDouble))
             && !Self::is_statement_terminator(self.peek_kind())
         {
             // Parse bare arguments like: use warnings 'void' or use constant FOO => 42
@@ -667,6 +667,23 @@ impl<'a> Parser<'a> {
                             _ => {
                                 // No separator, just continue
                             }
+                        }
+                    }
+                    Some(TokenKind::QuoteSingle) | Some(TokenKind::QuoteDouble) => {
+                        // Handle q{} / qq{} quote operators in use import lists
+                        // e.g. use overload q{""} => sub { ... };
+                        args.push(self.consume_token()?.text.to_string());
+
+                        // Handle fat arrow after quote key (same as String handling)
+                        match self.peek_kind() {
+                            Some(TokenKind::Comma) => {
+                                self.consume_token()?; // consume comma
+                            }
+                            Some(TokenKind::FatArrow) => {
+                                self.consume_token()?; // consume =>
+                                self.consume_use_import_value(&mut args)?;
+                            }
+                            _ => {}
                         }
                     }
                     Some(TokenKind::QuoteWords) => {

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
                             } else if self.peek_kind() == Some(TokenKind::LeftBrace) {
                                 // ->%{...} hash slice
                                 self.tokens.next()?; // consume {
-                                let key = self.parse_expression()?;
+                                let key = self.parse_hash_subscript_key()?;
                                 self.expect(TokenKind::RightBrace)?;
 
                                 let start = expr.location.start;
@@ -268,7 +268,7 @@ impl<'a> Parser<'a> {
                         Some(TokenKind::LeftBrace) => {
                             // Arrow hash dereference: $ref->{key}
                             self.tokens.next()?; // consume {
-                            let key = self.parse_expression()?;
+                            let key = self.parse_hash_subscript_key()?;
                             self.expect(TokenKind::RightBrace)?;
 
                             let start = expr.location.start;
@@ -490,7 +490,7 @@ impl<'a> Parser<'a> {
 
                     // Hash element access
                     self.tokens.next()?; // consume {
-                    let key = self.parse_expression()?;
+                    let key = self.parse_hash_subscript_key()?;
                     self.expect(TokenKind::RightBrace)?;
 
                     let start = expr.location.start;
@@ -906,5 +906,38 @@ impl<'a> Parser<'a> {
                 | Some(TokenKind::Eof)
                 | None
         )
+    }
+
+    /// Parse hash subscript key expression, treating lone keywords as bare
+    /// identifiers when they appear as `$h->{keyword}` or `$h{keyword}`.
+    ///
+    /// Keywords like `not`, `and`, `or`, `xor`, `do`, `eval` would normally be
+    /// consumed as operators or statement keywords. When one of these appears
+    /// inside a hash subscript followed immediately by `}`, it should be treated
+    /// as a bare hash key instead.
+    fn parse_hash_subscript_key(&mut self) -> ParseResult<Node> {
+        if let Some(kind) = self.peek_kind() {
+            let is_keyword_key = matches!(
+                kind,
+                TokenKind::WordNot
+                    | TokenKind::WordAnd
+                    | TokenKind::WordOr
+                    | TokenKind::WordXor
+                    | TokenKind::Do
+                    | TokenKind::Eval
+            );
+            if is_keyword_key {
+                if let Ok(second) = self.tokens.peek_second() {
+                    if second.kind == TokenKind::RightBrace {
+                        let token = self.tokens.next()?;
+                        return Ok(Node::new(
+                            NodeKind::Identifier { name: token.text.to_string() },
+                            SourceLocation { start: token.start, end: token.end },
+                        ));
+                    }
+                }
+            }
+        }
+        self.parse_expression()
     }
 }

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
@@ -1,0 +1,107 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Sub-bucket A: keyword as hash subscript key (arrow deref)
+#[test]
+fn test_arrow_hash_key_not() {
+    assert_clean_parse(r#"my $x = $opts->{not};"#);
+}
+
+#[test]
+fn test_arrow_hash_key_and() {
+    assert_clean_parse(r#"my $x = $opts->{and};"#);
+}
+
+#[test]
+fn test_arrow_hash_key_or() {
+    assert_clean_parse(r#"my $x = $opts->{or};"#);
+}
+
+#[test]
+fn test_arrow_hash_key_xor() {
+    assert_clean_parse(r#"my $x = $opts->{xor};"#);
+}
+
+#[test]
+fn test_arrow_hash_key_do() {
+    assert_clean_parse(r#"my $x = $opts->{do};"#);
+}
+
+#[test]
+fn test_arrow_hash_key_eval() {
+    assert_clean_parse(r#"my $x = $opts->{eval};"#);
+}
+
+// Assignment through keyword hash key
+#[test]
+fn test_arrow_hash_key_not_assign() {
+    assert_clean_parse(r#"$opts->{not} = \%not_want;"#);
+}
+
+// Bare hash subscript (no arrow)
+#[test]
+fn test_bare_hash_key_not() {
+    assert_clean_parse(r#"my $x = $h{not};"#);
+}
+
+#[test]
+fn test_bare_hash_key_and() {
+    assert_clean_parse(r#"my $x = $h{and};"#);
+}
+
+#[test]
+fn test_bare_hash_key_or() {
+    assert_clean_parse(r#"my $x = $h{or};"#);
+}
+
+#[test]
+fn test_bare_hash_key_xor() {
+    assert_clean_parse(r#"my $x = $h{xor};"#);
+}
+
+#[test]
+fn test_bare_hash_key_do() {
+    assert_clean_parse(r#"my $x = $h{do};"#);
+}
+
+#[test]
+fn test_bare_hash_key_eval() {
+    assert_clean_parse(r#"my $x = $h{eval};"#);
+}
+
+// Chained deref with keyword key
+#[test]
+fn test_chained_hash_key_not() {
+    assert_clean_parse(r#"my $x = $obj->{opts}->{not};"#);
+}
+
+// Keyword key in complex expression
+#[test]
+fn test_keyword_key_in_condition() {
+    assert_clean_parse(r#"if ($opts->{not}) { print "negated" }"#);
+}
+
+// Real-world pattern from Exporter::Tiny
+#[test]
+fn test_exporter_tiny_pattern() {
+    assert_clean_parse(r#"my %not_want; $global_opts->{not} = \%not_want;"#);
+}
+
+// Edge: keyword followed by expression (not just })
+// These should still parse as operators, not identifiers
+#[test]
+fn test_not_as_operator_in_hash() {
+    assert_clean_parse(r#"my $x = $h{not $flag};"#);
+}
+
+// Regression: regular hash keys still work
+#[test]
+fn test_regular_hash_key_still_works() {
+    assert_clean_parse(r#"my $x = $opts->{regular_key};"#);
+}
+
+// Regression: not as operator still works
+#[test]
+fn test_not_as_operator_still_works() {
+    assert_clean_parse(r#"my $x = not $y;"#);
+}

--- a/crates/perl-parser-core/tests/fix_use_quote_import.rs
+++ b/crates/perl-parser-core/tests/fix_use_quote_import.rs
@@ -1,0 +1,32 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_use_overload_q_brace_multi_stmt() {
+    assert_clean_parse(r#"use overload q{""} => sub { my $x = 1; $x };"#);
+}
+
+#[test]
+fn test_use_overload_q_paren_multi_stmt() {
+    assert_clean_parse(r#"use overload q("") => sub { my $x = 1; $x };"#);
+}
+
+#[test]
+fn test_use_overload_q_bracket_multi_stmt() {
+    assert_clean_parse(r#"use overload q[""] => sub { my $x = 1; $x };"#);
+}
+
+// Real-world from Regexp::Common
+#[test]
+fn test_regexp_common_pattern() {
+    assert_clean_parse(
+        r#"
+use overload
+    q{""} => sub {
+        my ($self) = @_;
+        my $pat = $self->{create}->($self, $self->{flags}, $self->{args});
+        return $pat;
+    };
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2189 — two independent fixes for the `unexpected_rbrace_expr` error bucket:

- **Sub-bucket A**: Keywords (`not`, `and`, `or`, `xor`, `do`, `eval`) used as bare hash keys in `$h->{keyword}` or `$h{keyword}` were parsed as operators instead of identifiers. Added `parse_hash_subscript_key()` helper that peeks ahead — if a keyword token is followed by `}`, it's consumed as a bare `Identifier` node. Applied at all 3 hash subscript parse sites in `postfix.rs`.
- **Sub-bucket B**: `q{}`/`qq{}` quote tokens in `use` import lists (e.g. `use overload q{""} => sub { ... }`) fell through to the complex use-args path, leaving dangling braces. Added `QuoteSingle`/`QuoteDouble` to the bare-args condition and match in `parse_use()`.

Fixes real-world patterns from Exporter::Tiny (`$global_opts->{not}`) and Regexp::Common (`use overload q{""} => ...`).

## Test plan

- [x] 19 new tests in `fix_unexpected_rbrace_hash_key.rs` (arrow deref, bare hash, chained, assignment, condition, regression)
- [x] 4 new tests in `fix_use_quote_import.rs` (q brace/paren/bracket, real-world Regexp::Common pattern)
- [x] Regression tests: `$h->{regular_key}` and `not $x` as operator still work
- [x] `cargo clippy -p perl-parser-core --tests` clean
- [x] Full `cargo test -p perl-parser-core` passes (no new failures)