### PR TITLE
fix: gate windows-only subprocess path import (#3000)

### DIFF
--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(clippy::all)]
 
 use std::fmt;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), windows))]
 use std::path::Path;
 
 /// Output from a subprocess execution


### PR DESCRIPTION
## Summary
- gate the subprocess `Path` import behind `windows` so Linux/bash clippy runs do not flag it as unused
- preserve the existing Windows command-resolution behavior

## Verification
- cargo test -p perl-subprocess-runtime
- bash -lc "cargo clippy -p perl-parser -p perl-lexer -p perl-parser-core --lib --locked -- -D warnings -A missing_docs"
