### PR TITLE
docs: make install and editor guides task-first (#2936)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,20 @@ This directory is the main documentation home for the repository. Treat it as a 
 
 Rule: if you see a project metric duplicated outside [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), treat it as suspect until reverified.
 
+## I Want To...
+
+- Install perl-lsp: [how-to/INSTALLATION.md](how-to/INSTALLATION.md)
+- Configure my editor: [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md)
+- Fix an install or editor problem: [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md)
+- Get the first working tour: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
+- Understand the current release posture: [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md)
+
 ## Start Here
 
+- Install perl-lsp: [how-to/INSTALLATION.md](how-to/INSTALLATION.md)
+- Configure your editor: [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md)
+- Fix setup issues: [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md)
 - Users: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
-- Editor setup: [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md)
 - Contributors: [../CONTRIBUTING.md](../CONTRIBUTING.md)
 - Current project posture: [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md)
 - Active milestone: [project/ROADMAP.md](project/ROADMAP.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -1,195 +1,39 @@
 # Editor Setup Guide
 
-This guide provides copy/paste ready configurations for setting up the Perl LSP server with popular editors.
+This guide assumes `perl-lsp` is already installed and available on your
+`PATH`. If it is not, start with [INSTALLATION.md](INSTALLATION.md).
 
-## Table of Contents
+## Pick Your Editor
 
-- [Prerequisites](#prerequisites)
 - [VS Code](#vs-code)
 - [Neovim](#neovim)
 - [Emacs](#emacs)
 - [Helix](#helix)
 - [Sublime Text](#sublime-text)
-- [Troubleshooting](#troubleshooting)
-
----
-
-## Prerequisites
-
-### Install the Server
-
-```bash
-# Option 1: Install from crates.io (recommended)
-cargo install perl-lsp
-
-# Option 2: Install from source
-git clone https://github.com/EffortlessMetrics/perl-lsp.git
-cd perl-lsp
-cargo install --path crates/perl-lsp
-
-# Option 3: Download pre-built binary
-# See https://github.com/EffortlessMetrics/perl-lsp/releases
-```
-
-### Verify Installation
-
-```bash
-# Check binary is in PATH
-which perl-lsp
-
-# Check version
-perl-lsp --version
-
-# Quick health check
-perl-lsp --health
-```
-
----
 
 ## VS Code
 
-### Option 1: Using Generic LSP Extension
-
-Install a generic LSP client extension (e.g., "Generic LSP Client" or "vscode-lsp-wl").
-
-Create or edit `.vscode/settings.json` in your workspace:
-
-```json
-{
-  "languageServerExtensions.serverConfigurations": [
-    {
-      "id": "perl-lsp",
-      "displayName": "Perl Language Server",
-      "command": "perl-lsp",
-      "args": ["--stdio"],
-      "scope": "workspace",
-      "fileEvents": ["**/*.pl", "**/*.pm", "**/*.t"]
-    }
-  ]
-}
-```
-
-### Option 2: Using the Official Extension
-
-Install from the VS Code marketplace:
+Install the official extension:
 
 ```bash
 code --install-extension EffortlessMetrics.perl-lsp-rs
 ```
 
-### Recommended Settings
-
-Add to your `settings.json` (Ctrl+Shift+P -> "Preferences: Open Settings (JSON)"):
+The extension auto-downloads the server binary. If you want to use a local
+binary instead, set `perl-lsp.serverPath` in your settings.
 
 ```json
 {
-  "perl-lsp.serverPath": "",
   "perl-lsp.autoDownload": true,
+  "perl-lsp.serverPath": "",
   "perl-lsp.trace.server": "off",
   "perl-lsp.enableDiagnostics": true,
-  "perl-lsp.enableSemanticTokens": true,
-  "perl-lsp.enableFormatting": true,
-  "perl-lsp.formatOnSave": false,
-  "perl-lsp.enableRefactoring": true,
-  "perl-lsp.includePaths": ["lib", "local/lib/perl5"],
-  "perl-lsp.enableTestIntegration": true
+  "perl-lsp.enableSemanticTokens": true
 }
 ```
-
-### Debug Logging
-
-For troubleshooting, enable server tracing:
-
-```json
-{
-  "perl-lsp.trace.server": "verbose"
-}
-```
-
----
 
 ## Neovim
 
-### Using nvim-lspconfig
-
-Add to your `init.lua`:
-
-```lua
--- Define perl-lsp in lspconfig
-local lspconfig = require('lspconfig')
-local configs = require('lspconfig.configs')
-
-if not configs.perl_lsp then
-  configs.perl_lsp = {
-    default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
-      filetypes = { 'perl' },
-      root_dir = lspconfig.util.root_pattern(
-        'Makefile.PL',
-        'Build.PL',
-        'cpanfile',
-        'dist.ini',
-        '.git'
-      ),
-      single_file_support = true,
-      settings = {
-        perl = {
-          workspace = {
-            includePaths = { 'lib', '.', 'local/lib/perl5' },
-            useSystemInc = false,
-            resolutionTimeout = 50,
-          },
-          inlayHints = {
-            enabled = true,
-            parameterHints = true,
-            typeHints = true,
-            chainedHints = false,
-            maxLength = 30,
-          },
-          testRunner = {
-            enabled = true,
-            command = 'perl',
-            args = {},
-            timeout = 60000,
-          },
-          limits = {
-            workspaceSymbolCap = 200,
-            referencesCap = 500,
-            completionCap = 100,
-            astCacheMaxEntries = 100,
-            maxIndexedFiles = 10000,
-            maxTotalSymbols = 500000,
-            workspaceScanDeadlineMs = 30000,
-            referenceSearchDeadlineMs = 2000,
-          },
-        },
-      },
-    },
-  }
-end
-
--- Enable the server
-lspconfig.perl_lsp.setup({
-  on_attach = function(client, bufnr)
-    -- Enable completion triggered by <c-x><c-o>
-    vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
-
-    -- Buffer local keymaps
-    local opts = { buffer = bufnr, noremap = true, silent = true }
-    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
-    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
-    vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
-  end,
-  capabilities = vim.lsp.protocol.make_client_capabilities(),
-})
-```
-
-### Minimal Configuration
-
-For a minimal setup:
-
 ```lua
 local lspconfig = require('lspconfig')
 local configs = require('lspconfig.configs')
@@ -199,7 +43,7 @@ if not configs.perl_lsp then
     default_config = {
       cmd = { 'perl-lsp', '--stdio' },
       filetypes = { 'perl' },
-      root_dir = lspconfig.util.root_pattern('.git'),
+      root_dir = lspconfig.util.root_pattern('.git', 'Makefile.PL', 'cpanfile', 'dist.ini'),
       single_file_support = true,
     },
   }
@@ -208,304 +52,41 @@ end
 lspconfig.perl_lsp.setup({})
 ```
 
-### With nvim-cmp Completion
-
-```lua
-lspconfig.perl_lsp.setup({
-  capabilities = require('cmp_nvim_lsp').default_capabilities(),
-})
-```
-
----
-
 ## Emacs
 
-### Using lsp-mode
-
-Add to your Emacs configuration:
-
 ```elisp
-(use-package lsp-mode
-  :ensure t
-  :hook ((cperl-mode . lsp-deferred)
-         (perl-mode . lsp-deferred))
-  :commands lsp
-  :init
-  (setq lsp-keymap-prefix "C-c l")
-  :config
-  ;; Register perl-lsp
-  (lsp-register-client
-   (make-lsp-client
-    :new-connection (lsp-stdio-connection '("perl-lsp" "--stdio"))
-    :major-modes '(cperl-mode perl-mode)
-    :priority -1
-    :server-id 'perl-lsp
-    :initialization-options
-    '((perl
-       (workspace
-        (includePaths . ["lib" "." "local/lib/perl5"])
-        (useSystemInc . :json-false)
-        (resolutionTimeout . 50))
-       (inlayHints
-        (enabled . t)
-        (parameterHints . t)
-        (typeHints . t))
-       (limits
-        (workspaceSymbolCap . 200)
-        (referencesCap . 500)
-        (completionCap . 100)))))))
-
-;; Optional: Enable lsp-ui for enhanced UI
-(use-package lsp-ui
-  :ensure t
-  :hook (lsp-mode . lsp-ui-mode)
-  :config
-  (setq lsp-ui-doc-enable t
-        lsp-ui-doc-show-with-cursor t
-        lsp-ui-sideline-enable t))
+(add-to-list 'eglot-server-programs
+             '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
 ```
 
-### Using eglot (Emacs 29+)
-
-```elisp
-(use-package eglot
-  :ensure t
-  :hook ((cperl-mode . eglot-ensure)
-         (perl-mode . eglot-ensure))
-  :config
-  (add-to-list 'eglot-server-programs
-               '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
-
-  ;; Optional: Configure initialization options
-  (setq-default eglot-workspace-configuration
-    '((perl
-       (workspace
-        (includePaths . ["lib" "." "local/lib/perl5"])
-        (useSystemInc . :json-false))
-       (limits
-        (workspaceSymbolCap . 200)
-        (referencesCap . 500))))))
-```
-
-### Keybindings for Emacs
-
-```elisp
-;; Common LSP keybindings for perl-mode
-(with-eval-after-load 'perl-mode
-  (define-key perl-mode-map (kbd "M-.") 'xref-find-definitions)
-  (define-key perl-mode-map (kbd "M-?") 'xref-find-references)
-  (define-key perl-mode-map (kbd "C-c r") 'lsp-rename)
-  (define-key perl-mode-map (kbd "C-c a") 'lsp-execute-code-action))
-```
-
----
+If you use `lsp-mode`, register the same command with `lsp-register-client`.
 
 ## Helix
-
-Add to `~/.config/helix/languages.toml`:
 
 ```toml
 [[language]]
 name = "perl"
-scope = "source.perl"
-injection-regex = "perl"
-file-types = ["pl", "pm", "t", "psgi"]
-roots = ["Makefile.PL", "Build.PL", "cpanfile", "dist.ini", ".git"]
-comment-token = "#"
-indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
 command = "perl-lsp"
 args = ["--stdio"]
-
-[language-server.perl-lsp.config.perl]
-workspace.includePaths = ["lib", ".", "local/lib/perl5"]
-workspace.useSystemInc = false
-workspace.resolutionTimeout = 50
-inlayHints.enabled = true
-inlayHints.parameterHints = true
-limits.workspaceSymbolCap = 200
-limits.referencesCap = 500
 ```
-
----
 
 ## Sublime Text
 
-1. Install the [LSP](https://packagecontrol.io/packages/LSP) package via Package Control
+Configure the LSP package to run:
 
-2. Open `Preferences > Package Settings > LSP > Settings` and add:
-
-```json
-{
-  "clients": {
-    "perl-lsp": {
-      "enabled": true,
-      "command": ["perl-lsp", "--stdio"],
-      "selector": "source.perl",
-      "initializationOptions": {
-        "perl": {
-          "workspace": {
-            "includePaths": ["lib", ".", "local/lib/perl5"],
-            "useSystemInc": false,
-            "resolutionTimeout": 50
-          },
-          "inlayHints": {
-            "enabled": true,
-            "parameterHints": true,
-            "typeHints": true
-          },
-          "limits": {
-            "workspaceSymbolCap": 200,
-            "referencesCap": 500,
-            "completionCap": 100
-          }
-        }
-      }
-    }
-  }
-}
+```text
+perl-lsp --stdio
 ```
 
----
+## What To Check
 
-## Troubleshooting
+After editor setup, open a Perl file and confirm:
 
-### Server Not Starting
+- the server starts without errors
+- diagnostics appear for obvious syntax issues
+- hover and completion work on a small test file
 
-1. **Verify binary location**:
-   ```bash
-   which perl-lsp
-   # Should output path like: /home/user/.cargo/bin/perl-lsp
-   ```
-
-2. **Check binary works**:
-   ```bash
-   perl-lsp --version
-   perl-lsp --health
-   ```
-
-3. **Test JSON-RPC communication**:
-   ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
-   ```
-
-### No Diagnostics
-
-1. **Check file type**: Ensure your file has a Perl extension (.pl, .pm, .t)
-
-2. **Check logs**: Most editors show LSP logs in a dedicated panel
-   - VS Code: View > Output > select "Perl Language Server"
-   - Neovim: `:LspLog`
-   - Emacs: `*lsp-log*` buffer
-
-3. **Enable debug logging**:
-   ```bash
-   RUST_LOG=perl_lsp=debug perl-lsp --stdio
-   ```
-
-### Slow Performance
-
-1. **Reduce result caps**:
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "workspaceSymbolCap": 100,
-         "referencesCap": 200,
-         "maxIndexedFiles": 5000
-       }
-     }
-   }
-   ```
-
-2. **Disable system @INC** if you have network filesystems:
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "useSystemInc": false
-       }
-     }
-   }
-   ```
-
-3. **Reduce resolution timeout**:
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "resolutionTimeout": 25
-       }
-     }
-   }
-   ```
-
-### Module Resolution Issues
-
-1. **Check include paths**:
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
-       }
-     }
-   }
-   ```
-
-2. **Verify module exists**:
-   ```bash
-   perl -e 'use Module::Name;'
-   ```
-
-3. **Check workspace root**: Ensure your editor opened the correct project root
-
-### Connection Issues
-
-1. Check for crash logs in your editor's log panel
-
-2. Run with logging enabled:
-   ```bash
-   perl-lsp --stdio --log 2>perl-lsp.log
-   ```
-
-3. Report issues with reproduction steps on [GitHub](https://github.com/EffortlessMetrics/perl-lsp/issues)
-
----
-
-## Command Line Reference
-
-```
-perl-lsp [options]
-
-Options:
-  --stdio          Use stdio for communication (default)
-  --socket         Use TCP socket for communication (not yet implemented)
-  --port PORT      Port to listen on (default: 9257)
-  --log            Enable logging to stderr
-  --health         Quick health check (prints 'ok <version>')
-  --version        Show version information
-  --features-json  Output features catalog as JSON
-  --help           Show help message
-
-Examples:
-  # Run in stdio mode (for editors)
-  perl-lsp --stdio
-
-  # Run with logging enabled
-  perl-lsp --stdio --log
-
-  # Run with debug output
-  RUST_LOG=perl_lsp=debug perl-lsp --stdio
-```
-
----
-
-## See Also
-
-- [CONFIG.md](../reference/CONFIG.md) - Complete configuration reference
-- [PERFORMANCE_SLO.md](../reference/PERFORMANCE_SLO.md) - Performance targets and limits
-- [LSP_FEATURES.md](../reference/LSP_FEATURES.md) - Supported LSP features
-- [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md) - Debugging setup with perl-dap
+If that does not happen, move to [TROUBLESHOOTING.md](TROUBLESHOOTING.md).

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -1,54 +1,50 @@
 # Installation Guide
 
-Perl Language Server (perl-lsp) is a high-performance Language Server Protocol
-implementation for Perl 5. The repository currently tracks the `v0.12.0`
-release target, while crates.io and GitHub Releases provide the latest
-published version. Always check the releases page before copying a version
-number from `main`.
+Install `perl-lsp` and confirm it works.
 
-## Install from crates.io
+## Fast Path
+
+If you just want the shortest path to a working install:
+
+```bash
+cargo install perl-lsp
+perl-lsp --version
+perl-lsp --health
+```
+
+If those commands work, the binary is installed correctly and you can move on
+to [EDITOR_SETUP.md](EDITOR_SETUP.md).
+
+## Install From crates.io
 
 ```bash
 cargo install perl-lsp
 ```
 
-If you already have an older version installed, upgrade in place:
+If you already have an older version installed:
 
 ```bash
 cargo install perl-lsp --force
 ```
 
-## Manual Installation
+## Install From A Release Binary
 
-### Pre-compiled Binaries
+Download the latest release from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
+and install the binary for your platform.
 
-1. Go to [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and download the latest release for your platform.
-2. Extract the archive.
-3. Move the `perl-lsp` binary to a directory in your PATH.
+### Linux / macOS
 
-Binaries are provided for the following platforms:
-
-| Platform | Binary suffix |
-|----------|--------------|
-| Linux x86_64 | `x86_64-unknown-linux-gnu` |
-| Linux aarch64 | `aarch64-unknown-linux-gnu` |
-| macOS Intel | `x86_64-apple-darwin` |
-| macOS Apple Silicon | `aarch64-apple-darwin` |
-| Windows x86_64 | `x86_64-pc-windows-msvc` |
-
-#### Linux / macOS (general)
 ```bash
 # Replace VERSION and ARCH with values from the releases page
-# e.g. VERSION=<published-version> ARCH=x86_64-unknown-linux-gnu
 wget https://github.com/EffortlessMetrics/perl-lsp/releases/download/v${VERSION}/perl-lsp-${VERSION}-${ARCH}.tar.gz
 tar xzf perl-lsp-${VERSION}-${ARCH}.tar.gz
 sudo cp perl-lsp-${VERSION}-${ARCH}/perl-lsp /usr/local/bin/
 chmod +x /usr/local/bin/perl-lsp
 ```
 
-#### Windows x86_64
+### Windows
+
 ```powershell
-# Replace VERSION with the version from the releases page
 $VERSION = "<published-version>"
 Invoke-WebRequest "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v$VERSION/perl-lsp-$VERSION-x86_64-pc-windows-msvc.zip" -OutFile perl-lsp.zip
 Expand-Archive perl-lsp.zip -DestinationPath perl-lsp
@@ -57,59 +53,24 @@ Copy-Item perl-lsp\perl-lsp.exe "C:\Program Files\perl-lsp\"
 
 ### Windows Package Managers
 
-The release automation keeps the Windows package-manager metadata in sync with
-each GitHub release, but only the repo-owned manifest refresh is automated.
-Upstream package submission and the final user-machine install checks remain
-manual.
+If you prefer a package manager on Windows:
 
 - Scoop: `scoop install perl-lsp`
 - Chocolatey: `choco install perl-lsp`
-- Winget: the repo tracks a local manifest in `distribution/winget/` and the
-  release workflow refreshes it; upstream `winget-pkgs` submission is still a
-  manual follow-up
+- Winget: use the release-linked manifest once it has been published
 
-#### Verification Boundary
-
-Repo-local checks can verify that:
-
-- the release workflow publishes the Windows zip and consolidated `SHA256SUMS`
-- the Scoop and Chocolatey bump workflows download that release asset, compute
-  the checksum, and call `distribution/windows/update-manifests.ps1`
-- placeholder guards fail if `__RELEASE_VERSION__`, `__RELEASE_HASH__`, or
-  other release tokens remain in the manifests after the update step
-
-Still manual:
-
-- upstream PR acceptance or merge in the Scoop and Chocolatey package repos
-- running `scoop install perl-lsp` or `choco install perl-lsp` on a Windows
-  machine
-- confirming `perl-lsp --health` and PATH discovery after installation
-- checking that VS Code or another editor can find the installed binary
-
-To smoke the repo-side story locally, run:
-
-```powershell
-powershell -NoLogo -NoProfile -File scripts/check-windows-distribution.ps1
-```
-
-For the latest version number, always check [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
-
-### Build from Source
-
-1. Install Rust (minimum version 1.92)
-2. Clone the repository
-3. Build the release binary
+## Build From Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
 cargo build --release --bin perl-lsp -p perl-lsp
-cp target/release/perl-lsp ~/.local/bin/
 ```
 
-## Verification
+After building from source, copy the binary onto your `PATH` or run it in
+place from `target/release/`.
 
-After installation, verify that perl-lsp is working:
+## Verify The Install
 
 ```bash
 perl-lsp --version
@@ -117,171 +78,14 @@ perl-lsp --health
 perl-lsp --info
 ```
 
-Expected output:
+Expected results:
 
-- `--version` prints the installed package version.
+- `--version` prints the installed version.
 - `--health` prints `ok <version>`.
-- `--info` prints version, build metadata, feature profile, and coverage summary.
+- `--info` prints version, build metadata, and feature information.
 
-## Editor Configuration
+## Next Steps
 
-### VS Code
-1. Install the [Perl LSP extension](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
-2. Open a Perl file (.pl or .pm)
-3. The language server will start automatically
-
-### Neovim
-Add to your `init.lua`:
-
-```lua
-local lspconfig = require('lspconfig')
-local configs = require('lspconfig.configs')
-
-if not configs.perl_lsp then
-  configs.perl_lsp = {
-    default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
-      filetypes = { 'perl' },
-      root_dir = lspconfig.util.root_pattern('.git', 'Makefile.PL', 'cpanfile', 'dist.ini'),
-      single_file_support = true,
-    },
-  }
-end
-
-lspconfig.perl_lsp.setup({})
-```
-
-### Emacs
-Add to your configuration:
-
-```elisp
-(use-package lsp-mode
-  :config
-  (add-to-list 'lsp-language-id-configuration '(perl-mode . "perl"))
-  (lsp-register-client
-    :make-interactive
-    :new-connection (lambda (&rest _) (list (cons "stdio" (start-process "perl-lsp" nil "perl-lsp" "--stdio"))))
-    :activation-fn (lsp-activate-on "perl-mode")
-    :server-id 'perllsp))
-
-(add-hook 'perl-mode-hook #'lsp)
-```
-
-### Other Editors
-Configure your editor to use the command:
-```
-perl-lsp --stdio
-```
-
-### API Access Patterns
-
-- **Direct Rust integration**: add `perl-lsp`, `perl-parser`, `perl-lexer`, and `perl-dap` via your normal Cargo workflow for library and binary usage.
-- **DAP / debugging clients**: run `perl-dap` in native or bridge mode from any DAP-compatible editor.
-- **FFI / non-Rust integration**: use the `tree-sitter-perl-rs` crate with its optional `c-parser` feature for C-oriented Tree-sitter integration where needed.
-
-## Features
-
-- **Broad Perl Syntax Coverage**: Handles Perl 5.8 through 5.40 syntax including modern constructs
-- **Real-time Syntax Checking**: Instant feedback on code issues
-- **Code Completion**: Intelligent autocomplete with type inference
-- **Go-to-Definition**: Navigate to symbol definitions
-- **Find References**: Locate all usages of a symbol
-- **Symbol Search**: Search across workspace files
-- **Refactoring Support**: Advanced code transformation operations
-- **Incremental Parsing**: <1ms updates for large files
-- **Cross-file Navigation**: Dual indexing for comprehensive workspace analysis
-- **Import Optimization**: Automatic import management
-
-## Troubleshooting
-
-### Installation Issues
-
-#### "Permission denied" error
-Ensure you have permission to write to the installation directory:
-```bash
-# For system-wide installation
-sudo chown $USER:$USER /usr/local/bin
-
-# Or install to user directory
-mkdir -p ~/.local/bin
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-#### "Command not found" after installation
-Add the installation directory to your PATH:
-
-**Bash (~/.bashrc):**
-```bash
-export PATH="$PATH:$HOME/.local/bin"
-```
-
-**Zsh (~/.zshrc):**
-```bash
-export PATH="$PATH:$HOME/.local/bin"
-```
-
-**Windows:**
-```powershell
-[Environment]::SetEnvironmentVariable('Path', "$env:Path;$HOME\.local\bin", 'User')
-```
-
-## Useful CLI Checks
-
-These commands are helpful both after installation and when debugging editor integration:
-
-```bash
-perl-lsp --version                 # Confirm the binary resolves on PATH
-perl-lsp --health                  # Fast readiness check
-perl-lsp --info                    # Print build and feature-profile information
-perl-lsp --check lib/My/Module.pm  # Validate a file without starting an editor
-perl-lsp --completion bash         # Generate shell completions
-```
-
-## Runtime Issues
-
-#### LSP server not starting
-1. Verify the binary is executable: `perl-lsp --version`
-2. Check your editor's LSP configuration
-3. Look for error messages in your editor's LSP logs
-
-#### Slow performance
-1. Ensure you're using the [latest release](https://github.com/EffortlessMetrics/perl-lsp/releases/latest)
-2. Check if your workspace has very large Perl files (>100KB)
-3. Consider using `.perl-lspignore` to exclude unnecessary files
-
-#### Incomplete syntax coverage
-1. Verify you're using a supported Perl version (5.10+)
-2. Check for syntax errors in your Perl files
-3. Report issues at [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
-
-## Getting Help
-
-- **Documentation Index**: [docs/INDEX.md](../INDEX.md)
-- **Full Documentation**: [Repository Docs](https://github.com/EffortlessMetrics/perl-lsp/tree/master/docs)
-- **Issues**: [GitHub Issues](https://github.com/EffortlessMetrics/perl-lsp/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/EffortlessMetrics/perl-lsp/discussions)
-- **Changelog**: [Release Notes](https://github.com/EffortlessMetrics/perl-lsp/releases)
-
-## Supported Platforms
-
-| Platform | Architecture | Status |
-|----------|-------------|--------|
-| Linux | x86_64 | Tested |
-| Linux | aarch64 | Tested |
-| macOS | x86_64 | Tested |
-| macOS | aarch64 | Tested |
-| Windows | x86_64 | Tested |
-
-## Minimum Requirements
-
-- **Rust**: 1.92+ (for building from source)
-- **Perl**: 5.10+ (for parsing)
-- **Memory**: 50MB base usage
-- **Disk**: 10MB for installation
-
-## Security Notes
-
-- perl-lsp only reads files in your workspace
-- No network access is required during normal operation
-- All dependencies are statically linked in release builds
-- Security vulnerabilities should be reported privately via SECURITY.md
+- Set up your editor: [EDITOR_SETUP.md](EDITOR_SETUP.md)
+- Fix a broken install or editor connection: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+- Review configuration options: [../reference/CONFIG.md](../reference/CONFIG.md)

--- a/docs/how-to/TROUBLESHOOTING.md
+++ b/docs/how-to/TROUBLESHOOTING.md
@@ -1,441 +1,73 @@
 # Troubleshooting Guide
 
-Common issues and their solutions when using perl-lsp.
+Use these checks when `perl-lsp` installs successfully but does not behave as
+expected in your editor.
 
-## Quick Diagnostics
+## Start Here
+
+Run the health checks first:
 
 ```bash
-# Check installation
-which perl-lsp && perl-lsp --version
-
-# Health check
+which perl-lsp
+perl-lsp --version
 perl-lsp --health
-
-# Test JSON-RPC communication
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
 ```
 
-## Build Issues
+If `perl-lsp` is missing, return to [INSTALLATION.md](INSTALLATION.md).
+If the binary works but the editor still does not connect, return to
+[EDITOR_SETUP.md](EDITOR_SETUP.md).
 
-### Compilation Fails
+## Binary Not Found
 
-**Problem**: `cargo build` fails with errors.
+If the shell says `perl-lsp: command not found`:
 
-**Solutions**:
+1. Check that Cargo installed the binary into `~/.cargo/bin`.
+2. Add that directory to your `PATH` if needed.
+3. Re-run `perl-lsp --version`.
 
-1. Ensure you have Rust 1.92+ (MSRV):
-   ```bash
-   rustup update stable
-   rustc --version  # Should be >= 1.92
-   ```
+On Windows, make sure the install location is on `PATH` and then start a new
+terminal session.
 
-2. Clean and rebuild:
-   ```bash
-   cargo clean
-   cargo build -p perl-lsp --release
-   ```
+## Editor Connects But Features Are Missing
 
-3. If using Nix:
-   ```bash
-   nix develop -c cargo build -p perl-lsp --release
-   ```
+If the server starts but you do not see diagnostics, completion, or hover:
 
-### Missing Dependencies
+1. Confirm the file is recognized as Perl.
+2. Verify the editor is launching `perl-lsp --stdio`.
+3. Check the editor's LSP output or log panel.
+4. Open a small test file and compare behavior with a known-good example.
 
-**Problem**: Build complains about missing system dependencies.
+## Slow Or Memory-Heavy
 
-**Solution**: perl-lsp is pure Rust and should not require system dependencies. If you see C compiler or libclang errors, you may be building optional crates. Use:
+If the server feels slow on a large workspace:
 
-```bash
-cargo build -p perl-lsp --release
-```
+1. Reduce the workspace scope or exclude generated directories.
+2. Turn off features you are not using.
+3. Lower the workspace limits in your editor configuration.
+4. Confirm you are not indexing a vendor directory by accident.
 
-Not `cargo build --workspace` which includes optional native crates.
+## Parsing Or Language Gaps
 
-## Installation Issues
+If a syntax construct is not handled well:
 
-### Binary Not Found
+1. Check [KNOWN_LIMITATIONS.md](../reference/KNOWN_LIMITATIONS.md).
+2. Reproduce the problem with the smallest possible Perl file.
+3. File an issue with the reproduction and the exact `perl-lsp --version` output.
 
-**Problem**: `perl-lsp: command not found` after installation.
+## Debug Adapter Problems
 
-**Solutions**:
+If `perl-dap` or a DAP bridge session is failing:
 
-1. Check Cargo's bin directory is in PATH:
-   ```bash
-   echo $PATH | tr ':' '\n' | grep cargo
-   # Should include: ~/.cargo/bin
-   ```
+1. Confirm the debugger binary is installed.
+2. Verify the Perl debugging runtime works from the shell.
+3. See [DAP_USER_GUIDE.md](../tutorials/DAP_USER_GUIDE.md) for the intended setup.
 
-2. Add to PATH if missing:
-   ```bash
-   # Add to ~/.bashrc or ~/.zshrc
-   export PATH="$HOME/.cargo/bin:$PATH"
-   ```
+## What To Include In A Bug Report
 
-3. Verify installation location:
-   ```bash
-   ls -la ~/.cargo/bin/perl-lsp
-   ```
+- `perl-lsp --version`
+- your OS and editor
+- the smallest reproducible Perl snippet
+- relevant logs from the editor or shell
 
-### Permission Denied
-
-**Problem**: Cannot execute perl-lsp binary.
-
-**Solution**:
-```bash
-chmod +x ~/.cargo/bin/perl-lsp
-```
-
-## Runtime Issues
-
-### Server Crashes on Startup
-
-**Problem**: perl-lsp exits immediately or crashes.
-
-**Solutions**:
-
-1. Run with debug logging:
-   ```bash
-   RUST_LOG=perl_lsp=debug perl-lsp --stdio 2>debug.log
-   ```
-
-2. Check for conflicting processes:
-   ```bash
-   ps aux | grep perl-lsp
-   ```
-
-3. Verify the binary is not corrupted:
-   ```bash
-   cargo install --path crates/perl-lsp --force
-   ```
-
-### High Memory Usage
-
-**Problem**: perl-lsp uses excessive memory on large projects.
-
-**Solutions**:
-
-1. Limit indexed files:
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "maxIndexedFiles": 1000
-       }
-     }
-   }
-   ```
-
-2. Exclude directories via workspace settings:
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "excludePaths": ["node_modules", "vendor", ".git"]
-       }
-     }
-   }
-   ```
-
-### Slow Performance
-
-**Problem**: LSP responses are slow.
-
-**Solutions**:
-
-1. Disable unused features:
-   ```json
-   {
-     "perl": {
-       "enableSemanticTokens": false,
-       "enableInlayHints": false
-     }
-   }
-   ```
-
-2. Reduce workspace scope - see [EDITOR_SETUP.md](EDITOR_SETUP.md#slow-performance)
-
-### No Diagnostics Appearing
-
-**Problem**: Syntax errors are not highlighted.
-
-**Solutions**:
-
-1. Ensure file has Perl extension: `.pl`, `.pm`, or `.t`
-
-2. Check editor recognizes file as Perl (language mode)
-
-3. Verify diagnostics are enabled in settings
-
-4. Check LSP logs for errors - see [EDITOR_SETUP.md](EDITOR_SETUP.md#no-diagnostics)
-
-### Completion Not Working
-
-**Problem**: No completions appear when typing.
-
-**Solutions**:
-
-1. Ensure you're in a valid completion context (after `$`, `@`, `%`, or mid-identifier)
-
-2. Check the file is recognized as Perl in your editor
-
-3. Try manually triggering completion:
-   - VS Code: `Ctrl+Space`
-   - Neovim: `<C-x><C-o>`
-   - Emacs: `M-TAB` or `C-M-i`
-
-4. Verify completion cap hasn't been reached:
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "completionCap": 200
-       }
-     }
-   }
-   ```
-
-### Go-to-Definition Not Working
-
-**Problem**: "Go to Definition" doesn't find the symbol.
-
-**Solutions**:
-
-1. Ensure the definition is in an indexed file:
-   - File must be in workspace or `includePaths`
-   - File count must be under `maxIndexedFiles` limit
-
-2. Check include paths are configured:
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "includePaths": ["lib", ".", "local/lib/perl5"]
-       }
-     }
-   }
-   ```
-
-3. For CPAN modules, enable system @INC (if safe):
-   ```json
-   {
-     "perl": {
-       "workspace": {
-         "useSystemInc": true
-       }
-     }
-   }
-   ```
-
-4. Verify the symbol is actually defined (not just imported)
-
-### References Returning Incomplete Results
-
-**Problem**: "Find References" doesn't show all occurrences.
-
-**Solutions**:
-
-1. Check the references cap:
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "referencesCap": 1000
-       }
-     }
-   }
-   ```
-
-2. Ensure all relevant files are indexed (check `maxIndexedFiles`)
-
-3. Wait for workspace indexing to complete (check progress notification)
-
-4. Check the reference search deadline:
-   ```json
-   {
-     "perl": {
-       "limits": {
-         "referenceSearchDeadlineMs": 5000
-       }
-     }
-   }
-   ```
-
-### Formatting Not Working
-
-**Problem**: Document formatting doesn't change the file.
-
-**Solutions**:
-
-1. Verify Perl::Tidy is installed:
-   ```bash
-   perl -e 'use Perl::Tidy;'
-   ```
-
-2. Check for `.perltidyrc` in your project or home directory
-
-3. Verify formatting is enabled in editor settings
-
-4. Check for errors in the LSP log - formatting errors are often reported there
-
-5. Try manual formatting via command palette to see error messages
-
-## Parser Issues
-
-### Incorrect Syntax Highlighting
-
-**Problem**: Code is parsed incorrectly or shows false errors.
-
-**Solutions**:
-
-1. Check if the syntax is a known limitation - see [KNOWN_LIMITATIONS.md](../reference/KNOWN_LIMITATIONS.md)
-
-2. Report unhandled syntax:
-   ```bash
-   # Create minimal reproduction
-   cat > test.pl << 'EOF'
-   # Your problematic code here
-   EOF
-
-   # Test parsing
-   perl-lsp --parse test.pl
-   ```
-
-3. File an issue at: https://github.com/EffortlessMetrics/perl-lsp/issues
-
-### Heredoc Issues
-
-**Problem**: Heredocs not parsed correctly.
-
-**Solution**: Ensure heredoc delimiters are on their own lines:
-
-```perl
-# Works
-my $text = <<'END';
-content here
-END
-
-# May not work
-my $text = <<'END'; print "after heredoc";
-content
-END
-```
-
-## DAP (Debug Adapter) Issues
-
-**Note**: DAP support is experimental. Current limitations:
-
-- Launch mode only (attach pending)
-- Variables/evaluate show placeholders
-- BridgeAdapter library available for advanced use
-
-### Debugger Not Starting
-
-**Problem**: Debug session fails to start.
-
-**Solutions**:
-
-1. Ensure perl-dap is installed:
-   ```bash
-   cargo install --path crates/perl-dap
-   ```
-
-2. Verify Perl::LanguageServer is available (for bridge mode):
-   ```bash
-   perl -e 'use Perl::LanguageServer;'
-   ```
-
-## Editor-Specific Issues
-
-For detailed editor configuration and troubleshooting:
-
-- [VS Code setup](EDITOR_SETUP.md#vs-code)
-- [Neovim setup](EDITOR_SETUP.md#neovim)
-- [Emacs setup](EDITOR_SETUP.md#emacs)
-- [Helix setup](EDITOR_SETUP.md#helix)
-- [General troubleshooting](EDITOR_SETUP.md#troubleshooting)
-
-### VS Code: Extension Not Activating
-
-**Problem**: The perl-lsp extension doesn't activate on Perl files.
-
-**Solutions**:
-
-1. Check file association in VS Code bottom status bar (should say "Perl")
-
-2. Manually set language mode: `Ctrl+K M` then select "Perl"
-
-3. Verify extension is installed and enabled:
-   ```bash
-   code --list-extensions | grep perl
-   ```
-
-4. Check VS Code Output panel for errors (View > Output > select "Perl Language Server")
-
-### Neovim: LSP Not Attaching
-
-**Problem**: `:LspInfo` shows no client attached.
-
-**Solutions**:
-
-1. Verify filetype is recognized:
-   ```vim
-   :set filetype?
-   " Should output: filetype=perl
-   ```
-
-2. Check lspconfig is loaded:
-   ```vim
-   :lua print(vim.inspect(require('lspconfig').perl_lsp))
-   ```
-
-3. Manually start the client:
-   ```vim
-   :LspStart perl_lsp
-   ```
-
-4. Check `:LspLog` for errors
-
-### Emacs: eglot Fails to Connect
-
-**Problem**: eglot reports connection failure.
-
-**Solutions**:
-
-1. Check the `*eglot stderr*` buffer for errors
-
-2. Verify the command works in shell:
-   ```bash
-   perl-lsp --stdio
-   ```
-
-3. Try lsp-mode as an alternative:
-   ```elisp
-   (require 'lsp-mode)
-   (add-hook 'perl-mode-hook #'lsp)
-   ```
-
-4. Check `*lsp-log*` buffer for detailed errors
-
-## Getting Help
-
-1. Check existing issues: https://github.com/EffortlessMetrics/perl-lsp/issues
-
-2. Enable debug logging and include logs in bug reports:
-   ```bash
-   RUST_LOG=perl_lsp=debug,perl_parser=debug perl-lsp --stdio 2>debug.log
-   ```
-
-3. Include:
-   - perl-lsp version (`perl-lsp --version`)
-   - Rust version (`rustc --version`)
-   - OS and editor
-   - Minimal code reproduction
-
-## See Also
-
-- [FAQ.md](../reference/FAQ.md) - Frequently asked questions
-- [GETTING_STARTED.md](../tutorials/GETTING_STARTED.md) - Installation and setup guide
-- [EDITOR_SETUP.md](EDITOR_SETUP.md) - Detailed editor configurations
-- [CONFIG.md](../reference/CONFIG.md) - All configuration options
-- [KNOWN_LIMITATIONS.md](../reference/KNOWN_LIMITATIONS.md) - Current parser limitations
+If the problem looks like a bug rather than a configuration issue, report it on
+GitHub with that information.


### PR DESCRIPTION
Broader Diatxais cleanup for the user-facing install/setup/troubleshooting layer.

Changes:
- tightened docs/README.md into a problem-first hub with direct I want-to routes
- reduced maintainer/operator bleed from docs/how-to/INSTALLATION.md
- turned docs/how-to/EDITOR_SETUP.md into an editor-only setup guide
- rewrote docs/how-to/TROUBLESHOOTING.md into a symptom-first troubleshooting guide

Validation:
- git diff --check
