### PR TITLE
chore(vscode): exclude coverage artifacts from VSIX

### DIFF
--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 out/test/**
+coverage/**
 src/**
 test/**
 .gitignore


### PR DESCRIPTION
## Summary\n- exclude generated Jest coverage artifacts from VSIX packaging\n- keep local test output from leaking into release bundles\n\n## Verification\n- cd vscode-extension && npm run verify:marketplace\n- confirmed coverage/ no longer appears in the packaged VSIX