### PR TITLE
docs: improve config and protocol crate landing pages (#2936)

### DIFF
--- a/crates/perl-lsp-completion/README.md
+++ b/crates/perl-lsp-completion/README.md
@@ -1,32 +1,38 @@
 # perl-lsp-completion
 
-Context-aware LSP completion engine for Perl, providing intelligent suggestions
-for variables, functions, methods, packages, keywords, and file paths.
+Context-aware completion engine for Perl source.
+
+## When to use this crate
+
+Use `perl-lsp-completion` when you want Perl-aware `textDocument/completion`
+behavior without embedding the full language server runtime.
+
+It is the right crate when you need:
+
+- ranked completion results at a source offset
+- completion logic that understands Perl sigils, packages, methods, and files
+- workspace-aware or AST-aware completion providers in Rust
 
 ## Public API
 
-- `CompletionProvider` -- builds a symbol table from an AST and optional workspace index, then generates ranked completion items at a given byte offset.
-- `CompletionContext` -- request-scoped context (position, trigger character, scope, prefix).
-- `CompletionItem` / `CompletionItemKind` -- completion payloads with label, insert text, sort priority, and text edit range.
+- `CompletionProvider`: builds a symbol table from an AST and optional workspace index, then generates ranked completion items at a given byte offset.
+- `CompletionContext`: request-scoped context for trigger character, scope, and prefix handling.
+- `CompletionItem` and `CompletionItemKind`: completion payloads with insert text, sort priority, and text-edit range.
 
-## Completion Sources
+## Example
 
-| Source | Trigger | Module |
-|--------|---------|--------|
-| Variables | `$`, `@`, `%` sigils | `variables` |
-| Functions | identifier prefix | `functions` |
-| Built-ins | identifier prefix | `builtins` |
-| Keywords | identifier prefix (with snippets) | `keywords` |
-| Methods | `->` | `methods` (includes DBI inference) |
-| Packages | `::` | `packages` (workspace index) |
-| Workspace symbols | identifier prefix | `workspace` |
-| Test::More | test file context | `test_more` |
-| File paths | inside string literals | `file_path` (secure traversal) |
-| Moo/Moose `has` options | inside `has(...)` | built-in |
+```rust,ignore
+use perl_lsp_completion::CompletionProvider;
 
-## Workspace Role
+let provider = CompletionProvider::new(&ast, Some(&workspace_index))?;
+let completions = provider.get_completions(source, position)?;
+assert!(!completions.is_empty());
+```
 
-Internal feature crate consumed by `perl-lsp` for `textDocument/completion` handling. Not intended for direct end-user use outside the workspace.
+## Workspace role
+
+Internal feature crate consumed by `perl-lsp` for completion handling. It is
+mostly a workspace building block rather than a standalone end-user crate.
 
 ## License
 

--- a/crates/perl-lsp-diagnostics/README.md
+++ b/crates/perl-lsp-diagnostics/README.md
@@ -1,32 +1,38 @@
 # perl-lsp-diagnostics
 
-LSP diagnostics provider for Perl. Generates editor-visible diagnostics from
-parse errors, scope analysis, lint checks, and workspace-wide dead code detection.
+Diagnostics and linting provider for Perl source.
 
-## Features
+## When to use this crate
 
-- **Parse error diagnostics** -- converts parser errors into positioned diagnostics
-- **Scope analysis** -- undeclared variables, unused variables/parameters, shadowing, redeclaration
-- **Lint passes** -- common mistakes (assignment in condition, numeric undef), deprecated syntax (`defined @array`, `$[`), missing `use strict`/`use warnings`
-- **Dead code detection** -- workspace-wide unused subroutine/variable/constant/package detection (non-WASM only)
-- **Deduplication** -- removes duplicate diagnostics by range, severity, code, and message
-- **ERROR node classification** -- classifies AST error nodes with suggestions and explanations
+Use `perl-lsp-diagnostics` when you want editor-facing diagnostics for Perl
+source without embedding the full `perl-lsp` runtime.
+
+It combines parse errors, semantic analysis, lint checks, and dead-code signals
+into one provider surface suitable for `textDocument/publishDiagnostics` or
+pull-diagnostics style flows.
 
 ## Public API
 
-| Export | Description |
-|--------|-------------|
-| `DiagnosticsProvider` | Core provider -- builds diagnostics from AST and parse errors |
-| `Diagnostic`, `DiagnosticSeverity`, `DiagnosticTag`, `RelatedInformation` | Diagnostic types |
-| `common_mistakes::check_common_mistakes` | Assignment-in-condition and numeric-undef checks |
-| `deprecated::check_deprecated_syntax` | Deprecated syntax detection |
-| `strict_warnings::check_strict_warnings` | Missing pragma advisories |
-| `detect_dead_code` | Workspace-wide dead code detection (non-WASM) |
+- `DiagnosticsProvider`: core provider that builds diagnostics from AST and parse errors.
+- `Diagnostic`, `DiagnosticSeverity`, `DiagnosticTag`, `RelatedInformation`: diagnostic payload types.
+- `common_mistakes`, `deprecated`, `strict_warnings`, `unused_imports`: lint families re-exported for direct use.
+- `detect_dead_code`: workspace-wide dead code detection when not targeting WASM.
 
-## Workspace Role
+## Example
 
-Internal feature crate consumed by `perl-lsp` to publish diagnostics to editors.
-Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+```rust,ignore
+use perl_lsp_diagnostics::DiagnosticsProvider;
+
+let provider = DiagnosticsProvider::new(&ast, source.to_string());
+let diagnostics = provider.get_diagnostics(&workspace_index);
+assert!(!diagnostics.is_empty());
+```
+
+## Workspace role
+
+Internal feature crate consumed by `perl-lsp` to publish diagnostics to
+editors. It is mostly a workspace building block rather than a standalone
+end-user crate.
 
 ## License
 

--- a/crates/perl-lsp-navigation/README.md
+++ b/crates/perl-lsp-navigation/README.md
@@ -1,25 +1,47 @@
 # perl-lsp-navigation
 
-LSP navigation providers for Perl: workspace symbols, type hierarchy, type definition, find references, and document links.
+Navigation providers for Perl source.
+
+## When to use this crate
+
+Use `perl-lsp-navigation` when you want the navigation slice of Perl LSP
+features without pulling in the full server binary.
+
+It is a good fit for Rust tooling that needs:
+
+- definition and reference helpers
+- workspace symbol search
+- type hierarchy or type-definition support
+- document-link extraction from Perl imports
 
 ## Public API
 
-- **`WorkspaceSymbolsProvider`** / **`WorkspaceSymbol`** -- indexes parsed documents and searches symbols with fuzzy, prefix, and exact matching.
-- **`TypeHierarchyProvider`** / **`TypeHierarchyItem`** / **`TypeHierarchySymbolKind`** -- compatibility re-exports from `perl-lsp-type-hierarchy`; prepares type hierarchy items and resolves super/subtypes via `@ISA`, `use parent`, and `use base`.
-- **`TypeDefinitionProvider`** -- go-to-type-definition for variables, method calls, constructors, and `bless` expressions (requires `lsp-compat` feature).
-- **`find_references_single_file`** -- finds all same-file references to a variable or subroutine by byte offset.
-- **`compute_links`** -- extracts document links from `use` and `require` statements with deferred resolution.
+- `WorkspaceSymbolsProvider` and `WorkspaceSymbol`: index parsed documents and search symbols.
+- `TypeHierarchyProvider`, `TypeHierarchyItem`, and `TypeHierarchySymbolKind`: build and resolve Perl type hierarchies.
+- `TypeDefinitionProvider`: go-to-type-definition support for variables, method calls, constructors, and `bless` expressions.
+- `find_references_single_file`: same-file reference lookup by byte offset.
+- `compute_links`: extracts document links from `use` and `require` statements.
 
-## Workspace Role
+## Example
 
-Internal feature crate consumed by `perl-lsp` navigation request handlers. Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+```rust,ignore
+use perl_lsp_navigation::{TypeHierarchyProvider, WorkspaceSymbolsProvider};
+
+let type_hierarchy = TypeHierarchyProvider::new(workspace_index);
+let workspace_symbols = WorkspaceSymbolsProvider::new(workspace_index);
+```
+
+## Workspace role
+
+Internal feature crate consumed by `perl-lsp` navigation request handlers. It
+is mostly a workspace building block rather than a standalone end-user crate.
 
 ## Features
 
 | Feature | Purpose |
 |---------|---------|
-| `lsp-compat` | Enables `TypeDefinitionProvider::find_type_definition` and LSP type imports |
-| `slow_tests` | Enables slow/expensive integration tests |
+| `lsp-compat` | Enables LSP-specific type-definition behavior |
+| `slow_tests` | Enables slow or expensive integration tests |
 
 ## License
 

--- a/crates/perl-lsp-rename/README.md
+++ b/crates/perl-lsp-rename/README.md
@@ -1,30 +1,41 @@
 # perl-lsp-rename
 
-LSP rename provider for Perl symbol refactoring.
+Rename provider for Perl refactoring.
 
-## Features
+## When to use this crate
 
-- **Prepare rename**: validates that a symbol at a given position is renameable
-- **Rename execution**: generates text edits for all occurrences (definitions + references)
-- **Name validation**: rejects empty names, keywords, invalid identifiers, and naming conflicts
-- **Sigil handling**: preserves Perl sigils (`$`, `@`, `%`, `&`) during variable renames
-- **Special variable protection**: prevents renaming of built-in variables and functions
-- **Optional text search**: can also rename occurrences in comments and strings
+Use `perl-lsp-rename` when you want rename and prepare-rename behavior for Perl
+symbols without depending on the full server runtime.
+
+It is the right crate for:
+
+- validating whether a symbol can be renamed
+- generating coordinated rename edits
+- preserving sigils and Perl naming rules during refactors
 
 ## Public API
 
-| Type | Purpose |
-|------|---------|
-| `RenameProvider` | Main entry point: `prepare_rename()` and `rename()` |
-| `RenameOptions` | Controls validation, comment/string renaming |
-| `RenameResult` | Contains edits, validity flag, and optional error |
-| `TextEdit` | A single location + replacement text |
+- `RenameProvider`: main entry point for `prepare_rename()` and `rename()`.
+- `RenameOptions`: controls validation and comment/string renaming.
+- `RenameResult`: contains edits, validity state, and error information.
+- `TextEdit`: a single location plus replacement text.
 
-## Workspace Role
+## Example
 
-Internal feature crate in the `tree-sitter-perl-rs` workspace, consumed by
-`perl-lsp` to handle `textDocument/rename` and `textDocument/prepareRename` requests.
-Depends on `perl-parser-core` for AST types and `perl-semantic-analyzer` for symbol tables.
+```rust,ignore
+use perl_lsp_rename::RenameProvider;
+
+let provider = RenameProvider::new(&ast, source.to_string());
+let prep = provider.prepare_rename(position)?;
+let result = provider.rename(position, "new_name", &options);
+assert!(prep.is_some());
+assert!(result.valid);
+```
+
+## Workspace role
+
+Internal feature crate consumed by `perl-lsp` for rename request handling.
+It is mostly a workspace building block rather than a standalone end-user crate.
 
 ## License
 


### PR DESCRIPTION
Problem-first README pass for the four provider crates in this isolated branch.

Files:
- crates/perl-lsp-completion/README.md
- crates/perl-lsp-diagnostics/README.md
- crates/perl-lsp-navigation/README.md
- crates/perl-lsp-rename/README.md

Validation:
- git diff --check