### PR TITLE
docs: second-pass README rework for DAP and module crates (#2936)

### DIFF
--- a/crates/perl-dap-breakpoint/README.md
+++ b/crates/perl-dap-breakpoint/README.md
@@ -1,55 +1,38 @@
 # perl-dap-breakpoint
 
-[![Crates.io](https://img.shields.io/crates/v/perl-dap-breakpoint.svg)](https://crates.io/crates/perl-dap-breakpoint)
-[![Documentation](https://docs.rs/perl-dap-breakpoint/badge.svg)](https://docs.rs/perl-dap-breakpoint)
+AST-based breakpoint validation for Perl DAP sessions.
 
-AST-based breakpoint validation for Perl DAP.
+Use this crate before you hand a breakpoint to the runtime. It answers two
+questions: is this line executable, and if not, what nearby line should the
+debugger suggest instead?
 
-## When to use this crate
+## Boundaries
 
-Use `perl-dap-breakpoint` when you need to decide whether a debugger breakpoint
-can be placed on a Perl source line.
+- `perl-dap` uses this crate to validate breakpoints before sending them to the
+  runtime.
+- `perl-dap-platform` and `perl-dap-shell` prepare launch inputs; they do not
+  validate source lines.
+- This crate does not speak DAP itself. It only reasons about source text and
+  parsed AST shape.
 
-It solves three related problems:
+## Key API
 
-- detect executable lines versus comments, blanks, and heredoc interiors
-- suggest the nearest valid line when the requested line is invalid
-- explain why a breakpoint was rejected or moved
+- `AstBreakpointValidator`
+- `BreakpointValidation`
+- `BreakpointValidator`
+- `ValidationReason`
+- `find_nearest_valid_line`
+- `SearchDirection`
 
-## Quick example
+## Example
 
 ```rust,ignore
 use perl_dap_breakpoint::{AstBreakpointValidator, BreakpointValidator};
 
-let validator = AstBreakpointValidator::new("# comment\nmy $x = 1;\n")?;
-let result = validator.validate(0);
+let source = "# comment\nmy $x = 1;\n";
+let validator = AstBreakpointValidator::new(source)?;
+let result = validator.validate(1);
+
 assert!(!result.verified);
+assert_eq!(result.reason, Some(perl_dap_breakpoint::ValidationReason::CommentLine));
 ```
-
-## Features
-
-- **AST-based validation** -- uses `perl-parser` to determine whether a line contains executable code
-- **Line suggestion** -- finds the nearest valid line via `find_nearest_valid_line` with configurable search direction and max distance
-- **Detailed rejection reasons** -- distinguishes blank lines, comment lines, heredoc interiors, and out-of-range lines (`ValidationReason`)
-
-## Public API
-
-| Item | Kind | Description |
-|------|------|-------------|
-| `BreakpointValidator` | trait | `validate`, `validate_with_column`, `is_executable_line` |
-| `AstBreakpointValidator` | struct | Parses source with `perl-parser` and implements `BreakpointValidator` |
-| `BreakpointValidation` | struct | Result with `verified`, `line`, `column`, `reason`, `message` fields |
-| `ValidationReason` | enum | `BlankLine`, `CommentLine`, `HeredocInterior`, `LineOutOfRange`, `ParseError` |
-| `BreakpointError` | enum | `ParseError(String)`, `LineOutOfRange(i64, usize)` |
-| `find_nearest_valid_line` | fn | Searches forward, backward, or both for the nearest executable line |
-| `suggestion::SearchDirection` | enum | `Forward`, `Backward`, `Both` |
-
-## Workspace role
-
-This is a support crate in the `perl-dap` family. It is useful on its own for
-debugger-side validation, but it is primarily consumed by the runtime and test
-layers that need breakpoint eligibility checks.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-dap-platform/README.md
+++ b/crates/perl-dap-platform/README.md
@@ -1,42 +1,35 @@
 # perl-dap-platform
 
-[![Crates.io](https://img.shields.io/crates/v/perl-dap-platform.svg)](https://crates.io/crates/perl-dap-platform)
-[![Documentation](https://docs.rs/perl-dap-platform/badge.svg)](https://docs.rs/perl-dap-platform)
+Cross-platform helpers for finding Perl and shaping the debugger launch
+environment.
 
-Cross-platform runtime helpers for Perl DAP process setup.
+This crate sits below the debugger runtime and above shell quoting. It handles
+the OS-specific parts of launch setup: finding the Perl executable, normalizing
+filesystem paths, and building `PERL5LIB`-style environment maps.
 
-## When to use this crate
+## Boundaries
 
-Use `perl-dap-platform` when you need the platform-specific pieces of Perl DAP
-launch/attach setup without pulling in the whole debugger runtime.
+- Use `perl-dap-shell` when you need shell-safe argument formatting.
+- Use `perl-dap-platform` when you need to resolve the executable or normalize
+  OS paths.
+- Use `perl-dap` when you want the server to actually launch and manage a
+  debug session.
 
-It covers three common problems:
+## Key API
 
-- finding the `perl` executable on `PATH`
-- normalizing platform-specific file paths for debugging
-- building the environment map used to launch Perl with `PERL5LIB`
+- `resolve_perl_path`
+- `normalize_path`
+- `setup_environment`
 
-## Quick example
+## Example
 
 ```rust
 use perl_dap_platform::{normalize_path, setup_environment};
 use std::path::PathBuf;
 
-let env = setup_environment(&[PathBuf::from("lib"), PathBuf::from("local/lib/perl5")]);
-assert!(env.contains_key("PERL5LIB"));
+let normalized = normalize_path(&PathBuf::from("/mnt/c/work/script.pl"));
+let env = setup_environment(&[PathBuf::from("/workspace/lib")]);
 
-let normalized = normalize_path(std::path::Path::new("/mnt/c/work/script.pl"));
-assert!(!normalized.as_os_str().is_empty());
+assert!(normalized.to_string_lossy().len() > 0);
+assert_eq!(env.get("PERL5LIB").map(String::as_str), Some("/workspace/lib"));
 ```
-
-## Public API
-
-- `resolve_perl_path`: locate `perl` on the current `PATH`
-- `normalize_path`: normalize Windows, WSL, and Unix path shapes
-- `setup_environment`: construct debugger launch environment variables
-
-## Workspace role
-
-This is a small utility crate inside the `perl-dap` family. It is useful on its
-own for tooling that needs Perl path handling, but it is primarily a support
-crate for the debugger runtime.

--- a/crates/perl-dap-shell/README.md
+++ b/crates/perl-dap-shell/README.md
@@ -1,40 +1,32 @@
 # perl-dap-shell
 
-[![Crates.io](https://img.shields.io/crates/v/perl-dap-shell.svg)](https://crates.io/crates/perl-dap-shell)
-[![Documentation](https://docs.rs/perl-dap-shell/badge.svg)](https://docs.rs/perl-dap-shell)
+Shell-facing helpers for launching Perl debugging sessions.
 
-Shell-oriented launch helpers for Perl DAP.
+This crate is the quoting-and-env layer. It takes launch intent and turns it
+into command arguments and environment variables that are safe to hand to a
+shell or launcher.
 
-## When to use this crate
+## Boundaries
 
-Use `perl-dap-shell` when you need to prepare command-line arguments or launch
-environment state for the DAP process layer.
+- `perl-dap-platform` finds Perl and normalizes paths.
+- `perl-dap-shell` formats shell arguments and launch environment values.
+- `perl-dap` consumes both when starting a debug session.
 
-It is useful when you want to:
+## Key API
 
-- format shell arguments safely for launch paths
-- keep shell-specific quoting separate from path normalization
-- build the process inputs consumed by `perl-dap`
+- `format_command_args`
+- `setup_environment`
 
-## Quick example
+## Example
 
 ```rust
 use perl_dap_shell::{format_command_args, setup_environment};
 use std::path::PathBuf;
 
-let args = format_command_args(&["file with spaces.pl".into()]);
-assert_eq!(args.len(), 1);
+let formatted = format_command_args(&["arg with space".to_string()]);
+let env = setup_environment(&[PathBuf::from("/workspace/lib")]);
 
-let env = setup_environment(&[PathBuf::from("lib")]);
-assert!(env.contains_key("PERL5LIB"));
+assert_eq!(formatted.len(), 1);
+assert!(formatted[0].contains("arg with space"));
+assert_eq!(env.get("PERL5LIB").map(String::as_str), Some("/workspace/lib"));
 ```
-
-## Public API
-
-- `format_command_args`: shell-quote launch arguments where needed
-- `setup_environment`: re-exported platform helper for `PERL5LIB`
-
-## Workspace role
-
-This crate keeps shell-specific concerns out of `perl-dap-platform`. Use it for
-launch-path assembly; use the platform crate for path discovery and normalization.

--- a/crates/perl-dap-types/README.md
+++ b/crates/perl-dap-types/README.md
@@ -1,36 +1,42 @@
 # perl-dap-types
 
-Shared session model types for the Perl Debug Adapter Protocol implementation.
+Shared DAP session model types for Perl debugging.
 
-## When to use this crate
+This crate is the transport-friendly data layer behind the debugger stack. It
+keeps stack frames, sources, and variables in one small package so `perl-dap`
+and tests can share the same shapes without pulling in the runtime.
 
-Use `perl-dap-types` when you need the small shared Rust data model behind Perl
-debug sessions without depending on the full `perl-dap` runtime.
+## Boundaries
 
-It is useful for:
+- Use this crate for shared DAP payloads and fixtures.
+- Use `perl-dap` for the wire protocol and server behavior.
+- Use `perl-dap-value` when you need the underlying Perl value model, not the
+  DAP transport shape.
+- Use `perl-dap-platform` and `perl-dap-shell` for launch-time environment and
+  command-line preparation.
 
-- tests that construct DAP stack frames and variables directly
-- bridge or transport layers that serialize DAP session state
-- tools that want stable Perl-specific debug value structs
+## Key types
 
-## Quick example
+- `StackFrame`
+- `Source`
+- `Variable`
+
+## Example
 
 ```rust
-use perl_dap_types::{Source, StackFrame};
+use perl_dap_types::{Source, StackFrame, Variable};
 
 let source = Source::new("/workspace/script.pl");
 let frame = StackFrame::new(1, "main::run", source, 42).with_column(3);
+let variable = Variable {
+    name: "$x".to_string(),
+    value: "42".to_string(),
+    type_: Some("SCALAR".to_string()),
+    variables_reference: 0,
+    named_variables: None,
+    indexed_variables: None,
+};
 
 assert_eq!(frame.line, 42);
-assert_eq!(frame.column, 3);
+assert_eq!(variable.value, "42");
 ```
-
-## Public API
-
-- `StackFrame`: stack-frame model with builder-style helpers
-- `Source`: source-file descriptor for debugger responses
-- `Variable`: debugger variable payload with DAP-friendly serialization
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-dap-value/README.md
+++ b/crates/perl-dap-value/README.md
@@ -1,39 +1,32 @@
 # perl-dap-value
 
-[![Crates.io](https://img.shields.io/crates/v/perl-dap-value.svg)](https://crates.io/crates/perl-dap-value)
-[![Documentation](https://docs.rs/perl-dap-value/badge.svg)](https://docs.rs/perl-dap-value)
+Shared Perl value model for debugger rendering.
 
-Shared Perl runtime value model for debugger and renderer crates.
+This crate models the values that show up in the variables pane: scalars,
+arrays, hashes, refs, objects, tied values, truncation, and inspection errors.
+It is the value layer under the DAP transport types.
 
-## When to use this crate
+## Boundaries
 
-Use `perl-dap-value` when you need to represent Perl runtime values in a form
-that can be serialized across the debugger stack.
+- Use `perl-dap-types` for stack frames, sources, and variables.
+- Use `perl-dap-value` when you need to describe what a variable actually
+  contains.
+- Use `perl-dap` when you need to serialize that model into DAP responses.
 
-It is the right crate for:
+## Key type
 
-- debugger variable inspection payloads
-- renderer or formatter code that needs a stable value enum
-- tests or adapters that need to compare Perl values structurally
+- `PerlValue`
 
-## Quick example
+## Example
 
 ```rust
 use perl_dap_value::PerlValue;
 
-let value = PerlValue::object("My::Class", PerlValue::scalar("hello"));
-assert_eq!(value.type_name(), "OBJECT");
+let value = PerlValue::object(
+    "My::Class",
+    PerlValue::array(vec![PerlValue::scalar("alpha"), PerlValue::Integer(42)]),
+);
+
 assert!(value.is_expandable());
+assert_eq!(value.type_name(), "OBJECT");
 ```
-
-## Public API
-
-- `PerlValue`: shared enum for `undef`, scalar, array, hash, reference, object, and error shapes
-- `PerlValue::type_name`: returns the debugger-facing type label
-- `PerlValue::child_count`: reports child counts for expandable values
-
-## Workspace role
-
-This is a small shared model crate for the DAP stack. It is usable on its own,
-but its main job is to keep debugger value shapes consistent across parser,
-transport, and renderer code.

--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -1,48 +1,31 @@
 # perl-dap
-[![Crates.io](https://img.shields.io/crates/v/perl-dap.svg)](https://crates.io/crates/perl-dap)
-[![Documentation](https://docs.rs/perl-dap/badge.svg)](https://docs.rs/perl-dap)
 
-Debug Adapter Protocol server for Perl.
+Native Debug Adapter Protocol server for Perl.
 
-## When to use this crate
+`perl-dap` is the runtime layer of the debugger stack. It speaks DAP over stdio
+or TCP, dispatches requests, validates breakpoints, and renders values. Use it
+when you want to debug Perl from a DAP-capable editor or tool.
 
-Use `perl-dap` when you want Perl debugging from a DAP-capable editor or tool:
+## Boundaries
 
-- run the native adapter against `perl -d`
-- expose debugging over stdio or TCP
-- bridge to `Perl::LanguageServer` during migration or compatibility work
+- `perl-dap-platform` finds the Perl executable, normalizes paths, and builds
+  launch environment maps.
+- `perl-dap-shell` formats shell-safe launch arguments and environment values.
+- `perl-dap-types` carries shared frame, source, and variable models.
+- `perl-dap-value` models debugger values for rendering.
+- `perl-dap-breakpoint` validates whether a source line can accept a breakpoint.
 
-This is the runtime-facing debugger crate in the
-[`perl-lsp`](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+## Key pieces
 
-## Features
+- `DapServer`, `DapConfig`, and `DapMode` wire the server and its launch mode.
+- `DapDispatcher` and `DebugAdapter` handle request routing and protocol state.
+- `BridgeAdapter` supports migration from `Perl::LanguageServer`.
+- `TcpAttachConfig` and `BreakpointStore` support socket attach and breakpoint tracking.
 
-- **Native adapter** (default): drives `perl -d` directly over stdio or TCP socket
-- **Bridge adapter** (library): proxies DAP messages to Perl::LanguageServer
-- **Breakpoint management** with AST-based validation via `perl-dap-breakpoint`
-- **Variable inspection** and **safe expression evaluation** via `perl-dap-variables` / `perl-dap-eval`
-- **Stack trace parsing** via `perl-dap-stack`
-- **Security hardening**: path traversal prevention, expression sanitization, resource limits
-- **Cross-platform**: Linux, macOS, Windows, and WSL path translation
-
-## Usage
+## Run
 
 ```bash
-cargo install perl-dap
-perl-dap --stdio            # Native adapter on stdio (default)
-perl-dap --socket --port 13603  # Native adapter on TCP
-perl-dap --bridge           # Bridge mode (requires Perl::LanguageServer)
-```
-
-## Bridge adapter
-
-`BridgeAdapter` proxies DAP messages to an existing `Perl::LanguageServer` installation:
-
-```bash
-cpanm Perl::LanguageServer
+perl-dap --stdio
+perl-dap --socket --port 13603
 perl-dap --bridge
 ```
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-boundary/README.md
+++ b/crates/perl-module-boundary/README.md
@@ -1,36 +1,31 @@
 # perl-module-boundary
 
-Standalone boundary checks for Perl module tokens on a single source line.
+Detect standalone Perl module tokens at lexical boundaries.
 
-## When to use this crate
+This crate answers a narrow question: does a line contain a module token that
+is truly standalone, or is it part of a larger identifier or path? That makes
+it the boundary-checking layer for import, reference, and rename workflows.
 
-Use `perl-module-boundary` when you need to find whole module names in a line
-without matching partial identifiers. It is the low-level guard used by import
-matching and rename workflows.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` parses the token span.
+- `perl-module-boundary` filters that span down to standalone matches.
+- `perl-module-import`, `perl-module-reference`, and `perl-module-rename` use
+  the result to avoid partial matches.
+
+## API
+
+- `ModuleTokenRange`
+- `ModuleTokenRangeIter`
+- `find_standalone_module_token_ranges`
+- `contains_standalone_module_token`
+
+## Example
 
 ```rust
 use perl_module_boundary::{contains_standalone_module_token, find_standalone_module_token_ranges};
 
-assert!(contains_standalone_module_token("use Foo::Bar;", "Foo::Bar"));
-assert!(!contains_standalone_module_token("use Foo::Barista;", "Foo::Bar"));
-assert_eq!(
-    find_standalone_module_token_ranges("use Foo::Bar;", "Foo::Bar").collect::<Vec<_>>().len(),
-    1,
-);
+let line = "use Foo::Bar;";
+assert!(contains_standalone_module_token(line, "Foo::Bar"));
+assert_eq!(find_standalone_module_token_ranges(line, "Foo::Bar").count(), 1);
 ```
-
-## Public API
-
-- `contains_standalone_module_token`
-- `find_standalone_module_token_ranges`
-- `ModuleTokenRange`
-
-## Workspace role
-
-Small utility crate used by the module-import and module-rename families.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-import-match/README.md
+++ b/crates/perl-module-import-match/README.md
@@ -1,31 +1,26 @@
 # perl-module-import-match
 
-Deterministic predicates for deciding whether an import line references a module.
+Boolean module-import matching for single Perl source lines.
 
-## When to use this crate
+Use this crate when you only need a yes/no answer: does this line reference the
+module import I care about? It is the fast predicate layer underneath rename
+and import workflows.
 
-Use `perl-module-import-match` when you need a yes/no decision for whether a
-single source line should be rewritten during a module rename. It combines
-import-head parsing with boundary-safe token matching so rename workflows avoid
-partial false positives.
+## Pipeline
 
-## Quick example
+- `perl-module-import` parses and classifies the statement.
+- `perl-module-import-match` answers the boolean match question.
+- `perl-module-rename` uses both when it plans edits.
+
+## API
+
+- `line_references_module_import`
+
+## Example
 
 ```rust
 use perl_module_import_match::line_references_module_import;
 
 assert!(line_references_module_import("use Foo::Bar;", "Foo::Bar"));
-assert!(!line_references_module_import("use Foo::Barista;", "Foo::Bar"));
+assert!(!line_references_module_import("use Foo::Bar;", "Other::Module"));
 ```
-
-## Public API
-
-- `line_references_module_import`
-
-## Workspace role
-
-Predicate crate used by module rename and token-rewrite workflows.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-import/README.md
+++ b/crates/perl-module-import/README.md
@@ -1,36 +1,36 @@
 # perl-module-import
 
-Single-line `use` and `require` parsing for Perl import workflows.
+Parse the leading shape of `use` and `require` lines.
 
-## When to use this crate
+This crate turns a single source line into a structured import head with stable
+byte offsets and dispatch semantics. Use it when you need to know what the
+statement is before you decide how to rewrite or inspect it.
 
-Use `perl-module-import` when you need to classify an import line before a
-rename, navigation, or refactoring pass. It parses the first token after
-`use`/`require`, records the byte range, and distinguishes `use parent` and
-`use base`.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` handles token spans.
+- `perl-module-import` classifies the leading statement and token.
+- `perl-module-import-match` gives you a boolean line check when you do not
+  need the full parse.
+- `perl-module-reference` and `perl-module-rename` use the parse result to find
+  or rewrite imports.
+
+## Key API
+
+- `LoadTiming`
+- `ImportBehavior`
+- `DispatchSemantics`
+- `RequireForm`
+- `ModuleImportKind`
+- `ModuleImportHead`
+- `parse_module_import_head`
+
+## Example
 
 ```rust
-use perl_module_import::{parse_module_import_head, ModuleImportKind};
+use perl_module_import::{ModuleImportKind, parse_module_import_head};
 
-let head = parse_module_import_head("use parent 'Foo::Bar';").unwrap();
-assert_eq!(head.kind, ModuleImportKind::UseParent);
-assert_eq!(head.token, "parent");
+let head = parse_module_import_head("use parent 'Foo::Bar';");
+assert!(matches!(head.as_ref().map(|h| h.kind), Some(ModuleImportKind::UseParent)));
+assert_eq!(head.as_ref().map(|h| h.token), Some("parent"));
 ```
-
-## Public API
-
-- `parse_module_import_head`
-- `ModuleImportHead`
-- `ModuleImportKind`
-- `RequireForm`
-- `DispatchSemantics`
-
-## Workspace role
-
-Parsing utility used by the module-reference and module-rename families.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-name/README.md
+++ b/crates/perl-module-name/README.md
@@ -1,33 +1,30 @@
 # perl-module-name
 
-Canonical and legacy Perl module-name separator helpers.
+Normalize Perl module names without touching paths or files.
 
-## When to use this crate
+This crate is the naming primitive in the module pipeline. It handles
+separator normalization and rename-friendly variants, but it does not resolve
+filesystem locations or parse whole statements.
 
-Use `perl-module-name` when you need to normalize or project Perl package
-separators. It is the shared naming layer for module-path, token, and rename
-workflows.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` and `perl-module-boundary` isolate module-shaped
+  tokens.
+- `perl-module-name` normalizes those tokens to canonical `::` form.
+- `perl-module-path`, `perl-module-reference`, and `perl-module-rename`
+  consume the normalized names.
 
-```rust
-use perl_module_name::{legacy_package_separator, module_variant_pairs, normalize_package_separator};
-
-assert_eq!(normalize_package_separator("Foo'Bar"), "Foo::Bar");
-assert_eq!(legacy_package_separator("Foo::Bar"), "Foo'Bar");
-assert_eq!(module_variant_pairs("Foo::Bar", "New::Path").len(), 2);
-```
-
-## Public API
+## Key API
 
 - `normalize_package_separator`
 - `legacy_package_separator`
 - `module_variant_pairs`
 
-## Workspace role
+## Example
 
-Shared naming utility used by module resolution and rename crates.
+```rust
+use perl_module_name::{legacy_package_separator, normalize_package_separator};
 
-## License
-
-MIT OR Apache-2.0
+assert_eq!(normalize_package_separator("Foo'Bar"), "Foo::Bar");
+assert_eq!(legacy_package_separator("Foo::Bar"), "Foo'Bar");
+```

--- a/crates/perl-module-path/README.md
+++ b/crates/perl-module-path/README.md
@@ -1,34 +1,30 @@
 # perl-module-path
 
-Perl module name and path conversion helpers.
+Convert Perl module names to filesystem paths and back.
 
-## When to use this crate
+This crate is the string-to-path bridge in the module pipeline. It knows about
+`Foo::Bar` and `Foo/Bar.pm`, but it does not search the filesystem or validate
+workspace boundaries.
 
-Use `perl-module-path` when you need to move between Perl module names and
-filesystem paths. It is the bridge used by rename, resolution, and workspace
-scanning code.
+## Pipeline
 
-## Quick example
+- `perl-module-name` normalizes module separators.
+- `perl-module-path` converts canonical names to path strings and back.
+- `perl-module-resolution-path` and `perl-module-resolution-uri` use those
+  strings when they search a workspace.
 
-```rust
-use perl_module_path::{file_path_to_module_name, module_name_to_path, module_path_to_name};
-
-assert_eq!(module_name_to_path("Foo::Bar"), "Foo/Bar.pm");
-assert_eq!(module_path_to_name("Foo/Bar.pm"), "Foo::Bar");
-assert_eq!(file_path_to_module_name("/workspace/lib/Foo/Bar.pm"), "Foo::Bar");
-```
-
-## Public API
+## Key API
 
 - `normalize_package_separator`
 - `module_name_to_path`
 - `module_path_to_name`
 - `file_path_to_module_name`
 
-## Workspace role
+## Example
 
-Shared path-conversion utility used across module rename and resolution crates.
+```rust
+use perl_module_path::{module_name_to_path, module_path_to_name};
 
-## License
-
-MIT OR Apache-2.0
+assert_eq!(module_name_to_path("Foo::Bar"), "Foo/Bar.pm");
+assert_eq!(module_path_to_name("Foo/Bar.pm"), "Foo::Bar");
+```

--- a/crates/perl-module-reference/README.md
+++ b/crates/perl-module-reference/README.md
@@ -1,35 +1,32 @@
 # perl-module-reference
 
-Cursor-aware module-reference extraction for Perl `use` and `require` lines.
+Find module references under a cursor in Perl source.
 
-## When to use this crate
+This crate is the cursor-aware layer above token parsing. It identifies the
+module name under the cursor inside `use`/`require` statements and can also
+look inside `use parent`/`use base` argument lists.
 
-Use `perl-module-reference` when you need to answer “what module is under the
-cursor?” for import lines. It returns the module token, its range, and the
-reference kind so navigation and rename code can make the right decision.
+## Pipeline
 
-## Quick example
+- `perl-module-token-parser` finds the token span.
+- `perl-module-reference` decides whether the cursor is on a `use`, `require`,
+  `parent`, or `base` reference.
+- `perl-module-rename` uses this information to plan edits.
 
-```rust
-use perl_module_reference::extract_module_reference;
+## Key API
 
-assert_eq!(extract_module_reference("use Foo::Bar;", 4), Some("Foo::Bar".to_string()));
-assert_eq!(extract_module_reference("require Foo::Bar;", 8), Some("Foo::Bar".to_string()));
-```
-
-## Public API
-
+- `ModuleReferenceKind`
+- `ModuleReference`
 - `find_module_reference`
 - `find_module_reference_extended`
 - `extract_module_reference`
 - `extract_module_reference_extended`
-- `ModuleReference`
-- `ModuleReferenceKind`
 
-## Workspace role
+## Example
 
-Shared lookup crate used by navigation and rename workflows.
+```rust
+use perl_module_reference::extract_module_reference;
 
-## License
-
-MIT OR Apache-2.0
+let reference = extract_module_reference("use Foo::Bar;", 9);
+assert_eq!(reference, Some("Foo::Bar".to_string()));
+```

--- a/crates/perl-module-rename/README.md
+++ b/crates/perl-module-rename/README.md
@@ -1,34 +1,33 @@
 # perl-module-rename
 
-Deterministic import-line rename planning for Perl module refactors.
+Plan module rename edits for Perl source lines.
 
-## When to use this crate
+This crate is the rewrite layer. It takes an old module name and a new one,
+then computes line edits for `use`/`require`, `@ISA`, and qualified calls.
 
-Use `perl-module-rename` when you need to rewrite module references during a
-rename workflow. It plans the line edits for import statements, `use parent`,
-`use base`, and related module-name prefixes while preserving canonical and
-legacy separator forms.
+## Pipeline
 
-## Quick example
+- `perl-module-reference` finds the relevant module reference.
+- `perl-module-import-match` and `perl-module-token` identify matching lines.
+- `perl-module-rename` produces the actual edit plan and applies it.
 
-```rust,ignore
-use perl_module_rename::{apply_module_rename_edits, plan_module_rename_edits};
+## Key API
 
-let edits = plan_module_rename_edits("use Foo::Bar;\n", "Foo::Bar", "New::Path");
-let rewritten = apply_module_rename_edits("use Foo::Bar;\n", &edits);
-assert!(rewritten.contains("New::Path"));
-```
-
-## Public API
-
+- `ModuleLineEdit`
 - `plan_module_rename_edits`
 - `apply_module_rename_edits`
-- `ModuleLineEdit`
+- `line_references_isa_assignment`
+- `line_references_qualified_call`
+- `replace_module_name_prefix`
 
-## Workspace role
+## Example
 
-Workspace rename helper used by module-path and import matching crates.
+```rust
+use perl_module_rename::{apply_module_rename_edits, plan_module_rename_edits};
 
-## License
+let source = "use Foo::Bar;\nFoo::Bar::init();\n";
+let edits = plan_module_rename_edits(source, "Foo::Bar", "Renamed::Module");
+let rewritten = apply_module_rename_edits(source, &edits);
 
-MIT OR Apache-2.0
+assert_eq!(rewritten, "use Renamed::Module;\nRenamed::Module::init();\n");
+```

--- a/crates/perl-module-resolution-path/README.md
+++ b/crates/perl-module-resolution-path/README.md
@@ -1,32 +1,30 @@
 # perl-module-resolution-path
 
-Workspace-aware Perl module-name to filesystem-path resolution.
+Resolve a Perl module name to a workspace-safe filesystem path candidate.
 
-## When to use this crate
+This crate is the path-first leg of module resolution. It searches include
+paths under a workspace root, validates the candidate stays inside that root,
+and falls back to `root/lib/<module>.pm` when needed.
 
-Use `perl-module-resolution-path` when you need a filesystem path candidate for
-a Perl module name inside a workspace root. It searches include paths under the
-root, applies workspace path validation, and falls back to `root/lib`.
+## Pipeline
 
-## Quick example
+- `perl-module-path` converts names to path strings.
+- `perl-module-resolution-path` applies workspace-safe search order.
+- `perl-module-resolution-uri` takes the same module name and returns a
+  `file://` URI instead of a path.
 
-```rust
+## Key API
+
+- `resolve_module_path`
+
+## Example
+
+```rust,ignore
 use perl_module_resolution_path::resolve_module_path;
 use std::path::Path;
 
 let root = Path::new("/workspace");
 let path = resolve_module_path(root, "Foo::Bar", &["lib".to_string()]);
+
 assert!(path.is_some());
 ```
-
-## Public API
-
-- `resolve_module_path`
-
-## Workspace role
-
-Filesystem-path resolution helper used by higher-level module resolution crates.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-resolution-uri/README.md
+++ b/crates/perl-module-resolution-uri/README.md
@@ -1,17 +1,28 @@
 # perl-module-resolution-uri
 
-Deterministic Perl module-to-URI resolution with workspace-safe search order.
+Resolve a Perl module name to a `file://` URI.
 
-## When to use this crate
+This crate is the URI-facing leg of module resolution. It keeps the search
+order deterministic, respects a timeout budget, and returns a compact outcome
+enum instead of throwing resolution policy into caller code.
 
-Use `perl-module-resolution-uri` when you need to resolve a Perl module name
-to a `file://` URI with a deterministic precedence order and a timeout budget.
-It is the URI-facing sibling of `perl-module-resolution-path`.
+## Pipeline
 
-## Quick example
+- `perl-module-resolution-path` resolves to filesystem paths.
+- `perl-module-resolution-uri` resolves to file URIs and tracks `NotFound` vs
+  `TimedOut`.
+- Higher-level workspace tools can pick the variant that fits their editor or
+  transport layer.
 
-```rust
-use perl_module_resolution_uri::{resolve_module_uri, ModuleUriResolution};
+## Key API
+
+- `ModuleUriResolution`
+- `resolve_module_uri`
+
+## Example
+
+```rust,ignore
+use perl_module_resolution_uri::{ModuleUriResolution, resolve_module_uri};
 use std::time::Duration;
 
 let result = resolve_module_uri(
@@ -24,18 +35,8 @@ let result = resolve_module_uri(
     Duration::from_millis(100),
 );
 
-assert!(matches!(result, ModuleUriResolution::NotFound | ModuleUriResolution::Resolved(_)));
+match result {
+    ModuleUriResolution::Resolved(uri) => assert!(uri.starts_with("file://")),
+    ModuleUriResolution::NotFound | ModuleUriResolution::TimedOut => {}
+}
 ```
-
-## Public API
-
-- `resolve_module_uri`
-- `ModuleUriResolution`
-
-## Workspace role
-
-URI-resolution helper for workspace-aware tools and editor integrations.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-token-core/README.md
+++ b/crates/perl-module-token-core/README.md
@@ -1,37 +1,32 @@
 # perl-module-token-core
 
-Shared low-level parsing and boundary primitives for Perl module tokens.
+Low-level module token span parsing and boundary predicates.
 
-## When to use this crate
+This crate is the lexical foundation for the module pipeline. It knows how to
+scan a token span, recognize canonical and legacy separators, and check whether
+the token stands alone on a line.
 
-Use `perl-module-token-core` when you need the grammar-level mechanics for
-module token parsing or boundary checking. It is the lowest layer in the
-module-name family and is intended to be reused by higher-level crates.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` parses spans.
+- `perl-module-boundary` filters standalone matches.
+- `perl-module-token` uses the result for replacement.
+- `perl-module-import`, `perl-module-reference`, and `perl-module-rename`
+  consume it higher up the stack.
+
+## Key API
+
+- `ModuleTokenSpan`
+- `parse_module_token`
+- `has_standalone_module_token_boundaries`
+- `is_module_token_char`
+- `is_module_identifier_char`
+
+## Example
 
 ```rust
-use perl_module_token_core::{has_standalone_module_token_boundaries, parse_module_token};
+use perl_module_token_core::{ModuleTokenSpan, has_standalone_module_token_boundaries, parse_module_token};
 
-assert_eq!(
-    parse_module_token("use Foo::Bar;", 4),
-    Some(perl_module_token_core::ModuleTokenSpan { start: 4, end: 12 }),
-);
+assert_eq!(parse_module_token("use Foo::Bar;", 4), Some(ModuleTokenSpan { start: 4, end: 12 }));
 assert!(has_standalone_module_token_boundaries("use Foo::Bar;", 4, 12));
 ```
-
-## Public API
-
-- `parse_module_token`
-- `ModuleTokenSpan`
-- `has_standalone_module_token_boundaries`
-- `is_module_identifier_char`
-- `is_module_token_char`
-
-## Workspace role
-
-Foundational parser utility used by the module boundary and rename stack.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-token-parser/README.md
+++ b/crates/perl-module-token-parser/README.md
@@ -1,32 +1,27 @@
 # perl-module-token-parser
 
-Single-line Perl module-token parsing for import and reference workflows.
+Cursor-aware module token parsing for import and reference workflows.
 
-## When to use this crate
+This crate is the bridge between raw text and token spans. It identifies the
+module token under a cursor so the higher-level import, reference, and rename
+crates can stay boundary-aware without reimplementing token scanning.
 
-Use `perl-module-token-parser` when you need to parse a module token from a
-cursor offset and feed that span into import, reference, or rename logic.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` scans spans.
+- `perl-module-token-parser` exposes the cursor-facing parser.
+- `perl-module-reference` and `perl-module-rename` use the span to find or
+  rewrite module names.
+
+## Key API
+
+- `ModuleTokenSpan`
+- `parse_module_token`
+
+## Example
 
 ```rust
-use perl_module_token_parser::parse_module_token;
+use perl_module_token_parser::{ModuleTokenSpan, parse_module_token};
 
-assert_eq!(
-    parse_module_token("use Foo::Bar;", 4),
-    Some(perl_module_token_parser::ModuleTokenSpan { start: 4, end: 12 }),
-);
+assert_eq!(parse_module_token("use Foo::Bar;", 4), Some(ModuleTokenSpan { start: 4, end: 12 }));
 ```
-
-## Public API
-
-- `parse_module_token`
-- `ModuleTokenSpan`
-
-## Workspace role
-
-Parsing helper used by import/reference/token rewriting crates.
-
-## License
-
-MIT OR Apache-2.0

--- a/crates/perl-module-token/README.md
+++ b/crates/perl-module-token/README.md
@@ -1,34 +1,29 @@
 # perl-module-token
 
-Boundary-safe Perl module token replacement helpers.
+Standalone Perl module token helpers for line-based workflows.
 
-## When to use this crate
+Use this crate when you need a quick yes/no or replacement for a module token
+on a single line, but not the full cursor-aware parse.
 
-Use `perl-module-token` when you need to detect or rewrite standalone module
-tokens without matching partial names. It is a small orchestration layer over
-the naming and boundary crates.
+## Pipeline
 
-## Quick example
+- `perl-module-token-core` parses the token span.
+- `perl-module-token` enforces standalone boundaries and performs replacement.
+- `perl-module-boundary` and `perl-module-rename` build on this behavior for
+  higher-level workflows.
+
+## Key API
+
+- `contains_module_token`
+- `replace_module_token`
+
+## Example
 
 ```rust
 use perl_module_token::{contains_module_token, replace_module_token};
 
 assert!(contains_module_token("use Foo::Bar;", "Foo::Bar"));
-let (updated, changed) = replace_module_token("use Foo::Bar;", "Foo::Bar", "New::Path");
+let (rewritten, changed) = replace_module_token("use Foo::Bar;", "Foo::Bar", "New::Module");
+assert_eq!(rewritten, "use New::Module;");
 assert!(changed);
-assert!(updated.contains("New::Path"));
 ```
-
-## Public API
-
-- `module_variant_pairs`
-- `contains_module_token`
-- `replace_module_token`
-
-## Workspace role
-
-Token rewrite helper used by module rename and matching workflows.
-
-## License
-
-MIT OR Apache-2.0


### PR DESCRIPTION
Refs #2936.

Second-pass rewrite of the targeted DAP and module-family READMEs.

Scope:
- make the docs problem-first and concise
- explain boundaries between crates in each family
- show the DAP stack layer for each support crate
- show the module pipeline / handoff so readers can pick the right crate
- keep docs.rs-facing surfaces compact, with examples only where they clarify the API

Validation:
- git diff --check
- cargo package --allow-dirty --list on a representative subset of touched crates, confirming README.md is included