### PR TITLE
docs(articles): add Economics and Efficiency with final Era 7 s4 data

### DIFF
--- a/docs/articles/ECONOMICS_AND_EFFICIENCY.md
+++ b/docs/articles/ECONOMICS_AND_EFFICIENCY.md
@@ -105,7 +105,7 @@ The codebase was consistently more mature than the backlog describing it.
 
 ### 4. Microcrates + worktrees = safe parallelism
 
-The 128-crate workspace means 246 agents can work simultaneously without merge conflicts. Each agent gets a git worktree (isolated copy of the repo) and works on a different microcrate.
+The 133-crate workspace means 246 agents can work simultaneously without merge conflicts. Each agent gets a git worktree (isolated copy of the repo) and works on a different microcrate.
 
 ### 5. Cache-read economics
 


### PR DESCRIPTION
## Summary
Adds `docs/articles/ECONOMICS_AND_EFFICIENCY.md` with final session economics data.

Key content:
- Two scarcity surfaces (weekly quota vs 5h session), not dollars
- +15% weekly quota for 246 agents, 49 PRs, 30 merged
- Every deep review found a real bug (11 documented examples)
- Transferable patterns: built-but-not-wired, queue compression, classification-first
- Process lessons: one PR per ops agent per worktree, spec freshness

## Evidence
- Docs-only change