### PR TITLE
docs(release): fix public install truth (#2936)

### DIFF
--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -1,11 +1,9 @@
 # NOW / NEXT / LATER
 
-> Last Updated: 2026-03-29
-> Workspace version line: `v0.12.0`
-> Latest published GitHub release: `v0.11.0` (verified 2026-03-29)
-> Active milestone: `v0.12.0` initial public alpha cut
-
-This file is the short planning snapshot. The detailed roadmap is [docs/project/ROADMAP.md](docs/project/ROADMAP.md). The evidence-backed status view is [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
+This file is the short planning snapshot for sequencing work. Use
+[docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the canonical milestone
+plan and [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for
+evidence-backed status and release facts.
 
 ## NOW
 
@@ -28,6 +26,7 @@ This file is the short planning snapshot. The detailed roadmap is [docs/project/
 
 ## Working Rules
 
+- Last updated: `2026-03-29`
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@
 
 <p align="center">
   <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/v/perl-lsp.svg" alt="crates.io" /></a>
-  <a href="https://docs.rs/perl-lsp"><img src="https://docs.rs/perl-lsp/badge.svg" alt="docs.rs" /></a>
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
+  <a href="docs/README.md"><img src="https://img.shields.io/badge/docs-project%20docs-blue.svg" alt="Project docs" /></a>
   <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="codecov" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
 </p>
 
 ---
-
-> Release status: `main` is preparing `v0.12.0`. The latest published GitHub release is `v0.11.0` (verified 2026-03-29).
 
 Perl editor support too often starts with "make Perl itself work first, then add the editor layer later." `perl-lsp` flips that around. Install one native binary and get completions, diagnostics, navigation, formatting, and debugging for Perl 5 on Windows, macOS, and Linux.
 
@@ -61,14 +59,19 @@ code --install-extension effortlessmetrics.perl-lsp-rs
 
 The VS Code extension auto-downloads the matching server binary for your platform.
 
-### Binary install
+### GitHub release binary
+
+Download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, and then verify it:
 
 ```bash
-cargo install perl-lsp
 perl-lsp --health
 ```
 
-You can also download prebuilt binaries from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
+If you are testing the workspace locally before a tagged release, install from source instead:
+
+```bash
+cargo install --path crates/perl-lsp
+```
 
 ### Windows package managers
 
@@ -147,7 +150,7 @@ Use [docs/reference/CONFIG.md](docs/reference/CONFIG.md) for the full reference 
 | [`crates/perl-semantic-analyzer`](crates/perl-semantic-analyzer/) | symbol, scope, and type analysis over parsed trees |
 | [`crates/perl-workspace-index`](crates/perl-workspace-index/) | document storage, indexing, and cross-file lookups |
 
-Published crates are documented on docs.rs. Internal and supporting docs start at [docs/README.md](docs/README.md).
+Published library crates are documented on docs.rs. Internal and supporting docs start at [docs/README.md](docs/README.md).
 
 ## Docs By Job
 
@@ -157,6 +160,7 @@ Published crates are documented on docs.rs. Internal and supporting docs start a
 - Commands and configuration: [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md), [docs/reference/CONFIG.md](docs/reference/CONFIG.md)
 - Project truth and planning: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
 - Full docs map: [docs/INDEX.md](docs/INDEX.md)
+- Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,13 +4,14 @@
 > The canonical planning document is [docs/project/ROADMAP.md](docs/project/ROADMAP.md).
 > Evidence and current receipts live in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md).
 
-## Current Framing
+Use this file to see what the project is trying to land next. Use the canonical
+project docs when you need exact release facts, receipts, or milestone detail.
 
-- Workspace version line: `v0.12.0`
-- Latest published GitHub release: `v0.11.0` (verified 2026-03-29)
-- Active milestone: `v0.12.0` initial public alpha cut
-- Canonical plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
+## State References
+
+- Active milestone plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
 - Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
+- Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
 ## Now
 

--- a/crates/perl-lsp/README.md
+++ b/crates/perl-lsp/README.md
@@ -1,8 +1,5 @@
 # perl-lsp
 
-[![Crates.io](https://img.shields.io/crates/v/perl-lsp.svg)](https://crates.io/crates/perl-lsp)
-[![Documentation](https://docs.rs/perl-lsp/badge.svg)](https://docs.rs/perl-lsp)
-
 Use this crate when you need the actual Perl language server entry point, not
 just parser or provider pieces.
 
@@ -21,8 +18,12 @@ smaller workspace crates such as `perl-parser`, `perl-lexer`, or the
 ## Installation
 
 ```bash
-cargo install perl-lsp
+cargo install --path crates/perl-lsp
 ```
+
+For the current public install paths, use the workspace-level guidance in the
+project README:
+<https://github.com/EffortlessMetrics/perl-lsp/blob/master/README.md>
 
 ## Quick start
 

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -9,15 +9,11 @@ expected, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## Fastest Path
 
-```bash
-cargo install perl-lsp
-```
+Use one of the public install paths that matches how you work:
 
-If you already have perl-lsp installed and want the current published build:
-
-```bash
-cargo install perl-lsp --force
-```
+- VS Code: install the `EffortlessMetrics.perl-lsp-rs` extension and let it download the matching server binary.
+- Other editors: download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and put it on your `PATH`.
+- Local testing or pre-release validation: install from this repo with `cargo install --path crates/perl-lsp`.
 
 Verify the install before wiring it into an editor:
 

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -22,7 +22,7 @@
 | Metric | Value | Source |
 | --- | --- | --- |
 | **Workspace version line** | `v0.12.0` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest published release** | `v0.11.0`, verified 2026-03-28 | GitHub Releases and crates.io |
+| **Latest published release** | `v0.11.0`, verified 2026-03-29 | GitHub Releases |
 | **Active milestone** | `v0.12.0` initial public alpha release prep | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,13 +3,13 @@
 > Canonical planning document.
 > Evidence and computed metrics belong in [CURRENT_STATUS.md](CURRENT_STATUS.md).
 > Current workspace version is taken from [`../../Cargo.toml`](../../Cargo.toml);
-> published release state must be verified against GitHub Releases or crates.io;
+> published release state must be verified against GitHub Releases;
 > current capability truth is taken from [`../../features.toml`](../../features.toml).
 
 ## Current Framing
 
 - Workspace version line: `v0.12.0`
-- Latest published release: `v0.11.0` (verified 2026-03-28)
+- Latest published release: `v0.11.0` (verified 2026-03-29)
 - Active release target: `v0.12.0` initial public alpha cut
 - Canonical local receipt: `nix develop -c just ci-gate`
 
@@ -133,7 +133,7 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Topic | Source |
 | --- | --- |
 | Workspace version line | [`../../Cargo.toml`](../../Cargo.toml) |
-| Latest published release | GitHub Releases / crates.io |
+| Latest published release | GitHub Releases |
 | Capability catalog | [`../../features.toml`](../../features.toml) |
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: the workspace/release target is `v0.12.0`, the latest published release is `v0.11.0` as verified on 2026-03-28, and the active milestone is `v0.12.0` initial public alpha release prep
+- **Release posture**: the workspace/release target is `v0.12.0`, the latest published GitHub release is `v0.11.0` as verified on 2026-03-29, and the active milestone is `v0.12.0` initial public alpha release prep
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 98 features all at GA maturity — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `bash scripts/ignored-test-count.sh` is the tracked-test-debt source
@@ -66,5 +66,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-03-28 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-03-29 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -7,11 +7,12 @@
 
 **Latest published release**: `v0.11.0`
 **Release target**: `v0.12.0` initial public alpha
-**Ship readiness**: Initial-public-alpha release prep is green on `master`; remaining work is release-day orchestration and publication
+**Ship readiness**: GitHub release and editor-managed install surfaces are green on `master`; public `cargo install perl-lsp` guidance stays off until the crate namespace aligns with this release line
 
 ## Active Blockers
 
-- Release-truth drift must stay closed: repo docs can say `v0.12.0` for `main`, but published-install guidance must stay tied to the latest tagged release until `v0.12.0` ships
+- Release-truth drift must stay closed: repo docs can say `v0.12.0` for `main`, but published-install guidance must stay tied to the latest tagged GitHub release until `v0.12.0` ships
+- Do not present `cargo install perl-lsp` as a shipped public install path until the crates.io package namespace matches this project’s release line
 
 ## Final Release Receipts (2026-03-29)
 

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -16,7 +16,13 @@ just release-check
 
 ### LSP Server
 ```bash
-# Quick install (Linux/macOS)
+# VS Code extension
+code --install-extension EffortlessMetrics.perl-lsp-rs
+
+# GitHub release binary
+# Download from https://github.com/EffortlessMetrics/perl-lsp/releases
+
+# Best-effort install script (Linux/macOS)
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 
 # Homebrew (macOS)
@@ -26,7 +32,7 @@ brew install perl-lsp
 # Build from source
 cargo build -p perl-lsp --release
 
-# Install globally
+# Install locally from this repo
 cargo install --path crates/perl-lsp
 
 # Run the LSP server
@@ -61,10 +67,12 @@ nix develop -c just ci-gate
 
 ## Build Commands
 
-### Published Crates
+### Published Crates and Local Binaries
 ```bash
-# Install from crates.io
-cargo install perl-lsp                     # LSP server
+# Install the LSP server from this checkout
+cargo install --path crates/perl-lsp       # LSP server
+
+# Add published library crates
 cargo add perl-parser                      # As library dependency
 cargo add perl-corpus --dev                # For testing
 

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -5,7 +5,6 @@
 ### How do I install perl-lsp?
 
 - **VS Code (recommended)**: install the [Perl LSP extension](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) — it downloads the server binary automatically.
-- **crates.io**: `cargo install perl-lsp`
 - **Pre-built binary**: download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
 - **Installer script (Linux/macOS, best-effort)**:
   `curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash`
@@ -162,5 +161,5 @@ Yes. perl-lsp is dual-licensed under [MIT](../../LICENSE-MIT) and [Apache-2.0](.
 perl-lsp is in active development. Releases are cut when meaningful milestones
 are ready, such as parser coverage gains, new LSP features, or release-surface
 hardening. The workspace version on `main` can move ahead of the latest
-published release during release prep, so check GitHub Releases or crates.io
-for the currently shipped version.
+published release during release prep, so check GitHub Releases for the
+currently shipped public release.

--- a/docs/reference/VARIABLE_RESOLUTION_GUIDE.md
+++ b/docs/reference/VARIABLE_RESOLUTION_GUIDE.md
@@ -196,12 +196,12 @@ The system uses intelligent confidence scoring for delimiter detection:
 
 ### For LSP Server Users
 
-1. **Install the enhanced perl-lsp server**:
-```bash
-cargo install perl-lsp
-# Or build from source with latest enhancements
-cargo build --release -p perl-lsp
-```
+1. **Install the enhanced perl-lsp server**. For published installs, use the
+   workspace-level guidance in [../../README.md](../../README.md). For local
+   source testing:
+   ```bash
+   cargo install --path crates/perl-lsp
+   ```
 
 2. **Configure your editor** to use the enhanced diagnostics:
 ```json

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -27,13 +27,19 @@ A **language server** is a program that runs alongside your editor and gives it 
 
 Choose one method:
 
-### Option 1: Install from crates.io (Recommended)
+### Option 1: VS Code extension (Recommended for VS Code users)
 
 ```bash
-cargo install perl-lsp
+code --install-extension EffortlessMetrics.perl-lsp-rs
 ```
 
-### Option 2: Install Script (Linux/macOS)
+The extension downloads the matching server binary for your platform.
+
+### Option 2: GitHub release binary (Recommended for other editors)
+
+Download the latest archive from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and place `perl-lsp` on your `PATH`.
+
+### Option 3: Install Script (Linux/macOS)
 
 Use the installer script (best-effort / non-canonical):
 
@@ -41,7 +47,7 @@ Use the installer script (best-effort / non-canonical):
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 ```
 
-### Option 3: Build from Source
+### Option 4: Build from Source
 
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git


### PR DESCRIPTION
## Summary
- remove release-status bookkeeping from the top of the README and keep the front door problem-first
- replace misleading public `cargo install perl-lsp` guidance in the active install/tutorial/reference surfaces with truthful current install paths
- update canonical status and roadmap docs to track the published release via GitHub Releases and explicitly keep crates.io guidance off until the package namespace aligns

## Validation
- just --shell "C:\Program Files\Git\bin\bash.exe" status-check
- just --shell "C:\Program Files\Git\bin\bash.exe" ci-doc-claims
- just --shell "C:\Program Files\Git\bin\bash.exe" release-check

## Notes
- Verified latest published GitHub release with `gh release list -L 3`
- Verified the current `crates.io/crates/perl-lsp` package is not this release line before removing public crates.io install guidance from the active docs