### PR TITLE
fix(lsp): ParentMap safety improvements — Phase 1 (#2810)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "perl-workspace-index",
  "regex",
  "rustc-hash",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -402,8 +402,10 @@ impl LspServer {
 
             let mut out = Vec::new();
             if let Some(ref ast) = doc.ast {
-                // Build parent map if not cached
-                let parent_map = crate::selection_range::build_parent_map(ast);
+                // Use the pre-built cached parent map rather than rebuilding on every request.
+                // `doc.parent_map` and `selection_range::build_parent_map` share the same
+                // underlying Node type (`perl_parser_core::ast::Node`), so no conversion is needed.
+                let parent_map = &doc.parent_map;
 
                 for pos in positions {
                     // Positions in array still need per-item extraction with graceful handling
@@ -414,7 +416,7 @@ impl LspServer {
                         pos["character"].as_u64().and_then(|v| u32::try_from(v).ok()).unwrap_or(0);
                     let off = self.pos16_to_offset(doc, line, col);
                     let chain =
-                        crate::selection_range::selection_chain(ast, &parent_map, off, &|o| {
+                        crate::selection_range::selection_chain(ast, parent_map, off, &|o| {
                             self.offset_to_pos16(doc, o)
                         });
                     out.push(chain);

--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -146,6 +146,11 @@ impl LspServer {
             let uri = req_uri(&params)?;
             let (line, character) = req_position(&params)?;
 
+            // Reject stale requests (parity with hover.rs:51-53 and completion.rs:312)
+            let req_version =
+                params["textDocument"]["version"].as_i64().and_then(|n| i32::try_from(n).ok());
+            self.ensure_latest(uri, req_version)?;
+
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
@@ -254,7 +259,7 @@ impl LspServer {
                 // Performance monitoring
                 let dt = t0.elapsed();
                 if doc.text.len() < 50_000 && dt > std::time::Duration::from_millis(50) {
-                    eprintln!("[warn] slow declaration: {:?} (uri={})", dt, uri);
+                    tracing::warn!(elapsed = ?dt, uri, "slow declaration");
                 }
             }
         }
@@ -269,6 +274,11 @@ impl LspServer {
         if let Some(params) = params {
             let uri = req_uri(&params)?;
             let (line, character) = req_position(&params)?;
+
+            // Reject stale requests (parity with hover.rs:51-53 and completion.rs:312)
+            let req_version =
+                params["textDocument"]["version"].as_i64().and_then(|n| i32::try_from(n).ok());
+            self.ensure_latest(uri, req_version)?;
 
             // First, extract module reference info while holding the document lock briefly
             // We need to release the lock before calling resolve_module_to_path to avoid deadlock
@@ -480,11 +490,11 @@ impl LspServer {
                             if let Some(symbol_key) =
                                 crate::declaration::symbol_at_cursor(ast, offset, current_package)
                             {
-                                eprintln!("Looking for definition of {:?}", symbol_key);
+                                tracing::debug!(symbol_key = ?symbol_key, "looking for definition");
 
                                 // Try to find definition using the symbol key
                                 if let Some(def_location) = workspace_index.find_def(&symbol_key) {
-                                    eprintln!("Found definition at {:?}", def_location);
+                                    tracing::debug!(location = ?def_location, "found definition");
                                     // Convert internal Location to LSP Location
                                     if let Some(lsp_location) =
                                         crate::workspace_index::lsp_adapter::to_lsp_location(
@@ -506,9 +516,9 @@ impl LspServer {
                                 if let Some(def_location) =
                                     workspace_index.find_definition(&symbol_name)
                                 {
-                                    eprintln!(
-                                        "Found definition via find_definition for {}",
-                                        symbol_name
+                                    tracing::debug!(
+                                        symbol_name,
+                                        "found definition via find_definition"
                                     );
                                     // Convert internal Location to LSP Location
                                     if let Some(lsp_location) =

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -28,6 +28,7 @@ perl-workspace-index = { workspace = true }
 perl-symbol-types = { workspace = true }
 regex = "1.12.2"
 rustc-hash = "2.1.1"
+tracing = "0.1"
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -171,25 +171,22 @@ impl<'a> DeclarationProvider<'a> {
         self
     }
 
+    /// Returns `true` if this provider is still fresh (version matches).
+    ///
+    /// In both debug and release builds: logs a warning and returns `false` on mismatch so
+    /// callers can return `None` early instead of operating on a stale AST snapshot.
     #[inline]
     #[track_caller]
-    fn assert_fresh(&self, current_version: i32) {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(
-                self.doc_version != i32::MIN,
-                "DeclarationProvider: with_doc_version() not called - provider must be initialized with document version"
+    fn is_fresh(&self, current_version: i32) -> bool {
+        if self.doc_version != current_version {
+            tracing::warn!(
+                provider_version = self.doc_version,
+                current_version,
+                "DeclarationProvider used after AST refresh — returning empty result"
             );
-            debug_assert_eq!(
-                self.doc_version, current_version,
-                "DeclarationProvider used after AST refresh (provider version: {}, current: {})",
-                self.doc_version, current_version
-            );
+            return false;
         }
-
-        // Suppress unused warning in release builds
-        #[cfg(not(debug_assertions))]
-        let _ = current_version;
+        true
     }
 
     /// Debug-only cycle detection for parent map
@@ -254,10 +251,16 @@ impl<'a> DeclarationProvider<'a> {
     /// ```
     pub fn build_parent_map(node: &Node, map: &mut ParentMap, parent: Option<*const Node>) {
         if let Some(p) = parent {
+            // SAFETY: `node` is a shared reference derived from `Arc<Node>` in `DocumentState.ast`.
+            // The Arc is held alive by the documents HashMap behind a parking_lot Mutex for the
+            // entire lifetime of `DeclarationProvider<'a>` (enforced by the lifetime parameter).
+            // The raw pointer is therefore valid for at least as long as the MutexGuard is held.
             map.insert(node as *const _, p);
         }
 
         for child in Self::get_children_static(node) {
+            // SAFETY: Same invariant as above — `child` is a child of `node`, both owned by the
+            // same `Arc<Node>` tree that is live under the documents MutexGuard.
             Self::build_parent_map(child, map, Some(node as *const _));
         }
     }
@@ -268,8 +271,10 @@ impl<'a> DeclarationProvider<'a> {
         offset: usize,
         current_version: i32,
     ) -> Option<Vec<LocationLink>> {
-        // Assert this provider is still fresh (not stale after AST refresh)
-        self.assert_fresh(current_version);
+        // Guard against stale provider usage after AST refresh (both debug and release)
+        if !self.is_fresh(current_version) {
+            return None;
+        }
 
         // Find the node at the cursor position
         let node = self.find_node_at_offset(&self.ast, offset)?;
@@ -293,6 +298,10 @@ impl<'a> DeclarationProvider<'a> {
     /// Find variable declaration using scope-aware lookup
     fn find_variable_declaration(&self, usage: &Node, var_name: &str) -> Option<Vec<LocationLink>> {
         // Walk upwards through scopes to find the nearest declaration
+        // SAFETY: `usage` is a shared reference into the `Arc<Node>` AST tree held by
+        // `DeclarationProvider<'a>`. The raw pointer is used only as a HashMap key for O(1)
+        // parent lookup and is never dereferenced directly; lookups go through `build_node_lookup_map`
+        // which re-derives safe `&Node` references from the same Arc tree.
         let mut current_ptr: *const Node = usage as *const _;
 
         // Build temporary parent map if not provided (for testing)

--- a/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
@@ -279,6 +279,66 @@ fn declaration_provider_with_doc_version() -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+/// Fix 2 (Phase 1): assert_fresh must return None on version mismatch in both debug and
+/// release builds.  Before the fix, the release build silently ignores the mismatch
+/// because `assert_fresh` was a debug-only no-op; `find_declaration` could still return
+/// results from a stale provider.  After the fix, a version mismatch always returns None.
+#[test]
+fn declaration_provider_version_mismatch_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "my $x = 1; my $y = $x;";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let ast_arc = Arc::new(ast);
+
+    let mut parent_map = ParentMap::default();
+    DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
+
+    // Use any valid offset inside the source; the stale-version guard fires before
+    // any node lookup so the exact position is irrelevant to what we are testing.
+    // Provider was built with version=1 but current_version=2 is passed to find_declaration.
+    let offset_of_y_usage = must_some(code.find("$y")) + 1; // skip '$' — offset inside source
+    let provider =
+        DeclarationProvider::new(ast_arc, code.to_string(), "file:///test.pl".to_string())
+            .with_parent_map(&parent_map)
+            .with_doc_version(1);
+
+    // Version mismatch: provider version=1, current_version=2
+    let result = provider.find_declaration(offset_of_y_usage, 2);
+    assert!(
+        result.is_none(),
+        "stale provider (version mismatch) must return None, not a result from the old AST"
+    );
+    Ok(())
+}
+
+/// Fix 2 (Phase 1, negative): assert_fresh must NOT suppress results when versions match.
+#[test]
+fn declaration_provider_matching_version_returns_result() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = "my $x = 1; print $x;";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let ast_arc = Arc::new(ast);
+
+    let mut parent_map = ParentMap::default();
+    DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
+
+    // $x usage is at the `print $x` site
+    let offset_of_x_usage = must_some(code.rfind("$x"));
+    let provider =
+        DeclarationProvider::new(ast_arc, code.to_string(), "file:///test.pl".to_string())
+            .with_parent_map(&parent_map)
+            .with_doc_version(3);
+
+    // Versions match: provider version=3, current_version=3 → should find the declaration
+    let result = provider.find_declaration(offset_of_x_usage, 3);
+    assert!(
+        result.is_some(),
+        "matching-version provider must still return a result for a declared variable"
+    );
+    Ok(())
+}
+
 #[test]
 fn declaration_provider_get_node_text() -> Result<(), Box<dyn std::error::Error>> {
     let code = "sub hello { 1 }";


### PR DESCRIPTION
## Summary

Implements all 5 Phase 1 fixes from the plan-reviewer spec for issue #2810 (ParentMap raw-pointer safety invariant).

The most impactful change is **Fix 2**: promoting the version-freshness guard from a debug-only `debug_assert!` panic to a production-safe `tracing::warn` + early `None` return. Previously, `find_declaration` called with a stale provider would silently proceed in release builds; now it returns `None` consistently in both builds and logs a structured warning. **Fix 1** closes a handler-level gap: `handle_declaration` and `handle_definition` did not call `ensure_latest()` before acquiring the document lock, unlike `handle_hover` and `handle_completion`. **Fix 5** eliminates an O(n) rebuild of the ParentMap on every `textDocument/selectionRange` request by using the pre-built `doc.parent_map` already stored in `DocumentState`.

All changes are additive on the happy path — no behavior changes when versions match and no lock patterns are altered.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged (ContentModified errors were already returned by ensure_latest for hover/completion; declaration/definition now match)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**`crates/perl-semantic-analyzer/src/analysis/declaration.rs`**
- Renamed `assert_fresh` → `is_fresh` returning `bool`; removed `#[cfg(debug_assertions)]` gate so the check runs in release builds. Added `tracing::warn!` on mismatch.
- `find_declaration`: replaced `self.assert_fresh(v)` (void) with `if !self.is_fresh(v) { return None; }`
- Added `// SAFETY:` comments at three raw-pointer creation sites in `build_parent_map` and `find_variable_declaration`
- Added `tracing = "0.1"` dependency (matches the `0.1.44` version already in the lockfile from perl-lsp)

**`crates/perl-lsp/src/runtime/language/navigation.rs`**
- `handle_declaration`: added `ensure_latest(uri, req_version)?` before `documents_guard()`
- `handle_definition`: added `ensure_latest(uri, req_version)?` before `documents_guard()`
- Converted 4 `eprintln!` calls to `tracing::warn!` / `tracing::debug!`

**`crates/perl-lsp/src/runtime/language/misc.rs`**
- `handle_selection_range`: replaced `crate::selection_range::build_parent_map(ast)` with `&doc.parent_map`. Both use `FxHashMap<*const perl_parser_core::ast::Node, *const perl_parser_core::ast::Node>` — same type, verified at use site.

**`crates/perl-semantic-analyzer/tests/extended_unit_tests.rs`**
- Added `declaration_provider_version_mismatch_returns_none`: verifies stale provider returns `None` (was a no-op in release before this fix)
- Added `declaration_provider_matching_version_returns_result`: regression guard ensuring matching-version providers still work

## How to review

Start at `declaration.rs:is_fresh` — this is the behavioral core of Fix 2. Then `navigation.rs` for the two `ensure_latest` insertions and 4 eprintln replacements. Then `misc.rs` for the one-line Fix 5 change. SAFETY comments are inline at the pointer creation sites.

The type-safety argument for Fix 5: `perl-lsp-providers::ide::lsp_compat::selection_range` imports `perl_parser_core::ast::Node` directly (line 9 of that file). `perl_semantic_analyzer`'s `ParentMap` is `FxHashMap<*const crate::ast::Node, *const crate::ast::Node>` where `crate::ast` re-exports `perl_parser_core::ast` (lib.rs line 51). Same concrete type.

## Evidence

```
fmt: PASS (both crates)
clippy -p perl-lsp --tests -- -D warnings: PASS
clippy -p perl-semantic-analyzer --tests -- -D warnings: PASS
test -p perl-lsp --lib: 257 passed, 0 failed
test -p perl-semantic-analyzer: 104 passed, 1 failed (pre-existing: symbol_extraction_method_preserves_attributes)

New tests:
  declaration_provider_version_mismatch_returns_none ... ok
  declaration_provider_matching_version_returns_result ... ok

ci-gate failure: perl-lsp-protocol expect_used in capability_advertisement_tests.rs:321
  — pre-existing on master, not introduced by this PR
```

## Risk & rollback

LOW risk. All 5 fixes are additive:
- Fix 1: New `ContentModified` rejections only fire for requests the client sent with a stale version; currently they silently returned empty results instead.
- Fix 2: The `None` early return on version mismatch is correct behavior — the provider was always supposed to guard this.
- Fix 3: Comments only, zero behavioral change.
- Fix 4: Log destination change only (eprintln → tracing); no logic change.
- Fix 5: Same data, different source. If `doc.parent_map` is ever empty at the selection_range call site, the behavior is the same as when `build_parent_map` would produce an empty map for a trivial AST.

Rollback: revert the commit. No schema changes, no data migration.

## Follow-ups

- Phase 2 arena migration: add `id: NodeId` to `ast::Node`, replace `ParentMap` type alias with `FxHashMap<NodeId, NodeId>`, remove `unsafe impl Send/Sync`. Scope: ~11 crates. File separately after Phase 1 merges. (As directed by plan-reviewer spec.)
- Pre-existing failures to track: `symbol_extraction_method_preserves_attributes` (perl-semantic-analyzer) and two `test_run_subtest_*` failures (perl-lsp execute_command tests) — both on master before this PR.