### PR TITLE
fix(tests): eliminate unwrap/expect in perl-semantic-analyzer tests

### DIFF
--- a/crates/perl-semantic-analyzer/tests/attribute_introspection_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/attribute_introspection_tests.rs
@@ -6,7 +6,7 @@
 use perl_semantic_analyzer::Parser;
 use perl_semantic_analyzer::analysis::semantic::{SemanticAnalyzer, get_attribute_documentation};
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind};
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 
 fn parse_and_analyze(code: &str) -> SemanticAnalyzer {
     let mut parser = Parser::new(code);
@@ -22,7 +22,7 @@ fn parse_and_analyze(code: &str) -> SemanticAnalyzer {
 fn attribute_doc_lvalue_has_description() {
     let doc = get_attribute_documentation("lvalue");
     assert!(doc.is_some(), "lvalue should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("lvalue")
             || doc.description.to_lowercase().contains("assign"),
@@ -35,7 +35,7 @@ fn attribute_doc_lvalue_has_description() {
 fn attribute_doc_method_has_description() {
     let doc = get_attribute_documentation("method");
     assert!(doc.is_some(), "method should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("method"),
         "method description should mention method, got: {}",
@@ -47,7 +47,7 @@ fn attribute_doc_method_has_description() {
 fn attribute_doc_prototype_has_description() {
     let doc = get_attribute_documentation("prototype");
     assert!(doc.is_some(), "prototype should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("prototype")
             || doc.description.to_lowercase().contains("calling"),
@@ -60,7 +60,7 @@ fn attribute_doc_prototype_has_description() {
 fn attribute_doc_const_has_description() {
     let doc = get_attribute_documentation("const");
     assert!(doc.is_some(), "const should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("const")
             || doc.description.to_lowercase().contains("immutable")
@@ -74,7 +74,7 @@ fn attribute_doc_const_has_description() {
 fn attribute_doc_shared_has_description() {
     let doc = get_attribute_documentation("shared");
     assert!(doc.is_some(), "shared should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("thread")
             || doc.description.to_lowercase().contains("shared"),
@@ -102,7 +102,7 @@ fn attribute_doc_covers_all_known_builtins() {
     for attr in &known_attrs {
         let doc = get_attribute_documentation(attr);
         assert!(doc.is_some(), "Expected documentation for attribute '{}' but got None", attr);
-        let doc = doc.unwrap();
+        let doc = must_some(doc);
         assert!(!doc.description.is_empty(), "Documentation for '{}' has empty description", attr);
     }
 }

--- a/crates/perl-semantic-analyzer/tests/builtin_context_docs_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/builtin_context_docs_tests.rs
@@ -6,6 +6,7 @@
 //! hover-position-lookup that can silently pass when hover returns null.
 
 use perl_semantic_analyzer::analysis::semantic::get_builtin_documentation;
+use perl_tdd_support::must_some;
 
 // ---------------------------------------------------------------------------
 // splice
@@ -13,7 +14,7 @@ use perl_semantic_analyzer::analysis::semantic::get_builtin_documentation;
 
 #[test]
 fn test_splice_scalar_context_doc() {
-    let doc = get_builtin_documentation("splice").expect("splice must have documentation");
+    let doc = must_some(get_builtin_documentation("splice"));
     assert!(
         doc.description.contains("scalar context"),
         "splice description must mention scalar context behavior: {}",
@@ -32,7 +33,7 @@ fn test_splice_scalar_context_doc() {
 
 #[test]
 fn test_sort_scalar_context_doc() {
-    let doc = get_builtin_documentation("sort").expect("sort must have documentation");
+    let doc = must_some(get_builtin_documentation("sort"));
     assert!(
         doc.description.contains("scalar context"),
         "sort description must warn about scalar context: {}",
@@ -57,7 +58,7 @@ fn test_sort_scalar_context_doc() {
 
 #[test]
 fn test_map_scalar_context_doc() {
-    let doc = get_builtin_documentation("map").expect("map must have documentation");
+    let doc = must_some(get_builtin_documentation("map"));
     assert!(
         doc.description.contains("scalar context"),
         "map description must mention scalar context behavior: {}",
@@ -71,7 +72,7 @@ fn test_map_scalar_context_doc() {
 
 #[test]
 fn test_grep_scalar_context_doc() {
-    let doc = get_builtin_documentation("grep").expect("grep must have documentation");
+    let doc = must_some(get_builtin_documentation("grep"));
     assert!(
         doc.description.contains("scalar context"),
         "grep description must mention scalar context count behavior: {}",
@@ -90,7 +91,7 @@ fn test_grep_scalar_context_doc() {
 
 #[test]
 fn test_wantarray_void_context_doc() {
-    let doc = get_builtin_documentation("wantarray").expect("wantarray must have documentation");
+    let doc = must_some(get_builtin_documentation("wantarray"));
     assert!(
         doc.description.contains("void context"),
         "wantarray description must mention void context returning undef: {}",
@@ -114,7 +115,7 @@ fn test_wantarray_void_context_doc() {
 
 #[test]
 fn test_keys_scalar_context_doc() {
-    let doc = get_builtin_documentation("keys").expect("keys must have documentation");
+    let doc = must_some(get_builtin_documentation("keys"));
     assert!(
         doc.description.contains("scalar context"),
         "keys description must mention scalar context: {}",
@@ -147,7 +148,7 @@ fn test_keys_scalar_context_doc() {
 
 #[test]
 fn test_values_scalar_context_doc() {
-    let doc = get_builtin_documentation("values").expect("values must have documentation");
+    let doc = must_some(get_builtin_documentation("values"));
     assert!(
         doc.description.contains("scalar context"),
         "values description must mention scalar context: {}",
@@ -166,7 +167,7 @@ fn test_values_scalar_context_doc() {
 
 #[test]
 fn test_each_iterator_reset_doc() {
-    let doc = get_builtin_documentation("each").expect("each must have documentation");
+    let doc = must_some(get_builtin_documentation("each"));
     assert!(
         doc.description.contains("resets") || doc.description.contains("reset"),
         "each description must mention iterator reset behavior: {}",
@@ -191,7 +192,7 @@ fn test_each_iterator_reset_doc() {
 
 #[test]
 fn test_stat_doc() {
-    let doc = get_builtin_documentation("stat").expect("stat must have documentation");
+    let doc = must_some(get_builtin_documentation("stat"));
     assert!(
         doc.description.contains("13"),
         "stat description must mention the 13-element return list: {}",
@@ -213,7 +214,7 @@ fn test_stat_doc() {
 
 #[test]
 fn test_caller_scalar_context_doc() {
-    let doc = get_builtin_documentation("caller").expect("caller must have documentation");
+    let doc = must_some(get_builtin_documentation("caller"));
     assert!(
         doc.description.contains("scalar context"),
         "caller description must mention scalar context (returns package name): {}",
@@ -232,7 +233,7 @@ fn test_caller_scalar_context_doc() {
 
 #[test]
 fn test_gmtime_context_doc() {
-    let doc = get_builtin_documentation("gmtime").expect("gmtime must have documentation");
+    let doc = must_some(get_builtin_documentation("gmtime"));
     assert!(
         doc.description.contains("scalar context"),
         "gmtime description must mention scalar context string form: {}",

--- a/crates/perl-semantic-analyzer/tests/die_warn_exception_context_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/die_warn_exception_context_tests.rs
@@ -6,6 +6,7 @@
 use perl_semantic_analyzer::analysis::semantic::{
     get_builtin_documentation, get_exception_context, is_exception_function,
 };
+use perl_tdd_support::must_some;
 
 // ---------------------------------------------------------------------------
 // Hover doc enrichment — die
@@ -15,7 +16,7 @@ use perl_semantic_analyzer::analysis::semantic::{
 fn test_die_hover_mentions_carp() {
     let doc = get_builtin_documentation("die");
     assert!(doc.is_some(), "die must have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("Carp"),
         "die hover should mention Carp upgrade path, got: {}",
@@ -27,7 +28,7 @@ fn test_die_hover_mentions_carp() {
 fn test_die_hover_mentions_error_variable() {
     let doc = get_builtin_documentation("die");
     assert!(doc.is_some(), "die must have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("$@"),
         "die hover should mention $@ error variable, got: {}",
@@ -43,7 +44,7 @@ fn test_die_hover_mentions_error_variable() {
 fn test_warn_hover_mentions_carp() {
     let doc = get_builtin_documentation("warn");
     assert!(doc.is_some(), "warn must have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("Carp"),
         "warn hover should mention Carp upgrade path, got: {}",
@@ -59,7 +60,7 @@ fn test_warn_hover_mentions_carp() {
 fn test_eval_hover_mentions_error_variable() {
     let doc = get_builtin_documentation("eval");
     assert!(doc.is_some(), "eval must have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("$@"),
         "eval hover should mention $@ error variable, got: {}",
@@ -99,7 +100,7 @@ fn test_cluck_has_docs() {
 fn test_confess_doc_mentions_stack_trace() {
     let doc = get_builtin_documentation("confess");
     assert!(doc.is_some(), "confess must have docs");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("stack"),
         "confess description should mention stack trace, got: {}",
@@ -111,7 +112,7 @@ fn test_confess_doc_mentions_stack_trace() {
 fn test_cluck_doc_mentions_stack_trace() {
     let doc = get_builtin_documentation("cluck");
     assert!(doc.is_some(), "cluck must have docs");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.contains("stack"),
         "cluck description should mention stack trace, got: {}",
@@ -166,7 +167,7 @@ fn test_print_is_not_exception_function() {
 fn test_die_exception_context_has_alternative() {
     let ctx = get_exception_context("die");
     assert!(ctx.is_some(), "die must have exception context");
-    let ctx = ctx.unwrap();
+    let ctx = must_some(ctx);
     assert!(ctx.preferred_alternative.is_some(), "die should have a preferred alternative (croak)");
     let alt = ctx.preferred_alternative.as_deref().unwrap_or("");
     assert!(alt.contains("croak"), "die preferred alternative should be croak, got: {}", alt);
@@ -176,7 +177,7 @@ fn test_die_exception_context_has_alternative() {
 fn test_die_exception_context_has_error_variable() {
     let ctx = get_exception_context("die");
     assert!(ctx.is_some(), "die must have exception context");
-    let ctx = ctx.unwrap();
+    let ctx = must_some(ctx);
     assert_eq!(ctx.error_variable.as_deref(), Some("$@"), "die error variable should be $@");
 }
 
@@ -184,7 +185,7 @@ fn test_die_exception_context_has_error_variable() {
 fn test_warn_exception_context_has_alternative() {
     let ctx = get_exception_context("warn");
     assert!(ctx.is_some(), "warn must have exception context");
-    let ctx = ctx.unwrap();
+    let ctx = must_some(ctx);
     assert!(ctx.preferred_alternative.is_some(), "warn should have a preferred alternative (carp)");
     let alt = ctx.preferred_alternative.as_deref().unwrap_or("");
     assert!(alt.contains("carp"), "warn preferred alternative should be carp, got: {}", alt);
@@ -194,7 +195,7 @@ fn test_warn_exception_context_has_alternative() {
 fn test_croak_exception_context_no_alternative() {
     let ctx = get_exception_context("croak");
     assert!(ctx.is_some(), "croak must have exception context");
-    let ctx = ctx.unwrap();
+    let ctx = must_some(ctx);
     assert!(
         ctx.preferred_alternative.is_none(),
         "croak has no preferred alternative (already preferred), got: {:?}",

--- a/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
@@ -30,7 +30,7 @@ use perl_semantic_analyzer::analysis::type_inference::{
 use perl_semantic_analyzer::symbol::{
     ScopeKind, SymbolExtractor, SymbolKind, SymbolTable, VarKind,
 };
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
@@ -167,7 +167,7 @@ fn symbol_at_cursor_on_method_call() -> Result<(), Box<dyn std::error::Error>> {
     // Debug: check what node is at the offset
     let node = find_node_at_offset(&ast, helper_offset);
     assert!(node.is_some(), "should find a node at the offset of 'helper'");
-    let node = node.unwrap();
+    let node = must_some(node);
     eprintln!(
         "Node at offset {}: kind={}, sexp={}",
         helper_offset,
@@ -181,7 +181,7 @@ fn symbol_at_cursor_on_method_call() -> Result<(), Box<dyn std::error::Error>> {
         "symbol_at_cursor should resolve method call, got node kind: {}",
         node.kind.kind_name()
     );
-    let key = sym.unwrap();
+    let key = must_some(sym);
     assert_eq!(key.name.as_ref(), "helper");
     // $self -> use current package
     assert_eq!(key.pkg.as_ref(), "MyPackage");
@@ -199,7 +199,7 @@ fn symbol_at_cursor_on_use_statement() -> Result<(), Box<dyn std::error::Error>>
 
     let node = find_node_at_offset(&ast, module_offset);
     assert!(node.is_some(), "should find node at offset of module name");
-    let node = node.unwrap();
+    let node = must_some(node);
     eprintln!(
         "Node at offset {}: kind={}, sexp={}",
         module_offset,

--- a/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
@@ -4,7 +4,7 @@ use perl_semantic_analyzer::{
     Parser,
     symbol::{SymbolExtractor, SymbolKind, SymbolTable},
 };
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 
 fn extract_symbols(code: &str) -> SymbolTable {
     let mut parser = Parser::new(code);
@@ -427,7 +427,7 @@ requires 'some_method', 'another_method';
         some_method.is_some(),
         "expected Subroutine symbol with declaration='requires' for `some_method`"
     );
-    assert!(some_method.unwrap().attributes.contains(&"requires=true".to_string()));
+    assert!(must_some(some_method).attributes.contains(&"requires=true".to_string()));
 
     let another_method =
         find_symbol_with_declaration(&table, "another_method", SymbolKind::Subroutine, "requires");

--- a/crates/perl-semantic-analyzer/tests/moose_type_hover_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/moose_type_hover_tests.rs
@@ -8,6 +8,7 @@
 use perl_semantic_analyzer::analysis::semantic::{
     get_attribute_documentation, get_moose_type_documentation,
 };
+use perl_tdd_support::must_some;
 
 // ---------------------------------------------------------------------------
 // get_moose_type_documentation — simple base types
@@ -17,7 +18,7 @@ use perl_semantic_analyzer::analysis::semantic::{
 fn moose_type_doc_str_has_description() {
     let doc = get_moose_type_documentation("Str");
     assert!(doc.is_some(), "Str should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("string")
             || doc.description.to_lowercase().contains("str"),
@@ -30,7 +31,7 @@ fn moose_type_doc_str_has_description() {
 fn moose_type_doc_int_has_description() {
     let doc = get_moose_type_documentation("Int");
     assert!(doc.is_some(), "Int should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("integer")
             || doc.description.to_lowercase().contains("int"),
@@ -43,7 +44,7 @@ fn moose_type_doc_int_has_description() {
 fn moose_type_doc_bool_has_description() {
     let doc = get_moose_type_documentation("Bool");
     assert!(doc.is_some(), "Bool should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("bool")
             || doc.description.to_lowercase().contains("true")
@@ -57,7 +58,7 @@ fn moose_type_doc_bool_has_description() {
 fn moose_type_doc_arrayref_has_description() {
     let doc = get_moose_type_documentation("ArrayRef");
     assert!(doc.is_some(), "ArrayRef should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("array")
             || doc.description.to_lowercase().contains("ref"),
@@ -70,7 +71,7 @@ fn moose_type_doc_arrayref_has_description() {
 fn moose_type_doc_hashref_has_description() {
     let doc = get_moose_type_documentation("HashRef");
     assert!(doc.is_some(), "HashRef should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("hash")
             || doc.description.to_lowercase().contains("ref"),
@@ -83,7 +84,7 @@ fn moose_type_doc_hashref_has_description() {
 fn moose_type_doc_maybe_has_description() {
     let doc = get_moose_type_documentation("Maybe");
     assert!(doc.is_some(), "Maybe should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("undef")
             || doc.description.to_lowercase().contains("maybe")
@@ -97,7 +98,7 @@ fn moose_type_doc_maybe_has_description() {
 fn moose_type_doc_num_has_description() {
     let doc = get_moose_type_documentation("Num");
     assert!(doc.is_some(), "Num should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("num")
             || doc.description.to_lowercase().contains("float")
@@ -111,7 +112,7 @@ fn moose_type_doc_num_has_description() {
 fn moose_type_doc_coderef_has_description() {
     let doc = get_moose_type_documentation("CodeRef");
     assert!(doc.is_some(), "CodeRef should have documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("code")
             || doc.description.to_lowercase().contains("subroutine")
@@ -136,7 +137,7 @@ fn moose_type_doc_arrayref_int_resolves_base() {
     // "ArrayRef[Int]" should resolve to the ArrayRef documentation
     let doc = get_moose_type_documentation("ArrayRef[Int]");
     assert!(doc.is_some(), "ArrayRef[Int] should resolve to ArrayRef documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("array")
             || doc.description.to_lowercase().contains("ref"),
@@ -150,7 +151,7 @@ fn moose_type_doc_maybe_str_resolves_base() {
     // "Maybe[Str]" should resolve to Maybe documentation
     let doc = get_moose_type_documentation("Maybe[Str]");
     assert!(doc.is_some(), "Maybe[Str] should resolve to Maybe documentation");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(
         doc.description.to_lowercase().contains("undef")
             || doc.description.to_lowercase().contains("maybe")
@@ -174,7 +175,7 @@ fn moose_type_doc_hashref_str_str_resolves_base() {
 #[test]
 fn moose_type_doc_str_signature_not_empty() {
     let doc = get_moose_type_documentation("Str");
-    let doc = doc.unwrap();
+    let doc = must_some(doc);
     assert!(!doc.signature.is_empty(), "Str signature should not be empty");
 }
 
@@ -206,7 +207,7 @@ fn moose_type_doc_covers_core_types() {
             "Expected documentation for Moose type '{}' but got None",
             type_name
         );
-        let doc = doc.unwrap();
+        let doc = must_some(doc);
         assert!(
             !doc.description.is_empty(),
             "Documentation for Moose type '{}' has empty description",


### PR DESCRIPTION
## Summary

- Replaces all 43 `unwrap()`/`expect()` calls across 6 test files in `perl-semantic-analyzer/tests/` with `perl_tdd_support::{must, must_some}` helpers
- Safe variants (`unwrap_or`, `unwrap_or_else`, `unwrap_or_default`) left untouched (10 instances across 5 files)
- All `.unwrap()` on `Option` -> `must_some()`
- All `.expect("msg")` on `Option` -> `must_some()`
- Added `use perl_tdd_support::must_some;` imports where needed

## Files changed (43 violations eliminated)

| File | Count | Pattern |
|------|-------|---------|
| `moose_type_hover_tests.rs` | 12 | `doc.unwrap()` -> `must_some(doc)` |
| `builtin_context_docs_tests.rs` | 11 | `.expect("...")` -> `must_some(...)` |
| `die_warn_exception_context_tests.rs` | 10 | `doc/ctx.unwrap()` -> `must_some(doc/ctx)` |
| `attribute_introspection_tests.rs` | 6 | `doc.unwrap()` -> `must_some(doc)` |
| `extended_unit_tests.rs` | 3 | `node/sym.unwrap()` -> `must_some(node/sym)` |
| `frameworks_moo.rs` | 1 | `some_method.unwrap()` -> `must_some(some_method)` |

## Test plan

- [x] `cargo test -p perl-semantic-analyzer` -- all 358 tests pass across 12 test files (1 pre-existing failure in `comprehensive_unit_tests.rs` unrelated to this change)
- [x] `cargo clippy -p perl-semantic-analyzer --tests -- -D warnings` -- clean
- [x] `cargo fmt` -- clean
- [x] Zero `unwrap()`/`expect()` remaining in `perl-semantic-analyzer/tests/`
- [x] All 10 safe `unwrap_or`/`unwrap_or_default` calls preserved

Closes #2649