### PR TITLE
fix(lsp): wire missing-semicolon quick-fix for PL001/PL002 (#2863)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -147,7 +147,10 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_bareword(&self.source, &qf_diag));
                     }
                     // PL001: General parse error (stable code)
-                    c if c == DiagnosticCode::ParseError.as_str() => {
+                    // PL002: Syntax error — same quick-fix routing as PL001
+                    c if c == DiagnosticCode::ParseError.as_str()
+                        || c == DiagnosticCode::SyntaxError.as_str() =>
+                    {
                         actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
                     }
                     // parse-error-* subcodes (legacy subtype codes from error classifier)

--- a/crates/perl-lsp-code-actions/src/quick_fixes.rs
+++ b/crates/perl-lsp-code-actions/src/quick_fixes.rs
@@ -354,6 +354,40 @@ pub fn fix_parse_error(
                 is_preferred: true,
             });
         }
+        "PL001" | "PL002"
+            if diagnostic.message.to_ascii_lowercase().contains("missing semicolon") =>
+        {
+            // PL001/PL002 are general parse error codes. When the message indicates a missing
+            // semicolon, apply the same fix — but skip heredoc contexts where insertion is wrong.
+            let at_heredoc = source[diagnostic.range.0..].get(..2).is_some_and(|s| s == "<<");
+            if !at_heredoc {
+                let line_end = source[diagnostic.range.0..]
+                    .find('\n')
+                    .map(|p| diagnostic.range.0 + p)
+                    .unwrap_or(source.len());
+
+                // Insert before trailing whitespace
+                let mut end_pos = line_end;
+                while end_pos > diagnostic.range.0
+                    && source.as_bytes()[end_pos - 1].is_ascii_whitespace()
+                {
+                    end_pos -= 1;
+                }
+
+                actions.push(CodeAction {
+                    title: "Add missing semicolon".to_string(),
+                    kind: CodeActionKind::QuickFix,
+                    diagnostics: vec![code.to_string()],
+                    edit: CodeActionEdit {
+                        changes: vec![TextEdit {
+                            location: SourceLocation { start: end_pos, end: end_pos },
+                            new_text: ";".to_string(),
+                        }],
+                    },
+                    is_preferred: true,
+                });
+            }
+        }
         "parse-error-unclosedstring" => {
             // Add closing quote
             actions.push(CodeAction {

--- a/crates/perl-lsp-code-actions/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-code-actions/tests/comprehensive_unit_tests.rs
@@ -363,6 +363,84 @@ fn parse_error_unknown_code_yields_no_actions_for_that_code() {
     );
 }
 
+// ---- PL001 / PL002 missing-semicolon via message text --------------------
+
+#[test]
+fn pl001_missing_semicolon_message_triggers_fix() {
+    let src = "my $x = 1\n";
+    let diags =
+        [make_diag(0, 9, "PL001", "Missing semicolon after statement. Add `;` here (found `my`)")];
+    let actions = parse_and_get_actions(src, &diags);
+    assert!(
+        has_action_matching(&actions, |a| a.title.contains("semicolon")),
+        "PL001 with missing-semicolon message must offer fix, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn pl002_missing_semicolon_message_triggers_fix() {
+    let src = "my $x = 1\n";
+    let diags =
+        [make_diag(0, 9, "PL002", "Missing semicolon after statement. Add `;` here (found `my`)")];
+    let actions = parse_and_get_actions(src, &diags);
+    assert!(
+        has_action_matching(&actions, |a| a.title.contains("semicolon")),
+        "PL002 with missing-semicolon message must offer fix"
+    );
+}
+
+#[test]
+fn pl001_generic_message_does_not_trigger_semicolon_fix() {
+    let src = "my $x = 1;\n";
+    let diags = [make_diag(0, 9, "PL001", "Unexpected token found `my`")];
+    let actions = parse_and_get_actions(src, &diags);
+    assert!(
+        !has_action_matching(&actions, |a| a.title.contains("semicolon")),
+        "PL001 with unrelated message must not offer semicolon fix"
+    );
+}
+
+#[test]
+fn pl001_semicolon_inserted_before_trailing_whitespace() {
+    // "my $x = 1   \n" — trailing spaces before newline
+    let src = "my $x = 1   \n";
+    let diags =
+        [make_diag(0, 9, "PL001", "Missing semicolon after statement. Add `;` here (found `my`)")];
+    let actions = parse_and_get_actions(src, &diags);
+    let fix = actions.iter().find(|a| a.title.contains("semicolon")).expect("fix must exist");
+    // The insertion point should be right after "1" (byte 9), not after trailing spaces
+    assert_eq!(
+        fix.edit.changes[0].location.start, 9,
+        "semicolon must be inserted after last non-whitespace char (byte 9)"
+    );
+}
+
+#[test]
+fn pl001_heredoc_does_not_trigger_semicolon_fix() {
+    // Source at range start looks like a heredoc — fix must be skipped
+    let src = "<<END\nhello\nEND\n";
+    let diags = [make_diag(0, 5, "PL001", "Missing semicolon after statement. Add `;` here")];
+    let actions = parse_and_get_actions(src, &diags);
+    assert!(
+        !has_action_matching(&actions, |a| a.title.contains("semicolon")),
+        "Heredoc context must not produce semicolon fix"
+    );
+}
+
+#[test]
+fn pl001_eof_without_newline_inserts_at_end() {
+    // No trailing newline — `unwrap_or(source.len())` path
+    let src = "my $x = 1";
+    let diags = [make_diag(0, 9, "PL001", "Missing semicolon after statement. Add `;` here")];
+    let actions = parse_and_get_actions(src, &diags);
+    let fix = actions.iter().find(|a| a.title.contains("semicolon")).expect("fix must exist");
+    assert_eq!(
+        fix.edit.changes[0].location.start, 9,
+        "EOF without newline must insert at source.len()"
+    );
+}
+
 // ---- unused-parameter -----------------------------------------------------
 
 #[test]

--- a/crates/perl-lsp/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp/src/features/code_actions_provider/mod.rs
@@ -135,6 +135,14 @@ impl CodeActionsProvider {
             Some(code) if code.starts_with("parse-error-") => {
                 fixes::fix_parse_error(self, diagnostic, code)
             }
+            // PL001 / PL002 are general parse error codes. When the diagnostic message
+            // indicates a missing semicolon, route through the same fix as
+            // "parse-error-missingsemicolon" so the quick-fix fires correctly.
+            Some("PL001") | Some("PL002")
+                if diagnostic.message.to_ascii_lowercase().contains("missing semicolon") =>
+            {
+                fixes::fix_parse_error(self, diagnostic, "parse-error-missingsemicolon")
+            }
             _ => Vec::new(),
         }
     }
@@ -1077,5 +1085,78 @@ mod tests {
 
         let range = source_utils::find_declaration_range(&provider, "$y", 6);
         assert_eq!(range, None);
+    }
+
+    // ── Quick-fix: PL001 / PL002 missing-semicolon via message text ─────
+
+    #[test]
+    fn test_pl001_missing_semicolon_message_triggers_fix() {
+        let source = "my $x = 1\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+
+        let diagnostic = make_diagnostic(
+            (0, 9),
+            DiagnosticSeverity::Error,
+            "PL001",
+            "Missing semicolon after statement. Add `;` here (found `my`)",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1, "Expected 1 action, got: {:?}", actions);
+        assert_eq!(actions[0].title, "Add missing semicolon");
+        assert_eq!(actions[0].kind, CodeActionKind::QuickFix);
+    }
+
+    #[test]
+    fn test_pl002_missing_semicolon_message_triggers_fix() {
+        let source = "my $x = 1\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+
+        let diagnostic = make_diagnostic(
+            (0, 9),
+            DiagnosticSeverity::Error,
+            "PL002",
+            "Missing semicolon after statement. Add `;` here",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add missing semicolon");
+    }
+
+    #[test]
+    fn test_pl001_generic_message_returns_no_semicolon_fix() {
+        let source = "my $x = 1;\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+
+        let diagnostic = make_diagnostic(
+            (0, 9),
+            DiagnosticSeverity::Error,
+            "PL001",
+            "Unexpected token at line 1",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert!(actions.is_empty(), "PL001 with unrelated message must not produce actions");
+    }
+
+    #[test]
+    fn test_pl001_semicolon_inserted_at_line_end() {
+        // "my $x = 1\n" — semicolon should be inserted after "1" (before \n)
+        let source = "my $x = 1\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+
+        let diagnostic = make_diagnostic(
+            (0, 9),
+            DiagnosticSeverity::Error,
+            "PL001",
+            "Missing semicolon after statement. Add `;` here",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1);
+        // find_line_end from diagnostic.range.1=9 -> finds '\n' at offset 0 from pos 9 -> returns 9
+        assert_eq!(actions[0].edit.range, (9, 9));
+        assert_eq!(actions[0].edit.new_text, ";");
     }
 }


### PR DESCRIPTION
## Summary

- The semicolon quick-fix existed but never fired due to a diagnostic code mismatch: providers matched on `"parse-error-missingsemicolon"` subcodes that are never actually emitted — only `"PL001"` (ParseError) and `"PL002"` (SyntaxError) are emitted to real diagnostics
- Fix: add message-text detection in both providers so `PL001`/`PL002` diagnostics with "missing semicolon" in their message now trigger the quick-fix
- Edge cases handled: heredoc guard (skip if source at range starts with `<<`), EOF without newline (existing `unwrap_or(source.len())`), trailing whitespace stripping

## Files Changed

- `crates/perl-lsp-code-actions/src/code_actions.rs` — route `PL002` (SyntaxError) alongside `PL001` (ParseError) to `fix_parse_error`
- `crates/perl-lsp-code-actions/src/quick_fixes.rs` — add `"PL001" | "PL002"` arm with message-based detection and heredoc guard
- `crates/perl-lsp/src/features/code_actions_provider/mod.rs` — add `Some("PL001") | Some("PL002")` arm that routes through `fix_parse_error` when message matches

## Test plan

- [x] `cargo test -p perl-lsp-code-actions -- --test-threads=2` — all 191 tests pass (6 new PL001/PL002 tests)
- [x] `RUST_TEST_THREADS=2 cargo test -p perl-lsp --lib -- --test-threads=2` — all 281 tests pass (4 new PL001/PL002 tests)
- [x] `cargo clippy -p perl-lsp-code-actions --lib` — clean
- [x] `cargo clippy -p perl-lsp --lib` — clean
- [x] `cargo fmt --check` — clean

Closes #2863