### PR TITLE
fix: reduce first batch of xtask clippy debt (#2997)

### DIFF
--- a/xtask/src/tasks/benchmarks.rs
+++ b/xtask/src/tasks/benchmarks.rs
@@ -165,11 +165,13 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_no_regression.json"),
-        1.0,
-        None,
-        &["No performance alerts detected"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_no_regression.json"),
+            multiplier: 1.0,
+            format: None,
+            expected: &["No performance alerts detected"],
+            expect_success: true,
+        },
     )?;
     run_alert_case(
         &root,
@@ -177,11 +179,13 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_warning.json"),
-        1.11,
-        None,
-        &["WARNING", "1"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_warning.json"),
+            multiplier: 1.11,
+            format: None,
+            expected: &["WARNING", "1"],
+            expect_success: true,
+        },
     )?;
     run_alert_case(
         &root,
@@ -189,11 +193,13 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_regression.json"),
-        1.25,
-        None,
-        &["REGRESSION"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_regression.json"),
+            multiplier: 1.25,
+            format: None,
+            expected: &["REGRESSION"],
+            expect_success: true,
+        },
     )?;
     run_alert_case(
         &root,
@@ -201,11 +207,13 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_critical.json"),
-        1.60,
-        None,
-        &["CRITICAL"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_critical.json"),
+            multiplier: 1.60,
+            format: None,
+            expected: &["CRITICAL"],
+            expect_success: true,
+        },
     )?;
     run_alert_case(
         &root,
@@ -213,11 +221,13 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_markdown.json"),
-        1.25,
-        Some("markdown"),
-        &["## Performance Benchmark Results", "⚠️ Performance Regressions"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_markdown.json"),
+            multiplier: 1.25,
+            format: Some("markdown"),
+            expected: &["## Performance Benchmark Results", "⚠️ Performance Regressions"],
+            expect_success: true,
+        },
     )?;
     run_alert_check_case(
         &root,
@@ -232,15 +242,25 @@ pub fn test_alert_system() -> Result<()> {
         &config_path,
         &baseline_path,
         &baseline,
-        workdir.join("alert_test_improvement.json"),
-        0.80,
-        None,
-        &["IMPROVED"],
-        true,
+        AlertCase {
+            current_path: workdir.join("alert_test_improvement.json"),
+            multiplier: 0.80,
+            format: None,
+            expected: &["IMPROVED"],
+            expect_success: true,
+        },
     )?;
 
     println!("All benchmark alert-system checks passed");
     Ok(())
+}
+
+struct AlertCase<'a> {
+    current_path: PathBuf,
+    multiplier: f64,
+    format: Option<&'a str>,
+    expected: &'a [&'a str],
+    expect_success: bool,
 }
 
 fn run_alert_case(
@@ -249,25 +269,21 @@ fn run_alert_case(
     config_path: &Path,
     baseline_path: &Path,
     baseline: &Value,
-    current_path: PathBuf,
-    multiplier: f64,
-    format: Option<&str>,
-    expected: &[&str],
-    expect_success: bool,
+    case: AlertCase<'_>,
 ) -> Result<()> {
     let mut current = baseline.clone();
-    mutate_parse_simple_script(&mut current, multiplier)?;
-    fs::write(&current_path, serde_json::to_string_pretty(&current)?)
-        .with_context(|| format!("Failed to write {}", current_path.display()))?;
+    mutate_parse_simple_script(&mut current, case.multiplier)?;
+    fs::write(&case.current_path, serde_json::to_string_pretty(&current)?)
+        .with_context(|| format!("Failed to write {}", case.current_path.display()))?;
 
     let mut args = vec![
         alert_script.to_string_lossy().to_string(),
         baseline_path.to_string_lossy().to_string(),
-        current_path.to_string_lossy().to_string(),
+        case.current_path.to_string_lossy().to_string(),
         "--config".to_string(),
         config_path.to_string_lossy().to_string(),
     ];
-    if let Some(format) = format {
+    if let Some(format) = case.format {
         args.push("--format".to_string());
         args.push(format.to_string());
     }
@@ -279,11 +295,11 @@ fn run_alert_case(
         .context("Failed to execute alert.py")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    if expect_success != output.status.success() {
-        bail!("alert.py command status mismatch (expected success: {expect_success})");
+    if case.expect_success != output.status.success() {
+        bail!("alert.py command status mismatch (expected success: {})", case.expect_success);
     }
 
-    for fragment in expected {
+    for fragment in case.expected {
         if !stdout.contains(fragment) {
             bail!("Expected output to contain '{fragment}'");
         }
@@ -524,8 +540,7 @@ fn rust_version() -> Result<String> {
 fn load_json(path: &Path) -> Result<Value> {
     let content =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-    Ok(serde_json::from_str(&content)
-        .with_context(|| format!("Invalid JSON in {}", path.display()))?)
+    serde_json::from_str(&content).with_context(|| format!("Invalid JSON in {}", path.display()))
 }
 
 fn run_script(script: &Path, args: &[&str], label: &str) -> Result<()> {

--- a/xtask/src/tasks/build_timing.rs
+++ b/xtask/src/tasks/build_timing.rs
@@ -367,10 +367,10 @@ fn detect_memory_gb() -> Value {
 
     command_output_parse_f64_or_unknown(&["sysctl", "-n", "hw.memsize"])
         .and_then(|value| {
-            if value.is_number() {
-                if let Some(raw) = value.as_f64() {
-                    return Some(Value::from((raw / 1024.0 / 1024.0 / 1024.0).round() as u64));
-                }
+            if value.is_number()
+                && let Some(raw) = value.as_f64()
+            {
+                return Some(Value::from((raw / 1024.0 / 1024.0 / 1024.0).round() as u64));
             }
             None
         })

--- a/xtask/src/tasks/check_toolchain.rs
+++ b/xtask/src/tasks/check_toolchain.rs
@@ -80,7 +80,7 @@ pub fn run(doctor: bool) -> Result<()> {
 
 fn parse_version_parts(version: &str) -> Vec<u32> {
     version
-        .split(|c| c == '.' || c == '-' || c == '+')
+        .split(['.', '-', '+'])
         .filter_map(|part| {
             part.chars().take_while(|c| c.is_ascii_digit()).collect::<String>().parse::<u32>().ok()
         })

--- a/xtask/src/tasks/features.rs
+++ b/xtask/src/tasks/features.rs
@@ -41,13 +41,15 @@ fn check_invariants() -> Result<()> {
             violations.push(format!("DUPLICATE_ID: {:?} appears more than once", feature.id));
         }
 
-        if feature.advertised && feature.maturity == Maturity::Ga && feature.tests.is_empty() {
-            if feature.counts_in_coverage {
-                violations.push(format!(
-                    "UNTESTED_GA: {:?} is advertised+GA but has no tests. Either add tests or set counts_in_coverage=false (if it's protocol plumbing).",
-                    feature.id
-                ));
-            }
+        if feature.advertised
+            && feature.maturity == Maturity::Ga
+            && feature.tests.is_empty()
+            && feature.counts_in_coverage
+        {
+            violations.push(format!(
+                "UNTESTED_GA: {:?} is advertised+GA but has no tests. Either add tests or set counts_in_coverage=false (if it's protocol plumbing).",
+                feature.id
+            ));
         }
     }
 

--- a/xtask/src/tasks/parser_matrix.rs
+++ b/xtask/src/tasks/parser_matrix.rs
@@ -10,8 +10,6 @@ use toml::Value;
 
 use super::corpus_audit::{AuditReport, FailingFile, ParseOutcomesSummary};
 
-const DEFAULT_REPORT_PATH: &str = "corpus_audit_report.json";
-const DEFAULT_OUTPUT_PATH: &str = "docs/reference/PARSER_FEATURE_MATRIX.md";
 const BASELINE_PATH: &str = "ci/parse_errors_baseline.txt";
 const UNKNOWN: &str = "unknown";
 
@@ -24,10 +22,6 @@ const CATEGORY_TAXONOMY: &[(&str, &str, &str)] = &[
     ("Subroutine", "P2", "Signatures, prototypes"),
     ("General", "P3", "Uncategorized"),
 ];
-
-pub fn run() -> Result<()> {
-    run_with_paths(PathBuf::from(DEFAULT_REPORT_PATH), PathBuf::from(DEFAULT_OUTPUT_PATH))
-}
 
 pub fn run_with_paths(report: PathBuf, output: PathBuf) -> Result<()> {
     let root = project_root()?;
@@ -105,12 +99,9 @@ fn success_rate(outcomes: &ParseOutcomesSummary) -> f64 {
 }
 
 fn format_location(file: &FailingFile) -> Option<String> {
-    file.line_number.map(|line_num| {
-        let location = match file.column {
-            Some(column) => format!("line {line_num}:{column}"),
-            None => format!("line {line_num}"),
-        };
-        location
+    file.line_number.map(|line_num| match file.column {
+        Some(column) => format!("line {line_num}:{column}"),
+        None => format!("line {line_num}"),
     })
 }
 

--- a/xtask/src/tasks/release_turnkey.rs
+++ b/xtask/src/tasks/release_turnkey.rs
@@ -38,7 +38,7 @@ impl ReleaseTurnkeyConfig {
         }
     }
 
-    fn to_args(self, version: &str) -> Vec<String> {
+    fn build_args(&self, version: &str) -> Vec<String> {
         let mut args = vec!["--version".to_string(), version.to_string()];
 
         if self.prerelease {
@@ -56,9 +56,9 @@ impl ReleaseTurnkeyConfig {
         if self.skip_docker {
             args.push("--skip-docker".to_string());
         }
-        if let Some(base_branch) = self.base_branch {
+        if let Some(base_branch) = &self.base_branch {
             args.push("--base-branch".to_string());
-            args.push(base_branch);
+            args.push(base_branch.clone());
         }
         if self.no_auto_merge {
             args.push("--no-auto-merge".to_string());
@@ -84,7 +84,7 @@ pub fn run(config: ReleaseTurnkeyConfig) -> Result<()> {
     let script = root.join("scripts").join("release-turnkey-pr.sh");
 
     let version = config.resolve_version()?;
-    let args = config.to_args(&version);
+    let args = config.build_args(&version);
 
     let status = Command::new("bash")
         .arg(&script)


### PR DESCRIPTION
## Summary
Reduce the first batch of xtask strict-clippy violations with small behavior-preserving cleanups.

## Scope
- remove the unused parser-matrix wrapper entrypoint
- simplify benchmark alert helper plumbing
- apply straightforward clippy rewrites in build timing, toolchain parsing, feature invariants, and release turnkey arg building

## Verification
- cargo clippy --bin xtask --locked -- -D warnings -A missing_docs now fails only in other xtask files outside this PR's scope
