### PR TITLE
test(parser): regression tests for s/''/'/g single-quote substitution delimiter (#2896)

### DIFF
--- a/crates/perl-parser-core/tests/fix_subst_squote_delimiter.rs
+++ b/crates/perl-parser-core/tests/fix_subst_squote_delimiter.rs
@@ -1,0 +1,53 @@
+//! Tests for issue #2896: s/''/'/g single-quote in substitution replacement
+//! with slash delimiter — the string-skip arm incorrectly treats `'` as a
+//! string opener, consuming past the closing `/`.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+/// Core failing case: empty pattern, single-quote replacement, slash delimiter.
+/// From TAP/Parser/YAMLish/Reader.pm and Log/Log4perl/DateFormat.pm.
+#[test]
+fn subst_slash_delim_squote_replacement() {
+    // $literal =~ s/''/'/g
+    assert_clean_parse(r#"$literal =~ s/''/'/g;"#);
+}
+
+/// Variant: single-quote pattern with double-single-quote replacement.
+/// From PgCommon.pm — this may already pass; kept as a regression guard.
+#[test]
+fn subst_slash_delim_squote_pattern_squote_replacement() {
+    // $value =~ s/'/''/g
+    assert_clean_parse(r#"$value =~ s/'/''/g;"#);
+}
+
+/// Double-quote variant: same structure with `"` as the replacement content.
+#[test]
+fn subst_slash_delim_dquote_replacement() {
+    assert_clean_parse(r#"$x =~ s/""/"/g;"#);
+}
+
+/// Single literal quote as the full replacement with /e modifier.
+#[test]
+fn subst_slash_delim_squote_replacement_e_modifier() {
+    assert_clean_parse(r#"$x =~ s/pat/'/e;"#);
+}
+
+/// Regression: s///e with string containing closing delimiter must still work.
+/// This exercises the string-skip logic that was added for issue #2395.
+#[test]
+fn subst_e_string_containing_closing_delim_regression() {
+    assert_clean_parse(r#"$str =~ s/([A-Za-z]+)/join('/', @parts)/ge;"#);
+}
+
+/// Regression: s///e with double-quoted string containing /.
+#[test]
+fn subst_e_dquoted_string_containing_slash_regression() {
+    assert_clean_parse(r#"$str =~ s/foo/sprintf("%s/%s", $a, $b)/e;"#);
+}
+
+/// Regression: plain s/// with slash delimiter still works.
+#[test]
+fn subst_slash_delim_basic_regression() {
+    assert_clean_parse(r#"$x =~ s/foo/bar/g;"#);
+}

--- a/crates/perl-quote/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-quote/tests/comprehensive_unit_tests.rs
@@ -5,7 +5,7 @@ use perl_quote::{
     extract_substitution_parts_strict, extract_transliteration_parts,
     validate_substitution_modifiers,
 };
-use perl_tdd_support::must::{must, must_err};
+use perl_tdd_support::{must, must_err};
 
 /// Helper to convert SubstitutionError results (which don't impl std::error::Error)
 fn strict(input: &str) -> (String, String, String) {
@@ -828,4 +828,38 @@ fn test_strict_subst_slash_in_double_quoted_replacement() {
     assert_eq!(pat, "foo");
     assert_eq!(repl, r#"sprintf("%s/%s", $a, $b)"#);
     assert_eq!(mods, "e");
+}
+
+// ──────────────────────────────────────────────────────────────
+// Issue #2896: s/''/'/g — single-quote as literal replacement char
+// ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_strict_subst_squote_as_replacement_char() {
+    // s/''/'/g — replacement is a literal single-quote character
+    // This is the primary failing case from TAP/Parser/YAMLish/Reader.pm
+    let (pat, repl, mods) = strict("s/''/'/g");
+    assert_eq!(pat, "''");
+    assert_eq!(repl, "'");
+    assert_eq!(mods, "g");
+}
+
+#[test]
+fn test_strict_subst_squote_slash_join_regression() {
+    // Regression guard: join('/', @parts) replacement must still work.
+    // `'` immediately followed by `/` (closing delimiter) then `'` (quote) —
+    // this is the tricky case that requires lookahead.
+    let (pat, repl, mods) = strict(r#"s/([A-Za-z]+)/join('/', @parts)/ge"#);
+    assert_eq!(pat, "([A-Za-z]+)");
+    assert_eq!(repl, "join('/', @parts)");
+    assert_eq!(mods, "ge");
+}
+
+#[test]
+fn test_strict_subst_dquote_as_replacement_char() {
+    // Double-quote variant of the same bug
+    let (pat, repl, mods) = strict(r#"s/""/"/g"#);
+    assert_eq!(pat, r#""""#);
+    assert_eq!(repl, r#"""#);
+    assert_eq!(mods, "g");
 }


### PR DESCRIPTION
## Summary

Adds regression tests for issue #2896: the s/''/'/g misparse where a single-quote character used as a literal replacement character (with slash as the substitution delimiter) was incorrectly treated as a string opener.

The core lexer and perl-quote fixes landed separately in master (lexer via `repl_inner_string_lookahead` guard, perl-quote via `scan_inner_string` lookahead). This PR adds the test coverage that documents and guards those fixes.

## Interface & compatibility
- perl-parser API: unchanged
- LSP surface: unchanged
- DAP surface: unchanged
- CLI: unchanged

## What changed

**New test file** `crates/perl-parser-core/tests/fix_subst_squote_delimiter.rs` (7 tests):
- `subst_slash_delim_squote_replacement` — primary case `$literal =~ s/''/'/g` from TAP/Parser/YAMLish/Reader.pm
- `subst_slash_delim_squote_pattern_squote_replacement` — `$value =~ s/'/''/g` from PgCommon.pm (regression guard)
- `subst_slash_delim_dquote_replacement` — double-quote variant
- `subst_slash_delim_squote_replacement_e_modifier` — `s/pat/'/e`
- Three regression guards for existing s///e string-skip behavior (issue #2395)

**Updated** `crates/perl-quote/tests/comprehensive_unit_tests.rs`:
- Fixed pre-existing broken import `perl_tdd_support::must::{must, must_err}` -> `perl_tdd_support::{must, must_err}`
- Added 3 new unit tests for `extract_substitution_parts_strict` covering s/''/'/g, the join('/', @parts) regression case, and double-quote variant

## How to review

Start at `crates/perl-parser-core/tests/fix_subst_squote_delimiter.rs` — all 7 tests should be green. Then check the 3 new tests at the bottom of `crates/perl-quote/tests/comprehensive_unit_tests.rs` and the import fix on line 8.

## Evidence

```
test result: ok. 7 passed; 0 failed; 0 ignored
  (fix_subst_squote_delimiter.rs — all cases including s/''/'/g)

test result: ok. 101 passed; 0 failed; 0 ignored
  (comprehensive_unit_tests.rs — 3 new tests + import fix)
```

## Risk & rollback

Test-only PR. No production code changes. Zero risk. Rollback = revert the commit.

## Follow-ups

None. Core fix is already in master. These tests complete the paper trail for issue #2896.