### PR TITLE
fix(lsp): make call hierarchy workspace-aware for unopened files

### DIFF
--- a/crates/perl-lsp/src/call_hierarchy_provider.rs
+++ b/crates/perl-lsp/src/call_hierarchy_provider.rs
@@ -27,6 +27,8 @@ pub struct CallHierarchyItem {
     pub selection_range: Range,
     /// Optional additional detail about the symbol
     pub detail: Option<String>,
+    /// Optional opaque data payload for round-tripping call hierarchy identity
+    pub data: Option<Value>,
 }
 
 /// Call Hierarchy Provider
@@ -126,6 +128,7 @@ impl CallHierarchyProvider {
                                     range,
                                     selection_range,
                                     detail,
+                                    data: None,
                                 });
                             }
                         } else {
@@ -146,6 +149,7 @@ impl CallHierarchyProvider {
                                 range,
                                 selection_range,
                                 detail,
+                                data: None,
                             });
                         }
                     }
@@ -159,6 +163,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        data: None,
                     });
                 }
                 NodeKind::FunctionCall { name, .. } => {
@@ -170,6 +175,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        data: None,
                     });
                 }
                 _ => {}
@@ -203,6 +209,7 @@ impl CallHierarchyProvider {
                         range,
                         selection_range,
                         detail: None,
+                        data: None,
                     };
 
                     // Search within this function
@@ -271,6 +278,7 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail: None,
+                    data: None,
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -296,6 +304,7 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail,
+                    data: None,
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -332,6 +341,7 @@ impl CallHierarchyProvider {
                 range,
                 selection_range,
                 detail,
+                data: None,
             })
         } else {
             None
@@ -628,6 +638,8 @@ impl CallHierarchyItem {
         if let Some(detail) = &self.detail {
             item["detail"] = json!(detail);
         }
+        item["data"] =
+            self.data.clone().unwrap_or_else(|| json!({ "uri": self.uri, "name": self.name }));
 
         item
     }
@@ -750,6 +762,7 @@ sub target_func {
                     end: Position { line: 10, character: 15 },
                 },
                 detail: None,
+                data: None,
             };
 
             let incoming = provider.incoming_calls(&ast, &target_item);
@@ -801,6 +814,7 @@ sub helper {
                     end: Position { line: 1, character: 8 },
                 },
                 detail: None,
+                data: None,
             };
 
             let outgoing = provider.outgoing_calls(&ast, &main_item);

--- a/crates/perl-lsp/src/runtime/language/hierarchy.rs
+++ b/crates/perl-lsp/src/runtime/language/hierarchy.rs
@@ -4,9 +4,13 @@
 //! prepareCallHierarchy, callHierarchy/incomingCalls, and callHierarchy/outgoingCalls.
 
 use super::super::*;
+use crate::Parser;
 use crate::protocol::{req_position, req_uri};
+use crate::runtime::file_discovery::discover_perl_files;
 use perl_position_tracking::{WirePosition, WireRange};
+use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
+use url::Url;
 
 static SUB_REGEX: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 static PACKAGE_REGEX: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
@@ -405,22 +409,13 @@ impl LspServer {
 
             let ch_item = self.json_to_call_hierarchy_item(item)?;
 
-            // Snapshot (doc_uri, text, ast) for all open documents so we can
-            // release the lock before the per-document provider work.
-            let documents = self.documents_guard();
-            let doc_snapshots: Vec<(String, String, std::sync::Arc<perl_parser::ast::Node>)> =
-                documents
-                    .iter()
-                    .filter_map(|(doc_uri, doc)| {
-                        doc.ast.as_ref().map(|ast| (doc_uri.clone(), doc.text.clone(), ast.clone()))
-                    })
-                    .collect();
-            drop(documents);
+            // Snapshot workspace documents (open docs plus unopened files on disk)
+            // so we can search across the workspace for call sites.
+            let doc_snapshots = self.collect_workspace_doc_snapshots();
 
             // Incoming call results keyed by (from_name, from_uri) to deduplicate
             // callers that appear in multiple scan passes.
-            let mut seen: std::collections::HashMap<(String, String), usize> =
-                std::collections::HashMap::new();
+            let mut seen: HashMap<(String, String), usize> = HashMap::new();
             let mut all_calls: Vec<crate::call_hierarchy_provider::CallHierarchyIncomingCall> =
                 Vec::new();
 
@@ -459,17 +454,12 @@ impl LspServer {
 
             eprintln!("Getting outgoing calls for: {}", item["name"].as_str().unwrap_or(""));
 
-            // Snapshot all open documents for cross-file callee resolution.
-            let documents = self.documents_guard();
-            let doc_snapshots: Vec<(String, String, std::sync::Arc<perl_parser::ast::Node>)> =
-                documents
-                    .iter()
-                    .filter_map(|(doc_uri, doc)| {
-                        doc.ast.as_ref().map(|ast| (doc_uri.clone(), doc.text.clone(), ast.clone()))
-                    })
-                    .collect();
+            // Snapshot workspace documents (open docs plus unopened files on disk)
+            // for cross-file callee resolution.
+            let doc_snapshots = self.collect_workspace_doc_snapshots();
 
             // Find outgoing calls within the target function's file.
+            let documents = self.documents_guard();
             let mut calls = if let Some(doc) = self.get_document(&documents, uri) {
                 if let Some(ref ast) = doc.ast {
                     let ch_item = self.json_to_call_hierarchy_item(item)?;
@@ -553,7 +543,55 @@ impl LspServer {
         };
 
         let detail = json["detail"].as_str().map(|s| s.to_string());
+        let data = json.get("data").cloned();
 
-        Ok(CallHierarchyItem { name, kind, uri, range, selection_range, detail })
+        Ok(CallHierarchyItem { name, kind, uri, range, selection_range, detail, data })
+    }
+
+    fn collect_workspace_doc_snapshots(
+        &self,
+    ) -> Vec<(String, String, std::sync::Arc<perl_parser::ast::Node>)> {
+        let mut doc_snapshots = Vec::new();
+        let mut seen_uris = HashSet::new();
+
+        {
+            let documents = self.documents_guard();
+            for (doc_uri, doc) in documents.iter() {
+                if let Some(ast) = &doc.ast {
+                    seen_uris.insert(doc_uri.clone());
+                    doc_snapshots.push((doc_uri.clone(), doc.text.clone(), ast.clone()));
+                }
+            }
+        }
+
+        for root_uri in self.workspace_roots() {
+            let Ok(root_path) = root_uri.to_file_path() else {
+                continue;
+            };
+
+            let discovery = discover_perl_files(&root_path);
+            for path in discovery.files {
+                let Ok(url) = Url::from_file_path(&path) else {
+                    continue;
+                };
+                let uri = url.to_string();
+                if seen_uris.contains(&uri) {
+                    continue;
+                }
+
+                let Ok(source) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                let mut parser = Parser::new(&source);
+                let Ok(ast) = parser.parse() else {
+                    continue;
+                };
+
+                seen_uris.insert(uri.clone());
+                doc_snapshots.push((uri, source, std::sync::Arc::new(ast)));
+            }
+        }
+
+        doc_snapshots
     }
 }

--- a/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
+++ b/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
@@ -1156,3 +1156,133 @@ process();
 
     Ok(())
 }
+
+/// Regression for #2878: incoming calls should discover callers in unopened workspace files.
+#[test]
+fn test_cross_file_incoming_calls_unopened_workspace_file() -> TestResult {
+    let (mut harness, workspace) = LspHarness::with_workspace(&[
+        (
+            "lib/Utils.pm",
+            r#"package Utils;
+
+sub format_string {
+    my $str = shift;
+    return uc($str);
+}
+
+1;
+"#,
+        ),
+        (
+            "bin/app.pl",
+            r#"use Utils;
+
+sub process {
+    return Utils::format_string("hello");
+}
+
+process();
+"#,
+        ),
+    ])?;
+
+    let utils_uri = workspace.uri("lib/Utils.pm");
+    let utils_text = std::fs::read_to_string(workspace.dir.path().join("lib/Utils.pm"))?;
+    harness.open(&utils_uri, &utils_text)?;
+    harness.barrier();
+
+    let prepare_response = harness.request(
+        "textDocument/prepareCallHierarchy",
+        json!({
+            "textDocument": { "uri": utils_uri },
+            "position": { "line": 2, "character": 4 }
+        }),
+    )?;
+
+    let items = prepare_response.as_array().ok_or("prepareCallHierarchy did not return array")?;
+    assert!(!items.is_empty(), "prepareCallHierarchy returned no item for format_string");
+    let item = &items[0];
+
+    // Close the defining file: incoming call lookup must continue to work
+    // using workspace-file discovery, not only open-document state.
+    harness.close(&utils_uri)?;
+    harness.barrier();
+
+    let incoming_response =
+        harness.request("callHierarchy/incomingCalls", json!({ "item": item }))?;
+    let calls = incoming_response.as_array().ok_or("incomingCalls did not return array")?;
+    let caller_names: Vec<String> =
+        calls.iter().filter_map(|c| c["from"]["name"].as_str()).map(String::from).collect();
+
+    assert!(
+        caller_names.contains(&"process".to_string()),
+        "Expected unopened workspace caller process(), got {:?}",
+        caller_names
+    );
+
+    Ok(())
+}
+
+/// Regression for #2878: outgoing calls should resolve unopened workspace-file targets.
+#[test]
+fn test_cross_file_outgoing_calls_unopened_workspace_target() -> TestResult {
+    let (mut harness, workspace) = LspHarness::with_workspace(&[
+        (
+            "lib/Utils.pm",
+            r#"package Utils;
+
+sub format_string {
+    my $str = shift;
+    return uc($str);
+}
+
+1;
+"#,
+        ),
+        (
+            "bin/app.pl",
+            r#"use Utils;
+
+sub process {
+    return Utils::format_string("hello");
+}
+
+process();
+"#,
+        ),
+    ])?;
+
+    let app_uri = workspace.uri("bin/app.pl");
+    let app_text = std::fs::read_to_string(workspace.dir.path().join("bin/app.pl"))?;
+    harness.open(&app_uri, &app_text)?;
+    harness.barrier();
+
+    let prepare_response = harness.request(
+        "textDocument/prepareCallHierarchy",
+        json!({
+            "textDocument": { "uri": app_uri },
+            "position": { "line": 2, "character": 4 }
+        }),
+    )?;
+    let items = prepare_response.as_array().ok_or("prepareCallHierarchy returned non-array")?;
+    assert!(!items.is_empty(), "prepareCallHierarchy returned empty array for process()");
+    let item = &items[0];
+
+    let outgoing_response =
+        harness.request("callHierarchy/outgoingCalls", json!({ "item": item }))?;
+    let calls = outgoing_response.as_array().ok_or("outgoingCalls returned non-array")?;
+
+    let utils_uri = workspace.uri("lib/Utils.pm");
+    let resolved = calls.iter().any(|call| {
+        let name_matches = call["to"]["name"]
+            .as_str()
+            .map(|name| name == "format_string" || name.ends_with("::format_string"))
+            .unwrap_or(false);
+        let uri_matches =
+            call["to"]["uri"].as_str().map(|uri| uri == utils_uri.as_str()).unwrap_or(false);
+        name_matches && uri_matches
+    });
+
+    assert!(resolved, "Expected outgoing call target to resolve to unopened Utils.pm");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The call-hierarchy feature only scanned the active/open document, so `incomingCalls` and `outgoingCalls` missed callers/callees in other workspace files (including unopened files). This change enables workspace-wide resolution so call hierarchy behaves as expected in multi-file projects.

### Description
- Added an optional `data: Option<Value>` field to `CallHierarchyItem` and made `to_json()` emit a `data` payload so item identity round-trips across LSP calls. (`crates/perl-lsp/src/call_hierarchy_provider.rs`)
- Reworked the call-hierarchy handlers to build a request-scoped workspace snapshot that includes both open documents and unopened workspace files discovered from workspace roots and parsed on-demand, and used that snapshot for incoming/outgoing resolution. (`crates/perl-lsp/src/runtime/language/hierarchy.rs`)
- Preserved `data` when decoding items from JSON in the runtime so subsequent `incomingCalls`/`outgoingCalls` can resolve targets correctly across files. (`crates/perl-lsp/src/runtime/language/hierarchy.rs`)
- Added integration regression tests that exercise cross-file call discovery for unopened files for both incoming and outgoing flows. (`crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs`)

### Testing
- Ran formatter via `cargo fmt --all` successfully.
- Ran the call-hierarchy integration tests with `cargo test -p perl-lsp --test lsp_call_hierarchy_tests` and all tests passed: 21 passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c526f927b083339eb0f9394587c5ff)