### PR TITLE
fix(lsp): preserve call hierarchy identity in item data

### DIFF
--- a/crates/perl-lsp/src/call_hierarchy_provider.rs
+++ b/crates/perl-lsp/src/call_hierarchy_provider.rs
@@ -27,6 +27,10 @@ pub struct CallHierarchyItem {
     pub selection_range: Range,
     /// Optional additional detail about the symbol
     pub detail: Option<String>,
+    /// Optional fully-qualified symbol name (e.g. Package::sub)
+    pub qualified_name: Option<String>,
+    /// Optional opaque data payload for LSP round-trips
+    pub data: Option<Value>,
 }
 
 /// Call Hierarchy Provider
@@ -126,6 +130,8 @@ impl CallHierarchyProvider {
                                     range,
                                     selection_range,
                                     detail,
+                                    qualified_name: None,
+                                    data: None,
                                 });
                             }
                         } else {
@@ -146,6 +152,8 @@ impl CallHierarchyProvider {
                                 range,
                                 selection_range,
                                 detail,
+                                qualified_name: None,
+                                data: None,
                             });
                         }
                     }
@@ -159,6 +167,8 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        qualified_name: None,
+                        data: None,
                     });
                 }
                 NodeKind::FunctionCall { name, .. } => {
@@ -170,6 +180,8 @@ impl CallHierarchyProvider {
                         range,
                         selection_range: range,
                         detail: None,
+                        qualified_name: Some(name.clone()),
+                        data: None,
                     });
                 }
                 _ => {}
@@ -203,6 +215,8 @@ impl CallHierarchyProvider {
                         range,
                         selection_range,
                         detail: None,
+                        qualified_name: None,
+                        data: None,
                     };
 
                     // Search within this function
@@ -271,6 +285,8 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail: None,
+                    qualified_name: Some(name.clone()),
+                    data: None,
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -296,6 +312,8 @@ impl CallHierarchyProvider {
                     range: self.node_to_range(node),
                     selection_range: self.node_to_range(node),
                     detail,
+                    qualified_name: None,
+                    data: None,
                 };
 
                 let ranges = vec![self.node_to_range(node)];
@@ -332,6 +350,8 @@ impl CallHierarchyProvider {
                 range,
                 selection_range,
                 detail,
+                qualified_name: None,
+                data: None,
             })
         } else {
             None
@@ -628,6 +648,15 @@ impl CallHierarchyItem {
         if let Some(detail) = &self.detail {
             item["detail"] = json!(detail);
         }
+        let data = self.data.clone().unwrap_or_else(|| {
+            json!({
+                "uri": self.uri,
+                "name": self.name,
+                "qualified_name": self.qualified_name,
+                "range": self.range
+            })
+        });
+        item["data"] = data;
 
         item
     }
@@ -750,6 +779,8 @@ sub target_func {
                     end: Position { line: 10, character: 15 },
                 },
                 detail: None,
+                qualified_name: None,
+                data: None,
             };
 
             let incoming = provider.incoming_calls(&ast, &target_item);
@@ -801,6 +832,8 @@ sub helper {
                     end: Position { line: 1, character: 8 },
                 },
                 detail: None,
+                qualified_name: None,
+                data: None,
             };
 
             let outgoing = provider.outgoing_calls(&ast, &main_item);
@@ -812,5 +845,31 @@ sub helper {
             assert!(called_names.contains(&&"process_data".to_string()));
             assert!(called_names.contains(&&"method_call".to_string()));
         }
+    }
+
+    #[test]
+    fn test_to_json_includes_data_payload() {
+        let item = CallHierarchyItem {
+            name: "format_string".to_string(),
+            kind: "function".to_string(),
+            uri: "file:///lib/Utils.pm".to_string(),
+            range: Range {
+                start: Position { line: 1, character: 0 },
+                end: Position { line: 4, character: 1 },
+            },
+            selection_range: Range {
+                start: Position { line: 1, character: 4 },
+                end: Position { line: 1, character: 17 },
+            },
+            detail: None,
+            qualified_name: Some("Utils::format_string".to_string()),
+            data: None,
+        };
+
+        let json = item.to_json();
+        assert!(json.get("data").is_some(), "CallHierarchyItem JSON must include data");
+        assert_eq!(json["data"]["uri"], "file:///lib/Utils.pm");
+        assert_eq!(json["data"]["name"], "format_string");
+        assert_eq!(json["data"]["qualified_name"], "Utils::format_string");
     }
 }

--- a/crates/perl-lsp/src/runtime/language/hierarchy.rs
+++ b/crates/perl-lsp/src/runtime/language/hierarchy.rs
@@ -553,7 +553,22 @@ impl LspServer {
         };
 
         let detail = json["detail"].as_str().map(|s| s.to_string());
+        let qualified_name = json
+            .get("data")
+            .and_then(|d| d.get("qualified_name"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let data = json.get("data").cloned();
 
-        Ok(CallHierarchyItem { name, kind, uri, range, selection_range, detail })
+        Ok(CallHierarchyItem {
+            name,
+            kind,
+            uri,
+            range,
+            selection_range,
+            detail,
+            qualified_name,
+            data,
+        })
     }
 }

--- a/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
+++ b/crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs
@@ -1042,6 +1042,10 @@ process();
 
     let item = &items[0];
     assert_eq!(item["name"], "format_string", "Expected to prepare on format_string");
+    assert!(
+        item.get("data").is_some(),
+        "prepareCallHierarchy item should include data for request round-trips"
+    );
 
     // Request incoming calls — must find the caller in the OTHER file
     let incoming_response =
@@ -1051,6 +1055,10 @@ process();
 
     let caller_names: Vec<String> =
         calls.iter().filter_map(|c| c["from"]["name"].as_str()).map(String::from).collect();
+    assert!(
+        calls.iter().all(|c| c["from"].get("data").is_some()),
+        "incomingCalls items should preserve data payload for follow-up requests"
+    );
 
     assert!(
         caller_names.contains(&"process".to_string()),
@@ -1113,12 +1121,20 @@ process();
 
     let item = &items[0];
     assert_eq!(item["name"], "process", "Expected to prepare on process");
+    assert!(
+        item.get("data").is_some(),
+        "prepareCallHierarchy item should include data for request round-trips"
+    );
 
     // Request outgoing calls
     let outgoing_response =
         harness.request("callHierarchy/outgoingCalls", json!({ "item": item }))?;
 
     let calls = outgoing_response.as_array().ok_or("outgoingCalls returned non-array")?;
+    assert!(
+        calls.iter().all(|c| c["to"].get("data").is_some()),
+        "outgoingCalls items should preserve data payload for follow-up requests"
+    );
 
     // Must find format_string as an outgoing call
     let callee_names: Vec<String> =


### PR DESCRIPTION
### Motivation
- Call-hierarchy requests lost canonical identity when items were round-tripped between `prepareCallHierarchy`, `incomingCalls`, and `outgoingCalls`, preventing workspace-aware resolution across files.
- The provider previously serialized only name/uri/ranges and omitted a `data` payload, so follow-up handlers could not disambiguate or resolve symbols in other files.

### Description
- Added `qualified_name: Option<String>` and `data: Option<Value>` to `CallHierarchyItem` so items can carry stable identity and an opaque payload across LSP round-trips (`crates/perl-lsp/src/call_hierarchy_provider.rs`).
- Updated `CallHierarchyItem::to_json()` to always emit a `data` object (fallback includes `uri`, `name`, `qualified_name`, and `range`) so clients return enough information for workspace resolution.
- Updated runtime deserialization in `json_to_call_hierarchy_item()` to preserve `data` and `qualified_name` when reconstructing `CallHierarchyItem` from client-provided JSON (`crates/perl-lsp/src/runtime/language/hierarchy.rs`).
- Strengthened tests by asserting the `data` payload is present on prepared, incoming, and outgoing items and added a unit test ensuring `to_json()` includes the expected `data` fields (`crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs` and provider unit test).

### Testing
- Ran formatter: `cargo fmt --all` (succeeded).
- Unit test: `cargo test -p perl-lsp --lib test_to_json_includes_data_payload -- --nocapture` (succeeded).
- Integration tests: `cargo test -p perl-lsp --test lsp_call_hierarchy_tests test_cross_file_incoming_calls -- --nocapture` (succeeded) and `cargo test -p perl-lsp --test lsp_call_hierarchy_tests test_cross_file_outgoing_calls_uri -- --nocapture` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c526f927b083339eb0f9394587c5ff)