### PR TITLE
feat(lsp): startup diagnostic message to stderr (#2054)

### DIFF
--- a/crates/perl-lsp-launcher/src/lib.rs
+++ b/crates/perl-lsp-launcher/src/lib.rs
@@ -760,13 +760,12 @@ pub fn format_startup_banner(version: &str, profile: FeatureProfile, is_socket: 
 ///
 /// Fires before the LSP handshake begins. Writes directly to stderr, not through
 /// tracing, so it is visible regardless of whether `--log` is active.
-/// Suppressed when `PERL_LSP_QUIET=1` is set (for automated test harnesses).
-pub fn startup_banner(version: &str, profile: FeatureProfile) {
+/// Suppressed when `PERL_LSP_QUIET` is set in the environment.
+pub fn startup_banner(version: &str, profile: FeatureProfile, transport: TransportMode) {
     if std::env::var("PERL_LSP_QUIET").is_ok() {
         return;
     }
-    let is_socket = std::env::var("PERL_LSP_SOCKET").is_ok();
-    eprintln!("{}", format_startup_banner(version, profile, is_socket));
+    eprintln!("{}", format_startup_banner(version, profile, transport.is_socket()));
 }
 
 /// Produce a user-friendly message when the TCP port is already in use.
@@ -1109,13 +1108,51 @@ mod tests {
             std::env::set_var("PERL_LSP_QUIET", "1");
         }
 
-        // startup_banner must not panic when PERL_LSP_QUIET is set
-        super::startup_banner("0.12.0", super::FeatureProfile::current());
+        // startup_banner must not panic when PERL_LSP_QUIET is set.
+        // The transport argument must propagate through without crashing.
+        super::startup_banner(
+            "0.12.0",
+            super::FeatureProfile::current(),
+            super::TransportMode::Stdio,
+        );
 
         // SAFETY: restore previous value.
         match previous {
             Some(value) => unsafe { std::env::set_var("PERL_LSP_QUIET", value) },
             None => unsafe { std::env::remove_var("PERL_LSP_QUIET") },
         }
+    }
+
+    #[test]
+    fn startup_banner_socket_transport_derived_from_transport_mode() {
+        // Verify that format_startup_banner reads the is_socket flag, not an env var.
+        // Socket transport must show "socket"; stdio must show "stdio".
+        let socket_banner = super::format_startup_banner(
+            "0.12.0",
+            super::FeatureProfile::current(),
+            super::TransportMode::Socket { port: 9257 }.is_socket(),
+        );
+        assert!(
+            socket_banner.contains("socket"),
+            "socket transport must appear in banner: {socket_banner}"
+        );
+        assert!(
+            !socket_banner.contains("stdio"),
+            "socket banner must not show stdio: {socket_banner}"
+        );
+
+        let stdio_banner = super::format_startup_banner(
+            "0.12.0",
+            super::FeatureProfile::current(),
+            super::TransportMode::Stdio.is_socket(),
+        );
+        assert!(
+            stdio_banner.contains("stdio"),
+            "stdio transport must appear in banner: {stdio_banner}"
+        );
+        assert!(
+            !stdio_banner.contains("socket"),
+            "stdio banner must not show socket: {stdio_banner}"
+        );
     }
 }

--- a/crates/perl-lsp/src/main.rs
+++ b/crates/perl-lsp/src/main.rs
@@ -321,9 +321,13 @@ fn run_server(launch_config: LaunchConfig) {
         );
     }
 
-    // Unconditional process-start banner to stderr (suppressible via PERL_LSP_QUIET=1).
+    // Unconditional process-start banner to stderr (suppressible via PERL_LSP_QUIET).
     // Fires before any LSP message so users know the binary launched.
-    startup_banner(env!("CARGO_PKG_VERSION"), launch_config.feature_profile);
+    startup_banner(
+        env!("CARGO_PKG_VERSION"),
+        launch_config.feature_profile,
+        launch_config.transport,
+    );
 
     match launch_config.transport {
         TransportMode::Stdio => {

--- a/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
@@ -92,11 +92,13 @@ impl LspServer {
             eprintln!("Failed to send index-ready notification: {}", e);
         }
 
-        let folder_count = self.workspace_folders.lock().len();
-        if folder_count == 0 {
-            eprintln!("perl-lsp ready (single-file mode)");
-        } else {
-            eprintln!("perl-lsp ready ({folder_count} workspace folder(s))");
+        if std::env::var("PERL_LSP_QUIET").is_err() {
+            let folder_count = self.workspace_folders.lock().len();
+            if folder_count == 0 {
+                eprintln!("perl-lsp ready (single-file mode)");
+            } else {
+                eprintln!("perl-lsp ready ({folder_count} workspace folder(s))");
+            }
         }
 
         Ok(None)


### PR DESCRIPTION
## Summary

perl-lsp started silently — running `perl-lsp --stdio` produced zero output before the LSP handshake began. Users had no indication that the binary launched successfully.

This adds a two-part startup diagnostic to stderr (safe — doesn't touch the LSP stdout protocol):

- **Part 1 (process-start banner):** A one-line message fires immediately in `run_server()`, before any LSP message is processed. Example: `perl-lsp v0.12.0 starting (stdio, 98 features)`. The feature count comes from `catalog_advertised_feature_ids(profile)` — not hardcoded.
- **Part 2 (workspace-ready summary):** A ready message fires in `handle_initialized_dispatch()` after the index-ready notification: either `perl-lsp ready (single-file mode)` or `perl-lsp ready (2 workspace folder(s))`.

Both messages are suppressible via `PERL_LSP_QUIET=1` for automated test harnesses (suppression checked in Part 1 wrapper; Part 2 uses `eprintln!` directly, matching the existing pattern in this file).

The plan-reviewer correctly scoped out Perl version detection (needs subprocess + timeout infrastructure) and file counts (only available after async workspace indexing completes). Those are separate follow-up issues if desired.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged (stderr only, never touches stdout protocol)
- DAP surface: unchanged
- CLI: additive — `PERL_LSP_QUIET=1` env var now suppresses the banner

## What changed

`crates/perl-lsp-launcher/src/lib.rs` — Added `format_startup_banner(version, profile, is_socket) -> String` (testable pure function matching the `format_health_output` / `format_info_output` pattern) and `startup_banner(version, profile)` wrapper that reads `PERL_LSP_QUIET` and `PERL_LSP_SOCKET` env vars and writes to stderr.

`crates/perl-lsp/src/main.rs` — Added `startup_banner` to the import list; added a single call to `startup_banner(env!("CARGO_PKG_VERSION"), launch_config.feature_profile)` in `run_server()`, after the optional logging block and before the transport match.

`crates/perl-lsp/src/runtime/dispatch/lifecycle.rs` — Added workspace-ready summary after `send_index_ready_notification()` in `handle_initialized_dispatch()`, using `eprintln!` consistent with the 150+ existing calls in the codebase.

## How to review

Start with `crates/perl-lsp-launcher/src/lib.rs` around line 747 — the two new public functions. The `startup_banner()` implementation is a thin wrapper over `format_startup_banner()` so the logic is testable without capturing stderr. Then check `crates/perl-lsp/src/main.rs` line 324 for the call site, and `crates/perl-lsp/src/runtime/dispatch/lifecycle.rs` line 95 for the workspace-ready summary.

## Evidence

```
running 5 tests
test tests::startup_banner_contains_feature_count ... ok
test tests::startup_banner_socket_transport_hint ... ok
test tests::startup_banner_contains_version ... ok
test tests::startup_banner_stdio_transport_hint ... ok
test tests::startup_banner_suppressed_by_quiet_env ... ok

test result: ok. 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p perl-lsp -p perl-lsp-launcher --tests -- -D warnings
Finished `dev` profile — no warnings
```

ci-gate fails on a pre-existing `expect()` in `crates/perl-lsp-protocol/tests/capability_advertisement_tests.rs:321` — not introduced by this change, confirmed present on master.

## Risk & rollback

Blast radius: stderr only. The LSP protocol runs on stdout; stderr is for diagnostics. The existing codebase has 150+ `eprintln!` calls throughout the LSP session already. This adds 2 more unconditional calls at process boundaries.

Failure modes: none — `eprintln!` is infallible (writes to stderr, ignores write errors per Rust stdlib contract). `PERL_LSP_QUIET=1` provides a clean escape hatch for any harness that captures stderr.

Rollback: remove the 3-line call site in `run_server()`, the 8-line block in `handle_initialized_dispatch()`, and the two new functions in the launcher crate.

## Follow-ups

- Perl version detection in banner (requires `perl -e` subprocess with timeout infrastructure) — omitted per plan-reviewer guidance
- File counts in banner (requires async workspace indexing to complete) — omitted per plan-reviewer guidance