### PR TITLE
feat(vscode): add Special Variables Reference command and promote hover tooltips (#2318)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to the Perl Language Server extension will be documented in 
 - **Categories**: Added "Testing" to reflect Test Explorer integration
 
 ### Added
+- **Special Variable Hover Tooltips**: Hover over any of 27 built-in Perl special variables (`$_`, `@_`, `$!`, `$@`, `%ENV`, `@INC`, `@ARGV`, `%SIG`, and more) to see inline documentation with code examples. Available in all Perl files without configuration.
+- **Special Variables Reference Panel**: Command palette `Perl: Show Special Variables Reference` opens a quick-reference panel listing all supported special variables with descriptions and examples.
 - **Open VSX Publishing**: Extension now publishes to Open VSX Registry alongside VS Marketplace, enabling first-class support for VSCodium and other open-source VS Code derivatives. Added `ovsx` publish/check scripts and `@types/vscode` dev dependency fix for compatible builds.
 - **Comprehensive README**: Rewritten for marketplace listing with full configuration reference table, keyboard shortcuts, troubleshooting guide, and command reference
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -14,7 +14,7 @@ A fast, native Perl 5 language server with 26+ IDE features. Written in Rust for
 ### Navigation and Intelligence
 - **Go to Definition** -- Jump to any symbol declaration across files
 - **Find References** -- Find all usages of a symbol across your project
-- **Hover Documentation** -- Instant docs for functions, variables, and modules
+- **Hover Documentation** -- Instant docs for functions, variables, and modules, including educational tooltips for Perl special variables (`$_`, `@_`, `%ENV`, and 20+ more)
 - **Auto-completion** -- Smart suggestions for variables, functions, and module names
 - **Signature Help** -- Real-time parameter hints as you type function calls
 - **Symbol Navigation** -- Outline view, breadcrumbs, and workspace symbol search
@@ -33,6 +33,7 @@ A fast, native Perl 5 language server with 26+ IDE features. Written in Rust for
 - **Document Formatting** -- Format with `perltidy` (`Shift+Alt+F`)
 
 ### Advanced Features
+- **Special Variables Reference** -- Hover over `$_`, `@_`, `%ENV`, `$!`, and 20+ built-in Perl special variables for instant documentation. Open the full reference via `Perl: Show Special Variables Reference` in the command palette.
 - **Semantic Highlighting** -- Context-aware syntax coloring beyond TextMate grammars
 - **Type Hierarchy** -- Navigate inheritance with `@ISA` and `use parent`
 - **Call Hierarchy** -- Trace function calls inbound and outbound

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -362,6 +362,12 @@
         "title": "Show What's New",
         "category": "Perl",
         "icon": "$(star-empty)"
+      },
+      {
+        "command": "perl-lsp.showSpecialVarsReference",
+        "title": "Show Special Variables Reference",
+        "category": "Perl",
+        "icon": "$(symbol-variable)"
       }
     ],
     "menus": {
@@ -401,6 +407,9 @@
         {
           "command": "perl-lsp.showRefactoringOptions",
           "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.showSpecialVarsReference"
         }
       ],
       "editor/title": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,7 @@ import { activateDebugger } from './debugAdapter';
 import { BinaryDownloader } from './downloader';
 import { OnboardingManager } from './onboarding';
 import { WhatsNewManager } from './whatsNew';
+import { showSpecialVarsReference } from './specialVarsReference';
 import { generateBoilerplate } from './fileCreation';
 
 let client: LanguageClient | undefined;
@@ -210,6 +211,10 @@ export async function activate(context: vscode.ExtensionContext) {
         await whatsNewManager.showWhatsNew();
     });
 
+    const showSpecialVarsRefCommand = vscode.commands.registerCommand('perl-lsp.showSpecialVarsReference', async () => {
+        await showSpecialVarsReference(context, outputChannel);
+    });
+
     const formatOnSaveDisposable = vscode.workspace.onWillSaveTextDocument((event) => {
         if (!shouldFormatOnSave(event.document)) {
             return;
@@ -268,6 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
         reinstallCommand,
         runHealthCheckCommand,
         showWhatsNewCommand,
+        showSpecialVarsRefCommand,
         formatOnSaveDisposable,
         configurationWatcher,
         fileCreationWatcher,

--- a/vscode-extension/src/specialVarsReference.ts
+++ b/vscode-extension/src/specialVarsReference.ts
@@ -1,0 +1,173 @@
+/**
+ * Special Variables Reference — show a WebView panel listing all known
+ * Perl special variables with descriptions and usage examples.
+ *
+ * Responsibilities:
+ * - Export SPECIAL_VARS array for testability.
+ * - Export buildSpecialVarsHtml() for testability.
+ * - Export showSpecialVarsReference() to be wired up to the command.
+ * - Never duplicate definitions from hover.rs — this is a self-contained
+ *   quick-reference aid, not a copy of the LSP hover text.
+ */
+
+import * as vscode from 'vscode';
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+export interface SpecialVar {
+    name: string;
+    description: string;
+    example: string;
+}
+
+export const SPECIAL_VARS: SpecialVar[] = [
+    { name: '$_',   description: 'Default variable — used implicitly by foreach, map, grep, print, chomp', example: 'for (@items) { print }' },
+    { name: '@_',   description: 'Subroutine arguments', example: 'my ($x, $y) = @_' },
+    { name: '$!',   description: 'OS error (errno) — numeric or string context', example: 'open $fh, "<", $f or die $!' },
+    { name: '$@',   description: 'Eval error', example: 'eval { die "oops" }; warn $@ if $@' },
+    { name: '$/',   description: 'Input record separator (default: newline)', example: 'local $/; my $all = <$fh>' },
+    { name: '$\\',  description: 'Output record separator appended after print', example: 'local $\\ = "\\n"' },
+    { name: '$$',   description: 'Current process ID', example: 'print "PID: $$"' },
+    { name: '$0',   description: 'Script name', example: 'print $0' },
+    { name: '$;',   description: 'Subscript separator for multidimensional hash emulation', example: '$h{$a,$b}' },
+    { name: '$,',   description: 'Output field separator for print', example: 'local $, = ", "' },
+    { name: '$.',   description: 'Current line number of last read filehandle', example: 'print "$."' },
+    { name: '$&',   description: 'Last successful regex match string', example: '"Hello" =~ /He/; print $&' },
+    { name: "$'",   description: 'String following last regex match', example: '"Hello" =~ /He/; print $\'' },
+    { name: '$`',   description: 'String preceding last regex match', example: '"Hello" =~ /el/; print $`' },
+    { name: '$+',   description: 'Last bracket (capture group) matched', example: '"x" =~ /(x)/; print $+' },
+    { name: '$?',   description: 'Child process status after system/backtick — exit code is $? >> 8', example: 'system("ls"); print $? >> 8' },
+    { name: '$^W',  description: 'Warning flag — prefer use warnings for lexical scope', example: 'local $^W = 1' },
+    { name: '$^O',  description: 'Operating system name (linux, darwin, MSWin32)', example: 'if ($^O eq "MSWin32") { }' },
+    { name: '$^V',  description: 'Perl version as v-string', example: 'print $^V' },
+    { name: '$^A',  description: 'Accumulator for format()/write()', example: 'formline("@<<<", "hi"); print $^A' },
+    { name: '$^T',  description: 'Script start time (seconds since epoch)', example: 'print time() - $^T' },
+    { name: '@ISA', description: 'Parent class list for method resolution', example: 'our @ISA = ("Animal")' },
+    { name: '%ENV', description: 'Environment variables hash', example: 'my $home = $ENV{HOME}' },
+    { name: '@INC', description: 'Module search paths', example: 'use lib "/my/modules"' },
+    { name: '%INC', description: 'Map of loaded module filenames to full paths', example: 'print $INC{"Foo/Bar.pm"}' },
+    { name: '@ARGV', description: 'Command-line arguments (not including script name)', example: 'my $file = shift @ARGV' },
+    { name: '%SIG', description: 'Signal handlers hash', example: '$SIG{INT} = sub { exit 1 }' },
+];
+
+// ---------------------------------------------------------------------------
+// HTML builder (exported for testing)
+// ---------------------------------------------------------------------------
+
+export function buildSpecialVarsHtml(): string {
+    const rows = SPECIAL_VARS.map(v => {
+        const name = escapeHtml(v.name);
+        const desc = escapeHtml(v.description);
+        const ex   = escapeHtml(v.example);
+        return `  <tr>
+    <td><code>${name}</code></td>
+    <td>${desc}<br><code class="example">${ex}</code></td>
+  </tr>`;
+    }).join('\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+<title>Perl Special Variables Reference</title>
+<style>
+  body {
+    font-family: var(--vscode-font-family, sans-serif);
+    font-size: var(--vscode-font-size, 13px);
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+    padding: 24px 32px;
+    max-width: 860px;
+    margin: 0 auto;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.6em; margin-bottom: 0.25em; }
+  p  { margin-top: 0; color: var(--vscode-descriptionForeground, #aaa); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1em;
+  }
+  th {
+    text-align: left;
+    border-bottom: 2px solid var(--vscode-panel-border, #444);
+    padding: 6px 8px;
+    font-weight: 600;
+  }
+  td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border, #333);
+    vertical-align: top;
+  }
+  tr:hover td { background: var(--vscode-list-hoverBackground, rgba(255,255,255,0.04)); }
+  code {
+    font-family: var(--vscode-editor-font-family, monospace);
+    background: var(--vscode-textCodeBlock-background, #1e1e1e);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+  code.example {
+    font-size: 0.9em;
+    color: var(--vscode-descriptionForeground, #aaa);
+    background: transparent;
+    padding: 0;
+  }
+  a { color: var(--vscode-textLink-foreground, #4daafc); }
+  .footer { margin-top: 1.5em; font-size: 0.9em; color: var(--vscode-descriptionForeground, #aaa); }
+</style>
+</head>
+<body>
+<h1>Perl Special Variables Reference</h1>
+<p>Hover over any of these variables in the editor for inline documentation.</p>
+<table>
+  <thead>
+    <tr><th>Variable</th><th>Description &amp; Example</th></tr>
+  </thead>
+  <tbody>
+${rows}
+  </tbody>
+</table>
+<p class="footer">
+  <a href="https://perldoc.perl.org/perlvar">Full perlvar documentation</a>
+</p>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Public command entry point
+// ---------------------------------------------------------------------------
+
+export async function showSpecialVarsReference(
+    _context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel,
+): Promise<void> {
+    const panel = vscode.window.createWebviewPanel(
+        'perlLspSpecialVars',
+        'Perl Special Variables Reference',
+        vscode.ViewColumn.One,
+        {
+            enableScripts: false,
+            localResourceRoots: [],
+        },
+    );
+
+    panel.webview.html = buildSpecialVarsHtml();
+    outputChannel.appendLine('[special-vars] Opened Special Variables Reference panel');
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -166,6 +166,7 @@ describe('package.json contributes', () => {
       expect(commandIds).toContain('perl-lsp.runTests');
       expect(commandIds).toContain('perl-lsp.showStatusMenu');
       expect(commandIds).toContain('perl-lsp.createDebugConfig');
+      expect(commandIds).toContain('perl-lsp.showSpecialVarsReference');
     });
 
     test('registers refactoring commands', () => {

--- a/vscode-extension/src/test/specialVarsReference.test.ts
+++ b/vscode-extension/src/test/specialVarsReference.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for specialVarsReference.
+ *
+ * Tests cover:
+ * - SPECIAL_VARS covers all 27 known variables
+ * - buildSpecialVarsHtml returns valid HTML with expected content
+ * - all entries have non-empty name, description, and example
+ */
+
+import { SPECIAL_VARS, buildSpecialVarsHtml } from '../specialVarsReference';
+
+describe('specialVarsReference', () => {
+    test('SPECIAL_VARS covers the 27 known variables', () => {
+        const names = SPECIAL_VARS.map(v => v.name);
+        expect(names).toContain('$_');
+        expect(names).toContain('@_');
+        expect(names).toContain('%ENV');
+        expect(names).toContain('$!');
+        expect(names).toContain('$?');
+        expect(names).toContain('@ARGV');
+        expect(names).toContain('%SIG');
+        expect(names).toContain('$^V');
+        expect(names).toContain('$^A');
+        expect(names).toContain('$^T');
+        expect(SPECIAL_VARS.length).toBeGreaterThanOrEqual(27);
+    });
+
+    test('buildSpecialVarsHtml returns valid HTML', () => {
+        const html = buildSpecialVarsHtml();
+        expect(html).toContain('<!DOCTYPE html>');
+        expect(html).toContain('$_');
+        expect(html).toContain('%ENV');
+        expect(html).toContain('perldoc.perl.org/perlvar');
+        expect(html).not.toContain('<script');  // enableScripts: false
+    });
+
+    test('all SPECIAL_VARS entries have non-empty name, description, and example', () => {
+        for (const v of SPECIAL_VARS) {
+            expect(v.name.length).toBeGreaterThan(0);
+            expect(v.description.length).toBeGreaterThan(0);
+            expect(v.example.length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The special variable hover tooltips feature (merged in #2262, extended in #2347) was fully working at the LSP layer but completely undiscoverable — nothing in the README, CHANGELOG, or command palette mentioned it. This PR makes the feature visible.

Adds `perl-lsp.showSpecialVarsReference` command that opens a static WebView panel listing all 27 Perl special variables with descriptions and examples. The panel is available in the command palette without any language restriction (useful as a reference without a Perl file open). Updates README and CHANGELOG to promote the existing hover tooltips.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged
- VSCode extension: additive — one new command, no existing behavior changed

## What changed

1. `vscode-extension/src/specialVarsReference.ts` (new) — exports `SPECIAL_VARS` array (27 entries), `buildSpecialVarsHtml()`, and `showSpecialVarsReference()`. Self-contained static data — does NOT duplicate Rust `hover.rs` definitions. CSP `default-src 'none'; style-src 'unsafe-inline'`, `enableScripts: false`, matches the `whatsNew.ts` security pattern.
2. `vscode-extension/src/extension.ts` — imports and registers the new command; pushes to `context.subscriptions`.
3. `vscode-extension/package.json` — adds entry in `contributes.commands` (with `$(symbol-variable)` icon) and `contributes.menus.commandPalette` (no `when` restriction).
4. `vscode-extension/README.md` — adds Special Variables Reference bullet under Advanced Features; updates Hover Documentation bullet to mention special variables explicitly.
5. `vscode-extension/CHANGELOG.md` — adds two bullets under `[0.12.0] ### Added` for the hover tooltips and the new reference panel.
6. `vscode-extension/src/test/specialVarsReference.test.ts` (new) — 3 tests covering SPECIAL_VARS coverage, HTML validity, and entry completeness.
7. `vscode-extension/src/test/configuration.test.ts` — adds one `toContain('perl-lsp.showSpecialVarsReference')` assertion to the existing `registers expected commands` test.

## How to review

Start with `specialVarsReference.ts` — it is entirely self-contained. The `SPECIAL_VARS` array and `buildSpecialVarsHtml()` are the core. The `extension.ts` diff is 6 lines (import + register + subscribe). The `package.json` diff is 10 lines (one command entry + one commandPalette entry).

Note: `configuration.test.ts` has 17 pre-existing failures (missing `createDebugConfig`, `openConfigurationGuide`, and related commands in `package.json`). These are not introduced by this PR.

## Evidence

```
npx tsc --noEmit     → exit 0 (no errors)
npx jest specialVarsReference
  Tests: 3 passed, 3 total

Full suite delta (vs baseline):
  Before: 29 failed, 218 passed, 247 total
  After:  29 failed, 221 passed, 250 total  (+3 new passing, 0 regressions)
```

## Risk & rollback

- Pure TypeScript/JSON/docs change — zero Rust changes, zero LSP protocol changes.
- The WebView command only activates when explicitly invoked; no auto-show logic.
- Rollback: revert this commit. The hover tooltips (LSP feature) are unaffected.

## Follow-ups

- The 17 pre-existing `configuration.test.ts` failures (`createDebugConfig`, `openConfigurationGuide`) are out of scope for this PR but worth a dedicated builder pass.
- `perl-lsp.showWhatsNew` is registered in `contributes.commands` but NOT in `commandPalette` — this omission is pre-existing and not corrected here (out of scope).