### PR TITLE
fix(lsp): preserve call-hierarchy identity metadata for cross-file resolution

### DIFF
--- a/crates/perl-lsp/src/call_hierarchy_provider.rs
+++ b/crates/perl-lsp/src/call_hierarchy_provider.rs
@@ -27,6 +27,8 @@ pub struct CallHierarchyItem {
     pub selection_range: Range,
     /// Optional additional detail about the symbol
     pub detail: Option<String>,
+    /// Optional fully-qualified name used for cross-file disambiguation
+    pub qualified_name: Option<String>,
 }
 
 /// Call Hierarchy Provider
@@ -78,7 +80,8 @@ impl CallHierarchyProvider {
         item: &CallHierarchyItem,
     ) -> Vec<CallHierarchyIncomingCall> {
         let mut calls = Vec::new();
-        self.find_incoming_calls(ast, &item.name, &mut calls, None);
+        let target_name = item.qualified_name.as_deref().unwrap_or(&item.name);
+        self.find_incoming_calls(ast, target_name, &mut calls, None);
         calls
     }
 
@@ -126,6 +129,7 @@ impl CallHierarchyProvider {
                                     range,
                                     selection_range,
                                     detail,
+                                    qualified_name: None,
                                 });
                             }
                         } else {
@@ -146,6 +150,7 @@ impl CallHierarchyProvider {
                                 range,
                                 selection_range,
                                 detail,
+                                qualified_name: None,
                             });
                         }
                     }
@@ -159,6 +164,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        qualified_name: None,
                     });
                 }
                 NodeKind::FunctionCall { name, .. } => {
@@ -170,6 +176,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        qualified_name: Some(name.clone()),
                     });
                 }
                 _ => {}
@@ -203,6 +210,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range,
                         detail: None,
+                        qualified_name: None,
                     };
 
                     // Search within this function
@@ -214,7 +222,11 @@ impl CallHierarchyProvider {
             }
             NodeKind::FunctionCall { name, .. } => {
                 // Match exact name or package-qualified name (e.g. "Utils::format_string")
-                let matches = name == target_name || name.ends_with(&format!("::{}", target_name));
+                let matches = if target_name.contains("::") {
+                    name == target_name
+                } else {
+                    name == target_name || name.ends_with(&format!("::{}", target_name))
+                };
                 if matches {
                     if let Some(from) = current_function {
                         let ranges = vec![self.node_to_range(node)];
@@ -271,6 +283,7 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail: None,
+                    qualified_name: Some(name.clone()),
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -296,6 +309,7 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail,
+                    qualified_name: None,
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -332,6 +346,7 @@ impl CallHierarchyProvider {
                 range,
                 selection_range,
                 detail,
+                qualified_name: None,
             })
         } else {
             None
@@ -628,6 +643,21 @@ impl CallHierarchyItem {
         if let Some(detail) = &self.detail {
             item["detail"] = json!(detail);
         }
+        item["data"] = json!({
+            "uri": self.uri,
+            "name": self.name,
+            "qualified_name": self.qualified_name,
+            "range": {
+                "start": {
+                    "line": self.range.start.line,
+                    "character": self.range.start.character
+                },
+                "end": {
+                    "line": self.range.end.line,
+                    "character": self.range.end.character
+                }
+            }
+        });
 
         item
     }
@@ -750,6 +780,7 @@ sub target_func {
                     end: Position { line: 10, character: 15 },
                 },
                 detail: None,
+                qualified_name: None,
             };
 
             let incoming = provider.incoming_calls(&ast, &target_item);
@@ -801,6 +832,7 @@ sub helper {
                     end: Position { line: 1, character: 8 },
                 },
                 detail: None,
+                qualified_name: None,
             };
 
             let outgoing = provider.outgoing_calls(&ast, &main_item);

--- a/crates/perl-lsp/src/runtime/language/hierarchy.rs
+++ b/crates/perl-lsp/src/runtime/language/hierarchy.rs
@@ -399,7 +399,13 @@ impl LspServer {
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
             let item = &params["item"];
-            let target_name = item["name"].as_str().unwrap_or("");
+            let target_name = item
+                .get("data")
+                .and_then(|d| d.get("qualified_name"))
+                .and_then(Value::as_str)
+                .filter(|name| !name.is_empty())
+                .or_else(|| item["name"].as_str())
+                .unwrap_or("");
 
             eprintln!("Getting incoming calls for: {}", target_name);
 
@@ -553,7 +559,12 @@ impl LspServer {
         };
 
         let detail = json["detail"].as_str().map(|s| s.to_string());
+        let qualified_name = json
+            .get("data")
+            .and_then(|d| d.get("qualified_name"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
 
-        Ok(CallHierarchyItem { name, kind, uri, range, selection_range, detail })
+        Ok(CallHierarchyItem { name, kind, uri, range, selection_range, detail, qualified_name })
     }
 }

--- a/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
+++ b/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
@@ -1156,3 +1156,81 @@ process();
 
     Ok(())
 }
+
+/// Ensures CallHierarchyItem.data is preserved in responses for follow-up requests.
+#[test]
+fn test_call_hierarchy_item_data_round_trip() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    harness.open(
+        "file:///lib/Utils.pm",
+        r#"package Utils;
+
+sub format_string {
+    my $str = shift;
+    return uc($str);
+}
+
+1;
+"#,
+    )?;
+
+    harness.open(
+        "file:///bin/app.pl",
+        r#"use Utils;
+
+sub process {
+    my $result = Utils::format_string("hello");
+    return $result;
+}
+
+process();
+"#,
+    )?;
+
+    harness.barrier();
+
+    let prepare_response = harness.request(
+        "textDocument/prepareCallHierarchy",
+        json!({
+            "textDocument": { "uri": "file:///bin/app.pl" },
+            "position": { "line": 2, "character": 4 }
+        }),
+    )?;
+    let item = prepare_response
+        .as_array()
+        .and_then(|items| items.first())
+        .ok_or("prepareCallHierarchy returned no items for process")?;
+
+    assert_eq!(
+        item["data"]["uri"].as_str().unwrap_or(""),
+        "file:///bin/app.pl",
+        "prepareCallHierarchy item data should include URI"
+    );
+    assert_eq!(
+        item["data"]["name"].as_str().unwrap_or(""),
+        "process",
+        "prepareCallHierarchy item data should include symbol name"
+    );
+
+    let outgoing_response = harness.request("callHierarchy/outgoingCalls", json!({ "item": item }))?;
+    let calls = outgoing_response.as_array().ok_or("outgoingCalls returned non-array")?;
+    let format_call = calls
+        .iter()
+        .find(|c| {
+            c["to"]["name"]
+                .as_str()
+                .map(|n| n == "format_string" || n.ends_with("::format_string"))
+                .unwrap_or(false)
+        })
+        .ok_or("format_string outgoing call not found")?;
+
+    assert_eq!(
+        format_call["to"]["data"]["uri"].as_str().unwrap_or(""),
+        "file:///lib/Utils.pm",
+        "outgoing callee should keep canonical URI in data"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The call-hierarchy round-trip lost canonical identity because `CallHierarchyItem::to_json()` did not emit a `data` field, preventing follow-up `incomingCalls`/`outgoingCalls` from resolving targets across files.
- Preserve and propagate symbol identity (`qualified_name` + defining `uri`/`range`) so runtime handlers can disambiguate and resolve cross-file call sites without changing the broader index/parse-on-demand strategy yet.

### Description
- Added `qualified_name: Option<String>` to `CallHierarchyItem` and populated it for call sites where a qualified name is known in `crates/perl-lsp/src/call_hierarchy_provider.rs`.
- Extended `CallHierarchyItem::to_json()` to always emit a `data` object containing `uri`, `name`, `qualified_name`, and `range` for safe round-trips through the LSP client.
- Updated incoming/outgoing handlers in `crates/perl-lsp/src/runtime/language/hierarchy.rs` to read `data.qualified_name` and rebuild `CallHierarchyItem` with `qualified_name` so providers prefer qualified identity when matching.
- Tightened matching logic so qualified targets (`Foo::bar`) match exactly when present and bare-name matches still fall back to the previous suffix rule.
- Added an integration test `test_call_hierarchy_item_data_round_trip` in `crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs` that verifies `prepareCallHierarchy` and `outgoingCalls` preserve `data` and that `to.data.uri` points to the canonical callee file.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-lsp --test lsp_call_hierarchy_tests` and all tests passed (`20 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c526f927b083339eb0f9394587c5ff)