### PR TITLE
fix(ci): fix pipeline-labels race condition on reviewed-deep (#3089)

### DIFF
--- a/.github/workflows/pipeline-labels.yml
+++ b/.github/workflows/pipeline-labels.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, labeled]
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, labeled]
   pull_request_review:
     types: [submitted]
 
@@ -45,46 +45,81 @@ jobs:
             });
 
   auto-label-approved:
-    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    # Fires on PR approval OR when the reviewed-deep label is added.
+    # The label path handles the race where reviewer-deep adds the label after
+    # the reviewer has already approved (webhook fired before label was present).
+    if: |
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'reviewed-deep')
     runs-on: ubuntu-latest
     steps:
       - name: Label PR as merge-ready on approval
         uses: actions/github-script@v7
         with:
           script: |
-            // Only add merge-ready if reviewed-deep label is present.
-            // This enforces the two-pass review pipeline (reviewer + reviewer-deep).
+            // Only add merge-ready if reviewed-deep label is present AND the PR
+            // has been approved. This enforces the two-pass review pipeline.
             // If reviewed-deep is missing, add needs-deep-review instead and wait.
+            // When triggered by the reviewed-deep label being added, we also need
+            // to verify the PR has an approval — fetch reviews to check.
+            // pull_request_review events carry payload.pull_request;
+            // pull_request labeled events also carry payload.pull_request.
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : null;
+            if (!prNumber) return;
+
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              pull_number: prNumber,
             });
             const prLabels = pr.data.labels.map(l => l.name);
+
             if (!prLabels.includes('reviewed-deep')) {
               // Flag for deep review - do not merge without reviewer-deep sign-off
               if (!prLabels.includes('needs-deep-review')) {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
+                  issue_number: prNumber,
                   labels: ['needs-deep-review'],
                 });
               }
               return; // Do not add merge-ready until reviewer-deep has signed off
             }
-            // reviewed-deep is present - proceed to merge-ready
+
+            // When triggered by label event, verify at least one approval exists.
+            if (context.eventName === 'pull_request') {
+              const reviews = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              const hasApproval = reviews.data.some(r => r.state === 'APPROVED');
+              if (!hasApproval) return; // Not yet approved — wait for the review event
+            }
+
+            // reviewed-deep is present and PR is approved - proceed to merge-ready
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: prNumber,
                 name: 'in-review'
+              });
+            } catch (e) { /* label might not exist */ }
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: 'needs-deep-review'
               });
             } catch (e) { /* label might not exist */ }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               labels: ['merge-ready']
             });


### PR DESCRIPTION
## Summary

Fixes the race condition in `pipeline-labels.yml` where the `auto-label-approved` job fires on `pull_request_review` but the `reviewed-deep` label hasn't been applied yet (reviewer approves first, then the reviewer-deep agent adds the label).

- Add `labeled` to the `pull_request` trigger types so the workflow re-fires when any label is added to a PR
- Update the `auto-label-approved` job condition to also trigger when the `reviewed-deep` label is added (`pull_request.labeled` event with `label.name == 'reviewed-deep'`)
- When triggered by the label event, fetch PR reviews to verify at least one approval exists before adding `merge-ready` (prevents early `merge-ready` if label is added before approval)
- Also clean up `needs-deep-review` when transitioning to `merge-ready` (was missing before)

## Root cause

The race: reviewer approves → webhook fires → workflow reads labels → `reviewed-deep` not yet present → adds `needs-deep-review`. Then reviewer-deep adds label, but the workflow doesn't re-fire, so `merge-ready` is never added automatically.

The fix makes the workflow self-healing: when `reviewed-deep` is added (regardless of order), the workflow fires again and if an approval already exists, adds `merge-ready`.

## Test plan

- [ ] Verify YAML structure is valid (no syntax errors)
- [ ] Confirm the `auto-label-approved` job condition correctly gates on both review approval and `reviewed-deep` label event
- [ ] Confirm label-before-approve path (reviewer-deep adds label, then reviewer approves) still works via the existing `pull_request_review` path
- [ ] Confirm approve-before-label path (reviewer approves, then reviewer-deep adds label) now works via the new `pull_request.labeled` path

Closes #3089