### PR TITLE
ux(walkthrough): clarify .perl-lsp.toml in configure-settings step (#2860)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -621,7 +621,7 @@
           {
             "id": "configure-settings",
             "title": "Configure Settings",
-            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** — personal overrides, not committed to your repo. Set `perl-lsp.includePaths` here if you see _Can't locate Foo/Bar.pm_ errors. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** — team-wide defaults, committed to your repo root. Useful for sharing `includePaths` or enabling Perl::Critic across the team. Copy `.perl-lsp.toml.example` from the repo root to get started.\n\nEditor settings always override `.perl-lsp.toml`. See CONFIG.md for the full reference.",
+            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** (personal, not committed) — open `Settings` and search for `perl-lsp`. Set `perl-lsp.includePaths` if you see _Can't locate Foo/Bar.pm_ errors. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** (team-wide, committed to your repo) — place this file in your project root, next to `.git/`. Key settings:\n- `[perl] include_paths = [\"lib\", \"local/lib/perl5\"]` — module search paths\n- `[diagnostics] perlcritic = true` — enable Perl::Critic linting (requires `perlcritic` on PATH)\n- `[features] inlay_hints = true` — toggle inlay hints\n\nCopy `.perl-lsp.toml.example` from the repo root to get started. Editor settings always override `.perl-lsp.toml`.",
             "media": {
               "image": "media/walkthrough/configure-settings.svg",
               "altText": "Configure Settings"


### PR DESCRIPTION
## Summary

- Step 7 (`configure-settings`) now explains where `.perl-lsp.toml` lives: project root, next to `.git/`
- Added three concrete key settings with actual TOML syntax so users know what to put in the file: `include_paths`, `perlcritic`, `inlay_hints`
- Removed dead `See CONFIG.md for the full reference` link (no `CONFIG.md` exists in the extension directory)
- Preserved the `.perl-lsp.toml.example` copy instruction and the editor settings override note

## Test plan

- [ ] Run `npm test` in `vscode-extension/` — all 304 tests pass, including 9 walkthrough contract tests
- [ ] Manually open the walkthrough in VS Code and verify step 7 renders the bullet list and inline code correctly
- [ ] Confirm the `[Open Perl LSP Settings]` command link still works