### PR TITLE
refactor(lsp): wire perl-lsp-inline-completion microcrate, remove duplicate impl (#2758)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "crates/perl-lsp-completion-item",
     "crates/perl-lsp-inline-completion",
     "crates/perl-lsp-code-actions",
+    "crates/perl-lsp-inline-completion",
     "crates/perl-lsp-document-highlight",
     "crates/perl-lsp-folding",
     "crates/perl-lsp-selection-range",
@@ -416,6 +417,7 @@ perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version =
 perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.0" }
 perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.0" }
 perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.0" }
+perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.0" }
 perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.0" }
 perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.0" }
 perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.0" }

--- a/crates/perl-lsp/src/features/inline_completions.rs
+++ b/crates/perl-lsp/src/features/inline_completions.rs
@@ -1,9 +1,7 @@
-//! Inline completions provider — delegated to perl-lsp-inline-completion (#2756).
+//! Inline completions provider — re-exported from `perl-lsp-inline-completion`.
 //!
-//! The upstream crate uses `utf16_line_col_to_offset` for correct UTF-16
-//! character-position handling as required by the LSP protocol (§3.17).
-//! The previous local implementation used raw byte offsets which gave
-//! silently wrong results for documents containing non-BMP characters.
+//! The authoritative implementation lives in the microcrate, which provides
+//! context-aware ghost-text completions with correct UTF-16 position handling.
 
 pub use perl_lsp_inline_completion::{
     InlineCompletionItem, InlineCompletionList, InlineCompletionProvider,

--- a/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
+++ b/crates/perl-lsp/tests/lsp_inline_completion_tests.rs
@@ -194,7 +194,6 @@ fn test_inline_completion_utf16_position_correct() -> Result<(), Box<dyn std::er
     );
     Ok(())
 }
-
 /// Edge case: completion requested on line 1 of a multiline document.
 /// Verifies that line_context_at_position correctly skips line 0 and
 /// returns the right prefix for line 1.


### PR DESCRIPTION
Salvage of the inline-completion microcrate wiring from the review branch.

Scope:
- re-export the authoritative  implementation from 
- keep the UTF-16 regression coverage in 
- preserve the existing multiline inline-completion regression already on current master

This is a narrow LSP/editor cleanup and correctness follow-up, not a broader parser or call-hierarchy change.