### PR TITLE
feat(perl-lsp-config): add error recovery for missing perl at workspace init (#2106)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ name = "perl-lsp-config"
 version = "0.12.0"
 dependencies = [
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/perl-lsp-config/Cargo.toml
+++ b/crates/perl-lsp-config/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools", "text-editors"]
 
 [dependencies]
 serde_json = "1.0.149"
+tracing = "0.1.44"
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -201,8 +201,8 @@ impl WorkspaceConfig {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn fetch_perl_inc() -> Vec<PathBuf> {
-        let output = Command::new("perl").args(["-e", "print join(\"\\n\", @INC)"]).output();
+    fn fetch_perl_inc_with_cmd(perl_cmd: &str) -> Vec<PathBuf> {
+        let output = Command::new(perl_cmd).args(["-e", "print join(\"\\n\", @INC)"]).output();
 
         match output {
             Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
@@ -210,8 +210,27 @@ impl WorkspaceConfig {
                 .filter(|line| !line.is_empty() && *line != ".")
                 .map(PathBuf::from)
                 .collect(),
-            _ => Vec::new(),
+            Ok(out) => {
+                tracing::warn!(
+                    exit_code = ?out.status.code(),
+                    "perl @INC query failed with non-zero exit; system include paths will be empty"
+                );
+                Vec::new()
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "perl not found in PATH; system include paths will be empty. \
+                     Install perl or disable useSystemInc in settings."
+                );
+                Vec::new()
+            }
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn fetch_perl_inc() -> Vec<PathBuf> {
+        Self::fetch_perl_inc_with_cmd("perl")
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -429,5 +448,27 @@ mod tests {
         // use_system_inc = false (default)
         let inc = config.get_system_inc();
         assert!(inc.is_empty(), "system inc is empty when use_system_inc=false");
+    }
+
+    // ── WorkspaceConfig::fetch_perl_inc error recovery ───────
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn fetch_perl_inc_with_missing_binary_returns_empty_vec() {
+        // Use a binary name that cannot exist on any system
+        let result =
+            WorkspaceConfig::fetch_perl_inc_with_cmd("perl-binary-that-definitely-does-not-exist");
+        assert!(
+            result.is_empty(),
+            "fetch_perl_inc must return empty Vec when perl binary is missing"
+        );
+    }
+
+    #[test]
+    #[cfg(all(not(target_arch = "wasm32"), unix))]
+    fn fetch_perl_inc_with_failing_command_returns_empty_vec() {
+        // 'false' always exits 1 on Unix
+        let result = WorkspaceConfig::fetch_perl_inc_with_cmd("false");
+        assert!(result.is_empty(), "fetch_perl_inc must return empty Vec when perl exits non-zero");
     }
 }


### PR DESCRIPTION
## Summary

When `perl -e 'print join("\n", @INC)'` fails during workspace initialization, the original code silently returned an empty `Vec` via a catch-all `_ => Vec::new()` arm. Users on systems without Perl installed received no diagnostic feedback — module resolution would silently degrade with no indication of why.

This PR adds structured `tracing::warn!` logging for both distinct failure modes: (1) the Perl binary is not found on PATH (`Err(e)`), and (2) Perl is found but exits non-zero (`Ok(out)` with failed status). To enable testing without PATH manipulation, `fetch_perl_inc` is split into `fetch_perl_inc_with_cmd(perl_cmd: &str)` (injectable command) + a wrapper that calls it with `"perl"`. The `tracing = "0.1.44"` dependency is added to `perl-lsp-config/Cargo.toml` (the crate previously had zero logging dependencies).

The wasm32 stub (`fn fetch_perl_inc() -> Vec<PathBuf> { Vec::new() }`) is intentionally unchanged — subprocess invocation is impossible in wasm and silent empty return is correct there.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged (behavior at call sites is identical — callers see the same empty `Vec`; only logging is added)
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-lsp-config/src/lib.rs` — replaced the catch-all `_ => Vec::new()` arm in the non-wasm `fetch_perl_inc` with two explicit arms that emit `tracing::warn!` before returning empty. Split into `fetch_perl_inc_with_cmd(perl_cmd: &str)` + `fetch_perl_inc()` wrapper. Added two tests: `fetch_perl_inc_with_missing_binary_returns_empty_vec` (exercises the `Err` arm via a nonexistent binary name) and `fetch_perl_inc_with_failing_command_returns_empty_vec` (exercises the non-zero exit arm via `false` on Unix).

`crates/perl-lsp-config/Cargo.toml` — added `tracing = "0.1.44"` to `[dependencies]`.

## How to review

Start at `crates/perl-lsp-config/src/lib.rs` line ~203. The entire change is the replacement of the `match output` block and the addition of the wrapper function below it. Test additions are at the bottom of the `mod tests` block.

Hotspot: confirm the `#[cfg(not(target_arch = "wasm32"))]` guard covers both `fetch_perl_inc_with_cmd` and the `fetch_perl_inc` wrapper, and that the wasm stub at line ~228 is untouched.

## Evidence

```
running 24 tests
test tests::fetch_perl_inc_with_failing_command_returns_empty_vec ... ok
test tests::fetch_perl_inc_with_missing_binary_returns_empty_vec ... ok
[... 22 other tests all ok ...]
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 20 tests
[... behavioral tests ...]
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo fmt -p perl-lsp-config -- --check  PASS
cargo clippy -p perl-lsp-config --tests -- -D warnings  PASS
```

Note: `just ci-gate` fails on pre-existing `expect()` calls in `xtask/tests/post_merge_status_regen_tests.rs` (7 violations already on master, zero xtask files changed in this PR).

## Risk & rollback

Blast radius: `perl-lsp-config` only. Additive change — no behavior change at call sites. The only observable difference is that `tracing` subscribers (if any are registered) will now receive warn events on Perl detection failure. If no subscriber is registered, the warn calls are no-ops. Rollback: revert this commit.

## Follow-ups

None. The plan-reviewer confirmed no fallback path changes are needed — callers already fall back to `WorkspaceConfig.include_paths` (`["lib", ".", "local/lib/perl5"]`) when `use_system_inc=false`.

Closes #2106