### PR TITLE
docs: refresh release note surface (#2936)

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,179 +1,41 @@
-# 🚀 Perl LSP v{{VERSION}} - {{RELEASE_TITLE}}
+# Perl LSP v{{VERSION}}
 
-## Release Date
-{{RELEASE_DATE}}
+Released {{RELEASE_DATE}}
 
-## 📋 Overview
+## Summary
 
 {{RELEASE_OVERVIEW}}
 
-## ✨ Key Highlights
+## Install or upgrade
 
-{{KEY_HIGHLIGHTS}}
-
-## 🎯 Major Features
-
-### {{FEATURE_1_TITLE}}
-{{FEATURE_1_DESCRIPTION}}
-
-### {{FEATURE_2_TITLE}}
-{{FEATURE_2_DESCRIPTION}}
-
-### {{FEATURE_3_TITLE}}
-{{FEATURE_3_DESCRIPTION}}
-
-## 🛠️ Installation
-
-### Quick Install
 ```bash
-# Install LSP server
 cargo install perl-lsp
-
-# Install DAP server (optional)
 cargo install perl-dap
-
-# Or quick install (Linux/macOS)
-curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 ```
 
-### Package Managers
+## Read this first
 
-#### Homebrew (macOS/Linux)
-```bash
-brew install perl-lsp
-```
+- [Docs home]({{DOCS_BASE_URL}}/README.md)
+- [Docs index]({{DOCS_BASE_URL}}/INDEX.md)
+- [Getting Started]({{DOCS_BASE_URL}}/tutorials/GETTING_STARTED.md)
+- [Installation Guide]({{DOCS_BASE_URL}}/how-to/INSTALLATION.md)
+- [Editor Setup]({{DOCS_BASE_URL}}/how-to/EDITOR_SETUP.md)
+- [Troubleshooting]({{DOCS_BASE_URL}}/how-to/TROUBLESHOOTING.md)
 
-#### Chocolatey (Windows)
-```powershell
-choco install perl-lsp
-```
+## Release assets
 
-#### Scoop (Windows)
-```powershell
-scoop install perl-lsp
-```
+- Platform binaries are attached to the release.
+- Verify downloads with the attached `SHA256SUMS` file.
 
-#### Winget (Windows)
-```powershell
-winget install --manifest .\distribution\winget\perl-lsp.yaml
-```
-
-> Winget manifest updates are generated in-repo first. Submission to
-> `winget-pkgs` remains a separate manual step.
-
-### Editor Setup
-
-#### VS Code
-```json
-{
-    "perl-lsp.serverPath": "/path/to/perl-lsp",
-    "perl-lsp.args": ["--stdio"]
-}
-```
-
-#### Neovim
-```lua
-require('lspconfig').perl_lsp.setup{
-    cmd = { "perl-lsp", "--stdio" }
-}
-```
-
-#### Emacs
-```elisp
-(add-to-list 'lsp-language-id-configuration '(perl-mode . "perl"))
-(lsp-register-client
-    (make-lsp-client :new-connection (lsp-stdio-connection "perl-lsp")
-                    :activation-fn (lsp-activate-on "perl")
-                    :server-id 'perl-lsp))
-```
-
-## 📊 Platform Support
-
-| Platform | Architecture | Status | Download |
-|----------|-------------|--------|----------|
-| Linux (GNU) | x86_64 | ✅ Tier 1 | [perl-lsp-x86_64-unknown-linux-gnu.tar.gz]({{DOWNLOAD_URL_LINUX_X64}}) |
-| Linux (musl) | x86_64 | ✅ Tier 1 | [perl-lsp-x86_64-unknown-linux-musl.tar.gz]({{DOWNLOAD_URL_LINUX_MUSL}}) |
-| Linux (GNU) | aarch64 | ✅ Tier 1 | [perl-lsp-aarch64-unknown-linux-gnu.tar.gz]({{DOWNLOAD_URL_LINUX_ARM64}}) |
-| macOS | x86_64 | ✅ Tier 1 | [perl-lsp-x86_64-apple-darwin.tar.gz]({{DOWNLOAD_URL_MACOS_X64}}) |
-| macOS | aarch64 | ✅ Tier 1 | [perl-lsp-aarch64-apple-darwin.tar.gz]({{DOWNLOAD_URL_MACOS_ARM64}}) |
-| Windows | x86_64 | ✅ Tier 1 | [perl-lsp-x86_64-pc-windows-msvc.zip]({{DOWNLOAD_URL_WINDOWS}}) |
-
-## 🔄 Migration Guide
-
-{{MIGRATION_GUIDE}}
-
-## 📈 Performance
-
-| Operation | Previous | Current | Improvement |
-|-----------|----------|---------|-------------|
-| {{PERF_METRIC_1}} | {{PERF_OLD_1}} | {{PERF_NEW_1}} | {{PERF_IMPROVEMENT_1}} |
-| {{PERF_METRIC_2}} | {{PERF_OLD_2}} | {{PERF_NEW_2}} | {{PERF_IMPROVEMENT_2}} |
-| {{PERF_METRIC_3}} | {{PERF_OLD_3}} | {{PERF_NEW_3}} | {{PERF_IMPROVEMENT_3}} |
-
-## 🐛 Bug Fixes
-
-- {{BUG_FIX_1}}
-- {{BUG_FIX_2}}
-- {{BUG_FIX_3}}
-
-## 🔧 Breaking Changes
-
-{{BREAKING_CHANGES}}
-
-## 🛡️ Security
-
-{{SECURITY_FIXES}}
-
-## 📚 Documentation
-
-- [Getting Started Guide]({{DOCS_BASE_URL}}/GETTING_STARTED.md)
-- [API Documentation]({{DOCS_BASE_URL}}/INDEX.md)
-- [Migration Guide]({{DOCS_BASE_URL}}/MIGRATION.md)
-- [Troubleshooting]({{DOCS_BASE_URL}}/TROUBLESHOOTING.md)
-
-## 🤝 Contributors
-
-{{CONTRIBUTORS}}
-
-Thank you to everyone who contributed to this release!
-
-## 🔗 Links
-
-- [Homepage]({{HOMEPAGE_URL}})
-- [Documentation]({{DOCS_BASE_URL}})
-- [GitHub Repository]({{REPO_URL}})
-- [Crates.io]({{CRATES_IO_URL}})
-- [VS Code Marketplace]({{VSCODE_MARKETPLACE_URL}})
-
-## 📋 Verification
+## Checks
 
 ```bash
-# Verify installation
 perl-lsp --version
-
-# Check LSP capabilities
 perl-lsp --capabilities
-
-# Run health check
 nix develop -c just health
 ```
 
-## 🎯 Support
+## Support
 
-- **GitHub Issues**: [Report bugs and request features]({{REPO_URL}}/issues)
-- **Discussions**: [Community discussions and Q&A]({{REPO_URL}}/discussions)
-- **Security**: Report security issues to security@perl-lsp.org
-
----
-
-## 📜 License
-
-Dual licensed under:
-- [MIT License]({{REPO_URL}}/blob/main/LICENSE-MIT)
-- [Apache License 2.0]({{REPO_URL}}/blob/main/LICENSE-APACHE)
-
----
-
-**Download Perl LSP v{{VERSION}} today and experience the future of Perl development!**
-
-🚀 [Get Started Now]({{DOCS_BASE_URL}}/GETTING_STARTED.md) | 📖 [Documentation]({{DOCS_BASE_URL}}) | 💬 [Community]({{REPO_URL}}/discussions)
+- [GitHub issues]({{REPO_URL}}/issues)
+- [Repository]({{REPO_URL}})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,25 +242,34 @@ jobs:
         run: |
           VERSION="${{ needs.release-metadata.outputs.version }}"
           cat > release_notes.md << EOF
-          ## Release ${VERSION}
+          ## Perl LSP ${VERSION}
 
-          ### Installation
+          This release ships the binaries and the docs needed to install, configure, and troubleshoot the current release line.
+
+          ### Install or upgrade
 
           ```bash
-          # Using cargo
           cargo install perl-lsp
-
-          # Or download binary for your platform
-          # See assets below
+          cargo install perl-dap
           ```
 
-          ### Changes
+          ### Read this first
 
-          See the [CHANGELOG](CHANGELOG.md) for detailed changes.
+          - [Docs home](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/README.md)
+          - [Docs index](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/INDEX.md)
+          - [Getting Started](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/tutorials/GETTING_STARTED.md)
+          - [Installation Guide](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/INSTALLATION.md)
+          - [Editor Setup](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/EDITOR_SETUP.md)
+          - [Troubleshooting](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/docs/how-to/TROUBLESHOOTING.md)
 
-          ### Checksums
+          ### Release assets
 
-          Verify downloads with the consolidated `SHA256SUMS` file attached to this release.
+          - Platform binaries are attached to this release.
+          - Verify downloads with the consolidated \`SHA256SUMS\` file.
+
+          ### Change log
+
+          See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ needs.release-metadata.outputs.tag }}/CHANGELOG.md) for the full release history.
           EOF
           cat release_notes.md
 


### PR DESCRIPTION
Focused release-note surface cleanup for v0.12.0.\n\n- Replaces the generic release template with a shorter operational body\n- Removes the stale docs/MIGRATION.md link\n- Points users at live docs entry points: docs/README.md, docs/INDEX.md, getting started, installation, editor setup, and troubleshooting\n- Aligns workflow-generated release notes with the same links and shipped release assets