### PR TITLE
fix(test): update stale capability snapshots after merge wave

### DIFF
--- a/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/perl-lsp/tests/lsp_features_snapshot_test.rs
-assertion_line: 42
 expression: "&snapshot_data"
 ---
 caps:
@@ -59,6 +58,7 @@ catalog:
   - lsp.configuration
   - lsp.declaration
   - lsp.definition
+  - lsp.diagnostic.unused_variable
   - lsp.diagnostic_refresh
   - lsp.did_change_configuration
   - lsp.did_change_watched_files


### PR DESCRIPTION
## Summary

- Updates the stale `lsp_features_snapshot_test__advertised_vs_caps.snap` insta snapshot that was causing CI failures across all PRs
- The snapshot was outdated because `lsp.diagnostic.unused_variable` was added to the feature catalog by recent merges but the snapshot was not regenerated
- The `lsp_capabilities_snapshot` tests (JSON-based, non-insta) were already passing on master -- only the insta snapshot in `lsp_features_snapshot_test` was stale

## What changed

The only file modified is `crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap`:
- Added `lsp.diagnostic.unused_variable` to the `catalog` list (alphabetically between `lsp.definition` and `lsp.diagnostic_refresh`)
- Removed the `assertion_line` metadata (insta regeneration artifact)

## Test plan

- [x] `cargo test -p perl-lsp --test lsp_capabilities_snapshot` -- all 5 tests pass
- [x] `cargo test -p perl-lsp --test lsp_features_snapshot_test` -- all 2 tests pass
- [x] `cargo fmt --all --check` -- clean
- [x] No perl-parser snapshot tests exist (verified)