### PR TITLE
feat(hover): dedicated Method Modifier hover card for Moo/Moose/Mouse before/after/around

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -96,6 +96,31 @@ impl LspServer {
         let analyzer = crate::semantic::SemanticAnalyzer::analyze_with_source(ast, text);
 
         if let Some(symbol_info) = analyzer.find_definition(offset) {
+            // Detect method modifier symbols (before/after/around) early and render
+            // a dedicated card instead of the generic "Subroutine" label.
+            if let Some(modifier_kind) =
+                symbol_info.attributes.iter().find_map(|a| a.strip_prefix("modifier="))
+            {
+                let method_name = &symbol_info.name;
+                let kind_label = match modifier_kind {
+                    "before" => "runs **before** the method — use for preconditions and logging",
+                    "after" => "runs **after** the method — use for postconditions and cleanup",
+                    "around" => {
+                        "wraps the method — receives `$orig` as first arg, must call `$orig->($self, @_)`"
+                    }
+                    _ => "modifies the method",
+                };
+                let doc = symbol_info.documentation.as_deref().unwrap_or("");
+                return HoverExtracted::Complete(json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": format!(
+                            "**Method Modifier (`{modifier_kind}`)**\n\n`{method_name}` — {kind_label}\n\n{doc}"
+                        ),
+                    },
+                }));
+            }
+
             use crate::symbol::VarKind;
             let kind_str = match symbol_info.kind {
                 crate::symbol::SymbolKind::Variable(VarKind::Scalar) => "Scalar Variable",

--- a/crates/perl-lsp/tests/fixtures/frameworks/moo_method_modifiers.pl
+++ b/crates/perl-lsp/tests/fixtures/frameworks/moo_method_modifiers.pl
@@ -1,0 +1,22 @@
+package Demo::WithModifiers;
+use Moo;
+
+sub save {
+    my ($self) = @_;
+    return 1;
+}
+
+before 'save' => sub {
+    my ($self) = @_;
+    # validation before save
+};
+
+after 'save' => sub {
+    my ($self) = @_;
+    # cleanup after save
+};
+
+around 'save' => sub {
+    my ($orig, $self, @args) = @_;
+    return $self->$orig(@args);
+};

--- a/crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs
@@ -386,7 +386,7 @@ fn test_workspace_symbol_finds_native_class_and_method() -> TestResult {
         let symbols2 = response2.as_array().ok_or("response2 is not an array")?;
         let names2: Vec<&str> = symbols2.iter().filter_map(|s| s["name"].as_str()).collect();
         assert!(
-            names2.iter().any(|n| *n == "MyPoint"),
+            names2.contains(&"MyPoint"),
             "workspace/symbol should find native class 'MyPoint', got: {:?}",
             names2
         );

--- a/crates/perl-lsp/tests/semantic_hover.rs
+++ b/crates/perl-lsp/tests/semantic_hover.rs
@@ -538,6 +538,164 @@ mod tied_variable_hover_tests {
 }
 
 #[cfg(test)]
+mod method_modifier_hover_tests {
+    use crate::common::test_utils::TestServerBuilder;
+    use serde_json::Value;
+
+    fn hover_content(resp: &Value) -> Option<String> {
+        let result = resp.get("result")?;
+        if result.is_null() {
+            return None;
+        }
+        let contents = result.get("contents")?;
+        let value = contents.get("value")?.as_str()?;
+        Some(value.to_string())
+    }
+
+    fn find_pos(
+        code: &str,
+        needle: &str,
+        target_line: usize,
+    ) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+        let line = code
+            .lines()
+            .nth(target_line)
+            .ok_or_else(|| format!("no line {} in test code", target_line))?;
+        let col = line
+            .find(needle)
+            .ok_or_else(|| format!("could not find `{needle}` on line {target_line}"))?;
+        Ok((target_line as u32, col as u32))
+    }
+
+    /// Hovering over the method name inside `before 'save' => sub { ... }`
+    /// should show "Method Modifier" rather than the generic "Subroutine" label.
+    #[test]
+    fn hover_on_before_modifier_shows_method_modifier_kind()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = include_str!("fixtures/frameworks/moo_method_modifiers.pl");
+        let uri = "file:///moo_modifiers.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Line 8 (0-indexed) is: before 'save' => sub {
+        let (line, col) = find_pos(code, "save", 8)?;
+        let response = server.get_hover(uri, line, col);
+        println!("BEFORE MODIFIER HOVER RESPONSE: {response:#}");
+
+        let content =
+            hover_content(&response).ok_or("expected hover content on before modifier")?;
+
+        assert!(
+            content.to_lowercase().contains("modifier") || content.contains("before"),
+            "hover should mention modifier kind, got: {content}"
+        );
+        assert!(
+            !content.contains("**Subroutine**"),
+            "hover should not show generic Subroutine label for a modifier, got: {content}"
+        );
+        Ok(())
+    }
+
+    /// Hovering over the method name inside `around 'save' => sub { ... }`
+    /// should mention "around" and show `$orig` usage semantics.
+    /// The improved hover card (after fix) will show "Method Modifier (`around`)"
+    /// and explain that around receives `$orig` as the first arg.
+    #[test]
+    fn hover_on_around_modifier_mentions_orig() -> Result<(), Box<dyn std::error::Error>> {
+        let code = include_str!("fixtures/frameworks/moo_method_modifiers.pl");
+        let uri = "file:///moo_modifiers_around.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Line 18 (0-indexed) is: around 'save' => sub {
+        let (line, col) = find_pos(code, "save", 18)?;
+        let response = server.get_hover(uri, line, col);
+        println!("AROUND MODIFIER HOVER RESPONSE: {response:#}");
+
+        let content =
+            hover_content(&response).ok_or("expected hover content on around modifier")?;
+
+        // After fix: hover should mention $orig (the key semantic of around modifiers).
+        // Before fix: shows generic "**Subroutine**" with no $orig guidance.
+        assert!(
+            content.contains("orig"),
+            "around modifier hover should explain $orig usage, got: {content}"
+        );
+        assert!(
+            !content.contains("**Subroutine**"),
+            "hover should not show generic Subroutine label for around modifier, got: {content}"
+        );
+        Ok(())
+    }
+
+    /// Hovering over the method name inside `after 'save' => sub { ... }`
+    /// should name the "after" modifier and not show the generic Subroutine label.
+    #[test]
+    fn hover_on_after_modifier_is_distinct_from_subroutine()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = include_str!("fixtures/frameworks/moo_method_modifiers.pl");
+        let uri = "file:///moo_modifiers_after.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Line 13 (0-indexed) is: after 'save' => sub {
+        let (line, col) = find_pos(code, "save", 13)?;
+        let response = server.get_hover(uri, line, col);
+        println!("AFTER MODIFIER HOVER RESPONSE: {response:#}");
+
+        let content = hover_content(&response).ok_or("expected hover content on after modifier")?;
+
+        assert!(
+            content.contains("after") || content.contains("modifier"),
+            "after modifier hover should name the modifier, got: {content}"
+        );
+        assert!(
+            !content.contains("**Subroutine**"),
+            "hover should not show generic Subroutine label for a modifier, got: {content}"
+        );
+        Ok(())
+    }
+
+    /// `use Mouse;` packages should get modifier symbols just like `use Moo;`.
+    /// This verifies that Mouse is recognized in symbol.rs framework detection.
+    /// Without the fix, Mouse is not in `update_framework_context`, so `is_moo`
+    /// is never set and the modifier symbol is never added — hover falls through
+    /// to the generic token fallback showing "**Perl**: `save`" with no modifier info.
+    #[test]
+    fn mouse_modifier_emits_symbol_with_modifier_attribute()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = "package MyApp::User;\nuse Mouse;\nbefore 'save' => sub { };\n";
+        let uri = "file:///mouse_modifier.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        // Line 2 (0-indexed) is: before 'save' => sub { };
+        let (line, col) = find_pos(code, "save", 2)?;
+        let response = server.get_hover(uri, line, col);
+        println!("MOUSE MODIFIER HOVER RESPONSE: {response:#}");
+
+        let content =
+            hover_content(&response).ok_or("expected hover content on Mouse before modifier")?;
+
+        // Must be a semantic hover (not just token fallback "**Perl**: `save`").
+        // The semantic hover will have Declaration/Attributes fields from the modifier symbol.
+        assert!(
+            content.contains("before") || content.contains("modifier"),
+            "Mouse before modifier should produce semantic hover mentioning the modifier, got: {content}"
+        );
+        assert!(
+            !content.contains("**Perl**"),
+            "hover should be semantic, not the generic token fallback, got: {content}"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
 mod module_hover_tests {
     use crate::common::test_utils::TestServerBuilder;
     use serde_json::Value;

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -1568,8 +1568,8 @@ impl SymbolExtractor {
         let pkg = self.table.current_package.clone();
 
         let framework_kind = match module {
-            "Moo" => Some(FrameworkKind::Moo),
-            "Moo::Role" => Some(FrameworkKind::MooRole),
+            "Moo" | "Mouse" => Some(FrameworkKind::Moo),
+            "Moo::Role" | "Mouse::Role" => Some(FrameworkKind::MooRole),
             "Moose" => Some(FrameworkKind::Moose),
             "Moose::Role" => Some(FrameworkKind::MooseRole),
             _ => None,


### PR DESCRIPTION
## Summary

Hovering over a method modifier declaration (`before 'save' => sub {}`, `after`, `around`) previously showed the generic `**Subroutine**` label with a raw machine-readable `modifier=before` attribute string. This PR replaces that with a dedicated `**Method Modifier (`before`)**` hover card that surfaces the semantic purpose of each modifier kind — including the `$orig` wrapping note for `around`.

A second fix adds `Mouse` and `Mouse::Role` to `update_framework_context` in `symbol.rs`, which was the only entry point missing these frameworks. Without it, `use Mouse;` packages never set the `is_moo` flag, so `try_extract_method_modifier` was never called and modifier symbols were never added to the symbol table — hover fell through to the generic token fallback.

Both fixes are surgical one-function changes with no API changes.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: hover response text improved (richer markdown content for modifier symbols)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**`hover.rs` (`extract_symbol_hover`)**: Before the generic `kind_str` match, detect if the found symbol has an attribute starting with `modifier=`. If so, return a dedicated hover card immediately with the modifier kind name and a human-readable description. The `around` description specifically mentions `$orig` — the key semantic developers need to see at hover time.

**`symbol.rs` (`update_framework_context`)**: Added `"Mouse"` and `"Mouse::Role"` as aliases for `FrameworkKind::Moo` and `FrameworkKind::MooRole`. Mouse has identical modifier syntax to Moo, so aliasing is correct. `class_model.rs` already handled Mouse; this brings `symbol.rs` to parity.

**Tests**: Added `method_modifier_hover_tests` module to `semantic_hover.rs` with 4 tests (before/around/after hover cards, Mouse modifier semantic hover). Added `moo_method_modifiers.pl` fixture. Also fixed a pre-existing `clippy::manual_contains` warning in `lsp_workspace_symbol_tests.rs` that would have blocked `-D warnings`.

## How to review

- `hover.rs:98–124` — the modifier detection block; verify it exits early before the Subroutine branch
- `symbol.rs:1571` — the two-line Mouse alias; confirm aliasing to Moo/MooRole is correct behavior
- `semantic_hover.rs` — the `method_modifier_hover_tests` module; confirm 4 tests cover before/after/around/Mouse
- `moo_method_modifiers.pl` — fixture file, verify line numbers match test `find_pos` call sites

## Evidence

```
# New tests: 4 pass
test method_modifier_hover_tests::hover_on_after_modifier_is_distinct_from_subroutine ... ok
test method_modifier_hover_tests::hover_on_around_modifier_mentions_orig ... ok
test method_modifier_hover_tests::hover_on_before_modifier_shows_method_modifier_kind ... ok
test method_modifier_hover_tests::mouse_modifier_emits_symbol_with_modifier_attribute ... ok
test result: ok. 4 passed; 0 failed

# moo_semantics_e2e: all pass
test result: ok. 16 passed; 0 failed

# semantic_hover: 33 pass, 1 pre-existing failure
test result: FAILED. 33 passed; 1 failed
# (pre-existing: module_hover_tests::hover_on_use_statement_module_found — confirmed failing on master before this PR)

# perl-semantic-analyzer: fmt + clippy clean
# (1 pre-existing test failure: symbol_extraction_method_preserves_attributes — confirmed on master)

# fmt: PASS
# clippy -D warnings: PASS (fixed pre-existing manual_contains)
```

## Risk & rollback

Blast radius is narrow: only `extract_symbol_hover` changes behavior, and only for symbols that carry a `modifier=X` attribute. Non-modifier symbols are unaffected — the new code exits early before the existing Subroutine/Method rendering. The Mouse framework detection change only affects packages that `use Mouse;`, which previously got zero semantic analysis for modifiers.

Rollback: revert `hover.rs` (25 lines) and `symbol.rs` (2 lines). No data migrations, no schema changes.

## Follow-ups

- Goto-definition from modifier to base method (`before 'save'` → `sub save {}`) — requires cross-symbol linking; out of scope for this PR. See issue #2328 Phase 3.
- "Show all modifiers applied to a method on hover" — requires wiring `ClassModelBuilder` into hover path; out of scope. Filed as follow-up.
- Array literal modifier target hover (`around ['save','delete']`) — hovering on strings inside the array literal doesn't currently match the modifier symbol span; the symbol is found at the FunctionCall level. Low-priority UX gap.
- `override`/`augment` Moose-only modifiers — not in scope (Moo is primary target).

Closes #2328.