### PR TITLE
fix(release): restore readme and harden hook fixtures (#2936)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,185 @@
-# hook test repo
+<p align="center">
+  <img src="vscode-extension/icon.png" alt="perl-lsp logo" width="120" />
+</p>
+
+<h1 align="center">perl-lsp</h1>
+
+<p align="center">
+  Native Perl 5 language tooling in Rust: editor support, parser infrastructure, and debugging without a Perl runtime dependency for IDE features.
+</p>
+
+<p align="center">
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml"><img src="https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
+  <a href="docs/README.md"><img src="https://img.shields.io/badge/docs-project%20docs-blue.svg" alt="Project docs" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="codecov" /></a>
+  <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
+</p>
+
+---
+
+Perl editor support too often starts with "make Perl itself work first, then add the editor layer later." `perl-lsp` flips that around. Install one native binary, `perllsp`, and get completions, diagnostics, navigation, formatting, and debugging for Perl 5 on Windows, macOS, and Linux.
+
+## Start Here
+
+| If you want to... | Start here |
+| --- | --- |
+| Get IDE support quickly | [Quick Start](#quick-start) |
+| Set up a specific editor | [docs/how-to/EDITOR_SETUP.md](docs/how-to/EDITOR_SETUP.md) |
+| Upgrade an existing install | [docs/how-to/UPGRADING.md](docs/how-to/UPGRADING.md) |
+| Troubleshoot a broken setup | [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md) |
+| See what is true right now | [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) |
+| See the current release plan | [docs/project/ROADMAP.md](docs/project/ROADMAP.md) |
+| Use the Rust crates directly | [`crates/perllsp`](crates/perllsp/), [`crates/perl-parser`](crates/perl-parser/), [`crates/perl-dap`](crates/perl-dap/) |
+
+## Why Teams Pick It
+
+- Native editor tooling: no Perl runtime dependency just to get LSP or DAP features into your editor.
+- One workspace, multiple entry points: install the binaries or depend on the parser, semantic, workspace, and protocol crates directly.
+- Real Perl coverage: parser and runtime changes are validated against curated corpus and release receipts, not only toy examples.
+- Windows included: install, path handling, packaging, and shell interactions are part of the release surface rather than an afterthought.
+
+## What You Get
+
+| Surface | What it covers |
+| --- | --- |
+| Language server | Diagnostics, completion, hover, navigation, rename, formatting, semantic tokens, code actions, code lens, workspace symbols |
+| Debug adapter | Breakpoints, stepping, stack frames, variables, evaluate support, and editor-driven DAP flows |
+| Parser stack | Native recursive-descent parser, lexer, semantic analysis, workspace indexing, and refactoring helpers |
+| Rust crates | Focused crates for parser, URI/path handling, LSP/DAP protocol layers, workspace indexing, and feature providers |
+
+## Quick Start
+
+### VS Code
+
+```bash
+code --install-extension effortlessmetrics.perl-lsp-rs
+```
+
+The VS Code extension auto-downloads the matching `perllsp` binary for your platform.
+
+### GitHub release binary
+
+Download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases), add it to your `PATH`, and then verify it:
+
+```bash
+perllsp --health
+```
+
+If you are testing the workspace locally before a tagged release, install from source instead:
+
+```bash
+cargo install --path crates/perllsp
+```
+
+Do not use `cargo install perl-lsp` on crates.io. That package name is owned by another project.
+
+### Other editors
+
+Neovim:
+
+```lua
+require('lspconfig').perl_ls.setup {
+  cmd = { "perllsp", "--stdio" },
+}
+```
+
+Emacs (`eglot`):
+
+```elisp
+(add-to-list 'eglot-server-programs '(perl-mode "perllsp" "--stdio"))
+```
+
+Generic LSP client:
+
+```text
+perllsp --stdio
+```
+
+For a full setup path, use [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md).
+
+## Configuration
+
+The defaults are meant to be usable without project-specific setup. When you do need configuration, you can use editor LSP settings or a repo-level `.perl-lsp.toml`.
+
+Editor settings example:
+
+```jsonc
+{
+  "perl-lsp.inlayHints": {
+    "enabled": true,
+    "parameterHints": true,
+    "typeHints": true
+  },
+  "perl-lsp.workspace": {
+    "includePaths": ["lib", ".", "local/lib/perl5"],
+    "useSystemInc": false
+  }
+}
+```
+
+Project config example:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5"]
+
+[diagnostics]
+perlcritic = false
+
+[features]
+inlay_hints = true
+```
+
+Use [docs/reference/CONFIG.md](docs/reference/CONFIG.md) for the full reference and precedence rules.
+
+## Workspace Entry Points
+
+| Crate | Use it when you need... |
+| --- | --- |
+| [`crates/perllsp`](crates/perllsp/) | the public Cargo package for installing the `perllsp` binary |
+| [`crates/perl-lsp`](crates/perl-lsp/) | the internal implementation crate behind the `perllsp` binary |
+| [`crates/perl-dap`](crates/perl-dap/) | the native debug adapter runtime |
+| [`crates/perl-parser`](crates/perl-parser/) | one facade for parsing, semantic analysis, and workspace tooling |
+| [`crates/perl-lexer`](crates/perl-lexer/) | tokenization and lexical state handling |
+| [`crates/perl-semantic-analyzer`](crates/perl-semantic-analyzer/) | symbol, scope, and type analysis over parsed trees |
+| [`crates/perl-workspace-index`](crates/perl-workspace-index/) | document storage, indexing, and cross-file lookups |
+
+Published library crates are documented on docs.rs. Internal and supporting docs start at [docs/README.md](docs/README.md).
+
+## Docs By Job
+
+- New user: [docs/tutorials/GETTING_STARTED.md](docs/tutorials/GETTING_STARTED.md)
+- Installation and editor setup: [docs/how-to/INSTALLATION.md](docs/how-to/INSTALLATION.md), [docs/how-to/EDITOR_SETUP.md](docs/how-to/EDITOR_SETUP.md)
+- Upgrade and troubleshooting: [docs/how-to/UPGRADING.md](docs/how-to/UPGRADING.md), [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md)
+- Commands and configuration: [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md), [docs/reference/CONFIG.md](docs/reference/CONFIG.md)
+- Project truth and planning: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
+- Full docs map: [docs/INDEX.md](docs/INDEX.md)
+- Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
+
+## Contributing
+
+```bash
+cargo build --workspace
+cargo test --workspace --lib
+cargo fmt --all
+nix develop -c just ci-gate
+```
+
+Use [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow and [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md) for the broader command surface.
+
+## Security
+
+Release artifacts include SBOM generation and provenance attestations. Production code is kept under the workspace ratchets for `unsafe`, `unwrap` / `expect`, and panic-family macros. See [docs/reference/SUPPLY_CHAIN_SECURITY.md](docs/reference/SUPPLY_CHAIN_SECURITY.md).
+
+## History
+
+This project started from the `tree-sitter-perl` line and grew into a native Rust Perl tooling workspace with its own parser, LSP, DAP, and release stack.
+
+## License
+
+Dual licensed under MIT or Apache-2.0:
+
+- [LICENSE-MIT](LICENSE-MIT)
+- [LICENSE-APACHE](LICENSE-APACHE)

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1802,7 +1802,7 @@ fn cmd_generate_badges(repo_root: &Path) -> Result<i32> {
 }
 
 fn cmd_install_githooks(repo_root: &Path) -> Result<i32> {
-    let hooks_dir = repo_root.join(".git").join("hooks");
+    let hooks_dir = resolve_git_hooks_dir(repo_root)?;
     fs::create_dir_all(&hooks_dir)?;
 
     let pre_commit_hook = r#"#!/usr/bin/env bash
@@ -1811,7 +1811,10 @@ set -euo pipefail
 GIT_USER_NAME="$(git config user.name 2>/dev/null || true)"
 GIT_USER_EMAIL="$(git config user.email 2>/dev/null || true)"
 
-if [ "$GIT_USER_NAME" = "Codex Release Validation" ] || [ "$GIT_USER_EMAIL" = "codex-release-validation@example.invalid" ]; then
+if [ "$GIT_USER_NAME" = "Codex Release Validation" ] || \
+   [ "$GIT_USER_EMAIL" = "codex-release-validation@example.invalid" ] || \
+   [ "$GIT_USER_NAME" = "xtask hook tests" ] || \
+   [ "$GIT_USER_EMAIL" = "xtask@example.invalid" ]; then
     echo "❌ Refusing commit with placeholder git identity"
     echo "   user.name:  $GIT_USER_NAME"
     echo "   user.email: $GIT_USER_EMAIL"
@@ -1881,6 +1884,29 @@ fi
     println!("   The pre-push hook runs 'nix develop -c just ci-gate' before each push");
     println!("   Skip with: git commit --no-verify / git push --no-verify");
     Ok(0)
+}
+
+fn resolve_git_hooks_dir(repo_root: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .current_dir(repo_root)
+        .args(["rev-parse", "--git-path", "hooks"])
+        .output()
+        .with_context(|| format!("resolving git hooks dir from {}", repo_root.display()))?;
+
+    if !output.status.success() {
+        return Err(color_eyre::eyre::eyre!(
+            "git rev-parse --git-path hooks failed in {}: {}",
+            repo_root.display(),
+            String::from_utf8_lossy(&output.stderr).trim_end()
+        ));
+    }
+
+    let hooks_path = String::from_utf8(output.stdout)
+        .context("git rev-parse --git-path hooks emitted non-UTF8 output")?;
+    let hooks_path = hooks_path.trim();
+    let hooks_dir = PathBuf::from(hooks_path);
+
+    Ok(if hooks_dir.is_absolute() { hooks_dir } else { repo_root.join(hooks_dir) })
 }
 
 fn write_git_hook(hook_path: &Path, hook: &str) -> Result<()> {

--- a/xtask/src/tasks/hook_checks.rs
+++ b/xtask/src/tasks/hook_checks.rs
@@ -121,6 +121,7 @@ pub fn run_hook_tests() -> Result<()> {
         SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
     ));
     fs::create_dir_all(&temp_root).context("Failed to create temporary ops directory")?;
+    ensure_temp_repo_isolated(&root, &temp_root)?;
 
     let task_repo = temp_root.join("task-completed-repo");
     create_non_rust_test_repo(&task_repo)?;
@@ -345,10 +346,40 @@ fn create_non_rust_test_repo(path: &Path) -> Result<()> {
         .with_context(|| format!("Failed to seed temp repo {}", path.display()))?;
 
     run_git(path, &["init"])?;
-    run_git(path, &["config", "user.name", "xtask hook tests"])?;
-    run_git(path, &["config", "user.email", "xtask@example.invalid"])?;
     run_git(path, &["add", "README.md"])?;
-    run_git(path, &["commit", "-m", "seed temp repo"])?;
+    run_git(
+        path,
+        &[
+            "-c",
+            "user.name=xtask hook tests",
+            "-c",
+            "user.email=xtask@example.invalid",
+            "commit",
+            "-m",
+            "seed temp repo",
+        ],
+    )?;
+
+    Ok(())
+}
+
+fn ensure_temp_repo_isolated(project_root: &Path, temp_root: &Path) -> Result<()> {
+    let canonical_project_root = project_root
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", project_root.display()))?;
+    let canonical_temp_root = temp_root
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", temp_root.display()))?;
+
+    if canonical_temp_root.starts_with(&canonical_project_root)
+        || canonical_project_root.starts_with(&canonical_temp_root)
+    {
+        bail!(
+            "Hook test temp root {} overlaps project root {}",
+            canonical_temp_root.display(),
+            canonical_project_root.display()
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- restore the repository README after the accidental hook-test overwrite landed on master
- harden xtask hook-tests so the fixture repo cannot overlap the real checkout and so the seed commit does not persist a fake local git identity
- make perl-ci-hygiene install git hooks correctly in worktrees and block the xtask placeholder identity in pre-commit

## Validation
- cargo fmt -p xtask -p perl-ci-hygiene
- cargo xtask hook-tests
- cargo test -p perl-ci-hygiene --locked
- cargo run -p perl-ci-hygiene -- install-githooks
