### PR TITLE
chore(xtask): remove unused imports

### DIFF
--- a/xtask/src/tasks/parser_matrix.rs
+++ b/xtask/src/tasks/parser_matrix.rs
@@ -1,6 +1,5 @@
 //! Generate the parser feature matrix documentation from a corpus audit report.
 
-use crate::tasks::corpus_audit;
 use crate::utils::project_root;
 use chrono::Local;
 use color_eyre::eyre::{Context, ContextCompat, Result, bail, eyre};

--- a/xtask/src/tasks/worktrees.rs
+++ b/xtask/src/tasks/worktrees.rs
@@ -1,7 +1,7 @@
 //! Worktree maintenance helpers used by local agent operations.
 
 use crate::utils::project_root;
-use color_eyre::eyre::{Result, bail, eyre};
+use color_eyre::eyre::{Result, bail};
 use std::process::{Command, Stdio};
 use std::str;
 


### PR DESCRIPTION
## Summary
- remove unused imports in xtask helper tasks
- keep the follow-up cleanup separate from 

## Testing
- not run (warning-only cleanup)