### PR TITLE
feat(distribution): automate Windows package manager updates (#2596)

### DIFF
--- a/.github/workflows/chocolatey-bump.yml
+++ b/.github/workflows/chocolatey-bump.yml
@@ -69,9 +69,9 @@ jobs:
           $assetDir = Join-Path $env:RUNNER_TEMP 'choco-assets'
 
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
-          Write-Host "Downloading perl-lsp-$version-x86_64-pc-windows-msvc.zip..."
+          Write-Host "Downloading perllsp-$version-x86_64-pc-windows-msvc.zip..."
           gh release download $tag `
-            --pattern "perl-lsp-$version-x86_64-pc-windows-msvc.zip" `
+            --pattern "perllsp-$version-x86_64-pc-windows-msvc.zip" `
             --dir $assetDir
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
         run: |
           $version = "${{ steps.tag.outputs.version }}"
           $assetDir = Join-Path $env:RUNNER_TEMP 'choco-assets'
-          $assetPath = Join-Path $assetDir "perl-lsp-$version-x86_64-pc-windows-msvc.zip"
+          $assetPath = Join-Path $assetDir "perllsp-$version-x86_64-pc-windows-msvc.zip"
 
           $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $assetPath).Hash.ToLowerInvariant()
           "sha256=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/.github/workflows/scoop-bump.yml
+++ b/.github/workflows/scoop-bump.yml
@@ -69,9 +69,9 @@ jobs:
           $assetDir = Join-Path $env:RUNNER_TEMP 'scoop-assets'
 
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
-          Write-Host "Downloading perl-lsp-$version-x86_64-pc-windows-msvc.zip..."
+          Write-Host "Downloading perllsp-$version-x86_64-pc-windows-msvc.zip..."
           gh release download $tag `
-            --pattern "perl-lsp-$version-x86_64-pc-windows-msvc.zip" `
+            --pattern "perllsp-$version-x86_64-pc-windows-msvc.zip" `
             --dir $assetDir
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
         run: |
           $version = "${{ steps.tag.outputs.version }}"
           $assetDir = Join-Path $env:RUNNER_TEMP 'scoop-assets'
-          $assetPath = Join-Path $assetDir "perl-lsp-$version-x86_64-pc-windows-msvc.zip"
+          $assetPath = Join-Path $assetDir "perllsp-$version-x86_64-pc-windows-msvc.zip"
 
           $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $assetPath).Hash.ToLowerInvariant()
           "sha256=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/.github/workflows/winget-bump.yml
+++ b/.github/workflows/winget-bump.yml
@@ -70,9 +70,9 @@ jobs:
           $assetDir = Join-Path $env:RUNNER_TEMP 'winget-assets'
 
           New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
-          Write-Host "Downloading perl-lsp-$version-x86_64-pc-windows-msvc.zip..."
+          Write-Host "Downloading perllsp-$version-x86_64-pc-windows-msvc.zip..."
           gh release download $tag `
-            --pattern "perl-lsp-$version-x86_64-pc-windows-msvc.zip" `
+            --pattern "perllsp-$version-x86_64-pc-windows-msvc.zip" `
             --dir $assetDir
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
         run: |
           $version = "${{ steps.tag.outputs.version }}"
           $assetDir = Join-Path $env:RUNNER_TEMP 'winget-assets'
-          $assetPath = Join-Path $assetDir "perl-lsp-$version-x86_64-pc-windows-msvc.zip"
+          $assetPath = Join-Path $assetDir "perllsp-$version-x86_64-pc-windows-msvc.zip"
 
           $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $assetPath).Hash.ToLowerInvariant()
           "sha256=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/distribution/windows/update-manifests.ps1
+++ b/distribution/windows/update-manifests.ps1
@@ -15,7 +15,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
-$releaseZipUrl = "$RepositoryUrl/releases/download/v$Version/perl-lsp-$Version-x86_64-pc-windows-msvc.zip"
+$releaseZipUrl = "$RepositoryUrl/releases/download/v$Version/perllsp-$Version-x86_64-pc-windows-msvc.zip"
 
 function Resolve-RepoPath {
   param([Parameter(Mandatory = $true)][string]$RelativePath)
@@ -50,7 +50,7 @@ if ($ScoopManifestPath) {
     $content = [regex]::Replace($content, '"version":\s*"[^"]+"', ('"version": "' + $Version + '"'), 1)
     $content = [regex]::Replace(
       $content,
-      '"url":\s*"https://github\.com/EffortlessMetrics/perl-lsp/releases/download/v[^"]+/perl-lsp-[^"]+-x86_64-pc-windows-msvc\.zip"',
+      '"url":\s*"https://github\.com/EffortlessMetrics/perl-lsp/releases/download/v[^"]+/perllsp-[^"]+-x86_64-pc-windows-msvc\.zip"',
       ('"url": "' + $releaseZipUrl + '"'),
       1
     )


### PR DESCRIPTION
## Summary

- Fix filename mismatch in all three Windows package manager bump workflows: `release.yml` packages the Windows binary as `perllsp-{version}-x86_64-pc-windows-msvc.zip` (note `perllsp-` prefix), but `scoop-bump.yml`, `chocolatey-bump.yml`, and `winget-bump.yml` were all downloading `perl-lsp-{version}-*.zip` (wrong `perl-lsp-` prefix), causing every release bump to fail silently with a missing asset error.
- Fix the `$releaseZipUrl` construction and Scoop URL regex in `distribution/windows/update-manifests.ps1` to use the correct `perllsp-` prefix, aligning the update script with the actual release artifact names.

## Root cause

The binary rename from `perl-lsp` to `perllsp` (PR #2936) updated `release.yml` to package as `perllsp-*` but the three bump workflows and the manifest update script were not updated in lockstep.

## Files changed

- `.github/workflows/scoop-bump.yml` — fix download pattern and asset path
- `.github/workflows/chocolatey-bump.yml` — fix download pattern and asset path
- `.github/workflows/winget-bump.yml` — fix download pattern and asset path
- `distribution/windows/update-manifests.ps1` — fix `$releaseZipUrl` construction and Scoop URL regex

## Test plan

- [ ] Verify `release.yml` packages as `perllsp-{version}-x86_64-pc-windows-msvc.zip` (confirmed in `release.yml` line 164)
- [ ] Verify `scoop-bump.yml` now downloads `perllsp-{version}-x86_64-pc-windows-msvc.zip`
- [ ] Verify `chocolatey-bump.yml` now downloads `perllsp-{version}-x86_64-pc-windows-msvc.zip`
- [ ] Verify `winget-bump.yml` now downloads `perllsp-{version}-x86_64-pc-windows-msvc.zip`
- [ ] Verify `update-manifests.ps1` constructs URL with `perllsp-` prefix
- [ ] Workflow dispatch test on next release tag

Closes #2596