### PR TITLE
test(dap): fix vacuous feature catalog test + enumerate all 10 DAP feature IDs (#2784)

### DIFF
--- a/crates/perl-dap/tests/dap_coverage_audit_tests.rs
+++ b/crates/perl-dap/tests/dap_coverage_audit_tests.rs
@@ -1169,10 +1169,30 @@ fn test_debug_adapter_new() {
 
 #[test]
 fn test_feature_catalog_has_feature_known() {
-    // The feature catalog should have some basic DAP features
     let result = perl_dap::feature_catalog::has_feature("dap.breakpoints.basic");
-    // Just verify it doesn't panic and returns a boolean
-    let _: bool = result;
+    assert!(result, "dap.breakpoints.basic should be a registered feature");
+}
+
+#[test]
+fn test_feature_catalog_all_dap_features_registered() {
+    let all_ids = [
+        "dap.core",
+        "dap.breakpoints.basic",
+        "dap.breakpoints.hit_condition",
+        "dap.breakpoints.logpoints",
+        "dap.completions",
+        "dap.exceptions.die",
+        "dap.exceptions.warn",
+        "dap.inline_values",
+        "dap.modules",
+        "dap.watchpoints",
+    ];
+    for id in all_ids {
+        assert!(
+            perl_dap::feature_catalog::has_feature(id),
+            "feature `{id}` should be registered in the DAP catalog"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes two test-layer defects in the DAP feature catalog registration tests, identified by plan-review of issue #2784.

**Gap 1 — Broken no-op test:** `test_feature_catalog_has_feature_known` used `let _: bool = result` with no assertion. It passed regardless of whether `has_feature` returned `true` or `false` — a silent vacuous pass that provided zero regression protection.

**Gap 2 — Missing enumeration test:** No test verified that all 10 DAP feature IDs (`dap.core`, `dap.breakpoints.basic`, `dap.breakpoints.hit_condition`, `dap.breakpoints.logpoints`, `dap.completions`, `dap.exceptions.die`, `dap.exceptions.warn`, `dap.inline_values`, `dap.modules`, `dap.watchpoints`) are registered in the catalog. A feature could be removed from `features.toml` without triggering any test failure.

Both fixes are in `crates/perl-dap/tests/dap_coverage_audit_tests.rs` only. No production code changes.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

`test_feature_catalog_has_feature_known`: replaced `let _: bool = result` with `assert!(result, "dap.breakpoints.basic should be a registered feature")`.

New `test_feature_catalog_all_dap_features_registered`: iterates all 10 DAP feature IDs and asserts each returns `true` from `perl_dap::feature_catalog::has_feature`. This test will fail immediately if any feature ID is removed or misspelled in `features.toml`.

## How to review

Single file change: `crates/perl-dap/tests/dap_coverage_audit_tests.rs` lines 1170–1208. The diff is 23 additions, 3 deletions.

## Evidence

```
running 4 tests
test test_feature_catalog_advertised_features_not_empty ... ok
test test_feature_catalog_all_dap_features_registered ... ok
test test_feature_catalog_has_feature_known ... ok
test test_feature_catalog_has_feature_unknown ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 75 filtered out; finished in 0.00s

fmt:    PASS (0.3s)
clippy: PASS (30.8s)
test:   PASS — 0 failures across all 37 perl-dap test groups
```

ci-gate note: The full `just ci-gate` fails on `ci-check-todos` with 14 pre-existing violations in `xtask/` and `crates/perl-parser-core/` (introduced by upstream merges after this worktree was created). The baseline file on `master` is also `0`, so this affects all PRs currently — not specific to this change. None of the violations are in files touched by this PR.

## Risk & rollback

Blast radius: test file only. Rollback: revert the commit. No production behavior changed.

## Follow-ups

None. Plan-reviewer confirmed the 8 other supposedly-untested features all have substantial dedicated test files — the scout's gap count was based on a grep methodology flaw. This PR closes issue #2784.