### PR TITLE
docs(release): tighten release-facing docs (#2936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,313 +11,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] - 2026-03-24
 
-This section covers 583 commits across ~90 PRs since the 0.12.0 finalization
-(2026-03-20), spanning Era 7 sessions 1-4. Key themes: parser corpus hardening
-against the strict-clean CPAN manifest snapshot that serves as the 0.12.0
-release bar, Moose/Moo class intelligence, diagnostic pipeline wiring, VS Code
-UX polish, performance hardening, and swarm infrastructure maturation.
+`v0.12.0` is the initial public alpha for the native Rust Perl 5 toolchain. The
+headline change is not one feature in isolation; it is that the parser, language
+server, debugger, install surface, and release process now line up well enough
+for normal editor use.
 
-### Added
+### Highlights
 
-#### Parser
-- **Error Recovery Substrate**: New `RecoverySite` and `RecoveryKind` infrastructure for structured recovery from parse failures (#2843, #2868)
-- **Parser Corpus Push**: Addressed top CPAN corpus error buckets — `and`+comma, `+` prototype, unclosed-paren identifier, typeglob punctuation `*<` `*>` `*(` `*)`, s///e replacement, x-operator precedence, C-style for loops, keyword hash keys in `use` imports (#2149, #2189, #2254, #2261, #2395, #2461, #2625, #2684, #2703, #2731, #2732, #2755, #2826, #2829, #2834-#2835, #2856, #2859)
-- **Parser Disambiguation**: Phase-block keywords as statement labels, anonymous sub with attributes, `bless []` as function call, regex-op names as hash subscript keys, leading `::` qualifier in subroutine names (#2601, #2710, #2754)
+#### Native editor path
 
-#### LSP Features
-- **Per-Feature Disable**: `initializationOptions.disabledFeatures` allows users to opt out of individual LSP features (#2170, #2766)
-- **Editor-Agnostic Project Config**: `.perl-lsp.toml` configuration file for project-level settings, recognized by all editors (#2053, #2805)
-- **Semantic Token Delta Encoding**: LSP 3.16 delta encoding for semantic tokens reduces bandwidth on edits (#2743)
-- **Document Ranges Formatting**: Advertise `documentRangesFormattingProvider` to close LSP 3.18 gap
-- **Workspace Symbol Resolve**: Emit documentation and fix `containerName` in `workspace/symbol/resolve` (#2100, #2798)
-- **Diagnostic Pull Path**: Wire diagnostic enrichment through pull diagnostic runtime path (#2102, #2795)
-- **Diagnostic Data Field**: Populate `Diagnostic.data` field for client-side diagnostic actions (#2592)
-- **Progress Notifications**: `$/progress` notifications during workspace indexing (#2317, #2356)
-- **Parse Error Telemetry**: Opt-in parse error telemetry wired into diagnostic pipeline (#2740)
-- **Startup Diagnostic**: Structured startup message to stderr for editor log integration (#2054, #2807)
-- **On-Type Formatting**: Advertise `\n` as formatting trigger character (#2746, #2779)
-- **POD Symbols in Outline**: `=head` POD sections appear in document symbol outline (#2614)
-- **Signature Help Retrigger**: Added retrigger characters for complex Perl call signatures
-- **InlayHint Resolve**: Wire `inlayHint/resolve` `labelDetails.location` for click-to-definition
-- **Commit Characters**: Add `commit_characters` to `CompletionItem` for both handlers (#2597)
-- **Binary File Guard**: Prevent parser from processing binary files in `didOpen`/`didChange` (#2107, #2764)
-- **CRLF Guard**: Add CRLF line-ending guard in `position_to_offset_rope` (#2108, #2736)
+- `perl-lsp` and `perl-dap` are now treated as first-class native binaries for editor integration and debugging.
+- VS Code, manual binary install, and release surfaces were tightened for first-run setup, health checks, and issue reporting.
+- `.perl-lsp.toml` gives teams a shared, editor-agnostic project configuration layer.
 
-#### Moose/Moo Intelligence
-- **Class Model Wired**: `ClassModel` detection wired into `SemanticAnalyzer` (#1661, #2741)
-- **Goto-Definition for Methods**: `$self->` and `$class->` method calls resolve via workspace index (#2536, #2831, #2858)
-- **Type Hierarchy**: C3 MRO linearization for Moose inheritance chains; `extends`/`with` wired into `TypeHierarchyProvider` (#2720); cross-file supertypes/subtypes via workspace scan (#2738)
-- **Role Composition Hover**: Hover card for `with`-applied roles showing consumed methods (#2325, #2745)
-- **Method Modifier Hover**: Dedicated hover card for `before`/`after`/`around` modifiers (#2744)
-- **Attribute Introspection**: `builder`, `coerce`, `predicate`, `clearer`, `trigger` in attribute hover (#2366)
+#### Better day-to-day language tooling
 
-#### Hover
-- **Phase Blocks**: BEGIN/END/INIT/CHECK/UNITCHECK get hover documentation and diagnostics (#2623)
-- **Special Variables**: Educational hover tooltips for Perl special variables (`$!`, `$@`, `$/`, etc.) (#2262, #2347)
-- **Tied Variables**: Show tied class and tie magic method docs on hover (#2609)
-- **Context-Sensitive Builtins**: Scalar/list context docs for 11 context-sensitive builtins (#2630)
-- **Perl Built-in Examples**: Phase 1 hover docs with capture vars, autoflush, MetaCPAN links, examples (#2831, #2839)
-- **Subroutine Complexity**: Complexity indicator shown in sub hover card
-- **POD on Use Statements**: Show POD documentation when hovering on `use Module` (#2304)
-- **Type Inference Display**: Wire `TypeInferenceEngine` to hover for inferred variable type (#2726)
-- **Regex Pattern Explainer**: Explain regex patterns in human-readable format (#2048)
-- **die/warn Enrich**: Enrich `die`/`warn` hover with docs and add `croak` modernize action (#2606)
+- Completion, hover, diagnostics, formatting, semantic tokens, workspace symbols, code lens, and code actions all received broad hardening.
+- Hover and completion coverage expanded for Perl built-ins, special variables, module flows, and workspace-aware suggestions.
+- Diagnostic wiring now consistently surfaces parser, project, and optional Perl::Critic signals through the LSP pipeline.
 
-#### Completion
-- **85 Missing Built-ins**: Add 85 missing Perl built-ins with documentation; fix LSP trigger characters (#2780, #2813)
-- **Relevance Sorting**: Relevance-based completion ranking with docs on builtins/keywords (#2832, #2841)
-- **Import-Aware Sort**: Workspace symbols sorted by import proximity (#2645)
-- **Auto-Import on Selection**: Auto-insert `use Module` when selecting an unimported symbol (#2322)
-- **Regex Operator Snippets**: 13 regex operator snippets and regex flag completions (#2607, #2635)
-- **Named Capture Groups**: Named capture group completions after `(?<name>)` (#2635)
-- **Template Toolkit**: Directive/filter snippet completions for `.tt` files (#2350, #2735)
-- **Test::More Snippets**: `ok`/`is`/`like` function hover documentation in completions
-- **Built-in Snippets**: Built-in Perl snippet completions for common idioms
+#### Better real-world Perl coverage
 
-#### Diagnostics
-- **PL200/PL201/PL300 Wired**: Emit `use strict`, `use warnings`, `package` diagnostics through the pipeline (#2781, #2803)
-- **PL405 Format Arity**: `printf`/`sprintf` format specifier arity lint (#2636)
-- **PL701 Module Not Found**: `ModuleNotFound` lint using workspace resolver (#2619)
-- **Perl Version Compatibility**: Warnings for syntax requiring specific Perl versions (#2050, #2739)
-- **Security Lints**: Security-focused lints for `eval`, two-arg `open`, backtick patterns; wire into pipeline (#2724)
-- **Unused Import Detection**: Detect and grey-out potentially unused imports
-- **Heredoc Anti-Pattern**: Warning for heredoc anti-patterns (#2438)
-- **Dead Code Detection**: Wire dead code analysis into diagnostic pipeline
-- **Perl::Critic Integration**: Wire perlcritic with severity/profile config and byte-offset mapping (opt-in) (#2362)
-- **Auto-Quote Suggestion**: Suggest quoting bareword warnings (#2365)
-- **Suppress on Empty Files**: Suppress `strict`/`warnings` lint on empty files (#2112, #2792)
-- **Context Hints**: Add `context_hint()` to `DiagnosticCode` with catalog surfacing
+- The native recursive-descent parser was hardened against curated common-corpus and CPAN-facing receipts instead of toy examples alone.
+- Semantic and workspace layers improved cross-file navigation, rename, inheritance-aware lookups, and framework-aware behavior for Moo and Moose patterns.
+- Workspace indexing, cancellation, timeouts, and runtime concurrency all received reliability work aimed at larger real projects.
 
-#### Navigation
-- **Go-to-Test / Go-to-Implementation**: Navigate between test files and implementation (#2532)
-- **use parent/use base**: Workspace rename respects `use parent`/`use base` dependency graph (#2747, #2782)
-- **Module Resolution**: Parse `use lib` and `FindBin` for include path resolution (#1662, #2620)
-- **Inline Rename Scope**: Route `all_occurrences` to workspace-wide lookup (#439, #2765)
+#### Release and contributor surface
 
-#### VS Code Extension
-- **Report Issue Command**: One-click issue reporting from the command palette (#2160, #2748)
-- **Extension Auto-Update Check**: Notify users when a new version is available (#2165, #2796)
-- **Special Variables Reference**: Command to open special variable reference panel (#2318, #2763)
-- **Debugger Setup Wizard**: Interactive DAP configuration wizard (#2338, #2762)
-- **Interactive Onboarding Walkthrough**: First-run walkthrough for new users (#2046)
-- **Smart File Creation**: New Perl file command inserts package boilerplate
-- **What's New Panel**: Show release notes webview on extension update
-- **Status Bar Health Widget**: Show file count and error counts in status bar
-- **Version in Status Bar**: Display `perl-lsp` version in status bar (#2340)
-- **Formatting Error Toasts**: Surface formatting errors as toast notifications (#2111, #2793)
-- **Wire 4 Unimplemented Commands**: `extractVariable`, `extractMethod`, `showRefactoringOptions`, `reportIssue` (#2849, #2854)
-- **Refactoring Discoverability**: Keyboard shortcuts and menu entries for refactoring actions
-- **Boilerplate Snippets**: Perl boilerplate snippet library (#2314)
+- Release prep, package-manager manifests, docs, validation receipts, and status pages were aligned for the public-alpha launch.
+- The workspace continued its crate-boundary cleanup so parser, runtime, LSP, DAP, and release tooling are easier to reason about independently.
 
-#### Code Actions
-- **Portable Shebang**: Quick-fix to suggest portable shebang line (#2255)
-- **Modernization Suggestions**: Perl modernization code actions (say, given/when, etc.)
-- **Bareword Filehandle Fix**: Quick-fix for `bareword-filehandle` and two-arg `open` patterns
-- **Find Undefined Functions**: Wire `find_undefined_functions` to semantic analyzer (#2692, #2719)
+### Notable user-facing additions
 
-#### Code Lens
-- **Test File Lenses**: Detect test functions and provide `Run Test`/`Debug Test` lenses
-- **Subtest Lenses**: Subtest detection with `perl.runSubtest` command (#2617, #2673)
+- project config via `.perl-lsp.toml`
+- richer hover coverage for special variables, built-ins, and framework-aware symbols
+- broader completion coverage and improved ranking
+- native DAP improvements for stepping, variables, and editor integration
+- stronger workspace symbol, formatting, code action, and code lens support
 
-#### Performance
-- **SemanticAnalyzer LRU Cache**: Cache hover/definition lookups to avoid repeated analysis (#2074, #2806)
-- **Asynchronous Workspace Indexing**: Non-blocking workspace scan (#2352)
-- **Request Prioritization**: Cancel stale requests; prioritize interactive over background work
-- **perltidy/perlcritic Timeout**: Thread-based subprocess timeout prevents editor hangs (#2616)
-- **Parser Cancellation**: Cancellation token checks in parser hot path for responsive LSP (#2615)
-- **Debounced Diagnostics**: Debounce diagnostic publication during rapid typing
-- **SymbolIndex Queries**: Wire `SymbolIndex` into completion and workspace symbols for O(1) lookups (#2728)
-- **Deferred Health Check**: Move VS Code health check from activation to first-error path (#2715)
-- **Workspace-Index CPAN Tuning**: Tune index for CPAN-scale workspaces (#1664)
+### Notable fixes
 
-#### CLI
-- **--check-project**: Parsability report for a directory tree (#2534)
-- **--check-format json**: Machine-readable JSON output for CI integration (#2734)
+- parser recovery and disambiguation across real Perl edge cases such as quote operators, slash parsing, prototypes, and framework-heavy code
+- deadlock, contention, and stale-state fixes in the LSP runtime and workspace index
+- safer handling for empty files, binary files, Windows and macOS path quirks, and shell-launch edge cases
+- stale capability drift, unwired command paths, and release-surface documentation mismatches
 
-#### Infrastructure
-- **Blocker Ledger**: Track known blockers to prevent scout rediscovery (#2586)
-- **Corpus Sweep Schema 1.2.0**: Add `files_by_bucket` to baseline schema (#2585)
-- **17 New Error Buckets**: Decompose `unexpected_token_in_expr` catch-all (#2611, #2814)
-- **Unwired Infrastructure Scanner**: Find built-but-not-wired crates automatically (#2667, #2827)
-- **Snapshot Testing**: Systematize snapshot tests for AST and error messages (#2104, #2823)
-- **nextest**: Enable cargo-nextest for `ci-test-lib` (#1909, #2804)
-
-### Fixed
-
-#### Parser
-- `and` operator collecting comma-separated RHS expressions (#2856, #2859)
-- `+` prototype character handling, fixes `unexpected_rbrace_expr` (#2835, #2838)
-- Unclosed-paren identifier patterns (#2834, #2840)
-- Typeglob punctuation variables `*<`, `*>`, `*(`, `*)` (#2755, #2826)
-- Keyword hash keys and `q{}` in `use` imports (#2189, #2723)
-- Keyword tokens as package names (#2150, #2706)
-- C-style `foreach` loops (#2149, #2703)
-- Leading `::` qualifier in subroutine names (#2710)
-- `s///e` replacement with `/` inside string literals (#2395)
-- x operator RHS precedence with `**` (#2625, #2684)
-- Substitution/transliteration modifier parsing regression (#2732, #2776)
-- Soft recovery for unclosed bracket in postfix expressions (#2148, #2688)
-- `unexpected_token_in_expr` decomposed into 4 sub-patterns (#2731, #2767)
-- Optional-arg unary builtins before binary operators (#2730, #2775)
-- Top corpus error buckets — multiple CPAN patterns fixed (#2461, #2829)
-- Sigil-peek heuristic for imported unary functions (#1943)
-- `$self->` and `$this->` method resolution via workspace index (#2536)
-- Regex-op names as hash subscript keys (#2754, #2789)
-- Phase-block keywords as statement labels
-- Strip `#` comments from `qw()` content before word-splitting (#2618)
-- Fat-arrow pairs as ternary branch expressions (#2402, #2613)
-- Word operators after `return`, loop control, indirect calls, paren lists
-- Missing special variables `$>`, `$<`, `$)` and empty `while` condition
-- Handle `my $var->{key} = ...` lvalue declaration
-- `defined`/`ref` without arg when followed by word operators (#2626)
-- `bless []` as function call, not subscript (#2387)
-- File-test-no-operand and `CORE::` builtins in grep/map context (#2674)
-- `ref ne/eq` and `or` comma-expr in `grep` blocks (#2388)
-- v-strings in expression and comparison contexts
-- Recover inline from missing semicolons in C-style for loops (#2593)
-- Relex slash as regex at statement start after closing brace
-- Replace restrictive import parser in `parse_no` with depth-tracking slurp
-
-#### Lexer
-- `after_var_subscript` flag clearing on `)` — fixes `if($var){m//}` (#2844, #2851)
-- `hash_brace_depth` narrowed to `after_var_subscript` — fixes quote-op suppression in blocks (#2833, #2837)
-- `try_heredoc` guarded against ExpectOperator mode — fixes bitshift-in-paren (#2750, #2769)
-- Whitespace-separated quote delimiters restricted to paired chars (#2732 regression, #2815)
-
-#### LSP Runtime
-- ABBA lock ordering deadlock eliminated; lock contention reduced (#2712)
-- Reentrant deadlock in `publish_diagnostics` fixed (#2646)
-- Concurrent workspace indexing scan prevention (#2641, #2711)
-- `ParentMap` safety improvements Phase 1 (#2810, #2819)
-- Semantic token legend synchronized with capability advertisement (#2103, #2772)
-- Advertise `TextDocumentSyncKind::Full` (not `Incremental`) to match actual behavior
-- Depth underflow panic in linked-editing backward bracket scan (#2603)
-- 5 advertised-but-unhandled commands wired in `execute-command` provider (#2691, #2717)
-
-#### Code Actions
-- 4 defects in extract variable/subroutine refactoring (#349, #2797)
-- Diagnostics lint checks wired into `get_diagnostics()` pipeline (#2544)
-
-#### Security
-- macOS sandbox path injection and profile file-path bug (#2749, #2799)
-- `strict`/`warnings` false positives suppressed on empty files (#2112, #2792)
-
-#### Tests
-- Replace `unwrap`/`expect` with `must`/`must_some` across workspace (#2649, #2721-#2727)
-- Use AST walk instead of string matching in `assert_clean_parse` (#2553, #2559)
-- Fix stale capability snapshots blocking CI (#2855)
-
-### Changed
-
-#### Refactoring
-- **17 Built-but-Unwired Crates Wired**: Wire 17 LSP provider microcrates into the runtime (#2756, #2768)
-- **7 Dead Navigation Functions Removed**: Delete prototype navigation functions from `perl-lsp` (#2713)
-- **`semantic.rs` God File Split**: 3,256-line `semantic.rs` split into 6 focused sub-modules
-- **Status Docs Modularized**: Monolithic `CURRENT_STATUS.md` split into `docs/project/status/*.md` subsystem files (#2801, #2830)
-- **`perl-lsp-inline-completion` Wired**: Replace inline duplicate impl with microcrate (#2758, #2786)
-- **Dead Code Cleanup**: Remove dead `perl-symbol-table` crate (#2714), dead `perl-source-editing` crate (#2699, #2716), dead `IndexAccessMode` lint suppressors (#2702, #2790)
-- **`perl-test-must` Extracted**: New micro-crate extracted from `perl-tdd-support` (#2842, #2864)
-- **Test Modules Extracted**: Inline test modules moved to `tests/` directories (#2462-#2466)
-- **`logos` Lexer Archived**: Broken logos experiment archived; `chumsky` dependency removed (#2612)
-- **ADR Renumbering**: Duplicate ADR-0035/0036 renumbered to ADR-0039/0040 (#2808, #2816)
-
-#### CI
-- Consolidate clippy passes; enable nextest for library tests (#1909, #2804)
-- Pre-push hook updated to track test counts (#2128)
-
-#### CPAN Corpus
-- The 0.12.0 release bar is the ratcheted strict-clean CPAN manifest snapshot;
-  broader installed-corpus expansion remains follow-up work
-- Corpus baseline ratcheted from 85.7% toward 90%+ through multiple parser fix waves
-
-### Performance
-
-- **SemanticAnalyzer LRU Cache**: Avoid repeated analysis on hover/definition (#2074, #2806)
-- **Async Workspace Indexing**: Non-blocking index scan for large workspaces (#2352)
-- **Parser Cancellation Token**: Check cancellation in parser hot path (#2615)
-- **Debounced Diagnostics**: Debounce publication during rapid typing
-- **SymbolIndex O(1) Queries**: Wire `SymbolIndex` for completion and workspace symbols (#2728)
-- **perltidy/perlcritic Timeout**: Subprocess timeout prevents editor hangs (#2616)
-- **CPAN-Scale Index Tuning**: Workspace index tuned for large CPAN workspaces (#1664)
-
-
-This release is the **public alpha launch** -- the first release intended for broad
-external adoption. It spans 590+ commits and 200+ merged PRs, delivering major parser
-improvements (83% to 85.7% CPAN corpus), new LSP features, distribution tooling, and
-comprehensive documentation for first-time users.
-
-### Added
-- **Graceful Degradation**: Three-tier degradation for partial parse results -- full AST, partial recovery, and graceful fallback (#2219).
-- **Large File Guard**: Skip parsing for oversized files to prevent editor hangs (#2163, #2229).
-- **Hover: Module Path**: Show resolved module path on `use` statement hover (#2211).
-- **DAP Inline Values**: Display variable values inline during debugging sessions (#2212).
-- **Parser: Fix Suggestions**: Helpful fix suggestions in parser error messages (#2200).
-- **Distribution: cargo-binstall**: Pre-built binary installation via `cargo binstall perl-lsp` (#2071, #2209).
-- **Distribution: Man Page**: `man perl-lsp` page generated from CLI definition (#2210).
-- **Distribution: PowerShell Completions**: Shell completion generation for PowerShell (#2075, #2214).
-- **VS Code: Test Explorer**: Test explorer integration for Perl `.t` files (#2033).
-- **VS Code: Extension Polish**: Marketplace metadata, test suite, and documentation for 0.12.0 (#2032, #2034).
-- **First-Run Experience**: Getting-started guide and improved install verification for new users (#1658).
-- **Completion: Import Lists**: `use Module qw(...)` triggers symbol completion from the target module (#1937).
-- **Completion: Regex Literals**: Variable and function completions inside `/…/`, `m/…/`, `qr/…/` patterns (#1925).
-- **Completion: Scope-Ranked Locals**: Local symbols ranked by scope distance for more relevant suggestions (#1983).
-- **Completion: Qualified Variables**: Workspace-qualified variable completion for cross-package symbols (#1731).
-- **Global Reference Index**: O(1) symbol lookups via a new global reference HashMap in workspace-index (#1934).
-- **V-String Tokenization**: Version strings (`v5.36.0`) now tokenized as a dedicated token type (#1914).
-- **DeadBranch Detection**: Dead code analysis detects constant-condition `if`/`unless` branches (#1596).
-- **Class Field Declarations**: Parser supports Perl class field declaration syntax (#1808+).
-- **CLI Flags**: `--check`, `--info`, `--completion` flags for scripting and editor integration (#1682).
-- **Diagnostic Accessibility**: Improved error message quality and accessibility in diagnostics (#1672).
-- **Async Runtime with Concurrent Dispatch**: Two-lane scheduler -- exclusive worker for mutations + 4-worker read pool for concurrent requests. `$/cancelRequest` processed inline (#1555).
-- **Goto AST Node**: Dedicated `Goto` node with full `TokenKind::display_name` support (#1521).
-- **Smarter Selection Range**: Expand/shrink selection chains with semantic awareness (#1545).
-- **Cross-file Go-to-Definition**: Improved navigation for method calls and `use parent`/`base` statements (#1542, #1544).
-- **Enhanced Diagnostics**: Added `suggestion` field to diagnostic messages (#1543).
-- **Inlay Hints for Builtins**: Parameter names derived from builtin function signatures (#1541).
-- **Semantic Tokens**: Comprehensive AST walker with new token types for broader coverage (#1540).
-- **Cross-sigil Variable Highlighting**: Highlight `@foo`/`%foo` references when cursor is on `$foo` (#1538).
-- **Extract Variable for Methods**: Code actions handle method calls and hash/array access (#1534).
-- **Workspace Symbols Ranking**: Improved ranking algorithm with comprehensive tests (#1529).
-- **Completion for Moo/Moose Accessors**: Show `isa` type in completion for accessor methods (#1525).
-- **Signature Help Builtin Coverage**: Expanded coverage for common Perl builtins (#1532).
-- **DAP Improvements**: POD detection, conditional expression validation in breakpoints (#1536), improved variable inspection rendering (#1535), hardened smoke tests and timeout handling (#1883).
-- **Hover Enhancements**: Improved documentation quality in hover responses (#1537).
-- **VS Code Extension**: Trace support, config change detection (#1876), `--health` binary validation before starting LSP client (#1598), Open VSX keywords and metadata (#1879), client refresh behavior fix.
-
-### Fixed
-- **Parser -- Control Flow**: Handle orphaned `else`/`elsif` and `unless`+`else`/`elsif` chains (#1981), allow bare `return` in ternary branches (#1727), handle statement-start nullary builtin precedence (#1724), recover bare list-operator calls in postfix args (#1989), handle `for`/`foreach` without explicit loop variable (#1700, #2040), handle ternary after named-unary operators (#2025).
-- **Parser -- Expressions**: Accept fat arrows in expression contexts (#1985), support last-index deref `->$#*` in bracket expressions (#1988), slurp trailing operators after Number/String in `use` import values (#1980), handle `use constant NAME => expr` fully (#1577), handle complex expressions in parenthesized arguments (#1704, #2206), accept complex expressions in `use`/`no` import lists (#2184, #2221), audit fat arrow expressions (#1651, #2171), allow postfix operators after typeglob expressions (#2188, #2238).
-- **Parser -- Disambiguation**: Disambiguate `field` keyword from bareword identifier (#1978), allow keyword barewords as subroutine names (#1986), allow keyword methods and trailing separators (#1993), recover field bareword calls in recovery parser, validate declaration attributes.
-- **Parser -- Builtins**: `map`/`grep`/`sort` BLOCK LIST without trailing semicolon (#1623), `tie(VARIABLE, CLASS, LIST)` with parenthesized args (#1630), `defined`/`ref` at statement start (#1618), `push`/`pop` with postfix deref lvalue (#1619), nullary builtins in paren expressions (#1629), improve word operator handling for 43 CPAN files (#1922).
-- **Parser -- OO**: Tighten qualified class-name and namespaced class parsing, statement modifiers after complex expressions (#1550), package-qualified variable subscripts (#1548).
-- **Parser -- Misc**: Tighten deref parsing (#1884), transliteration delimiter parsing, operator strings in `use overload` (#1492), chained method calls after deref constructs (#1474), ternary then-branch assignments (#1516, #1518), guard semicolon break with `at_top_level` in `use` imports (#2237), add `RightBrace` to indirect call argument terminators (#2222, #2236).
-- **Lexer**: Prevent prototype mode leak after `sub` keyword (#1906), disambiguate regex after bare builtins (#1965), recognize special punctuation variables `$~`, `$^`, `$=`, `$%`, `$;`, `$^W` etc. (#1615), disambiguate `$$var` scalar deref from `$$` PID variable (#1572), peek/reset state restoration, make regex parse budget reachable (#1455).
-- **Completion**: Preserve regex interpolation completions (#1925).
-- **Workspace Index**: Rebuild find-definition symbol cache after index updates (#1919).
-- **LSP Runtime**: Preserve scheduler ordering and stabilize tests (#1882), close outbound sender before joining writer thread (#1593), stop advertising unsupported `debugTests` command (#1742).
-- **Incremental Parsing**: Improved efficiency and fixed position underflow (#1539).
-- **On-Type Formatting**: Heredoc suppression, string/comment-aware brace matching, correct trigger semantics (#1530).
-- **Diagnostics**: Suppress strict/warnings false positives for OO frameworks (#1565).
-- **DAP**: Fix socket default port, harden debugger smoke and timeout handling (#1883), prevent subtraction overflow in inline values (#1515).
-
-### Changed
-- **Microcrate Extractions**: 10 new microcrates extracted -- perl-dap-config, perl-dap-session-model, perl-ast-v2, perl-ts-statement-tracker, perl-lsp-type-hierarchy, perl-perltidy, perl-lsp-completion-filepath, perl-workspace-index-monitor, perl-lsp-code-lens, perl-lsp-document-highlight.
-- **God File Splits**: `debug_adapter.rs` (6778 lines) split into focused domain modules (#1666, #1639, #2208), `lsp_comprehensive_3_17_test.rs` split into feature-specific test files (#1681), `cpan_pattern_tests.rs` split into 16 standalone test files (#1665), runtime `mod.rs` handler groups extracted (#1676).
-- **Refactored Internals**: Execute command modules, code actions provider, perl critic tooling, centralized server startup logging (#1826).
-- **Feature Gating**: Tightened LSP capability feature gating and feature profile normalization.
-- **Native Debt Report**: `xtask` now has a native `debt-report` subcommand (#1528).
-- **Devex Targeted Checks**: Converted from shell script to native Rust xtask subcommand (#1527).
-- **CI**: Auto-fix formatting instead of failing on `cargo fmt` (#1625), pre-push hook to update test counts (#2128).
-- **CPAN Corpus**: Baseline ratcheted from 83% to 85.7% (6081/7095 files) (#1892, #2233, #2244).
-- **Documentation**: Comprehensive README for 0.12.0 (#2012), launch articles covering development story, reference implementation, AI-native operating model, and case studies (#2203, #2235, #2240, #2242, #2243), contributing guide update (#2010).
-
-### Performance
-- **find_definition**: Replaced O(n*m) scan with O(1) HashMap lookup in workspace-index (#1919).
-- **LSP Async Scheduling**: Improved read scheduling for lower latency on concurrent requests (#1837).
-- **Completion**: Reduced unnecessary clones in completion hot path (#2073, #2220).
-- **Document Highlight**: Linear dedup for small highlight sets, eliminated clone (#1928).
-- **Workspace Symbols**: Reduced allocations in workspace symbol search (#1908).
-- **Performance Baselines**: Established 0.12.0 performance baselines (#1654, #2166).
+For the detailed receipts behind this release, see [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and [docs/project/status/index.md](docs/project/status/index.md).
 
 ## [0.11.0] - 2026-03-12
 

--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -1,24 +1,24 @@
 # NOW / NEXT / LATER
 
-> Last Updated: 2026-03-28
+> Last Updated: 2026-03-29
 > Workspace version line: `v0.12.0`
-> Latest published release: `v0.11.0` (verified 2026-03-28)
-> Active milestone: `v0.12.0` initial public alpha release prep
+> Latest published GitHub release: `v0.11.0` (verified 2026-03-29)
+> Active milestone: `v0.12.0` initial public alpha cut
 
 This file is the short planning snapshot. The detailed roadmap is [docs/project/ROADMAP.md](docs/project/ROADMAP.md). The evidence-backed status view is [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
 
 ## NOW
 
-- Parser hardening: raise the CPAN baseline, keep boundedness receipts green, and land Wave 2-4 parser fixes
-- Semantic framework coverage: Moo, Moose, Class::Accessor, `use parent` / `use base`, and export-list-aware resolution
-- Release and tooling hygiene: keep `nix develop -c just ci-gate` green while initial public alpha prep lands
-- Documentation alignment: keep README, roadmap, status, and install guidance consistent about workspace version versus latest published release
+- Release execution: keep `nix develop -c just ci-gate` and release receipts green while `v0.12.0` moves from version line to shipped release
+- Parser hardening: keep corpus ratchets honest and finish the highest-value edge-case fixes
+- Semantic coverage: land the framework-aware resolution work that blocks real project navigation
+- Docs alignment: keep README, roadmap, changelog, status, and install guidance consistent about what is already published versus what is still on `main`
 
 ## NEXT
 
 - Diagnostic hardening around `strict`, `warnings`, safe static analysis, and dead-code signals
-- Refactoring and debugger reliability beyond the current preview posture
-- Broader release-surface cleanup after the `v0.12.0` initial public alpha cut
+- Refactoring and debugger reliability beyond the current alpha posture
+- Post-release cleanup for package-manager, docs, and distribution surfaces
 
 ## LATER
 

--- a/README.md
+++ b/README.md
@@ -5,48 +5,61 @@
 <h1 align="center">perl-lsp</h1>
 
 <p align="center">
-  A fast, native <strong>Perl language server</strong> written in Rust — bringing modern IDE features to Perl 5.
+  Native Perl 5 language tooling in Rust: editor support, parser infrastructure, and debugging without a Perl runtime dependency for IDE features.
 </p>
 
 <p align="center">
   <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/v/perl-lsp.svg" alt="crates.io" /></a>
   <a href="https://docs.rs/perl-lsp"><img src="https://docs.rs/perl-lsp/badge.svg" alt="docs.rs" /></a>
-  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="codecov" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="codecov" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
-  <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/d/perl-lsp.svg" alt="Downloads" /></a>
 </p>
 
 ---
 
-> **Initial Public Alpha (`main` preparing v0.12.0)** -- perl-lsp is production-ready for daily use and actively improving.
-> The workspace version is already `v0.12.0`, but the latest published release remains `v0.11.0` until the `v0.12.0` tag is cut.
-> Install in minutes, get completions and navigation immediately.
-> [Report issues](https://github.com/EffortlessMetrics/perl-lsp/issues) or [join the conversation](https://github.com/EffortlessMetrics/perl-lsp/discussions).
+> Release status: `main` is preparing `v0.12.0`. The latest published GitHub release is `v0.11.0` (verified 2026-03-29).
 
-**The only Perl language server that doesn't require Perl to work.** A zero-dependency Rust binary with broad LSP and DAP coverage, validated against real-world CPAN modules. Works on Windows, macOS, and Linux out of the box.
+Perl editor support too often starts with "make Perl itself work first, then add the editor layer later." `perl-lsp` flips that around. Install one native binary and get completions, diagnostics, navigation, formatting, and debugging for Perl 5 on Windows, macOS, and Linux.
 
-## Why perl-lsp?
+## Start Here
 
-- **No Perl runtime required** -- a single native binary; no dependency on a working Perl installation for IDE features.
-- **Fast** -- sub-millisecond incremental parsing, under 50ms LSP response times.
-- **Comprehensive** -- completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic highlighting, code actions, and debugging in one native toolchain.
-- **Perl-aware hover** -- hover over special variables such as `$_`, `@ARGV`, `%ENV`, and `$/` to get built-in documentation inline without leaving your editor.
-- **Broad syntax coverage** -- parses Perl 5.8 through 5.40 including heredocs, regex, quoting constructs, formats, and OO frameworks.
-- **CPAN-validated** -- continuously tested against top CPAN distributions with a ratchet-only-forward CI gate that never allows regressions.
+| If you want to... | Start here |
+| --- | --- |
+| Get IDE support quickly | [Quick Start](#quick-start) |
+| Set up a specific editor | [docs/how-to/EDITOR_SETUP.md](docs/how-to/EDITOR_SETUP.md) |
+| Upgrade an existing install | [docs/how-to/UPGRADING.md](docs/how-to/UPGRADING.md) |
+| Troubleshoot a broken setup | [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md) |
+| See what is true right now | [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) |
+| See the current release plan | [docs/project/ROADMAP.md](docs/project/ROADMAP.md) |
+| Use the Rust crates directly | [`crates/perl-lsp`](crates/perl-lsp/), [`crates/perl-parser`](crates/perl-parser/), [`crates/perl-dap`](crates/perl-dap/) |
+
+## Why Teams Pick It
+
+- Native editor tooling: no Perl runtime dependency just to get LSP or DAP features into your editor.
+- One workspace, multiple entry points: install the binaries or depend on the parser, semantic, workspace, and protocol crates directly.
+- Real Perl coverage: parser and runtime changes are validated against curated corpus and release receipts, not only toy examples.
+- Windows included: install, path handling, packaging, and shell interactions are part of the release surface rather than an afterthought.
+
+## What You Get
+
+| Surface | What it covers |
+| --- | --- |
+| Language server | Diagnostics, completion, hover, navigation, rename, formatting, semantic tokens, code actions, code lens, workspace symbols |
+| Debug adapter | Breakpoints, stepping, stack frames, variables, evaluate support, and editor-driven DAP flows |
+| Parser stack | Native recursive-descent parser, lexer, semantic analysis, workspace indexing, and refactoring helpers |
+| Rust crates | Focused crates for parser, URI/path handling, LSP/DAP protocol layers, workspace indexing, and feature providers |
 
 ## Quick Start
 
-### VS Code (recommended)
-
-Install the extension and open a Perl file -- completions, diagnostics, hover, and navigation work immediately:
+### VS Code
 
 ```bash
 code --install-extension effortlessmetrics.perl-lsp-rs
 ```
 
-The extension auto-downloads the server binary for your platform.
+The VS Code extension auto-downloads the matching server binary for your platform.
 
 ### Binary install
 
@@ -55,13 +68,18 @@ cargo install perl-lsp
 perl-lsp --health
 ```
 
-That installs the latest published release from crates.io. For the current `main`
-branch during `v0.12.0` initial-public-alpha prep, use the source install below or
-download the matching artifact once the release is tagged.
+You can also download prebuilt binaries from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 
-Or download a pre-built binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
+### Windows package managers
 
-### Neovim
+```powershell
+scoop install perl-lsp
+choco install perl-lsp
+```
+
+### Other editors
+
+Neovim:
 
 ```lua
 require('lspconfig').perl_ls.setup {
@@ -69,102 +87,43 @@ require('lspconfig').perl_ls.setup {
 }
 ```
 
-### Emacs (eglot)
+Emacs (`eglot`):
 
 ```elisp
 (add-to-list 'eglot-server-programs '(perl-mode "perl-lsp" "--stdio"))
 ```
 
-### Other editors
+Generic LSP client:
 
-Any editor with LSP support works. Point it at `perl-lsp --stdio` as the language server command.
+```text
+perl-lsp --stdio
+```
 
-For a full walkthrough with troubleshooting tips, see the **[Getting Started guide](docs/tutorials/GETTING_STARTED.md)**.
-
-## Features
-
-| What you see | What it does |
-|-------------|-------------|
-| **Diagnostics** | Real-time parse error detection as you type |
-| **Completions** | Builtins, workspace symbols, modules, and keywords |
-| **Go to definition** | Cross-file navigation for subs, methods, and modules |
-| **Hover** | Function signatures, documentation, module info, and **built-in special variable docs** (hover over `$_`, `@ARGV`, `%ENV`, etc. for instant reference) |
-| **Find references** | Locate all usages of a symbol across your workspace |
-| **Rename** | Scoped refactoring across files |
-| **Formatting** | Perl::Tidy integration |
-| **Code actions** | Organize imports, modernize syntax, quick fixes |
-| **Semantic highlighting** | Context-aware syntax coloring |
-| **Debugging** | Built-in DAP: breakpoints, stepping, variables, watch — [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) |
-| **And more** | Inlay hints, code lens, call hierarchy, folding, color decorators |
-
-The full feature catalog lives in [`features.toml`](features.toml). For live project metrics, see [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
-
-### Demo Walkthroughs
-
-The launch demo assets are staged as storyboard SVG previews in [`vscode-extension/media/walkthrough/`](vscode-extension/media/walkthrough/). They are planning aids, not final demos.
-
-- [Install → auto-download → health check](vscode-extension/media/walkthrough/install-health.svg)
-- [Go to definition + find references](vscode-extension/media/walkthrough/find-references.svg)
-- [Extract variable code action](vscode-extension/media/walkthrough/extract-variable.svg)
-
-When the screen recordings are ready, render them with [`scripts/marketing/render-walkthrough-gif.py`](scripts/marketing/render-walkthrough-gif.py). Use `--max-bytes` so the final GIF stays readable and README-friendly.
-
-## Comparison
-
-| | perl-lsp | PerlNavigator | Perl::LanguageServer |
-|---|----------|--------------|---------------------|
-| **Language** | Rust (native binary) | Perl | Perl |
-| **Requires Perl runtime** | No | Yes | Yes |
-| **Windows support** | Native | Via Perl | Limited |
-| **Incremental parsing** | Yes (sub-ms) | N/A | N/A |
-| **Debug adapter** | Built-in (DAP) | No | Built-in |
-| **CPAN corpus validation** | CI-gated, ratchet-forward | N/A | N/A |
-| **Install** | Single binary | CPAN + Perl | CPAN + Perl |
+For a full setup path, use [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
 
 ## Configuration
 
-perl-lsp is configured through your editor's LSP settings (via `didChangeConfiguration`). All settings are optional -- defaults work out of the box.
+The defaults are meant to be usable without project-specific setup. When you do need configuration, you can use editor LSP settings or a repo-level `.perl-lsp.toml`.
+
+Editor settings example:
 
 ```jsonc
-// VS Code settings.json example
 {
   "perl-lsp.inlayHints": {
     "enabled": true,
     "parameterHints": true,
-    "typeHints": true,
-    "maxLength": 30
+    "typeHints": true
   },
   "perl-lsp.workspace": {
     "includePaths": ["lib", ".", "local/lib/perl5"],
     "useSystemInc": false
-  },
-  "perl-lsp.testRunner": {
-    "enabled": true,
-    "command": "perl",
-    "timeout": 60000
   }
 }
 ```
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `inlayHints.enabled` | `true` | Toggle inlay hints globally |
-| `inlayHints.parameterHints` | `true` | Show parameter name hints at call sites |
-| `inlayHints.typeHints` | `true` | Show inferred type hints for variables |
-| `workspace.includePaths` | `["lib", ".", "local/lib/perl5"]` | Module resolution search paths |
-| `workspace.useSystemInc` | `false` | Include system `@INC` paths |
-| `testRunner.command` | `"perl"` | Command for integrated test runner (`perl`, `prove`) |
-| `testRunner.timeout` | `60000` | Test execution timeout (ms) |
-
-For Neovim and other editors, pass these as the LSP `settings` table under the `perl-lsp` key.
-
-### Project Configuration File
-
-For team-wide defaults, add a `.perl-lsp.toml` to your repository root. It is editor-agnostic and committed to version control:
+Project config example:
 
 ```toml
-# .perl-lsp.toml — shared project defaults for perl-lsp
-
 [perl]
 include_paths = ["lib", "local/lib/perl5"]
 
@@ -175,132 +134,48 @@ perlcritic = false
 inlay_hints = true
 ```
 
-Settings from `.perl-lsp.toml` are the lowest-priority layer. Editor settings (`initializationOptions` / `didChangeConfiguration`) always override them. See [CONFIG.md](docs/reference/CONFIG.md) for the full reference including precedence rules.
+Use [docs/reference/CONFIG.md](docs/reference/CONFIG.md) for the full reference and precedence rules.
 
-## Install
+## Workspace Entry Points
 
-### From crates.io
+| Crate | Use it when you need... |
+| --- | --- |
+| [`crates/perl-lsp`](crates/perl-lsp/) | the actual language server binary or embedding entry point |
+| [`crates/perl-dap`](crates/perl-dap/) | the native debug adapter runtime |
+| [`crates/perl-parser`](crates/perl-parser/) | one facade for parsing, semantic analysis, and workspace tooling |
+| [`crates/perl-lexer`](crates/perl-lexer/) | tokenization and lexical state handling |
+| [`crates/perl-semantic-analyzer`](crates/perl-semantic-analyzer/) | symbol, scope, and type analysis over parsed trees |
+| [`crates/perl-workspace-index`](crates/perl-workspace-index/) | document storage, indexing, and cross-file lookups |
 
-```bash
-cargo install perl-lsp
-perl-lsp --health
-```
+Published crates are documented on docs.rs. Internal and supporting docs start at [docs/README.md](docs/README.md).
 
-### From source
+## Docs By Job
 
-```bash
-git clone https://github.com/EffortlessMetrics/perl-lsp.git
-cd perl-lsp
-cargo install --path crates/perl-lsp
-perl-lsp --health
-```
-
-### Pre-built binaries
-
-Download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
-
-### Windows package managers
-
-The release automation keeps the Windows package-manager manifests in sync with
-each release. If you are on Windows, these are the user-facing install paths:
-
-```powershell
-scoop install perl-lsp
-choco install perl-lsp
-```
-
-After installation, verify the binary with `perl-lsp --health`.
-The repo documents the automated vs manual verification boundary in
-[docs/how-to/INSTALLATION.md](docs/how-to/INSTALLATION.md) and
-[docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md).
-
-### Linux package-manager scaffold
-
-Repo-owned packaging templates for `apt`, `dnf`, and `pacman` live under [`distribution/linux/`](distribution/linux/).
-They are intentionally kept as templates only in this slice, so downstream release automation can render them without depending on external distro approvals.
-To render them for a specific release, use [`scripts/render-linux-packages.py`](scripts/render-linux-packages.py) with the values from [`distribution/linux/package-metadata.toml`](distribution/linux/package-metadata.toml).
-
-### VS Code Extension
-
-Install from the VS Code Marketplace or:
-
-```bash
-code --install-extension effortlessmetrics.perl-lsp-rs
-```
-
-You can set `perl-lsp.serverPath` to use a specific binary, or disable `perl-lsp.autoDownload` for airgapped environments.
-
-## Parser
-
-The v3 parser is a native recursive-descent implementation covering broad Perl 5 syntax
-(5.8 through 5.40), including heredocs, regex, quoting constructs, and formats. It is
-tested continuously against real-world Perl code:
-
-- **Corpus test suite** -- 600+ test sections plus 70+ standalone `.pl` fixtures.
-- **CPAN corpus** -- benchmarked against the top 1000 CPAN distributions with a ratchet-only-forward CI gate.
-- **Common-files gate** -- a curated set of core modules that must parse with zero errors on every PR.
-
-Current parse rates and the edge-case roadmap are tracked in [CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and [PARSER_EDGE_CASE_ROADMAP.md](docs/project/PARSER_EDGE_CASE_ROADMAP.md).
-
-## Architecture
-
-The workspace is organized as many focused Rust crates, each with a single responsibility. The main entry points:
-
-| Crate | Purpose |
-|-------|---------|
-| [`perl-lsp`](crates/perl-lsp/) | LSP server binary |
-| [`perl-dap`](crates/perl-dap/) | Debug Adapter Protocol server |
-| [`perl-parser`](crates/perl-parser/) | Native recursive-descent Perl parser |
-| [`perl-lexer`](crates/perl-lexer/) | Context-aware tokenizer |
-| [`perl-semantic-analyzer`](crates/perl-semantic-analyzer/) | Semantic analysis and resolution |
-
-Published crates are available on [crates.io](https://crates.io/crates/perl-lsp): `perl-lsp`, `perl-dap`, `perl-parser`, `perl-lexer`, and `perl-corpus`.
-
-For design details, see the [LSP Implementation Guide](docs/reference/LSP_IMPLEMENTATION_GUIDE.md), [Crate Architecture Guide](docs/reference/CRATE_ARCHITECTURE_GUIDE.md), and [Architecture Decision Records](docs/adr/README.md).
+- New user: [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md)
+- Installation and editor setup: [docs/how-to/INSTALLATION.md](docs/how-to/INSTALLATION.md), [docs/how-to/EDITOR_SETUP.md](docs/how-to/EDITOR_SETUP.md)
+- Upgrade and troubleshooting: [docs/how-to/UPGRADING.md](docs/how-to/UPGRADING.md), [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md)
+- Commands and configuration: [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md), [docs/reference/CONFIG.md](docs/reference/CONFIG.md)
+- Project truth and planning: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
+- Full docs map: [docs/INDEX.md](docs/INDEX.md)
 
 ## Contributing
 
 ```bash
-cargo build --workspace            # Build everything
-cargo test --workspace --lib       # Run all tests
-cargo clippy --workspace --lib     # Lint
-cargo fmt --all                    # Format
-nix develop -c just ci-gate        # Full local gate (required before push)
+cargo build --workspace
+cargo test --workspace --lib
+cargo fmt --all
+nix develop -c just ci-gate
 ```
 
-Quick iteration: `just pr-fast`. Environment check: `just devex` or `just doctor`.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines,
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards,
-and [SUPPORT.md](SUPPORT.md) for how to get help.
+Use [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow and [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md) for the broader command surface.
 
 ## Security
 
-Release artifacts include SBOM generation (SPDX and CycloneDX) and SLSA Level 2
-provenance attestations. Production code enforces zero `unsafe`, zero `unwrap`/`expect`,
-and zero `panic!`-family macros via CI ratchets.
-
-See [Supply Chain Security](docs/reference/SUPPLY_CHAIN_SECURITY.md) for details.
-
-## Documentation
-
-| Resource | Description |
-|----------|-------------|
-| **[Getting Started](docs/tutorials/GETTING_STARTED.md)** | Installation, editor setup, and first-run walkthrough |
-| [Full Documentation Index](docs/INDEX.md) | Complete guide to all project documentation |
-| [Current Status](docs/project/CURRENT_STATUS.md) | Live project metrics |
-| [Roadmap](docs/project/ROADMAP.md) | Version milestones and planning |
-| [Troubleshooting](docs/how-to/TROUBLESHOOTING.md) | Common issues and solutions |
-| [features.toml](features.toml) | Canonical LSP feature catalog |
-| [Stability Policy](docs/reference/STABILITY.md) | API versioning and compatibility |
-| [DAP User Guide](docs/tutorials/DAP_USER_GUIDE.md) | Debugger setup and usage |
-| [Contributing](CONTRIBUTING.md) | Development guidelines and workflow |
-| [Changelog](CHANGELOG.md) | Release history and notable changes |
-| **[Report an Issue](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose)** | Bug reports, feature requests, parser issues |
+Release artifacts include SBOM generation and provenance attestations. Production code is kept under the workspace ratchets for `unsafe`, `unwrap` / `expect`, and panic-family macros. See [docs/reference/SUPPLY_CHAIN_SECURITY.md](docs/reference/SUPPLY_CHAIN_SECURITY.md).
 
 ## History
 
-This project began as a fork of [tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl) in July 2025. It has since been rewritten as a native Rust recursive-descent parser and grown into a full-featured LSP/DAP toolkit.
+This project started from the `tree-sitter-perl` line and grew into a native Rust Perl tooling workspace with its own parser, LSP, DAP, and release stack.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,32 +6,33 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.12.0` (`Cargo.toml` `workspace.package.version`)
-- Latest published release: `v0.11.0` (GitHub Releases / crates.io, verified 2026-03-28)
-- Active milestone: `v0.12.0` initial public alpha release prep
-- Current priorities: parser-quality ratchets, semantic-framework coverage, DAP/LSP hardening, and documentation alignment
+- Workspace version line: `v0.12.0`
+- Latest published GitHub release: `v0.11.0` (verified 2026-03-29)
+- Active milestone: `v0.12.0` initial public alpha cut
+- Canonical plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
+- Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
 
 ## Now
 
-- Raise the CPAN baseline and keep parser boundedness receipts green
-- Land semantic framework work for Moo, Moose, `use parent` / `use base`, and export-list-aware resolution
-- Keep release and validation flows stable while initial public alpha prep lands
-- Align top-level documentation so README, roadmap, status, and release guidance stop contradicting each other about `main` versus the latest published artifacts
+- Keep release validation green while `v0.12.0` moves from version line to shipped release
+- Raise parser and corpus confidence without hiding regressions behind broader receipts
+- Finish framework-aware semantic work for real-world Perl projects
+- Keep README, docs, changelog, and release guidance aligned so users do not have to infer the release state
 
 ## Next
 
-- Diagnostic hardening around `strict`, `warnings`, dead-code signals, and safe analysis
-- Refactoring reliability and debugger hardening beyond the current preview posture
-- Distribution and release-surface cleanup after the `v0.12.0` initial public alpha cut
+- Harden diagnostics, refactoring, and debugger behavior after the alpha cut
+- Follow through on distribution and packaging cleanup once the release line is live
+- Keep shrinking the gap between crate-level docs, editor docs, and release operations
 
 ## Later
 
 - `v0.15.0` stability contract for APIs and advertised wire behavior
-- Platform certification and broader distribution packaging
-- Performance, security, and API-stability hardening on the path to `v1.0.0`
+- Broader packaging and platform certification
+- Performance, security, and compatibility hardening on the path to `v1.0.0`
 
 ## Update Rules
 
 - Update [docs/project/ROADMAP.md](docs/project/ROADMAP.md) when milestone framing changes.
 - Update [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) with `just status-update` and `just status-check` when generated metrics move.
-- Keep this file short. If it starts carrying detailed receipts or large milestone tables again, move that detail back to the canonical project docs.
+- Keep this file short. Detailed receipts, milestone criteria, and subsystem metrics belong in the canonical project docs.

--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -1,10 +1,11 @@
 # perl-dap
 
-Native Debug Adapter Protocol server for Perl.
+Use this crate when you need a native Debug Adapter Protocol server for Perl,
+not just debugger helper components.
 
 `perl-dap` is the runtime layer of the debugger stack. It speaks DAP over stdio
-or TCP, dispatches requests, validates breakpoints, and renders values. Use it
-when you want to debug Perl from a DAP-capable editor or tool.
+or TCP, dispatches requests, validates breakpoints, and renders values for
+DAP-capable editors and tools.
 
 ## Boundaries
 

--- a/crates/perl-lsp/README.md
+++ b/crates/perl-lsp/README.md
@@ -3,11 +3,12 @@
 [![Crates.io](https://img.shields.io/crates/v/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
 [![Documentation](https://docs.rs/perl-lsp/badge.svg)](https://docs.rs/perl-lsp)
 
-Standalone Language Server Protocol server for Perl.
+Use this crate when you need the actual Perl language server entry point, not
+just parser or provider pieces.
 
 ## When to use this crate
 
-Use `perl-lsp` when you want to run or embed the actual Perl language server:
+Use `perl-lsp` when you want to run or embed the real language server:
 
 - run the `perl-lsp` binary behind an editor such as VS Code, Neovim, Emacs, or Helix
 - expose Perl LSP features over stdio or TCP

--- a/crates/perl-parser/README.md
+++ b/crates/perl-parser/README.md
@@ -1,17 +1,16 @@
 # perl-parser
 
-High-level facade for the Perl parsing stack.
+Use this crate when you want one dependency for parsing Perl plus the higher
+layers that usually come next: semantic analysis, workspace indexing,
+refactoring, and the LSP-oriented provider re-exports.
 
-Use this crate when you want one entry point for parsing, semantic analysis,
-workspace indexing, refactoring, and the LSP provider re-exports that sit on
-top of them. If you only need the parser engine, use `perl-parser-core`
-directly.
+If you only need the parser engine itself, use `perl-parser-core` directly.
 
 ## Where it fits
 
-`perl-parser` is the top of the parsing stack. It re-exports the lower-level
-parser, analysis, workspace, and refactoring crates so downstream code can
-depend on one crate instead of the whole family.
+`perl-parser` is the top of the parsing stack. It lets downstream tools depend
+on one crate instead of wiring the parser, analysis, workspace, and refactoring
+families together by hand.
 
 ## Main entry points
 
@@ -35,5 +34,5 @@ assert!(!ast.to_sexp().is_empty());
 ## Typical use
 
 Use `perl-parser` when you are building editor tooling, code transforms, or
-tests that need both parsing and the higher-level analysis layers. If you only
-need a small slice of the stack, depend on the lower-level crate directly.
+tests that need both parsing and the layers above parsing. If you only need a
+small slice of the stack, depend on the narrower crate directly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # perl-lsp Documentation
 
-Use this directory as the docs front door. It is organized by task, not by the
-project's internal crate layout.
+Use this directory as the short docs front door. It tells you where to go next
+without making you learn the workspace layout first. For the full Diataxis-style
+map of the docs tree, use [INDEX.md](INDEX.md).
 
 ## Canonical Sources
 
@@ -15,29 +16,25 @@ project's internal crate layout.
 
 Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), treat it as stale until reverified.
 
-## I Need To...
+## Common Routes
 
-- install or upgrade perl-lsp: [how-to/INSTALLATION.md](how-to/INSTALLATION.md)
-- configure an editor: [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md)
-- fix a broken setup: [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md)
-- upgrade an existing install: [how-to/UPGRADING.md](how-to/UPGRADING.md)
-- understand what is shipped now: [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md)
-- see the current release plan: [project/ROADMAP.md](project/ROADMAP.md)
-- work on the codebase: [../CONTRIBUTING.md](../CONTRIBUTING.md)
+| If you need to... | Read this |
+| --- | --- |
+| get working fast | [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md) |
+| install or upgrade | [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/UPGRADING.md](how-to/UPGRADING.md) |
+| configure an editor | [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md) |
+| troubleshoot a broken setup | [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md) |
+| see what is true now | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) |
+| see the current release plan | [project/ROADMAP.md](project/ROADMAP.md) |
+| work on the codebase | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
+| browse the full docs map | [INDEX.md](INDEX.md) |
 
-## Start Here
+## Docs by Type
 
-- New users: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
-- Existing installs: [how-to/UPGRADING.md](how-to/UPGRADING.md)
-- Editor setup: [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md)
-- Contributors: [../CONTRIBUTING.md](../CONTRIBUTING.md)
-
-## Docs by Job
-
-- Tutorials: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
+- Tutorial: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
 - How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md)
 - Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md)
-- Project: [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md)
+- Explanation and project docs: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md)
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary
This tightens the release-facing docs surfaces so the project reads like a coherent public alpha release instead of a mix of internal receipts, duplicated entrypoints, and stale summary blocks.

## What changed
- rewrote the root `README.md` into a shorter problem-first entrypoint with clearer install, editor, docs, and crate routes
- tightened `docs/README.md` into a short routing page and pushed the broader map responsibility to `docs/INDEX.md`
- cleaned the top-level `ROADMAP.md` and `NOW_NEXT_LATER.md` summaries so they stay short and consistent with the canonical project docs
- replaced the duplicated and contradictory `0.12.0` changelog block with a concise release-quality summary
- improved the crate landing-page intros for `perl-parser`, `perl-lsp`, and `perl-dap` so they explain the user problem before internal structure

## Verification
- `just --shell "C:\Program Files\Git\bin\bash.exe" status-check`
- `just --shell "C:\Program Files\Git\bin\bash.exe" ci-doc-claims`
- `just --shell "C:\Program Files\Git\bin\bash.exe" release-check`

## Notes
- Published release state was reverified against GitHub releases before updating the top-level release-status wording.
- Cargo metadata for publishable crates was also audited separately; no blocking metadata gaps were found in this sweep.