### PR TITLE
ci: add parser branch coverage ratchet (#2099)

### DIFF
--- a/.ci/coverage-baseline.txt
+++ b/.ci/coverage-baseline.txt
@@ -1,0 +1,12 @@
+# Branch coverage baseline policy for the parser coverage lane.
+#
+# Keep this file in sync with the current parser branch coverage snapshot.
+# The gate allows at most 1.00 percentage point regression from baseline.
+# The long-term target is 80%+, but the first slice only ratchets from the
+# current baseline so the lane stays green on the existing master shape.
+schema_version=1
+coverage_scope=perl-parser-lib
+baseline_branch_coverage=11.27
+baseline_line_coverage=13.49
+allowed_drop_percentage=1.00
+target_branch_coverage=80.00

--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -471,9 +471,9 @@ gates:
     description: "Code coverage collection and reporting"
     required: false
     command: >-
-      cargo install cargo-llvm-cov --locked 2>/dev/null || true;
-      cargo llvm-cov -p perl-parser --tests --lcov --output-path lcov.info;
-      cargo llvm-cov report -p perl-parser
+      rustup run nightly cargo install cargo-llvm-cov --locked 2>/dev/null || true;
+      rustup run nightly cargo llvm-cov -p perl-parser --lib --branch --lcov --output-path lcov.info;
+      bash ./scripts/check-coverage-baseline.sh lcov.info .ci/coverage-baseline.txt
     timeout_seconds: 900
     retry_count: 0
     budgets:

--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -179,7 +179,7 @@ labels:
   ci:lsp: 'Full LSP integration tests'
 
   # Code coverage generation
-  ci:coverage: 'Generate coverage reports'
+  ci:coverage: 'Generate branch-aware coverage reports'
 
   # Performance benchmarks
   ci:bench: 'Run benchmarks'

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -194,7 +194,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
 
@@ -204,8 +204,13 @@ jobs:
           key: ${{ runner.os }}-coverage-${{ hashFiles('Cargo.lock') }}
           cache-on-failure: true
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: rustup run nightly cargo install cargo-llvm-cov --locked
 
       - name: Create legacy LSP fixtures (CI-only)
         run: |
@@ -218,9 +223,7 @@ jobs:
         env:
           RUSTFLAGS: "-Copt-level=1 -Cdebuginfo=2"
           CARGO_BUILD_JOBS: 2
-        run: |
-          cargo llvm-cov -p perl-parser --tests --lcov --output-path lcov.info
-          cargo llvm-cov report -p perl-parser
+        run: just coverage-branch-gate
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/docs/how-to/COVERAGE.md
+++ b/docs/how-to/COVERAGE.md
@@ -6,6 +6,10 @@ This document describes the code coverage infrastructure for perl-lsp.
 
 The perl-lsp project uses **cargo-llvm-cov** for code coverage generation and **Codecov** for coverage aggregation, trending, and PR reporting.
 
+Branch coverage is enabled in the coverage lane with `cargo-llvm-cov --branch`. That requires a nightly Rust toolchain because LLVM branch coverage uses unstable `-Z coverage-options=branch` support.
+
+The initial PR slice keeps the branch gate on library/unit tests (`--lib`) so it stays stable on current master. Integration snapshot suites can still be run separately outside the coverage lane.
+
 ## Quick Start
 
 ### Local Coverage Reports
@@ -18,9 +22,10 @@ just coverage
 
 This will:
 1. Install `cargo-llvm-cov` if not present
-2. Run tests with coverage instrumentation
-3. Generate an HTML report at `target/coverage/index.html`
-4. Attempt to open the report in your browser
+2. Use a nightly Rust toolchain for branch coverage support
+3. Run tests with coverage instrumentation
+4. Generate an HTML report at `target/coverage/index.html`
+5. Attempt to open the report in your browser
 
 ### Terminal Summary
 
@@ -44,23 +49,25 @@ This creates `lcov.info` in the project root.
 
 ### Automatic Coverage Reports
 
-Coverage is automatically generated and uploaded to Codecov:
+Coverage is automatically generated and uploaded to Codecov from the nightly `test-coverage` job in `.github/workflows/ci-nightly.yml`:
 
-- **On every push to `main`/`master`**: Full workspace coverage
-- **On PRs with `ci:coverage` label**: Full workspace coverage
-- **On manual workflow dispatch**: Full workspace coverage
+- **On every push to `main`/`master`**: No coverage job by default
+- **On PRs with `ci:coverage` label**: Parser coverage with branch data
+- **On manual workflow dispatch**: Parser coverage with branch data
 
 ### Viewing Coverage in PRs
 
 When the `ci:coverage` label is applied to a PR:
 
-1. The coverage workflow runs automatically
+1. The nightly coverage job runs automatically
 2. Coverage data is uploaded to Codecov
 3. Codecov posts a comment to the PR showing:
    - Overall coverage percentage
    - Coverage diff (lines added/removed)
    - Per-file coverage changes
    - Flags for each crate (parser, lsp, lexer, dap, corpus)
+
+The nightly coverage lane also generates branch coverage in `lcov.info` and checks it against `.ci/coverage-baseline.txt`. The first slice is a ratchet: branch coverage can stay flat or improve, and it fails if the total drops by more than the allowed percentage point budget.
 
 ### Coverage Badge
 
@@ -88,6 +95,12 @@ Coverage thresholds are defined in `codecov.yml`:
 - **75% for patches**: Encourages well-tested new code
 - **Per-crate targets**: Higher for core, testable components (parser, lexer)
 
+Branch coverage uses the checked-in policy file instead of Codecov status thresholds for the initial PR slice:
+
+- `.ci/coverage-baseline.txt` stores the current branch-coverage baseline and regression budget
+- `scripts/check-coverage-baseline.sh` compares the generated `lcov.info` against that baseline
+- `target_branch_coverage` documents the intended longer-term 80% floor
+
 ## Exclusions
 
 The following paths are excluded from coverage analysis (configured in `codecov.yml`):
@@ -105,16 +118,17 @@ The following paths are excluded from coverage analysis (configured in `codecov.
 
 ## Coverage Workflow
 
-The coverage workflow (`.github/workflows/coverage.yml`) performs these steps:
+The nightly coverage job (`.github/workflows/ci-nightly.yml`, `test-coverage`) performs these steps:
 
 1. **Install toolchain**: Rust stable with `llvm-tools-preview` component
 2. **Install cargo-llvm-cov**: Using `taiki-e/install-action@v2` for speed
 3. **Cache dependencies**: Uses `Swatinem/rust-cache@v2` for faster builds
 4. **Create fixtures**: Legacy LSP test fixtures (if needed)
-5. **Generate coverage**: Run tests with LLVM instrumentation
+5. **Generate coverage**: Run tests with LLVM instrumentation and branch coverage
 6. **Display summary**: Show coverage summary in logs
-7. **Upload to Codecov**: Upload `lcov.info` to Codecov service
-8. **Archive report**: Save `lcov.info` as workflow artifact (30-day retention)
+7. **Check baseline**: Compare branch coverage to `.ci/coverage-baseline.txt`
+8. **Upload to Codecov**: Upload `lcov.info` to Codecov service
+9. **Archive report**: Save `lcov.info` as workflow artifact (30-day retention)
 
 ### Environment Variables
 
@@ -136,7 +150,7 @@ The `codecov.yml` file at the project root configures:
 - Per-crate flags for detailed tracking
 - PR comment layout
 
-### .github/workflows/coverage.yml
+### .github/workflows/ci-nightly.yml
 
 The coverage workflow file defines:
 
@@ -161,6 +175,9 @@ Some tests may be flaky under coverage instrumentation due to timing or memory c
 
 - Lower optimization (`-Copt-level=1`) for faster builds
 - Limited parallelism (`CARGO_BUILD_JOBS=2`, `RUST_TEST_THREADS=2`)
+
+If branch coverage is involved, make sure you are using `cargo +nightly llvm-cov` or a nightly-installed Rust toolchain. Stable rustc cannot compile the `--branch` instrumentation path.
+If your shell does not proxy `cargo +nightly` correctly on Windows, use `rustup run nightly cargo ...` instead.
 
 ### Codecov upload fails
 
@@ -199,6 +216,8 @@ When reviewing PRs with coverage:
 3. Ask: "Are the uncovered lines error paths that should be tested?"
 4. Don't aim for 100% - focus on meaningful test coverage
 
+For branch coverage, pay attention to error paths and recovery branches. A file can have acceptable line coverage while still leaving branches untested.
+
 ### Coverage-Driven Development
 
 Use coverage to find gaps:
@@ -220,6 +239,8 @@ Coverage is **not** part of the fast merge gate (`just ci-gate`) to avoid slowin
 - On `main`/`master` for baseline tracking
 - On PRs with explicit `ci:coverage` label
 - On manual workflow dispatch
+
+Branch coverage in the parser coverage lane is enforced separately through the baseline ratchet in `.ci/coverage-baseline.txt`.
 
 This keeps the merge gate fast (<5 min) while providing coverage visibility when needed.
 

--- a/docs/project/CI.md
+++ b/docs/project/CI.md
@@ -44,6 +44,7 @@ These typically complete in **~810 minutes** with caching.
 To keep PRs fast by default, expensive jobs are gated behind labels. Apply these labels to your PR to opt in:
 
 - **`ci:coverage`**  Run code coverage analysis with `cargo-llvm-cov` (generates lcov reports)
+  - Uses the nightly branch-coverage lane and the `.ci/coverage-baseline.txt` ratchet
 - **`ci:bench`**  Run performance benchmarks (nightly toolchain, heavier runtime)
 - **`ci:mutation`**  Run mutation testing with `cargo-mutants` (long-running; informational only)
 - **`ci:strict`**  Enable stricter Clippy lints (`pedantic`, `nursery`, `cargo`)

--- a/justfile
+++ b/justfile
@@ -1151,11 +1151,11 @@ perf-baseline:
 # Generate local HTML coverage report
 coverage:
     @echo "📊 Generating coverage report..."
-    @if ! command -v cargo-llvm-cov >/dev/null 2>&1; then \
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
         echo "❌ cargo-llvm-cov not found. Installing..."; \
-        cargo install cargo-llvm-cov --locked; \
+        "$HOME/.cargo/bin/rustup" run nightly cargo install cargo-llvm-cov --locked; \
     fi
-    @cargo llvm-cov --workspace --locked --exclude xtask --html --output-dir target/coverage \
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser --lib --locked --branch --html --output-dir target/coverage \
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-rs/|(^|/)crates/tree-sitter-perl-c/'
     @echo "✅ Coverage report: target/coverage/index.html"
     @echo "📈 Opening report in browser..."
@@ -1166,11 +1166,11 @@ coverage:
 # Generate coverage report (lcov format for CI)
 coverage-lcov:
     @echo "📊 Generating coverage (lcov format)..."
-    @if ! command -v cargo-llvm-cov >/dev/null 2>&1; then \
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
         echo "❌ cargo-llvm-cov not found. Installing..."; \
-        cargo install cargo-llvm-cov --locked; \
+        "$HOME/.cargo/bin/rustup" run nightly cargo install cargo-llvm-cov --locked; \
     fi
-    @cargo llvm-cov --workspace --locked --exclude xtask --lcov --output-path lcov.info \
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser --lib --locked --branch --lcov --output-path lcov.info \
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-rs/|(^|/)crates/tree-sitter-perl-c/'
     @echo "✅ Coverage: lcov.info"
 
@@ -1178,12 +1178,23 @@ coverage-lcov:
 coverage-summary:
     @echo "📊 Coverage Summary"
     @echo "==================="
-    @if ! command -v cargo-llvm-cov >/dev/null 2>&1; then \
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
         echo "❌ cargo-llvm-cov not found. Installing..."; \
-        cargo install cargo-llvm-cov --locked; \
+        "$HOME/.cargo/bin/rustup" run nightly cargo install cargo-llvm-cov --locked; \
     fi
-    @cargo llvm-cov --workspace --locked --exclude xtask \
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser --lib --locked --branch \
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-rs/|(^|/)crates/tree-sitter-perl-c/'
+
+# Generate branch coverage and fail if it regresses against the baseline policy
+coverage-branch-gate:
+    @echo "📊 Generating branch coverage gate data..."
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
+        echo "❌ cargo-llvm-cov not found. Installing..."; \
+        "$HOME/.cargo/bin/rustup" run nightly cargo install cargo-llvm-cov --locked; \
+    fi
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser --lib --locked --branch --lcov --output-path lcov.info \
+        --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-rs/|(^|/)crates/tree-sitter-perl-c/'
+    @bash ./scripts/check-coverage-baseline.sh lcov.info .ci/coverage-baseline.txt
 
 # ============================================================================
 # Technical Debt Tracking (Issue #XXX)

--- a/scripts/check-coverage-baseline.sh
+++ b/scripts/check-coverage-baseline.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lcov_path="${1:-lcov.info}"
+baseline_path="${2:-.ci/coverage-baseline.txt}"
+
+if [[ ! -f "$lcov_path" ]]; then
+  echo "error: coverage file not found: $lcov_path" >&2
+  exit 1
+fi
+
+if [[ ! -f "$baseline_path" ]]; then
+  echo "error: baseline file not found: $baseline_path" >&2
+  exit 1
+fi
+
+get_value() {
+  local key="$1"
+  local value
+
+  value="$(grep -E "^${key}=" "$baseline_path" | head -n1 | cut -d= -f2- || true)"
+  value="${value%%#*}"
+  value="${value//[[:space:]]/}"
+  printf '%s' "$value"
+}
+
+baseline_branch_coverage="$(get_value baseline_branch_coverage)"
+baseline_line_coverage="$(get_value baseline_line_coverage)"
+allowed_drop_percentage="$(get_value allowed_drop_percentage)"
+target_branch_coverage="$(get_value target_branch_coverage)"
+
+if [[ -z "$baseline_branch_coverage" || -z "$allowed_drop_percentage" || -z "$target_branch_coverage" ]]; then
+  echo "error: baseline file is missing required keys" >&2
+  exit 1
+fi
+
+coverage_stats="$(
+  awk '
+    /^BRF:/ { branch_found += substr($0, 5) + 0 }
+    /^BRH:/ { branch_hit += substr($0, 5) + 0 }
+    /^LF:/ { line_found += substr($0, 4) + 0 }
+    /^LH:/ { line_hit += substr($0, 4) + 0 }
+    END {
+      branch_pct = branch_found > 0 ? (branch_hit / branch_found * 100.0) : 100.0
+      line_pct = line_found > 0 ? (line_hit / line_found * 100.0) : 100.0
+      printf "%.2f %.2f %d %d %d %d\n", branch_pct, line_pct, branch_hit, branch_found, line_hit, line_found
+    }
+  ' "$lcov_path"
+)"
+
+read -r current_branch_coverage current_line_coverage branch_hit branch_found line_hit line_found <<<"$coverage_stats"
+
+printf 'Branch coverage: %.2f%% (%s/%s)\n' "$current_branch_coverage" "$branch_hit" "$branch_found"
+printf 'Line coverage:   %.2f%% (%s/%s)\n' "$current_line_coverage" "$line_hit" "$line_found"
+printf 'Baseline branch: %.2f%%\n' "$baseline_branch_coverage"
+if [[ -n "$baseline_line_coverage" ]]; then
+  printf 'Baseline line:   %.2f%%\n' "$baseline_line_coverage"
+fi
+printf 'Allowed drop:    %.2f%%\n' "$allowed_drop_percentage"
+printf 'Target branch:   %.2f%%\n' "$target_branch_coverage"
+
+awk -v current_branch="$current_branch_coverage" \
+    -v baseline_branch="$baseline_branch_coverage" \
+    -v allowed_drop="$allowed_drop_percentage" \
+    -v target_branch="$target_branch_coverage" '
+  BEGIN {
+    exit_code = 0
+    drop = baseline_branch - current_branch
+
+    if (drop > allowed_drop) {
+      printf "error: branch coverage dropped by %.2f%%, which exceeds the allowed %.2f%%\n", drop, allowed_drop > "/dev/stderr"
+      exit_code = 1
+    }
+
+    if (current_branch < target_branch) {
+      printf "warning: branch coverage is below the long-term target of %.2f%%\n", target_branch > "/dev/stderr"
+    }
+
+    exit exit_code
+  }
+'


### PR DESCRIPTION
Refs #2099.

Initial PR slice:
- enables a parser branch-coverage lane with nightly llvm-cov
- adds a checked-in branch coverage baseline and regression ratchet
- documents the lane and usage

This is scoped to perl-parser --lib so it stays green on current master.