### PR TITLE
docs: clarify release operator docs (#2936)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,9 @@
 # Release Guide
 
 This document covers the end-to-end process for releasing a new version of `perl-lsp`.
-For the release preflight checklist, see [docs/project/RELEASE_CHECKLIST.md](docs/project/RELEASE_CHECKLIST.md).
+Use it together with [docs/project/RELEASE_CHECKLIST.md](docs/project/RELEASE_CHECKLIST.md)
+for the release-status checklist and [docs/project/PUBLISHING_ROADMAP.md](docs/project/PUBLISHING_ROADMAP.md)
+for the reusable preflight command flow.
 
 ## Table of Contents
 

--- a/docs/project/PUBLISHING_ROADMAP.md
+++ b/docs/project/PUBLISHING_ROADMAP.md
@@ -1,9 +1,11 @@
 # Publishing Roadmap
 
 > Machine-executable release guide. Every step is a command or a binary pass/fail check.
-> Covers: v0.13.0 (next release) and any subsequent minor release.
-> Authoritative release mechanics: `RELEASE.md`. Authoritative feature catalog: `features.toml`.
-> Replace `NEW_VERSION` and `PREV_VERSION` throughout with actual semver strings (e.g., `0.13.0`, `0.12.0`).
+> Covers the current release target and any subsequent minor release.
+> Authoritative operator sequence: `RELEASE.md`.
+> Authoritative release-status checklist: `docs/project/RELEASE_CHECKLIST.md`.
+> Authoritative feature catalog: `features.toml`.
+> Replace `NEW_VERSION` and `PREV_VERSION` throughout with the actual semver strings for the release you are cutting.
 
 ---
 
@@ -13,8 +15,9 @@
 
 ```bash
 export CARGO_TARGET_DIR="/tmp/release-preflight-target"
-export NEW_VERSION="0.13.0"
-export PREV_VERSION="0.12.0"
+# Set these for the release you are cutting:
+export NEW_VERSION="0.12.0"
+export PREV_VERSION="0.11.0"
 ```
 
 ### 1.2 Verify all version strings agree
@@ -47,7 +50,7 @@ gh workflow run version-bump.yml --field version=NEW_VERSION
 
 ```bash
 grep "## \[${NEW_VERSION}\]" CHANGELOG.md
-# Must match: ## [0.13.0] - YYYY-MM-DD
+# Must match: ## [NEW_VERSION] - YYYY-MM-DD
 ```
 
 Fail if missing. To promote [Unreleased] to a dated release:
@@ -62,7 +65,7 @@ git commit -m "chore: finalize CHANGELOG for v${NEW_VERSION}"
 CHANGELOG section structure (required):
 
 ```markdown
-## [0.13.0] - 2026-MM-DD
+## [NEW_VERSION] - 2026-MM-DD
 
 ### Added
 - ...
@@ -328,7 +331,7 @@ git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
 git push origin "v${NEW_VERSION}"
 ```
 
-Tag must be: `v` + semver. Examples: `v0.13.0`, `v0.13.1`. Never: `0.13.0`, `release-0.13.0`.
+Tag must be: `v` + semver. Examples: `v${NEW_VERSION}`, `v${NEW_VERSION}.1`. Never: `0.12.0`, `release-0.12.0`.
 
 ### 3.3 GitHub release
 
@@ -534,10 +537,10 @@ Triage SLA:
 |----------|---------------|
 | Crash or hang | Same day — file P0 issue, assign to next build cycle |
 | Parse error on valid Perl | 48 hours — file issue, label `parser-corpus` |
-| Feature gap | 1 week — triage to v0.13.x milestone |
+| Feature gap | 1 week — triage to the next active roadmap milestone |
 | Enhancement | Triage to roadmap, no SLA |
 
-### 4.4 v0.13.0 issue triage (Week 1 — after release)
+### 4.4 Post-release issue triage (Week 1 — after release)
 
 ```bash
 # List all open issues
@@ -546,10 +549,10 @@ gh issue list --state open --limit 200
 # Label new issues from post-release feedback
 # Use these labels: bug, parser-corpus, lsp-feature, enhancement, good-first-issue
 gh issue edit ISSUE_NUMBER --add-label "parser-corpus"
-gh issue edit ISSUE_NUMBER --milestone "v0.13.0"
+gh issue edit ISSUE_NUMBER --milestone "ROADMAP_MILESTONE"
 ```
 
-Milestone priorities for v0.13.0 (from ROADMAP.md):
+Milestone priorities come from [ROADMAP.md](ROADMAP.md) and should be applied to the next active milestone after the release:
 
 1. Diagnostic hardening: `strict`, `warnings`, dead-code signals
 2. CPAN corpus clean-parse rate to 95%+

--- a/docs/project/RELEASE_CHECKLIST.md
+++ b/docs/project/RELEASE_CHECKLIST.md
@@ -1,6 +1,11 @@
 # Release Checklist
 
-This checklist is for the current release run. The end-to-end release mechanics live in [RELEASE.md](../../RELEASE.md); crates publishing details live in [PUBLISHING.md](../PUBLISHING.md); changelog generation lives in [CHANGELOG_WORKFLOW.md](../CHANGELOG_WORKFLOW.md).
+This checklist is for the current release run. Use it with
+[RELEASE.md](../../RELEASE.md) for the operator sequence and
+[PUBLISHING_ROADMAP.md](../PUBLISHING_ROADMAP.md) for the machine-executable
+preflight flow. Crates publishing details live in
+[PUBLISHING.md](../PUBLISHING.md); changelog generation lives in
+[CHANGELOG_WORKFLOW.md](../CHANGELOG_WORKFLOW.md).
 
 Use `NEW_VERSION` as the target semver string for the release you are preparing.
 


### PR DESCRIPTION
Align the release/operator docs for the v0.12.0 release path.

- make the relationship between RELEASE.md, RELEASE_CHECKLIST.md, and PUBLISHING_ROADMAP.md explicit
- remove stale v0.13.0 framing from the roadmap and keep it reusable for the current release target
- keep the docs machine-executable and operator-focused

Validation:
- git diff --check