### PR TITLE
fix(vscode): nudge completion on arrow intent (#2865)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -794,7 +794,7 @@ export function shouldNudgeArrowCompletion(linePrefix: string): boolean {
         return false;
     }
 
-    return /(?:\$[\w:]+|[@%][\w:]+|\)|\]|\}|[A-Z]\w*)$/.test(beforeDash);
+    return /(?:\$[\w:]+|[@%][\w:]+|[A-Z]\w*)$/.test(beforeDash);
 }
 
 export function maybeNudgeArrowCompletion(event: vscode.TextDocumentChangeEvent): void {

--- a/vscode-extension/src/test/arrowCompletion.test.ts
+++ b/vscode-extension/src/test/arrowCompletion.test.ts
@@ -65,4 +65,10 @@ describe('arrow completion nudge', () => {
     expect(shouldNudgeArrowCompletion('Foo:-')).toBe(false);
     expect(shouldNudgeArrowCompletion('Foo::')).toBe(false);
   });
+
+  test('does not treat closing delimiters as arrow intent', () => {
+    expect(shouldNudgeArrowCompletion('$arr[0]-')).toBe(false);
+    expect(shouldNudgeArrowCompletion('(foo)-')).toBe(false);
+    expect(shouldNudgeArrowCompletion('$h{key}-')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- nudge VS Code suggest when `-` looks like Perl arrow intent
- keep subtraction-like `-` and `::` behavior out of the nudge path
- add focused extension tests for the arrow-intent heuristic

## Verification
- cd vscode-extension && npm run test:ci -- src/test/arrowCompletion.test.ts --runInBand
- cd vscode-extension && npm run compile