### PR TITLE
docs(extension): align feature-count claim

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
-  "description": "Fast, native Perl 5 language server: go-to-definition, completions, diagnostics, refactoring, debugging, and 26+ IDE features. Zero runtime dependencies.",
+  "description": "Fast, native Perl 5 language server: go-to-definition, completions, diagnostics, refactoring, debugging, and 98 LSP/DAP features. Zero runtime dependencies.",
   "version": "0.12.0",
   "publisher": "EffortlessMetrics",
   "preview": true,


### PR DESCRIPTION
## Summary
- align VS Code extension description with the current public feature-count claim
- keep CPAN baseline docs unchanged because they report different metrics

## Testing
- not run (metadata-only cleanup)