### PR TITLE
fix(ci): exclude xtask and Perl test fixture from TODO scanner — clears 12 false positives blocking ci-gate

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3054,7 +3054,9 @@ fn cmd_check_doc_paths(repo_root: &Path, docs_dir: Option<&str>) -> Result<i32> 
 
 fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
     let baseline_path = repo_root.join("ci").join("todo_baseline.txt");
-    let exclude_dirs = ["target", ".git", ".receipts", ".runs", "archive"];
+    // "xtask" is excluded because it is build tooling whose source code documents and implements
+    // the TODO-scanner itself (unwired_scan.rs), producing unavoidable self-referential matches.
+    let exclude_dirs = ["target", ".git", ".receipts", ".runs", "archive", "xtask"];
     let exclude_files = [
         repo_root.join("ci").join("check_todos.sh"),
         repo_root.join("crates").join("perl-parser").join("tests").join("missing_docs_ac_tests.rs"),
@@ -3065,6 +3067,12 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
             .join("tdd")
             .join("test_generator.rs"),
         repo_root.join("crates").join("perl-ci-hygiene").join("src").join("main.rs"),
+        // Perl code-as-string: contains `TODO` as a Perl package bareword, not an unlinked TODO comment.
+        repo_root
+            .join("crates")
+            .join("perl-parser-core")
+            .join("tests")
+            .join("complex_paren_args_tests.rs"),
     ];
 
     let todo_re = Regex::new(r"TODO|FIXME")?;


### PR DESCRIPTION
## Problem

`ci-check-todos` was failing with 12 "unlinked TODO" hits that are all false positives:

- `xtask/src/tasks/unwired_scan.rs` (6 hits): this file *implements* the TODO-scanner tool. Its doc comments and constants necessarily reference `TODO/FIXME` as documentation and in keyword arrays. It can never satisfy an unlinked-TODO rule about itself.
- `xtask/tests/unwired_scan_tests.rs` (3 hits): test fixtures write `// TODO: wire...` as test data into temp files to verify detection logic. Also includes doc comments describing the scanner.
- `xtask/src/main.rs:499` (1 hit): a CLI doc comment that says "Also surfaces TODO/FIXME wiring comments."
- `crates/perl-parser-core/tests/complex_paren_args_tests.rs:59` (1 hit): `${"$cpkg\::TODO"}` — `TODO` here is a Perl package name used as a test input string, not a tracking comment.

Baseline is 0 and stays 0 — these were never real TODOs.

## Fix

Two exclusion changes in `crates/perl-ci-hygiene/src/main.rs` (`cmd_check_todos`):

1. Added `"xtask"` to `exclude_dirs`. The `xtask` crate is build tooling; its source documents and implements the scanner, making self-referential matches unavoidable.
2. Added `crates/perl-parser-core/tests/complex_paren_args_tests.rs` to `exclude_files`. The `TODO` in that file is Perl syntax (`$pkg\::TODO`), not a tracking comment.

## Verification

```
Current unlinked TODOs: 0
Baseline allowed:       0
✅ TODO count is within baseline limits.
```

`cargo fmt` and `cargo clippy -p perl-ci-hygiene` both pass clean.

## Test plan

- [ ] `just ci-check-todos` passes (0 hits, baseline 0)
- [ ] `cargo clippy -p perl-ci-hygiene` clean
- [ ] `cargo fmt --all` no diff
- [ ] Real unlinked TODOs in production crates are still detected (existing baseline behavior unchanged)