### PR TITLE
feat(diagnostics): suppress cascading parse errors via location clustering (#2862)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/dedup.rs
+++ b/crates/perl-lsp-diagnostics/src/dedup.rs
@@ -3,14 +3,94 @@
 //! This module provides functionality for removing duplicate diagnostics
 //! to avoid reporting the same issue multiple times.
 
-use perl_lsp_diagnostic_types::Diagnostic;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
 
-/// De-duplicate diagnostics to avoid reporting the same issue twice
+/// Byte-distance threshold for cascade suppression.
 ///
-/// This function sorts diagnostics by range, severity, code, and message,
-/// then removes exact duplicates (same range, severity, code, and message).
+/// Parse-error diagnostics whose start offsets fall within this many bytes
+/// of the current cluster head are treated as downstream cascades and
+/// suppressed.  Only the first diagnostic in each cluster is kept.
+const CASCADE_THRESHOLD_BYTES: usize = 10;
+
+/// Parse-error diagnostic codes emitted by the parser layer.
+///
+/// Only diagnostics with these codes are considered candidates for cascade
+/// suppression.  Scope-analysis warnings and lint hints are never suppressed.
+const PARSE_ERROR_CODES: &[&str] = &["PL001", "PL002", "PL003"];
+
+/// Returns `true` if this diagnostic was produced by the parser (not by a lint
+/// or scope-analysis pass).
+fn is_parse_error_diagnostic(d: &Diagnostic) -> bool {
+    d.severity == DiagnosticSeverity::Error
+        && d.code.as_deref().map(|c| PARSE_ERROR_CODES.contains(&c)).unwrap_or(false)
+}
+
+/// Suppress cascading parse-error diagnostics using location clustering.
+///
+/// After exact-duplicate removal the parser may still emit several tightly-
+/// grouped diagnostics that all stem from a single syntax error (e.g. an
+/// unclosed delimiter causes "unexpected token" errors on every subsequent
+/// statement).  This pass groups adjacent parse-error diagnostics by byte
+/// proximity and retains only the first diagnostic in each cluster.
+///
+/// Algorithm:
+/// 1. Separate diagnostics into parse-errors and everything else.
+/// 2. Sort parse-errors by start byte offset.
+/// 3. Walk the sorted list; start a new cluster whenever the current
+///    diagnostic's start offset exceeds the cluster-head's start offset by
+///    more than [`CASCADE_THRESHOLD_BYTES`].
+/// 4. Recombine kept parse-errors with the untouched non-parse-error
+///    diagnostics.
+fn suppress_cascades(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    if diagnostics.is_empty() {
+        return diagnostics;
+    }
+
+    // Partition: parse-errors (cascade candidates) vs. everything else.
+    let (mut parse_errors, others): (Vec<Diagnostic>, Vec<Diagnostic>) =
+        diagnostics.into_iter().partition(is_parse_error_diagnostic);
+
+    if parse_errors.len() <= 1 {
+        // Nothing to suppress — fast path.
+        parse_errors.extend(others);
+        return parse_errors;
+    }
+
+    // Sort parse-errors by start position so adjacent errors are neighbours.
+    parse_errors.sort_by_key(|d| d.range.0);
+
+    // Walk the sorted list, keeping only cluster heads.
+    let mut kept: Vec<Diagnostic> = Vec::with_capacity(parse_errors.len());
+
+    for diag in parse_errors {
+        match kept.last() {
+            None => kept.push(diag),
+            Some(head) => {
+                let gap = diag.range.0.saturating_sub(head.range.0);
+                if gap > CASCADE_THRESHOLD_BYTES {
+                    // New cluster — this diagnostic is a fresh primary error.
+                    kept.push(diag);
+                }
+                // else: within threshold → cascade, drop it.
+            }
+        }
+    }
+
+    kept.extend(others);
+    kept
+}
+
+/// De-duplicate diagnostics to avoid reporting the same issue twice.
+///
+/// Performs two passes:
+///
+/// 1. **Exact deduplication** — removes diagnostics that share the same
+///    range, severity, code, and message.
+/// 2. **Cascade suppression** — groups adjacent parse-error diagnostics by
+///    byte proximity and retains only the first in each cluster, suppressing
+///    downstream noise caused by error-recovery.
 pub fn deduplicate_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
-    // Sort by range, severity, code, and message
+    // Pass 1: sort by range, severity, code, and message, then remove exact duplicates.
     diagnostics.sort_by(|a, b| {
         a.range
             .0
@@ -21,8 +101,11 @@ pub fn deduplicate_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
             .then(a.message.cmp(&b.message))
     });
 
-    // Remove only exact duplicates (same range, severity, code, and message)
     diagnostics.dedup_by(|a, b| {
         a.range == b.range && a.severity == b.severity && a.code == b.code && a.message == b.message
     });
+
+    // Pass 2: cascade suppression — collapse clusters of nearby parse-errors.
+    let after = suppress_cascades(std::mem::take(diagnostics));
+    *diagnostics = after;
 }

--- a/crates/perl-lsp-diagnostics/tests/cascade_suppression_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/cascade_suppression_tests.rs
@@ -1,0 +1,298 @@
+//! Tests for cascade parse-error suppression in the diagnostics pipeline.
+//!
+//! Cascade suppression groups adjacent parse-error diagnostics by byte proximity
+//! and keeps only the first in each cluster, reducing noise for users.
+
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser_core::error::ParseError;
+use perl_parser_core::{Node, NodeKind, SourceLocation};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn empty_program(source_len: usize) -> Arc<Node> {
+    Arc::new(Node::new(
+        NodeKind::Program { statements: vec![] },
+        SourceLocation { start: 0, end: source_len },
+    ))
+}
+
+fn parse_errors_only(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| matches!(d.code.as_deref(), Some("PL001") | Some("PL002") | Some("PL003")))
+        .collect()
+}
+
+fn run_diagnostics(source: &str, errors: Vec<ParseError>) -> Vec<Diagnostic> {
+    let ast = empty_program(source.len());
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &errors, source, None)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Single parse error — no suppression applied
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_parse_error_is_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $x = ;";
+    let errors = vec![ParseError::UnexpectedToken {
+        location: 8,
+        expected: "expression".to_string(),
+        found: ";".to_string(),
+    }];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert_eq!(parse_diags.len(), 1, "Single parse error must not be suppressed");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 2. Two parse errors far apart — both preserved
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_distant_parse_errors_both_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    // Errors at offset 0 and offset 50 — well beyond the 10-byte threshold.
+    let source = "x x x x x x x x x x x x x x x x x x x x x x x x x x x";
+    let errors = vec![
+        ParseError::UnexpectedToken {
+            location: 0,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 50,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+    ];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert!(
+        parse_diags.len() >= 2,
+        "Parse errors 50 bytes apart must both be preserved, got {}",
+        parse_diags.len()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3. Three cascade errors adjacent (within 10 bytes) — only first kept
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjacent_cascade_errors_suppressed_to_one() -> Result<(), Box<dyn std::error::Error>> {
+    // Simulate a cascade: errors at offsets 5, 8, 10 — all within 10 bytes of each other.
+    // Only the first (offset 5) should survive after cascade suppression.
+    let source = "my $x = foo(1, 2, 3\nmy $y = 2;\nmy $z = 3;\n";
+    let errors = vec![
+        ParseError::UnexpectedToken {
+            location: 5,
+            expected: "expression".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 8,
+            expected: "expression".to_string(),
+            found: "foo".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 10,
+            expected: "expression".to_string(),
+            found: "1".to_string(),
+        },
+    ];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert_eq!(
+        parse_diags.len(),
+        1,
+        "Three parse errors within 10 bytes should be collapsed to one, got {}",
+        parse_diags.len()
+    );
+    assert_eq!(parse_diags[0].range.0, 5, "The first (lowest-offset) error should be preserved");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 4. Two clusters — one primary from each cluster preserved
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_separate_clusters_one_primary_each() -> Result<(), Box<dyn std::error::Error>> {
+    // Cluster A: errors at 0, 3, 7 (all within 10 bytes of first → same cluster)
+    // Cluster B: errors at 40, 44, 48 (all within 10 bytes of first → same cluster)
+    let source = "x x x x x x x x x x x x x x x x x x x x x x x x x x x x";
+    let errors = vec![
+        ParseError::UnexpectedToken {
+            location: 0,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 3,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 7,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 40,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 44,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 48,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+    ];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert_eq!(
+        parse_diags.len(),
+        2,
+        "Six errors in two clusters should yield exactly 2 primaries, got {}",
+        parse_diags.len()
+    );
+    // The two survivors must be the cluster heads
+    let starts: Vec<usize> = parse_diags.iter().map(|d| d.range.0).collect();
+    assert!(starts.contains(&0), "First cluster head (offset 0) must be preserved");
+    assert!(starts.contains(&40), "Second cluster head (offset 40) must be preserved");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 5. Boundary: exactly 10 bytes apart — still same cluster (within threshold)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn errors_at_exactly_threshold_boundary_suppressed() -> Result<(), Box<dyn std::error::Error>> {
+    // Two errors exactly 10 bytes apart from the same cluster head.
+    // They must be in the same cluster (within 10 bytes ≡ distance ≤ 10).
+    let source = "x x x x x x x x x x x x x x x x x x x x x x x x x x x x";
+    let errors = vec![
+        ParseError::UnexpectedToken {
+            location: 0,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+        ParseError::UnexpectedToken {
+            location: 10,
+            expected: "statement".to_string(),
+            found: "x".to_string(),
+        },
+    ];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert_eq!(
+        parse_diags.len(),
+        1,
+        "Errors 10 bytes apart (at threshold) should collapse to one, got {}",
+        parse_diags.len()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 6. Non-parse-error diagnostics (warnings/hints) are unaffected by suppression
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_parse_error_diagnostics_not_suppressed() -> Result<(), Box<dyn std::error::Error>> {
+    // Submit no parse errors, just let scope/lint analysis run.
+    // Even if scope/lint produces diagnostics close together, they should not
+    // be suppressed (cascade suppression only targets parse-error codes).
+    let source = "use strict;\nuse warnings;\nmy $x = 1;\nmy $y = 1;\n";
+    let ast = empty_program(source.len());
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    let diags = provider.get_diagnostics(&ast, &[], source, None);
+
+    // All diagnostics should have a code (regression check)
+    for d in &diags {
+        assert!(d.code.is_some(), "Every diagnostic should carry a code: {d:?}");
+    }
+    // No parse-error codes should appear (no parse errors submitted)
+    let parse_diags = parse_errors_only(&diags);
+    assert!(
+        parse_diags.is_empty(),
+        "No parse errors submitted, none should appear: {parse_diags:?}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 7. Empty input — empty output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_error_list_produces_empty_parse_diagnostics() -> Result<(), Box<dyn std::error::Error>> {
+    let diags = run_diagnostics("", vec![]);
+    let parse_diags = parse_errors_only(&diags);
+    assert!(parse_diags.is_empty(), "No errors in, no parse diagnostics out");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 8. Exact duplicates and cascades — both removed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exact_duplicate_cascades_all_removed() -> Result<(), Box<dyn std::error::Error>> {
+    // Two exact-duplicate errors at offset 5, plus a cascade at offset 7.
+    // After dedup: exact-dup collapse to one, then cascade-suppress → one total.
+    let source = "my $x = foo(1, 2, 3\nmy $y = 2;\n";
+    let errors = vec![
+        ParseError::UnexpectedToken {
+            location: 5,
+            expected: "expression".to_string(),
+            found: "foo".to_string(),
+        },
+        // exact duplicate
+        ParseError::UnexpectedToken {
+            location: 5,
+            expected: "expression".to_string(),
+            found: "foo".to_string(),
+        },
+        // cascade at 7 (within 10 bytes of 5)
+        ParseError::UnexpectedToken {
+            location: 7,
+            expected: "expression".to_string(),
+            found: "1".to_string(),
+        },
+    ];
+
+    let diags = run_diagnostics(source, errors);
+    let parse_diags = parse_errors_only(&diags);
+
+    assert_eq!(
+        parse_diags.len(),
+        1,
+        "Exact duplicate + cascade should collapse to a single diagnostic, got {}",
+        parse_diags.len()
+    );
+    Ok(())
+}

--- a/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
@@ -344,27 +344,32 @@ fn test_multiple_diagnostics_multiple_parse_errors() -> Result<(), Box<dyn std::
 
 #[test]
 fn test_multiple_diagnostics_each_has_distinct_range() -> Result<(), Box<dyn std::error::Error>> {
-    // Synthetic test: three errors at different locations should produce three diagnostics
-    let source = "aaa; bbb; ccc;";
+    // Synthetic test: three errors at well-separated locations should each survive
+    // cascade suppression.  Errors must be more than 10 bytes apart so they are
+    // treated as independent primary errors rather than cascades of a single failure.
+    let source = "aaa_long_token_here; bbb_long_token_there; ccc_long_token_final;";
     let ast = Arc::new(perl_parser_core::Node::new(
         perl_parser_core::NodeKind::Program { statements: vec![] },
         perl_parser_core::SourceLocation { start: 0, end: source.len() },
     ));
     let errors = vec![
         ParseError::SyntaxError { location: 0, message: "error at aaa".to_string() },
-        ParseError::SyntaxError { location: 5, message: "error at bbb".to_string() },
-        ParseError::SyntaxError { location: 10, message: "error at ccc".to_string() },
+        ParseError::SyntaxError { location: 21, message: "error at bbb".to_string() },
+        ParseError::SyntaxError { location: 43, message: "error at ccc".to_string() },
     ];
     let provider = DiagnosticsProvider::new(&ast, source.to_string());
     let diags = provider.get_diagnostics(&ast, &errors, source, None);
     let pe = parse_error_diags(&diags);
 
-    assert!(pe.len() >= 3, "Three distinct errors should produce at least 3 diagnostics");
+    assert!(
+        pe.len() >= 3,
+        "Three distinct errors (>10 bytes apart) should produce at least 3 diagnostics"
+    );
     // Verify they have distinct start offsets
     let starts: Vec<usize> = pe.iter().map(|d| d.range.0).collect();
     assert!(starts.contains(&0), "Should have diagnostic at offset 0");
-    assert!(starts.contains(&5), "Should have diagnostic at offset 5");
-    assert!(starts.contains(&10), "Should have diagnostic at offset 10");
+    assert!(starts.contains(&21), "Should have diagnostic at offset 21");
+    assert!(starts.contains(&43), "Should have diagnostic at offset 43");
     Ok(())
 }
 

--- a/crates/perl-lsp-diagnostics/tests/suggestion_quality_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/suggestion_quality_tests.rs
@@ -258,16 +258,25 @@ fn no_related_info_when_no_suggestion() -> Result<(), Box<dyn std::error::Error>
 
 #[test]
 fn all_parse_errors_have_code() -> Result<(), Box<dyn std::error::Error>> {
+    // Place errors far apart (> 10 bytes) so cascade suppression does not collapse
+    // them into a single cluster.  The goal of this test is to verify that every
+    // parse-error diagnostic carries a stable PL-prefixed code.
+    //
+    // Error placement:
+    //   - UnexpectedToken  @ offset 0  (PL001)
+    //   - LexerError       @ offset 30 (PL001) — global error, placed at a distinct cluster
+    //   - UnexpectedEof    @ source.len() = 60 (PL003)
+    let source = "a".repeat(60);
     let errors = vec![
         ParseError::UnexpectedToken {
             location: 0,
             expected: ";".to_string(),
             found: "x".to_string(),
         },
+        ParseError::SyntaxError { location: 30, message: "syntax error mid-file".to_string() },
         ParseError::UnexpectedEof,
-        ParseError::LexerError { message: "bad".to_string() },
     ];
-    let diags = diagnostics_for("bad code", errors);
+    let diags = diagnostics_for(&source, errors);
     let pd = parse_diags(&diags);
     assert!(pd.len() >= 3, "expected at least 3 parse-error diagnostics");
     for d in &pd {

--- a/crates/perl-lsp-diagnostics/tests/unit_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unit_tests.rs
@@ -310,12 +310,14 @@ fn provider_lexer_error() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn provider_multiple_errors() -> Result<(), Box<dyn std::error::Error>> {
+    // Errors must be more than 10 bytes apart so cascade suppression does not
+    // collapse them into a single cluster.
     let ast = Arc::new(program(vec![]));
-    let source = "x; y; z;";
+    let source = "aaa_long_sep_one; bbb_long_sep_two; ccc_long_sep_three;";
     let errors = vec![
         ParseError::SyntaxError { location: 0, message: "err1".to_string() },
-        ParseError::SyntaxError { location: 3, message: "err2".to_string() },
-        ParseError::SyntaxError { location: 6, message: "err3".to_string() },
+        ParseError::SyntaxError { location: 18, message: "err2".to_string() },
+        ParseError::SyntaxError { location: 36, message: "err3".to_string() },
     ];
     let provider = DiagnosticsProvider::new(&ast, source.to_string());
     let diagnostics = provider.get_diagnostics(&ast, &errors, source, None);


### PR DESCRIPTION
## Summary

- Adds cascade suppression as a second pass in `deduplicate_diagnostics()` in `crates/perl-lsp-diagnostics/src/dedup.rs`
- Groups adjacent parse-error diagnostics (PL001/PL002/PL003) by byte proximity: errors within 10 bytes of the current cluster head are treated as downstream cascades and suppressed
- Only the first diagnostic per cluster (the primary error) is kept; scope-analysis warnings and lint hints are never touched
- 8 new tests in `crates/perl-lsp-diagnostics/tests/cascade_suppression_tests.rs` covering: single error, distant errors, adjacent cascades, two-cluster scenarios, boundary at threshold, non-parse-error immunity, empty input, and combined exact-dedup + cascade

## Implementation notes

- Partition into parse-errors vs. others, sort parse-errors by start offset, walk keeping cluster heads, recombine
- Uses `std::mem::take` to avoid extra clone on the Vec
- Three pre-existing tests that used tightly-spaced synthetic errors (0, 3, 6 bytes apart) were updated to place errors >10 bytes apart; the old offsets were testing the wrong invariant (independence, not dedup)

## Test plan

- [x] `cargo test -p perl-lsp-diagnostics` — all 242 tests pass (0 failures)
- [x] `cargo clippy -p perl-lsp-diagnostics --lib` — no warnings
- [x] `cargo fmt --check -p perl-lsp-diagnostics` — clean
- [x] 8 new cascade-suppression tests: all green