### PR TITLE
docs(economics): session analysis with quality-honest assessment (#3076)

### DIFF
--- a/docs/articles/research/SESSION_ECONOMICS_2026_04_02.md
+++ b/docs/articles/research/SESSION_ECONOMICS_2026_04_02.md
@@ -4,6 +4,7 @@
 **Duration**: ~5 hours (single session, ongoing)
 **Model**: Claude Opus 4.6 (1M context)
 **Operator**: Steven Zimmerman (orchestrator)
+**Session type**: Normal Claude Code run — not a special swarm event. Agent calls were natural parallelism for a release cleanup task that grew organically into multi-release build-out. This is roughly what a typical productive session looks like.
 
 ---
 
@@ -127,21 +128,36 @@ The blockers.yaml staleness is the most expensive: it caused the roadmap to plan
 
 **Implication**: Automated staleness detection for status files (corpus baselines, blocker ledgers, feature catalogs) would prevent this class of waste. Issue #2026 (automate corpus ratchet) addresses the parser baseline; similar automation for blockers.yaml would help.
 
-### 4. Targeted Deployment Beats Mass Parallelism
+### 4. This Was a Normal Session, Not a Swarm Event
 
-Comparing to session 6 (2026-03-22):
+This was not an orchestrated 200-agent swarm deployment. It was a normal Claude Code session — the user asked to do release cleanup, it naturally grew into multi-release planning, and agents were called as a normal tool for parallelizing independent work. The ~30 agents were spawned in 3 natural waves, not pre-planned.
 
-| Metric | Session 6 | This session | Ratio |
-|--------|-----------|-------------|-------|
+Comparing to session 6 (2026-03-22), which was a deliberate mass-swarm:
+
+| Metric | Session 6 (mass swarm) | This session (normal run) | Ratio |
+|--------|----------------------|--------------------------|-------|
 | Agents deployed | 200+ | ~30 | 0.15x |
 | PRs merged | 59 | 22 | 0.37x |
 | Weekly budget | 8% | 9% | 1.1x |
 | PRs per agent | 0.30 | 0.73 | 2.4x |
 | Bugs caught pre-merge | 0 (not tracked) | 4 | — |
+| Session type | Deliberate orchestrated swarm | Organic normal session | — |
 
-This session used 85% fewer agents but achieved 2.4x higher per-agent yield. The difference: full pipeline coverage (scout → plan-review → build → two-pass review → merge) vs. mass builder deployment with lighter review.
+The normal session had 2.4x higher PRs-per-agent, but **PRs-per-agent is a throughput metric, not a quality metric.** This session merged multiple PRs on smoke-green without the full merge gate. The swarm session enforced `just ci-gate` on every PR. Higher throughput with lower gate enforcement is not necessarily higher yield — it may just be lower standards.
 
-Mass parallelism maximizes throughput when the work queue is well-defined and pre-validated. Targeted deployment maximizes quality and avoids waste when the work queue contains stale items.
+Honest comparison:
+
+| Dimension | Session 6 (swarm) | This session (normal) | Better? |
+|-----------|-------------------|----------------------|---------|
+| Throughput (PRs) | 59 | 22 | Swarm |
+| Agent efficiency (PRs/agent) | 0.30 | 0.73 | Normal (but see quality) |
+| CI gate enforcement | Full (`just ci-gate`) | Partial (smoke only) | Swarm |
+| Bugs caught pre-merge | Not tracked | 4 | Normal (deep review) |
+| Bugs shipped (unknown) | Unknown | Likely higher | Swarm (stricter gates) |
+
+**The real question is: how many of these 22 PRs would have passed `just ci-gate`?** We don't know, because we didn't run it. The deep review pipeline caught 4 text-pattern bugs that CI wouldn't have, but CI catches type errors, API breakage, and integration failures that deep review doesn't.
+
+**Implication**: PRs-per-agent is a vanity metric without quality adjustment. A fairer comparison would be *trusted PRs per unit of budget* — but that requires knowing whether the merged PRs are actually correct, which we won't know until the next CI run or user report.
 
 ### 5. The Orchestrator's Primary Job Is Routing, Not Building
 


### PR DESCRIPTION
Replaces #3098/#3099 with corrected analysis. Includes quality concerns (merged-red), counterintuitive insights, and honest throughput-vs-quality comparison.