### PR TITLE
chore(release): prep v0.12.1 fix-forward (#2936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No unreleased changes have been recorded yet.
 
+## [0.12.1] - 2026-03-30
+
+`v0.12.1` is the fix-forward cut after the initial public alpha release. It does
+not reopen the wider alpha scope; it closes the release-surface regressions that
+slipped into the first `v0.12.0` tag and keeps the install and publish story
+aligned.
+
+### Fixed
+
+- restored the top-level README and release-facing docs so the source snapshot
+  no longer presents hook-test fixture content as the project front page
+- hardened hook-test fixture setup so temporary repos must live outside the real
+  checkout and seed commits no longer write placeholder git identities into repo
+  config
+- fixed local git-hook installation for worktrees and added pre-commit blocking
+  for the known placeholder identities used by release and hook tests
+
+### Changed
+
+- workspace, feature-catalog, VS Code extension, and operator release surfaces
+  now target `0.12.1`
+- status and roadmap docs now treat `v0.12.0` as the latest published GitHub
+  release and `v0.12.1` as the active fix-forward cut
+
 ## [0.12.0] - 2026-03-24
 
 `v0.12.0` is the initial public alpha for the native Rust Perl 5 toolchain. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1534,21 +1534,21 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-utils"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
 ]
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-builtins"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-builtins-phf",
  "perl-tdd-support",
@@ -1556,14 +1556,14 @@ dependencies = [
 
 [[package]]
 name = "perl-builtins-phf"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "phf",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1576,11 +1576,11 @@ dependencies = [
 
 [[package]]
 name = "perl-content-length-framing"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-corpus"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-breakpoint"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser",
  "perl-tdd-support",
@@ -1642,11 +1642,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-command-args"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-dap-config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-eval"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-platform"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "perl-dap-command-args",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-security"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-shell"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-dap-command-args",
  "perl-dap-platform",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-stack"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-types"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-value"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-variables"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "once_cell",
  "perl-dap-value",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-workspace-index",
  "serde",
@@ -1744,14 +1744,14 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics-codes"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perl-edit"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "perl-error"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "perl-feature-catalog"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
  "serde",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "perl-heredoc"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -1807,11 +1807,11 @@ dependencies = [
 
 [[package]]
 name = "perl-keywords"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lexer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "memchr",
@@ -1826,14 +1826,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp-cancellation"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-capability-map"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-ids",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-actions"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast-utils",
  "perl-builtins",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-lens"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser",
  "perl-parser-core",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-color-provider"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "once_cell",
  "perl-position-tracking",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "perl-keywords",
@@ -1903,14 +1903,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion-item"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-config"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1920,14 +1920,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-critic-parser"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp-diagnostic-catalog"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-diagnostics-codes",
  "serde_json",
@@ -1935,11 +1935,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-diagnostic-types"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lsp-diagnostics"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-diagnostics-codes",
  "perl-lsp-diagnostic-types",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-highlight"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
  "perl-parser",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-links"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-import",
  "perl-module-path",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-contracts"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-flags"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-ids",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-governance"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-grid",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-grid"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-policy",
@@ -2015,11 +2015,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-ids"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lsp-feature-policy"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
@@ -2028,14 +2028,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-profile"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-contracts",
 ]
 
 [[package]]
 name = "perl-lsp-feature-profile-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-feature-policy",
  "perl-lsp-feature-profile",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-file-completion"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-completion-item",
  "perl-path-security",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-folding"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-formatting-types",
  "perl-lsp-tooling",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting-types"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2080,11 +2080,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-import-management"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lsp-inlay-hints"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-builtins",
  "perl-parser-core",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-inline-completion"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "perl-position-tracking",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-input-validation"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-launcher"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "perl-lsp-feature-governance",
@@ -2130,14 +2130,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-limits"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-navigation"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2153,14 +2153,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-on-type-formatting"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-performance"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "moka",
  "perl-parser-core",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-protocol"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-contracts",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-providers"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "nix",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rename"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-keywords",
  "perl-parser-core",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2319,14 +2319,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-selection-range"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-semantic-tokens"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2336,15 +2336,15 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-symbol-query"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lsp-text-utils"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-lsp-tooling"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-transport"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-content-length-framing",
  "perl-lsp-protocol",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-type-hierarchy"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-core",
  "perl-position-tracking",
@@ -2380,14 +2380,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-uri"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-workspace-symbols"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-symbol-query",
  "perl-module-path",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-boundary"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-path",
  "perl-module-token",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import-match"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-boundary",
  "perl-module-import",
@@ -2432,21 +2432,21 @@ dependencies = [
 
 [[package]]
 name = "perl-module-name"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-path"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-name",
 ]
 
 [[package]]
 name = "perl-module-reference"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-rename"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-import-match",
  "perl-module-path",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-resolution-path",
  "perl-module-resolution-uri",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-path"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-uri"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-boundary",
  "perl-module-name",
@@ -2512,14 +2512,14 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-token-parser"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-reference",
  "perl-module-token-core",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-normalize"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-security"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-path-normalize",
  "tempfile",
@@ -2623,18 +2623,18 @@ dependencies = [
 
 [[package]]
 name = "perl-percentile"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-pod"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
  "perl-tdd-support",
@@ -2655,14 +2655,14 @@ dependencies = [
 
 [[package]]
 name = "perl-qualified-name"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-quote"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
  "proptest",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-path",
  "perl-parser-core",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
  "thiserror",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-core",
  "perl-symbol-types",
@@ -2707,29 +2707,29 @@ dependencies = [
 
 [[package]]
 name = "perl-source-file"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-cursor"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-index"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-symbol-surface"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast",
  "perl-position-tracking",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "perl-symbol-types"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -2759,18 +2759,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-text-line"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-module-token-parser",
  "perl-tdd-support",
@@ -2779,11 +2779,11 @@ dependencies = [
 
 [[package]]
 name = "perl-token"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-tokenizer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-ast-v2",
  "perl-error",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-advanced-parsers"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-analysis"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "encoding_rs",
  "perl-tdd-support",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-heredoc-parser"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-logos-lexer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "logos",
  "perl-tdd-support",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-partial-ast"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-parser-pest",
  "perl-tdd-support",
@@ -2850,11 +2850,11 @@ dependencies = [
 
 [[package]]
 name = "perl-ts-statement-tracker"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-uri"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -2865,14 +2865,14 @@ dependencies = [
 
 [[package]]
 name = "perl-uri-classify"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "url",
 ]
 
 [[package]]
 name = "perl-workspace-discovery"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-source-file",
  "perl-workspace-ignore",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-folder"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-uri",
  "proptest",
@@ -2894,11 +2894,11 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-ignore"
-version = "0.12.0"
+version = "0.12.1"
 
 [[package]]
 name = "perl-workspace-index"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-monitoring"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "parking_lot",
  "perl-tdd-support",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-slo"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "parking_lot",
  "perl-percentile",
@@ -2936,14 +2936,14 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-state-machine"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "perllsp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -4159,7 +4159,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -306,143 +306,143 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.0" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.1" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.12.0" }
-perl-quote = { path = "crates/perl-quote", version = "0.12.0" }
-perl-edit = { path = "crates/perl-edit", version = "0.12.0" }
-perl-builtins = { path = "crates/perl-builtins", version = "0.12.0" }
-perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.12.0" }
-perl-regex = { path = "crates/perl-regex", version = "0.12.0" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.12.0" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.12.0" }
-perl-ast = { path = "crates/perl-ast", version = "0.12.0" }
-perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.0" }
-perl-error = { path = "crates/perl-error", version = "0.12.0" }
-perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.0" }
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.0" }
-perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.12.0" }
-perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.12.0" }
-perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.12.0" }
-perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.12.0" }
-perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.12.0" }
-perl-module-token = { path = "crates/perl-module-token", version = "0.12.0" }
-perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.12.0" }
-perl-module-name = { path = "crates/perl-module-name", version = "0.12.0" }
-perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.12.0" }
-perl-module-reference = { path = "crates/perl-module-reference", version = "0.12.0" }
-perl-module-import = { path = "crates/perl-module-import", version = "0.12.0" }
-perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.12.0" }
-perl-module-path = { path = "crates/perl-module-path", version = "0.12.0" }
-perl-module-rename = { path = "crates/perl-module-rename", version = "0.12.0" }
-perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.12.0" }
-perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.12.0" }
-perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.12.0" }
-perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.12.0" }
-perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.12.0" }
-perl-keywords = { path = "crates/perl-keywords", version = "0.12.0" }
-perl-source-file = { path = "crates/perl-source-file", version = "0.12.0" }
-perl-text-line = { path = "crates/perl-text-line", version = "0.12.0" }
-perl-line-index = { path = "crates/perl-line-index", version = "0.12.0" }
-perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.12.0" }
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.0" }
-perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.12.0" }
-perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.12.0" }
-perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.12.0" }
-perl-ast-utils = { path = "crates/perl-ast-utils", version = "0.12.0" }
-perl-symbol-surface = { path = "crates/perl-symbol-surface", version = "0.12.0" }
-perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.12.0" }
-perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.12.0" }
-perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.12.0" }
-perl-uri = { path = "crates/perl-uri", version = "0.12.0" }
-perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.12.0" }
-perl-percentile = { path = "crates/perl-percentile", version = "0.12.0" }
-perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.12.0" }
-perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.12.0" }
-perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.12.0" }
-perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.12.0" }
-perl-path-security = { path = "crates/perl-path-security", version = "0.12.0" }
-perl-pod = { path = "crates/perl-pod", version = "0.12.0" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.12.0" }
-perl-dap = { path = "crates/perl-dap", version = "0.12.0" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.0" }
-perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.12.0" }
-perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.12.0" }
-perl-dap-config = { path = "crates/perl-dap-config", version = "0.12.0" }
-perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.12.0" }
-perl-dap-value = { path = "crates/perl-dap-value", version = "0.12.0" }
-perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.12.0" }
-perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.12.0" }
-perl-dap-types = { path = "crates/perl-dap-types", version = "0.12.0" }
-perl-dap-security = { path = "crates/perl-dap-security", version = "0.12.0" }
-perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.12.0" }
-perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.12.0" }
-perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.12.0" }
-perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.12.0" }
-perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.12.0" }
-perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.12.0" }
+perl-token = { path = "crates/perl-token", version = "0.12.1" }
+perl-quote = { path = "crates/perl-quote", version = "0.12.1" }
+perl-edit = { path = "crates/perl-edit", version = "0.12.1" }
+perl-builtins = { path = "crates/perl-builtins", version = "0.12.1" }
+perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.12.1" }
+perl-regex = { path = "crates/perl-regex", version = "0.12.1" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.12.1" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.12.1" }
+perl-ast = { path = "crates/perl-ast", version = "0.12.1" }
+perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.1" }
+perl-error = { path = "crates/perl-error", version = "0.12.1" }
+perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.1" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.1" }
+perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.12.1" }
+perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.12.1" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.12.1" }
+perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.12.1" }
+perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.12.1" }
+perl-module-token = { path = "crates/perl-module-token", version = "0.12.1" }
+perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.12.1" }
+perl-module-name = { path = "crates/perl-module-name", version = "0.12.1" }
+perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.12.1" }
+perl-module-reference = { path = "crates/perl-module-reference", version = "0.12.1" }
+perl-module-import = { path = "crates/perl-module-import", version = "0.12.1" }
+perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.12.1" }
+perl-module-path = { path = "crates/perl-module-path", version = "0.12.1" }
+perl-module-rename = { path = "crates/perl-module-rename", version = "0.12.1" }
+perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.12.1" }
+perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.12.1" }
+perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.12.1" }
+perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.12.1" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.12.1" }
+perl-keywords = { path = "crates/perl-keywords", version = "0.12.1" }
+perl-source-file = { path = "crates/perl-source-file", version = "0.12.1" }
+perl-text-line = { path = "crates/perl-text-line", version = "0.12.1" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.12.1" }
+perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.12.1" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.1" }
+perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.12.1" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.12.1" }
+perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.12.1" }
+perl-ast-utils = { path = "crates/perl-ast-utils", version = "0.12.1" }
+perl-symbol-surface = { path = "crates/perl-symbol-surface", version = "0.12.1" }
+perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.12.1" }
+perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.12.1" }
+perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.12.1" }
+perl-uri = { path = "crates/perl-uri", version = "0.12.1" }
+perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.12.1" }
+perl-percentile = { path = "crates/perl-percentile", version = "0.12.1" }
+perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.12.1" }
+perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.12.1" }
+perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.12.1" }
+perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.12.1" }
+perl-path-security = { path = "crates/perl-path-security", version = "0.12.1" }
+perl-pod = { path = "crates/perl-pod", version = "0.12.1" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.12.1" }
+perl-dap = { path = "crates/perl-dap", version = "0.12.1" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.1" }
+perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.12.1" }
+perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.12.1" }
+perl-dap-config = { path = "crates/perl-dap-config", version = "0.12.1" }
+perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.12.1" }
+perl-dap-value = { path = "crates/perl-dap-value", version = "0.12.1" }
+perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.12.1" }
+perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.12.1" }
+perl-dap-types = { path = "crates/perl-dap-types", version = "0.12.1" }
+perl-dap-security = { path = "crates/perl-dap-security", version = "0.12.1" }
+perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.12.1" }
+perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.12.1" }
+perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.12.1" }
+perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.12.1" }
+perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.12.1" }
+perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.12.1" }
 
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.0" }
-perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.12.0" }
-perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.12.0" }
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.0" }
-perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.12.0" }
-perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.12.0" }
-perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.12.0" }
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.0" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.1" }
+perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.12.1" }
+perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.12.1" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.1" }
+perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.12.1" }
+perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.12.1" }
+perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.12.1" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.1" }
 perl-test-must = { path = "crates/perl-test-must" }
-perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.12.0" }
-perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.12.0" }
-perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.12.0" }
-perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.12.0" }
-perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.12.0" }
-perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.12.0" }
-perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.12.0" }
-perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.12.0" }
-perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.12.0" }
-perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.12.0" }
-perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.12.0" }
-perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.12.0" }
-perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.12.0" }
-perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.12.0" }
-perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.12.0" }
-perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.12.0" }
-perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.12.0" }
-perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.12.0" }
-perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.12.0" }
-perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.12.0" }
-perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.12.0" }
-perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.12.0" }
-perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.12.0" }
-perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.12.0" }
-perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.0" }
-perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.0" }
-perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.0" }
-perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.0" }
-perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.0" }
-perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.0" }
+perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.12.1" }
+perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.12.1" }
+perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.12.1" }
+perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.12.1" }
+perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.12.1" }
+perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.12.1" }
+perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.12.1" }
+perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.12.1" }
+perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.12.1" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.12.1" }
+perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.12.1" }
+perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.12.1" }
+perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.12.1" }
+perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.12.1" }
+perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.12.1" }
+perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.12.1" }
+perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.12.1" }
+perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.12.1" }
+perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.12.1" }
+perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.12.1" }
+perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.12.1" }
+perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.12.1" }
+perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.12.1" }
+perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.12.1" }
+perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.1" }
+perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.1" }
+perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.1" }
+perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.1" }
+perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.1" }
+perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.1" }
 perl-ts-heredoc-analysis = { path = "crates/perl-ts-heredoc-analysis" }
 
 # Tier 3: Two-level dependencies
-perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.12.0" }
-perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.12.0" }
-perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.12.0" }
-perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.12.0" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.0" }
-perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.12.0" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.0" }
+perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.12.1" }
+perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.12.1" }
+perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.12.1" }
+perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.12.1" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.1" }
+perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.12.1" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.1" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.0" }
-perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.12.0", default-features = false }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.1" }
+perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.12.1", default-features = false }
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.12.0" }
-perl-lsp-rs = { path = "crates/perl-lsp", version = "0.12.0" }
+perl-parser = { path = "crates/perl-parser", version = "0.12.1" }
+perl-lsp-rs = { path = "crates/perl-lsp", version = "0.12.1" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.0" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.1" }
 
 # External dependencies
 tree-sitter-perl = { path = "crates/tree-sitter-perl-rs", features = ["pure-rust"] }

--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -7,7 +7,8 @@ evidence-backed status and release facts.
 
 ## NOW
 
-- Release execution: keep `nix develop -c just ci-gate` and release receipts green while `v0.12.0` moves from version line to shipped release
+- Release execution: keep `nix develop -c just ci-gate` and release receipts green while `v0.12.1` closes the launch regressions found after `v0.12.0`
+- Packaging truth: keep `perllsp` and `perl-lsp-rs` aligned across Cargo, docs, release assets, and operator runbooks
 - Parser hardening: keep corpus ratchets honest and finish the highest-value edge-case fixes
 - Semantic coverage: land the framework-aware resolution work that blocks real project navigation
 - Docs alignment: keep README, roadmap, changelog, status, and install guidance consistent about what is already published versus what is still on `main`
@@ -26,7 +27,7 @@ evidence-backed status and release facts.
 
 ## Working Rules
 
-- Last updated: `2026-03-29`
+- Last updated: `2026-03-30`
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -127,7 +127,7 @@ git tag | grep 'v0\.12\.0'
 
 ```bash
 grep '^version' Cargo.toml | head -1
-# Expected output: version = "0.12.0"
+# Expected output: version = "0.12.1"
 ```
 
 ### 7. All publishable crate versions match
@@ -139,7 +139,7 @@ meta = json.load(sys.stdin)
 ws = set(meta["workspace_members"])
 for pkg in meta["packages"]:
     if pkg["id"] in ws:
-        if pkg["version"] != "0.12.0":
+        if pkg["version"] != "0.12.1":
             print(f"MISMATCH: {pkg[\"name\"]}@{pkg[\"version\"]}")
 '
 # Should print nothing
@@ -155,7 +155,7 @@ The release is triggered via a single manual workflow dispatch. The orchestratio
 
 ```bash
 gh workflow run release-orchestration.yml \
-  --field version=0.12.0 \
+  --field version=0.12.1 \
   --field prerelease=false \
   --field skip_crates=false \
   --field skip_extension=false \
@@ -168,7 +168,7 @@ gh workflow run release-orchestration.yml \
 2. Select **Release Orchestration** from the left sidebar.
 3. Click **Run workflow**.
 4. Fill in the fields:
-   - **Release version**: `0.12.0` (no `v` prefix)
+   - **Release version**: `0.12.1` (no `v` prefix)
    - **Mark as prerelease**: unchecked for stable releases
    - **Skip crates.io publishing**: leave unchecked
    - **Skip VSCode extension publishing**: leave unchecked
@@ -179,7 +179,7 @@ gh workflow run release-orchestration.yml \
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `version` | Release version without `v` prefix, e.g. `0.12.0` | required |
+| `version` | Release version without `v` prefix, e.g. `0.12.1` | required |
 | `prerelease` | Mark the GitHub release as a prerelease | `false` |
 | `skip_crates` | Skip crates.io publish (for re-runs after partial failure) | `false` |
 | `skip_extension` | Skip VS Code Marketplace publish | `false` |
@@ -192,7 +192,7 @@ If the release orchestration fails mid-way (e.g., crates.io succeeds but Docker 
 ```bash
 # Re-run only Docker (crates and extension already published)
 gh workflow run release-orchestration.yml \
-  --field version=0.12.0 \
+  --field version=0.12.1 \
   --field skip_crates=true \
   --field skip_extension=true \
   --field skip_docker=false
@@ -227,35 +227,35 @@ After all workflows complete, verify that each distribution channel received the
 ### 1. GitHub Release
 
 ```bash
-gh release view v0.12.0
+gh release view v0.12.1
 # Should show assets including:
-# - perl-lsp-0.12.0-x86_64-unknown-linux-gnu.tar.gz
-# - perllsp-0.12.0-aarch64-unknown-linux-gnu.tar.gz
-# - perllsp-0.12.0-x86_64-unknown-linux-musl.tar.gz
-# - perllsp-0.12.0-aarch64-unknown-linux-musl.tar.gz
-# - perllsp-0.12.0-x86_64-apple-darwin.tar.gz
-# - perllsp-0.12.0-aarch64-apple-darwin.tar.gz
-# - perllsp-0.12.0-x86_64-pc-windows-msvc.zip
+# - perllsp-0.12.1-x86_64-unknown-linux-gnu.tar.gz
+# - perllsp-0.12.1-aarch64-unknown-linux-gnu.tar.gz
+# - perllsp-0.12.1-x86_64-unknown-linux-musl.tar.gz
+# - perllsp-0.12.1-aarch64-unknown-linux-musl.tar.gz
+# - perllsp-0.12.1-x86_64-apple-darwin.tar.gz
+# - perllsp-0.12.1-aarch64-apple-darwin.tar.gz
+# - perllsp-0.12.1-x86_64-pc-windows-msvc.zip
 # - SHA256SUMS
 # - sbom-spdx.json
-# - perl-lsp-rs-0.12.0.vsix
+# - perl-lsp-rs-0.12.1.vsix
 ```
 
 ### 2. crates.io
 
 ```bash
 cargo search perllsp --limit 1
-# Expected: perllsp = "0.12.0"
+# Expected: perllsp = "0.12.1"
 
 cargo search perl-lsp-rs --limit 1
-# Expected: perl-lsp-rs = "0.12.0"
+# Expected: perl-lsp-rs = "0.12.1"
 ```
 
 ### 3. VS Code Marketplace
 
 Visit: https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs
 
-Check that the version shown is `0.12.0`.
+Check that the version shown is `0.12.1`.
 
 ### 4. Open VSX Registry
 
@@ -264,20 +264,20 @@ Visit: https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs
 ### 5. Docker images
 
 ```bash
-docker pull effortlessmetrics/perl-lsp:0.12.0
-docker run --rm effortlessmetrics/perl-lsp:0.12.0 perllsp --version
-# Expected: perllsp 0.12.0
+docker pull effortlessmetrics/perl-lsp:0.12.1
+docker run --rm effortlessmetrics/perl-lsp:0.12.1 perllsp --version
+# Expected: perllsp 0.12.1
 ```
 
 ```bash
-docker pull ghcr.io/effortlessmetrics/perl-lsp:0.12.0
+docker pull ghcr.io/effortlessmetrics/perl-lsp:0.12.1
 ```
 
 ### 6. Verify binary checksum
 
 ```bash
 # Download the Linux binary and verify its SHA256 matches the release
-gh release download v0.12.0 --pattern 'perllsp-0.12.0-x86_64-unknown-linux-gnu.tar.gz' --pattern SHA256SUMS
+gh release download v0.12.1 --pattern 'perllsp-0.12.1-x86_64-unknown-linux-gnu.tar.gz' --pattern SHA256SUMS
 sha256sum --check SHA256SUMS --ignore-missing
 ```
 
@@ -293,11 +293,11 @@ After the release merges, the corpus metrics auto-regenerate. No manual step is 
 
 ```bash
 # Delete the release (keeps the tag)
-gh release delete v0.12.0 --yes
+gh release delete v0.12.1 --yes
 
 # Delete the tag if needed
-git push origin :refs/tags/v0.12.0
-git tag -d v0.12.0
+git push origin :refs/tags/v0.12.1
+git tag -d v0.12.1
 ```
 
 ### crates.io (irreversible — yank, do not delete)
@@ -306,10 +306,13 @@ Once published to crates.io, a crate version cannot be deleted. Use `cargo yank`
 
 ```bash
 # Yank a specific crate version
-cargo yank --version 0.12.0 <crate-name>
+cargo yank --version 0.12.1 <crate-name>
 
-# Example: yank perl-lsp
-cargo yank --version 0.12.0 perl-lsp
+# Example: yank the public facade crate
+cargo yank --version 0.12.1 perllsp
+
+# Example: yank the implementation crate
+cargo yank --version 0.12.1 perl-lsp-rs
 ```
 
 The crates are published in topological order. If the workflow fails mid-way, earlier crates in the publish order are already live. Yank each published crate individually. The publish order is computed by `publish-crates.yml` from `cargo metadata`; run this to see the order:
@@ -326,8 +329,8 @@ print("\n".join(allow))
 To yank all at once after a botched release:
 
 ```bash
-# Replace 0.12.0 with the bad version
-VERSION=0.12.0
+# Replace 0.12.1 with the bad version
+VERSION=0.12.1
 cargo metadata --format-version=1 --no-deps | python3 -c '
 import json, sys
 meta = json.load(sys.stdin)
@@ -351,7 +354,7 @@ Same as VS Code Marketplace — publish a patch release to supersede.
 ```bash
 # Delete a specific tag via Docker Hub API (requires login)
 curl -X DELETE \
-  "https://hub.docker.com/v2/repositories/effortlessmetrics/perl-lsp/tags/0.12.0/" \
+  "https://hub.docker.com/v2/repositories/effortlessmetrics/perl-lsp/tags/0.12.1/" \
   -H "Authorization: Bearer <token>"
 ```
 
@@ -370,7 +373,7 @@ If `release-orchestration.yml` fails after the tag is created but before all dow
 3. If the tag was pushed but the GitHub release was not created, run `release.yml` directly:
    ```bash
    gh workflow run release.yml \
-     --field tag=v0.12.0 \
+     --field tag=v0.12.1 \
      --field prerelease=false
    ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,8 @@ project docs when you need exact release facts, receipts, or milestone detail.
 
 ## Now
 
-- Keep release validation green while `v0.12.0` moves from version line to shipped release
+- Keep release validation green while `v0.12.1` closes the launch regressions discovered after `v0.12.0`
+- Keep install guidance and package naming aligned with the actual `perllsp` / `perl-lsp-rs` surfaces
 - Raise parser and corpus confidence without hiding regressions behind broader receipts
 - Finish framework-aware semantic work for real-world Perl projects
 - Keep README, docs, changelog, and release guidance aligned so users do not have to infer the release state

--- a/crates/perl-ast-v2/Cargo.toml
+++ b/crates/perl-ast-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ast-v2"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-ast/Cargo.toml
+++ b/crates/perl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ast"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins-phf/Cargo.toml
+++ b/crates/perl-builtins-phf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins-phf"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-builtins/Cargo.toml
+++ b/crates/perl-builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-builtins"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ keywords = ["perl", "builtins", "parser", "lsp", "signatures"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.12.0" }
+perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.12.1" }
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-corpus"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-breakpoint/Cargo.toml
+++ b/crates/perl-dap-breakpoint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-breakpoint"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 # Perl parser for AST-based validation
-perl-parser = { path = "../perl-parser", version = "0.12.0" }
+perl-parser = { path = "../perl-parser", version = "0.12.1" }
 
 # Rope for position mapping
 ropey = "1.6.1"

--- a/crates/perl-dap-eval/Cargo.toml
+++ b/crates/perl-dap-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-eval"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-platform/Cargo.toml
+++ b/crates/perl-dap-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-platform"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-security/Cargo.toml
+++ b/crates/perl-dap-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-security"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-shell/Cargo.toml
+++ b/crates/perl-dap-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-shell"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-stack"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap-variables/Cargo.toml
+++ b/crates/perl-dap-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap-variables"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dap"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-dead-code"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-diagnostics-codes/Cargo.toml
+++ b/crates/perl-diagnostics-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-diagnostics-codes"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-edit/Cargo.toml
+++ b/crates/perl-edit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-edit"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-error/Cargo.toml
+++ b/crates/perl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-error"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-feature-catalog/Cargo.toml
+++ b/crates/perl-feature-catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-feature-catalog"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-heredoc/Cargo.toml
+++ b/crates/perl-heredoc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-heredoc"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-incremental-parsing"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lexer"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-capability-map"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-document-highlight/Cargo.toml
+++ b/crates/perl-lsp-document-highlight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-document-highlight"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-contracts"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-grid/Cargo.toml
+++ b/crates/perl-lsp-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-grid"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-policy"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-feature-profile/Cargo.toml
+++ b/crates/perl-lsp-feature-profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-feature-profile"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 authors = { workspace = true }

--- a/crates/perl-lsp-folding/Cargo.toml
+++ b/crates/perl-lsp-folding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-folding"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-protocol/Cargo.toml
+++ b/crates/perl-lsp-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-protocol"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-providers"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-lsp-selection-range/Cargo.toml
+++ b/crates/perl-lsp-selection-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-lsp-selection-range"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-core"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-parser-pest"
-version = "0.12.0"
+version = "0.12.1"
 publish = false
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/perl-pragma/Cargo.toml
+++ b/crates/perl-pragma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-pragma"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-quote/Cargo.toml
+++ b/crates/perl-quote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-quote"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-refactoring/Cargo.toml
+++ b/crates/perl-refactoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-refactoring"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-regex/Cargo.toml
+++ b/crates/perl-regex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-regex"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-semantic-analyzer"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-symbol-types/Cargo.toml
+++ b/crates/perl-symbol-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-symbol-types"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tdd-support"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-test-must/Cargo.toml
+++ b/crates/perl-test-must/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-test-must"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-token/Cargo.toml
+++ b/crates/perl-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-token"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-tokenizer/Cargo.toml
+++ b/crates/perl-tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-tokenizer"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-ts-advanced-parsers/Cargo.toml
+++ b/crates/perl-ts-advanced-parsers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-advanced-parsers"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Composed parser experiments for Perl"

--- a/crates/perl-ts-heredoc-analysis/Cargo.toml
+++ b/crates/perl-ts-heredoc-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-analysis"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Standalone heredoc analysis tools for Perl parsing"

--- a/crates/perl-ts-heredoc-parser/Cargo.toml
+++ b/crates/perl-ts-heredoc-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-heredoc-parser"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Heredoc parsing pipeline for Perl"

--- a/crates/perl-ts-logos-lexer/Cargo.toml
+++ b/crates/perl-ts-logos-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-logos-lexer"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Logos-based token parser for Perl"

--- a/crates/perl-ts-partial-ast/Cargo.toml
+++ b/crates/perl-ts-partial-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-partial-ast"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Partial parse and anti-pattern AST for Perl"

--- a/crates/perl-ts-statement-tracker/Cargo.toml
+++ b/crates/perl-ts-statement-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-ts-statement-tracker"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 description = "Statement boundary and heredoc context tracking for Perl tree-sitter tooling"

--- a/crates/perl-uri/Cargo.toml
+++ b/crates/perl-uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-uri"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-workspace-index"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-perl-c"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Tree-sitter Perl grammar with C scanner (legacy implementation)"

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -21,9 +21,9 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.12.0` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest published release** | `v0.11.0`, verified 2026-03-29 | GitHub Releases |
-| **Active milestone** | `v0.12.0` initial public alpha release prep | [status/index.md](status/index.md) |
+| **Workspace version line** | `v0.12.1` | [`Cargo.toml`](../../Cargo.toml) |
+| **Latest published release** | `v0.12.0`, verified 2026-03-30 | GitHub Releases |
+| **Active milestone** | `v0.12.1` fix-forward release prep | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |
 | **Test counts** | See [status/tests.md](status/tests.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -8,9 +8,9 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.12.0`
-- Latest published release: `v0.11.0` (verified 2026-03-29)
-- Active release target: `v0.12.0` initial public alpha cut
+- Workspace version line: `v0.12.1`
+- Latest published release: `v0.12.0` (verified 2026-03-30)
+- Active release target: `v0.12.1` fix-forward cut
 - Canonical local receipt: `nix develop -c just ci-gate`
 
 ## How To Read This File
@@ -19,45 +19,47 @@
 - This roadmap tells you what we are trying to land next.
 - [../../ROADMAP.md](../../ROADMAP.md) and [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) are summaries, not the canonical plan.
 
-## Current Release Target: v0.12.0 Initial Public Alpha Prep
+## Current Release Target: v0.12.1 Fix-Forward Prep
 
-`main` is already version-bumped to `v0.12.0`, but the latest published release
-is still `v0.11.0` until the final tag and publish flow complete. This roadmap
-tracks the work needed to turn that version bump into the initial public alpha
-release without documentation or packaging drift.
+`main` is now version-bumped to `v0.12.1`. The latest published GitHub release
+is `v0.12.0`, verified on 2026-03-30. This roadmap tracks the narrow
+fix-forward cut needed after the initial public alpha release so the repo front
+door, hook hygiene, and operator surfaces stay aligned with the shipped
+artifact line.
 
-Recent shipped work in the published `v0.10.x` to `v0.11.x` line:
+Recent shipped work in the published `v0.12.0` line:
 
-- Initial public-alpha packaging and marketplace preparation
-- Release orchestration and topological publish validation
-- Continued parser, workspace, and LSP microcrate extraction
-- Security hardening, validation receipts, and docs restructuring
+- Initial public alpha GitHub release with native `perllsp` assets and VSIX
+- Package rename split across `perllsp` and `perl-lsp-rs`
+- Release orchestration, topological publish validation, and launch-day docs cleanup
+- Continued parser, workspace, and LSP microcrate extraction and hardening
 
-## Active Milestone: v0.12.0 Initial Public Alpha Release Prep
+## Active Milestone: v0.12.1 Fix-Forward Release Prep
 
-This milestone is about finishing the remaining hardening work, keeping the
-receipts green, and cutting `v0.12.0` as the initial public alpha release.
+This milestone is about closing the launch regressions that surfaced right after
+`v0.12.0`, keeping the receipts green, and cutting `v0.12.1` without reopening
+the broader alpha scope.
 
 ### Main tracks
 
-- **Corpus and ratchets**: commit and ratchet the CPAN baseline, keep system/common corpus receipts green
-- **Parser robustness**: land Wave 2-4 parser fixes, keep edge-case and hang-risk suites bounded
-- **Semantic framework coverage**: Moo, Moose, Class::Accessor, `use parent` / `use base`, and export-list-aware resolution
-- **Editor and debugger hardening**: keep LSP and DAP flows solid while parser work lands
-- **Documentation and release alignment**: keep top-level docs, status, release notes, and packaging guidance aligned with the pre-tag `v0.12.0` state
+- **Release surface repair**: keep the README, release notes, install guidance,
+  and asset examples aligned with the actual `perllsp` / `perl-lsp-rs` shipped
+  surfaces
+- **Hook hygiene**: keep hook-test fixtures isolated from the real checkout and
+  block placeholder identities before they can leak into local commit metadata
+- **Packaging follow-through**: keep Cargo, VS Code, docs, and operator runbooks
+  aligned around `v0.12.1` while `v0.12.0` remains the latest published GitHub release
+- **Post-launch stability**: keep `nix develop -c just ci-gate` and the release
+  receipts green while the fix-forward cut is prepared
 
 ### Exit criteria
 
-- [ ] `.ci/cpan-corpus-baseline.json` is committed and ratcheted
-- [ ] CPAN top-1000 clean parse rate reaches `90%+`
-- [ ] Internal edge-case, parser-stress, and hang-risk suites stay green
-- [ ] No hang, crash, or stack-overflow regressions appear in corpus sweeps
-- [ ] Common corpus remains strict zero-error and only grows
-- [ ] CPAN known-clean manifest grows without regressions once seeded
-- [ ] Moo/Moose/Class::Accessor coverage reaches the maintained test targets
-- [ ] Cross-file inheritance resolution via `use parent` / `use base` lands
-- [ ] Exporter/Sub::Exporter-style export-list parsing improves semantic resolution
-- [ ] `nix develop -c just ci-gate` stays green through initial public alpha release prep
+- [ ] `Cargo.toml`, `features.toml`, and `vscode-extension/package.json` all report `0.12.1`
+- [ ] `CHANGELOG.md` contains a dated `## [0.12.1]` entry and leaves `[Unreleased]` empty
+- [ ] The top-level README and release docs no longer drift from the shipped `perllsp` asset line
+- [ ] Hook-test fixtures cannot mutate repo-local git identity or front-door files in the real checkout
+- [ ] `nix develop -c just ci-gate` stays green through the `v0.12.1` fix-forward prep
+- [ ] The `v0.12.1` release flow completes without tag, package-name, or install-surface drift
 
 ### Supporting docs
 
@@ -69,9 +71,9 @@ receipts green, and cutting `v0.12.0` as the initial public alpha release.
 
 ### Now
 
-- Raise CPAN clean-parse coverage while keeping ratchets honest
-- Finish semantic framework work needed for real-world Perl projects
-- Keep the release surface and docs aligned with the split between workspace version and latest published release
+- Close the launch regressions discovered after the `v0.12.0` tag without reopening the wider alpha scope
+- Keep package names, install guidance, and operator docs aligned with `perllsp` and `perl-lsp-rs`
+- Finish the `v0.12.1` fix-forward cut with clean release receipts and no more front-door drift
 
 ### Next
 
@@ -90,6 +92,11 @@ receipts green, and cutting `v0.12.0` as the initial public alpha release.
 ### v0.12.0
 
 Initial public alpha release across parser quality, semantic framework coverage, docs alignment, and release receipts.
+
+### v0.12.1
+
+Fix-forward release to close launch regressions in README, hook-fixture isolation,
+git-hook installation, and release-surface alignment after the initial public alpha cut.
 
 ### v0.13.0
 

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: the workspace/release target is `v0.12.0`, the latest published GitHub release is `v0.11.0` as verified on 2026-03-29, and the active milestone is `v0.12.0` initial public alpha release prep
+- **Release posture**: the latest published GitHub release is `v0.12.0` as verified on 2026-03-30, the workspace version line is `v0.12.1`, and the active milestone is `v0.12.1` fix-forward release prep
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 98 features all at GA maturity — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `bash scripts/ignored-test-count.sh` is the tracked-test-debt source
@@ -26,13 +26,11 @@
 
 ## What's Next
 
-**Now (active milestone: v0.12.0 initial public alpha release prep)**
-- Raise the CPAN top-1000 full-corpus baseline from `85.4%` (`3717/4355`) to `90%+` clean parses while keeping the strict known-clean manifest at `100%`
-- Close repo-corpus coverage gaps (`63/68` NodeKinds currently covered) and retire the remaining parser audit `P2` hang-risk candidate
-- Land Moo/Moose/Class::Accessor, `use parent`/`use base`, and export-list disambiguation work needed for public-alpha expectations
-- Raise workspace production-code coverage from the new baseline of `44.7%` lines / `46.9%` functions / `42.6%` regions
-- Burn down the residual coverage-gate blockers in `perl-parser` control-flow tests and `tree-sitter-perl-rs` parser/heredoc/glob suites
-- Keep README, roadmap, status, and release guidance aligned with the split between workspace version and published release
+**Now (active milestone: v0.12.1 fix-forward release prep)**
+- Keep `nix develop -c just ci-gate` and the release receipts green while `v0.12.1` closes the launch regressions found after the `v0.12.0` tag
+- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line and the `perl-lsp-rs` VS Code package
+- Keep public Cargo install guidance tied to what crates.io actually serves, not just the workspace version line
+- Resume parser, corpus, and semantic hardening immediately after the fix-forward release cut
 
 **Next (v0.12.x hardening)**
 - Ratchet system-corpus and CPAN baselines as parser coverage improves
@@ -66,5 +64,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-03-29 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-03-30 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -5,20 +5,20 @@
 
 ## Current Release Call
 
-**Latest published release**: `v0.11.0`
-**Release target**: `v0.12.0` initial public alpha
-**Ship readiness**: GitHub release and editor-managed install surfaces are green on `master`; public `cargo install perllsp` guidance stays off until `v0.12.0` is actually published to crates.io
+**Latest published release**: `v0.12.0`
+**Release target**: `v0.12.1` fix-forward cut
+**Ship readiness**: `master` carries the README and hook cleanup needed for a clean `v0.12.1` cut; install guidance must still stay tied to the actual GitHub release and crates.io state rather than the workspace version alone
 
 ## Active Blockers
 
-- Release-truth drift must stay closed: repo docs can say `v0.12.0` for `main`, but published-install guidance must stay tied to the latest tagged GitHub release until `v0.12.0` ships
-- Do not present `cargo install perllsp` as a shipped public install path until `v0.12.0` is live on crates.io
+- Release-truth drift must stay closed: repo docs and runbooks must match the actual `perllsp` / `perl-lsp-rs` shipped surfaces, not stale pre-rename examples
+- Public install guidance must stay tied to the crates.io truth at release time, not just the local workspace version line
 
-## Final Release Receipts (2026-03-29)
+## Fix-Forward Receipts (2026-03-30)
 
-- `just release-check` passed on merged `master`
-- `just status-check` passed after regenerating computed status docs
-- `CHANGELOG.md` already contains a dated `## [0.12.0] - 2026-03-24` section and keeps `## [Unreleased]`
+- `v0.12.0` is live on GitHub Releases as of 2026-03-30
+- the README and hook-fixture regressions from the first `v0.12.0` tag were fixed on `master`
+- this branch bumps the operator and version-sync surfaces to `v0.12.1`
 
 ## Component Summary
 
@@ -60,4 +60,4 @@ Native + Bridge preview. Harden preview flows is active work.
 
 ---
 
-*Last Updated: 2026-03-29*
+*Last Updated: 2026-03-30*

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.12.0"
+version = "0.12.1"
 lsp_version = "3.18"
 compliance_percent = 100  # 98/98 protocol features implemented, 53/53 advertised
 

--- a/man/perl-lsp.1
+++ b/man/perl-lsp.1
@@ -1,8 +1,8 @@
-.TH PERL-LSP 1 "2026-03-28" "perl-lsp 0.12.0" "Perl Language Server"
+.TH PERLLSP 1 "2026-03-30" "perllsp 0.12.1" "Perl Language Server"
 .SH NAME
-perl\-lsp \- Perl Language Server Protocol implementation
+perllsp \- Perl Language Server Protocol implementation
 .SH SYNOPSIS
-.B perl\-lsp
+.B perllsp
 .RI [ options ]
 .br
 .B perl\-lsp

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Perl Language Server extension will be documented in this file.
 
+## [0.12.1] - 2026-03-30
+
+### Fixed
+- **Release Surface Recovery**: Restored the top-level source snapshot and release-facing docs after the launch regressions that slipped into the first `0.12.0` tag.
+- **Hook Hygiene**: Hardened hook-test fixture isolation and worktree hook installation so placeholder identities do not leak into normal local commit flows.
+
+### Changed
+- **Version Bump**: 0.12.1 fix-forward release aligned with the workspace and shipped `perllsp` asset line.
+
 ## [0.12.0] - 2026-03-19
 
 ### Changed

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.0 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
+> **0.12.1 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
 
 ## Features
 
@@ -109,7 +109,7 @@ All settings are under the `perl-lsp.*` namespace. Open settings with `Ctrl+,` a
 | `perl-lsp.autoDownload` | `true` | Automatically download `perllsp` if not found locally |
 | `perl-lsp.serverPath` | `""` | Absolute path to a `perllsp` binary (overrides auto-download) |
 | `perl-lsp.channel` | `"latest"` | Release channel: `latest`, `stable`, or `tag` |
-| `perl-lsp.versionTag` | `""` | Specific release tag (e.g. `v0.12.0`) when channel is `tag` |
+| `perl-lsp.versionTag` | `""` | Specific release tag (e.g. `v0.12.1`) when channel is `tag` |
 | `perl-lsp.enableDiagnostics` | `true` | Enable real-time syntax diagnostics |
 | `perl-lsp.enableSemanticTokens` | `true` | Enable semantic syntax highlighting |
 | `perl-lsp.enableFormatting` | `true` | Enable document formatting (requires `perltidy`) |

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Fast, native Perl 5 language server: go-to-definition, completions, diagnostics, refactoring, debugging, and 98 LSP/DAP features. Zero runtime dependencies.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",
@@ -307,7 +307,7 @@
             "type": "string",
             "default": "",
             "order": 20,
-            "markdownDescription": "Specific release tag (for example `v0.12.0`) when channel is set to `tag`."
+            "markdownDescription": "Specific release tag (for example `v0.12.1`) when channel is set to `tag`."
           },
           "perl-lsp.downloadBaseUrl": {
             "type": "string",

--- a/xtask/src/tasks/prep_crates_io_launch.rs
+++ b/xtask/src/tasks/prep_crates_io_launch.rs
@@ -317,13 +317,13 @@ mod tests {
             packages: vec![
                 MetadataPackage {
                     name: "perl-parser".to_string(),
-                    version: "0.12.0".to_string(),
+                    version: "0.12.1".to_string(),
                     manifest_path: "/workspace/crates/perl-parser/Cargo.toml".to_string(),
                     publish: Some(JsonValue::Bool(true)),
                 },
                 MetadataPackage {
                     name: "perl-lexer".to_string(),
-                    version: "0.12.0".to_string(),
+                    version: "0.12.1".to_string(),
                     manifest_path: "/workspace/crates/perl-lexer/Cargo.toml".to_string(),
                     publish: Some(JsonValue::Bool(true)),
                 },
@@ -352,13 +352,13 @@ mod tests {
     fn crate_archive_path_points_to_packaged_archive_in_target_directory() {
         let package = MetadataPackage {
             name: "perl-parser".to_string(),
-            version: "0.12.0".to_string(),
+            version: "0.12.1".to_string(),
             manifest_path: "/workspace/crates/perl-parser/Cargo.toml".to_string(),
             publish: Some(JsonValue::Bool(true)),
         };
 
         let path = crate_archive_path(Path::new("/workspace/custom-target"), &package);
 
-        assert_eq!(path, Path::new("/workspace/custom-target/package/perl-parser-0.12.0.crate"));
+        assert_eq!(path, Path::new("/workspace/custom-target/package/perl-parser-0.12.1.crate"));
     }
 }


### PR DESCRIPTION
## Summary

Prepare the `v0.12.1` fix-forward cut after the initial `v0.12.0` GitHub release.

- bump the workspace, feature catalog, VS Code extension, lockfile, and operator docs to `0.12.1`
- update roadmap/status surfaces to treat `v0.12.0` as the latest published GitHub release and `v0.12.1` as the active fix-forward target
- refresh release docs, extension docs, the man page, and `prep-crates-io-launch` tests so the `perllsp` / `perl-lsp-rs` surfaces stay aligned

## Validation

- `just --shell "C:\Program Files\Git\bin\bash.exe" status-check`
- `cargo xtask check-version-sync`
- `cargo check -p perllsp --locked`
- `cargo check -p perl-lsp-rs --locked`
- `cargo test -p xtask prep_crates_io_launch --locked`
- `just --shell "C:\Program Files\Git\bin\bash.exe" ci-doc-claims`
- `just --shell "C:\Program Files\Git\bin\bash.exe" release-check`

## Release Context

As of 2026-03-30, GitHub shows `v0.12.0` as the latest published release, while the `Publish to crates.io` workflow for `v0.12.0` is still in progress. This PR prepares the fix-forward `v0.12.1` branch without rewriting or retagging `v0.12.0`.