### PR TITLE
fix(deny): remove stale hashbrown@0.15.5 skip entry (#2749)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -81,9 +81,6 @@ skip = [
     { crate = "rand_core@0.9.5", reason = "transitive dep version split during rand_core 0.9 -> 0.10 migration" },
     { crate = "getrandom@0.3.4", reason = "older getrandom pulled by rand 0.9 transitives" },
 
-    # hashbrown: 0.15 vs 0.16 split
-    { crate = "hashbrown@0.15.5", reason = "transitive dep version split during hashbrown 0.15 -> 0.16 migration" },
-
     # cpufeatures: 0.2 vs 0.3 split
     { crate = "cpufeatures@0.2.17", reason = "transitive dep version split during cpufeatures 0.2 -> 0.3 migration" },
 


### PR DESCRIPTION
## Summary

- Removes the `hashbrown@0.15.5` skip entry from `deny.toml` that cargo deny was reporting as "skipped crate was not encountered"
- The transitive dependency has migrated to 0.16, making the skip entry stale/dead
- `cargo deny check` passes cleanly after removal: `advisories ok, bans ok, licenses ok, sources ok`

Closes #2749 (partial — the only quick-win actionable item from the security audit findings).

## Test plan

- [x] `cargo deny check` passes with no warnings or errors
- [x] No functional code changes — deny.toml config only