### PR TITLE
feat(vscode): wire debugger setup wizard — package.json + extension.ts (#2338)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -56,7 +56,8 @@
     "onLanguage:perl",
     "onCommand:perl-lsp.restart",
     "onCommand:perl-lsp.showVersion",
-    "onCommand:perl-lsp.reinstall"
+    "onCommand:perl-lsp.reinstall",
+    "onCommand:perl-lsp.createDebugConfig"
   ],
   "contributes": {
     "languages": [
@@ -369,6 +370,12 @@
         "title": "Show Special Variables Reference",
         "category": "Perl",
         "icon": "$(symbol-variable)"
+      },
+      {
+        "command": "perl-lsp.createDebugConfig",
+        "title": "Create Debug Configuration",
+        "category": "Perl",
+        "icon": "$(debug-alt)"
       }
     ],
     "menus": {
@@ -411,6 +418,10 @@
         },
         {
           "command": "perl-lsp.showSpecialVarsReference"
+        },
+        {
+          "command": "perl-lsp.createDebugConfig",
+          "when": "workspaceFolderCount >= 1"
         }
       ],
       "editor/title": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -11,7 +11,7 @@ import {
     Trace
 } from 'vscode-languageclient/node';
 import { PerlTestAdapter } from './testAdapter';
-import { activateDebugger } from './debugAdapter';
+import { activateDebugger, offerDebugConfigOnFirstPerlOpen } from './debugAdapter';
 import { BinaryDownloader } from './downloader';
 import { OnboardingManager } from './onboarding';
 import { WhatsNewManager } from './whatsNew';
@@ -151,6 +151,11 @@ export async function activate(context: vscode.ExtensionContext) {
                 command: 'editor.action.formatDocument',
                 disabled: !isPerl
             },
+            {
+                label: '$(debug-alt) Create Debug Configuration',
+                detail: 'Set up .vscode/launch.json for Perl debugging',
+                command: 'perl-lsp.createDebugConfig'
+            },
 
             { label: 'Information', kind: vscode.QuickPickItemKind.Separator },
             { label: '$(output) Show Output', detail: 'Open the extension output channel', command: 'perl-lsp.showOutput' },
@@ -281,6 +286,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Initialize debug adapter
     activateDebugger(context);
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument(doc => {
+            offerDebugConfigOnFirstPerlOpen(doc).catch(() => { /* swallow */ });
+        })
+    );
     await initializeLanguageClient(context);
 
     // First-run onboarding: show welcome notification once per installation


### PR DESCRIPTION
## Summary

PR #2500 (merged 2026-03-20) implemented the full debugger setup wizard in `debugAdapter.ts` — `buildLaunchJsonContent`, `createDebugConfigWizard`, `offerDebugConfigOnFirstPerlOpen`, and supporting helpers — but never wired three required integration points. The wizard logic has been dead code since merge.

This PR is a pure completion pass: three additive wiring changes, no logic written, no changes to `debugAdapter.ts`.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged
- VSCode command palette: additive — `Perl: Create Debug Configuration` now visible when a workspace is open
- VSCode status bar menu: additive — new entry in the Perl LSP quick-pick menu
- VSCode activation: additive — extension now activates on `onCommand:perl-lsp.createDebugConfig`

## What changed

**`vscode-extension/package.json` (3 additions):**
1. `contributes.commands` — added `perl-lsp.createDebugConfig` declaration with `category: "Perl"` and `icon: "$(debug-alt)"`
2. `activationEvents` — added `"onCommand:perl-lsp.createDebugConfig"` so VSCode activates the extension when the command is invoked cold
3. `contributes.menus.commandPalette` — added entry with `when: "workspaceFolderCount >= 1"` (workspace-scoped, not file-scoped, because the wizard makes sense before any Perl file is open)

**`vscode-extension/src/extension.ts` (2 additions):**
1. Import — added `offerDebugConfigOnFirstPerlOpen` to the existing `./debugAdapter` import
2. `onDidOpenTextDocument` subscription — wired after `activateDebugger(context)` call; the handler calls `offerDebugConfigOnFirstPerlOpen(doc)` fire-and-forget with `.catch(() => { /* swallow */ })` to prevent uncaught promise rejections from blocking extension startup
3. Status bar menu — added `$(debug-alt) Create Debug Configuration` entry after Format Document, before the Information separator

## How to review

- `vscode-extension/package.json`: three small JSON additions. Check that the `when` clause on commandPalette is `workspaceFolderCount >= 1` (not `editorLangId == perl` — the wizard is workspace-scoped).
- `vscode-extension/src/extension.ts` line 14: import diff. Lines ~155 and ~285: the two new wiring sites.
- `debugAdapter.ts`: should be untouched. If any diff appears there, it is a bug.

## Evidence

```
Before: Tests: 29 failed, 218 passed, 247 total
After:  Tests: 24 failed, 223 passed, 247 total

5 newly-passing tests (configuration.test.ts):
  ✓ package.json contributes > commands > registers expected commands
  ✓ createDebugConfig command > registers perl-lsp.createDebugConfig command
  ✓ createDebugConfig command > createDebugConfig has Perl category
  ✓ createDebugConfig command > createDebugConfig is listed in commandPalette
  ✓ createDebugConfig command > createDebugConfig has an activation event

Remaining 24 failures are pre-existing (walkthrough, onboarding,
openConfigurationGuide, configuration array grouping) — all outside
this PR's scope.
```

## Risk & rollback

Risk: LOW. All changes are additive. The command handler itself (`activateDebugger` in `debugAdapter.ts`) was already registered at runtime since PR #2500 — this PR only makes it visible to VSCode's command palette and activation system.

Blast radius: VSCode extension only. No Rust crates touched. No LSP protocol changes.

Rollback: revert the two files. The wizard returns to its pre-existing dead-code state.

## Follow-ups

The test run revealed the same "dead code not wired" pattern for two more features from PR #2500's batch:
- `perl-lsp.openConfigurationGuide` — command missing from `package.json` (4 failing tests in `configuration.test.ts`)
- `contributes.walkthroughs` — walkthrough contribution missing from `package.json` (9 failing tests in `walkthrough.test.ts`)
- `perl-lsp.runHealthCheck` — command missing from `package.json` (3 failing tests in `onboarding.test.ts`)

Recommend follow-up scout/builder issues for each.