### PR TITLE
fix(vscode): wire 4 unimplemented commands — extractVariable, extractMethod, showRefactoringOptions, reportIssue (#2849)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -60,7 +60,6 @@
     "onCommand:perl-lsp.createDebugConfig",
     "onCommand:perl-lsp.runHealthCheck",
     "onCommand:perl-lsp.openConfigurationGuide",
-    "onCommand:perl-lsp.runHealthCheck",
     "onWalkthrough:perl-lsp.gettingStarted"
   ],
   "contributes": {
@@ -434,6 +433,12 @@
         "title": "Open Configuration Guide",
         "category": "Perl",
         "icon": "$(gear)"
+      },
+      {
+        "command": "perl-lsp.reportIssue",
+        "title": "Report Issue",
+        "category": "Perl",
+        "icon": "$(github)"
       }
     ],
     "menus": {
@@ -483,6 +488,9 @@
         },
         {
           "command": "perl-lsp.openConfigurationGuide"
+        },
+        {
+          "command": "perl-lsp.reportIssue"
         }
       ],
       "editor/title": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,7 @@ import { BinaryDownloader } from './downloader';
 import { OnboardingManager } from './onboarding';
 import { WhatsNewManager } from './whatsNew';
 import { generateBoilerplate } from './fileCreation';
+import { handleFormattingError } from './formattingErrors';
 
 let client: LanguageClient | undefined;
 let outputChannel: vscode.OutputChannel;
@@ -220,6 +221,199 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const extractVariableCommand = vscode.commands.registerCommand('perl-lsp.extractVariable', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.languageId !== 'perl') {
+            vscode.window.showErrorMessage('Extract Variable requires an active Perl file with a selection');
+            return;
+        }
+        if (editor.selection.isEmpty) {
+            vscode.window.showWarningMessage('Select an expression to extract as a variable');
+            return;
+        }
+        if (!client) {
+            vscode.window.showWarningMessage('Perl Language Server is not running. Restart the server and try again.');
+            return;
+        }
+        const range = editor.selection;
+        const params = {
+            textDocument: { uri: editor.document.uri.toString() },
+            range: {
+                start: { line: range.start.line, character: range.start.character },
+                end: { line: range.end.line, character: range.end.character },
+            },
+            context: { diagnostics: [], only: ['refactor.extract'], triggerKind: 2 },
+        };
+        type CodeActionResult = Array<{ title: string; kind?: string; edit?: unknown; command?: unknown }> | null;
+        const actions = await client.sendRequest<CodeActionResult>('textDocument/codeAction', params);
+        if (!actions || actions.length === 0) {
+            vscode.window.showInformationMessage('No extract actions available for the selected expression');
+            return;
+        }
+        const variableAction = actions.find(a => a.title.toLowerCase().includes('variable'));
+        const action = variableAction ?? actions[0];
+        if (action.edit) {
+            const workspaceEdit = await client.protocol2CodeConverter.asWorkspaceEdit(
+                action.edit as Parameters<typeof client.protocol2CodeConverter.asWorkspaceEdit>[0]
+            );
+            if (workspaceEdit) {
+                await vscode.workspace.applyEdit(workspaceEdit);
+            }
+        } else if (action.command) {
+            const cmd = action.command as { command: string; arguments?: unknown[] };
+            await vscode.commands.executeCommand(cmd.command, ...(cmd.arguments ?? []));
+        } else {
+            vscode.window.showInformationMessage('No extract variable action is available for the current selection');
+        }
+    });
+
+    const extractMethodCommand = vscode.commands.registerCommand('perl-lsp.extractMethod', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.languageId !== 'perl') {
+            vscode.window.showErrorMessage('Extract Method requires an active Perl file with a selection');
+            return;
+        }
+        if (editor.selection.isEmpty) {
+            vscode.window.showWarningMessage('Select code to extract as a method');
+            return;
+        }
+        if (!client) {
+            vscode.window.showWarningMessage('Perl Language Server is not running. Restart the server and try again.');
+            return;
+        }
+        const range = editor.selection;
+        const params = {
+            textDocument: { uri: editor.document.uri.toString() },
+            range: {
+                start: { line: range.start.line, character: range.start.character },
+                end: { line: range.end.line, character: range.end.character },
+            },
+            context: { diagnostics: [], only: ['refactor.extract'], triggerKind: 2 },
+        };
+        type CodeActionResult = Array<{ title: string; kind?: string; edit?: unknown; command?: unknown }> | null;
+        const actions = await client.sendRequest<CodeActionResult>('textDocument/codeAction', params);
+        if (!actions || actions.length === 0) {
+            vscode.window.showInformationMessage('No extract actions available for the selected code');
+            return;
+        }
+        const subroutineAction = actions.find(
+            a => a.title.toLowerCase().includes('subroutine') || a.title.toLowerCase().includes('method') || a.title.toLowerCase().includes('function')
+        );
+        const action = subroutineAction ?? actions[actions.length - 1];
+        if (action.edit) {
+            const workspaceEdit = await client.protocol2CodeConverter.asWorkspaceEdit(
+                action.edit as Parameters<typeof client.protocol2CodeConverter.asWorkspaceEdit>[0]
+            );
+            if (workspaceEdit) {
+                await vscode.workspace.applyEdit(workspaceEdit);
+            }
+        } else if (action.command) {
+            const cmd = action.command as { command: string; arguments?: unknown[] };
+            await vscode.commands.executeCommand(cmd.command, ...(cmd.arguments ?? []));
+        } else {
+            vscode.window.showInformationMessage('No extract method action is available for the current selection');
+        }
+    });
+
+    const showRefactoringOptionsCommand = vscode.commands.registerCommand('perl-lsp.showRefactoringOptions', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.languageId !== 'perl') {
+            vscode.window.showErrorMessage('Refactoring options require an active Perl file');
+            return;
+        }
+
+        interface RefactorAction extends vscode.QuickPickItem {
+            command: string;
+            args?: unknown[];
+        }
+
+        const items: RefactorAction[] = [
+            {
+                label: '$(symbol-variable) Extract Variable',
+                description: 'Shift+Alt+V',
+                detail: editor.selection.isEmpty
+                    ? 'Select an expression first to extract it as a variable'
+                    : 'Extract selected expression as a local variable',
+                command: 'perl-lsp.extractVariable',
+            },
+            {
+                label: '$(symbol-method) Extract Method',
+                description: 'Shift+Alt+M',
+                detail: editor.selection.isEmpty
+                    ? 'Select code first to extract it as a subroutine'
+                    : 'Extract selected code as a named subroutine',
+                command: 'perl-lsp.extractMethod',
+            },
+            {
+                label: '$(organization) Organize Imports',
+                description: 'Shift+Alt+O',
+                detail: 'Sort and deduplicate use statements',
+                command: 'perl-lsp.organizeImports',
+            },
+        ];
+
+        const selection = await vscode.window.showQuickPick(items, {
+            placeHolder: 'Perl Refactoring Options',
+        });
+
+        if (selection) {
+            await vscode.commands.executeCommand(selection.command, ...(selection.args ?? []));
+        }
+    });
+
+    const reportIssueCommand = vscode.commands.registerCommand('perl-lsp.reportIssue', async () => {
+        const extensionVersion = context.extension.packageJSON.version as string ?? 'unknown';
+        const vscodeVersion = vscode.version;
+        const platform = process.platform;
+        const arch = process.arch;
+
+        const getServerVersion = (): Promise<string> =>
+            new Promise(resolve => {
+                if (!currentServerPath) {
+                    resolve('unavailable');
+                    return;
+                }
+                execFile(currentServerPath, ['--version'], { timeout: 3000 }, (err: Error | null, stdout: string) => {
+                    if (err) {
+                        resolve('unavailable');
+                        return;
+                    }
+                    const firstLine = stdout.trim().split('\n')[0] ?? '';
+                    resolve(firstLine.trim() || 'unavailable');
+                });
+            });
+
+        const serverVersion = await getServerVersion();
+
+        const diagnosticInfo = [
+            `perl-lsp server: ${serverVersion}`,
+            `Extension: ${extensionVersion}`,
+            `VS Code: ${vscodeVersion}`,
+            `Platform: ${platform}/${arch}`,
+        ].join('\n');
+
+        const selection = await vscode.window.showInformationMessage(
+            'Open a GitHub issue to report a bug or request a feature.',
+            'Copy Diagnostic Info',
+            'Open Issue Form'
+        );
+
+        if (selection === 'Copy Diagnostic Info') {
+            try {
+                await vscode.env.clipboard.writeText(diagnosticInfo);
+                vscode.window.showInformationMessage('Diagnostic info copied. Paste it into the issue form.');
+            } catch {
+                // Clipboard unavailable — continue to open browser anyway
+            }
+        }
+
+        if (selection === 'Copy Diagnostic Info' || selection === 'Open Issue Form') {
+            const url = vscode.Uri.parse(
+                'https://github.com/EffortlessMetrics/perl-lsp/issues/new?template=bug_report.yml'
+            );
+            await vscode.env.openExternal(url);
+        }
+    });
 
     const formatOnSaveDisposable = vscode.workspace.onWillSaveTextDocument((event) => {
         if (!shouldFormatOnSave(event.document)) {
@@ -280,6 +474,10 @@ export async function activate(context: vscode.ExtensionContext) {
         runHealthCheckCommand,
         showWhatsNewCommand,
         openConfigurationGuideCommand,
+        extractVariableCommand,
+        extractMethodCommand,
+        showRefactoringOptionsCommand,
+        reportIssueCommand,
         formatOnSaveDisposable,
         configurationWatcher,
         fileCreationWatcher,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Contract tests for the four previously-unimplemented VSCode commands:
+ *   - perl-lsp.extractVariable   (Shift+Alt+V)
+ *   - perl-lsp.extractMethod     (Shift+Alt+M)
+ *   - perl-lsp.showRefactoringOptions
+ *   - perl-lsp.createDebugConfig
+ *
+ * These are static contract tests — they verify that package.json declares
+ * the commands with correct metadata (no live VSCode extension host needed).
+ * The implementation is verified in extension.ts; these tests guard regressions
+ * to the manifest contract that users and keybinding tables depend on.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const EXT_ROOT = path.resolve(__dirname, '..', '..');
+
+function readPackageJson(): any {
+  return JSON.parse(fs.readFileSync(path.join(EXT_ROOT, 'package.json'), 'utf8'));
+}
+
+// ---------------------------------------------------------------------------
+// extractVariable
+// ---------------------------------------------------------------------------
+describe('perl-lsp.extractVariable command', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('is declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map((c: any) => c.command);
+    expect(ids).toContain('perl-lsp.extractVariable');
+  });
+
+  test('has title "Extract Variable"', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.extractVariable');
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe('Extract Variable');
+  });
+
+  test('has Perl category', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.extractVariable');
+    expect(cmd.category).toBe('Perl');
+  });
+
+  test('is listed in commandPalette restricted to perl with a selection', () => {
+    const palette = pkg.contributes.menus.commandPalette;
+    const entry = palette.find((e: any) => e.command === 'perl-lsp.extractVariable');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+    expect(entry.when).toContain('editorHasSelection');
+  });
+
+  test('has Shift+Alt+V keybinding scoped to perl with selection', () => {
+    const keybindings: any[] = pkg.contributes.keybindings;
+    const kb = keybindings.find((k: any) => k.command === 'perl-lsp.extractVariable');
+    expect(kb).toBeDefined();
+    expect(kb.key.toLowerCase()).toBe('shift+alt+v');
+    expect(kb.when).toContain('editorLangId == perl');
+    expect(kb.when).toContain('editorHasSelection');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractMethod
+// ---------------------------------------------------------------------------
+describe('perl-lsp.extractMethod command', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('is declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map((c: any) => c.command);
+    expect(ids).toContain('perl-lsp.extractMethod');
+  });
+
+  test('has title "Extract Method"', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.extractMethod');
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe('Extract Method');
+  });
+
+  test('has Perl category', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.extractMethod');
+    expect(cmd.category).toBe('Perl');
+  });
+
+  test('is listed in commandPalette restricted to perl with a selection', () => {
+    const palette = pkg.contributes.menus.commandPalette;
+    const entry = palette.find((e: any) => e.command === 'perl-lsp.extractMethod');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+    expect(entry.when).toContain('editorHasSelection');
+  });
+
+  test('has Shift+Alt+M keybinding scoped to perl with selection', () => {
+    const keybindings: any[] = pkg.contributes.keybindings;
+    const kb = keybindings.find((k: any) => k.command === 'perl-lsp.extractMethod');
+    expect(kb).toBeDefined();
+    expect(kb.key.toLowerCase()).toBe('shift+alt+m');
+    expect(kb.when).toContain('editorLangId == perl');
+    expect(kb.when).toContain('editorHasSelection');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// showRefactoringOptions
+// ---------------------------------------------------------------------------
+describe('perl-lsp.showRefactoringOptions command', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('is declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map((c: any) => c.command);
+    expect(ids).toContain('perl-lsp.showRefactoringOptions');
+  });
+
+  test('has title "Show Refactoring Options"', () => {
+    const cmd = pkg.contributes.commands.find(
+      (c: any) => c.command === 'perl-lsp.showRefactoringOptions'
+    );
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe('Show Refactoring Options');
+  });
+
+  test('has Perl category', () => {
+    const cmd = pkg.contributes.commands.find(
+      (c: any) => c.command === 'perl-lsp.showRefactoringOptions'
+    );
+    expect(cmd.category).toBe('Perl');
+  });
+
+  test('is listed in commandPalette restricted to perl', () => {
+    const palette = pkg.contributes.menus.commandPalette;
+    const entry = palette.find((e: any) => e.command === 'perl-lsp.showRefactoringOptions');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDebugConfig
+// ---------------------------------------------------------------------------
+describe('perl-lsp.createDebugConfig command', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('is declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map((c: any) => c.command);
+    expect(ids).toContain('perl-lsp.createDebugConfig');
+  });
+
+  test('has title "Create Debug Configuration"', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.createDebugConfig');
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe('Create Debug Configuration');
+  });
+
+  test('has Perl category', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.createDebugConfig');
+    expect(cmd.category).toBe('Perl');
+  });
+
+  test('is listed in commandPalette with workspace restriction', () => {
+    const palette = pkg.contributes.menus.commandPalette;
+    const entry = palette.find((e: any) => e.command === 'perl-lsp.createDebugConfig');
+    expect(entry).toBeDefined();
+    // Available when at least one workspace folder is open
+    expect(entry.when).toContain('workspaceFolderCount');
+  });
+
+  test('has an activation event', () => {
+    expect(pkg.activationEvents).toContain('onCommand:perl-lsp.createDebugConfig');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No duplicate activation events
+// ---------------------------------------------------------------------------
+describe('package.json activationEvents', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('has no duplicate activation events', () => {
+    const events: string[] = pkg.activationEvents;
+    const unique = new Set(events);
+    expect(unique.size).toBe(events.length);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2849. Four VSCode commands were declared in `package.json` with keybindings but had no handler, making them silently no-ops.

- **`perl-lsp.extractVariable` (Shift+Alt+V)**: Sends `textDocument/codeAction` LSP request with `only: ['refactor.extract']`, selects the action whose title contains `'variable'`, and applies the returned `WorkspaceEdit` via `client.protocol2CodeConverter`.
- **`perl-lsp.extractMethod` (Shift+Alt+M)**: Same flow, selects action containing `'subroutine'`, `'method'`, or `'function'` in the title.
- **`perl-lsp.showRefactoringOptions`**: QuickPick menu offering Extract Variable, Extract Method, and Organize Imports — shows selection-state hints so users know which actions require a selection.
- **`perl-lsp.reportIssue`**: Collects server version + OS/editor diagnostics, offers Copy Diagnostic Info before opening the GitHub issue form. Matches the behavior from PR #2748 (merged on master, absent in this branch due to divergence).

**Also fixed (opportunistic):**
- Added missing `import { handleFormattingError } from './formattingErrors'` — the function was called in the middleware but never imported (pre-existing TS error).
- Removed duplicate `onCommand:perl-lsp.runHealthCheck` activation event (lines 61/63 of `package.json`).
- `perl-lsp.createDebugConfig` is already registered in `debugAdapter.ts` via `activateDebugger(context)` — correctly NOT re-registered here.

## Test plan

- [ ] `cd vscode-extension && npm test` — all 304 tests pass (20 new contract tests in `src/test/commands.test.ts`)
- [ ] `tsc --noEmit` — zero TypeScript errors
- [ ] Manual: open a Perl file, select an expression, press Shift+Alt+V — should trigger extract variable via LSP
- [ ] Manual: press Shift+Alt+M with selection — should trigger extract method via LSP
- [ ] Manual: run "Perl: Show Refactoring Options" from command palette — should show QuickPick menu
- [ ] Manual: run "Perl: Report Issue" — should show info notification then open GitHub issue form
- [ ] Manual: run "Perl: Create Debug Configuration" — should still work (from debugAdapter.ts)