### PR TITLE
test(dap): DAP protocol compliance and integration tests (#2785)

### DIFF
--- a/crates/perl-dap/tests/dap_protocol_compliance_tests.rs
+++ b/crates/perl-dap/tests/dap_protocol_compliance_tests.rs
@@ -7,6 +7,10 @@
 //! 4. Response schema validation (required body fields)
 //! 5. Integration scenarios (cancel signal, state transitions)
 
+// Tests use `panic!` in match arms as structured test failure reporters,
+// and `expect()` on response body values that must be present per DAP spec.
+#![allow(clippy::panic, clippy::expect_used)]
+
 use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
 use serde_json::{Value, json};
 use std::sync::mpsc::channel;
@@ -131,13 +135,13 @@ fn test_goto_unknown_target_id_returns_failure() {
     let mut adapter = make_adapter();
     let args = json!({ "threadId": 1, "targetId": 9999 });
     let response = adapter.handle_request(1, "goto", Some(args));
+    // targetId 9999 has never been registered via gotoTargets, so the implementation
+    // removes it from the goto_map (returning None) and unconditionally returns failure.
     match response {
         DapMessage::Response { success, command, message, .. } => {
             assert_eq!(command, "goto");
-            // Either fails due to unknown target OR no active session — both are failure modes
-            if !success {
-                assert!(message.is_some(), "failure must include message");
-            }
+            assert!(!success, "goto with unregistered targetId must fail");
+            assert!(message.is_some(), "failure response must include a message");
         }
         other => panic!("expected Response, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

- Adds 36 new tests in `crates/perl-dap/tests/dap_protocol_compliance_tests.rs` covering all compliance gaps identified in issue #2785
- All 10 previously-untested DAP commands now have error-path test coverage: `breakpointLocations`, `cancel`, `exceptionInfo`, `goto`, `gotoTargets`, `loadedSources`, `restartFrame`, `setExpression`, `stepInTargets`, `terminateThreads`
- Security validation tests confirm newline injection is blocked in `evaluate` and `setExpression`, and path traversal inputs don't panic
- Protocol state machine tests verify sequence number monotonicity and that the `initialized` event seq follows the initialize response seq
- Response schema tests verify that all 7 response bodies with required array/field keys (`targets`, `sources`, `breakpoints`, `exceptionId`, `breakMode`) are present
- Integration scenarios cover cancel idempotency, disconnect-without-session, and full initialize→disconnect lifecycle

## Test plan

- [x] `cargo test -p perl-dap --test dap_protocol_compliance_tests` — 36/36 pass
- [x] `cargo test -p perl-dap` — full suite passes (no regressions)
- [x] `cargo clippy -p perl-dap` — no warnings
- [x] `cargo fmt -p perl-dap` — clean

## Related

Closes #2785