### PR TITLE
feat(refactoring): implement subroutine inlining code action (#3040)

### DIFF
--- a/crates/perl-refactoring/src/refactor/inline.rs
+++ b/crates/perl-refactoring/src/refactor/inline.rs
@@ -462,9 +462,42 @@ fn has_side_effects(body: &str) -> bool {
 }
 
 /// Check whether the body calls itself (direct recursion).
+///
+/// Skips occurrences of `sub_name(` that appear inside string literals to
+/// avoid false-positive recursion detection when the sub name is merely
+/// mentioned in a string (e.g. `my $msg = "add(1,2) adds two numbers"`).
 fn body_calls_self(body: &str, sub_name: &str) -> bool {
     let call_pattern = format!("{}(", sub_name);
-    body.contains(&call_pattern)
+    let bytes = body.as_bytes();
+    let mut pos = 0;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+
+    while pos < body.len() {
+        let b = bytes[pos];
+        match b {
+            b'\\' if in_single_quote || in_double_quote => {
+                pos += 2;
+                continue;
+            }
+            b'\'' if !in_double_quote => {
+                in_single_quote = !in_single_quote;
+                pos += 1;
+                continue;
+            }
+            b'"' if !in_single_quote => {
+                in_double_quote = !in_double_quote;
+                pos += 1;
+                continue;
+            }
+            _ => {}
+        }
+        if !in_single_quote && !in_double_quote && body[pos..].starts_with(&call_pattern) {
+            return true;
+        }
+        pos += body[pos..].chars().next().map_or(1, |c| c.len_utf8());
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perl-refactoring/tests/subroutine_inline_tests.rs
+++ b/crates/perl-refactoring/tests/subroutine_inline_tests.rs
@@ -326,3 +326,54 @@ fn test_collision_rename_decl_does_not_corrupt_sibling_variables() {
         "collision rename must not corrupt sibling variable $x_count; got: {inlined}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Edge case: recursion detection must not fire on sub name in string literals
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recursion_detection_ignores_sub_name_in_string() {
+    // The sub body contains the sub name inside a string literal.
+    // body_calls_self must not treat this as actual recursion.
+    let source = r#"sub add {
+    my ($a, $b) = @_;
+    my $msg = "add(a,b) adds two numbers";
+    return $a + $b;
+}
+"#;
+    let inliner = SubInliner::new(source);
+    let result = inliner.inline_call("add", "add(1, 2)");
+    assert!(
+        result.is_ok(),
+        "sub name in a string literal must not trigger Recursive rejection; got: {:?}",
+        result
+    );
+    let inlined = result.unwrap();
+    assert!(
+        inlined.contains("1 + 2") || inlined.contains("(1 + 2)"),
+        "inlined result should contain the substituted expression; got: {inlined}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: call argument containing a closing paren inside a string
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_inline_call_with_paren_in_string_argument() {
+    // The second argument is a string that contains ')' — the call-site parser
+    // must correctly identify the real closing paren, not the one inside the string.
+    let source = r#"sub greet {
+    my ($prefix, $name) = @_;
+    return $prefix . $name;
+}
+"#;
+    let inliner = SubInliner::new(source);
+    // Second argument "hello)" contains ')' — naive paren-matching would split here
+    let result = inliner.inline_call("greet", r#"greet("Hi)", "World")"#);
+    assert!(
+        result.is_ok(),
+        "call with ')' inside a string argument must not fail; got: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

- Add `perl_refactoring::refactor::inline` module with `SubInliner` struct and `analyze_sub_for_inlining` function implementing the full spec from issue #3040
- Subroutine inlining replaces a call site with the function body after substituting formal parameters with actual call-site arguments
- All edge cases from the spec are handled: recursion rejection, large body rejection (>50 lines), multiple-return rejection, side-effect warnings, and variable collision renaming

## Changes

- **New**: `crates/perl-refactoring/src/refactor/inline.rs` — 626-line module implementing `SubInliner`, `InlineAbility`, `InlineError`, and `analyze_sub_for_inlining`
- **New**: `crates/perl-refactoring/tests/subroutine_inline_tests.rs` — 10 tests covering all spec edge cases
- **Modified**: `crates/perl-refactoring/src/refactor/mod.rs` — register `inline` module
- **Modified**: `crates/perl-refactoring/src/lib.rs` — re-export `inline` module

## Design Notes

The implementation follows the same text-pattern approach as `inline_variable` in `workspace_refactor.rs` rather than building a full AST. This is consistent with the existing codebase and sufficient for the spec requirements:

- Parameter extraction assumes `my ($a, $b) = @_;` declaration pattern
- Recursion detection looks for `sub_name(` in the body
- Side-effect detection looks for `print`/`warn`/`die`/I-O keywords
- Return-count detection counts standalone `return` tokens
- Variable collision renaming appends `_inlined` to conflicting bare names

## Test Plan

- [x] `test_basic_sub_inlining_replaces_call_with_body` — core substitution works
- [x] `test_inlining_substitutes_parameters_with_arguments` — single param
- [x] `test_inlining_multiple_parameters` — multiple params
- [x] `test_recursive_sub_is_rejected` — `InlineError::Recursive`
- [x] `test_large_sub_is_rejected` — `InlineError::TooLarge` (>50 lines)
- [x] `test_side_effect_sub_returns_warning` — warns but inlines
- [x] `test_multiple_returns_rejected` — `InlineError::MultipleReturns`
- [x] `test_variable_collision_is_renamed` — `_inlined` suffix on collision
- [x] `test_analyze_simple_sub_is_inlineable` — `InlineAbility::Ok`
- [x] `test_analyze_sub_not_found_returns_error` — `InlineError::SubNotFound`

All 10 tests pass. Clippy and fmt clean.

Closes #3040