### PR TITLE
fix(parser): handle + prototype character, fixing unexpected_rbrace_expr (#2835)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -759,13 +759,16 @@ impl<'a> Parser<'a> {
                 Ok(match token.kind {
                     // These are unambiguously prototype tokens.
                     // `+` means "scalar or array/hash ref" (perlsub), valid in prototypes.
+                    // `++` is also valid: Perl's lexer merges two `+` into `Increment`, so
+                    // `(++$)` has peek_second == Increment.
                     TokenKind::Star
                     | TokenKind::Backslash
                     | TokenKind::Semicolon
                     | TokenKind::BitwiseAnd
                     | TokenKind::SubSigil
                     | TokenKind::GlobSigil
-                    | TokenKind::Plus => true,
+                    | TokenKind::Plus
+                    | TokenKind::Increment => true,
                     // Sigils: peek past to distinguish prototype ($;@%) from signature ($x, @rest)
                     TokenKind::ScalarSigil | TokenKind::ArraySigil | TokenKind::HashSigil => {
                         match self.tokens.peek_third() {
@@ -812,8 +815,10 @@ impl<'a> Parser<'a> {
                 TokenKind::SubSigil | TokenKind::BitwiseAnd => prototype.push('&'),
                 TokenKind::Semicolon => prototype.push(';'),
                 TokenKind::Backslash => prototype.push('\\'),
-                // `+` means "scalar or array/hash ref" (perlsub prototype character)
+                // `+` means "scalar or array/hash ref" (perlsub prototype character).
+                // `++` is the Increment token produced when two `+` chars appear together.
                 TokenKind::Plus => prototype.push('+'),
+                TokenKind::Increment => prototype.push_str("++"),
                 _ => {
                     // For any other token, just add its text
                     // This handles cases where sigils might be parsed differently

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
@@ -160,6 +160,24 @@ fn test_proto_backslash_bracket_guard() {
 }
 
 // ---------------------------------------------------------------------------
+// Edge case: `++` in prototype — lexer merges two `+` into Increment token
+// ---------------------------------------------------------------------------
+
+/// `sub foo(++$)` — Perl allows `++` in prototypes (two consecutive `+` chars).
+/// The lexer produces `Increment` (not two `Plus` tokens), so `is_likely_prototype`
+/// and `parse_prototype` must handle `TokenKind::Increment` explicitly.
+#[test]
+fn test_proto_double_plus() {
+    assert_clean_parse("sub foo(++$) { 1 }");
+}
+
+/// `++` prototype with no other args.
+#[test]
+fn test_proto_double_plus_only() {
+    assert_clean_parse("sub foo(++) { 1 }");
+}
+
+// ---------------------------------------------------------------------------
 // Non-regression: `+` in sub BODY must not be confused with a prototype `+`
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Root cause**: `is_likely_prototype` did not recognise `TokenKind::Plus` (`+`) as a valid prototype character, so `sub foo (+) { ... }` was routed into signature parsing. The signature parser failed on `+`, then hit the closing `}` in an expression context, producing the `unexpected_rbrace_expr` error.

- **Fix**: Add `TokenKind::Plus` to the unambiguous-prototype match arm in `is_likely_prototype`, and add an explicit `Plus => prototype.push('+')` arm in `parse_prototype`.

- **Spec**: Perl's `+` prototype means "scalar, or a reference to an array or hash" (see `perlsub`). It is used in modules like List::Util, Scalar::Util, and various CPAN distribution helpers.

## Files changed

- `crates/perl-parser-core/src/engine/parser/variables.rs` — 4 lines changed: prototype detection + prototype emission
- `crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs` — 18 regression tests (new file)

## Test plan

- [ ] `cargo test -p perl-parser-core --test fix_unexpected_rbrace_proto_plus_2835` — 18 pass, 0 fail
- [ ] `cargo test -p perl-parser-core` — no new failures introduced (6 pre-existing failures in `fix_expected_colon` are unrelated to this change and fail on master too)
- [ ] `cargo fmt --all` — no formatting changes
- [ ] `cargo clippy -p perl-parser-core --tests` — no errors

## Known pre-existing failures (not introduced by this PR)

`fix_expected_colon::test_sub_prototype_and_attribute` and 5 related tests in that file fail on master before this change. They test `sub foo ($) : lvalue { }` (prototype-then-attribute ordering), which is a separate known issue tracked in issue #2835's decomposition.

Closes part of #2835.