### PR TITLE
fix(refactoring): route inline all_occurrences to workspace-wide lookup (#439)

### DIFF
--- a/crates/perl-refactoring/src/refactor/refactoring.rs
+++ b/crates/perl-refactoring/src/refactor/refactoring.rs
@@ -1674,53 +1674,108 @@ impl RefactoringEngine {
         {
             #[cfg(feature = "workspace_refactor")]
             {
-                let mut files_modified = 0;
-                let mut changes_made = 0;
-                let mut applied = false;
-
-                for file in files {
-                    // Try to find and inline variable in this file
-                    match self.workspace_refactor.inline_variable(symbol_name, file, (0, 0)) {
+                if all_occurrences {
+                    // Route to workspace-wide inlining — finds all references via WorkspaceIndex.
+                    // Requires that files[0] is the definition file; callers must call
+                    // index_file() for each workspace file before invoking this path so that
+                    // cross-file lookup works. The `files` slice beyond [0] is not used here;
+                    // the workspace index is the authoritative source of all occurrences.
+                    // Known limitation: SymbolKey uses pkg="main" hardcoded, so
+                    // package-qualified variables from other packages fall through to a
+                    // text-scan fallback inside inline_variable_all.
+                    let def_file = files.first().ok_or_else(|| ParseError::SyntaxError {
+                        message:
+                            "Inline all_occurrences requires at least one file (definition file)"
+                                .to_string(),
+                        location: 0,
+                    })?;
+                    match self.workspace_refactor.inline_variable_all(symbol_name, def_file, (0, 0))
+                    {
                         Ok(refactor_result) => {
                             let edits = refactor_result.file_edits;
-                            if !edits.is_empty() {
-                                let mod_count = self.apply_file_edits(&edits)?;
-                                if mod_count > 0 {
-                                    files_modified += mod_count;
-                                    changes_made +=
-                                        edits.iter().map(|e| e.edits.len()).sum::<usize>();
-                                    applied = true;
-                                    // AC1: If not all_occurrences, stop after first successful inlining
-                                    if !all_occurrences {
+                            if edits.is_empty() {
+                                warnings.push(format!(
+                                    "Symbol '{}' not found across workspace",
+                                    symbol_name
+                                ));
+                                return Ok(RefactoringResult {
+                                    success: false,
+                                    files_modified: 0,
+                                    changes_made: 0,
+                                    warnings,
+                                    errors: vec![],
+                                    operation_id: None,
+                                });
+                            }
+                            let changes_made = edits.iter().map(|e| e.edits.len()).sum::<usize>();
+                            let files_modified = self.apply_file_edits(&edits)?;
+                            return Ok(RefactoringResult {
+                                success: true,
+                                files_modified,
+                                changes_made,
+                                warnings: refactor_result.warnings,
+                                errors: vec![],
+                                operation_id: None,
+                            });
+                        }
+                        Err(crate::workspace_refactor::RefactorError::SymbolNotFound {
+                            ..
+                        }) => {
+                            warnings.push(format!(
+                                "Symbol '{}' definition not found in provided files",
+                                symbol_name
+                            ));
+                        }
+                        Err(e) => {
+                            warnings.push(format!("Error during workspace inlining: {}", e));
+                        }
+                    }
+                } else {
+                    // Single-file path: iterate provided files, stop after first success.
+                    let mut files_modified = 0;
+                    let mut changes_made = 0;
+                    let mut applied = false;
+
+                    for file in files {
+                        match self.workspace_refactor.inline_variable(symbol_name, file, (0, 0)) {
+                            Ok(refactor_result) => {
+                                let edits = refactor_result.file_edits;
+                                if !edits.is_empty() {
+                                    let mod_count = self.apply_file_edits(&edits)?;
+                                    if mod_count > 0 {
+                                        files_modified += mod_count;
+                                        changes_made +=
+                                            edits.iter().map(|e| e.edits.len()).sum::<usize>();
+                                        applied = true;
                                         break;
                                     }
                                 }
                             }
-                        }
-                        Err(crate::workspace_refactor::RefactorError::SymbolNotFound {
-                            ..
-                        }) => continue,
-                        Err(e) => {
-                            warnings.push(format!("Error checking {}: {}", file.display(), e));
+                            Err(crate::workspace_refactor::RefactorError::SymbolNotFound {
+                                ..
+                            }) => continue,
+                            Err(e) => {
+                                warnings.push(format!("Error checking {}: {}", file.display(), e));
+                            }
                         }
                     }
-                }
 
-                if !applied && warnings.is_empty() {
-                    warnings.push(format!(
-                        "Symbol '{}' definition not found in provided files",
-                        symbol_name
-                    ));
-                }
+                    if !applied && warnings.is_empty() {
+                        warnings.push(format!(
+                            "Symbol '{}' definition not found in provided files",
+                            symbol_name
+                        ));
+                    }
 
-                return Ok(RefactoringResult {
-                    success: applied,
-                    files_modified,
-                    changes_made,
-                    warnings,
-                    errors: vec![],
-                    operation_id: None,
-                });
+                    return Ok(RefactoringResult {
+                        success: applied,
+                        files_modified,
+                        changes_made,
+                        warnings,
+                        errors: vec![],
+                        operation_id: None,
+                    });
+                }
             }
 
             #[cfg(not(feature = "workspace_refactor"))]
@@ -3257,5 +3312,74 @@ sub complex {
             assert!(!old_backup.exists());
             // temp_dir cleanup is automatic
         }
+    }
+
+    // --- Inline all_occurrences routing tests ---
+
+    /// AC1: When all_occurrences=true, perform_inline routes to inline_variable_all, which
+    /// uses the workspace index to find references across ALL indexed files — not just those
+    /// explicitly passed in `files`. path_b is indexed but intentionally omitted from `files`;
+    /// the workspace lookup must still find and inline the usage there.
+    #[cfg(feature = "workspace_refactor")]
+    #[test]
+    fn test_inline_all_occurrences_routes_to_workspace_lookup() {
+        let temp_dir = must(tempfile::tempdir());
+        let path_a = temp_dir.path().join("a.pl");
+        let path_b = temp_dir.path().join("b.pl");
+
+        // path_a holds the definition; path_b only references $const
+        let content_a = "my $const = 42;\nprint $const;\n";
+        let content_b = "print $const;\n";
+
+        must(std::fs::write(&path_a, content_a));
+        must(std::fs::write(&path_b, content_b));
+
+        let mut engine = RefactoringEngine::new();
+        engine.config.safe_mode = false;
+
+        // Index both files — workspace index must know about path_b for cross-file lookup
+        must(engine.index_file(&path_a, content_a));
+        must(engine.index_file(&path_b, content_b));
+
+        // Pass only path_a (definition file); path_b is omitted from `files` intentionally
+        let result = must(engine.refactor(
+            RefactoringType::Inline { symbol_name: "$const".to_string(), all_occurrences: true },
+            vec![path_a.clone()],
+        ));
+
+        assert!(result.success, "expected success, warnings: {:?}", result.warnings);
+
+        // path_b must have its $const replaced — inline_variable_all found it via workspace index
+        let updated_b = must(std::fs::read_to_string(&path_b));
+        assert!(
+            !updated_b.contains("$const"),
+            "expected $const to be inlined in path_b, but found: {:?}",
+            updated_b
+        );
+    }
+
+    /// When all_occurrences=false, only the single-file path is taken.
+    /// The definition file (path_a) contains the symbol; inlining within it should succeed.
+    #[cfg(feature = "workspace_refactor")]
+    #[test]
+    fn test_inline_single_occurrence_stops_after_first_file() {
+        let temp_dir = must(tempfile::tempdir());
+        let path_a = temp_dir.path().join("a.pl");
+
+        let content_a = "my $x = 99;\nprint $x;\n";
+        must(std::fs::write(&path_a, content_a));
+
+        let mut engine = RefactoringEngine::new();
+        engine.config.safe_mode = false;
+
+        must(engine.index_file(&path_a, content_a));
+
+        let result = must(engine.refactor(
+            RefactoringType::Inline { symbol_name: "$x".to_string(), all_occurrences: false },
+            vec![path_a.clone()],
+        ));
+
+        assert!(result.success, "expected success, warnings: {:?}", result.warnings);
+        assert_eq!(result.files_modified, 1);
     }
 }


### PR DESCRIPTION
## Summary

The `perform_inline` function in `perl-refactoring` accepted an `all_occurrences` flag but never acted on it for cross-file inlining. The flag was read (used to break a loop early for single-file mode), but the code always called `inline_variable` — the per-file method — even when `all_occurrences=true`. The workspace-wide method `inline_variable_all` existed at `workspace_refactor.rs:833` and was never called from `perform_inline`.

This fix adds a routing branch: when `all_occurrences=true`, the call goes to `inline_variable_all`, which uses `WorkspaceIndex.find_refs()` to locate all occurrences across all indexed documents, not just the files in the `files` parameter. When `all_occurrences=false`, the original single-file loop is preserved unchanged.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged
- perl-refactoring API: unchanged — `RefactoringType::Inline` struct and `refactor()` signature unchanged; only internal routing corrected

## What changed

`crates/perl-refactoring/src/refactor/refactoring.rs` — the `#[cfg(feature = "workspace_refactor")]` block inside `perform_inline` (lines 1675–1724) is replaced with a branch on `all_occurrences`:

- `all_occurrences=true`: calls `self.workspace_refactor.inline_variable_all(symbol_name, files[0], (0, 0))`. Callers must pre-index all workspace files via `engine.index_file()` for cross-file lookup to work.
- `all_occurrences=false`: preserves original file-loop behavior (iterate `files`, stop after first successful inline).

Known limitation (pre-existing, not fixed here): `inline_variable_all` uses `pkg="main"` hardcoded in its `SymbolKey`, so package-qualified variables from other packages fall through to a text-scan fallback.

## How to review

- Start at `perform_inline` around line 1675 — the entire change is in the `#[cfg(feature = "workspace_refactor")]` block.
- The `else` branch is the old code restructured with no logic changes.
- Two new tests at the bottom of the `tests` module: `test_inline_all_occurrences_routes_to_workspace_lookup` and `test_inline_single_occurrence_stops_after_first_file`.
- The `#[cfg(not(feature = "workspace_refactor"))]` fallback block at line 1726 is untouched.

## Evidence

```
test result: ok. 105 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.68s
test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.73s
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.43s
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
338 tests total — 0 failures

fmt: PASS
clippy -D warnings: PASS

just ci-gate note: fails on pre-existing xtask/tests/post_merge_status_regen_tests.rs
  (7 expect() calls in xtask test file; present on master before this branch)
```

## Risk & rollback

- Risk: LOW. Single crate, no API changes, no new infrastructure. The `inline_variable_all` method has its own test suite (workspace_refactor.rs lines 1424–1504) that continues to pass.
- Rollback: revert the one commit on this branch. The feature-disabled path (`#[cfg(not(feature = "workspace_refactor"))]`) is unchanged.

## Follow-ups

- `inline_variable_all` hardcodes `pkg="main"` in its `SymbolKey` — package-qualified variables from other namespaces fall through to text-scan. Recommend a follow-up scout to track this as a separate issue.
- Subroutine inlining (AC4/AC5 from the original issue) was explicitly cut as out-of-scope — no existing infrastructure. Recommend a separate issue.