### PR TITLE
test(hover): add hash/string type inference tests and fix pre-existing test bugs (#348)

### DIFF
--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -418,7 +418,12 @@ mod tests {
         let uri: Uri = "file:///test.pl".parse()?;
         let items = get_full_items(provider.get_document_diagnostics(&uri, "my $x = ;", None));
         assert!(!items.is_empty());
-        let diag = &items[0];
+        // Find the PL001 (ParseError) diagnostic — ordering may vary depending on
+        // which lints run first (e.g., PL100 MissingStrict may precede PL001).
+        let diag = items
+            .iter()
+            .find(|d| d.data.as_ref().and_then(|v| v["code"].as_str()) == Some("PL001"))
+            .ok_or("expected a PL001 ParseError diagnostic in the results")?;
         let data = diag.data.as_ref().ok_or("data should be populated")?;
         assert_eq!(data["code"], "PL001");
         assert_eq!(data["category"], "Parser");

--- a/crates/perl-lsp/tests/hover_provider_coverage.rs
+++ b/crates/perl-lsp/tests/hover_provider_coverage.rs
@@ -825,6 +825,53 @@ $name;
         Ok(())
     }
 
+    // ── Additional type inference coverage for Issue #348 ────────────────
+
+    #[test]
+    fn test_hover_hash_variable_shows_inferred_type() -> Result<(), Box<dyn std::error::Error>> {
+        // Hash variables should show their inferred type when concretely assigned.
+        let code = "my %config = (host => 'localhost', port => 8080);\n%config;\n";
+        let resp = hover_at(code, "file:///hash_type.pl", "%config", 1)?;
+        let content = hover_content(&resp).ok_or("expected hover for %config")?;
+
+        assert!(
+            content.contains("Hash Variable"),
+            "hover should indicate Hash Variable, got: {content}"
+        );
+        assert!(
+            content.contains("**Type**"),
+            "hover on hash variable should include **Type** annotation, got: {content}"
+        );
+        assert!(
+            content.contains("Hash"),
+            "hover should show Hash type for %config, got: {content}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_string_literal_assignment_shows_str_type()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Scalar holding a string literal should infer to Str type.
+        let code = "my $greeting = \"hello\";\n$greeting;\n";
+        let resp = hover_at(code, "file:///str_type.pl", "$greeting", 1)?;
+        let content = hover_content(&resp).ok_or("expected hover for $greeting")?;
+
+        assert!(
+            content.contains("Scalar Variable"),
+            "hover should indicate Scalar Variable, got: {content}"
+        );
+        assert!(
+            content.contains("**Type**"),
+            "hover should include **Type** annotation for string literal, got: {content}"
+        );
+        assert!(
+            content.contains("Str"),
+            "hover should show Str for string literal assignment, got: {content}"
+        );
+        Ok(())
+    }
+
     // ── Test::More hover documentation ───────────────────────────────────
 
     #[test]

--- a/crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs
@@ -386,7 +386,7 @@ fn test_workspace_symbol_finds_native_class_and_method() -> TestResult {
         let symbols2 = response2.as_array().ok_or("response2 is not an array")?;
         let names2: Vec<&str> = symbols2.iter().filter_map(|s| s["name"].as_str()).collect();
         assert!(
-            names2.iter().any(|n| *n == "MyPoint"),
+            names2.contains(&"MyPoint"),
             "workspace/symbol should find native class 'MyPoint', got: {:?}",
             names2
         );


### PR DESCRIPTION
## Summary

Closes #348 — Wire Semantic Analyzer to Hover and Diagnostics.

Both halves of this feature were already implemented on master before this PR:
- **Hover type inference**: `TypeInferenceEngine` was wired into `extract_symbol_hover()` in commit `4e5985200` (PR #2726). It displays inferred variable types (Int, Str, Array, Hash) in hover tooltips, filtered for uninformative types (Any, Void).
- **Diagnostics (unused variables)**: `ScopeAnalyzer` is already called in `crates/perl-lsp-diagnostics/src/diagnostics.rs:107`, producing `PL102 UnusedVariable` diagnostics with `DiagnosticTag::Unnecessary`.

This PR adds regression test coverage for the remaining uncovered type inference paths and fixes two pre-existing test failures discovered during verification.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged (hover type inference already shipped in #2726)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**New tests** (`crates/perl-lsp/tests/hover_provider_coverage.rs`):
- `test_hover_hash_variable_shows_inferred_type` — verifies `%hash` variables display `**Type**: \`Hash\`` annotation
- `test_hover_string_literal_assignment_shows_str_type` — verifies string literal assignment infers to `Str` type

**Pre-existing test fixes**:
- `diagnostic_data_for_parse_error` (`pull.rs`): was taking `items[0]` assuming parse error is always first; now finds the `PL001` diagnostic by code to handle ordering changes (PL100 MissingStrict may now precede PL001)
- `test_workspace_symbol_finds_native_class_and_method` (`lsp_workspace_symbol_tests.rs`): replaced `.iter().any(|n| *n == "MyPoint")` with `.contains(&"MyPoint")` to fix `clippy::manual_contains` warning

## How to review

- Start at `crates/perl-lsp/tests/hover_provider_coverage.rs` lines 828–873 for the two new tests
- The pre-existing implementation is in `crates/perl-lsp/src/runtime/language/hover.rs` lines 176–190 (TypeInferenceEngine block)
- The diagnostics wiring is in `crates/perl-lsp-diagnostics/src/diagnostics.rs:107` and `crates/perl-lsp-diagnostics/src/scope.rs`

## Evidence

```
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.58s
(hover_provider_coverage — 66 original + 2 new, 0 ignored)

features::diagnostics::pull::tests: 5 passed; 0 failed
lsp_workspace_symbol_tests: 7 passed; 0 failed
```

fmt: PASS, clippy: PASS (fixed manual_contains warning)

## Risk & rollback

Low risk — test-only changes plus two test fixes for pre-existing failures. No production code changed. Rollback: revert this commit; the underlying implementation remains on master.

## Follow-ups

- PR #2741 (DRAFT) adds ClassModel wiring into SemanticAnalyzer (related to the broader issue #348 vision)
- Cross-package type inference (e.g., `Foo->new()` resolving to `Object(Foo)`) is not yet implemented — the blessed ref test explicitly documents this as future work