### PR TITLE
fix(ci): block placeholder git identity in local hooks (#2936)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1802,11 +1802,29 @@ fn cmd_generate_badges(repo_root: &Path) -> Result<i32> {
 }
 
 fn cmd_install_githooks(repo_root: &Path) -> Result<i32> {
-    let hook_path = repo_root.join(".git").join("hooks").join("pre-push");
-    if let Some(parent) = hook_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let hook = r#"#!/usr/bin/env bash
+    let hooks_dir = repo_root.join(".git").join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+
+    let pre_commit_hook = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_USER_NAME="$(git config user.name 2>/dev/null || true)"
+GIT_USER_EMAIL="$(git config user.email 2>/dev/null || true)"
+
+if [ "$GIT_USER_NAME" = "Codex Release Validation" ] || [ "$GIT_USER_EMAIL" = "codex-release-validation@example.invalid" ]; then
+    echo "❌ Refusing commit with placeholder git identity"
+    echo "   user.name:  $GIT_USER_NAME"
+    echo "   user.email: $GIT_USER_EMAIL"
+    echo ""
+    echo "   Fix this repo-local override first:"
+    echo "   git config --local --unset-all user.name"
+    echo "   git config --local --unset-all user.email"
+    exit 1
+fi
+"#;
+    write_git_hook(&hooks_dir.join("pre-commit"), pre_commit_hook)?;
+
+    let pre_push_hook = r#"#!/usr/bin/env bash
 set -euo pipefail
 
 echo "🚪 Running local gate before push: nix develop -c just ci-gate"
@@ -1856,17 +1874,24 @@ else
     exit 0
 fi
 "#;
-    fs::write(&hook_path, format!("{hook}\n"))
+    write_git_hook(&hooks_dir.join("pre-push"), pre_push_hook)?;
+
+    println!("✅ Installed pre-commit and pre-push hooks");
+    println!("   The pre-commit hook blocks known placeholder git identities");
+    println!("   The pre-push hook runs 'nix develop -c just ci-gate' before each push");
+    println!("   Skip with: git commit --no-verify / git push --no-verify");
+    Ok(0)
+}
+
+fn write_git_hook(hook_path: &Path, hook: &str) -> Result<()> {
+    fs::write(hook_path, format!("{hook}\n"))
         .with_context(|| format!("writing {:?}", hook_path))?;
     #[cfg(unix)]
     {
-        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))
+        fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))
             .with_context(|| format!("setting executable bit for {:?}", hook_path))?;
     }
-    println!("✅ Installed pre-push hook");
-    println!("   The hook runs 'nix develop -c just ci-gate' before each push");
-    println!("   Skip with: git push --no-verify");
-    Ok(0)
+    Ok(())
 }
 
 fn read_required_usize(path: &Path) -> Result<usize> {

--- a/xtask/src/tasks/ci_hygiene.rs
+++ b/xtask/src/tasks/ci_hygiene.rs
@@ -4,6 +4,7 @@
 //! either via an existing local debug binary or via `cargo run`.
 
 use color_eyre::eyre::{Context, Result, bail};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -15,7 +16,7 @@ pub fn run(command: String, args: Vec<String>) -> Result<()> {
     let root = project_root()?;
     let status = {
         let local_binary = local_binary_path(&root);
-        if local_binary.exists() {
+        if local_binary_is_fresh(&root, &local_binary) {
             Command::new(local_binary)
                 .arg(&command)
                 .args(&args)
@@ -45,4 +46,34 @@ fn local_binary_path(root: &Path) -> PathBuf {
         path.set_extension(std::env::consts::EXE_EXTENSION);
     }
     path
+}
+
+fn local_binary_is_fresh(root: &Path, local_binary: &Path) -> bool {
+    let Ok(binary_meta) = fs::metadata(local_binary) else {
+        return false;
+    };
+    let Ok(binary_modified) = binary_meta.modified() else {
+        return false;
+    };
+
+    for source in ci_hygiene_sources(root) {
+        let Ok(source_meta) = fs::metadata(source) else {
+            return false;
+        };
+        let Ok(source_modified) = source_meta.modified() else {
+            return false;
+        };
+        if source_modified > binary_modified {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn ci_hygiene_sources(root: &Path) -> [PathBuf; 2] {
+    [
+        root.join("crates").join(CI_HYGIENE_PACKAGE).join("Cargo.toml"),
+        root.join("crates").join(CI_HYGIENE_PACKAGE).join("src").join("main.rs"),
+    ]
 }


### PR DESCRIPTION
## Summary
This prevents this repo's local hook installer from allowing commits under the placeholder `Codex Release Validation` identity that later surfaces as bad co-author attribution on squash merges.

It also fixes the `xtask ci-hygiene` wrapper so it does not reuse a stale `perl-ci-hygiene` binary after the installer source changes.

## What changed
- install a `pre-commit` hook that blocks the known placeholder git identity before commit
- keep the existing `pre-push` gate installation intact
- teach `xtask` to fall back to `cargo run -p perl-ci-hygiene` when the local debug binary is older than the current `perl-ci-hygiene` sources

## Evidence
- `cargo run -p perl-ci-hygiene -- install-githooks`
  - built the updated installer
  - installed the new `pre-commit` and `pre-push` hooks in this checkout

## Risk
Low. This only affects local development hook installation and the helper path that dispatches `perl-ci-hygiene` commands from `xtask`.