### PR TITLE
test(parser): update known-broken hash subscript tests — $h{s} and $h{q} now clean (#2732)

### DIFF
--- a/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
+++ b/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
@@ -175,34 +175,29 @@ fn test_chained_hash_access_quote_op_keys() {
     assert_clean_parse(source);
 }
 
-// ── Known limitation: non-arrow hash subscript with quote-op keys ────────────
+// ── Non-arrow hash subscript with quote-op keys ──────────────────────────────
 //
-// $h{s} (no arrow) is a pre-existing bug documented in the PR's follow-ups.
-// Without `->`, after_arrow is false so the lexer treats `s` as a quote
-// operator and tries to parse `s}` as a substitution, failing. The is_quote_op_key
-// fix in parse_hash_subscript_key only catches the Identifier token emitted when
-// after_arrow=true (the arrow case). Fixing the non-arrow case requires broader
-// lexer context tracking for hash-subscript `{` and is out of scope for this PR.
-//
-// These tests assert the CURRENT (broken) behavior to prevent silent regression
-// (a future fix must convert these to assert_clean_parse).
+// $h{s} (no arrow) was previously broken — the lexer treated `s` as a quote
+// operator because after_arrow was false. Fixed by subsequent lexer work
+// (after_var_subscript tracking in PR #2833/#2844), which correctly suppresses
+// quote-operator recognition inside hash subscript braces even without `->`.
 
-/// $h{s} — bare hash subscript (no arrow) with quote-op key — known limitation.
-/// This fails with "Missing closing delimiter in substitution" because after_arrow
-/// is false so the lexer treats `s` as a substitution operator.
+/// $h{s} — bare hash subscript (no arrow) with quote-op key.
+/// Previously broken: lexer treated `s` as substitution operator.
+/// Fixed by after_var_subscript lexer tracking.
 #[test]
-fn test_non_arrow_hash_key_s_known_broken() {
-    // TODO(#2732-followup): fix non-arrow $h{s} — convert to assert_clean_parse when fixed
+fn test_non_arrow_hash_key_s() {
     let source = r#"my $x = $h{s};"#;
-    assert_has_error(source, "substitution");
+    assert_clean_parse(source);
 }
 
-/// $h{q} — bare hash subscript with 'q' key — known limitation.
+/// $h{q} — bare hash subscript with 'q' key.
+/// Previously broken: lexer treated `q` as quote operator.
+/// Fixed by after_var_subscript lexer tracking.
 #[test]
-fn test_non_arrow_hash_key_q_known_broken() {
-    // TODO(#2732-followup): fix non-arrow $h{q} — convert to assert_clean_parse when fixed
+fn test_non_arrow_hash_key_q() {
     let source = r#"my $x = $h{q};"#;
-    assert_has_error(source, "");
+    assert_clean_parse(source);
 }
 
 // ── Regression: space before paren delimiter (all four paired chars covered) ─


### PR DESCRIPTION
## Summary

- Converts two `assert_has_error` tests to `assert_clean_parse` in `fix_subst_unusual_delimiters_2732.rs`
- `test_non_arrow_hash_key_s_known_broken` → `test_non_arrow_hash_key_s` (assert clean)
- `test_non_arrow_hash_key_q_known_broken` → `test_non_arrow_hash_key_q` (assert clean)

These tests were written in PR #2776 to document that `$h{s}` and `$h{q}` (bare hash subscripts without `->`) were broken: the lexer treated `s`/`q` as quote operators when `after_arrow=false`. Subsequent lexer work (after_var_subscript tracking, PRs #2833 and #2844) fixed this behavior.

The tests were already **failing** on master because the parser had been fixed — they expected errors but found clean parses. This PR resolves the regression by updating the tests to match the corrected behavior.

## Evidence

```
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Before: `26 passed; 2 failed`
After: `28 passed; 0 failed`

Verified: `my $x = $h{s};` and `my $x = $h{q};` both parse with 0 ERROR nodes under the current parser.

## Interface & compatibility

- No production code changes — test file only
- No parser API changes

## Notes

**Data/Dumper.pm remaining error**: The 1 ERROR node still present in `/usr/lib/x86_64-linux-gnu/perl/5.38.2/Data/Dumper.pm` (at byte position 19006, `expected expression, found '}'`) is a pre-existing `unexpected_rbrace_expr` regression unrelated to issue #2732. It is in a different error bucket from `substitution_misparse` and traces back to the complex `$s->_dump(...)` call structure inside `sub _dump`, not any substitution operator parsing. This is tracked separately.

Closes #2732.