### PR TITLE
docs: audit and fix documentation for v0.12.0 public alpha (#2847)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ cargo test --workspace --lib          # Run all tests
 
 ## Crate Structure
 
-128 workspace members across 129 crate directories (see `cargo metadata --no-deps`). Key crates:
+134 workspace members across 135 crate directories (see `cargo metadata --no-deps`). Key crates:
 
 | Crate | Path | Purpose |
 |-------|------|---------|

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 > Install in minutes, get completions and navigation immediately.
 > [Report issues](https://github.com/EffortlessMetrics/perl-lsp/issues) or [join the conversation](https://github.com/EffortlessMetrics/perl-lsp/discussions).
 
-**The only Perl language server that doesn't require Perl to work.** A zero-dependency Rust binary with 97 LSP features, validated against thousands of real-world CPAN modules. Works on Windows, Mac, and Linux out of the box.
+**The only Perl language server that doesn't require Perl to work.** A zero-dependency Rust binary with 98 LSP features, validated against thousands of real-world CPAN modules. Works on Windows, Mac, and Linux out of the box.
 
 ## Why perl-lsp?
 
 - **No Perl runtime required** -- a single native binary; no dependency on a working Perl installation for IDE features.
 - **Fast** -- sub-millisecond incremental parsing, under 50ms LSP response times.
-- **Comprehensive** -- 97 LSP/DAP features including completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic highlighting, code actions, and debugging.
+- **Comprehensive** -- 98 LSP/DAP features including completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic highlighting, code actions, and debugging.
 - **Broad syntax coverage** -- parses Perl 5.8 through 5.40 including heredocs, regex, quoting constructs, formats, and OO frameworks.
 - **CPAN-validated** -- continuously tested against top CPAN distributions with a ratchet-only-forward CI gate that never allows regressions.
 
@@ -207,7 +207,7 @@ Current parse rates and the edge-case roadmap are tracked in [CURRENT_STATUS.md]
 
 ## Architecture
 
-The workspace is organized as 120+ focused Rust crates, each with a single responsibility. The main entry points:
+The workspace is organized as 130+ focused Rust crates, each with a single responsibility. The main entry points:
 
 | Crate | Purpose |
 |-------|---------|

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Perl Language Server (perl-lsp) v0.12.0 provides a high-performance Language Server Protocol implementation for Perl with ~100% syntax coverage.
+Perl Language Server (perl-lsp) is a high-performance Language Server Protocol implementation for Perl 5. The current release is [v0.12.0](https://github.com/EffortlessMetrics/perl-lsp/releases/latest) (public alpha).
 
 ## Install from crates.io
 
@@ -18,48 +18,40 @@ cargo install perl-lsp --force
 
 ### Pre-compiled Binaries
 
-1. Download the appropriate binary for your system from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
-2. Extract the archive
-3. Move the `perl-lsp` binary to a directory in your PATH
+1. Go to [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and download the latest release for your platform.
+2. Extract the archive.
+3. Move the `perl-lsp` binary to a directory in your PATH.
 
-#### Linux x86_64
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.12.0/perl-lsp-0.12.0-x86_64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.12.0-x86_64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.12.0-x86_64-unknown-linux-gnu/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
+Binaries are provided for the following platforms:
 
-#### Linux aarch64
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.12.0/perl-lsp-0.12.0-aarch64-unknown-linux-gnu.tar.gz
-tar xzf perl-lsp-0.12.0-aarch64-unknown-linux-gnu.tar.gz
-sudo cp perl-lsp-0.12.0-aarch64-unknown-linux-gnu/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
+| Platform | Binary suffix |
+|----------|--------------|
+| Linux x86_64 | `x86_64-unknown-linux-gnu` |
+| Linux aarch64 | `aarch64-unknown-linux-gnu` |
+| macOS Intel | `x86_64-apple-darwin` |
+| macOS Apple Silicon | `aarch64-apple-darwin` |
+| Windows x86_64 | `x86_64-pc-windows-msvc` |
 
-#### macOS x86_64
+#### Linux / macOS (general)
 ```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.12.0/perl-lsp-0.12.0-x86_64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.12.0-x86_64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.12.0-x86_64-apple-darwin/perl-lsp /usr/local/bin/
-chmod +x /usr/local/bin/perl-lsp
-```
-
-#### macOS aarch64 (Apple Silicon)
-```bash
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.12.0/perl-lsp-0.12.0-aarch64-apple-darwin.tar.gz
-tar xzf perl-lsp-0.12.0-aarch64-apple-darwin.tar.gz
-sudo cp perl-lsp-0.12.0-aarch64-apple-darwin/perl-lsp /usr/local/bin/
+# Replace VERSION and ARCH with values from the releases page
+# e.g. VERSION=0.12.0 ARCH=x86_64-unknown-linux-gnu
+wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perl-lsp-${VERSION}-${ARCH}.tar.gz
+tar xzf perl-lsp-${VERSION}-${ARCH}.tar.gz
+sudo cp perl-lsp-${VERSION}-${ARCH}/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
 #### Windows x86_64
 ```powershell
-wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.12.0/perl-lsp-0.12.0-x86_64-pc-windows-msvc.zip
-Expand-Archive perl-lsp-0.12.0-x86_64-pc-windows-msvc.zip
-Copy-Item perl-lsp-0.12.0-x86_64-pc-windows-msvc\perl-lsp.exe C:\Program Files\perl-lsp\
+# Replace VERSION with the version from the releases page (e.g. 0.12.0)
+$VERSION = "0.12.0"
+Invoke-WebRequest "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v$VERSION/perl-lsp-$VERSION-x86_64-pc-windows-msvc.zip" -OutFile perl-lsp.zip
+Expand-Archive perl-lsp.zip -DestinationPath perl-lsp
+Copy-Item perl-lsp\perl-lsp.exe "C:\Program Files\perl-lsp\"
 ```
+
+For the latest version number, always check [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
 ### Build from Source
 
@@ -148,7 +140,7 @@ perl-lsp --stdio
 
 ## Features
 
-- **~100% Perl Syntax Coverage**: Handles all modern Perl constructs
+- **Broad Perl Syntax Coverage**: Handles Perl 5.8 through 5.40 syntax including modern constructs
 - **Real-time Syntax Checking**: Instant feedback on code issues
 - **Code Completion**: Intelligent autocomplete with type inference
 - **Go-to-Definition**: Navigate to symbol definitions
@@ -212,7 +204,7 @@ perl-lsp --completion bash         # Generate shell completions
 3. Look for error messages in your editor's LSP logs
 
 #### Slow performance
-1. Ensure you're using the latest version (v0.12.0)
+1. Ensure you're using the [latest release](https://github.com/EffortlessMetrics/perl-lsp/releases/latest)
 2. Check if your workspace has very large Perl files (>100KB)
 3. Consider using `.perl-lspignore` to exclude unnecessary files
 

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,9 +5,9 @@
 
 ## What's True Right Now
 
-- **Release posture**: the current release line is `v0.11.0` public alpha; the active milestone is `v0.12.0` hardening, not a shipped release
+- **Release posture**: `v0.12.0` is the current shipped public alpha; the active milestone is `v0.12.0` hardening and CPAN coverage improvement
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
-- **LSP server**: `features.toml` is the canonical capability catalog; computed coverage is generated from it
+- **LSP server**: `features.toml` is the canonical capability catalog; 98 features all at GA maturity — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `bash scripts/ignored-test-count.sh` is the tracked-test-debt source
 - **Parser stack**: the default parser path is the native recursive-descent stack backed by the Rust lexer and parser-core crates
 - **Refactoring engine**: inline and move-code flows exist; broader refactoring hardening is still roadmap work
@@ -26,8 +26,8 @@
 
 ## What's Next
 
-**Now (active milestone: v0.12.0 hardening sprint on top of the v0.11.0 release line)**
-- Raise the CPAN top-1000 full-corpus baseline from `72.1%` (`3139/4355`) to `90%+` clean parses while keeping the strict known-clean manifest at `100%`
+**Now (active milestone: v0.12.0 hardening)**
+- Raise the CPAN top-1000 full-corpus baseline from `85.4%` (`3717/4355`) to `90%+` clean parses while keeping the strict known-clean manifest at `100%`
 - Close repo-corpus coverage gaps (`63/68` NodeKinds currently covered) and retire the remaining parser audit `P2` hang-risk candidate
 - Land Moo/Moose/Class::Accessor, `use parent`/`use base`, and export-list disambiguation work needed for public-alpha expectations
 - Raise workspace production-code coverage from the new baseline of `44.7%` lines / `46.9%` functions / `42.6%` regions
@@ -66,5 +66,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-03-22 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-03-23 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -27,10 +27,10 @@ perl-lsp --stdio --log  # With debug logging
 ### DAP Server (Debug Adapter)
 ```bash
 # Build DAP server
-cargo build -p perl-parser --bin perl-dap --release
+cargo build -p perl-dap --release
 
 # Install DAP server globally
-cargo install --path crates/perl-parser --bin perl-dap
+cargo install --path crates/perl-dap
 
 # Run the DAP server (for VSCode integration)
 perl-dap --stdio  # Standard DAP transport
@@ -83,7 +83,7 @@ cargo build -p perl-parser --features incremental --release
 cargo build --all
 ```
 
-## Workspace Configuration (v0.8.8+)
+## Workspace Configuration
 
 The workspace uses an exclusion strategy to ensure reliable builds across all platforms:
 
@@ -115,64 +115,26 @@ The xtask crate is excluded from the workspace to maintain clean builds while pr
 
 ## Test Commands
 
-### Workspace Testing (v0.8.8)
+### Workspace Testing
 ```bash
-# Test core published crates (workspace members only)
-cargo test                              # Tests perl-lexer, perl-parser, perl-corpus, perl-lsp
-                                        # Excludes crates with system dependencies
+# Test all workspace crates
+cargo test --workspace --lib            # Library tests only (fast)
+cargo test --workspace                  # All tests
 
-# Test individual published crates
-cargo test -p perl-parser               # Main parser library tests (195 tests)
-cargo test -p perl-lexer                # Lexer tests (40 tests)  
-cargo test -p perl-corpus               # Corpus tests (12 tests)
-cargo test -p perl-lsp                  # LSP integration tests
-
-# Advanced test commands (excluded from workspace, run from xtask directory)
-# cd xtask && cargo run test            # Advanced xtask test suite
-# cd xtask && cargo run corpus          # Dual-scanner corpus comparison
+# Test individual crates
+cargo test -p perl-parser               # Parser tests
+cargo test -p perl-lexer                # Lexer tests
+cargo test -p perl-lsp                  # LSP server tests
+cargo test -p perl-dap                  # DAP server tests
 ```
 
-### Comprehensive Integration Testing
+### LSP Integration Testing
 ```bash
-# LSP E2E tests
-cargo test -p perl-parser --test lsp_comprehensive_e2e_test  # 33 LSP E2E tests
+# Run with reduced thread count for reliability
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 
-# Symbol documentation tests (comment extraction)
-cargo test -p perl-parser --test symbol_documentation_tests
-
-# File completion tests
-cargo test -p perl-parser --test file_completion_tests
-
-# DAP tests
-cargo test -p perl-parser --test dap_comprehensive_test
-cargo test -p perl-parser --test dap_integration_test -- --ignored  # Full integration test
-
-# Incremental parsing tests
-cargo test -p perl-parser --test incremental_integration_test --features incremental
-cargo test -p perl-parser --features incremental
-cargo test -p perl-parser incremental_v2::tests            # IncrementalParserV2 tests
-
-# Performance and benchmark tests  
-cargo test -p perl-parser --test incremental_perf_test
-cargo bench incremental --features incremental
-```
-
-### Enhanced Workspace Navigation Tests (v0.8.8)
-```bash
-# Test comprehensive AST traversal with ExpressionStatement support
-cargo test -p perl-parser --test workspace_comprehensive_traversal_test
-
-# Test enhanced code actions and refactoring
-cargo test -p perl-parser code_actions_enhanced
-
-# Test improved call hierarchy provider
-cargo test -p perl-parser call_hierarchy_provider
-
-# Test enhanced workspace indexing and symbol resolution
-cargo test -p perl-parser workspace_index workspace_rename
-
-# Test TDD basic functionality enhancements
-cargo test -p perl-parser tdd_basic
+# Run specific test by name
+cargo test -p perl-parser -- test_name --exact
 ```
 
 ### WSL-Safe Local Gate (*Diataxis: How-to Guide* - Resource-constrained testing)
@@ -214,73 +176,19 @@ CARGO_BUILD_JOBS=4 RUST_TEST_THREADS=2 ./scripts/gate-local.sh
 | `RUST_TEST_THREADS` | 1 | Test parallelism (1 = serial) |
 | `GATE_RELEASE` | unset | Set to "1" for release builds |
 
-### Performance Testing (PR #140) (*Diataxis: How-to Guide* - Test reliability)
+### LSP Test Threading
 
-PR #140 delivers significant performance optimizations for test speed and reliability:
-
-- **LSP behavioral tests**: 1560s+ → 0.31s
-- **User story tests**: 1500s+ → 0.32s
-- **Workspace tests**: 60s+ → 0.26s
-- **Overall suite**: 60s+ → <10s
-
-The testing infrastructure includes adaptive threading configuration that scales timeouts and concurrency based on system constraints, enhanced with intelligent symbol waiting and optimized idle detection cycles.
+The LSP test suite uses adaptive threading. Use `RUST_TEST_THREADS=2` for reliable CI behavior:
 
 ```bash
-# CI testing with adaptive timeouts (PR #140 optimizations)
-RUST_TEST_THREADS=2 cargo test -p perl-lsp              # Adaptive threading behavioral tests
-RUST_TEST_THREADS=2 cargo test -p perl-parser           # Enhanced with intelligent symbol waiting
+# Reliable CI and development default
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 
-# Optimized single-threaded testing (maximum reliability)
-RUST_TEST_THREADS=1 cargo test --test lsp_comprehensive_e2e_test  # Exponential backoff protection
+# Override test timeouts for slow environments
+LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp
 
-# High-performance development environment
-cargo test -p perl-lsp                                   # 200ms idle detection cycles (was 1000ms)
-cargo test                                               # <10s total execution (was >60s)
-
-# Enhanced timeout configuration (PR #140 features)
-LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp        # Override adaptive timeouts
-LSP_TEST_SHORT_MS=1000 cargo test -p perl-lsp           # Fine-grained timeout control
-
-# Advanced debugging with performance monitoring
-LSP_TEST_ECHO_STDERR=1 RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --nocapture
-RUST_LOG=debug cargo test -p perl-lsp -- --nocapture    # Monitor timeout scaling
-```
-
-#### Performance Matrix (*Diataxis: Reference* - PR #140 achievements)
-
-| Test Suite | Before PR #140 | After PR #140 |
-|------------|----------------|----------------|
-| **lsp_behavioral_tests** | 1560s+ | 0.31s |
-| **lsp_full_coverage_user_stories** | 1500s+ | 0.32s |
-| **Individual workspace tests** | 60s+ | 0.26s |
-| **lsp_golden_tests** | 45s | 2.1s |
-| **Overall test suite** | 60s+ | <10s |
-
-#### Enhanced Thread Configuration Reference (*Diataxis: Reference* - Multi-tier timeout scaling)
-
-| Environment | Thread Count | LSP Harness | Comprehensive | Idle Detection | Use Case |
-|------------|-------------|-------------|--------------|----------------|----------|
-| **CI/GitHub Actions** | 0-2 | 500ms | 15s | 200ms cycles | Resource-constrained automation |
-| **Constrained Dev** | 3-4 | 300ms | 10s | 200ms cycles | Limited hardware development |
-| **Light Constraint** | 5-8 | 200ms | 7.5s | 200ms cycles | Modern development machines |
-| **Full Workstation** | >8 | 200ms | 5s | 200ms cycles | High-performance development |
-
-#### Thread-Aware Test Examples (*Diataxis: Tutorial* - Common testing patterns)
-
-```bash
-# GitHub Actions CI configuration
-- name: Run LSP tests
-  run: RUST_TEST_THREADS=2 cargo test -p perl-lsp
-  timeout-minutes: 10
-
-# Local development on limited hardware
-RUST_TEST_THREADS=4 cargo test -p perl-parser --test lsp_comprehensive_e2e_test
-
-# High-performance workstation (default behavior)
-cargo test  # Uses all available threads, standard 5-second timeouts
-
-# Debug timeout issues
-RUST_LOG=debug LSP_TEST_ECHO_STDERR=1 RUST_TEST_THREADS=1 cargo test -p perl-lsp --test specific_test
+# Debug failing tests
+RUST_LOG=debug LSP_TEST_ECHO_STDERR=1 cargo test -p perl-lsp -- --nocapture
 ```
 
 ## Parser Commands
@@ -308,21 +216,14 @@ cargo run -p perl-parser --example lsp_capabilities
 ### Core LSP Testing (*Diataxis: How-to Guide* - Development workflows)
 
 ```bash
-# Run LSP tests with performance optimizations (v0.8.8+)
-cargo test -p perl-parser lsp
-
-# Run LSP integration tests with controlled threading (recommended)
+# Run LSP tests (recommended thread configuration)
 RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 
-# Performance testing with enhanced test harness (PR #140)
-LSP_TEST_FALLBACKS=1 cargo test -p perl-lsp             # Fast mode with mock responses
+# Run parser-side LSP unit tests
+cargo test -p perl-parser lsp
 
-# Optimal CI performance with adaptive configuration
-RUST_TEST_THREADS=2 LSP_TEST_FALLBACKS=1 cargo test -p perl-lsp -- --test-threads=2
-
-# Enhanced test harness features (PR #140)
-cargo test -p perl-lsp --test lsp_behavioral_tests       # Adaptive threading tests
-cargo test -p perl-lsp --test lsp_full_coverage_user_stories  # User story tests
+# Fast mode for CI
+RUST_TEST_THREADS=2 cargo test -p perl-lsp -- --test-threads=2
 
 # Run specific performance-sensitive tests with threading control
 RUST_TEST_THREADS=2 cargo test -p perl-lsp test_completion_detail_formatting -- --test-threads=2
@@ -347,66 +248,36 @@ perl-lsp --stdio < test_requests.jsonrpc
 
 ### LSP Testing Environment Variables (*Diataxis: Reference* - Configuration options)
 
-**RUST_TEST_THREADS** (**Enhanced in PR #140**):
+**RUST_TEST_THREADS**:
 ```bash
-# Control test thread concurrency for optimal performance
+# Control test thread concurrency
 export RUST_TEST_THREADS=2                # Recommended for CI
 
-# Performance testing with adaptive timeouts
-RUST_TEST_THREADS=2 cargo test -p perl-lsp --test lsp_behavioral_tests     # 0.31s (was 1560s+)
-RUST_TEST_THREADS=2 cargo test -p perl-lsp --test lsp_full_coverage_user_stories  # 0.32s (was 1500s+)
-
-# Benefits of PR #140 threading optimization:
-# - Significantly faster behavioral test execution
-# - 100% test pass rate (was ~55% due to timeouts)
-# - Intelligent symbol waiting with exponential backoff
-# - Optimized idle detection (1000ms → 200ms cycles)
-# - Enhanced test harness with mock responses and graceful degradation
-
 # Thread configuration examples:
-cargo test -p perl-lsp -- --test-threads=2              # Optimal CI configuration
+cargo test -p perl-lsp -- --test-threads=2              # Reliable CI configuration
 RUST_TEST_THREADS=1 cargo test -p perl-lsp              # Maximum reliability mode
 RUST_TEST_THREADS=4 cargo test -p perl-lsp              # High-performance development
 ```
 
-**LSP_TEST_FALLBACKS** (**NEW in v0.8.8**):
+**LSP test environment**:
 ```bash
-# Enable fast testing mode (reduces test timeouts by ~75%)
-export LSP_TEST_FALLBACKS=1
-
 # Optional external dependencies for enhanced features
 export PERLTIDY_PATH="/usr/local/bin/perltidy"    # Custom perltidy location
 export PERLCRITIC_PATH="/usr/local/bin/perlcritic" # Custom perlcritic location
 
-# Performance characteristics in fallback mode:
-# - Base timeout: 500ms (vs 2000ms)
-# - Wait for idle: 50ms (vs 2000ms)  
-# - Symbol polling: single 200ms attempt (vs progressive backoff)
-# - Result: 99.5% faster test execution (60s+ → 0.26s for workspace tests)
+# Override adaptive test timeouts
+LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp
+LSP_TEST_SHORT_MS=1000 cargo test -p perl-lsp
 
-# Use cases:
-cargo test -p perl-lsp                    # Fast CI/development testing
-LSP_TEST_FALLBACKS=1 cargo test --workspace  # Quick workspace validation
-LSP_TEST_FALLBACKS=1 cargo check --workspace # Fast build verification
+# Debug test output
+LSP_TEST_ECHO_STDERR=1 cargo test -p perl-lsp -- --nocapture
 ```
 
-**PERL_LSP_INCREMENTAL**:
-```bash
-# Enable incremental parsing
-export PERL_LSP_INCREMENTAL=1
-perl-lsp --stdio
+### LSP executeCommand Integration (*Diataxis: How-to Guide* - Execute command usage)
 
-# Performance benefits:
-# - <1ms LSP updates with 70-99% node reuse efficiency
-# - Production-stable incremental parsing
-# - Enterprise-grade workspace refactoring support
-```
+The LSP server supports `workspace/executeCommand` with integrated perlcritic analysis and advanced code actions.
 
-### LSP executeCommand Integration ⭐ **NEW: Issue #145** (*Diataxis: How-to Guide* - Execute command usage)
-
-The LSP server now supports comprehensive `workspace/executeCommand` functionality with integrated perlcritic analysis and advanced code actions.
-
-#### perl.runCritic Command Usage ⭐ **NEW: Issue #145**
+#### perl.runCritic Command Usage
 
 **Dual Analyzer Strategy Overview** (*Diataxis: Explanation* - Architecture design):
 
@@ -551,7 +422,7 @@ cargo test -p perl-lsp --test lsp_performance_tests -- test_execute_command_late
 
 #### Supported executeCommand Operations (*Diataxis: Reference* - Complete command list)
 
-**Core Commands** (Available since v0.8.8+):
+**Core Commands**:
 ```bash
 # Test all supported executeCommand operations
 cargo test -p perl-lsp --test lsp_execute_command_tests -- test_supported_commands
@@ -567,9 +438,9 @@ cargo test -p perl-lsp --test lsp_behavioral_tests -- test_execute_command_debug
 - ✅ `perl.runFile` - Execute single Perl file with output capture
 - ✅ `perl.runTestSub` - Execute specific test subroutine with isolation
 - ✅ `perl.debugTests` - Debug test execution with breakpoint support
-- ✅ `perl.runCritic` - **NEW**: Perl::Critic analysis with dual analyzer strategy
+- ✅ `perl.runCritic` - Perl::Critic analysis with dual analyzer strategy (external + built-in fallback)
 
-### Advanced Code Actions Testing ⭐ **NEW: Issue #145** (*Diataxis: How-to Guide* - Code action workflows)
+### Advanced Code Actions Testing (*Diataxis: How-to Guide* - Code action workflows)
 
 **Refactoring Operations** (*Diataxis: Tutorial* - Using code actions for refactoring):
 ```bash
@@ -653,20 +524,16 @@ cargo test -p perl-lsp --test lsp_performance_benchmarks -- test_code_actions_th
 
 **Quality Assurance Commands**:
 ```bash
-# Acceptance criteria validation (Issue #145)
-cargo test -p perl-lsp --test lsp_execute_command_tests -- test_ac1_execute_command_implementation  # AC1
-cargo test -p perl-lsp --test lsp_execute_command_tests -- test_ac2_perlcritic_integration          # AC2
-cargo test -p perl-lsp --test lsp_code_actions_tests -- test_ac3_advanced_refactoring_operations   # AC3
-
-# Previously ignored tests now enabled
-cargo test -p perl-lsp --test lsp_behavioral_tests | grep -v "ignored"  # Verify test enablement
+# executeCommand integration tests
+cargo test -p perl-lsp --test lsp_execute_command_tests
+cargo test -p perl-lsp --test lsp_code_actions_tests
 ```
 
 The enhanced executeCommand and code actions integration delivers LSP functionality with <50ms response times, comprehensive error handling, and robust tool integration patterns.
 
 ## Benchmark Commands
 
-### Workspace Benchmarks (v0.8.8)
+### Workspace Benchmarks
 ```bash
 # Run parser benchmarks (workspace crates)
 cargo bench                             # Benchmarks for published crates
@@ -680,7 +547,7 @@ cargo bench -p perl-corpus              # Corpus validation performance
 cargo test -p perl-parser --test incremental_perf_test  # Incremental parsing performance
 ```
 
-### Comprehensive C vs Rust Benchmark Framework (v0.8.8)
+### Comprehensive C vs Rust Benchmark Framework
 ```bash
 # Run complete cross-language benchmark suite with statistical analysis
 cargo xtask bench                       # Complete benchmark workflow with C vs Rust comparison
@@ -721,7 +588,7 @@ cargo run --bin xtask -- validate-memory-profiling  # Test dual-mode memory meas
 
 ## Code Quality Commands
 
-### Workspace Quality Checks (v0.8.8)
+### Workspace Quality Checks
 ```bash
 # Run standard Rust quality checks (workspace crates)
 cargo fmt                              # Format workspace code
@@ -753,7 +620,7 @@ The watch recipes use `bacon.toml` with project-tuned jobs for faster local feed
 
 ## Dual-Scanner Corpus Comparison (*Diataxis: How-to Guide* - Testing procedures)
 
-### Running Dual-Scanner Corpus Tests (v0.8.8+)
+### Running Dual-Scanner Corpus Tests
 ```bash
 # Prerequisites: Install libclang-dev for C scanner support
 sudo apt-get install libclang-dev  # Ubuntu/Debian
@@ -1104,7 +971,7 @@ The unified scanner architecture provides:
 
 ## Edge Case Testing Commands
 
-### Workspace Edge Case Tests (v0.8.8)
+### Workspace Edge Case Tests
 ```bash  
 # Run comprehensive edge case tests (workspace crates)
 cargo test -p perl-parser               # Includes all edge case coverage

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -5,7 +5,7 @@
 [![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 
-A fast, native Perl 5 language server with 26+ IDE features. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
+A fast, native Perl 5 language server with 30+ IDE features. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
 > **0.12.0 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
 
@@ -172,6 +172,8 @@ The `perl-lsp` binary works with any editor that supports the Language Server Pr
 | **Cursor** | This extension |
 | **Neovim** | `nvim-lspconfig` with `perl_lsp` server |
 | **Emacs** | `lsp-mode` or `eglot` |
+| **Helix** | `languages.toml` with `perl-lsp --stdio` |
+| **Sublime Text** | LSP package with `perl-lsp --stdio` |
 | **GitHub Codespaces** | This extension |
 | **Gitpod** | This extension |
 


### PR DESCRIPTION
## Summary

Audits and fixes all user-facing documentation for accuracy after the v0.12.0 public alpha release.

- **README.md**: feature count 97→98 (matches `features.toml`), crate count 120+→130+
- **vscode-extension/README.md**: IDE feature count 26+→30+, add Helix and Sublime Text to compatibility table
- **docs/project/status/index.md**: fix stale v0.11.0 release posture → v0.12.0 (shipped), update CPAN baseline 72.1% (3139/4355) → 85.4% (3717/4355), note all 98 features at GA maturity
- **docs/how-to/INSTALLATION.md**: replace hardcoded v0.12.0 binary download URLs with version-neutral releases-page approach; fix `~100% syntax coverage` overclaim
- **docs/reference/COMMANDS_REFERENCE.md**: remove stale v0.8.8 version labels, PR #140 internal dev notes, Issue #145 acceptance-criteria references; fix incorrect DAP build commands (was `perl-parser --bin perl-dap`, now `perl-dap`)
- **CLAUDE.md**: update workspace crate count 128→134

## Root cause

The issue spec identified that status/index.md still described v0.11.0 as the release line and showed 72.1% corpus coverage despite v0.12.0 shipping and corpus reaching 85.4%. The corpus baseline was verified against `.ci/cpan-corpus-baseline.json` (3717/4355 clean files as of 2026-03-20). Feature count was verified against `features.toml` (98 `[[feature]]` entries, all `maturity = "ga"`). Crate count verified via `cargo metadata --no-deps` (134 members).

## What was NOT changed

- CONTRIBUTING.md: already current, no fixes needed
- docs/reference/CONFIG.md: comprehensive and accurate
- docs/reference/FAQ.md: already comprehensive (15+ Q&A pairs)
- CONFIGURATION.md: already a redirect stub to CONFIG.md, working correctly

## Test plan

- [ ] Verify README.md feature count matches `grep -c '^\[\[feature\]\]' features.toml` (should be 98)
- [ ] Verify INSTALLATION.md binary download section no longer has hardcoded version in URLs
- [ ] Verify status/index.md no longer says v0.11.0 or 72.1%
- [ ] Verify COMMANDS_REFERENCE.md has no remaining `v0.8.8`, `PR #140`, or `Issue #145` references
- [ ] Follow the INSTALLATION.md "Pre-compiled Binaries" instructions on a fresh machine — should reach the releases page without obsolete URLs