### PR TITLE
fix: align VS Code extension config and snippets

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -200,147 +200,197 @@
         ]
       }
     ],
-    "configuration": {
-      "title": "Perl LSP",
-      "properties": {
-        "perl-lsp.channel": {
-          "type": "string",
-          "enum": [
-            "latest",
-            "stable",
-            "tag"
-          ],
-          "default": "latest",
-          "markdownDescription": "Release channel: `latest` for newest release, `stable` for latest stable, `tag` for specific version"
-        },
-        "perl-lsp.versionTag": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Specific release tag (e.g., `v0.12.0`) when channel is set to `tag`"
-        },
-        "perl-lsp.serverPath": {
-          "type": "string",
-          "default": "",
-          "scope": "machine",
-          "markdownDescription": "Absolute path to `perl-lsp` binary. Leave empty to auto-download latest release."
-        },
-        "perl-lsp.autoDownload": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Automatically download `perl-lsp` binary if not found locally. Set to false for internal deployments using `serverPath`."
-        },
-        "perl-lsp.downloadBaseUrl": {
-          "type": "string",
-          "default": "",
-          "scope": "machine",
-          "markdownDescription": "Internal base URL hosting perl-lsp archives and SHA256SUMS (bypasses GitHub releases). Example: `https://internal.example.com/perl-lsp/`"
-        },
-        "perl-lsp.trace.server": {
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "markdownDescription": "Controls the logging verbosity of the language server communication. Allowed values: `off`, `messages`, `verbose`. Useful for debugging LSP issues."
-        },
-        "perl-lsp.enableDiagnostics": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable real-time **syntax diagnostics**."
-        },
-        "perl-lsp.enableSemanticTokens": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable **semantic syntax highlighting**."
-        },
-        "perl-lsp.enableFormatting": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable document formatting using `perltidy`. Requires `perltidy` to be installed on your system."
-        },
-        "perl-lsp.formatOnSave": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Format document on save. **Note:** This requires a formatter (like `perltidy`) to be configured."
-        },
-        "perl-lsp.enableRefactoring": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable refactoring-related code actions when supported by the connected `perl-lsp` server."
-        },
-        "perl-lsp.perltidyConfig": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Path to your `.perltidyrc` configuration file. If omitted, searches workspace and home directory."
-        },
-        "perl-lsp.includePaths": {
-          "type": "array",
-          "default": [
-            "lib",
-            "local/lib/perl5"
-          ],
-          "markdownDescription": "Additional library paths (like `use lib`) to search for Perl modules. Relative paths resolve from workspace root."
-        },
-        "perl-lsp.enableTestIntegration": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable `Test::More` and `Test2` integration"
-        },
-        "perl-lsp.autoPopulateNewFiles": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Auto-populate new `.pm` files with a `package` declaration and new `.t` files with `Test::More` boilerplate."
-        },
-        "perl-lsp.featureProfile": {
-          "type": "string",
-          "enum": [
-            "auto",
-            "ga-lock",
-            "ga",
-            "prod",
-            "production",
-            "all"
-          ],
-          "default": "auto",
-          "markdownDescription": "Select runtime LSP feature profile (`auto` follows binary build mode)."
-        },
-        "perl-lsp.disabledFeatures": {
-          "type": "array",
-          "items": {
+    "configuration": [
+      {
+        "title": "Perl LSP: Core",
+        "properties": {
+          "perl-lsp.serverPath": {
+            "type": "string",
+            "default": "",
+            "scope": "machine",
+            "order": 10,
+            "markdownDescription": "Absolute path to the `perl-lsp` binary. Leave empty to auto-download a release build."
+          },
+          "perl-lsp.autoDownload": {
+            "type": "boolean",
+            "default": true,
+            "order": 20,
+            "markdownDescription": "Automatically download the `perl-lsp` binary if it is not found locally. Disable this for internal deployments that set `serverPath`."
+          },
+          "perl-lsp.includePaths": {
+            "type": "array",
+            "default": [
+              "lib",
+              "local/lib/perl5"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "order": 30,
+            "markdownDescription": "Additional library paths (like `use lib`) to search for Perl modules. Set this if you see `Can't locate Foo/Bar.pm` style module lookup errors. Relative paths resolve from the workspace root."
+          },
+          "perl-lsp.enableDiagnostics": {
+            "type": "boolean",
+            "default": true,
+            "order": 40,
+            "markdownDescription": "Enable real-time syntax diagnostics."
+          },
+          "perl-lsp.enableSemanticTokens": {
+            "type": "boolean",
+            "default": true,
+            "order": 50,
+            "markdownDescription": "Enable semantic syntax highlighting."
+          }
+        }
+      },
+      {
+        "title": "Perl LSP: Editor",
+        "properties": {
+          "perl-lsp.enableFormatting": {
+            "type": "boolean",
+            "default": true,
+            "order": 10,
+            "markdownDescription": "Enable document formatting using `perltidy`. This requires `perltidy` to be installed on your system."
+          },
+          "perl-lsp.formatOnSave": {
+            "type": "boolean",
+            "default": false,
+            "order": 20,
+            "markdownDescription": "Format the document on save. This requires a formatter such as `perltidy`."
+          },
+          "perl-lsp.perltidyConfig": {
+            "type": "string",
+            "default": "",
+            "order": 30,
+            "markdownDescription": "Path to your `.perltidyrc` configuration file. If omitted, perl-lsp searches the workspace and home directory."
+          },
+          "perl-lsp.enableRefactoring": {
+            "type": "boolean",
+            "default": true,
+            "order": 40,
+            "markdownDescription": "Enable refactoring-related code actions when supported by the connected `perl-lsp` server."
+          },
+          "perl-lsp.enableTestIntegration": {
+            "type": "boolean",
+            "default": true,
+            "order": 50,
+            "markdownDescription": "Enable `Test::More` and `Test2` integration."
+          },
+          "perl-lsp.autoPopulateNewFiles": {
+            "type": "boolean",
+            "default": true,
+            "order": 60,
+            "markdownDescription": "Auto-populate new `.pm` files with a `package` declaration and new `.t` files with `Test::More` boilerplate."
+          }
+        }
+      },
+      {
+        "title": "Perl LSP: Advanced",
+        "properties": {
+          "perl-lsp.channel": {
             "type": "string",
             "enum": [
-              "lsp.completion",
-              "lsp.hover",
-              "lsp.definition",
-              "lsp.declaration",
-              "lsp.references",
-              "lsp.document_symbol",
-              "lsp.workspace_symbol",
-              "lsp.code_action",
-              "lsp.code_lens",
-              "lsp.rename",
-              "lsp.folding_range",
-              "lsp.selection_range",
-              "lsp.linked_editing_range",
-              "lsp.inlay_hint",
-              "lsp.semantic_tokens",
-              "lsp.call_hierarchy",
-              "lsp.type_hierarchy",
-              "lsp.pull_diagnostics",
-              "lsp.document_color",
-              "lsp.signature_help",
-              "lsp.document_highlight",
-              "lsp.formatting",
-              "lsp.range_formatting"
-            ]
+              "latest",
+              "stable",
+              "tag"
+            ],
+            "enumDescriptions": [
+              "Track the newest published release.",
+              "Stay on the latest stable release line.",
+              "Pin the extension to a specific release tag."
+            ],
+            "default": "latest",
+            "order": 10,
+            "markdownDescription": "Release channel: `latest` for newest release, `stable` for latest stable, `tag` for specific version"
           },
-          "default": [],
-          "markdownDescription": "Feature IDs to disable at server startup. Use canonical `lsp.*` IDs (e.g., `lsp.semantic_tokens`). Changes take effect after server restart."
+          "perl-lsp.versionTag": {
+            "type": "string",
+            "default": "",
+            "order": 20,
+            "markdownDescription": "Specific release tag (for example `v0.12.0`) when channel is set to `tag`."
+          },
+          "perl-lsp.downloadBaseUrl": {
+            "type": "string",
+            "default": "",
+            "scope": "machine",
+            "order": 30,
+            "markdownDescription": "Internal base URL hosting perl-lsp archives and SHA256SUMS, bypassing GitHub releases. Example: `https://internal.example.com/perl-lsp/`."
+          },
+          "perl-lsp.featureProfile": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "ga-lock",
+              "ga",
+              "prod",
+              "production",
+              "all"
+            ],
+            "enumDescriptions": [
+              "Choose the profile automatically based on the bundled binary.",
+              "Lock to the general-availability profile with conservative defaults.",
+              "Use the general-availability profile.",
+              "Use the production profile alias.",
+              "Use the production profile alias.",
+              "Enable every supported feature."
+            ],
+            "default": "auto",
+            "order": 40,
+            "markdownDescription": "Select the runtime LSP feature profile. `auto` follows the bundled binary build mode."
+          },
+          "perl-lsp.disabledFeatures": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "lsp.completion",
+                "lsp.hover",
+                "lsp.definition",
+                "lsp.declaration",
+                "lsp.references",
+                "lsp.document_symbol",
+                "lsp.workspace_symbol",
+                "lsp.code_action",
+                "lsp.code_lens",
+                "lsp.rename",
+                "lsp.folding_range",
+                "lsp.selection_range",
+                "lsp.linked_editing_range",
+                "lsp.inlay_hint",
+                "lsp.semantic_tokens",
+                "lsp.call_hierarchy",
+                "lsp.type_hierarchy",
+                "lsp.pull_diagnostics",
+                "lsp.document_color",
+                "lsp.signature_help",
+                "lsp.document_highlight",
+                "lsp.formatting",
+                "lsp.range_formatting"
+              ]
+            },
+            "default": [],
+            "order": 50,
+            "markdownDescription": "Feature IDs to disable at server startup. Use canonical `lsp.*` IDs such as `lsp.semantic_tokens`. Changes take effect after restarting the language server."
+          },
+          "perl-lsp.trace.server": {
+            "type": "string",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "enumDescriptions": [
+              "Disable protocol tracing.",
+              "Log request and response messages.",
+              "Log full verbose protocol details."
+            ],
+            "default": "off",
+            "order": 60,
+            "markdownDescription": "Controls the logging verbosity of the language server communication. Allowed values: `off`, `messages`, `verbose`. Useful for debugging LSP issues."
+          }
         }
       }
-    },
+    ],
     "commands": [
       {
         "command": "perl-lsp.restart",

--- a/vscode-extension/snippets/launch.json
+++ b/vscode-extension/snippets/launch.json
@@ -6,7 +6,7 @@
             "    \"type\": \"perl\",",
             "    \"request\": \"launch\",",
             "    \"name\": \"Perl: Launch Script\",",
-            "    \"program\": \"${workspaceFolder}/${1:script.pl}\",",
+            "    \"program\": \"\\${workspaceFolder}/${1:script.pl}\",",
             "    \"stopOnEntry\": true",
             "}"
         ],

--- a/vscode-extension/snippets/perl.json
+++ b/vscode-extension/snippets/perl.json
@@ -329,63 +329,63 @@
     "Test Ok": {
         "prefix": ["tm-ok", "ok"],
         "body": [
-            "ok(${1:$got}, '${2:test description}');"
+            "ok(${1:\\$got}, '${2:test description}');"
         ],
         "description": "Simple boolean test (Test::More)"
     },
     "Test Is": {
         "prefix": ["tm-is", "is"],
         "body": [
-            "is(${1:$got}, ${2:$expected}, '${3:test description}');"
+            "is(${1:\\$got}, ${2:\\$expected}, '${3:test description}');"
         ],
         "description": "Test if two values are equal (Test::More)"
     },
     "Test Isnt": {
         "prefix": ["tm-isnt", "isnt"],
         "body": [
-            "isnt(${1:$got}, ${2:$expected}, '${3:test description}');"
+            "isnt(${1:\\$got}, ${2:\\$expected}, '${3:test description}');"
         ],
         "description": "Test if two values are not equal (Test::More)"
     },
     "Test Is Deeply": {
         "prefix": ["tm-is_deeply", "is_deeply"],
         "body": [
-            "is_deeply(${1:$got}, ${2:$expected}, '${3:test description}');"
+            "is_deeply(${1:\\$got}, ${2:\\$expected}, '${3:test description}');"
         ],
         "description": "Test if two data structures are identical (Test::More)"
     },
     "Test Like": {
         "prefix": ["tm-like", "like"],
         "body": [
-            "like(${1:$got}, qr/${2:pattern}/, '${3:test description}');"
+            "like(${1:\\$got}, qr/${2:pattern}/, '${3:test description}');"
         ],
         "description": "Test if value matches regex (Test::More)"
     },
     "Test Unlike": {
         "prefix": ["tm-unlike", "unlike"],
         "body": [
-            "unlike(${1:$got}, qr/${2:pattern}/, '${3:test description}');"
+            "unlike(${1:\\$got}, qr/${2:pattern}/, '${3:test description}');"
         ],
         "description": "Test if value does not match regex (Test::More)"
     },
     "Test Cmp Ok": {
         "prefix": ["tm-cmp_ok", "cmp_ok"],
         "body": [
-            "cmp_ok(${1:$got}, '${2:op}', ${3:$expected}, '${4:test description}');"
+            "cmp_ok(${1:\\$got}, '${2:op}', ${3:\\$expected}, '${4:test description}');"
         ],
         "description": "Compare two arguments using an operator (Test::More)"
     },
     "Test Isa Ok": {
         "prefix": ["tm-isa_ok", "isa_ok"],
         "body": [
-            "isa_ok(${1:$obj}, '${2:Class::Name}', '${3:object name}');"
+            "isa_ok(${1:\\$obj}, '${2:Class::Name}', '${3:object name}');"
         ],
         "description": "Test if object is of a given class (Test::More)"
     },
     "Test Can Ok": {
         "prefix": ["tm-can_ok", "can_ok"],
         "body": [
-            "can_ok(${1:$obj}, qw(${2:methods}));"
+            "can_ok(${1:\\$obj}, qw(${2:methods}));"
         ],
         "description": "Test if object or class has methods (Test::More)"
     },


### PR DESCRIPTION
## Summary
- align the VS Code extension configuration contribution with the grouped settings contract exercised by the repo tests
- add explicit enum descriptions, ordering metadata, and stronger include-path guidance in the extension settings surface
- fix malformed snippet placeholders so the packaged extension stops warning about snippet variable syntax

## Validation
- `npm ci`
- `npm run test:ci`
- `npm run verify:marketplace`
- stable packaged VS Code smoke from the built VSIX
  - clean activation
  - plain Perl symbols and diagnostics
  - DBI completion, hover, and signature help
  - Moo/Moose cross-file definition, references, and call hierarchy
