### PR TITLE
fix(lexer): clear after_var_subscript on ) and ] to fix if($var){m//} (#2844)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2553,6 +2553,11 @@ impl<'a> PerlLexer<'a> {
                 }
                 self.after_arrow = false;
                 self.paren_depth = self.paren_depth.saturating_sub(1);
+                // A closing paren ends any var-subscript context: `if ($var)` should
+                // NOT leave after_var_subscript set, otherwise the following `{` would
+                // incorrectly increment hash_brace_depth and suppress regex operators
+                // inside the block body (issue #2844).
+                self.after_var_subscript = false;
                 self.mode = LexerMode::ExpectOperator;
                 Some(Token {
                     token_type: TokenType::RightParen,
@@ -2600,6 +2605,11 @@ impl<'a> PerlLexer<'a> {
             }
             ']' => {
                 self.advance();
+                // A closing `]` from an array subscript leaves us in a state where
+                // a `{` immediately following is a hash subscript — e.g. `$arr[$i]{key}`.
+                // Set after_var_subscript so the `{` handler recognises it as such.
+                // This mirrors the `}` handler's behavior when closing a hash subscript.
+                self.after_var_subscript = true;
                 self.mode = LexerMode::ExpectOperator;
                 Some(Token {
                     token_type: TokenType::RightBracket,

--- a/crates/perl-parser-core/tests/fix_hash_brace_depth_in_blocks.rs
+++ b/crates/perl-parser-core/tests/fix_hash_brace_depth_in_blocks.rs
@@ -295,3 +295,84 @@ fn test_tr_in_sub_body_correct_content() {
         sexp
     );
 }
+
+// --- ISSUE #2844: after_var_subscript not cleared by `)` and `]` handlers ---
+//
+// When `$var` sets `after_var_subscript = true` and then `)` or `]` appears,
+// the flag remains set. The following `{` then incorrectly increments
+// `hash_brace_depth`, causing regex operators inside the block to be suppressed.
+//
+// Fix: `)` must clear `after_var_subscript`; `]` must set it to `true`
+// (chained subscripts: `$arr[$i]{key}` must still work).
+
+// Pattern A: if ($var) { m//; } — the canonical broken case from the issue
+#[test]
+fn test_regex_after_if_with_var_condition() {
+    let source = r#"if ($var) { $x =~ m/pattern/; }"#;
+    let sexp = parse(source).to_sexp();
+    assert!(
+        sexp.contains(r#""/pattern/""#),
+        "Expected regex '/pattern/' inside if($var) block, got sexp: {}",
+        sexp
+    );
+}
+
+// Pattern B: while (func($x)) { m//; }
+#[test]
+fn test_regex_after_while_with_func_arg() {
+    let source = r#"while (func($x)) { $line =~ m/abc/; }"#;
+    let sexp = parse(source).to_sexp();
+    assert!(
+        sexp.contains(r#""/abc/""#),
+        "Expected regex '/abc/' inside while(func($x)) block, got sexp: {}",
+        sexp
+    );
+}
+
+// Pattern C: if ($x) { $h{m} = 1; } — hash subscript inside if-with-var block
+// must still work after the fix
+#[test]
+fn test_hash_subscript_inside_if_with_var_condition() {
+    let source = r#"if ($x) { $h{m} = 1; }"#;
+    assert_clean_parse(source);
+}
+
+// Pattern D: chained array+hash subscript must still work (regression guard)
+// $arr[$i]{key} — `]` sets after_var_subscript=true so `{` sees it
+#[test]
+fn test_chained_array_hash_subscript() {
+    assert_clean_parse("my $v = $arr[$i]{key};");
+}
+
+// Pattern E: if ($var) { m//; } clean parse (no Error nodes)
+#[test]
+fn test_if_var_regex_clean_parse() {
+    assert_clean_parse(r#"if ($var) { $x =~ m/pattern/; }"#);
+}
+
+// Pattern F: nested if — outer condition has var, inner has regex
+#[test]
+fn test_nested_if_with_var_then_regex() {
+    let source = r#"
+sub process {
+    if ($flag) {
+        if ($str =~ m/foo/) {
+            return 1;
+        }
+    }
+}
+"#;
+    assert_clean_parse(source);
+}
+
+// Pattern G: if ($var) block with s/// substitution
+#[test]
+fn test_substitution_after_if_with_var_condition() {
+    let source = r#"if ($ok) { $x =~ s/foo/bar/; }"#;
+    let sexp = parse(source).to_sexp();
+    assert!(
+        sexp.contains("foo") && sexp.contains("bar"),
+        "Expected s/foo/bar/ inside if($ok) block, got sexp: {}",
+        sexp
+    );
+}


### PR DESCRIPTION
## Summary

Fixes issue #2844: `after_var_subscript` flag was not cleared by the `)` handler and not set by the `]` handler in `try_delimiter()` in `crates/perl-lexer/src/lib.rs`.

This caused `if ($var) { m/pattern/; }` to produce a mangled regex — `"/;}/"` instead of `"/pattern/"` — because:
1. `$var` sets `after_var_subscript = true`
2. `)` did not clear it
3. `{` saw `after_var_subscript = true` and incremented `hash_brace_depth`
4. Regex lexer suppressed quote-op detection inside the block

## Changes

**`crates/perl-lexer/src/lib.rs`** — 2 one-line fixes in `try_delimiter()`:
- `)` handler: add `self.after_var_subscript = false` — a closing paren ends any var-subscript context
- `]` handler: add `self.after_var_subscript = true` — mirrors `}` handler, enables chained subscripts like `$arr[$i]{key}`

**`crates/perl-parser-core/tests/fix_hash_brace_depth_in_blocks.rs`** — 7 new tests appended to existing file:
- Pattern A: `if ($var) { $x =~ m/pattern/; }` — sexp content assertion (was producing `"/;}/"`)
- Pattern B: `while (func($x)) { $line =~ m/abc/; }` — sexp content assertion
- Pattern C: `if ($x) { $h{m} = 1; }` — hash subscript regression guard
- Pattern D: `$arr[$i]{key}` — chained array+hash subscript regression guard
- Pattern E: `if ($var) { m//; }` — clean-parse assertion
- Pattern F: nested `if ($flag) { if ($str =~ m/foo/) { ... } }` — clean-parse
- Pattern G: `if ($ok) { $x =~ s/foo/bar/; }` — sexp content assertion

## Test Results

- 31 tests pass in `fix_hash_brace_depth_in_blocks` (24 pre-existing + 7 new)
- All `perl-lexer` unit and doc tests pass
- Pre-existing failures in `fix_expected_colon` (5 tests, known blocker `expected_colon`) and `enhanced_edge_case_parsing_tests` (1 test) are unrelated to this change

## Verification

The 3 sexp-content tests (Patterns A, B, G) were confirmed to fail before the fix — they showed `"/;}/"` as the regex content. After the fix they produce correct regex text.

## References

- Issue #2844 (this fix)
- PR #2837 (introduced `after_var_subscript`, explicitly noted `)` / `]` cleanup as a follow-up)
- Issue #2833 (original hash_brace_depth corpus bucket)