### PR TITLE
feat(diagnostics): wire security lint, unused imports, and dedup

### DIFF
--- a/crates/perl-lsp-diagnostics/src/dedup.rs
+++ b/crates/perl-lsp-diagnostics/src/dedup.rs
@@ -9,7 +9,6 @@ use perl_lsp_diagnostic_types::Diagnostic;
 ///
 /// This function sorts diagnostics by range, severity, code, and message,
 /// then removes exact duplicates (same range, severity, code, and message).
-#[allow(dead_code)]
 pub fn deduplicate_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
     // Sort by range, severity, code, and message
     diagnostics.sort_by(|a, b| {

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -9,10 +9,13 @@ use perl_pragma::PragmaTracker;
 use perl_semantic_analyzer::scope_analyzer::ScopeAnalyzer;
 use perl_semantic_analyzer::symbol::SymbolExtractor;
 
+use crate::dedup::deduplicate_diagnostics;
 use crate::lints::common_mistakes::check_common_mistakes;
 use crate::lints::deprecated::check_deprecated_syntax;
 use crate::lints::printf_format::check_printf_format;
+use crate::lints::security::check_security;
 use crate::lints::strict_warnings::check_strict_warnings;
+use crate::lints::unused_imports::check_unused_imports;
 use crate::scope::scope_issues_to_diagnostics;
 
 // Re-export diagnostic types from the shared SRP microcrate.
@@ -116,6 +119,12 @@ impl DiagnosticsProvider {
         check_common_mistakes(ast, &symbol_table, &mut diagnostics);
         check_printf_format(ast, &mut diagnostics);
 
+        // Security anti-pattern detection (string eval, two-arg open, backtick exec)
+        check_security(ast, &mut diagnostics);
+
+        // Unused import detection
+        check_unused_imports(ast, source, &mut diagnostics);
+
         // Missing module lint (PL701) — only when a resolver is provided
         if let Some(resolver) = module_resolver {
             crate::lints::missing_module::check_missing_modules(
@@ -125,6 +134,9 @@ impl DiagnosticsProvider {
                 &mut diagnostics,
             );
         }
+
+        // Remove duplicate diagnostics before returning
+        deduplicate_diagnostics(&mut diagnostics);
 
         diagnostics
     }

--- a/crates/perl-lsp-diagnostics/src/lints/security.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/security.rs
@@ -32,6 +32,13 @@ pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 check_string_eval(name, args, n, diagnostics);
             }
 
+            // The parser produces Eval { block } for both `eval { ... }` and
+            // `eval "string"`.  Block evals are safe (exception handling);
+            // string/variable evals are a security risk.
+            NodeKind::Eval { block } => {
+                check_eval_node(block, n, diagnostics);
+            }
+
             // Backtick strings: the parser stores `cmd` and qx(cmd) as
             // String { value: "`cmd`", interpolated: true }
             NodeKind::String { value, interpolated: true } if is_backtick_string(value) => {
@@ -54,6 +61,37 @@ pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
             _ => {}
         }
+    });
+}
+
+/// Detect string `eval` from `NodeKind::Eval` nodes.
+///
+/// The parser produces `Eval { block }` for both `eval { ... }` and
+/// `eval "string"`. Block evals (`eval { ... }`) are safe exception handling;
+/// string/variable evals are a security risk.
+fn check_eval_node(block: &Node, eval_node: &Node, diagnostics: &mut Vec<Diagnostic>) {
+    let is_string_eval = matches!(&block.kind, NodeKind::String { .. } | NodeKind::Variable { .. })
+        || matches!(&block.kind, NodeKind::Binary { op, .. } if op == ".");
+
+    if !is_string_eval {
+        return;
+    }
+
+    diagnostics.push(Diagnostic {
+        range: (eval_node.location.start, eval_node.location.end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(DiagnosticCode::SecurityStringEval.as_str().to_string()),
+        message: "String eval is a security risk. Consider eval { } for exception handling."
+            .to_string(),
+        related_information: vec![RelatedInformation {
+            location: (eval_node.location.start, eval_node.location.end),
+            message: "String eval executes arbitrary Perl code at runtime. If the string contains user input, this allows code injection.".to_string(),
+        }],
+        tags: Vec::new(),
+        suggestion: Some(
+            "Use eval { } for exception handling, or consider safer alternatives like Try::Tiny"
+                .to_string(),
+        ),
     });
 }
 

--- a/crates/perl-lsp-diagnostics/src/walker.rs
+++ b/crates/perl-lsp-diagnostics/src/walker.rs
@@ -74,6 +74,9 @@ where
         NodeKind::PhaseBlock { block, .. } => {
             walk_node(block, func);
         }
+        NodeKind::Eval { block } => {
+            walk_node(block, func);
+        }
         _ => {} // Other nodes don't have children or are handled differently
     }
 }

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -223,3 +223,106 @@ fn lint_pipeline_strict_inside_init_suppresses_pl100() {
         missing_strict.len()
     );
 }
+
+// =========================================================================
+// 10. Security lint: string eval fires through the full pipeline (#2693)
+// =========================================================================
+
+#[test]
+fn lint_pipeline_string_eval_emits_pl600() {
+    // eval("code") -- string eval is a security risk, should emit PL600
+    let source = "use strict;\nuse warnings;\neval(\"system('rm -rf /');\");\n";
+    let diags = diagnostics_for(source);
+
+    let security: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL600")).collect();
+
+    assert!(
+        !security.is_empty(),
+        "Expected security-string-eval (PL600) diagnostic from get_diagnostics(), \
+         got {} total diags with codes: {:?}",
+        diags.len(),
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        security[0].severity,
+        DiagnosticSeverity::Warning,
+        "security-string-eval should be Warning severity"
+    );
+    assert!(security[0].suggestion.is_some(), "security-string-eval should carry a suggestion");
+}
+
+// =========================================================================
+// 11. Unused imports lint fires through the full pipeline (#2694)
+// =========================================================================
+
+#[test]
+fn lint_pipeline_unused_import_emits_pl700() {
+    // `use Some::Module;` with no reference to Some::Module elsewhere -- should emit PL700
+    let source = "use strict;\nuse warnings;\nuse Some::Module;\nmy $x = 1;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+
+    let unused: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL700")).collect();
+
+    assert!(
+        !unused.is_empty(),
+        "Expected unused-import (PL700) diagnostic from get_diagnostics(), \
+         got {} total diags with codes: {:?}",
+        diags.len(),
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        unused[0].severity,
+        DiagnosticSeverity::Hint,
+        "unused-import should be Hint severity"
+    );
+    assert!(
+        unused[0].tags.contains(&DiagnosticTag::Unnecessary),
+        "unused-import should carry DiagnosticTag::Unnecessary"
+    );
+}
+
+// =========================================================================
+// 12. Used import does NOT fire PL700 (#2694)
+// =========================================================================
+
+#[test]
+fn lint_pipeline_used_import_no_pl700() {
+    // `use Some::Module;` WITH a reference to Some::Module -- should NOT emit PL700
+    let source = "use strict;\nuse warnings;\nuse Some::Module;\nmy $obj = Some::Module->new();\n";
+    let diags = diagnostics_for(source);
+
+    let unused: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL700")).collect();
+
+    assert!(
+        unused.is_empty(),
+        "Should NOT get unused-import (PL700) when module is referenced, \
+         got: {:?}",
+        unused.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =========================================================================
+// 13. Dedup removes duplicate diagnostics (#2696)
+// =========================================================================
+
+#[test]
+fn lint_pipeline_dedup_removes_exact_duplicates() {
+    // The dedup stage runs at the end of get_diagnostics(). We verify that no
+    // two diagnostics in the output share the same (range, severity, code, message).
+    let source = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+
+    for (i, a) in diags.iter().enumerate() {
+        for b in diags.iter().skip(i + 1) {
+            let is_dup = a.range == b.range
+                && a.severity == b.severity
+                && a.code == b.code
+                && a.message == b.message;
+            assert!(
+                !is_dup,
+                "Found duplicate diagnostics after dedup: code={:?}, message={:?}",
+                a.code, a.message
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wire three built-but-unwired diagnostic features into `DiagnosticsProvider::get_diagnostics()`:

- **Security lint** (`check_security`): Detects string eval (PL600), two-arg open (PL401), and backtick execution (PL601)
- **Unused imports lint** (`check_unused_imports`): Flags `use Module;` statements where the module is never referenced (PL700)
- **Diagnostic deduplication** (`deduplicate_diagnostics`): Removes exact-duplicate diagnostics at the end of the pipeline

### Changes

**`diagnostics.rs`** (3 new calls):
- `check_security(ast, &mut diagnostics)` after existing lint checks
- `check_unused_imports(ast, source, &mut diagnostics)` after security
- `deduplicate_diagnostics(&mut diagnostics)` before return

**`lints/security.rs`** (new `check_eval_node` function):
- The real parser emits `NodeKind::Eval { block }` for eval expressions, not `FunctionCall`. Added handler for this node kind so the security lint fires on real parsed code.

**`walker.rs`** (1 new arm):
- Added `NodeKind::Eval` traversal so the walker visits eval node bodies.

**`dedup.rs`**:
- Removed `#[allow(dead_code)]` since `deduplicate_diagnostics` is now called.

### Tests added

4 new integration tests in `lint_pipeline_integration_tests.rs`:
1. `lint_pipeline_string_eval_emits_pl600` -- verifies security lint fires through full pipeline
2. `lint_pipeline_unused_import_emits_pl700` -- verifies unused import lint fires through full pipeline
3. `lint_pipeline_used_import_no_pl700` -- verifies used imports are NOT flagged
4. `lint_pipeline_dedup_removes_exact_duplicates` -- verifies no duplicates in output

All 184 crate tests pass. Clippy clean.

## Test plan

- [x] `cargo test -p perl-lsp-diagnostics` -- all 184 tests pass
- [x] `cargo clippy -p perl-lsp-diagnostics -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean

Closes #2693, closes #2694, closes #2696