### PR TITLE
feat(hover): wire TypeInferenceEngine to hover for variable type display

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -174,8 +174,10 @@ impl LspServer {
             };
 
             // Run type inference to get inferred type for the symbol.
+            // Only applies to variables; subroutines, packages, and constants
+            // are never stored in the type environment so inference adds nothing.
             // Filter out uninformative types (Any, Void) that add no value.
-            let type_info = {
+            let type_info = if symbol_info.kind.is_variable() {
                 let mut engine = perl_parser::type_inference::TypeInferenceEngine::new();
                 let _ = engine.infer(ast);
                 engine
@@ -183,6 +185,8 @@ impl LspServer {
                     .filter(|label| label != "Any" && label != "Void")
                     .map(|label| format!("\n**Type**: `{}`", label))
                     .unwrap_or_default()
+            } else {
+                String::new()
             };
 
             let complexity_section = if complexity_info.is_empty() {

--- a/crates/perl-lsp/tests/hover_provider_coverage.rs
+++ b/crates/perl-lsp/tests/hover_provider_coverage.rs
@@ -784,6 +784,47 @@ $name;
         Ok(())
     }
 
+    #[test]
+    fn test_hover_subroutine_does_not_show_type_annotation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Subroutines are not variables — the type inference engine only tracks
+        // variable types.  Hovering on a sub must never emit a spurious **Type** line.
+        let code = "sub compute { return 42; }\ncompute();\n";
+        let resp = hover_at(code, "file:///sub_no_type.pl", "compute", 0)?;
+        let content = hover_content(&resp).ok_or("expected hover for compute()")?;
+
+        assert!(content.contains("Subroutine"), "hover should indicate Subroutine, got: {content}");
+        assert!(
+            !content.contains("**Type**"),
+            "hover on a subroutine must not display a **Type** line, got: {content}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_array_variable_shows_inferred_type() -> Result<(), Box<dyn std::error::Error>> {
+        // Array variables should show their inferred element type when concrete.
+        let code = "my @nums = (1, 2, 3);\n@nums;\n";
+        let resp = hover_at(code, "file:///array_type.pl", "@nums", 1)?;
+        let content = hover_content(&resp).ok_or("expected hover for @nums")?;
+
+        assert!(
+            content.contains("Array Variable"),
+            "hover should indicate Array Variable, got: {content}"
+        );
+        assert!(
+            content.contains("**Type**"),
+            "hover on array with integer elements should include **Type** annotation, got: {content}"
+        );
+        assert!(
+            content.contains("Array"),
+            "hover should show Array type for @nums, got: {content}"
+        );
+
+        Ok(())
+    }
+
     // ── Test::More hover documentation ───────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2686.

- Wires `TypeInferenceEngine` into the hover handler (`extract_symbol_hover()`) so that hovering on variables shows inferred types (e.g., `**Type**: \`Int\``)
- Filters uninformative types (`Any`, `Void`) to avoid cluttering the hover display
- Un-ignores 3 tests in `hover_provider_coverage.rs` and strengthens their assertions to verify actual type content
- Fixes a pre-existing bug in `test_hover_blessed_ref_shows_class_type_from_new` where `target_line: 5` pointed at `package main;` instead of `$obj;` (line 7)

## Files changed

- `crates/perl-lsp/src/runtime/language/hover.rs` — ~10 lines: type inference call + Any/Void filter
- `crates/perl-lsp/tests/hover_provider_coverage.rs` — remove `#[ignore]`, fix line number, strengthen assertions

## Test plan

- [x] All 64 hover_provider_coverage tests pass (including 3 previously ignored)
- [x] `cargo clippy -p perl-lsp --tests` clean (only pre-existing unrelated warning)
- [x] `cargo fmt --all` clean
- [x] Pre-existing test failures in `execute_command_mutation_hardening_public_api_tests` confirmed on master