### PR TITLE
docs(marketing): add walkthrough storyboard assets (#2336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ For a full walkthrough with troubleshooting tips, see the **[Getting Started gui
 
 The full feature catalog lives in [`features.toml`](features.toml). For live project metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
 
+### Demo Walkthroughs
+
+The launch demo assets are staged as storyboard SVGs in [`vscode-extension/media/walkthrough/`](vscode-extension/media/walkthrough/). The final GIF recording pass is still pending manual capture.
+
+- [Install → auto-download → health check](vscode-extension/media/walkthrough/install-health.svg)
+- [Go to definition + find references](vscode-extension/media/walkthrough/find-references.svg)
+- [Extract variable code action](vscode-extension/media/walkthrough/extract-variable.svg)
+
+When the screen recordings are ready, render them with [`scripts/marketing/render-walkthrough-gif.py`](scripts/marketing/render-walkthrough-gif.py).
+
 ## Comparison
 
 | | perl-lsp | PerlNavigator | Perl::LanguageServer |

--- a/scripts/marketing/render-walkthrough-gif.py
+++ b/scripts/marketing/render-walkthrough-gif.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Render a compressed demo GIF from a manually captured screen recording."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def build_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a palette-optimized GIF from a manual screen recording."
+    )
+    parser.add_argument("--input", required=True, help="Path to the recorded video file.")
+    parser.add_argument("--output", required=True, help="Path to the output GIF file.")
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=12,
+        help="Output frame rate for the GIF (default: 12).",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=960,
+        help="Target width for the GIF; height is computed automatically (default: 960).",
+    )
+    parser.add_argument(
+        "--start",
+        default=None,
+        help="Optional ffmpeg start offset (for example 00:00:02.0).",
+    )
+    parser.add_argument(
+        "--duration",
+        default=None,
+        help="Optional ffmpeg duration cap (for example 00:00:08.0).",
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Keep the temporary palette file for debugging.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = build_args()
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        print("error: ffmpeg is required but was not found on PATH", file=sys.stderr)
+        return 2
+
+    input_video = Path(args.input)
+    if not input_video.exists():
+        print(f"error: input video not found: {input_video}", file=sys.stderr)
+        return 2
+
+    output_gif = Path(args.output)
+    output_gif.parent.mkdir(parents=True, exist_ok=True)
+
+    start_args: list[str] = []
+    if args.start is not None:
+        start_args.extend(["-ss", args.start])
+
+    duration_args: list[str] = []
+    if args.duration is not None:
+        duration_args.extend(["-t", args.duration])
+
+    scale_filter = f"fps={args.fps},scale={args.width}:-1:flags=lanczos"
+    palette_filter = f"{scale_filter},palettegen=stats_mode=diff"
+    use_filter = f"{scale_filter}[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        palette = temp_path / "palette.png"
+
+        run(
+            [
+                ffmpeg,
+                "-y",
+                *start_args,
+                "-i",
+                str(input_video),
+                *duration_args,
+                "-vf",
+                palette_filter,
+                str(palette),
+            ]
+        )
+
+        run(
+            [
+                ffmpeg,
+                "-y",
+                *start_args,
+                "-i",
+                str(input_video),
+                *duration_args,
+                "-i",
+                str(palette),
+                "-lavfi",
+                use_filter,
+                str(output_gif),
+            ]
+        )
+
+        gifsicle = shutil.which("gifsicle")
+        if gifsicle is not None:
+            optimized = temp_path / "optimized.gif"
+            run([gifsicle, "-O3", str(output_gif), "-o", str(optimized)])
+            optimized.replace(output_gif)
+
+        if args.keep_temp:
+            temp_copy = output_gif.with_suffix(".palette.png")
+            shutil.copy2(palette, temp_copy)
+
+    print(f"wrote {output_gif}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -51,10 +51,17 @@ A fast, native Perl 5 language server with 30+ IDE features. Written in Rust for
 - **Run Tests** -- Run individual tests or entire files from the Testing panel (`Shift+Alt+T`)
 - **TAP Support** -- Native Test Anything Protocol result parsing
 
-<!-- Screenshots placeholder: add screenshots showing features in action -->
-<!-- ![Go to Definition](images/goto-definition.png) -->
-<!-- ![Diagnostics](images/diagnostics.png) -->
-<!-- ![Completions](images/completions.png) -->
+### Walkthrough Previews
+
+These storyboard SVGs document the launch demos from issue #2336. The final GIF recordings still need a manual capture pass.
+
+<p align="center">
+  <a href="media/walkthrough/install-health.svg"><img src="media/walkthrough/install-health.svg" alt="Install, auto-download, and health check storyboard" width="31%" /></a>
+  <a href="media/walkthrough/find-references.svg"><img src="media/walkthrough/find-references.svg" alt="Go to definition and find references storyboard" width="31%" /></a>
+  <a href="media/walkthrough/extract-variable.svg"><img src="media/walkthrough/extract-variable.svg" alt="Extract variable code action storyboard" width="31%" /></a>
+</p>
+
+See [media/walkthrough/README.md](media/walkthrough/README.md) for the capture plan and GIF render helper.
 
 ## Installation
 

--- a/vscode-extension/media/walkthrough/README.md
+++ b/vscode-extension/media/walkthrough/README.md
@@ -1,0 +1,34 @@
+# Walkthrough Assets
+
+This directory is the current home for the launch-demo visuals called out in issue #2336.
+
+Status:
+- The SVG files in this folder are storyboard previews, not recorded GIFs.
+- The final GIF pass still needs a manual screen-recording capture in VS Code.
+- Once a recording exists, use `scripts/marketing/render-walkthrough-gif.py` to produce the compressed GIF.
+
+## Planned GIFs
+
+| Target GIF | Storyboard | Source material |
+| --- | --- | --- |
+| `install-health.gif` | [`install-health.svg`](install-health.svg) | Fresh install, extension auto-download, and `perl-lsp --health` |
+| `find-references.gif` | [`find-references.svg`](find-references.svg) | Go to definition and find references over `demo_workspace/main.pl` and `demo_workspace/lib/Utils.pm` |
+| `extract-variable.gif` | [`extract-variable.svg`](extract-variable.svg) | Code action refactor flow in `demo_workspace/main.pl` |
+
+## Manual Capture Notes
+
+Use the sample files in [`../../../demo_workspace/`](../../../demo_workspace/) for a reproducible demo workspace:
+
+- `main.pl`
+- `lib/Utils.pm`
+- `lib/Database.pm`
+
+Capture the interactions in a clean editor window, then render the recording with the helper script. Keep the final artifact small enough for GitHub README usage and preserve the on-screen text at readable size.
+
+## Render Helper
+
+```bash
+python scripts/marketing/render-walkthrough-gif.py --help
+```
+
+The helper expects a recorded input video and produces a palette-optimized GIF. It does not generate the recording itself.

--- a/vscode-extension/media/walkthrough/extract-variable.svg
+++ b/vscode-extension/media/walkthrough/extract-variable.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <text x="60" y="58" font-family="sans-serif" font-size="28" fill="#e2e8f0">Storyboard preview: code action extract variable</text>
+  <text x="60" y="92" font-family="sans-serif" font-size="16" fill="#94a3b8">Manual recording still required. This file documents the intended shot order for the final GIF.</text>
+
+  <rect x="55" y="130" width="345" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="425" y="130" width="345" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="795" y="130" width="350" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+
+  <circle cx="100" cy="170" r="18" fill="#2563eb"/>
+  <text x="95" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">1</text>
+  <text x="130" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Select the expression</text>
+  <rect x="80" y="215" width="295" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="100" y="250" font-family="monospace" font-size="18" fill="#94a3b8">demo_workspace/main.pl</text>
+  <text x="100" y="292" font-family="monospace" font-size="20" fill="#cbd5e1">my $total = $price *</text>
+  <rect x="96" y="300" width="215" height="28" rx="6" fill="#1d4ed8" opacity="0.55"/>
+  <text x="100" y="326" font-family="monospace" font-size="20" fill="#cbd5e1">$qty + $tax;</text>
+  <text x="100" y="362" font-family="sans-serif" font-size="15" fill="#94a3b8">Record the selection highlight before invoking the light bulb.</text>
+
+  <polygon points="405,320 420,305 420,335" fill="#38bdf8"/>
+  <line x1="405" y1="320" x2="420" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="470" cy="170" r="18" fill="#2563eb"/>
+  <text x="465" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">2</text>
+  <text x="500" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Invoke the code action</text>
+  <rect x="445" y="215" width="295" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <circle cx="510" cy="270" r="18" fill="#fbbf24"/>
+  <text x="504" y="277" font-family="sans-serif" font-size="18" fill="#111827">💡</text>
+  <text x="545" y="274" font-family="sans-serif" font-size="18" fill="#e2e8f0">Code actions</text>
+  <rect x="470" y="298" width="250" height="38" rx="8" fill="#1d4ed8"/>
+  <text x="490" y="323" font-family="sans-serif" font-size="16" fill="#eff6ff">Extract variable</text>
+  <rect x="470" y="348" width="250" height="38" rx="8" fill="#0f172a" stroke="#334155"/>
+  <text x="490" y="373" font-family="sans-serif" font-size="16" fill="#cbd5e1">Extract subroutine</text>
+  <text x="470" y="410" font-family="sans-serif" font-size="15" fill="#94a3b8">Highlight the light bulb and the chosen action.</text>
+
+  <polygon points="775,320 790,305 790,335" fill="#38bdf8"/>
+  <line x1="775" y1="320" x2="790" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="850" cy="170" r="18" fill="#2563eb"/>
+  <text x="845" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">3</text>
+  <text x="885" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Result after refactor</text>
+  <rect x="820" y="215" width="290" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="840" y="252" font-family="monospace" font-size="18" fill="#94a3b8">demo_workspace/main.pl</text>
+  <text x="840" y="292" font-family="monospace" font-size="20" fill="#cbd5e1">my $subtotal = $price * $qty;</text>
+  <text x="840" y="324" font-family="monospace" font-size="20" fill="#cbd5e1">my $total = $subtotal + $tax;</text>
+  <rect x="835" y="340" width="250" height="28" rx="6" fill="#16a34a" opacity="0.55"/>
+  <text x="840" y="380" font-family="sans-serif" font-size="15" fill="#94a3b8">The refactor should land on a clean, readable result.</text>
+
+  <text x="60" y="590" font-family="sans-serif" font-size="16" fill="#94a3b8">Planned output: `extract-variable.gif`. Keep the before/after sequence tight so the change is obvious.</text>
+  <text x="60" y="624" font-family="sans-serif" font-size="16" fill="#94a3b8">Source references: `demo_workspace/main.pl` and the refactoring UI in VS Code.</text>
+</svg>

--- a/vscode-extension/media/walkthrough/find-references.svg
+++ b/vscode-extension/media/walkthrough/find-references.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <text x="60" y="58" font-family="sans-serif" font-size="28" fill="#e2e8f0">Storyboard preview: go to definition + find references</text>
+  <text x="60" y="92" font-family="sans-serif" font-size="16" fill="#94a3b8">Manual recording still required. This file documents the intended shot order for the final GIF.</text>
+
+  <rect x="55" y="130" width="345" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="425" y="130" width="345" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="795" y="130" width="350" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+
+  <circle cx="100" cy="170" r="18" fill="#2563eb"/>
+  <text x="95" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">1</text>
+  <text x="130" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Ctrl+Click the symbol</text>
+  <rect x="80" y="215" width="295" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="100" y="250" font-family="monospace" font-size="18" fill="#94a3b8">demo_workspace/main.pl</text>
+  <text x="100" y="288" font-family="monospace" font-size="20" fill="#cbd5e1">my $processed = Utils::</text>
+  <text x="100" y="318" font-family="monospace" font-size="20" fill="#38bdf8" text-decoration="underline">process_data</text>
+  <text x="285" y="318" font-family="monospace" font-size="20" fill="#cbd5e1">($data);</text>
+  <text x="100" y="356" font-family="sans-serif" font-size="15" fill="#94a3b8">Use the click to jump to the definition in the module.</text>
+
+  <polygon points="405,320 420,305 420,335" fill="#38bdf8"/>
+  <line x1="405" y1="320" x2="420" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="470" cy="170" r="18" fill="#2563eb"/>
+  <text x="465" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">2</text>
+  <text x="500" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Jumped to definition</text>
+  <rect x="445" y="215" width="295" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="465" y="250" font-family="monospace" font-size="18" fill="#94a3b8">demo_workspace/lib/Utils.pm</text>
+  <text x="465" y="290" font-family="monospace" font-size="20" fill="#f472b6">sub</text>
+  <text x="505" y="290" font-family="monospace" font-size="20" fill="#fbbf24">process_data</text>
+  <text x="670" y="290" font-family="monospace" font-size="20" fill="#cbd5e1">{</text>
+  <text x="465" y="330" font-family="monospace" font-size="20" fill="#cbd5e1">    my ($data) = @_;</text>
+  <text x="465" y="360" font-family="monospace" font-size="20" fill="#cbd5e1">    ...</text>
+  <text x="465" y="397" font-family="sans-serif" font-size="15" fill="#94a3b8">The jump should feel instantaneous in the recording.</text>
+
+  <polygon points="775,320 790,305 790,335" fill="#38bdf8"/>
+  <line x1="775" y1="320" x2="790" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="850" cy="170" r="18" fill="#2563eb"/>
+  <text x="845" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">3</text>
+  <text x="885" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Find references panel</text>
+  <rect x="820" y="215" width="290" height="225" rx="14" fill="#0f172a" stroke="#334155"/>
+  <rect x="840" y="238" width="250" height="40" rx="8" fill="#111827" stroke="#334155"/>
+  <text x="860" y="264" font-family="sans-serif" font-size="16" fill="#cbd5e1">Find References: process_data</text>
+  <rect x="840" y="292" width="250" height="34" rx="8" fill="#1d4ed8"/>
+  <text x="860" y="315" font-family="sans-serif" font-size="16" fill="#eff6ff">main.pl:3  call site</text>
+  <rect x="840" y="334" width="250" height="34" rx="8" fill="#1d4ed8"/>
+  <text x="860" y="357" font-family="sans-serif" font-size="16" fill="#eff6ff">Utils.pm:8  definition</text>
+  <rect x="840" y="376" width="250" height="34" rx="8" fill="#1d4ed8"/>
+  <text x="860" y="399" font-family="sans-serif" font-size="16" fill="#eff6ff">main.pl:8  second usage</text>
+
+  <text x="60" y="590" font-family="sans-serif" font-size="16" fill="#94a3b8">Planned output: `find-references.gif`. Capture both the jump and the references list in one take.</text>
+  <text x="60" y="624" font-family="sans-serif" font-size="16" fill="#94a3b8">Source references: `demo_workspace/main.pl` and `demo_workspace/lib/Utils.pm`.</text>
+</svg>

--- a/vscode-extension/media/walkthrough/install-health.svg
+++ b/vscode-extension/media/walkthrough/install-health.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <text x="60" y="58" font-family="sans-serif" font-size="28" fill="#e2e8f0">Storyboard preview: install → auto-download → health check</text>
+  <text x="60" y="92" font-family="sans-serif" font-size="16" fill="#94a3b8">Manual recording still required. This file documents the intended shot order for the final GIF.</text>
+
+  <rect x="55" y="130" width="330" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="445" y="130" width="330" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+  <rect x="835" y="130" width="310" height="400" rx="18" fill="#1e293b" stroke="#334155"/>
+
+  <circle cx="100" cy="170" r="18" fill="#2563eb"/>
+  <text x="95" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">1</text>
+  <text x="130" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Install extension</text>
+  <rect x="80" y="215" width="280" height="165" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="100" y="255" font-family="monospace" font-size="26" fill="#cbd5e1">code --install-extension</text>
+  <text x="100" y="291" font-family="monospace" font-size="26" fill="#cbd5e1">EffortlessMetrics.perl-lsp-rs</text>
+  <rect x="100" y="320" width="160" height="34" rx="17" fill="#22c55e"/>
+  <text x="132" y="343" font-family="sans-serif" font-size="16" fill="#052e16">Installing…</text>
+  <text x="100" y="392" font-family="sans-serif" font-size="15" fill="#94a3b8">Capture the marketplace install or VSIX install path.</text>
+
+  <polygon points="395,320 435,305 435,335" fill="#38bdf8"/>
+  <line x1="395" y1="320" x2="435" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="490" cy="170" r="18" fill="#2563eb"/>
+  <text x="485" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">2</text>
+  <text x="520" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Auto-download server</text>
+  <rect x="470" y="215" width="280" height="165" rx="14" fill="#0f172a" stroke="#334155"/>
+  <rect x="490" y="238" width="240" height="30" rx="8" fill="#111827" stroke="#334155"/>
+  <text x="505" y="258" font-family="monospace" font-size="16" fill="#cbd5e1">Downloading perl-lsp binary…</text>
+  <rect x="490" y="285" width="240" height="18" rx="9" fill="#1d4ed8"/>
+  <rect x="490" y="285" width="180" height="18" rx="9" fill="#38bdf8"/>
+  <text x="490" y="335" font-family="sans-serif" font-size="15" fill="#94a3b8">Show the managed binary arriving without manual setup.</text>
+  <text x="490" y="360" font-family="sans-serif" font-size="15" fill="#94a3b8">Keep the capture honest: the spinner should be visible.</text>
+
+  <polygon points="785,320 825,305 825,335" fill="#38bdf8"/>
+  <line x1="785" y1="320" x2="825" y2="320" stroke="#38bdf8" stroke-width="6" stroke-linecap="round"/>
+
+  <circle cx="878" cy="170" r="18" fill="#2563eb"/>
+  <text x="873" y="177" font-family="sans-serif" font-size="18" fill="#ffffff">3</text>
+  <text x="910" y="177" font-family="sans-serif" font-size="22" fill="#f8fafc">Health check passes</text>
+  <rect x="855" y="215" width="250" height="165" rx="14" fill="#0f172a" stroke="#334155"/>
+  <text x="875" y="250" font-family="monospace" font-size="18" fill="#cbd5e1">perl-lsp --health</text>
+  <rect x="875" y="270" width="190" height="34" rx="17" fill="#14532d" stroke="#16a34a"/>
+  <text x="913" y="292" font-family="sans-serif" font-size="16" fill="#dcfce7">Health: OK</text>
+  <text x="875" y="338" font-family="sans-serif" font-size="15" fill="#94a3b8">End on the green status so the result is obvious in the GIF.</text>
+
+  <text x="60" y="590" font-family="sans-serif" font-size="16" fill="#94a3b8">Planned output: `install-health.gif` under `vscode-extension/media/walkthrough/` once a manual recording exists.</text>
+  <text x="60" y="624" font-family="sans-serif" font-size="16" fill="#94a3b8">Source references: `demo_workspace/main.pl`, `demo_workspace/lib/Utils.pm`, `demo_workspace/lib/Database.pm`.</text>
+</svg>


### PR DESCRIPTION
Refs #2336.

Initial PR slice:
- adds storyboard assets for the three planned launch demos
- wires README and extension README to the walkthrough set
- adds a helper for rendering final GIFs after manual recording

This is an honest first slice: storyboard and capture kit now, real recorded GIFs in a follow-up manual pass.