### PR TITLE
test: add missing tests for error builders, lexer modes, and error paths (#3024, #3030, #3039)

### DIFF
--- a/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
+++ b/crates/perl-lexer/tests/lexer_mode_issue_3030.rs
@@ -1,0 +1,260 @@
+//! Tests for lexer mode tracking — closes #3030
+//!
+//! Covers `LexerMode` enum properties, `is_expect_term()`, `is_expect_operator()`,
+//! copy/clone/equality semantics, and integration with the PerlLexer `set_mode` API.
+//! Fills gaps left by the existing comprehensive unit tests, specifically
+//! `is_expect_operator()` for the non-operator variants.
+
+use perl_lexer::{LexerMode, PerlLexer, TokenType};
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+// ============================================================================
+// is_expect_operator — exhaustive variant coverage
+// ============================================================================
+
+#[test]
+fn is_expect_operator_false_for_expect_delimiter() {
+    assert!(
+        !LexerMode::ExpectDelimiter.is_expect_operator(),
+        "ExpectDelimiter must not satisfy is_expect_operator"
+    );
+}
+
+#[test]
+fn is_expect_operator_false_for_in_format_body() {
+    assert!(
+        !LexerMode::InFormatBody.is_expect_operator(),
+        "InFormatBody must not satisfy is_expect_operator"
+    );
+}
+
+#[test]
+fn is_expect_operator_false_for_in_data_section() {
+    assert!(
+        !LexerMode::InDataSection.is_expect_operator(),
+        "InDataSection must not satisfy is_expect_operator"
+    );
+}
+
+#[test]
+fn is_expect_operator_true_only_for_expect_operator() {
+    let variants = [
+        (LexerMode::ExpectTerm, false),
+        (LexerMode::ExpectOperator, true),
+        (LexerMode::ExpectDelimiter, false),
+        (LexerMode::InFormatBody, false),
+        (LexerMode::InDataSection, false),
+    ];
+    for (mode, expected) in &variants {
+        assert_eq!(
+            mode.is_expect_operator(),
+            *expected,
+            "is_expect_operator() for {:?} should be {}",
+            mode,
+            expected
+        );
+    }
+}
+
+#[test]
+fn is_expect_term_false_for_expect_operator() {
+    assert!(
+        !LexerMode::ExpectOperator.is_expect_term(),
+        "ExpectOperator must not satisfy is_expect_term"
+    );
+}
+
+#[test]
+fn is_expect_term_false_for_expect_delimiter() {
+    assert!(
+        !LexerMode::ExpectDelimiter.is_expect_term(),
+        "ExpectDelimiter must not satisfy is_expect_term"
+    );
+}
+
+#[test]
+fn is_expect_term_true_only_for_expect_term() {
+    let variants = [
+        (LexerMode::ExpectTerm, true),
+        (LexerMode::ExpectOperator, false),
+        (LexerMode::ExpectDelimiter, false),
+        (LexerMode::InFormatBody, false),
+        (LexerMode::InDataSection, false),
+    ];
+    for (mode, expected) in &variants {
+        assert_eq!(
+            mode.is_expect_term(),
+            *expected,
+            "is_expect_term() for {:?} should be {}",
+            mode,
+            expected
+        );
+    }
+}
+
+// ============================================================================
+// Mutually exclusive — is_expect_term and is_expect_operator never both true
+// ============================================================================
+
+#[test]
+fn modes_term_and_operator_are_mutually_exclusive() {
+    let all_modes = [
+        LexerMode::ExpectTerm,
+        LexerMode::ExpectOperator,
+        LexerMode::ExpectDelimiter,
+        LexerMode::InFormatBody,
+        LexerMode::InDataSection,
+    ];
+    for mode in &all_modes {
+        assert!(
+            !(mode.is_expect_term() && mode.is_expect_operator()),
+            "mode {:?} must not be both expect_term and expect_operator",
+            mode
+        );
+    }
+}
+
+// ============================================================================
+// Copy / Clone / PartialEq / Eq semantics
+// ============================================================================
+
+#[test]
+fn lexer_mode_copy_semantics() {
+    // LexerMode is Copy, so assignment creates an independent copy
+    let original = LexerMode::ExpectOperator;
+    let copy = original;
+    assert_eq!(original, copy);
+    // Both are still usable after copy
+    assert!(original.is_expect_operator());
+    assert!(copy.is_expect_operator());
+}
+
+#[test]
+fn lexer_mode_clone_is_equal() {
+    for mode in &[
+        LexerMode::ExpectTerm,
+        LexerMode::ExpectOperator,
+        LexerMode::ExpectDelimiter,
+        LexerMode::InFormatBody,
+        LexerMode::InDataSection,
+    ] {
+        let cloned = *mode;
+        assert_eq!(*mode, cloned, "clone of {:?} must equal original", mode);
+    }
+}
+
+#[test]
+fn lexer_mode_different_variants_not_equal() {
+    assert_ne!(LexerMode::ExpectTerm, LexerMode::ExpectOperator);
+    assert_ne!(LexerMode::ExpectTerm, LexerMode::ExpectDelimiter);
+    assert_ne!(LexerMode::ExpectTerm, LexerMode::InFormatBody);
+    assert_ne!(LexerMode::ExpectTerm, LexerMode::InDataSection);
+    assert_ne!(LexerMode::ExpectOperator, LexerMode::ExpectDelimiter);
+    assert_ne!(LexerMode::ExpectOperator, LexerMode::InFormatBody);
+    assert_ne!(LexerMode::ExpectOperator, LexerMode::InDataSection);
+    assert_ne!(LexerMode::ExpectDelimiter, LexerMode::InFormatBody);
+    assert_ne!(LexerMode::ExpectDelimiter, LexerMode::InDataSection);
+    assert_ne!(LexerMode::InFormatBody, LexerMode::InDataSection);
+}
+
+// ============================================================================
+// Default variant is ExpectTerm
+// ============================================================================
+
+#[test]
+fn default_mode_is_expect_term() {
+    let mode = LexerMode::default();
+    assert_eq!(mode, LexerMode::ExpectTerm);
+    assert!(mode.is_expect_term());
+    assert!(!mode.is_expect_operator());
+}
+
+// ============================================================================
+// Debug format is non-empty for all variants
+// ============================================================================
+
+#[test]
+fn all_modes_have_non_empty_debug_output() {
+    let modes = [
+        LexerMode::ExpectTerm,
+        LexerMode::ExpectOperator,
+        LexerMode::ExpectDelimiter,
+        LexerMode::InFormatBody,
+        LexerMode::InDataSection,
+    ];
+    for mode in &modes {
+        let dbg = format!("{:?}", mode);
+        assert!(!dbg.is_empty(), "debug output for {:?} must be non-empty", mode);
+    }
+}
+
+// ============================================================================
+// Integration: set_mode controls slash disambiguation
+// ============================================================================
+
+#[test]
+fn set_mode_expect_operator_makes_slash_division() -> R {
+    // When mode is ExpectOperator, a leading slash is division, not regex start
+    let mut lexer = PerlLexer::new("/ 2");
+    lexer.set_mode(LexerMode::ExpectOperator);
+    let tok = lexer.next_token().ok_or("expected a token")?;
+    // Should be a Division or similar operator token, not a RegexMatch token
+    assert!(
+        !matches!(tok.token_type, TokenType::RegexMatch),
+        "with ExpectOperator mode, '/' must not start a regex; got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn set_mode_expect_term_makes_slash_regex() -> R {
+    // When mode is ExpectTerm (default), a leading slash starts a regex
+    let mut lexer = PerlLexer::new("/pattern/");
+    lexer.set_mode(LexerMode::ExpectTerm);
+    let tok = lexer.next_token().ok_or("expected a token")?;
+    assert!(
+        matches!(tok.token_type, TokenType::RegexMatch),
+        "with ExpectTerm mode, '/' must start a regex; got {:?}",
+        tok.token_type
+    );
+    Ok(())
+}
+
+#[test]
+fn mode_transitions_after_identifier() -> R {
+    // After an identifier the lexer should enter ExpectOperator mode
+    // so that the subsequent '/' is division
+    let mut lexer = PerlLexer::new("$x / 2");
+    let tokens: Vec<_> = lexer
+        .collect_tokens()
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect();
+    // We expect: Variable($x), Division(/), IntLiteral(2)
+    let has_divide = tokens.iter().any(|t| matches!(t.token_type, TokenType::Division));
+    let has_regex = tokens.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_divide, "after $x the slash must be division, not regex");
+    assert!(!has_regex, "must not produce a Regex token after an identifier");
+    Ok(())
+}
+
+#[test]
+fn mode_transitions_after_keyword_to_expect_term() -> R {
+    // After 'if' the lexer should enter ExpectTerm mode
+    // so that the following '/' starts a regex
+    let mut lexer = PerlLexer::new("if /pattern/");
+    let tokens: Vec<_> = lexer
+        .collect_tokens()
+        .into_iter()
+        .filter(|t| {
+            !matches!(t.token_type, TokenType::Whitespace | TokenType::Newline | TokenType::EOF)
+        })
+        .collect();
+    let has_regex = tokens.iter().any(|t| matches!(t.token_type, TokenType::RegexMatch));
+    assert!(has_regex, "after 'if' keyword the slash must start a regex");
+    Ok(())
+}

--- a/crates/perl-lsp-protocol/tests/error_builders_issue_3024.rs
+++ b/crates/perl-lsp-protocol/tests/error_builders_issue_3024.rs
@@ -1,0 +1,413 @@
+//! Tests for LSP error response builders — closes #3024
+//!
+//! Covers serialisation round-trips, JSON-RPC conformance, and edge cases
+//! for all public functions in `perl-lsp-protocol/src/errors.rs` that were
+//! not yet individually exercised elsewhere.
+
+use perl_lsp_protocol::*;
+use serde_json::{Value, json};
+
+// ============================================================================
+// Full JSON-RPC serialization round-trips
+// ============================================================================
+
+#[test]
+fn cancelled_response_roundtrip_produces_valid_jsonrpc() -> Result<(), Box<dyn std::error::Error>> {
+    let id = json!(42);
+    let resp = cancelled_response(&id);
+    let serialized = serde_json::to_value(&resp)?;
+
+    assert_eq!(serialized["jsonrpc"], "2.0");
+    assert_eq!(serialized["id"], 42);
+    assert_eq!(serialized["error"]["code"], REQUEST_CANCELLED);
+    assert_eq!(serialized["error"]["message"], "Request cancelled");
+    // "result" must be absent per JSON-RPC spec
+    assert!(!serialized.as_object().is_some_and(|o| o.contains_key("result")));
+    Ok(())
+}
+
+#[test]
+fn cancelled_response_with_method_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+    let id = json!("req-007");
+    let resp = cancelled_response_with_method(&id, "textDocument/completion");
+    let serialized = serde_json::to_value(&resp)?;
+
+    assert_eq!(serialized["jsonrpc"], "2.0");
+    assert_eq!(serialized["id"], "req-007");
+    assert_eq!(serialized["error"]["code"], REQUEST_CANCELLED);
+    let msg = serialized["error"]["message"].as_str().unwrap_or_default();
+    assert!(msg.contains("completion"), "message must contain provider name");
+    let data = &serialized["error"]["data"];
+    assert_eq!(data["provider"], "textDocument/completion");
+    assert!(data["timestamp"].is_number(), "timestamp must be numeric");
+    Ok(())
+}
+
+// ============================================================================
+// cancelled_response_with_method — provider name extraction logic
+// ============================================================================
+
+#[test]
+fn cancelled_response_with_method_three_segment_path() {
+    let resp = cancelled_response_with_method(&json!(1), "textDocument/semanticTokens/full/delta");
+    assert!(resp.error.is_some(), "cancelled_response_with_method must include an error");
+    if let Some(err) = resp.error.as_ref() {
+        // The last segment "delta" is extracted as the provider name
+        assert!(err.message.contains("delta"), "provider name 'delta' must appear in message");
+    }
+}
+
+#[test]
+fn cancelled_response_with_method_result_is_always_none() {
+    let resp = cancelled_response_with_method(&json!(5), "workspace/symbol");
+    assert!(resp.result.is_none(), "result must be None in cancelled response");
+}
+
+#[test]
+fn cancelled_response_with_method_data_has_request_id() {
+    let id = json!(99);
+    let resp = cancelled_response_with_method(&id, "textDocument/hover");
+    assert!(
+        resp.error.as_ref().and_then(|e| e.data.as_ref()).is_some(),
+        "data must be present in cancelled_response_with_method"
+    );
+    if let Some(data) = resp.error.as_ref().and_then(|e| e.data.as_ref()) {
+        assert_eq!(data["request_id"], id, "request_id in data must match the original id");
+    }
+}
+
+// ============================================================================
+// req_uri — INVALID_PARAMS error code in all error cases
+// ============================================================================
+
+#[test]
+fn req_uri_missing_uri_key_returns_invalid_params() {
+    let params = json!({ "textDocument": {} });
+    let result = req_uri(&params);
+    assert!(result.is_err(), "req_uri must return Err for missing URI key");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+    }
+}
+
+#[test]
+fn req_uri_array_value_returns_invalid_params() {
+    let params = json!({ "textDocument": { "uri": ["not", "a", "string"] } });
+    let result = req_uri(&params);
+    assert!(result.is_err(), "req_uri must return Err for array URI value");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+    }
+}
+
+#[test]
+fn req_uri_object_value_returns_invalid_params() {
+    let params = json!({ "textDocument": { "uri": { "nested": true } } });
+    let result = req_uri(&params);
+    assert!(result.is_err(), "req_uri must return Err for object URI value");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+    }
+}
+
+#[test]
+fn req_uri_empty_string_is_accepted() -> Result<(), Box<dyn std::error::Error>> {
+    // Empty string is a valid string value — req_uri returns it unchanged
+    let params = json!({ "textDocument": { "uri": "" } });
+    let uri = req_uri(&params)?;
+    assert_eq!(uri, "");
+    Ok(())
+}
+
+// ============================================================================
+// req_position — error message content
+// ============================================================================
+
+#[test]
+fn req_position_missing_line_error_message_names_field() {
+    let params = json!({ "position": { "character": 5 } });
+    let result = req_position(&params);
+    assert!(result.is_err(), "req_position must return Err when line is missing");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("position.line"),
+            "error message must name the missing field; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_position_missing_character_error_message_names_field() {
+    let params = json!({ "position": { "line": 0 } });
+    let result = req_position(&params);
+    assert!(result.is_err(), "req_position must return Err when character is missing");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("position.character"),
+            "error message must name the missing field; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_position_line_overflow_error_message_names_field() {
+    let over = u64::from(u32::MAX) + 1;
+    let params = json!({ "position": { "line": over, "character": 0 } });
+    let result = req_position(&params);
+    assert!(result.is_err(), "req_position must return Err when line overflows u32");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("u32"),
+            "overflow error must mention u32; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_position_character_overflow_error_message_names_field() {
+    let over = u64::from(u32::MAX) + 1;
+    let params = json!({ "position": { "line": 0, "character": over } });
+    let result = req_position(&params);
+    assert!(result.is_err(), "req_position must return Err when character overflows u32");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("u32"),
+            "overflow error must mention u32; got: {}",
+            err.message
+        );
+    }
+}
+
+// ============================================================================
+// req_range — missing individual components produce specific messages
+// ============================================================================
+
+#[test]
+fn req_range_missing_start_character_names_field() {
+    let params = json!({
+        "range": {
+            "start": { "line": 0 },
+            "end": { "line": 1, "character": 0 }
+        }
+    });
+    let result = req_range(&params);
+    assert!(result.is_err(), "req_range must return Err when start.character is missing");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("range.start.character"),
+            "error must name range.start.character; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_range_missing_end_line_names_field() {
+    let params = json!({
+        "range": {
+            "start": { "line": 0, "character": 0 },
+            "end": { "character": 0 }
+        }
+    });
+    let result = req_range(&params);
+    assert!(result.is_err(), "req_range must return Err when end.line is missing");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("range.end.line"),
+            "error must name range.end.line; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_range_overflow_start_character_error_message() {
+    let over = u64::from(u32::MAX) + 1;
+    let params = json!({
+        "range": {
+            "start": { "line": 0, "character": over },
+            "end": { "line": 0, "character": 0 }
+        }
+    });
+    let result = req_range(&params);
+    assert!(result.is_err(), "req_range must return Err when start.character overflows u32");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("u32"),
+            "overflow error must mention u32; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_range_overflow_end_character_error_message() {
+    let over = u64::from(u32::MAX) + 1;
+    let params = json!({
+        "range": {
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": 0, "character": over }
+        }
+    });
+    let result = req_range(&params);
+    assert!(result.is_err(), "req_range must return Err when end.character overflows u32");
+    if let Err(err) = result {
+        assert_eq!(err.code, INVALID_PARAMS);
+        assert!(
+            err.message.contains("u32"),
+            "overflow error must mention u32; got: {}",
+            err.message
+        );
+    }
+}
+
+#[test]
+fn req_range_zero_range_is_valid() -> Result<(), Box<dyn std::error::Error>> {
+    // A zero-length range (start == end) is valid per LSP spec
+    let params = json!({
+        "range": {
+            "start": { "line": 5, "character": 3 },
+            "end": { "line": 5, "character": 3 }
+        }
+    });
+    let ((sl, sc), (el, ec)) = req_range(&params)?;
+    assert_eq!((sl, sc), (5, 3));
+    assert_eq!((el, ec), (5, 3));
+    Ok(())
+}
+
+// ============================================================================
+// Error builder — no-data contracts
+// ============================================================================
+
+#[test]
+fn method_not_found_has_no_data() {
+    let err = method_not_found("some/method");
+    assert!(err.data.is_none(), "method_not_found must not include data field");
+}
+
+#[test]
+fn method_not_advertised_has_no_data() {
+    let err = method_not_advertised();
+    assert!(err.data.is_none(), "method_not_advertised must not include data field");
+}
+
+#[test]
+fn server_not_initialized_has_no_data() {
+    let err = server_not_initialized();
+    assert!(err.data.is_none(), "server_not_initialized must not include data field");
+}
+
+#[test]
+fn invalid_params_has_no_data() {
+    let err = invalid_params("test");
+    assert!(err.data.is_none(), "invalid_params must not include data field");
+}
+
+#[test]
+fn internal_error_has_no_data() {
+    let err = internal_error("test");
+    assert!(err.data.is_none(), "internal_error must not include data field");
+}
+
+#[test]
+fn connection_closed_error_has_no_data() {
+    let err = connection_closed_error();
+    assert!(err.data.is_none(), "connection_closed_error must not include data field");
+}
+
+#[test]
+fn transport_error_has_no_data() {
+    let err = transport_error("some I/O failure");
+    assert!(err.data.is_none(), "transport_error must not include data field");
+}
+
+// ============================================================================
+// Error builder — JSON serialisation produces correct field names
+// ============================================================================
+
+#[test]
+fn error_json_fields_use_correct_names() -> Result<(), Box<dyn std::error::Error>> {
+    let err = internal_error("boom");
+    let v: Value = serde_json::to_value(&err)?;
+    assert!(v.as_object().is_some_and(|o| o.contains_key("code")));
+    assert!(v.as_object().is_some_and(|o| o.contains_key("message")));
+    Ok(())
+}
+
+#[test]
+fn transport_error_serialises_code_and_message() -> Result<(), Box<dyn std::error::Error>> {
+    let err = transport_error("disk full");
+    let v: Value = serde_json::to_value(&err)?;
+    assert_eq!(v["code"], TRANSPORT_ERROR);
+    assert_eq!(v["message"], "disk full");
+    Ok(())
+}
+
+// ============================================================================
+// document_not_found_error — value structure
+// ============================================================================
+
+#[test]
+fn document_not_found_error_is_object() {
+    let v = document_not_found_error();
+    assert!(v.is_object(), "document_not_found_error must return a JSON object");
+}
+
+#[test]
+fn document_not_found_error_message_is_string() {
+    let v = document_not_found_error();
+    assert!(v["message"].is_string(), "document_not_found_error message field must be a string");
+}
+
+// ============================================================================
+// enhanced_error — server_info sub-fields
+// ============================================================================
+
+#[test]
+fn enhanced_error_server_info_has_name() {
+    let err = enhanced_error(INTERNAL_ERROR, "test", "TestError", None);
+    assert!(err.data.is_some(), "enhanced_error must include data");
+    if let Some(data) = err.data.as_ref() {
+        let name = data["server_info"]["name"].as_str().unwrap_or_default();
+        assert!(!name.is_empty(), "server_info.name must be non-empty");
+    }
+}
+
+#[test]
+fn enhanced_error_server_info_has_version() {
+    let err = enhanced_error(INTERNAL_ERROR, "test", "TestError", None);
+    assert!(err.data.is_some(), "enhanced_error must include data");
+    if let Some(data) = err.data.as_ref() {
+        let version = data["server_info"]["version"].as_str().unwrap_or_default();
+        assert!(!version.is_empty(), "server_info.version must be non-empty");
+    }
+}
+
+#[test]
+fn enhanced_error_error_type_field_matches_input() {
+    let err = enhanced_error(INTERNAL_ERROR, "msg", "CustomErrorKind", None);
+    assert!(err.data.is_some(), "enhanced_error must include data");
+    if let Some(data) = err.data.as_ref() {
+        assert_eq!(data["error_type"], "CustomErrorKind");
+    }
+}
+
+#[test]
+fn enhanced_error_with_method_stores_full_method_path() {
+    let err = enhanced_error(METHOD_NOT_FOUND, "nope", "MethodNotFound", Some("$/progress"));
+    assert!(err.data.is_some(), "enhanced_error must include data");
+    if let Some(data) = err.data.as_ref() {
+        assert_eq!(data["method"], "$/progress");
+    }
+}

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -1686,4 +1686,138 @@ mod tests {
 
         Ok(())
     }
+
+    // =========================================================================
+    // Error-path tests — closes #3039
+    //
+    // These tests verify that each handler correctly propagates INVALID_PARAMS
+    // errors when required LSP parameters are missing.  They use Result<()>
+    // returns and explicit Err-branch assertions rather than #[should_panic].
+    // =========================================================================
+
+    /// handle_did_close with no textDocument.uri must return INVALID_PARAMS.
+    #[test]
+    fn handle_did_close_missing_uri_returns_invalid_params() {
+        let server = LspServer::new();
+        let result = server.handle_did_close(Some(json!({ "textDocument": {} })));
+        assert!(result.is_err(), "handle_did_close must error on missing URI");
+        if let Err(err) = result {
+            assert_eq!(
+                err.code,
+                crate::protocol::INVALID_PARAMS,
+                "error code must be INVALID_PARAMS; got {}",
+                err.code
+            );
+            assert!(
+                err.message.contains("textDocument.uri"),
+                "error message must name the missing field; got: {}",
+                err.message
+            );
+        }
+    }
+
+    /// handle_did_close with None params must succeed silently (no-op).
+    #[test]
+    fn handle_did_close_none_params_is_ok() {
+        let server = LspServer::new();
+        let result = server.handle_did_close(None);
+        assert!(result.is_ok(), "handle_did_close with None params must not error");
+    }
+
+    /// handle_did_close for a non-existent URI must succeed silently.
+    #[test]
+    fn handle_did_close_unknown_uri_is_ok() {
+        let server = LspServer::new();
+        let result = server.handle_did_close(Some(
+            json!({ "textDocument": { "uri": "file:///never_opened.pl" } }),
+        ));
+        assert!(result.is_ok(), "closing a document that was never opened must not error");
+    }
+
+    /// handle_did_save with no textDocument.uri must return INVALID_PARAMS.
+    #[test]
+    fn handle_did_save_missing_uri_returns_invalid_params() {
+        let server = LspServer::new();
+        let result = server.handle_did_save(Some(json!({ "textDocument": {} })));
+        assert!(result.is_err(), "handle_did_save must error on missing URI");
+        if let Err(err) = result {
+            assert_eq!(
+                err.code,
+                crate::protocol::INVALID_PARAMS,
+                "error code must be INVALID_PARAMS; got {}",
+                err.code
+            );
+        }
+    }
+
+    /// handle_did_save with None params must succeed silently (no-op).
+    #[test]
+    fn handle_did_save_none_params_is_ok() {
+        let server = LspServer::new();
+        let result = server.handle_did_save(None);
+        assert!(result.is_ok(), "handle_did_save with None params must not error");
+    }
+
+    /// did_open with a missing textDocument.text field must return INVALID_PARAMS.
+    #[test]
+    fn did_open_missing_text_returns_invalid_params() {
+        let server = LspServer::new();
+        let result = server.did_open(json!({
+            "textDocument": {
+                "uri": "file:///missing_text.pl",
+                "languageId": "perl",
+                "version": 1
+            }
+        }));
+        assert!(result.is_err(), "did_open must error when textDocument.text is absent");
+        if let Err(err) = result {
+            assert_eq!(
+                err.code,
+                crate::protocol::INVALID_PARAMS,
+                "error code must be INVALID_PARAMS; got {}",
+                err.code
+            );
+        }
+    }
+
+    /// did_open with a missing textDocument.uri field must return INVALID_PARAMS.
+    #[test]
+    fn did_open_missing_uri_returns_invalid_params() {
+        let server = LspServer::new();
+        let result = server.did_open(json!({
+            "textDocument": {
+                "languageId": "perl",
+                "version": 1,
+                "text": "my $x = 1;\n"
+            }
+        }));
+        assert!(result.is_err(), "did_open must error when textDocument.uri is absent");
+        if let Err(err) = result {
+            assert_eq!(
+                err.code,
+                crate::protocol::INVALID_PARAMS,
+                "error code must be INVALID_PARAMS; got {}",
+                err.code
+            );
+        }
+    }
+
+    /// handle_did_change with missing URI must return INVALID_PARAMS.
+    #[test]
+    fn handle_did_change_missing_uri_returns_invalid_params() {
+        let server = LspServer::new();
+        let result = server.handle_did_change(Some(json!({
+            "textDocument": {},
+            "contentChanges": []
+        })));
+        assert!(result.is_err(), "handle_did_change with missing URI must error");
+        if let Err(err) = result {
+            assert_eq!(
+                err.code,
+                crate::protocol::INVALID_PARAMS,
+                "error code must be INVALID_PARAMS; got {}",
+                err.code
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **#3024** (perl-lsp-protocol): 33 tests for LSP error response builder functions covering JSON-RPC roundtrips, provider name extraction, INVALID_PARAMS error codes, no-data contracts, and enhanced_error server_info sub-fields
- **#3030** (perl-lexer): 17 tests for `LexerMode` enum — fills the gap of `is_expect_operator()` not being tested for `InFormatBody`, `InDataSection`, and `ExpectDelimiter` variants; also covers copy/clone semantics, mutual exclusivity, default variant, and slash disambiguation integration
- **#3039** (perl-lsp): 8 inline error-path tests in `text_sync::tests` covering `handle_did_close`, `handle_did_save`, `did_open`, and `handle_did_change` with missing URI and None-params scenarios

## Changes

- `crates/perl-lsp-protocol/tests/error_builders_issue_3024.rs` (new, 33 tests) — external test file for error builder functions
- `crates/perl-lexer/tests/lexer_mode_issue_3030.rs` (new, 17 tests) — external test file for LexerMode enum
- `crates/perl-lsp/src/runtime/text_sync.rs` (+134 lines) — 8 error-path tests appended to the existing `#[cfg(test)] mod tests` block

## Evidence

- **Commits**: 1
- **Tests**: 21/21 text_sync::tests, 33/33 error_builders, 17/17 lexer_mode — all green
- **Lint**: `cargo clippy -p perl-lsp-protocol --tests` and `-p perl-lexer --tests` both clean
- **Files**: 3 changed, +807/-0 lines

## Test Plan

```bash
export CARGO_TARGET_DIR="/tmp/test-cov"
cargo test -p perl-lsp-protocol                          # 33 new tests in error_builders_issue_3024
cargo test -p perl-lexer                                 # 17 new tests in lexer_mode_issue_3030
RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs "text_sync::tests" -- --test-threads=2  # 21 tests (8 new)
```

## Unknowns

- `is_expect_operator()` for a hypothetical 6th `LexerMode` variant would require updating the exhaustive table test — intentional, acts as a guard
- The `handle_did_change` None-params path isn't explicitly tested (the function signature may require `Some(...)`) — the missing-URI case is covered
- Pre-existing clippy errors in `perl-lsp-rs` (in `lsp_harness.rs`, `test_utils.rs`, `implementation_provider.rs`, `misc.rs`) are unrelated to this PR and pre-date these changes

Closes #3024, #3030, #3039