### PR TITLE
fix(release): repair changelog tag extraction (#2936)

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -163,7 +163,7 @@ jobs:
           CHANGELOG_SECTION="$(mktemp)"
           awk -v ver="${VERSION}" '
             $0 ~ "^## \\[" ver "\\]" { in_section=1; next }
-            in_section && /^## \\[/ { exit }
+            in_section && /^## \[/ { exit }
             in_section { print }
           ' CHANGELOG.md > "$CHANGELOG_SECTION"
 


### PR DESCRIPTION
## Summary
- fix the release orchestration changelog extraction regex so tag creation does not fail on the Actions runner
- keep the change scoped to the workflow hotfix only

## Validation
- ran the extraction snippet locally against the current 0.12.0 changelog section
- reproduced the failure from the Actions log and verified the fixed pattern returns the expected section
