### PR TITLE
feat(distribution): Docker image with perl-lsp and Perl runtime (#2083)

### DIFF
--- a/.docker/perl-lsp/Dockerfile
+++ b/.docker/perl-lsp/Dockerfile
@@ -1,0 +1,67 @@
+# perl-lsp Docker image — Perl runtime + perllsp LSP server
+#
+# Stage 1: Build the perllsp binary from source
+# Stage 2: Minimal runtime image with Perl installed
+#
+# Usage (stdio LSP transport):
+#   docker run --rm -i -v "${PWD}:/workspace" ghcr.io/effortlessmetrics/perl-lsp:latest-perl
+#
+# Build locally:
+#   docker build -f .docker/perl-lsp/Dockerfile -t perl-lsp:local .
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 1: builder
+# ─────────────────────────────────────────────────────────────────────────────
+FROM rust:1.85-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy workspace manifests first for layer-cache efficiency.
+# We copy the full tree because the workspace has 130+ crates; selective
+# copy would be fragile and rarely faster.
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo/ ./.cargo/
+COPY crates/ ./crates/
+COPY xtask/ ./xtask/
+
+# Build the public perllsp binary in release mode.
+RUN cargo build -p perllsp --release --bin perllsp
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2: runtime
+# ─────────────────────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Perl runtime + common CPAN modules useful for real projects.
+# cpanminus bootstraps further module installs inside the container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    perl \
+    perl-modules-5.36 \
+    libmoose-perl \
+    cpanminus \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the compiled LSP server binary.
+COPY --from=builder /build/target/release/perllsp /usr/local/bin/perllsp
+
+RUN chmod +x /usr/local/bin/perllsp
+
+# Non-root user for safety.
+RUN useradd --create-home --uid 10001 --shell /bin/bash appuser
+
+# Default workspace mount point — callers bind-mount their Perl project here.
+RUN mkdir -p /workspace && chown appuser:appuser /workspace
+
+WORKDIR /workspace
+USER appuser
+
+# LSP communicates via stdin/stdout — no port exposure needed.
+# Pass --help to see available options.
+ENTRYPOINT ["perllsp"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build ${{ matrix.platform }}
+    name: Build builder image (${{ matrix.platform }})
     runs-on: ubuntu-24.04
     needs: init
     timeout-minutes: 30
@@ -104,6 +104,60 @@ jobs:
           provenance: true
           sbom: true
 
+  build-perl-runtime:
+    name: Build perl-lsp runtime image (${{ matrix.platform }})
+    runs-on: ubuntu-24.04
+    needs: init
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-perl
+          tags: |
+            type=raw,value=${{ needs.init.outputs.version }}
+            type=raw,value=${{ needs.init.outputs.major_minor }}
+            type=raw,value=${{ needs.init.outputs.major }}
+            type=raw,value=latest
+
+      - name: Build and push perl-lsp runtime image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .docker/perl-lsp/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event.inputs.push != 'false' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
   publish-dockerhub:
     name: Publish to Docker Hub
     runs-on: ubuntu-24.04
@@ -138,7 +192,7 @@ jobs:
             type=raw,value=${{ needs.init.outputs.major }}
             type=raw,value=latest
 
-      - name: Build and push multi-arch
+      - name: Build and push multi-arch (builder image)
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -152,9 +206,56 @@ jobs:
           provenance: true
           sbom: true
 
+  publish-dockerhub-perl:
+    name: Publish perl-lsp runtime to Docker Hub
+    runs-on: ubuntu-24.04
+    needs: init
+    timeout-minutes: 60
+    if: github.event.inputs.push != 'false'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta-perl
+        uses: docker/metadata-action@v6
+        with:
+          images: effortlessmetrics/perl-lsp
+          tags: |
+            type=raw,value=${{ needs.init.outputs.version }}-perl
+            type=raw,value=${{ needs.init.outputs.major_minor }}-perl
+            type=raw,value=latest-perl
+
+      - name: Build and push multi-arch (perl-lsp runtime image)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .docker/perl-lsp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-perl.outputs.tags }}
+          labels: ${{ steps.meta-perl.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
   summary:
     name: Summary
-    needs: [build, publish-dockerhub]
+    needs: [build, build-perl-runtime, publish-dockerhub, publish-dockerhub-perl]
     runs-on: ubuntu-24.04
     if: always()
 
@@ -167,18 +268,21 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Docker Images Published :whale:" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Images Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Platforms**: linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Images" >> $GITHUB_STEP_SUMMARY
+          echo "### Builder image (Rust CI)" >> $GITHUB_STEP_SUMMARY
           echo "- \`ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`effortlessmetrics/perl-lsp:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`effortlessmetrics/perl-lsp:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Runtime image (perllsp + Perl)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`ghcr.io/${{ github.repository }}-perl:${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`effortlessmetrics/perl-lsp:${{ steps.version.outputs.version }}-perl\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Usage" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "docker run --rm -v \${PWD}:/workspace effortlessmetrics/perl-lsp:${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "# Run LSP server with your project mounted (stdio transport)" >> $GITHUB_STEP_SUMMARY
+          echo "docker run --rm -i -v \"\${PWD}:/workspace\" effortlessmetrics/perl-lsp:${{ steps.version.outputs.version }}-perl" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# docker-compose.yml — local testing for the perl-lsp Docker image
+#
+# Usage:
+#   docker compose build                         # build the image
+#   docker compose run --rm perl-lsp             # run LSP server (stdio)
+#   docker compose run --rm perl-lsp --version   # print version
+#
+# The container mounts the current directory as /workspace so perllsp
+# can index your Perl project's files.
+
+services:
+  perl-lsp:
+    build:
+      context: .
+      dockerfile: .docker/perl-lsp/Dockerfile
+    image: perl-lsp:local
+    # stdin_open + tty false = bare stdio transport (standard LSP mode)
+    stdin_open: true
+    tty: false
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+        read_only: true
+    # Override the entrypoint for quick smoke tests, e.g.:
+    #   docker compose run --rm perl-lsp --version
+    # command: ["--version"]


### PR DESCRIPTION
## Summary

- Add `.docker/perl-lsp/Dockerfile` — multi-stage build: `rust:1.85-slim-bookworm` builder stage compiles the `perllsp` binary; `debian:bookworm-slim` runtime stage installs Perl (5.36) + `libmoose-perl` + `cpanminus`.
- Add `docker-compose.yml` for local smoke testing with workspace bind-mount.
- Extend `.github/workflows/docker-publish.yml` with two new jobs (`build-perl-runtime` and `publish-dockerhub-perl`) that build and publish the runtime image under the `-perl` tag suffix.

Existing builder-image jobs, tags, and behavior are unchanged.

## Usage

```bash
# Build locally
docker build -f .docker/perl-lsp/Dockerfile -t perl-lsp:local .

# Run LSP server (stdio transport)
docker run --rm -i -v "${PWD}:/workspace" perl-lsp:local

# Local compose
docker compose build
docker compose run --rm perl-lsp --version
```

## Published images

- `effortlessmetrics/perl-lsp:<version>-perl` — runtime image (perllsp + Perl)
- `ghcr.io/effortlessmetrics/perl-lsp-perl:<version>` — GHCR runtime image

## Test plan

- [ ] `docker build -f .docker/perl-lsp/Dockerfile -t perl-lsp:test .` succeeds (builds both stages)
- [ ] `docker run --rm perl-lsp:test --version` prints version
- [ ] `docker compose build` succeeds
- [ ] `docker compose run --rm perl-lsp --version` succeeds
- [ ] Workflow dispatch with `push: false` triggers both build jobs without publishing
- [ ] Workflow YAML is valid (no syntax errors)

Closes #2083