### PR TITLE
feat(dap): cross-platform continue and interrupt signal handling (#3028)

### DIFF
--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -86,7 +86,7 @@ perl-feature-catalog = { workspace = true }
 nix = { version = "0.31.1", features = ["signal"] }  # For SIGINT handling (AC9)
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["processthreadsapi"] }  # For Ctrl+C (AC9)
+winapi = { version = "0.3.9", features = ["processthreadsapi", "wincon"] }  # For Ctrl+C and GenerateConsoleCtrlEvent (AC9, #3028)
 
 [features]
 default = ["dap-phase1", "dap-phase2", "dap-phase3"]

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1632,4 +1632,46 @@ mod tests {
         }
         Ok(())
     }
+
+    // --- Signal handling tests (#3028) ---
+
+    #[test]
+    fn test_send_continue_signal_does_not_panic_on_pid_1() {
+        // PID 1 on Unix is init (EPERM), on Windows GenerateConsoleCtrlEvent returns 0.
+        // Must not panic on any platform.
+        let adapter = DebugAdapter::new();
+        let _ = adapter.send_continue_signal(1);
+    }
+
+    #[test]
+    fn test_send_interrupt_signal_does_not_panic_on_pid_1() {
+        let adapter = DebugAdapter::new();
+        let _ = adapter.send_interrupt_signal(1);
+    }
+
+    #[test]
+    fn test_send_continue_signal_pid_zero_returns_false() {
+        let adapter = DebugAdapter::new();
+        assert!(!adapter.send_continue_signal(0));
+    }
+
+    #[test]
+    fn test_send_interrupt_signal_pid_zero_returns_false() {
+        let adapter = DebugAdapter::new();
+        assert!(!adapter.send_interrupt_signal(0));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_send_continue_signal_nonexistent_pid_returns_false() {
+        let adapter = DebugAdapter::new();
+        assert!(!adapter.send_continue_signal(999_999));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_send_interrupt_signal_nonexistent_pid_returns_false() {
+        let adapter = DebugAdapter::new();
+        assert!(!adapter.send_interrupt_signal(999_999));
+    }
 }

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -1242,85 +1242,126 @@ impl DebugAdapter {
         }
     }
 
-    /// Send continue/resume signal to process (Unix only)
-    #[allow(unused_variables)]
+    /// Send continue/resume signal to process.
+    ///
+    /// On Unix, sends SIGCONT. On Windows there is no direct equivalent of SIGCONT
+    /// for externally-attached processes; the function returns `false` and logs a
+    /// structured warning. Note that `handle_continue` emits the DAP `continued`
+    /// event unconditionally, so the client will not be left in a stuck state even
+    /// when this returns `false`.
     pub(super) fn send_continue_signal(&self, pid: u32) -> bool {
+        if pid == 0 {
+            tracing::warn!("send_continue_signal called with pid 0, ignoring");
+            return false;
+        }
         #[cfg(unix)]
         {
-            let pid = pid as i32;
-            match signal::kill(Pid::from_raw(pid), Signal::SIGCONT) {
+            let pid_i = pid as i32;
+            match signal::kill(Pid::from_raw(pid_i), Signal::SIGCONT) {
                 Ok(()) => {
-                    eprintln!("Sent SIGCONT to process {}", pid);
+                    tracing::info!("Sent SIGCONT to process {}", pid);
                     true
                 }
                 Err(e) => {
-                    eprintln!("Failed to send SIGCONT to process {}: {}", pid, e);
-                    false
-                }
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            eprintln!("Continue signal not supported on this platform");
-            false
-        }
-    }
-
-    /// Send interrupt signal to process (cross-platform)
-    #[allow(unused_variables)] // pid unused on non-unix/non-windows platforms (e.g., wasm32)
-    pub(super) fn send_interrupt_signal(&self, pid: u32) -> bool {
-        #[cfg(unix)]
-        {
-            let pid = pid as i32;
-            match signal::kill(Pid::from_raw(pid), Signal::SIGINT) {
-                Ok(()) => {
-                    eprintln!("Sent SIGINT to process {}", pid);
-                    true
-                }
-                Err(e) => {
-                    eprintln!("Failed to send SIGINT to process {}: {}", pid, e);
+                    tracing::warn!("Failed to send SIGCONT to process {}: {}", pid, e);
                     false
                 }
             }
         }
         #[cfg(windows)]
         {
-            // On Windows, we use TerminateProcess or send Ctrl+C event
-            // For Perl debugger, we can try sending input directly
+            // Windows has no direct SIGCONT equivalent for external processes.
+            // The caller (handle_continue) emits the continued event regardless.
+            tracing::warn!(
+                "send_continue_signal: SIGCONT not available on Windows for pid {}",
+                pid
+            );
+            false
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            tracing::warn!("send_continue_signal: unsupported platform for pid {}", pid);
+            false
+        }
+    }
+
+    /// Send interrupt signal to process (cross-platform).
+    ///
+    /// On Unix, sends SIGINT. On Windows, tries `GenerateConsoleCtrlEvent` first
+    /// (works when the target is in the same console group), then falls back to
+    /// writing the interrupt character to debugger stdin (session mode only).
+    /// Returns `false` on unsupported platforms.
+    pub(super) fn send_interrupt_signal(&self, pid: u32) -> bool {
+        if pid == 0 {
+            tracing::warn!("send_interrupt_signal called with pid 0, ignoring");
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            let pid_i = pid as i32;
+            match signal::kill(Pid::from_raw(pid_i), Signal::SIGINT) {
+                Ok(()) => {
+                    tracing::info!("Sent SIGINT to process {}", pid);
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to send SIGINT to process {}: {}", pid, e);
+                    false
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            use winapi::um::wincon::{CTRL_C_EVENT, GenerateConsoleCtrlEvent};
+            // Try GenerateConsoleCtrlEvent first (works for processes in same console group).
+            let result = unsafe { GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid) };
+            if result != 0 {
+                tracing::info!("Sent Ctrl+C event to process {}", pid);
+                return true;
+            }
+            tracing::warn!(
+                "GenerateConsoleCtrlEvent failed for pid {}, trying stdin fallback",
+                pid
+            );
+
+            // Fallback: write interrupt character to debugger stdin (session mode only).
             if let Some(ref mut session) = *lock_or_recover(&self.session, "debug_adapter.session")
             {
                 if let Some(stdin) = session.process.stdin.as_mut() {
-                    // Send interrupt character (Ctrl+C equivalent in Perl debugger)
                     match stdin.write_all(b"\x03\n") {
                         Ok(()) => {
                             let _ = stdin.flush();
-                            eprintln!("Sent interrupt signal to Perl debugger on process {}", pid);
+                            tracing::info!("Sent interrupt via stdin to process {}", pid);
                             true
                         }
                         Err(e) => {
-                            eprintln!("Failed to send interrupt to process {}: {}", pid, e);
-                            // Fallback: try to kill the process
+                            tracing::error!("Failed to send interrupt to process {}: {}", pid, e);
                             if Self::terminate_child_process(&mut session.process) {
-                                eprintln!("Terminated process {} as fallback", pid);
+                                tracing::warn!("Terminated process {} as fallback", pid);
                                 session.state = DebugState::Terminated;
                                 true
                             } else {
-                                eprintln!("Failed to terminate process {}", pid);
+                                tracing::error!("Failed to terminate process {}", pid);
                                 false
                             }
                         }
                     }
                 } else {
-                    eprintln!("No stdin handle for process {}", pid);
+                    tracing::warn!("No stdin handle for process {}", pid);
                     false
                 }
             } else {
+                // attached_pid mode: GenerateConsoleCtrlEvent was already attempted above.
+                tracing::warn!(
+                    "GenerateConsoleCtrlEvent failed and no session active for pid {}",
+                    pid
+                );
                 false
             }
         }
         #[cfg(not(any(unix, windows)))]
         {
-            eprintln!("Interrupt signal not supported on this platform");
+            tracing::warn!("send_interrupt_signal: unsupported platform for pid {}", pid);
             false
         }
     }


### PR DESCRIPTION
## Summary

- Add pid-0 guard to both `send_continue_signal` and `send_interrupt_signal` — prevents accidental signal dispatch to pid 0 (would target every process in the process group on Unix)
- Replace all `eprintln!` calls in signal functions with `tracing::{info,warn,error}` — aligns with coding standards and respects log level configuration
- Split `#[cfg(not(unix))]` in `send_continue_signal` into explicit `#[cfg(windows)]` + `#[cfg(not(any(unix, windows)))]` arms with structured warnings
- Add `GenerateConsoleCtrlEvent` (winapi `wincon` feature) to the Windows `send_interrupt_signal` path — tries the console event first (works for processes in same console group), falls back to stdin write, then terminate
- Cover the `attached_pid` mode gap: previously the Windows path silently returned `false` when no session was active; now it logs a structured warning explaining why
- Add `wincon` to winapi features in `Cargo.toml`
- Add 6 unit tests: no-panic on pid 1 (cross-platform), pid-zero returns false (cross-platform), nonexistent pid returns false (`#[cfg(unix)]` only — `GenerateConsoleCtrlEvent` cannot be integration-tested on Linux CI)

## Test plan

- [ ] `cargo build -p perl-dap` — clean build on Windows (winapi wincon feature)
- [ ] `cargo test -p perl-dap --lib` — 110 tests pass (106 existing + 4 new cross-platform signal tests)
- [ ] `cargo clippy -p perl-dap -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` — no warnings
- [ ] GitHub CI green (Linux: 6 tests run including the 2 `#[cfg(unix)]` nonexistent-pid tests)

Closes #3028