### PR TITLE
refactor(routing): delete dead IndexAccessMode lint suppressors and DegradedBehavior trait (#2702)

### DIFF
--- a/crates/perl-lsp/src/runtime/routing.rs
+++ b/crates/perl-lsp/src/runtime/routing.rs
@@ -41,9 +41,6 @@
 //!     }
 //! }
 //! ```
-// This module is part of ongoing refactoring - allow unused code during development
-#![allow(dead_code)]
-#![allow(unreachable_pub)]
 
 #[cfg(feature = "workspace")]
 use perl_parser::workspace_index::{DegradationReason, IndexCoordinator, IndexPhase, IndexState};
@@ -197,19 +194,6 @@ fn degradation_reason_str(reason: &DegradationReason) -> &'static str {
         DegradationReason::ScanTimeout { .. } => "index degraded (scan timeout)",
         DegradationReason::ResourceLimit { .. } => "index degraded (resource limit)",
     }
-}
-
-/// Helper trait for handlers to implement degraded behavior
-///
-/// Handlers can implement this trait to provide consistent degraded
-/// behavior across the codebase.
-#[allow(dead_code)]
-pub(crate) trait DegradedBehavior<T> {
-    /// The default empty result for this handler
-    fn empty_result() -> T;
-
-    /// Description of what's unavailable in degraded mode
-    fn unavailable_feature() -> &'static str;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The `crates/perl-lsp/src/runtime/routing.rs` module had two stale module-level lint suppressors (`#![allow(dead_code)]` and `#![allow(unreachable_pub)]`) left over from when `IndexAccessMode` and `route_index_access()` were first introduced. Handler migration to `route_index_access()` was completed across all relevant handlers (navigation, references, rename, completion, workspace symbols), so both suppressors are now invalid — the items are live and reachable via `pub mod routing`.

Additionally, the `DegradedBehavior<T>` trait (lines 202–213) had zero implementations and zero callers anywhere in the codebase. Its own item-level `#[allow(dead_code)]` confirmed it was never used. It is deleted outright.

This is a pure dead-code cleanup: no handler logic changes, no behavior changes, no API surface changes.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`crates/perl-lsp/src/runtime/routing.rs` — 16 lines deleted:
1. Comment + `#![allow(dead_code)]` + `#![allow(unreachable_pub)]` (lines 44–46 pre-change)
2. `DegradedBehavior<T>` trait with doc comment and item-level allow (lines 202–213 pre-change)

## How to review

Single file, pure deletion. Verify:
- The removed `#![allow(dead_code)]` was hiding nothing real (clippy passes clean after deletion)
- The `DegradedBehavior` trait had no implementations or callers (confirmed by grep — zero hits outside routing.rs itself)
- The `#![allow(unreachable_pub)]` was incorrect — `IndexAccessMode` and `route_index_access` are `pub` and used from `crates/perl-lsp/tests/lsp_degraded_mode_tests.rs`

## Evidence

```
cargo clippy -p perl-lsp --lib
    Finished `dev` profile [optimized + debuginfo] target(s) in 3m 42s
    (zero warnings, zero errors)

cargo test -p perl-lsp -- routing
    running 16 tests
    test runtime::routing::tests::test_access_mode_none_without_workspace ... ok
    test runtime::routing::tests::test_access_mode_partial ... ok
    test runtime::routing::tests::workspace_tests::test_route_building_state ... ok
    test runtime::routing::tests::workspace_tests::test_route_degraded_parse_storm ... ok
    test runtime::routing::tests::workspace_tests::test_route_none_coordinator ... ok
    test result: ok. 16 passed; 0 failed
```

Note: 2 pre-existing failures exist in `execute_command_mutation_hardening_public_api_tests` (test_run_subtest_*) that are unrelated to this change — they fail on master as well.

## Risk & rollback

Risk: minimal. This is lint suppressor removal and a dead trait deletion. No runtime behavior changes.

Rollback: revert the commit. No data migrations, no state changes.

## Follow-ups

None. The handler migration that motivated this cleanup is already complete on master.