### PR TITLE
docs(distribution): audit windows package manager verification (#2089)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ perl-lsp --health
 
 Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
+### Windows package managers
+
+The release automation keeps the Windows package-manager manifests in sync with
+each release. If you are on Windows, these are the user-facing install paths:
+
+```powershell
+scoop install perl-lsp
+choco install perl-lsp
+```
+
+After installation, verify the binary with `perl-lsp --health`.
+The repo documents the automated vs manual verification boundary in
+[docs/how-to/INSTALLATION.md](docs/how-to/INSTALLATION.md) and
+[docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md).
+
 ### VS Code Extension
 
 Install from the VS Code Marketplace or:

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -276,6 +276,25 @@ and checksum data used by Scoop and Chocolatey. Submitting the manifest to
 winget install --manifest .\distribution\winget\perl-lsp.yaml
 ```
 
+### Windows Package-Manager Verification
+
+The repo-owned verification story is intentionally narrower than the user-facing
+install story:
+
+- Automated: the release workflow publishes the Windows zip and
+  `SHA256SUMS`; the Scoop and Chocolatey bump workflows download that asset,
+  recompute the checksum, and rewrite the repo-owned manifests through
+  `distribution/windows/update-manifests.ps1`.
+- Guard rails: both bump workflows fail if release placeholders remain in the
+  manifests after the update step.
+- Manual: upstream PR acceptance in the Scoop and Chocolatey package repos,
+  then a real Windows install check with `scoop install perl-lsp` or
+  `choco install perl-lsp`, followed by `perl-lsp --health` and editor/PATH
+  discovery.
+
+Run `powershell -NoLogo -NoProfile -File scripts/check-windows-distribution.ps1`
+to audit the repo-side claims above.
+
 ### Docker
 
 Multi-arch Docker images are published to:

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -54,13 +54,39 @@ Copy-Item perl-lsp\perl-lsp.exe "C:\Program Files\perl-lsp\"
 ### Windows Package Managers
 
 The release automation keeps the Windows package-manager metadata in sync with
-each GitHub release.
+each GitHub release, but only the repo-owned manifest refresh is automated.
+Upstream package submission and the final user-machine install checks remain
+manual.
 
 - Scoop: `scoop install perl-lsp`
 - Chocolatey: `choco install perl-lsp`
 - Winget: the repo tracks a local manifest in `distribution/winget/` and the
   release workflow refreshes it; upstream `winget-pkgs` submission is still a
   manual follow-up
+
+#### Verification Boundary
+
+Repo-local checks can verify that:
+
+- the release workflow publishes the Windows zip and consolidated `SHA256SUMS`
+- the Scoop and Chocolatey bump workflows download that release asset, compute
+  the checksum, and call `distribution/windows/update-manifests.ps1`
+- placeholder guards fail if `__RELEASE_VERSION__`, `__RELEASE_HASH__`, or
+  other release tokens remain in the manifests after the update step
+
+Still manual:
+
+- upstream PR acceptance or merge in the Scoop and Chocolatey package repos
+- running `scoop install perl-lsp` or `choco install perl-lsp` on a Windows
+  machine
+- confirming `perl-lsp --health` and PATH discovery after installation
+- checking that VS Code or another editor can find the installed binary
+
+To smoke the repo-side story locally, run:
+
+```powershell
+powershell -NoLogo -NoProfile -File scripts/check-windows-distribution.ps1
+```
 
 For the latest version number, always check [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 

--- a/scripts/check-windows-distribution.ps1
+++ b/scripts/check-windows-distribution.ps1
@@ -1,0 +1,69 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+function Require-File {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+
+  $fullPath = Join-Path $repoRoot $Path
+  if (-not (Test-Path -LiteralPath $fullPath)) {
+    throw "Missing ${Label}: $Path"
+  }
+}
+
+function Require-Pattern {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Pattern,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+
+  $fullPath = Join-Path $repoRoot $Path
+  if (-not (Select-String -LiteralPath $fullPath -Pattern $Pattern -Quiet)) {
+    throw "$Label not found in $Path"
+  }
+}
+
+Write-Host "Windows distribution verification audit"
+Write-Host "Repo: $repoRoot"
+Write-Host ""
+
+Require-File '.github/workflows/scoop-bump.yml' 'Scoop bump workflow'
+Require-File '.github/workflows/chocolatey-bump.yml' 'Chocolatey bump workflow'
+Require-File '.github/workflows/release.yml' 'release workflow'
+Require-File 'README.md' 'root README'
+Require-File 'docs/how-to/INSTALLATION.md' 'installation guide'
+Require-File 'docs/RELEASE_PROCESS.md' 'release process doc'
+Require-File 'distribution/windows/update-manifests.ps1' 'shared manifest updater'
+
+Require-Pattern '.github/workflows/scoop-bump.yml' 'update-manifests\.ps1' 'Scoop workflow manifest updater call'
+Require-Pattern '.github/workflows/scoop-bump.yml' 'Select-String.*__RELEASE_VERSION__\|__RELEASE_HASH__' 'Scoop placeholder guard'
+Require-Pattern '.github/workflows/chocolatey-bump.yml' 'update-manifests\.ps1' 'Chocolatey workflow manifest updater call'
+Require-Pattern '.github/workflows/chocolatey-bump.yml' 'Select-String.*__RELEASE_VERSION__\|__RELEASE_SHA256__' 'Chocolatey placeholder guard'
+Require-Pattern '.github/workflows/release.yml' 'SHA256SUMS' 'release checksum bundle'
+Require-Pattern 'README.md' 'Windows package managers' 'README Windows install section'
+Require-Pattern 'README.md' 'scoop install perl-lsp' 'README Scoop command'
+Require-Pattern 'README.md' 'choco install perl-lsp' 'README Chocolatey command'
+Require-Pattern 'docs/how-to/INSTALLATION.md' 'Verification Boundary' 'installation verification boundary'
+Require-Pattern 'docs/how-to/INSTALLATION.md' 'perl-lsp --health' 'installation health check'
+Require-Pattern 'docs/RELEASE_PROCESS.md' 'Windows Package-Manager Verification' 'release verification section'
+Require-Pattern 'docs/RELEASE_PROCESS.md' 'powershell -NoLogo -NoProfile -File scripts/check-windows-distribution\.ps1' 'release check command'
+
+Write-Host 'PASS: repo-side Windows distribution story is documented and wired.'
+Write-Host ''
+Write-Host 'Verified in repo:'
+Write-Host '- release workflow publishes the Windows zip plus consolidated SHA256SUMS'
+Write-Host '- Scoop and Chocolatey workflows refresh repo-owned manifests from that release asset'
+Write-Host '- placeholder guards fail if release tokens remain after the update step'
+Write-Host '- README and installation docs point users at Scoop and Chocolatey install commands'
+Write-Host ''
+Write-Host 'Still manual / external:'
+Write-Host '- upstream PR acceptance or merge in ScoopInstaller/Main and Chocolatey packaging repos'
+Write-Host '- installing on a Windows machine and checking PATH discovery'
+Write-Host '- running perl-lsp --health after install'
+Write-Host '- confirming editor discovery, including VS Code'


### PR DESCRIPTION
Refs #2089.

Initial stacked PR slice on top of #2596 / issue/2596:
- documents exactly what the repo-side Scoop/Chocolatey automation verifies
- adds a focused Windows distribution verification smoke script
- makes the remaining manual checks explicit instead of implying they are automated

This branch is intentionally stacked on the Windows manifest automation branch so the review only shows the verification/docs delta.