### PR TITLE
docs: document .perl-lsp.toml project configuration (#2846)

### DIFF
--- a/.perl-lsp.toml.example
+++ b/.perl-lsp.toml.example
@@ -1,0 +1,66 @@
+# .perl-lsp.toml — project configuration for perl-lsp
+#
+# Copy this file to your workspace root and rename it to .perl-lsp.toml.
+# Commit it to version control to share team-wide defaults with all editors.
+#
+# All sections and keys are optional. The file may be empty or omitted entirely.
+# Unknown keys and sections are silently ignored for forward compatibility.
+# Invalid TOML produces a warning notification in your editor.
+#
+# Configuration precedence (last-write-wins):
+#   .perl-lsp.toml  ->  initializationOptions  ->  didChangeConfiguration
+#   (this file)         (editor startup)            (live editor settings)
+#
+# Editor settings always override this file, so team members can still
+# customize their own environments.
+
+# ── [perl] ───────────────────────────────────────────────────────────────────
+# Module resolution settings.
+
+[perl]
+
+# Perl version hint for the project (e.g. "5.38", "5.40").
+# Parsed but not yet wired to diagnostics; reserved for future use.
+# version = "5.38"
+
+# Additional module include paths, relative to the workspace root.
+# Overrides the built-in defaults (lib, ., local/lib/perl5) when non-empty.
+# An empty list (include_paths = []) is treated as "not set" and leaves
+# the built-in defaults unchanged.
+#
+# include_paths = ["lib", "local/lib/perl5"]
+
+# ── [diagnostics] ────────────────────────────────────────────────────────────
+# Linting settings. perlcritic is opt-in and requires perlcritic installed.
+
+[diagnostics]
+
+# Enable perlcritic diagnostics (default: false).
+# Requires `perlcritic` available on $PATH.
+#
+# perlcritic = false
+
+# Minimum perlcritic severity to report (1 = most severe, 5 = everything).
+# Default: 3 (Harsh). Must be in the range 1-5.
+# Equivalent to `perlcritic --severity N`.
+#
+# perlcritic_severity = 3
+
+# ── [features] ───────────────────────────────────────────────────────────────
+# LSP feature toggles.
+
+[features]
+
+# Enable or disable all inlay hints globally (default: true).
+# Individual hint types (parameterHints, typeHints, chainedHints) are
+# controlled via editor settings.
+#
+# inlay_hints = true
+
+# ── [formatting] ─────────────────────────────────────────────────────────────
+# Reserved for future perltidy configuration. Not yet active.
+# Keys in this section are silently ignored.
+
+# [formatting]
+# perltidy = true
+# perltidy_profile = ".perltidyrc"

--- a/README.md
+++ b/README.md
@@ -142,6 +142,25 @@ perl-lsp is configured through your editor's LSP settings (via `didChangeConfigu
 
 For Neovim and other editors, pass these as the LSP `settings` table under the `perl-lsp` key.
 
+### Project Configuration File
+
+For team-wide defaults, add a `.perl-lsp.toml` to your repository root. It is editor-agnostic and committed to version control:
+
+```toml
+# .perl-lsp.toml — shared project defaults for perl-lsp
+
+[perl]
+include_paths = ["lib", "local/lib/perl5"]
+
+[diagnostics]
+perlcritic = false
+
+[features]
+inlay_hints = true
+```
+
+Settings from `.perl-lsp.toml` are the lowest-priority layer. Editor settings (`initializationOptions` / `didChangeConfiguration`) always override them. See [CONFIG.md](docs/reference/CONFIG.md) for the full reference including precedence rules.
+
 ## Install
 
 ### From crates.io

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,7 @@ Choose the path that matches what you are trying to do:
 | Install the language server | [Installation Guide](how-to/INSTALLATION.md) |
 | Get a working editor setup quickly | [Getting Started](tutorials/GETTING_STARTED.md) |
 | Configure editor or workspace settings | [Configuration Reference](reference/CONFIG.md) |
+| Share project settings with my team | [Project Configuration File (.perl-lsp.toml)](reference/CONFIG.md#project-configuration-file-perl-lsptoml) |
 | Troubleshoot startup, indexing, or editor issues | [Troubleshooting](how-to/TROUBLESHOOTING.md) |
 | Understand the server architecture | [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) |
 | Work on LSP features as a contributor | [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) |

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -5,6 +5,8 @@ This document is the authoritative list of all configuration keys for the Perl L
 ## Table of Contents
 
 - [Configuration Format](#configuration-format)
+- [Project Configuration File (.perl-lsp.toml)](#project-configuration-file-perl-lsptoml)
+- [Configuration Precedence](#configuration-precedence)
 - [Workspace Settings](#workspace-settings)
 - [Inlay Hints](#inlay-hints)
 - [Test Runner](#test-runner)
@@ -33,6 +35,110 @@ All LSP server settings are under the `perl` namespace:
   }
 }
 ```
+
+---
+
+## Project Configuration File (.perl-lsp.toml)
+
+`.perl-lsp.toml` is an optional, editor-agnostic project configuration file that you commit to your repository. It lets you share settings with your whole team without requiring each developer to configure their own editor. The file lives at the **workspace root** (the directory containing your `.git` folder or `Makefile.PL` / `cpanfile`).
+
+The server silently skips the file if it does not exist. If the file exists but contains invalid TOML, the server emits a `window/showMessage` warning and continues with defaults.
+
+Unknown keys and sections are silently ignored for forward compatibility.
+
+### File Location
+
+```
+your-project/
+  .git/
+  .perl-lsp.toml   ← add this file
+  lib/
+  t/
+```
+
+### Supported Sections and Keys
+
+#### `[perl]` — Module Resolution
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `include_paths` | `string[]` | `[]` | Additional include paths for module resolution, relative to workspace root. An empty list leaves the built-in defaults (`lib`, `.`, `local/lib/perl5`) unchanged. |
+| `version` | `string` | (none) | Perl version hint, e.g. `"5.38"`. Parsed but not yet wired to diagnostics; reserved for future use. |
+
+#### `[diagnostics]` — Linting
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `perlcritic` | `boolean` | (unset) | Enable perlcritic diagnostics. When unset, the server default (`false`) applies. Requires `perlcritic` installed on the system. |
+| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. 1 = most severe (gentle), 5 = everything (brutal). Must be in the range 1–5; values outside this range are a parse error. |
+
+#### `[features]` — LSP Feature Toggles
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `inlay_hints` | `boolean` | (unset) | Enable or disable all inlay hints globally. When unset, the server default (`true`) applies. |
+
+#### `[formatting]` — Future Use (Reserved)
+
+The `[formatting]` section is reserved for future perltidy configuration and is not yet wired. Keys in this section are silently ignored. You may include it in your file today using the full example below without causing errors.
+
+### Full Example
+
+```toml
+# .perl-lsp.toml — project-wide defaults for perl-lsp
+# Commit this file to share settings across your team.
+# All keys are optional. Unknown keys are silently ignored.
+
+[perl]
+# Perl version hint (reserved for future diagnostic targeting)
+version = "5.38"
+
+# Module search paths relative to workspace root.
+# Leave empty (or omit this key) to keep the built-in defaults:
+#   lib, ., local/lib/perl5
+include_paths = ["lib", "local/lib/perl5"]
+
+[diagnostics]
+# Enable perlcritic linting (opt-in; requires perlcritic installed)
+perlcritic = false
+
+# Minimum severity to report: 1 (most severe) to 5 (everything)
+perlcritic_severity = 3
+
+[features]
+# Toggle all inlay hints globally
+inlay_hints = true
+
+[formatting]
+# Reserved — not yet active. Keys here are silently ignored.
+perltidy = true
+perltidy_profile = ".perltidyrc"
+```
+
+An example file is also available at [`.perl-lsp.toml.example`](../../.perl-lsp.toml.example) in the repository root.
+
+---
+
+## Configuration Precedence
+
+The server applies configuration in three layers, last-write-wins:
+
+```
+.perl-lsp.toml          (lowest priority — project defaults)
+       ↓
+initializationOptions   (set at server startup by your editor)
+       ↓
+didChangeConfiguration  (highest priority — live editor settings)
+```
+
+This means:
+- Values in `.perl-lsp.toml` act as project-wide defaults.
+- Your editor's `initializationOptions` (set once at startup) override TOML values.
+- `workspace/didChangeConfiguration` updates (live settings changes) always win.
+
+Only keys **explicitly set** in `.perl-lsp.toml` override the built-in defaults. Absent keys are untouched, not zeroed.
+
+**Exception for `include_paths`**: an empty `include_paths = []` in the TOML file is treated as "not set" and leaves the built-in defaults (`lib`, `.`, `local/lib/perl5`) unchanged. This prevents an empty list from accidentally wiping your module paths. Set at least one path to override the defaults.
 
 ---
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -221,9 +221,58 @@ perl-lsp provides:
 
 ## Project Configuration
 
-For project-specific settings, the server reads configuration from your editor's LSP settings.
+perl-lsp supports two ways to configure your project: a **project configuration file** for team-wide defaults, and **LSP settings** for personal or editor-specific overrides.
 
-### Example: Configure Module Search Paths
+### Project Configuration File (.perl-lsp.toml)
+
+The `.perl-lsp.toml` file lives at your workspace root and is committed to version control. It lets you share configuration with your whole team without requiring each developer to configure their own editor. The file is optional — if it does not exist, the server uses its built-in defaults.
+
+Create a `.perl-lsp.toml` in the root of your project:
+
+```toml
+# .perl-lsp.toml — project-wide defaults for perl-lsp
+
+[perl]
+# Perl version hint (for future use)
+version = "5.38"
+
+# Module include paths relative to workspace root
+include_paths = ["lib", "local/lib/perl5"]
+
+[diagnostics]
+# Enable perlcritic linting (requires perlcritic installed)
+perlcritic = false
+perlcritic_severity = 3
+
+[features]
+# Toggle all inlay hints
+inlay_hints = true
+```
+
+**Key behaviors:**
+- If the file does not exist, the server starts normally with defaults.
+- Unknown keys and sections are silently ignored — safe to add future fields.
+- Invalid TOML produces a warning notification in your editor.
+- An empty `include_paths = []` is treated as "not set" and leaves the defaults unchanged.
+
+A ready-to-copy example is available at [`.perl-lsp.toml.example`](../../.perl-lsp.toml.example) in the repo root.
+
+### Configuration Precedence
+
+Settings are applied in this order, last-write-wins:
+
+```
+.perl-lsp.toml  →  initializationOptions  →  didChangeConfiguration
+(project file)      (editor startup)           (live editor settings)
+```
+
+Editor settings always override the project file. This lets individual developers override team defaults locally.
+
+### LSP Settings (Editor-Specific)
+
+For per-developer or editor-specific settings, configure via your editor's LSP mechanism.
+
+#### Example: Configure Module Search Paths
 
 ```json
 {
@@ -235,7 +284,7 @@ For project-specific settings, the server reads configuration from your editor's
 }
 ```
 
-### Example: Tune for Large Projects
+#### Example: Tune for Large Projects
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Adds full documentation for the `.perl-lsp.toml` project configuration file introduced in PR #2805 but never documented
- Documents all supported sections (`[perl]`, `[diagnostics]`, `[features]`, `[formatting]`), all keys with types and defaults, and key behaviors (missing file, unknown keys, invalid TOML, empty `include_paths`)
- Documents configuration precedence: file < initializationOptions < didChangeConfiguration

## Changes

| File | Change |
|------|--------|
| `docs/reference/CONFIG.md` | New `.perl-lsp.toml` section with schema tables, full example, and a standalone Configuration Precedence section |
| `docs/tutorials/GETTING_STARTED.md` | Expanded "Project Configuration" section: TOML example, key behaviors, precedence diagram, restructured LSP settings as subsection |
| `README.md` | Added "Project Configuration File" subsection under Configuration with minimal working example |
| `docs/INDEX.md` | Added "Share project settings with my team" routing row pointing at the new CONFIG.md anchor |
| `.perl-lsp.toml.example` | Annotated template at repo root ready to copy-paste into a project |

## Schema Coverage (from `crates/perl-lsp-config/src/lib.rs`)

- `[perl].include_paths` — `string[]`, overrides built-in defaults when non-empty
- `[perl].version` — `string`, reserved for future use
- `[diagnostics].perlcritic` — `bool`, opt-in perlcritic integration
- `[diagnostics].perlcritic_severity` — `u8` (1–5), clamped at runtime
- `[features].inlay_hints` — `bool`, global inlay hint toggle
- `[formatting]` — reserved section, silently ignored

## Precedence (documented in CONFIG.md and GETTING_STARTED.md)

```
.perl-lsp.toml  →  initializationOptions  →  didChangeConfiguration
(lowest)                                       (highest)
```

## Test plan

- [ ] All 13 existing tests in `crates/perl-lsp-config/tests/project_config.rs` remain green (no code changes)
- [ ] Review `.perl-lsp.toml.example` is valid TOML
- [ ] Check that CONFIG.md anchors match the heading text for the TOC links
- [ ] Verify `docs/INDEX.md` link resolves correctly in rendered markdown

Closes #2846