### PR TITLE
docs(features): catalog strict/warnings and unreachable-code diagnostics (#3093)

### DIFF
--- a/features.toml
+++ b/features.toml
@@ -208,6 +208,33 @@ tests = ["tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
 
 [[feature]]
+id = "lsp.diagnostic.missing_strict"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/strict_warnings_tests.rs"]
+description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.missing_warnings"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/strict_warnings_tests.rs"]
+description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.unreachable_code"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
+
+[[feature]]
 id = "lsp.diagnostic.unused_variable"
 spec = "perl-lsp"
 area = "text_document"


### PR DESCRIPTION
## Summary

- Adds 3 features.toml entries for diagnostics that are implemented but not catalogued:
  - `lsp.diagnostic.missing_strict` (PL100) — missing `use strict`
  - `lsp.diagnostic.missing_warnings` (PL101) — missing `use warnings`
  - `lsp.diagnostic.unreachable_code` (PL406) — dead code after return/die/exit

Closes #3093, closes #3094.

## Test plan

- [ ] `just status-check` passes with updated feature count
- [ ] features.toml is valid TOML