### PR TITLE
fix(xtask): use cargo publish dry-run for launch prep

### DIFF
--- a/xtask/src/tasks/prep_crates_io_launch.rs
+++ b/xtask/src/tasks/prep_crates_io_launch.rs
@@ -187,6 +187,7 @@ fn run_cargo_publish_dry_run(root: &Path, crate_name: &str, patch_args: &[String
     let mut args = vec![
         "publish".to_string(),
         "--dry-run".to_string(),
+        "--locked".to_string(),
         "-p".to_string(),
         crate_name.to_string(),
     ];


### PR DESCRIPTION
## Summary
- split the remaining launch-prep fix out of local residue
- use cargo publish --dry-run instead of cargo package --no-verify in the prep flow
- align user-facing status text and error reporting with the command actually being run

## Testing
- cargo test -p xtask prep_crates_io_launch