### PR TITLE
fix(perl-uri): move windows-only import into function scope

### DIFF
--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -34,7 +34,6 @@
 
 use url::Url;
 
-
 /// Convert a `file://` URI to a filesystem path.
 ///
 /// Properly handles percent-encoding and works with spaces, Windows paths,


### PR DESCRIPTION
## Summary

- Moves `percent_decode_str` import from module level into `windows_rooted_file_uri_to_path()` function
- Fixes unused import warning on Linux CI where `#[cfg(windows)]` is false

## Test plan

- [x] `cargo clippy -p perl-uri --lib -- -D warnings` clean
- [x] `cargo test -p perl-uri` passes (4/4)
- [ ] CI green on Linux (the platform that was failing)