### PR TITLE
docs(readme): second-pass crate docs and devex guidance (#2936)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,13 @@ just status-check
 
 Run `just status-update` and `just status-check` when you change capability docs, generated status sections, or other docs that depend on computed project metrics.
 
+## PR Hygiene
+
+- Use isolated worktrees and focused branches for agent-driven PR work.
+- Give PRs a CI-compliant title before opening them: `type(scope): summary (#1234)`.
+- The `validate-title` check rejects titles that do not include an issue reference.
+- Put the issue reference in the PR title, not just in the body.
+
 ## Documentation Discipline
 
 - [`docs/project/CURRENT_STATUS.md`](docs/project/CURRENT_STATUS.md) is the evidence document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,11 @@ bash scripts/install-githooks.sh
 ### 5. Open a Pull Request
 
 1. Push your branch and open a PR
-2. Describe your changes and link related issues (e.g., "Fixes #123")
-3. All PRs run format checks, clippy, and tests automatically in CI
-4. Merge with a conventional, descriptive squash commit
+2. Give the PR a CI-safe title in the form `type(scope): summary (#1234)` so
+   the title check passes on the first run
+3. Describe your changes and link related issues in the PR body
+4. All PRs run format checks, clippy, and tests automatically in CI
+5. Merge with a conventional, descriptive squash commit
 
 Once checks are green and reviews are complete, use an explicit conventional commit
 subject when squashing so history is release-friendly and changelog-friendly.
@@ -129,7 +131,17 @@ Conventional subject format:
 - include `!` for breaking changes, e.g. `feat!: ...`
 
 Do not rely on PR title defaults (often noisy, e.g. `(...#NNNN)`), because they
-break commit consistency for changelog generation.
+break commit consistency for changelog generation and can fail `validate-title`.
+
+Example PR title:
+
+```text
+docs(parser): rewrite the upgrade guide (#3052)
+```
+
+If you are driving the work from an agent or a worktree, keep the branch scoped
+to one concern and open the PR from that isolated worktree instead of editing
+the main checkout.
 
 #### CI Labels and Gates
 

--- a/crates/perl-lsp-launcher/README.md
+++ b/crates/perl-lsp-launcher/README.md
@@ -1,32 +1,36 @@
 # perl-lsp-launcher
 
-Microcrate for Perl LSP startup parsing and launch configuration.
+Command-line launch parsing and startup reporting for `perl-lsp`.
 
-## When to use this crate
+Use this crate when you need to turn CLI flags into a launch plan, startup
+banner, or feature-profile summary without pulling the server runtime into the
+caller.
 
-Use `perl-lsp-launcher` when you need the startup and launch-contract layer for
-the Perl language server.
+## Where it fits
 
-It is the right crate for:
+This is the boundary between shell entry points and the long-lived LSP server.
+It owns startup configuration, transport selection, logging setup, and
+human-readable launch output.
 
-- parsing `perl-lsp` CLI flags and transport options
-- selecting feature profiles consistently across binaries and tooling
-- emitting startup timing and launch metadata
-- sharing the same launch contract with tests and editor integrations
+## Key entry points
 
-## Public surface
+- `TransportArgs` and `LspArgs` - typed CLI input
+- `TransportMode`, `LaunchAction`, `LaunchConfig`, `LaunchPlan`
+- `parse_args(args)` - convert raw argv into a launch plan
+- `help_text()` and `shell_completion(shell)` - CLI help and completion text
+- `startup_banner(...)` and `log_server_startup(...)` - startup output helpers
 
-- Parse CLI arguments for the `perl-lsp` binary.
-- Normalize feature profile selection.
-- Provide transport mode and startup metadata as a typed API.
-- Expose BDD-grid-compatible feature catalog output for a selected profile.
+## Example
 
-This crate intentionally keeps startup concerns separate from `perl-lsp` runtime logic
-so editors and tooling can share the same contract without duplicating parsing rules.
+```rust
+use perl_lsp_launcher::{TransportMode, parse_args};
 
-## Main types
+let plan = parse_args(["perl-lsp", "--stdio"])?;
+assert_eq!(plan.config.transport.mode(), TransportMode::Stdio);
+```
 
-- `LspArgs`: CLI argument parser for the binary entry point
-- `TransportArgs` and `TransportMode`: stdio/socket transport selection
-- `FeatureProfile`: selected capability profile
-- `StartupTimer` and `StartupReport`: startup instrumentation
+## Typical use
+
+Use `perl-lsp-launcher` when you are wiring the binary entry point, generating
+shell completions, or testing startup behavior. If you only need the long-lived
+server logic, use `perl-lsp` instead.

--- a/crates/perl-module-resolution/README.md
+++ b/crates/perl-module-resolution/README.md
@@ -1,35 +1,28 @@
 # perl-module-resolution
 
-Deterministic, secure Perl module resolution helpers for workspace-aware tools.
+Module-name resolution for workspace-aware Perl tooling.
 
-## When to use this crate
+Use this crate when you need to turn `Foo::Bar` into a filesystem path or
+`file://` URI while respecting workspace roots, open documents, and include
+paths.
 
-Use `perl-module-resolution` when you need to turn Perl module names into
-filesystem or URI targets in a workspace-aware tool.
+## Where it fits
 
-It is the right crate for:
+This crate sits above the low-level path and URI helpers and below editor
+providers. It combines the `perl-module-resolution-path` and
+`perl-module-resolution-uri` layers so callers can resolve modules without
+re-implementing workspace lookup rules.
 
-- `Foo::Bar` to path/URI resolution
-- `use lib`-aware include-path discovery
-- resolution that respects workspace folders, open documents, and optional system `@INC`
-- a separate path-validation boundary for secure tooling
+## Key entry points
 
-## Public surface
+- `resolve_module_path(root, module_name, include_paths)` - filesystem lookup
+- `resolve_module_uri(...)` - workspace-aware URI resolution
+- `ModuleUriResolution` - result type for URI lookups
+- `use_lib` - helpers for `use lib` and `FindBin` include-path discovery
 
-- Resolve module names (for example, `Foo::Bar`) to filesystem paths
-- Resolve module names to `file://` URIs across open documents, workspace folders, and optional system `@INC`
-- Enforce workspace path validation to prevent traversal via include paths (via
-  `perl-module-resolution-path`)
-- Apply timeout-aware resolution for responsive editor workflows
+## Typical use
 
-## API
-
-- `resolve_module_path(root, module_name, include_paths)`
-- `resolve_module_uri(module_name, open_document_uris, workspace_folders, include_paths, use_system_inc, system_inc, timeout)`
-- `ModuleUriResolution`
-
-## Workspace role
-
-This crate is a workspace utility used by editor and language-server features.
-It is useful when you need module lookup behavior without reimplementing path
-rules in each consumer.
+Use `perl-module-resolution` when you already know the module name and need to
+find the right file or URI for navigation, completion, or hover features. If
+you only need path safety or URI normalization, use the lower-level crates
+directly.

--- a/crates/perl-parser-core/README.md
+++ b/crates/perl-parser-core/README.md
@@ -1,43 +1,38 @@
 # perl-parser-core
 
-Core parsing engine for the [perl-parser](https://github.com/EffortlessMetrics/perl-lsp) workspace. Provides a recursive descent parser with IDE-friendly error recovery, AST construction, token stream utilities, and position mapping for LSP integration.
+Core parsing engine for Perl source.
 
-## When to use this crate
+Use this crate when you need the parser, AST, position mapping, or trivia
+preservation layers without the higher-level workspace or LSP facades.
 
-Use `perl-parser-core` when you want the lower-level parser engine without the
-broader re-export surface of `perl-parser`.
+## Where it fits
 
-It is the right entry point when you need:
+`perl-parser-core` is the low-level parsing layer used by `perl-parser`,
+`perl-semantic-analyzer`, `perl-workspace-index`, and `perl-refactoring`. It
+turns source text into AST nodes and exposes the building blocks that higher
+layers compose.
 
-- the recursive-descent parser itself
-- AST and token-stream types
-- IDE-friendly error recovery and position mapping
-- a foundation for custom tooling built on parsed Perl syntax
+## Key entry points
 
-## Public API
+- `Parser` - recursive-descent parser
+- `ParseError`, `ParseResult`, `ParseOutput`
+- `Node`, `NodeKind`, `SourceLocation`
+- `TokenStream`, `Token`, `TokenKind`
+- `PositionMapper` and `LineEnding`
+- `Trivia`, `TriviaPreservingParser`, `format_with_trivia`
 
-- **`Parser`** -- recursive descent parser with `parse()` and `parse_with_recovery()` methods
-- **`RecoveryParser`** / **`ParserContext`** -- error-tolerant parsing with budget-controlled recovery
-- **`Node`**, **`NodeKind`**, **`SourceLocation`** -- AST types re-exported from `perl-ast`
-- **`TokenStream`**, **`Token`**, **`TokenKind`** -- buffered token stream with lookahead
-- **`ParseError`**, **`ParseOutput`**, **`ParseResult`** -- error types and result wrappers
-- **`PositionMapper`**, **`LineIndex`** -- UTF-8/UTF-16 position conversion for LSP
-- **`Trivia`**, **`TriviaPreservingParser`** -- whitespace/comment preservation for formatters
-
-## Usage
+## Example
 
 ```rust
 use perl_parser_core::Parser;
 
 let mut parser = Parser::new("my $x = 42; sub hello { print $x; }");
 let ast = parser.parse()?;
-// Recovered errors available via parser.errors()
+assert!(!ast.to_sexp().is_empty());
 ```
 
-## Workspace role
+## Typical use
 
-Tier 2 crate that aggregates Tier 1 leaf crates (`perl-lexer`, `perl-token`, `perl-ast`, `perl-error`, etc.) into the parsing engine consumed by `perl-parser` and higher-level analysis crates.
-
-## License
-
-MIT OR Apache-2.0
+Use `perl-parser-core` when you are building parser-adjacent tooling or adding
+new syntax behavior. If you want the higher-level analysis and refactoring
+re-exports in one crate, use `perl-parser`.

--- a/crates/perl-parser/README.md
+++ b/crates/perl-parser/README.md
@@ -1,55 +1,39 @@
 # perl-parser
-[![Crates.io](https://img.shields.io/crates/v/perl-parser.svg)](https://crates.io/crates/perl-parser)
-[![Documentation](https://docs.rs/perl-parser/badge.svg)](https://docs.rs/perl-parser)
 
-Native Perl parser and parser-hub crate for the `perl-lsp` workspace.
+High-level facade for the Perl parsing stack.
 
-## When to use this crate
+Use this crate when you want one entry point for parsing, semantic analysis,
+workspace indexing, refactoring, and the LSP provider re-exports that sit on
+top of them. If you only need the parser engine, use `perl-parser-core`
+directly.
 
-Use `perl-parser` when you want one entry point that combines parsing with the
-rest of the Perl analysis stack:
+## Where it fits
 
-- parse Perl source into an AST
-- plug into semantic analysis and workspace indexing
-- access LSP-facing provider crates from one crate family
+`perl-parser` is the top of the parsing stack. It re-exports the lower-level
+parser, analysis, workspace, and refactoring crates so downstream code can
+depend on one crate instead of the whole family.
 
-If you only need tokenization or the lower-level parser engine, prefer
-`perl-lexer` or `perl-parser-core`.
+## Main entry points
 
-## Usage
+- `Parser` plus `ast`, `position`, `error`, and `ParseResult`
+- `analysis::*` from `perl-semantic-analyzer`
+- `workspace::*` from `perl-workspace-index`
+- `refactor::*` from `perl-refactoring`
+- `completion`, `diagnostics`, `rename`, and other LSP provider re-exports
+- `perl-parse` when the `cli` feature is enabled
+
+## Example
 
 ```rust
 use perl_parser::Parser;
 
 let mut parser = Parser::new("my $x = 42;");
 let ast = parser.parse()?;
-println!("{}", ast.to_sexp());
+assert!(!ast.to_sexp().is_empty());
 ```
 
-## Included binary
+## Typical use
 
-`perl-parse` (requires the `cli` feature) parses Perl files and prints the AST
-in S-expression, JSON, or debug format.
-
-## Key re-exports
-
-| Module | Source crate | Purpose |
-|--------|-------------|---------|
-| `engine` | `perl-parser-core` | Recursive-descent parser, AST, error recovery |
-| `analysis` | `perl-semantic-analyzer` | Scope analysis, type inference, symbol tables |
-| `workspace` | `perl-workspace-index` | Cross-file symbol indexing and document store |
-| `refactor` | `perl-refactoring` | Import optimizer, modernization, refactoring engine |
-| `tdd` | `perl-tdd-support` | Test generation and TDD workflow |
-| `completion`, `diagnostics`, `rename`, ... | `perl-lsp-*` | LSP feature providers |
-
-## Workspace role
-
-`perl-parser` is the broadest library entry point in the
-[`perl-lsp`](https://github.com/EffortlessMetrics/perl-lsp) workspace. It is a
-good choice for downstream tools that want parser access plus room to grow into
-semantic or editor features later.
-
-## License
-
-Licensed under either of [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-or [MIT license](http://opensource.org/licenses/MIT) at your option.
+Use `perl-parser` when you are building editor tooling, code transforms, or
+tests that need both parsing and the higher-level analysis layers. If you only
+need a small slice of the stack, depend on the lower-level crate directly.

--- a/crates/perl-path-security/README.md
+++ b/crates/perl-path-security/README.md
@@ -1,32 +1,27 @@
 # perl-path-security
 
-Workspace-bound path validation utilities for the Perl LSP/DAP ecosystem.
+Workspace path validation for editor-facing file operations.
 
-## When to use this crate
+Use this crate when user input needs to become a filesystem path but must stay
+inside the active workspace.
 
-Use `perl-path-security` when you need to validate a user-supplied path before
-touching the filesystem.
+## Where it fits
 
-It focuses on the common security boundary problems:
+This is a guardrail crate at the protocol edge. It sits between LSP/DAP request
+handling and any filesystem access, and it is also used by path-based completion
+helpers.
 
-- rejecting parent-directory traversal
-- keeping paths inside a workspace root
-- rejecting null-byte and control-character injection
-- normalizing safe completion inputs for downstream completion or file-finding code
+## Key entry points
 
-## Public surface
+- `validate_workspace_path(path, workspace_root)` - normalize and bound-check a path
+- `WorkspacePathError` - traversal, outside-workspace, and invalid-character errors
+- `sanitize_completion_path_input(path)` - reject traversal before path completion
+- `split_completion_path_components(path)` - split a safe completion path
+- `resolve_completion_base_directory(dir_part)` - locate the directory side of a completion path
+- `is_safe_completion_filename(filename)` - reject reserved, malformed, or unsafe names
 
-- Validates user-supplied paths stay inside a workspace root
-- Prevents parent-directory traversal (e.g. `../../`)
-- Rejects null-byte/control-character path injection
-- Normalizes safe relative paths for downstream operations
+## Typical use
 
-## API
-
-- `validate_workspace_path(path, workspace_root)`
-- `WorkspacePathError`
-
-## Workspace role
-
-This is a small security boundary crate used by `perl-lsp`, `perl-dap`, and
-other workspace tools that accept paths from editors or test harnesses.
+Use `perl-path-security` before any file open, rename, or completion operation
+that starts from user input. If the caller already has a trusted absolute path,
+this crate is not the right layer for filesystem discovery.

--- a/crates/perl-pod/README.md
+++ b/crates/perl-pod/README.md
@@ -1,42 +1,44 @@
 # perl-pod
 
-[![Crates.io](https://img.shields.io/crates/v/perl-pod.svg)](https://crates.io/crates/perl-pod)
-[![Documentation](https://docs.rs/perl-pod/badge.svg)](https://docs.rs/perl-pod)
+POD extractor for Perl `.pm` files.
 
-POD extraction utilities for Perl modules.
+Use this crate when you need structured documentation text for hover cards,
+module docs, or other editor surfaces without pulling in the full parser or LSP
+stack.
 
-## When to use this crate
+## Where it fits
 
-Use `perl-pod` when you need lightweight access to POD sections from a Perl
-source file, especially for hover text, module summaries, or local
-documentation indexing.
+`perl-pod` sits at the documentation edge of the workspace. It reads POD blocks
+from source text or files and returns a small data model that downstream crates
+can render or attach to diagnostics.
 
-It extracts a focused structured view:
+## Key entry points
 
-- module name and short description
-- synopsis text
-- description text
-- `=head2` method sections
+- `PodDoc` - extracted `NAME`, `SYNOPSIS`, `DESCRIPTION`, and method docs
+- `extract_pod(source)` - parse POD from a Perl source string
+- `extract_pod_from_file(path)` - read a file and extract its POD
 
-## Quick example
+## Example
 
 ```rust
-use perl_pod::extract_pod;
+use perl_pod::{PodDoc, extract_pod};
 
-let doc = extract_pod(
-    "=head1 NAME\nMy::Module - Example module\n\n=head1 SYNOPSIS\nuse My::Module;\n=cut\n",
+let doc: PodDoc = extract_pod(
+    r#"
+=head1 NAME
+My::Module - example module
+
+=head1 SYNOPSIS
+use My::Module;
+=cut
+"#,
 );
 
-assert!(doc.name.is_some());
-assert!(doc.synopsis.is_some());
+assert_eq!(doc.name.as_deref(), Some("My::Module - example module"));
 ```
 
-## Public API
+## Typical use
 
-- `extract_pod`: extract POD from a source string
-- `extract_pod_from_file`: read a file and extract POD
-- `PodDoc`: structured extracted documentation
-
-## License
-
-MIT OR Apache-2.0
+Use `perl-pod` when a caller already has Perl source and only needs the
+documentation sections. If you need syntax analysis or symbol resolution first,
+parse with `perl-parser` and then layer POD extraction on top.

--- a/crates/perl-refactoring/README.md
+++ b/crates/perl-refactoring/README.md
@@ -1,43 +1,41 @@
 # perl-refactoring
 
-Refactoring and modernization utilities for Perl code, part of the
-[tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+Refactoring and code-modernization utilities for Perl source.
 
-## When to use this crate
+Use this crate when you have parsed source plus analysis context and need to
+rewrite code, not just inspect it.
 
-Use `perl-refactoring` when you want source-edit generation rather than just
-analysis. It is the right crate for:
+## Where it fits
 
-- import cleanup and reordering
-- modernization suggestions and transforms
-- cross-file rename workflows
-- higher-level workspace refactoring coordination
+`perl-refactoring` sits above the parser and workspace index. It consumes AST
+and symbol information, then performs import cleanup, modernization, rename,
+and workspace-wide transformations.
 
-## Features
+## Key entry points
 
-- **Import Optimization** -- detect unused/duplicate imports, generate optimized `use` statements (`ImportOptimizer`)
-- **Code Modernization** -- suggest modern Perl idioms (lexical filehandles, three-argument `open`, `say`, `strict`/`warnings`) via `PerlModernizer`
-- **Unified Refactoring Engine** -- `RefactoringEngine` coordinates rename, modernize, and import-optimize operations with backup/rollback support
-- **Workspace Refactoring** -- cross-file rename, extract module, move subroutine, inline variable (`WorkspaceRefactor`)
-- **Workspace Rename** -- scope-aware, atomic symbol rename across an entire workspace with progress reporting (`WorkspaceRename`)
+- `import_optimizer::ImportOptimizer`
+- `modernize::PerlModernizer`
+- `refactoring::RefactoringEngine`
+- `workspace_refactor::WorkspaceRefactor`
+- `workspace_rename::WorkspaceRename`
 
-## Cargo Features
+## Cargo features
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `workspace_refactor` | yes | Workspace-wide refactoring via `WorkspaceIndex` |
-| `modernize` | no | Code modernization transforms in `RefactoringEngine` |
+- `workspace_refactor` enables workspace-wide refactoring via `WorkspaceIndex`
+- `modernize` enables modernization transforms in `RefactoringEngine`
 
-## Usage
+## Example
 
 ```rust
 use perl_refactoring::import_optimizer::ImportOptimizer;
 
 let optimizer = ImportOptimizer::new();
 let analysis = optimizer.analyze_content("use Carp qw(croak); print 1;")?;
-let optimized = optimizer.generate_optimized_imports(&analysis);
+let _optimized = optimizer.generate_optimized_imports(&analysis);
 ```
 
-## License
+## Typical use
 
-Licensed under either of MIT or Apache-2.0 at your option.
+Use `perl-refactoring` when you need to migrate code, remove unused imports, or
+perform cross-file symbol edits. If you only need symbol analysis or workspace
+lookup, use the lower-level crates directly.

--- a/crates/perl-semantic-analyzer/README.md
+++ b/crates/perl-semantic-analyzer/README.md
@@ -1,49 +1,38 @@
 # perl-semantic-analyzer
 
-Semantic analysis, symbol extraction, and type inference for Perl source code. Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace.
+Semantic analysis for Perl source.
 
-## When to use this crate
+Use this crate when you already have an AST and need symbols, scopes, types,
+declaration lookup, or dead-code signals before you get to editor features.
 
-Use `perl-semantic-analyzer` when parsing alone is not enough and you need
-symbol- or scope-aware understanding of Perl code.
+## Where it fits
 
-Typical use cases:
+`perl-semantic-analyzer` sits above `perl-parser-core` and next to
+`perl-workspace-index`. It turns parsed trees into analysis artifacts that the
+workspace, refactoring, and LSP layers can consume.
 
-- extracting definitions and references from an AST
-- computing semantic tokens or scope diagnostics
-- inferring types or detecting dead code
-- preparing symbol data for navigation, rename, or workspace indexing
+## Key entry points
 
-## Features
+- `analysis::symbol::SymbolExtractor`
+- `analysis::scope_analyzer::ScopeAnalyzer`
+- `analysis::type_inference::TypeInferenceEngine`
+- `analysis::semantic::SemanticAnalyzer`
+- `analysis::declaration::DeclarationProvider`
+- `analysis::index::WorkspaceIndex`
 
-- **Symbol extraction** -- `SymbolExtractor` builds a `SymbolTable` of definitions, references, and scopes from a parsed AST.
-- **Semantic tokens** -- `SemanticAnalyzer` classifies tokens (`SemanticTokenType`, `SemanticTokenModifier`) for LSP syntax highlighting and hover info.
-- **Scope analysis** -- `ScopeAnalyzer` detects unused variables, shadowing, undeclared variables, and other scope issues.
-- **Type inference** -- `TypeInferenceEngine` infers `PerlType` for variables and expressions with a scoped `TypeEnvironment`.
-- **Dead code detection** -- `DeadCodeDetector` identifies unused subroutines, variables, imports, and unreachable code (non-WASM only).
-- **Declaration provider** -- `DeclarationProvider` resolves go-to-declaration with `LocationLink` results and parent-map traversal.
-- **Workspace index** -- local `WorkspaceIndex` for cross-file symbol lookup by name, URI, or query.
-
-## Dependencies
-
-Builds on `perl-parser-core` (AST/parsing), `perl-workspace-index` (cross-file references), and `perl-symbol-types` (symbol taxonomy).
-
-## Usage
+## Example
 
 ```rust
-use perl_semantic_analyzer::{Parser, analysis::symbol::SymbolExtractor};
+use perl_parser_core::Parser;
+use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
 
 let mut parser = Parser::new("sub hello { my $x = 1; }");
 let ast = parser.parse()?;
-let table = SymbolExtractor::new().extract(&ast);
+let _symbols = SymbolExtractor::new().extract(&ast);
 ```
 
-## Workspace role
+## Typical use
 
-`perl-semantic-analyzer` sits between parsing and editor/runtime features. It
-is the crate to reach for when you need semantic meaning rather than just
-syntactic structure.
-
-## License
-
-Licensed under MIT OR Apache-2.0 at your option.
+Use `perl-semantic-analyzer` when you are building hover, declaration, type,
+or diagnostics features from parsed Perl source. If you need cross-file lookup
+or document caching, pair it with `perl-workspace-index`.

--- a/crates/perl-uri/README.md
+++ b/crates/perl-uri/README.md
@@ -1,46 +1,37 @@
 # perl-uri
 
-URI and filesystem-path conversion utilities for Perl editor tooling.
+URI and filesystem-path normalization for Perl tooling.
 
-## When to use this crate
+Use this crate when a caller may hand you either a `file://` URI or a raw
+filesystem path and you need a stable representation for caches, lookups, or
+workspace edges.
 
-Use `perl-uri` when you need a small utility crate for:
+## Where it fits
 
-- converting between `file://` URIs and local filesystem paths
-- normalizing Windows and Unix file references into stable URI keys
-- handling raw absolute paths that may arrive from editors or test harnesses
+`perl-uri` sits at the protocol boundary. It is used by LSP and DAP code before
+files hit the parser, workspace index, or other path-sensitive layers.
 
-It is useful outside the full `perl-lsp` runtime when you only need file-URI
-logic.
+## Key entry points
 
-## Public API
+- `uri_to_fs_path(uri)` - convert `file://` URIs to filesystem paths
+- `fs_path_to_uri(path)` - convert filesystem paths to `file://` URIs
+- `normalize_uri(uri)` - normalize raw paths, malformed file URIs, and valid URIs
+- `uri_key(uri)` - produce a lookup key with Windows drive-letter normalization
+- `is_file_uri(uri)` and `is_special_scheme(uri)` - classify URIs
+- `uri_extension(uri)` - extract the extension from a URI string
 
-| Function | Purpose |
-|----------|---------|
-| `uri_to_fs_path` | Convert a `file://` URI to a `PathBuf` (non-wasm only) |
-| `fs_path_to_uri` | Convert a filesystem path to a `file://` URI string (non-wasm only) |
-| `normalize_uri` | Normalize a URI (or bare path) to a consistent `file://` form |
-| `uri_key` | Normalize a URI for use as a lookup key (lowercases Windows drive letters) |
-| `is_file_uri` | Check whether a URI uses the `file://` scheme |
-| `is_special_scheme` | Check whether a URI uses a non-file scheme (`untitled:`, `git:`, etc.) |
-| `uri_extension` | Extract the file extension from a URI string |
-
-## Usage
+## Example
 
 ```rust
-use perl_uri::{uri_to_fs_path, fs_path_to_uri, uri_key};
+use perl_uri::{normalize_uri, uri_key};
 
-let path = uri_to_fs_path("file:///tmp/test.pl");    // Some(PathBuf)
-let uri  = fs_path_to_uri("/tmp/test.pl").unwrap();   // "file:///tmp/test.pl"
-let key  = uri_key("file:///C:/Users/test.pl");        // "file:///c:/Users/test.pl"
+#[cfg(windows)]
+assert_eq!(normalize_uri(r"C:\workspace\script.pl"), "file:///c:/workspace/script.pl");
+assert_eq!(uri_key("file:///C:/Users/test.pl"), "file:///c:/Users/test.pl");
 ```
 
-## Platform support
+## Typical use
 
-`uri_to_fs_path`, `fs_path_to_uri`, and `normalize_uri` require filesystem access and are
-not available on `wasm32` targets. The remaining helpers work on all platforms.
-
-## License
-
-Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
-[MIT license](LICENSE-MIT) at your option.
+Use `perl-uri` when you need consistent cache keys or filesystem lookups
+without making callers care whether they passed a URI or a path. On `wasm32`,
+only the URI-parsing helpers are available.

--- a/crates/perl-workspace-index/README.md
+++ b/crates/perl-workspace-index/README.md
@@ -1,48 +1,25 @@
 # perl-workspace-index
 
-Workspace-wide symbol indexing and cross-file navigation for Perl LSP tooling.
+Workspace indexing and cross-file lookup for Perl tooling.
 
-## When to use this crate
+Use this crate when you need to track open documents, build a symbol index, or
+answer workspace-wide queries such as references, symbols, and rename targets.
 
-Use `perl-workspace-index` when you need cross-file symbol tracking for Perl:
+## Where it fits
 
-- workspace-wide definition and reference lookup
-- document storage and incremental reindexing
-- rename and workspace-symbol operations
-- cache-aware coordination for large workspaces
+`perl-workspace-index` sits above `perl-parser-core` and below the editor and
+refactoring layers. It owns document storage, incremental updates, and the
+workspace symbol index that the rest of the stack queries.
 
-It is a core runtime crate in the
-[`perl-lsp`](https://github.com/EffortlessMetrics/perl-lsp) workspace rather
-than a standalone end-user package.
+## Key entry points
 
-## Overview
+- `workspace::document_store::DocumentStore`
+- `workspace::workspace_index::WorkspaceIndex`
+- `workspace::workspace_rename::WorkspaceRename`
+- `Parser`, `Node`, `NodeKind`, and `SourceLocation` re-exports from `perl-parser-core`
 
-`perl-workspace-index` provides the indexing engine behind go-to-definition,
-find-references, workspace symbol search, and rename refactoring.
+## Typical use
 
-## Key Components
-
-- **`WorkspaceIndex`** -- core symbol index with dual indexing (qualified and bare names) for O(1) lookups
-- **`DocumentStore`** -- thread-safe in-memory document cache with version tracking
-- **`IndexStateMachine`** -- lifecycle state machine (Idle, Initializing, Building, Ready, Degraded, Error)
-- **`ProductionIndexCoordinator`** -- production coordinator integrating bounded LRU caches and SLO monitoring
-- **`SloTracker`** -- service-level objective tracking with P50/P95/P99 latency percentiles
-- **`BoundedLruCache`** -- generic bounded LRU cache with configurable size and TTL
-
-## Public surface
-
-Most consumers enter through the `workspace` module and the `WorkspaceIndex`,
-`DocumentStore`, or `ProductionIndexCoordinator` types, depending on whether
-they need a simple symbol index or a production-oriented coordinator with cache
-and monitoring hooks.
-
-## Features
-
-| Feature | Purpose |
-|---------|---------|
-| `workspace` | Full workspace support (enables benchmarks) |
-| `lsp-compat` | Adds `lsp-types` integration |
-
-## License
-
-Licensed under either of [MIT](https://opensource.org/licenses/MIT) or [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) at your option.
+Use `perl-workspace-index` when you already have parsed documents and need to
+keep the workspace view current as files change. If you only need syntax trees,
+depend on `perl-parser-core` instead.

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -1,51 +1,37 @@
 # tree-sitter-perl
 
-Internal pure-Rust Perl parser and validation harness for the
-[tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp)
-workspace. **Not published to crates.io.**
+Pure-Rust Perl parser and comparison harness for the workspace.
 
-## When to use this crate
+This crate is not published to crates.io. Use it for parser work, regression
+checks, and benchmark comparisons against the native parser stack.
 
-Use `tree-sitter-perl` when you need the experimental pure-Rust parser and
-comparison harness that sit alongside the main Perl LSP parser stack.
+## Where it fits
 
-It is useful for:
+`tree-sitter-perl` is the validation and parser-compatibility crate. The
+`pure-rust` path emits tree-sitter-compatible ASTs, while the comparison tools
+let us measure behavior against the rest of the workspace.
 
-- benchmarking parser behavior against the native parser implementation
-- running pure-Rust parser comparisons and edge-case experiments
-- exercising tree-sitter-compatible parser output during development
+## Key entry points
 
-## Purpose
+- `PureRustPerlParser`, `PerlParser`, `AstNode`
+- `EnhancedPerlParser`, `FullPerlParser`, `EnhancedFullPerlParser`
+- `ComparisonHarness`
+- `language()`, `parse()`, `parse_with_tree()`
 
-Provides a Pest-based Perl 5 parser that emits tree-sitter-compatible
-S-expressions, plus a comparison harness for benchmarking against the
-native v3 recursive-descent parser (`perl-parser`).
+## Example
 
-## Public API (feature-gated)
+```rust
+use tree_sitter_perl::parse;
 
-| Export | Feature | Description |
-|--------|---------|-------------|
-| `PureRustPerlParser` | `pure-rust` | Main Pest-based parser |
-| `PerlParser`, `AstNode` | `pure-rust` | Grammar rule parser and AST nodes |
-| `EnhancedPerlParser`, `FullPerlParser` | `pure-rust` | Advanced parser variants |
-| `ComparisonHarness` | `pure-rust` / `test-utils` | C-vs-Rust parser comparison runner |
-| `language()`, `parse()` | `c-parser` | Tree-sitter C FFI (benchmarking only) |
+let tree = parse("my $x = 1;")?;
+assert!(tree.root_node().child_count() > 0);
+```
 
 ## Commands
 
 ```bash
-cargo build -p tree-sitter-perl                           # build
-cargo test  -p tree-sitter-perl                           # test
-cargo run   -p tree-sitter-perl --bin ts_test_parsers --features pure-rust  # parser comparison
-cargo run   -p tree-sitter-perl --bin ts_benchmark_parsers --features pure-rust  # benchmarks
+cargo build -p tree-sitter-perl
+cargo test -p tree-sitter-perl
+cargo run -p tree-sitter-perl --bin ts_test_parsers --features pure-rust
+cargo run -p tree-sitter-perl --bin ts_benchmark_parsers --features pure-rust
 ```
-
-## Workspace role
-
-This is an internal development crate, not a published library. Keep using the
-main [`perl-parser`](../perl-parser/README.md) crate for the production parser
-path.
-
-## License
-
-MIT OR Apache-2.0

--- a/docs/handoff/agent-swarm-workflow/README.md
+++ b/docs/handoff/agent-swarm-workflow/README.md
@@ -3,8 +3,8 @@
 > Status: archived portable bundle.
 >
 > For `perl-lsp`, the canonical swarm runtime lives in the tracked `.claude/`
-> directory plus [SWARM_DESIGN.md](../../SWARM_DESIGN.md) and
-> [SKILL_AND_AGENT_DESIGN.md](../../../reference/SKILL_AND_AGENT_DESIGN.md).
+> directory plus [SWARM_DESIGN.md](../SWARM_DESIGN.md) and
+> [SKILL_AND_AGENT_DESIGN.md](../../reference/SKILL_AND_AGENT_DESIGN.md).
 > This directory is kept as a historical/exportable bundle for the older
 > wave-based workflow, not as the primary source of truth for the repo.
 
@@ -65,11 +65,16 @@ Orchestrator (main thread)
    Implementation agents just write code. PR agents validate, branch, commit,
    push, and create the pull request.
 
-5. **Wave pattern** -- Work is organized in waves by category (fixes, tests,
+5. **PR titles must satisfy CI** -- Use the repo pattern
+   `type(scope): summary (#1234)` before opening the PR so the title check does
+   not fail on the first run. The issue reference belongs in the title, not
+   only in the body.
+
+6. **Wave pattern** -- Work is organized in waves by category (fixes, tests,
    docs, cleanup). This lets the orchestrator merge one category before
    starting the next, reducing conflict probability.
 
-6. **Quality ratcheting** -- After merges, baselines are updated so metrics
+7. **Quality ratcheting** -- After merges, baselines are updated so metrics
    can only improve. Test counts, lint warnings, coverage -- once they get
    better, they stay better.
 
@@ -102,6 +107,8 @@ For `perl-lsp` itself, do not bootstrap from this bundle; use the tracked repo
 2. Customize the placeholders (`$TEST_CMD`, `$LINT_CMD`, etc.) in the copied
    slash commands
 3. Start Claude Code and use `/wave` to launch your first swarm
+4. Keep agent-written changes in isolated worktrees and create one focused PR
+   per worktree
 
 ## Language support
 

--- a/docs/handoff/agent-swarm-workflow/slash-commands/worktree-pr.md
+++ b/docs/handoff/agent-swarm-workflow/slash-commands/worktree-pr.md
@@ -50,7 +50,7 @@ EOF
 6. **Push and PR**:
 ```bash
 git push -u origin <branch-name>
-gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+gh pr create --title "<type>(<scope>): <description> (#1234)" --body "$(cat <<'EOF'
 ## Summary
 <what and why>
 
@@ -61,5 +61,9 @@ gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+The PR title must include an issue reference so `validate-title` passes. Keep
+the body focused on the worktree's actual change and use the issue number the
+branch is tracking.
 
 7. **Return the PR URL**.


### PR DESCRIPTION
Second-pass README/devex rewrite from an isolated worktree.

Scope:
- reworked the owned crate READMEs to be concise, problem-first, and stack-oriented
- added explicit PR title guidance for agent-driven work so validate-title does not fail after opening
- documented isolated worktree/branch usage in the agent swarm handoff docs

Validation:
- git diff --check
- link existence check for changed docs
- representative cargo package README inclusion checks