### PR TITLE
fix: remove xtask clippy warnings in CI helpers (#2998)

### DIFF
--- a/xtask/src/tasks/ci_audit_workflows.rs
+++ b/xtask/src/tasks/ci_audit_workflows.rs
@@ -3,7 +3,7 @@
 //! Mirrors `scripts/ci-audit-workflows.py` by checking workflow files for
 //! pull-request-triggered jobs that do not have explicit gating (`if:`).
 
-use color_eyre::eyre::{eyre, Context, Result};
+use color_eyre::eyre::{Context, Result, eyre};
 use serde_yaml_ng::Value;
 use std::fs;
 

--- a/xtask/src/tasks/ci_hygiene.rs
+++ b/xtask/src/tasks/ci_hygiene.rs
@@ -3,7 +3,7 @@
 //! This task keeps shell wrappers thin and delegates to the crate directly,
 //! either via an existing local debug binary or via `cargo run`.
 
-use color_eyre::eyre::{bail, Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/xtask/src/tasks/ci_metrics.rs
+++ b/xtask/src/tasks/ci_metrics.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use color_eyre::eyre::{bail, Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
 use std::collections::{BTreeMap, HashMap};
@@ -175,11 +175,7 @@ pub fn run_cost_monitor(days: u64, json_output: bool) -> Result<()> {
 
             let elapsed_seconds = end.and_then(|end_ts| {
                 let elapsed = (end_ts - start).num_seconds();
-                if elapsed > 0 {
-                    u64::try_from(elapsed).ok()
-                } else {
-                    None
-                }
+                if elapsed > 0 { u64::try_from(elapsed).ok() } else { None }
             });
 
             let elapsed_seconds = elapsed_seconds.unwrap_or(0);
@@ -668,11 +664,7 @@ fn round_one_decimal(value: f64) -> f64 {
 }
 
 fn percent(part: u64, total: u64) -> f64 {
-    if total == 0 {
-        0.0
-    } else {
-        round_one_decimal((part as f64 * 100.0) / (total as f64))
-    }
+    if total == 0 { 0.0 } else { round_one_decimal((part as f64 * 100.0) / (total as f64)) }
 }
 
 fn percentile(values: &[u64], percentile: f64) -> u64 {
@@ -694,11 +686,7 @@ fn workflow_key(name: &str) -> String {
         }
     }
 
-    if key.is_empty() {
-        "workflow".to_string()
-    } else {
-        key
-    }
+    if key.is_empty() { "workflow".to_string() } else { key }
 }
 
 fn build_baseline_markdown(report: &BaselineReport) -> Result<String> {

--- a/xtask/src/tasks/ci_policy.rs
+++ b/xtask/src/tasks/ci_policy.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::{bail, Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use regex::Regex;
 use std::fs;
 use std::path::Path;

--- a/xtask/src/tasks/doc_claims.rs
+++ b/xtask/src/tasks/doc_claims.rs
@@ -1,7 +1,7 @@
 //! Validate known stale publication claims inside docs/articles.
 
 use crate::utils::project_root;
-use color_eyre::eyre::{bail, Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use std::{fs, path::PathBuf};
 
 const ARTICLES_DIR: &str = "docs/articles";


### PR DESCRIPTION
## Summary
Clean up the batch-2 xtask clippy warnings in the CI helper modules only.

## Scope
- xtask/src/tasks/ci_audit_workflows.rs
- xtask/src/tasks/ci_hygiene.rs
- xtask/src/tasks/ci_metrics.rs
- xtask/src/tasks/ci_policy.rs
- xtask/src/tasks/doc_claims.rs

## Verification
- cargo clippy -p xtask --bin xtask -- -D warnings -A missing_docs no longer reports any of the batch-2 files
- the full xtask clippy lane still fails on unrelated files outside this batch, which are being handled separately
