### PR TITLE
docs(lsp): update LSP_API_CONTRACTS.md to reflect implemented features (#346)

### DIFF
--- a/crates/perl-parser/LSP_API_CONTRACTS.md
+++ b/crates/perl-parser/LSP_API_CONTRACTS.md
@@ -3,9 +3,9 @@
 This document defines the stable API contracts for the Perl LSP server implementation.
 These contracts are enforced by tests in `tests/lsp_api_contracts.rs`.
 
-**Version:** 0.8.3
+**Version:** 0.12.0
 **LSP Specification:** 3.17
-**Last Updated:** 2025-02-19
+**Last Updated:** 2026-03-21
 
 ## 1. Initialization Contract
 
@@ -230,7 +230,7 @@ These contracts are enforced by the following test categories:
 1. **Initialization Tests**
    - ✅ Basic initialization
    - ✅ Minimal client capabilities
-   - ⚠️ Double initialization rejection (TODO: Fix server)
+   - ✅ Double initialization rejection
 
 2. **Response Shape Tests**
    - ✅ Completion response shapes
@@ -239,7 +239,7 @@ These contracts are enforced by the following test categories:
 
 3. **Performance Tests**
    - ✅ Large file responsiveness
-   - ⚠️ Bounded module resolution (TODO: Fix timeout)
+   - ✅ Bounded module resolution
 
 4. **Compatibility Tests**
    - ✅ URI validation
@@ -260,13 +260,6 @@ These contracts are enforced by the following test categories:
 | Performance | ✅ Complete | 100% | Module timeout implemented |
 | Error Handling | ✅ Complete | 100% | Standard codes used |
 | Compatibility | ✅ Complete | 100% | Backwards compatible |
-
-## Known Issues
-
-### Test Infrastructure
-- `test_bounded_definition_timeout`: Test harness may block on server communication,
-  preventing proper timeout validation. The server implementation has correct timeouts
-  but the test infrastructure needs improvement.
 
 ## Breaking Changes Policy
 


### PR DESCRIPTION
## Summary

`crates/perl-parser/LSP_API_CONTRACTS.md` contained stale content that misrepresented the implementation state. Two features marked as TODO/unimplemented (`double initialization rejection` and `bounded module resolution`) have passing tests. The Known Issues section claimed the test harness may block — that concern was resolved when the harness was made async in commit `cd6909fcc`. The header also showed version 0.8.3 from 2025-02-19 while the project is at 0.12.0.

This is a pure documentation fix. No code paths were changed.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

Four targeted edits to `crates/perl-parser/LSP_API_CONTRACTS.md`:

1. **Header** — Version `0.8.3` → `0.12.0`, Last Updated `2025-02-19` → `2026-03-21`
2. **Test Coverage / Initialization Tests** — `⚠️ Double initialization rejection (TODO: Fix server)` → `✅ Double initialization rejection`
3. **Test Coverage / Performance Tests** — `⚠️ Bounded module resolution (TODO: Fix timeout)` → `✅ Bounded module resolution`
4. **Known Issues section** — deleted entirely (the harness concern it described was resolved in commit `cd6909fcc` when `request_with_timeout` was established)

The Implementation Status table already showed `Performance | ✅ Complete | 100%` — the fix makes the Test Coverage section consistent with it.

## How to review

Single file, 15-line diff. Read top to bottom — header, then Test Coverage bullets at lines ~232-242, then the removed Known Issues section that previously followed the Implementation Status table.

## Evidence

```
$ grep -n "TODO\|⚠️\|Known Issues\|0\.8\.3\|2025-02-19" crates/perl-parser/LSP_API_CONTRACTS.md
(no output)
```

Verification command produces no output — all stale content removed.

## Risk & rollback

Blast radius: documentation only. No code, no tests, no dependencies affected. Rollback by reverting the single commit.

## Follow-ups

- `Future Contracts (v0.9.x)` section at the bottom of the doc is also stale (project is at 0.12.0), but was explicitly marked out of scope for this issue by the plan-reviewer. Recommend a follow-up doc update if desired.