### PR TITLE
docs: large-workspace testing and profiling guide (#3022)

### DIFF
--- a/docs/large-workspaces/MEMORY_PATTERNS.md
+++ b/docs/large-workspaces/MEMORY_PATTERNS.md
@@ -1,0 +1,243 @@
+# Memory Patterns for Large Workspaces
+
+This document describes how memory grows with workspace size, which
+components hold the most memory, and how to reduce usage without
+sacrificing correctness.
+
+---
+
+## Memory Scaling Overview
+
+From the `WorkspaceIndex` module documentation:
+
+> Memory usage: ~1MB per 10K symbols with optimized storage.
+
+At the cache defaults (`CacheConfig::default`):
+
+| Cache          | Max items | Max bytes | Notes                          |
+|----------------|-----------|-----------|--------------------------------|
+| AST node cache | 10 000    | 50 MB     | Evicted LRU when limit reached |
+| Symbol cache   | 50 000    | 30 MB     | Most frequently accessed       |
+| Workspace cache | 1 000    | 20 MB     | Per-file metadata              |
+
+The index itself stores two `HashMap` entries per symbol (qualified name
+`Package::sub` and bare name `sub`), each holding a `Location` value
+(URI + `Range`). At 64-bit pointers:
+
+- ~100 bytes per symbol entry (key string + location struct + hash overhead)
+- 50 000 symbols -> ~5 MB for the index tables alone
+- At 10 000 files with 5 subs each -> ~50 000 symbols -> ~5 MB index
+
+The dominant cost for large workspaces is therefore the **AST cache**, not
+the symbol tables.
+
+---
+
+## WorkspaceIndex Memory Scaling
+
+### Symbol Count Projections
+
+| Workspace files | Avg. subs/file | Total symbols | Approx. index RAM |
+|-----------------|----------------|---------------|-------------------|
+| 100             | 5              | 500           | ~50 KB            |
+| 1 000           | 5              | 5 000         | ~500 KB           |
+| 5 000           | 5              | 25 000        | ~2.5 MB           |
+| 10 000          | 5              | 50 000        | ~5 MB             |
+| 50 000          | 5              | 250 000       | ~25 MB            |
+
+These figures are for the index tables only. Add AST cache and document
+store on top.
+
+### What Holds Memory After Indexing
+
+1. **Symbol HashMap** (`qualified_index`, `bare_index`) — proportional to
+   symbol count; bounded by `IndexResourceLimits::max_total_symbols`.
+2. **AST cache** (`BoundedLruCache`) — caches parsed ASTs; bounded by
+   `CacheConfig::max_items` and `CacheConfig::max_bytes`.
+3. **DocumentStore** — holds the raw text of open documents; bounded by
+   the number of open editor tabs, not workspace size.
+4. **Reference index** — stores back-references from symbol to use sites;
+   grows faster than definitions.
+
+---
+
+## AST Cache Behavior
+
+The `BoundedLruCache` in `crates/perl-workspace-index/src/workspace/cache.rs`
+uses an LRU eviction policy:
+
+- **Hit**: Returns the cached AST; touches the entry to mark it recently
+  used.
+- **Miss**: Parses the file on demand; inserts the new AST, evicting the
+  least-recently-used entry if either `max_items` or `max_bytes` is
+  exceeded.
+- **TTL**: Optional. If set, entries expire regardless of access pattern.
+  Useful for preventing stale ASTs after external file changes.
+
+### When ASTs Are Cached
+
+An AST is cached when `index_file` is called and the result is retained
+by the `ProductionIndexCoordinator`. The cache is queried first; if the
+file's content has not changed (same text hash), the existing AST is
+returned without re-parsing.
+
+### When ASTs Are Evicted
+
+- The cache exceeds `max_items` (default 10 000).
+- The cache exceeds `max_bytes` (default 50 MB).
+- `DocumentStore::update` is called with new content (content change
+  invalidates the cache entry for that URI).
+- The coordinator receives a workspace invalidation signal.
+
+### Tuning the AST Cache
+
+In the LSP configuration (`perllsp.json` or editor settings):
+
+```json
+{
+  "perl": {
+    "limits": {
+      "astCacheMaxEntries": 2000,
+      "astCacheMaxBytes": 10485760
+    }
+  }
+}
+```
+
+Lower values reduce peak memory; higher values reduce re-parse latency.
+For a 5 000-file workspace where most files fit in memory, 5 000 entries
+with 25 MB is a reasonable sweet spot.
+
+---
+
+## Common Memory Anti-Patterns
+
+### 1. Unbounded String Duplication
+
+**Pattern**: Cloning `String` values from the symbol table into every
+caller.
+
+**Consequence**: At 50 000 symbols, returning `Vec<String>` from
+`find_symbols` allocates thousands of copies per query.
+
+**Fix**: Return `&str` references, `Arc<str>`, or `Cow<str>` from symbol
+lookup functions. The symbol table keys are already `String` values owned
+by the index; returning a reference avoids the copy entirely.
+
+### 2. Holding All Symbols in a `Vec` for Filtering
+
+**Pattern**: `index.all_symbols().into_iter().filter(|s| s.contains(q))`
+
+**Consequence**: Forces all symbols into a temporary `Vec` before
+filtering, even if only a handful match.
+
+**Fix**: Use the `find_symbols` prefix query, which filters inside the
+index before allocating the result set. The index is already sorted in
+a way that supports prefix scanning.
+
+### 3. Circular References via `Arc`
+
+**Pattern**: `Arc<WorkspaceIndex>` inside a `DocumentStore` that is also
+inside `WorkspaceIndex`.
+
+**Consequence**: Neither side is ever dropped; both leak indefinitely.
+
+**Fix**: Use `Weak<T>` for back-references. The `ProductionIndexCoordinator`
+owns both; individual components should not own each other.
+
+### 4. Retaining Stale File Content
+
+**Pattern**: `DocumentStore` never calling `close` for files removed from
+the workspace.
+
+**Consequence**: Raw text for deleted files accumulates in memory.
+
+**Fix**: Send `textDocument/didClose` notifications from the editor, or
+wire a file-watcher that calls `DocumentStore::close` on `fs::remove`.
+
+---
+
+## Memory Optimization Techniques
+
+### Capacity Hints
+
+When you know the workspace size upfront, pre-allocate the symbol table:
+
+```rust
+// Future API — not yet on WorkspaceIndex, but demonstrates the pattern
+let index = WorkspaceIndex::with_capacity(
+    50_000,  // expected symbol count
+    10_000,  // expected file count
+);
+```
+
+This avoids incremental `HashMap` resize storms during initial indexing.
+
+### `Arc<str>` for Repeated String Keys
+
+If the same package name appears in thousands of symbols, interning the
+package prefix under an `Arc<str>` reduces allocations:
+
+```rust
+use std::sync::Arc;
+
+// Instead of:
+let key = format!("{}::{}", package, name);
+
+// Consider:
+let pkg: Arc<str> = Arc::from(package);
+let key = format!("{}::{}", pkg, name);
+// Arc<str> clones share the heap allocation
+```
+
+For heavier deduplication, a string-interning crate such as `string_cache`
+or `lasso` reduces per-symbol memory further.
+
+### Weak References for Back-Pointers
+
+```rust
+use std::sync::{Arc, Weak};
+
+struct WorkspaceIndex {
+    coordinator: Weak<ProductionIndexCoordinator>, // not Arc
+    ...
+}
+```
+
+### Memory-Mapped File Reading
+
+For very large workspaces, reading each file with `mmap` rather than
+`fs::read_to_string` avoids copying the entire file content into heap
+memory before parsing. This is a significant change and should be
+benchmarked carefully.
+
+---
+
+## Monitoring Memory in Production
+
+The `SloTracker` records request latencies but not memory. To monitor
+memory at runtime:
+
+```bash
+# Check RSS of the running LSP server
+ps -o pid,rss,comm -p $(pgrep perllsp)
+
+# Detailed per-mapping view
+cat /proc/$(pgrep perllsp)/smaps_rollup
+```
+
+For continuous monitoring, the `--health` flag prints index statistics
+including estimated symbol count, which correlates with memory:
+
+```bash
+perllsp --health
+```
+
+---
+
+## See Also
+
+- `TESTING_GUIDE.md` — generating workspaces to trigger these patterns
+- `PROFILING_GUIDE.md` — measuring actual allocation with heaptrack
+- `TROUBLESHOOTING.md` — diagnosing memory growth in a running server
+- `docs/how-to/PERFORMANCE_TUNING.md` — configuration knobs for memory limits

--- a/docs/large-workspaces/PROFILING_GUIDE.md
+++ b/docs/large-workspaces/PROFILING_GUIDE.md
@@ -1,0 +1,265 @@
+# Profiling Guide for Contributors
+
+Step-by-step instructions for identifying where time is spent in the LSP
+server and workspace indexer. Read this before filing a performance-related
+issue or submitting a performance fix.
+
+---
+
+## Tool Overview
+
+| Tool | What it measures | Platform |
+|------|-----------------|----------|
+| `cargo criterion` | Statistical micro-benchmarks | All |
+| `cargo flamegraph` | CPU time, call-tree | Linux/macOS |
+| `heaptrack` | Heap allocations and lifetimes | Linux |
+| `DHAT` (via Valgrind) | Heap profiling | Linux |
+| `samply` | CPU sampling, works on macOS | macOS |
+| `perf` + `hotspot` | CPU sampling | Linux |
+
+Start with criterion because it requires no extra tooling and is already
+integrated. Move to flamegraph or heaptrack when you need to understand
+_where_ inside the hot path allocations or CPU time accumulate.
+
+---
+
+## Quick Start: Criterion Benchmarks
+
+The workspace index has a benchmark suite in
+`crates/perl-workspace-index/benches/workspace_index_benchmark.rs`.
+
+```bash
+# Run all benchmarks and save results
+just bench
+
+# Quick smoke test (~30s)
+just bench-quick
+
+# Compare against saved baseline
+just bench-compare
+
+# Strict mode: fail if regression detected
+just bench-compare-strict
+```
+
+To run a single benchmark by name:
+
+```bash
+cargo bench -p perl-workspace-index --features workspace \
+    -- "initial index small workspace"
+```
+
+Criterion writes HTML reports to `target/criterion/`. Open
+`target/criterion/report/index.html` in a browser to inspect the
+violin plots and regression analysis.
+
+---
+
+## CPU Profiling with Flamegraph
+
+### Linux
+
+```bash
+# Install once
+cargo install flamegraph
+# Some distributions also need: apt install linux-perf / pacman -S perf
+
+# Run the workspace index benchmark under flamegraph
+CARGO_PROFILE_RELEASE_DEBUG=true \
+cargo flamegraph -p perl-workspace-index \
+    --features workspace \
+    --bench workspace_index_benchmark \
+    -- --bench
+
+# Open the SVG
+xdg-open flamegraph.svg
+```
+
+### macOS
+
+`cargo flamegraph` calls `dtrace` on macOS. It usually requires `sudo`:
+
+```bash
+sudo cargo flamegraph -p perl-workspace-index \
+    --features workspace \
+    --bench workspace_index_benchmark \
+    -- --bench
+```
+
+Alternatively, use `samply`:
+
+```bash
+cargo install samply
+samply record cargo bench -p perl-workspace-index --features workspace \
+    -- --bench
+# samply opens a browser-based flamechart automatically
+```
+
+### Reading the Flamegraph
+
+- Wide bars = high cumulative CPU time
+- Look for unexpected depth in `WorkspaceIndex::index_file` or
+  `WorkspaceIndex::find_symbols`
+- `parking_lot::RwLock` contention shows as `lock_contended` or
+  `futex_wait` in the stacks
+
+---
+
+## Memory Profiling with Heaptrack
+
+Heaptrack traces every allocation and shows heap usage over time. It is
+available on Linux via most package managers.
+
+```bash
+# Install
+apt install heaptrack heaptrack-gui  # Debian/Ubuntu
+# or build from source: https://github.com/KDE/heaptrack
+
+# Build with debug symbols
+CARGO_PROFILE_RELEASE_DEBUG=true cargo build \
+    -p perl-workspace-index --release
+
+# Run the LSP server under heaptrack while exercising a large workspace
+heaptrack ./target/release/perllsp --stdio < /dev/null
+# OR: attach a profiling harness binary
+
+# Open the GUI
+heaptrack_gui heaptrack.perllsp.*.gz
+```
+
+For a more focused view, write a small harness binary that indexes a
+synthetic workspace and exits:
+
+```rust
+// bin/heaptrack-harness.rs (temporary, not committed)
+use perl_workspace_index::workspace_index::WorkspaceIndex;
+use std::fs;
+use tempfile::TempDir;
+use url::Url;
+
+fn main() {
+    let dir = TempDir::new().unwrap();
+    let index = WorkspaceIndex::new();
+    for i in 0..10_000 {
+        let path = dir.path().join(format!("m{i}.pm"));
+        let src = format!("package M{i};\nsub s_{i} {{}}\n1;\n");
+        fs::write(&path, &src).unwrap();
+        let uri = Url::from_file_path(&path).unwrap();
+        index.index_file(uri, src).ok();
+    }
+    eprintln!("Done indexing {} files", 10_000);
+}
+```
+
+The heaptrack GUI shows:
+- Total allocated bytes over time
+- Leaked allocations at exit
+- Peak heap usage
+- Per-call-stack allocation counts
+
+---
+
+## Profiling a Specific LSP Handler
+
+To profile one handler (e.g., `workspace/symbol`), use the LSP integration
+tests with a large fixture and a timing wrapper:
+
+```bash
+# Enable trace logging to measure handler latency
+RUST_LOG=perl_lsp=trace cargo test -p perl-lsp-rs \
+    -- workspace_symbol --nocapture 2>&1 | grep "handler.*ms"
+```
+
+For systematic measurement, add a `Span` around the handler under test and
+read the output from the SLO tracker:
+
+```rust
+// In your test — use the re-export path from workspace::mod
+use perl_workspace_index::workspace::{OperationResult, OperationType, SloConfig, SloTracker};
+use std::sync::Arc;
+
+let tracker = Arc::new(SloTracker::new(SloConfig::default()));
+let start = tracker.start_operation(OperationType::WorkspaceSymbol);
+let _ = coordinator.find_symbols("query");
+tracker.record_operation(start, OperationResult::Success);
+let stats = tracker.statistics(OperationType::WorkspaceSymbol);
+println!("stats = {stats:?}");
+```
+
+---
+
+## Common Bottlenecks and How to Spot Them
+
+### HashMap Resize Storms
+
+`WorkspaceIndex` uses `HashMap` for its symbol tables. When many files are
+indexed in rapid succession, the maps may resize repeatedly.
+
+**Symptom**: `std::collections::hash_map::resize` appears wide in the
+flamegraph during `index_file` calls.
+
+**Mitigation**: Pre-allocate with `HashMap::with_capacity`. When you know
+the approximate symbol count upfront (e.g., from a previous run stored in
+the state machine), pass it to `WorkspaceIndex::with_capacity`.
+
+### Clone vs. Borrow
+
+String cloning shows as `alloc::string::String::clone` in the flamegraph.
+
+**Where to look**: The symbol extraction pass in `workspace_index.rs` builds
+`String` keys for every symbol. If you see many clones in this path, audit
+whether an `Arc<str>` or a string-interning pass would help.
+
+### Async Task Overhead
+
+The LSP server dispatches handler tasks via Tokio. In a large workspace,
+the `workspace/symbol` handler may spawn many subtasks.
+
+**Symptom**: `tokio::runtime::task::harness` appears repeatedly at the top
+of flamegraph stacks for short-lived futures.
+
+**Mitigation**: Batch sub-queries inside a single task rather than spawning
+one per file.
+
+### Lock Contention
+
+`WorkspaceIndex` uses `parking_lot::RwLock`. If many threads try to take a
+write lock simultaneously (e.g., during parallel indexing), they queue up.
+
+**Symptom**: `parking_lot::raw_rwlock::RawRwLock::lock_exclusive` appears
+in the flamegraph alongside `futex_wait`.
+
+**Mitigation**: Reduce write-lock scope; prefer coarse-grained batch writes
+over per-symbol locking.
+
+---
+
+## Interpreting Criterion Output
+
+Criterion prints:
+
+```
+initial index small workspace (5 files)
+                        time:   [1.2345 ms 1.2567 ms 1.2789 ms]
+                        change: [-3.4512% -1.2345% +0.8765%] (p = 0.21 > 0.05)
+                        No change in performance detected.
+```
+
+- The three values are the lower bound, estimate, and upper bound of the
+  95% confidence interval.
+- `change` shows the percentage difference versus the saved baseline.
+- `p = 0.21 > 0.05`: the change is not statistically significant.
+
+A regression is flagged when the lower bound of the change interval is
+positive and `p < 0.05`. `just bench-compare-strict` exits non-zero in
+this case.
+
+---
+
+## See Also
+
+- `TESTING_GUIDE.md` — how to generate large test workspaces
+- `MEMORY_PATTERNS.md` — memory scaling characteristics
+- `docs/reference/PERFORMANCE_MONITORING.md` — automated regression alerts
+- `docs/benchmarks/BENCHMARK_DESIGN.md` — benchmark architecture
+- `docs/reference/PERFORMANCE_SLO.md` — SLO targets

--- a/docs/large-workspaces/README.md
+++ b/docs/large-workspaces/README.md
@@ -1,0 +1,37 @@
+# Large-Workspace Contributor Guides
+
+Practical guides for contributors working with or testing against large
+Perl workspaces (5 000–10 000+ files).
+
+| Guide | When to read it |
+|-------|----------------|
+| [TESTING_GUIDE.md](TESTING_GUIDE.md) | Generating test workspaces, writing large-workspace tests, performance baselines |
+| [PROFILING_GUIDE.md](PROFILING_GUIDE.md) | CPU flamegraphs, heap profiling, criterion benchmarks |
+| [MEMORY_PATTERNS.md](MEMORY_PATTERNS.md) | How memory scales, cache behavior, common anti-patterns |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Diagnosing slowdowns, stale symbols, index degradation |
+
+## Quick Reference
+
+```bash
+# Generate a 5 000-file synthetic workspace
+bash scripts/gen-large-workspace.sh /tmp/big-workspace 5000
+
+# Run the workspace index benchmarks
+just bench
+
+# Compare against baseline
+just bench-compare
+
+# Check running LSP server health
+perllsp --health
+
+# Debug log for troubleshooting
+RUST_LOG=perl_lsp=debug,perl_workspace_index=debug perllsp --stdio 2>debug.log
+```
+
+## Related Documentation
+
+- `docs/how-to/PERFORMANCE_TUNING.md` — end-user configuration for large workspaces
+- `docs/reference/PERFORMANCE_SLO.md` — response time targets and degradation thresholds
+- `docs/reference/PERFORMANCE_MONITORING.md` — automated regression alerts
+- `docs/benchmarks/BENCHMARK_DESIGN.md` — benchmark architecture

--- a/docs/large-workspaces/TESTING_GUIDE.md
+++ b/docs/large-workspaces/TESTING_GUIDE.md
@@ -1,0 +1,197 @@
+# Large-Workspace Testing Guide
+
+Practical guidance for contributors who need to test and validate behavior at
+scale. CI fixtures are intentionally small; large-workspace behavior must be
+exercised separately.
+
+## When You Need This Guide
+
+- You are optimizing workspace indexing performance
+- You changed `WorkspaceIndex`, `DocumentStore`, or `ProductionIndexCoordinator`
+- A performance issue was reported against a workspace with 5k-10k+ Perl files
+- You want to establish a baseline before and after a change
+
+---
+
+## Generating a Synthetic Workspace
+
+The benchmarks in `crates/perl-workspace-index/benches/workspace_index_benchmark.rs`
+show the standard pattern: write Perl source into a `TempDir` using the
+helpers already in `perl-tdd-support`.
+
+For ad-hoc manual testing, the following shell snippet generates a realistic
+workspace at different scales. Save it to `scripts/gen-large-workspace.sh`
+and run it once:
+
+```bash
+#!/usr/bin/env bash
+# Usage: bash scripts/gen-large-workspace.sh <output-dir> <file-count>
+# Example: bash scripts/gen-large-workspace.sh /tmp/big-workspace 5000
+set -euo pipefail
+
+DIR="${1:?output dir required}"
+COUNT="${2:-1000}"
+mkdir -p "$DIR/lib/App"
+
+for i in $(seq 1 "$COUNT"); do
+  PKG="App::Module${i}"
+  FILE="$DIR/lib/App/Module${i}.pm"
+  cat > "$FILE" <<EOF
+package $PKG;
+use strict;
+use warnings;
+our \$VERSION = '0.01';
+
+sub new {
+    my \$class = shift;
+    return bless {}, \$class;
+}
+
+sub compute_${i} {
+    my (\$self, \$x) = @_;
+    return \$x * ${i};
+}
+
+sub describe_${i} {
+    return "Module number ${i}";
+}
+
+1;
+EOF
+done
+
+echo "Generated $COUNT files in $DIR"
+```
+
+Size guide:
+
+| Scale       | File count | Approx. symbols | Expected index time |
+|-------------|------------|-----------------|---------------------|
+| Small       | 100        | ~500            | <50ms               |
+| Medium      | 1 000      | ~5 000          | <500ms              |
+| Large       | 5 000      | ~25 000         | <3s                 |
+| Extra-large | 10 000     | ~50 000         | <10s                |
+
+The numbers above are targets, not guarantees. Measure on your machine.
+
+---
+
+## Writing a Large-Workspace Integration Test
+
+Add a test under `crates/perl-workspace-index/tests/` that mirrors the
+benchmark pattern but asserts correctness rather than timing:
+
+```rust
+use perl_workspace_index::workspace_index::WorkspaceIndex;
+use perl_tdd_support::must;
+use tempfile::TempDir;
+use url::Url;
+use std::fs;
+
+#[test]
+fn large_workspace_symbol_lookup_finds_all_subs() {
+    let dir = must(TempDir::new());
+    let index = WorkspaceIndex::new();
+    let n = 500; // keep CI fast; use 5_000 locally
+
+    for i in 0..n {
+        let path = dir.path().join(format!("module{i}.pm"));
+        let src = format!(
+            "package App::Mod{i};\nsub func_{i} {{ return {i}; }}\n1;\n"
+        );
+        must(fs::write(&path, &src));
+        let uri = must(Url::from_file_path(&path));
+        must(index.index_file(uri, src));
+    }
+
+    // Every sub must be discoverable
+    for i in 0..n {
+        let name = format!("func_{i}");
+        let hits = index.find_symbols(&name);
+        assert!(!hits.is_empty(), "missing symbol {name}");
+    }
+}
+```
+
+Run it in isolation before adding to the test suite:
+
+```bash
+export CARGO_TARGET_DIR="/tmp/agent-$(git branch --show-current | tr '/' '-')-target"
+cargo test -p perl-workspace-index large_workspace_symbol_lookup -- --nocapture
+```
+
+---
+
+## Performance Baselines by Workspace Size
+
+The authoritative baselines live in `benchmarks/results/baseline.json`.
+To record a new one:
+
+```bash
+just bench
+just bench-baseline "$(date +%Y-%m-%d)"
+```
+
+To compare your branch against the baseline:
+
+```bash
+just bench-compare
+```
+
+Expected latency targets (from `docs/reference/PERFORMANCE_SLO.md`):
+
+| Operation              | P95 target | Hard limit |
+|------------------------|------------|------------|
+| Symbol lookup          | 50µs       | 200µs      |
+| Incremental index update | 1ms      | 5ms        |
+| Initial index (1 000 files) | 500ms | 3s        |
+| Workspace symbol search | 50ms      | 150ms      |
+
+---
+
+## Resource Limit Configuration During Testing
+
+`IndexResourceLimits` controls when the index enters the `Degraded` state.
+For stress testing you may want to raise or lower these:
+
+```rust
+use perl_workspace_index::workspace_index::IndexResourceLimits;
+
+let limits = IndexResourceLimits {
+    max_files: 50_000,
+    max_total_symbols: 1_000_000,
+    max_symbols_per_file: 500,
+    workspace_scan_deadline_ms: 60_000,
+    reference_search_deadline_ms: 5_000,
+    ..Default::default()
+};
+```
+
+For testing degradation behavior specifically, set `max_files` below the
+size of your test workspace to force a controlled transition to `Degraded`.
+
+---
+
+## CI Integration Notes
+
+Large-workspace tests are not part of the default `cargo test` run because
+they exceed the 30-second CI budget. Options:
+
+1. **Label-gated**: Add a `#[ignore]` attribute and run with `cargo test --
+   large_workspace_symbol_lookup_finds_all_subs --ignored` in a separate CI
+   lane.
+2. **Benchmark lane**: Add to the criterion benchmark suite under the
+   `workspace` feature flag (already gated in `Cargo.toml`).
+3. **Nightly only**: Register the lane in `.ci/` alongside `ci-full`.
+
+Prefer option 2 for performance-sensitive cases; prefer option 1 when you
+need correctness assertions across many files.
+
+---
+
+## See Also
+
+- `PROFILING_GUIDE.md` — how to measure where time is actually spent
+- `MEMORY_PATTERNS.md` — how memory scales with symbol count
+- `docs/reference/PERFORMANCE_SLO.md` — authoritative SLO targets
+- `docs/how-to/PERFORMANCE_TUNING.md` — end-user configuration guide

--- a/docs/large-workspaces/TROUBLESHOOTING.md
+++ b/docs/large-workspaces/TROUBLESHOOTING.md
@@ -1,0 +1,259 @@
+# Large-Workspace Troubleshooting
+
+Diagnosis steps and remediation strategies for performance and correctness
+issues that only appear at scale (5 000+ files, 6+ hours of uptime).
+
+For general setup problems (binary not found, server won't start), see
+`docs/how-to/TROUBLESHOOTING.md` first.
+
+---
+
+## Quick Triage
+
+Before digging into logs:
+
+```bash
+perllsp --version    # confirm the right binary is running
+perllsp --health     # print index state, symbol count, SLO snapshot
+RUST_LOG=perl_lsp=debug perllsp --stdio 2>perllsp-debug.log
+```
+
+The `--health` output includes:
+
+- `index_state`: `Ready`, `Building`, or `Degraded`
+- `file_count` / `symbol_count`: current index size
+- `slo_compliance`: pass/fail per operation type
+
+If `index_state` is `Degraded`, check the `reason` field — this is the
+first branching point in every large-workspace investigation.
+
+---
+
+## Index Enters `Degraded` State
+
+### Symptoms
+
+- Completions become stale or empty
+- Go-to-definition stops working for recently added files
+- `perllsp --health` shows `index_state: Degraded`
+
+### Causes and Remediation
+
+| Cause | How to confirm | Fix |
+|-------|----------------|-----|
+| `max_files` limit hit | `reason: ResourceLimit(Files)` | Raise `maxIndexedFiles` or add `.lspignore` |
+| `max_total_symbols` limit hit | `reason: ResourceLimit(Symbols)` | Raise `maxTotalSymbols` |
+| Scan timeout | `reason: Timeout` | Raise `workspaceScanDeadlineMs` |
+| IO error | `reason: IoError` | Check disk health; check NFS mount |
+| Parse storm | `reason: ParseStorm` | Reduce concurrent editors; check for watch loops |
+
+To trigger recovery after fixing the root cause, run
+`workspace/executeCommand: perl.reindex` from the editor command palette,
+or restart the LSP server.
+
+---
+
+## Slow Startup (>10s on a Large Workspace)
+
+### Symptoms
+
+- Editor shows "loading" spinner for an unusually long time
+- `RUST_LOG=perl_lsp=debug` shows many `Indexing file…` messages spaced
+  far apart
+
+### Diagnosis
+
+```bash
+# Time the full index cycle end-to-end
+time RUST_LOG=perl_lsp=info perllsp --stdio < /dev/null 2>&1 \
+    | grep -E "index (started|completed|degraded)"
+```
+
+Compare against the expected baseline from `TESTING_GUIDE.md`.
+
+### Common Causes
+
+1. **Network filesystem**: NFS or SMB adds per-file `open()` latency.
+   Migrate the workspace to a local disk or ramdisk for development.
+
+2. **Deep directory tree with many non-Perl files**: The scanner visits
+   every directory. Exclude heavy directories:
+
+   ```json
+   { "perl": { "workspace": { "excludePatterns": ["node_modules", ".git", "vendor"] } } }
+   ```
+
+3. **Very large individual files**: A single 50 000-line Perl script can
+   take hundreds of milliseconds to parse. Confirm with:
+
+   ```bash
+   wc -l lib/**/*.pm | sort -rn | head -10
+   ```
+
+   Break up files larger than ~5 000 lines into modules, or add them to
+   the exclude list.
+
+---
+
+## IDE Slowdowns After 4-6 Hours
+
+This is the classic large-workspace degradation pattern. The index starts
+fast but response times climb over a long session.
+
+### Symptoms
+
+- Hover and completion were fast at session start, now consistently >200ms
+- Memory usage visible in the OS task manager has grown significantly
+- No crash; the server is still running
+
+### Diagnosis Steps
+
+1. **Check the SLO snapshot**:
+
+   ```bash
+   perllsp --health 2>&1 | grep slo
+   ```
+
+   If `slo_compliance: fail` for `hover` or `completion`, the latency
+   has crossed the hard limit.
+
+2. **Check for cache bloat**:
+
+   After 4-6 hours on a large workspace, the AST cache may be evicting and
+   re-inserting entries frequently. Enable the cache-stats log:
+
+   ```bash
+   RUST_LOG=perl_workspace_index::workspace::cache=debug perllsp --stdio \
+       2>&1 | grep "eviction\|hit_rate"
+   ```
+
+   A healthy hit rate is >90%. If you see `hit_rate: 0.4` or lower, the
+   cache is too small for the working set.
+
+3. **Check for write-lock contention**:
+
+   ```bash
+   RUST_LOG=perl_workspace_index=trace perllsp --stdio 2>&1 \
+       | grep "write.lock\|lock.wait"
+   ```
+
+4. **Check for unbounded document store growth**:
+
+   If the editor opens many files and never closes them, the `DocumentStore`
+   grows. Count open documents:
+
+   ```bash
+   perllsp --health 2>&1 | grep "open_documents"
+   ```
+
+### Remediation
+
+- **Short term**: Restart the LSP server. This flushes all caches and
+  returns to baseline memory.
+- **Medium term**: Raise `astCacheMaxEntries` if hit rate is low:
+
+  ```json
+  { "perl": { "limits": { "astCacheMaxEntries": 5000 } } }
+  ```
+
+- **Long term**: If restart frequency is high (more than once per day),
+  file an issue with the `--health` output and the log snippet showing
+  where latency grows. This is likely a caching or index-invalidation bug.
+
+---
+
+## Symbol Resolution Returns Wrong Results
+
+### Symptoms
+
+- Go-to-definition jumps to the wrong file
+- `workspace/symbol` returns symbols that no longer exist
+- Completions include renamed or deleted subs
+
+### Diagnosis
+
+The dual indexing strategy (PR #122) indexes symbols under both
+`Package::name` and `name`. Stale entries in either table produce
+ghost results.
+
+```bash
+# Ask the server to dump the index state (if the dump command is enabled)
+RUST_LOG=perl_workspace_index::workspace::workspace_index=debug \
+    perllsp --stdio 2>&1 | grep "stale\|evict\|remove"
+```
+
+Check whether the workspace received a `workspace/didDeleteFiles` or
+`workspace/didChangeWatchedFiles` notification for the affected file.
+If not, the editor's file-watcher may be misconfigured.
+
+### Remediation
+
+1. Reindex: `perl.reindex` command from the editor command palette.
+2. If stale symbols persist after reindex, the index may not be removing
+   old file entries before re-inserting new ones. Confirm by checking
+   `WorkspaceIndex::index_file`'s remove-then-insert pattern.
+
+---
+
+## Workspace Index Corruption
+
+### Symptoms
+
+- Panic or internal error in the LSP server log
+- `index_state` cannot transition out of `Error`
+- Symbols from deleted packages still appear after full reindex
+
+### Diagnosis
+
+```bash
+RUST_LOG=perl_workspace_index=error perllsp --stdio 2>&1 \
+    | grep -E "ERROR|WARN|panic"
+```
+
+Corruption is rare because `WorkspaceIndex` uses `parking_lot::RwLock`
+to prevent concurrent writes. If you see it, check:
+
+- Whether the workspace was written to by another process while the
+  server was indexing (race condition in file watchers).
+- Whether a recent change modified `workspace_index.rs` without updating
+  the remove-before-insert invariant.
+
+### Remediation
+
+Restart the LSP server. If corruption recurs after restart, reduce
+`maxIndexedFiles` and report with a minimal reproduction.
+
+---
+
+## Collecting a Diagnostic Bundle
+
+When filing a performance issue, include:
+
+```bash
+# Version and health
+perllsp --version
+perllsp --health
+
+# Debug log (5-10 seconds of activity)
+RUST_LOG=perl_lsp=debug,perl_workspace_index=debug \
+    perllsp --stdio 2>perllsp-debug.log &
+# ... trigger the slow operation in the editor ...
+kill %1
+
+# Workspace size
+find . -name "*.pm" -o -name "*.pl" | wc -l
+find . -name "*.pm" -o -name "*.pl" | xargs wc -l | tail -1
+```
+
+Attach `perllsp-debug.log` (trimmed to the relevant time window), the
+version string, the health output, and the workspace size numbers.
+
+---
+
+## See Also
+
+- `TESTING_GUIDE.md` — reproducing issues with synthetic workspaces
+- `PROFILING_GUIDE.md` — capturing flamegraphs and heap profiles
+- `MEMORY_PATTERNS.md` — understanding why memory grows
+- `docs/how-to/TROUBLESHOOTING.md` — general (non-large-workspace) issues
+- `docs/reference/PERFORMANCE_SLO.md` — SLO targets and degradation thresholds


### PR DESCRIPTION
## Summary

Closes #3022.

Adds `docs/large-workspaces/` with four practical contributor guides for working with large Perl workspaces (5 000–10 000+ files):

- **TESTING_GUIDE.md** — synthetic workspace generation script, test patterns using `perl-tdd-support`, performance baselines table, CI integration options (ignore/benchmark/nightly)
- **PROFILING_GUIDE.md** — criterion benchmarks, `cargo flamegraph`, heaptrack, `samply`, common bottleneck catalog (HashMap resize, clone vs. borrow, async task overhead, lock contention), reading criterion output
- **MEMORY_PATTERNS.md** — scaling projections by workspace size, AST cache eviction behavior, common anti-patterns (unbounded string duplication, retaining stale docs), optimization techniques (`Arc<str>`, capacity hints, weak references)
- **TROUBLESHOOTING.md** — `Degraded` state diagnosis table, slow startup triage, IDE slowdown after 4-6 hours, stale symbol resolution, diagnostic bundle instructions

## Grounding

- All API names verified against source: `WorkspaceIndex`, `IndexResourceLimits`, `BoundedLruCache`, `CacheConfig`, `SloTracker`, `OperationType` (`start_operation` + `record_operation` signatures confirmed)
- All cross-referenced docs confirmed to exist (`PERFORMANCE_SLO.md`, `PERFORMANCE_MONITORING.md`, `BENCHMARK_DESIGN.md`, `how-to/TROUBLESHOOTING.md`, `how-to/PERFORMANCE_TUNING.md`)
- Memory scaling numbers derived from the workspace index source doc comment: "~1MB per 10K symbols"
- Cache defaults (10 000 items / 50 MB AST, 50 000 / 30 MB symbol, 1 000 / 20 MB workspace) taken directly from `cache.rs`

## Test plan

- [ ] Doc files render correctly on GitHub (tables, code blocks)
- [ ] No broken cross-references
- [ ] The bash snippet in TESTING_GUIDE.md runs and generates files
- [ ] The criterion commands in PROFILING_GUIDE.md produce benchmark output