### PR TITLE
fix(xtask): normalize cpanm install names

### DIFF
--- a/xtask/src/tasks/cpan_corpus.rs
+++ b/xtask/src/tasks/cpan_corpus.rs
@@ -629,10 +629,7 @@ mod tests {
     fn test_normalize_distribution_for_cpanm() {
         assert_eq!(normalize_distribution_for_cpanm("Try-Tiny"), "Try::Tiny");
         assert_eq!(normalize_distribution_for_cpanm("ExtUtils-MakeMaker"), "ExtUtils::MakeMaker");
-        assert_eq!(
-            normalize_distribution_for_cpanm("namespace-autoclean"),
-            "namespace::autoclean"
-        );
+        assert_eq!(normalize_distribution_for_cpanm("namespace-autoclean"), "namespace::autoclean");
         assert_eq!(normalize_distribution_for_cpanm("libwww-perl"), "LWP");
         assert_eq!(normalize_distribution_for_cpanm("PathTools"), "PathTools");
     }


### PR DESCRIPTION
## Summary
- split the remaining CPAN corpus fix out of local residue
- normalize dashed distribution names before invoking cpanm, with a special case for libwww-perl -> LWP
- count per-distribution failures from cpanm stderr instead of treating a whole batch as a single failure

## Testing
- cargo test -p xtask cpanm