### PR TITLE
docs: second-pass provider landing pages (#2936)

### DIFF
--- a/crates/perl-lsp-code-actions/README.md
+++ b/crates/perl-lsp-code-actions/README.md
@@ -1,30 +1,30 @@
 # perl-lsp-code-actions
 
-LSP code actions provider for the Perl LSP ecosystem. Generates quick fixes
-driven by diagnostic codes and refactoring actions driven by AST analysis.
+Perl code action engine for quick fixes and AST-driven refactorings. It turns
+diagnostics and structured syntax into actionable edits such as import fixes,
+declaration insertion, extract-variable refactors, and loop conversions.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-code-actions` when you want Perl-aware `textDocument/codeAction`
-support without pulling in the full `perl-lsp` runtime. It is most useful for
-Rust-based editor tooling that already has diagnostics or AST context and needs
-to build quick fixes or refactorings.
+Use `perl-lsp-code-actions` if you need the code-action logic itself. Use
+`perl-lsp-providers` when you want the umbrella re-export surface. This crate is
+the provider layer, not the editor transport layer.
 
-## Public API
+## Key exports
 
-- `CodeActionsProvider` -- diagnostic-driven quick fixes (declare variable,
-  add pragmas, fix parse errors, fix barewords, handle unused variables).
-- `EnhancedCodeActionsProvider` -- AST-driven refactorings (extract variable,
-  extract subroutine, loop conversion, import management, postfix conversion,
-  error-checking insertion).
-- `CodeAction`, `CodeActionKind`, `CodeActionEdit` -- result types.
+- `CodeActionsProvider` - diagnostic-driven fixes for common Perl problems
+- `EnhancedCodeActionsProvider` - AST-driven refactorings and structural edits
+- `CodeAction`, `CodeActionKind`, `CodeActionEdit` - shared action types
 
-## Workspace Role
+## What it covers
 
-Internal feature crate in the `tree-sitter-perl-rs` workspace, consumed by
-`perl-lsp` for `textDocument/codeAction` request dispatch. Not intended for
-standalone use outside the workspace.
+- missing variable declarations and pragma fixes
+- parse-error and bareword recovery actions
+- import management and other refactor helpers
+- extract-variable, extract-subroutine, and loop-modernization actions
 
-## License
+## Stack role
 
-MIT OR Apache-2.0
+This crate sits behind the editor-facing LSP code-action handlers in `perl-lsp`.
+It consumes diagnostics and AST state, then returns the edits the client can
+offer to the user.

--- a/crates/perl-lsp-code-lens/README.md
+++ b/crates/perl-lsp-code-lens/README.md
@@ -1,37 +1,33 @@
 # perl-lsp-code-lens
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp-code-lens.svg)](https://crates.io/crates/perl-lsp-code-lens)
-[![Documentation](https://docs.rs/perl-lsp-code-lens/badge.svg)](https://docs.rs/perl-lsp-code-lens)
+Perl code lens provider for inline actions above code. It is responsible for
+test-run lenses, reference-count lenses, and script-level actions such as
+running a shebang file.
 
-Inline code-lens generation for Perl editors and language servers.
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-code-lens` if you need the code-lens logic itself. It is the
+layer between parsed Perl code and the editor commands that sit above it.
 
-Use `perl-lsp-code-lens` when you want Perl-aware inline actions such as:
+## Key exports
 
-- run-test lenses for `.t` files and test subroutines
-- reference-count lenses for packages and subroutines
-- run-script lenses for executable Perl files with a shebang
+- `CodeLensProvider` - extracts lenses from an AST and optional file path
+- `CodeLens` / `Command` - serialized lens payloads
+- `resolve_code_lens` - turns reference-count data into a runnable command
+- `get_shebang_lens` - adds a top-of-file "Run Script" action
+- `is_test_file` - `.t` file detection for test-specific lenses
 
-This crate is primarily intended for the `perl-lsp` workspace and other Rust
-language-server integrations. It is not a standalone editor plugin.
+## Example
 
-## Quick example
+```rust,ignore
+use perl_lsp_code_lens::CodeLensProvider;
 
-```rust
-use perl_lsp_code_lens::{get_shebang_lens, is_test_file};
-
-assert!(is_test_file("t/basic.t"));
-assert!(get_shebang_lens("#!/usr/bin/env perl\nprint \"ok\\n\";\n").is_some());
+let provider = CodeLensProvider::new(source.to_string())
+    .with_file_path("t/basic.t".to_string());
+let lenses = provider.extract(&ast);
 ```
 
-## Public API
+## Stack role
 
-- `CodeLensProvider`: extracts lenses from a Perl AST
-- `resolve_code_lens`: fills in deferred reference-count data
-- `get_shebang_lens`: detects executable-script lenses from source text
-- `is_test_file`: detects Perl test-file naming
-
-## License
-
-MIT OR Apache-2.0
+`perl-lsp` uses this crate to surface inline run and reference actions in the
+editor. It sits on top of parser output and file context.

--- a/crates/perl-lsp-color-provider/README.md
+++ b/crates/perl-lsp-color-provider/README.md
@@ -1,35 +1,29 @@
 # perl-lsp-color-provider
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp-color-provider.svg)](https://crates.io/crates/perl-lsp-color-provider)
-[![Documentation](https://docs.rs/perl-lsp-color-provider/badge.svg)](https://docs.rs/perl-lsp-color-provider)
+Perl color detection and presentation provider. It finds color values in source
+text and turns them into LSP color information and presentation variants.
 
-Document-color detection and presentation helpers for Perl source code.
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-color-provider` if you need document-color behavior for Perl
+strings, hex values, ANSI colors, or named CSS colors. It is the feature layer
+that sits beneath the editor-facing protocol implementation.
 
-Use `perl-lsp-color-provider` when you want `textDocument/documentColor` or
-`textDocument/colorPresentation` support for Perl code. It recognizes:
+## Key exports
 
-- hex colors such as `#ff00aa`
-- ANSI escape sequences
-- named CSS colors in quoted strings
-- `Term::ANSIColor` calls
+- `ColorInformation` / `Color` - detected color ranges and parsed color values
+- `detect_colors` - scan source text for supported color forms
+- `color_to_presentations` - build alternative color presentations for the UI
 
-## Quick example
+## Example
 
-```rust
+```rust,ignore
 use perl_lsp_color_provider::detect_colors;
 
-let colors = detect_colors(r#"my $accent = "#ff00aa";"#);
-assert_eq!(colors.len(), 1);
+let colors = detect_colors("my $red = '#ff0000';");
 ```
 
-## Public API
+## Stack role
 
-- `detect_colors`: scans Perl source for color literals
-- `color_to_presentations`: returns editor-facing replacement formats
-- `ColorInformation` and `Color`: simple range and RGBA value types
-
-## License
-
-MIT OR Apache-2.0
+`perl-lsp` uses this crate for `textDocument/documentColor` and related editor
+features. It is intentionally small and focused on color extraction only.

--- a/crates/perl-lsp-completion-item/README.md
+++ b/crates/perl-lsp-completion-item/README.md
@@ -1,60 +1,56 @@
 # perl-lsp-completion-item
 
-Standalone SRP microcrate for completion item domain types and stable deduplicating sort behavior.
+Shared completion-item types and deterministic sorting for the Perl LSP stack.
+Use this crate when you need a stable completion payload model without the full
+completion engine.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-completion-item` when you need deterministic completion-item
-ordering and deduplication without depending on a full completion provider.
+Use `perl-lsp-completion-item` for data-model work, tests, or adapters that need
+the same item semantics as the completion provider. Use
+`perl-lsp-completion` when you want the actual suggestion engine.
 
-It is useful for:
+## Key exports
 
-- provider crates that generate completion candidates
-- tests that need stable sort behavior
-- adapters that turn completion results into protocol payloads later
+- `CompletionItem` - normalized completion payload
+- `CompletionItemKind` - completion classification
+- `deduplicate_and_sort` - stable ordering and duplicate suppression
 
-## Quick example
+## Example
 
-```rust
+```rust,ignore
 use perl_lsp_completion_item::{CompletionItem, CompletionItemKind, deduplicate_and_sort};
 
 let items = vec![
     CompletionItem {
-        label: "print".into(),
+        label: "print".to_string(),
         kind: CompletionItemKind::Function,
         detail: None,
         documentation: None,
         insert_text: None,
-        sort_text: Some("020".into()),
+        sort_text: None,
         filter_text: None,
         additional_edits: Vec::new(),
         text_edit_range: None,
         commit_characters: None,
     },
     CompletionItem {
-        label: "print".into(),
-        kind: CompletionItemKind::Keyword,
+        label: "printf".to_string(),
+        kind: CompletionItemKind::Function,
         detail: None,
         documentation: None,
         insert_text: None,
-        sort_text: Some("100".into()),
+        sort_text: None,
         filter_text: None,
         additional_edits: Vec::new(),
         text_edit_range: None,
         commit_characters: None,
     },
 ];
-
 let sorted = deduplicate_and_sort(items);
-assert_eq!(sorted.len(), 1);
 ```
 
-## Public API
+## Stack role
 
-- `CompletionItemKind`: crate-local completion taxonomy
-- `CompletionItem`: stable completion domain type
-- `deduplicate_and_sort`: deterministic deduplication and ordering policy
-
-## License
-
-MIT OR Apache-2.0
+This crate sits at the boundary between provider logic and editor payloads. It
+keeps the completion result shape consistent across the wider provider stack.

--- a/crates/perl-lsp-completion/README.md
+++ b/crates/perl-lsp-completion/README.md
@@ -1,39 +1,35 @@
 # perl-lsp-completion
 
-Context-aware completion engine for Perl source.
+Perl-aware completion engine for `textDocument/completion`. It turns an AST,
+the current cursor location, and optional workspace context into ranked
+completion items for variables, functions, keywords, packages, methods, file
+paths, and test helpers.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-completion` when you want Perl-aware `textDocument/completion`
-behavior without embedding the full language server runtime.
+Use `perl-lsp-completion` if you need the completion logic itself. Use
+`perl-lsp-completion-item` if you only need the item types and deterministic
+sorting, and use `perl-lsp-providers` when you want the umbrella re-export
+surface for the whole provider stack.
 
-It is the right crate when you need:
+## Key exports
 
-- ranked completion results at a source offset
-- completion logic that understands Perl sigils, packages, methods, and files
-- workspace-aware or AST-aware completion providers in Rust
-
-## Public API
-
-- `CompletionProvider`: builds a symbol table from an AST and optional workspace index, then generates ranked completion items at a given byte offset.
-- `CompletionContext`: request-scoped context for trigger character, scope, and prefix handling.
-- `CompletionItem` and `CompletionItemKind`: completion payloads with insert text, sort priority, and text-edit range.
+- `CompletionProvider` - builds completion results from AST and optional index
+- `CompletionContext` - request-scoped state such as prefix and trigger
+- `CompletionItem` / `CompletionItemKind` - normalized completion payloads
+- `get_dbi_method_documentation` and `get_test_more_documentation` - Perl-aware
+  documentation helpers for completion hints
 
 ## Example
 
 ```rust,ignore
 use perl_lsp_completion::CompletionProvider;
 
-let provider = CompletionProvider::new(&ast, Some(&workspace_index))?;
-let completions = provider.get_completions(source, position)?;
-assert!(!completions.is_empty());
+let provider = CompletionProvider::new_with_index(&ast, None);
+let items = provider.get_completions(source, byte_offset);
 ```
 
-## Workspace role
+## Stack role
 
-Internal feature crate consumed by `perl-lsp` for completion handling. It is
-mostly a workspace building block rather than a standalone end-user crate.
-
-## License
-
-MIT OR Apache-2.0
+This is the feature crate that backs `perl-lsp` completion handling. It sits
+above parsing and workspace indexing, and below the editor-facing LSP runtime.

--- a/crates/perl-lsp-diagnostics/README.md
+++ b/crates/perl-lsp-diagnostics/README.md
@@ -1,39 +1,38 @@
 # perl-lsp-diagnostics
 
-Diagnostics and linting provider for Perl source.
+Perl diagnostics engine for editor-facing parse errors, lint checks, semantic
+warnings, and dead-code reporting. This crate turns parser and analysis results
+into `publishDiagnostics`-style output.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-diagnostics` when you want editor-facing diagnostics for Perl
-source without embedding the full `perl-lsp` runtime.
+Use `perl-lsp-diagnostics` if you need the diagnostic logic itself. If you only
+need the shared diagnostic types, depend on the re-exported types rather than
+rebuilding the provider stack. If you want the umbrella API, use
+`perl-lsp-providers`.
 
-It combines parse errors, semantic analysis, lint checks, and dead-code signals
-into one provider surface suitable for `textDocument/publishDiagnostics` or
-pull-diagnostics style flows.
+## Key exports
 
-## Public API
-
-- `DiagnosticsProvider`: core provider that builds diagnostics from AST and parse errors.
-- `Diagnostic`, `DiagnosticSeverity`, `DiagnosticTag`, `RelatedInformation`: diagnostic payload types.
-- `common_mistakes`, `deprecated`, `strict_warnings`, `unused_imports`: lint families re-exported for direct use.
-- `detect_dead_code`: workspace-wide dead code detection when not targeting WASM.
+- `DiagnosticsProvider` - assembles diagnostics from AST, source, and optional
+  workspace context
+- `Diagnostic`, `DiagnosticSeverity`, `DiagnosticTag`, `RelatedInformation` -
+  shared diagnostic types
+- `common_mistakes`, `deprecated`, `missing_module`, `package_subroutine`,
+  `security`, `strict_warnings`, `unused_imports`, `version_compat` - lint
+  families re-exported for targeted checks
+- `detect_dead_code` - workspace-wide dead-code detection outside WASM builds
 
 ## Example
 
 ```rust,ignore
 use perl_lsp_diagnostics::DiagnosticsProvider;
 
-let provider = DiagnosticsProvider::new(&ast, source.to_string());
-let diagnostics = provider.get_diagnostics(&workspace_index);
-assert!(!diagnostics.is_empty());
+let provider = DiagnosticsProvider::new();
+let diagnostics = provider.generate_diagnostics(&ast, source, Some(&workspace_index))?;
 ```
 
-## Workspace role
+## Stack role
 
-Internal feature crate consumed by `perl-lsp` to publish diagnostics to
-editors. It is mostly a workspace building block rather than a standalone
-end-user crate.
-
-## License
-
-MIT OR Apache-2.0
+This crate sits between parsing and the editor runtime. It consumes ASTs,
+scope analysis, and workspace data, then emits the diagnostics that `perl-lsp`
+publishes to clients.

--- a/crates/perl-lsp-document-highlight/README.md
+++ b/crates/perl-lsp-document-highlight/README.md
@@ -1,36 +1,30 @@
 # perl-lsp-document-highlight
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp-document-highlight.svg)](https://crates.io/crates/perl-lsp-document-highlight)
-[![Documentation](https://docs.rs/perl-lsp-document-highlight/badge.svg)](https://docs.rs/perl-lsp-document-highlight)
+Perl document-highlight provider for symbol-occurrence highlighting around the
+cursor. It answers the question "where else is this thing used in the current
+document?"
 
-Symbol-occurrence highlighting for Perl editors and language servers.
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-document-highlight` if you need the highlight logic itself. It is
+lighter-weight than the navigation crates and narrower than the full provider
+umbrella.
 
-Use `perl-lsp-document-highlight` when you need
-`textDocument/documentHighlight` behavior for Perl source. Given a parsed AST,
-source text, and cursor offset, it returns the matching symbol occurrences in
-the current file and distinguishes read vs write access where possible.
+## Key exports
 
-This crate is intended for Rust-based LSP integrations, especially the
-`perl-lsp` workspace.
+- `DocumentHighlightProvider` - finds highlights for the active symbol
+- `DocumentHighlight` / `DocumentHighlightKind` - serialized highlight payloads
 
-## Quick example
+## Example
 
 ```rust,ignore
 use perl_lsp_document_highlight::DocumentHighlightProvider;
 
 let provider = DocumentHighlightProvider::new();
-let highlights = provider.find_highlights(&ast, source, cursor_byte_offset);
-assert!(!highlights.is_empty());
+let highlights = provider.find_highlights(&ast, line, character, source);
 ```
 
-## Public API
+## Stack role
 
-- `DocumentHighlightProvider`: main entry point
-- `DocumentHighlight`: returned range plus highlight kind
-- `DocumentHighlightKind`: `Text`, `Read`, or `Write`
-
-## License
-
-MIT OR Apache-2.0
+`perl-lsp` uses this crate for `textDocument/documentHighlight`. It sits on top
+of parsed source and symbol lookup.

--- a/crates/perl-lsp-inline-completion/README.md
+++ b/crates/perl-lsp-inline-completion/README.md
@@ -1,33 +1,32 @@
 # perl-lsp-inline-completion
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp-inline-completion.svg)](https://crates.io/crates/perl-lsp-inline-completion)
-[![Documentation](https://docs.rs/perl-lsp-inline-completion/badge.svg)](https://docs.rs/perl-lsp-inline-completion)
+Perl inline-completion provider for ghost-text style suggestions. It prepares
+request context from the current buffer and returns inline completions for the
+editor to render.
 
-Deterministic inline-completion support for Perl editors and language servers.
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-inline-completion` if you need inline suggestions, not the normal
+completion-list UI. It is adjacent to `perl-lsp-completion`, but optimized for
+single-line, in-buffer suggestions.
 
-Use `perl-lsp-inline-completion` when you want ghost-text suggestions driven by
-local code context instead of a remote model. The provider extracts nearby
-variables, imports, package context, and simple syntactic cues to produce
-predictable inline completions.
+## Key exports
 
-## Quick example
+- `InlineCompletionProvider` - computes inline completions from buffer state
+- `PreparedInlineCompletionContext` - parsed context for a cursor location
+- `InlineCompletionItem` / `InlineCompletionList` - inline completion payloads
+
+## Example
 
 ```rust,ignore
 use perl_lsp_inline_completion::InlineCompletionProvider;
 
 let provider = InlineCompletionProvider::new();
-let list = provider.get_inline_completions("my $name = 'A';\nprint $na", 1, 9);
-assert!(!list.items.is_empty());
+let completions = provider.get_inline_completions("sub hello", 0, 9);
 ```
 
-## Public API
+## Stack role
 
-- `InlineCompletionProvider`: main provider
-- `PreparedInlineCompletionContext`: extracted local code context
-- `InlineCompletionItem` and `InlineCompletionList`: LSP 3.18 preview types
-
-## License
-
-MIT OR Apache-2.0
+`perl-lsp` uses this crate for inline completion requests. It sits on top of
+the same Perl-aware parsing and context analysis as the standard completion
+engine.

--- a/crates/perl-lsp-navigation/README.md
+++ b/crates/perl-lsp-navigation/README.md
@@ -1,48 +1,39 @@
 # perl-lsp-navigation
 
-Navigation providers for Perl source.
+Perl navigation provider crate for symbol lookup and cross-file navigation.
+It covers workspace symbols, type hierarchy, type definition, single-file
+references, and document links.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-navigation` when you want the navigation slice of Perl LSP
-features without pulling in the full server binary.
+Use `perl-lsp-navigation` if you need the navigation logic itself. Use
+`perl-lsp-workspace-symbols` when you only need symbol indexing and search, and
+use `perl-lsp-providers` when you want the umbrella re-export surface.
 
-It is a good fit for Rust tooling that needs:
+## Key exports
 
-- definition and reference helpers
-- workspace symbol search
-- type hierarchy or type-definition support
-- document-link extraction from Perl imports
-
-## Public API
-
-- `WorkspaceSymbolsProvider` and `WorkspaceSymbol`: index parsed documents and search symbols.
-- `TypeHierarchyProvider`, `TypeHierarchyItem`, and `TypeHierarchySymbolKind`: build and resolve Perl type hierarchies.
-- `TypeDefinitionProvider`: go-to-type-definition support for variables, method calls, constructors, and `bless` expressions.
-- `find_references_single_file`: same-file reference lookup by byte offset.
-- `compute_links`: extracts document links from `use` and `require` statements.
+- `WorkspaceSymbolsProvider` / `WorkspaceSymbol` - search indexed symbols with
+  ranking and container names
+- `TypeHierarchyProvider` / `TypeHierarchyItem` - infer parent and child types
+  from Perl inheritance relationships
+- `TypeDefinitionProvider` - find the type behind a variable, method call, or
+  constructor expression
+- `find_references_single_file` - same-file reference discovery
+- `compute_links` - document links for `use` and `require`
 
 ## Example
 
 ```rust,ignore
-use perl_lsp_navigation::{TypeHierarchyProvider, WorkspaceSymbolsProvider};
+use perl_lsp_navigation::{WorkspaceSymbolsProvider, find_references_single_file};
 
-let type_hierarchy = TypeHierarchyProvider::new(workspace_index);
-let workspace_symbols = WorkspaceSymbolsProvider::new(workspace_index);
+let mut provider = WorkspaceSymbolsProvider::new();
+provider.index_document("file:///lib/Foo.pm", &ast, source);
+let symbols = provider.search("logger", &source_map);
+let refs = find_references_single_file(&ast, byte_offset);
 ```
 
-## Workspace role
+## Stack role
 
-Internal feature crate consumed by `perl-lsp` navigation request handlers. It
-is mostly a workspace building block rather than a standalone end-user crate.
-
-## Features
-
-| Feature | Purpose |
-|---------|---------|
-| `lsp-compat` | Enables LSP-specific type-definition behavior |
-| `slow_tests` | Enables slow or expensive integration tests |
-
-## License
-
-MIT OR Apache-2.0
+This crate is the navigation layer used by `perl-lsp` request handlers. It sits
+on top of parser output and semantic analysis, and below the editor protocol
+surface.

--- a/crates/perl-lsp-providers/README.md
+++ b/crates/perl-lsp-providers/README.md
@@ -1,46 +1,37 @@
 # perl-lsp-providers
 
-LSP provider aggregation and tooling integrations for Perl.
+Umbrella re-export crate for the Perl LSP provider stack. Use it when you want
+one dependency surface for completion, diagnostics, navigation, rename, code
+actions, formatting, and IDE compatibility shims.
 
-Part of the [tree-sitter-perl-rs](https://github.com/EffortlessMetrics/perl-lsp) workspace (Tier 4).
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-providers` if your application wants the whole provider surface
+in one place. If you only need one feature family, depend on the dedicated
+crate instead so the boundary stays explicit.
 
-Use `perl-lsp-providers` when you want one dependency that re-exports the main
-Perl LSP feature crates behind a unified surface. It is a good fit for internal
-workspace consumers and external Rust tools that want completion, diagnostics,
-rename, formatting, and similar providers without wiring each microcrate
-manually.
+## Key exports
 
-If you want the runnable server, use `perl-lsp`. If you want just one feature,
-prefer the narrower `perl-lsp-*` crate for that area.
+- `completion`, `diagnostics`, `navigation`, `rename`, `code_actions` - primary
+  provider families
+- `formatting`, `semantic_tokens`, `inlay_hints`, `folding` - additional LSP
+  feature surfaces
+- `tooling` - perltidy / perlcritic integrations
+- `ide` - LSP and DAP compatibility shims
+- `Node`, `NodeKind`, `SourceLocation`, `Parser`, `ast`, `position` - parser
+  core re-exports for convenience
 
-## Overview
+## Example
 
-This crate is the central aggregation point for all LSP feature providers in the Perl LSP ecosystem. It re-exports individual microcrates (completion, diagnostics, formatting, navigation, rename, semantic tokens, inlay hints, code actions) through a unified API and provides IDE integration shims and backward-compatible legacy import paths.
+```rust,ignore
+use perl_lsp_providers::{completion::CompletionProvider, diagnostics::DiagnosticsProvider};
 
-## Public API
+let completion = CompletionProvider::new(&ast);
+let diagnostics = DiagnosticsProvider::new();
+```
 
-Top-level re-export modules (preferred for new code):
+## Stack role
 
-- `completion` -- from `perl-lsp-completion`
-- `diagnostics` -- from `perl-lsp-diagnostics`
-- `formatting` -- from `perl-lsp-formatting`
-- `navigation` -- from `perl-lsp-navigation`
-- `rename` -- from `perl-lsp-rename`
-- `semantic_tokens` -- from `perl-lsp-semantic-tokens`
-- `inlay_hints` -- from `perl-lsp-inlay-hints`
-- `code_actions` -- from `perl-lsp-code-actions`
-- `folding` -- from `perl-lsp-folding`
-- `tooling` -- from `perl-lsp-tooling` (perltidy, perlcritic)
-- `ide` -- LSP/DAP runtime compatibility shims
-
-Core parser types (`Node`, `NodeKind`, `SourceLocation`, `Parser`, `ast`, `position`) are re-exported from `perl-parser-core`.
-
-## Features
-
-- `lsp-compat` (default) -- enables LSP protocol type compatibility via `lsp-types`
-
-## License
-
-Licensed under either of [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0) or [MIT license](http://opensource.org/licenses/MIT) at your option.
+This crate is the convenience integration layer for the workspace. It keeps the
+individual feature crates available under one root without hiding their real
+boundaries.

--- a/crates/perl-lsp-rename/README.md
+++ b/crates/perl-lsp-rename/README.md
@@ -1,42 +1,35 @@
 # perl-lsp-rename
 
-Rename provider for Perl refactoring.
+Perl rename provider for `textDocument/prepareRename` and `textDocument/rename`.
+It validates a symbol first, then produces the text edits needed to rename it
+consistently across definitions and references.
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-rename` when you want rename and prepare-rename behavior for Perl
-symbols without depending on the full server runtime.
+Use `perl-lsp-rename` if you need rename logic with Perl-specific rules. It is
+the right layer when you need validation, scope-aware symbol resolution, and
+edit generation. If you only need the shared provider surface, use
+`perl-lsp-providers`.
 
-It is the right crate for:
+## Key exports
 
-- validating whether a symbol can be renamed
-- generating coordinated rename edits
-- preserving sigils and Perl naming rules during refactors
-
-## Public API
-
-- `RenameProvider`: main entry point for `prepare_rename()` and `rename()`.
-- `RenameOptions`: controls validation and comment/string renaming.
-- `RenameResult`: contains edits, validity state, and error information.
-- `TextEdit`: a single location plus replacement text.
+- `RenameProvider` - main entry point for `prepare_rename()` and `rename()`
+- `RenameOptions` - controls validation and whether comments/strings are
+  included
+- `RenameResult` - edits plus validation state
+- `TextEdit` - single replacement at a location
 
 ## Example
 
 ```rust,ignore
-use perl_lsp_rename::RenameProvider;
+use perl_lsp_rename::{RenameOptions, RenameProvider};
 
 let provider = RenameProvider::new(&ast, source.to_string());
-let prep = provider.prepare_rename(position)?;
-let result = provider.rename(position, "new_name", &options);
-assert!(prep.is_some());
-assert!(result.valid);
+let _prepared = provider.prepare_rename(position);
+let result = provider.rename(position, "new_name", &RenameOptions::default());
 ```
 
-## Workspace role
+## Stack role
 
-Internal feature crate consumed by `perl-lsp` for rename request handling.
-It is mostly a workspace building block rather than a standalone end-user crate.
-
-## License
-
-MIT OR Apache-2.0
+This is the rename engine consumed by `perl-lsp`. It relies on parser, scope,
+and symbol data, then returns the precise edits that the editor applies.

--- a/crates/perl-lsp-selection-range/README.md
+++ b/crates/perl-lsp-selection-range/README.md
@@ -1,35 +1,27 @@
 # perl-lsp-selection-range
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp-selection-range.svg)](https://crates.io/crates/perl-lsp-selection-range)
-[![Documentation](https://docs.rs/perl-lsp-selection-range/badge.svg)](https://docs.rs/perl-lsp-selection-range)
+Smart selection-range expansion for Perl source. It returns the nested regions
+an editor should select as the user expands the current selection.
 
-Smart selection expansion for Perl editors and language servers.
+## Use this crate when
 
-## When to use this crate
+Use `perl-lsp-selection-range` if you need the selection-range algorithm itself.
+It is a narrow helper crate, not the umbrella provider surface.
 
-Use `perl-lsp-selection-range` when you want
-`textDocument/selectionRange` behavior for Perl source. It expands a cursor or
-selection outward through useful syntax boundaries such as:
+## Key exports
 
-- string content -> full string -> expression
-- hash key -> subscript -> full access expression
-- identifier -> statement -> block -> enclosing function
+- `selection_ranges` - compute nested selection ranges for one or more cursors
 
-## Quick example
+## Example
 
-```rust
+```rust,ignore
 use lsp_types::Position;
 use perl_lsp_selection_range::selection_ranges;
 
-let source = "my $value = foo($bar);\n";
-let ranges = selection_ranges(source, &[Position::new(0, 4)]);
-assert_eq!(ranges.len(), 1);
+let ranges = selection_ranges(source, &[Position::new(3, 8)]);
 ```
 
-## Public API
+## Stack role
 
-- `selection_ranges`: returns nested LSP `SelectionRange` trees for positions
-
-## License
-
-MIT OR Apache-2.0
+`perl-lsp` uses this crate for `textDocument/selectionRange`. It turns parsed
+Perl structure into progressively larger editor selections.

--- a/crates/perl-lsp-workspace-symbols/README.md
+++ b/crates/perl-lsp-workspace-symbols/README.md
@@ -1,34 +1,30 @@
 # perl-lsp-workspace-symbols
 
-Single-responsibility microcrate for Perl LSP `workspace/symbol` indexing and search.
+Workspace symbol indexing and search for Perl. This crate answers "what symbols
+exist across the workspace, and where are they?"
 
-## When to use this crate
+## Use this crate when
 
-Use `perl-lsp-workspace-symbols` when you want a focused implementation of
-LSP `workspace/symbol` for Perl without pulling in the full server runtime.
+Use `perl-lsp-workspace-symbols` if you need the search/indexing layer itself.
+Use `perl-lsp-navigation` when you want workspace symbols together with type
+definition, document links, and references.
 
-It handles:
+## Key exports
 
-- indexing symbols from parsed Perl files
-- searching workspace symbols by query
-- shaping results into LSP-friendly workspace symbol payloads
+- `WorkspaceSymbolsProvider` - indexes documents and performs ranked search
+- `WorkspaceSymbol` - search result payload with location, kind, and container
 
-## Quick example
+## Example
 
 ```rust,ignore
 use perl_lsp_workspace_symbols::WorkspaceSymbolsProvider;
 
 let mut provider = WorkspaceSymbolsProvider::new();
-provider.index_document("file:///test.pl", &ast, source);
-let results = provider.search("hello", &source_map);
-assert!(!results.is_empty());
+provider.index_document("file:///lib/Foo.pm", &ast, source);
+let symbols = provider.search("logger", &source_map);
 ```
 
-## Public API
+## Stack role
 
-- `WorkspaceSymbolsProvider`: index and query entry point
-- `WorkspaceSymbol`: workspace-symbol result type
-
-## License
-
-MIT OR Apache-2.0
+This crate is the symbol index used by the navigation layer in `perl-lsp`.
+It is focused on ranked symbol lookup, not on editor protocol wiring.


### PR DESCRIPTION
Second-pass rewrite of the docs.rs landing pages for the provider crates.

This keeps the pages concise, problem-first, and stack-aware across the completion, diagnostics, navigation, rename, code actions, code lens, completion item, color provider, document highlight, inline completion, selection range, workspace symbols, and umbrella providers crates.

Validation:
- git diff --check
- cargo package --allow-dirty --list -p <each touched crate> includes README.md