### PR TITLE
fix(ci): enable automatic release triggers (#2954)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,7 @@ jobs:
           cat release_notes.md
 
       - name: Create GitHub Release
+        if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -284,6 +285,7 @@ jobs:
           cargo sbom --output-format spdx_json_2_3 > sbom-spdx.json
 
       - name: Upload SBOM as release asset
+        if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           files: sbom-spdx.json


### PR DESCRIPTION
Closes #2954

Adds release: types: [published] trigger to release.yml.

Previously workflow_dispatch-only, meaning automated distribution (Scoop, Chocolatey, winget) never fired on release.