### PR TITLE
docs: clarify release operator docs (#2936)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,9 @@
 # Release Guide
 
-This document covers the end-to-end process for releasing a new version of `perl-lsp`.
-For the release preflight checklist, see [docs/project/RELEASE_CHECKLIST.md](docs/project/RELEASE_CHECKLIST.md).
+This is the operational release runbook for `perl-lsp`.
+Use it with [docs/project/RELEASE_CHECKLIST.md](docs/project/RELEASE_CHECKLIST.md)
+for the preflight gate and [docs/project/PUBLISHING_ROADMAP.md](docs/project/PUBLISHING_ROADMAP.md)
+for the release-day sequence and post-release verification.
 
 ## Table of Contents
 
@@ -15,6 +17,8 @@ For the release preflight checklist, see [docs/project/RELEASE_CHECKLIST.md](doc
 ---
 
 ## Prerequisites Checklist
+
+Use this section to confirm the release inputs are ready before dispatching the workflow.
 
 ### Required Secrets
 
@@ -53,7 +57,7 @@ grep '## \[' CHANGELOG.md | head -5
 
 ### CI Green on master
 
-The release workflow validates this automatically, but verify locally first:
+Verify the latest `master` run is green before dispatching the release workflow:
 
 ```bash
 # Check current CI state for the HEAD commit on master
@@ -374,13 +378,13 @@ If `release-orchestration.yml` fails after the tag is created but before all dow
 After a release ships, trigger the version bump workflow to prepare the next development cycle:
 
 ```bash
-# Bump to next minor version (e.g., 0.12.0 -> 0.13.0)
+# Bump to the next minor version.
 gh workflow run version-bump.yml \
   --field bump_type=minor
 
 # Or specify an exact version
 gh workflow run version-bump.yml \
-  --field version=0.13.0
+  --field version=NEW_VERSION
 ```
 
-This creates a `release/v0.13.0` branch with updated `Cargo.toml` and `CHANGELOG.md`, then opens a PR for review.
+This creates a `release/vNEW_VERSION` branch with updated `Cargo.toml` and `CHANGELOG.md`, then opens a PR for review.

--- a/docs/project/PUBLISHING_ROADMAP.md
+++ b/docs/project/PUBLISHING_ROADMAP.md
@@ -1,9 +1,8 @@
 # Publishing Roadmap
 
-> Machine-executable release guide. Every step is a command or a binary pass/fail check.
-> Covers the current release target and subsequent minor releases.
-> Authoritative release mechanics: `RELEASE.md`. Authoritative feature catalog: `features.toml`.
-> Replace `NEW_VERSION` and `PREV_VERSION` throughout with actual semver strings (e.g., `0.13.0`, `0.12.0`).
+> Machine-executable release-day playbook. Every step is a command or a binary pass/fail check.
+> Use with `RELEASE.md` for release mechanics and `RELEASE_CHECKLIST.md` for the preflight gate.
+> Replace `NEW_VERSION` and `PREV_VERSION` throughout with the actual semver strings for the cut.
 
 ---
 
@@ -13,8 +12,8 @@
 
 ```bash
 export CARGO_TARGET_DIR="/tmp/release-preflight-target"
-export NEW_VERSION="0.13.0"
-export PREV_VERSION="0.12.0"
+export NEW_VERSION="NEW_VERSION"
+export PREV_VERSION="PREV_VERSION"
 ```
 
 ### 1.2 Verify all version strings agree
@@ -47,7 +46,7 @@ gh workflow run version-bump.yml --field version=NEW_VERSION
 
 ```bash
 grep "## \[${NEW_VERSION}\]" CHANGELOG.md
-# Must match: ## [0.13.0] - YYYY-MM-DD
+# Must match: ## [NEW_VERSION] - YYYY-MM-DD
 ```
 
 Fail if missing. To promote [Unreleased] to a dated release:
@@ -62,7 +61,7 @@ git commit -m "chore: finalize CHANGELOG for v${NEW_VERSION}"
 CHANGELOG section structure (required):
 
 ```markdown
-## [0.13.0] - 2026-MM-DD
+## [NEW_VERSION] - YYYY-MM-DD
 
 ### Added
 - ...
@@ -328,7 +327,7 @@ git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
 git push origin "v${NEW_VERSION}"
 ```
 
-Tag must be: `v` + semver. Examples: `v0.13.0`, `v0.13.1`. Never: `0.13.0`, `release-0.13.0`.
+Tag must be: `v` + semver. Examples: `vNEW_VERSION`, `vNEXT_PATCH_VERSION`. Never: `NEW_VERSION`, `release-NEW_VERSION`.
 
 ### 3.3 GitHub release
 
@@ -461,7 +460,7 @@ gh workflow run version-bump.yml \
   --field bump_type=minor
 # OR:
 gh workflow run version-bump.yml \
-  --field version=0.14.0
+  --field version=NEW_VERSION
 
 # Merge the resulting version-bump PR.
 ```
@@ -534,10 +533,10 @@ Triage SLA:
 |----------|---------------|
 | Crash or hang | Same day — file P0 issue, assign to next build cycle |
 | Parse error on valid Perl | 48 hours — file issue, label `parser-corpus` |
-| Feature gap | 1 week — triage to v0.13.x milestone |
+| Feature gap | 1 week — triage to the next release milestone |
 | Enhancement | Triage to roadmap, no SLA |
 
-### 4.4 v0.13.0 issue triage (Week 1 — after release)
+### 4.4 Current release issue triage (Week 1 — after release)
 
 ```bash
 # List all open issues
@@ -546,10 +545,10 @@ gh issue list --state open --limit 200
 # Label new issues from post-release feedback
 # Use these labels: bug, parser-corpus, lsp-feature, enhancement, good-first-issue
 gh issue edit ISSUE_NUMBER --add-label "parser-corpus"
-gh issue edit ISSUE_NUMBER --milestone "v0.13.0"
+gh issue edit ISSUE_NUMBER --milestone "NEW_VERSION"
 ```
 
-Milestone priorities for v0.13.0 (from ROADMAP.md):
+Milestone priorities for NEW_VERSION (from ROADMAP.md):
 
 1. Diagnostic hardening: `strict`, `warnings`, dead-code signals
 2. CPAN corpus clean-parse rate to 95%+

--- a/docs/project/RELEASE_CHECKLIST.md
+++ b/docs/project/RELEASE_CHECKLIST.md
@@ -1,6 +1,9 @@
 # Release Checklist
 
-This checklist is for the current release run. The end-to-end release mechanics live in [RELEASE.md](../../RELEASE.md); crates publishing details live in [PUBLISHING.md](../PUBLISHING.md); changelog generation lives in [CHANGELOG_WORKFLOW.md](../CHANGELOG_WORKFLOW.md).
+This checklist is the release gate for the current cut.
+The mechanics live in [RELEASE.md](../../RELEASE.md), the release-day sequence lives in
+[PUBLISHING_ROADMAP.md](../PUBLISHING_ROADMAP.md), and changelog generation lives in
+[CHANGELOG_WORKFLOW.md](../CHANGELOG_WORKFLOW.md).
 
 Use `NEW_VERSION` as the target semver string for the release you are preparing.
 


### PR DESCRIPTION
Supersedes #3054.

This restacks the release-ops cleanup on the current origin/master and keeps the relationships explicit:
- RELEASE.md = operational release runbook
- RELEASE_CHECKLIST.md = preflight gate
- PUBLISHING_ROADMAP.md = release-day sequence and post-release verification

Validation:
- git diff --check
- verified all changed doc links exist