### PR TITLE
ux(vscode): clarify .perl-lsp.toml in walkthrough step 7 (#2860)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -621,7 +621,7 @@
           {
             "id": "configure-settings",
             "title": "Configure Settings",
-            "description": "Open Perl LSP settings to set includePaths, formatting, and feature profiles.",
+            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** — personal overrides, not committed to your repo. Set `perl-lsp.includePaths` here if you see _Can't locate Foo/Bar.pm_ errors. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** — team-wide defaults, committed to your repo root. Useful for sharing `includePaths` or enabling Perl::Critic across the team. Copy `.perl-lsp.toml.example` from the repo root to get started.\n\nEditor settings always override `.perl-lsp.toml`. See CONFIG.md for the full reference.",
             "media": {
               "image": "media/walkthrough/configure-settings.svg",
               "altText": "Configure Settings"


### PR DESCRIPTION
## Summary

- Create `.perl-lsp.toml.example` at repo root — all three sections (`[perl]`, `[diagnostics]`, `[features]`) with all keys commented out, derived from `crates/perl-lsp-config/src/lib.rs`
- Update walkthrough `configure-settings` step description to explain both configuration paths, use a `command:` URI for the settings link, mention `.perl-lsp.toml`, and state precedence (editor settings always win)

## Changes

- `.perl-lsp.toml.example` — new file, 28 lines, all keys commented, covers the three sections parsed by `ProjectConfig`
- `vscode-extension/package.json` — `configure-settings` step description updated from 1 line to multi-paragraph with `[Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)` link

## Test Plan

- [x] `cargo test -p perl-lsp-config` — 56 tests pass (no Rust changes, confirms no regression)
- [x] `package.json` is valid JSON (Python json.load verified)
- [ ] Fresh VS Code install: open walkthrough step 7 → verify both config methods mentioned
- [ ] Click "Open Perl LSP Settings" link in walkthrough → VS Code settings panel opens filtered to `perl-lsp.*`
- [ ] Confirm `.perl-lsp.toml.example` is at repo root and copyable
- [ ] Copy to `.perl-lsp.toml`, uncomment `include_paths`, restart server → paths take effect

## Notes

- `[formatting]` section deliberately omitted — lib.rs comment says it is reserved for future perltidy integration and not yet wired; including it would mislead users
- `command:` URI is the correct VS Code walkthrough mechanism for clickable actions — external URLs are not rendered as clickable links in all walkthrough contexts
- Precedence claim ("editor settings always override") is verified by the existing `project_config_lsp_override_wins_over_toml_base` integration test