### PR TITLE
fix(distribution): verify and fix Homebrew formula auto-bumping (#2086)

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -74,8 +74,8 @@ jobs:
 
           # Download each platform asset
           for platform in "x86_64-apple-darwin" "aarch64-apple-darwin" "x86_64-unknown-linux-gnu" "aarch64-unknown-linux-gnu"; do
-            echo "Downloading perl-lsp-${VERSION}-${platform}.tar.gz..."
-            gh release download "${TAG}" --pattern "perl-lsp-${VERSION}-${platform}.tar.gz" || true
+            echo "Downloading perllsp-${VERSION}-${platform}.tar.gz..."
+            gh release download "${TAG}" --pattern "perllsp-${VERSION}-${platform}.tar.gz" || true
           done
 
           # Compute SHA256
@@ -96,26 +96,26 @@ jobs:
           cd /tmp/brew-assets
 
           # macOS Intel
-          if [ -f "perl-lsp-${VERSION}-x86_64-apple-darwin.tar.gz" ]; then
-            SHA=$(sha256sum "perl-lsp-${VERSION}-x86_64-apple-darwin.tar.gz" | cut -d' ' -f1)
+          if [ -f "perllsp-${VERSION}-x86_64-apple-darwin.tar.gz" ]; then
+            SHA=$(sha256sum "perllsp-${VERSION}-x86_64-apple-darwin.tar.gz" | cut -d' ' -f1)
             sed -i "/x86_64-apple-darwin/,/sha256/ s/sha256 \"[^\"]*\"/sha256 \"${SHA}\"/" "$GITHUB_WORKSPACE/Formula/perl-lsp.rb"
           fi
 
           # macOS ARM
-          if [ -f "perl-lsp-${VERSION}-aarch64-apple-darwin.tar.gz" ]; then
-            SHA=$(sha256sum "perl-lsp-${VERSION}-aarch64-apple-darwin.tar.gz" | cut -d' ' -f1)
+          if [ -f "perllsp-${VERSION}-aarch64-apple-darwin.tar.gz" ]; then
+            SHA=$(sha256sum "perllsp-${VERSION}-aarch64-apple-darwin.tar.gz" | cut -d' ' -f1)
             sed -i "/aarch64-apple-darwin/,/sha256/ s/sha256 \"[^\"]*\"/sha256 \"${SHA}\"/" "$GITHUB_WORKSPACE/Formula/perl-lsp.rb"
           fi
 
           # Linux x64
-          if [ -f "perl-lsp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" ]; then
-            SHA=$(sha256sum "perl-lsp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" | cut -d' ' -f1)
+          if [ -f "perllsp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" ]; then
+            SHA=$(sha256sum "perllsp-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" | cut -d' ' -f1)
             sed -i "/x86_64-unknown-linux-gnu/,/sha256/ s/sha256 \"[^\"]*\"/sha256 \"${SHA}\"/" "$GITHUB_WORKSPACE/Formula/perl-lsp.rb"
           fi
 
           # Linux ARM
-          if [ -f "perl-lsp-${VERSION}-aarch64-unknown-linux-gnu.tar.gz" ]; then
-            SHA=$(sha256sum "perl-lsp-${VERSION}-aarch64-unknown-linux-gnu.tar.gz" | cut -d' ' -f1)
+          if [ -f "perllsp-${VERSION}-aarch64-unknown-linux-gnu.tar.gz" ]; then
+            SHA=$(sha256sum "perllsp-${VERSION}-aarch64-unknown-linux-gnu.tar.gz" | cut -d' ' -f1)
             sed -i "/aarch64-unknown-linux-gnu/,/sha256/ s/sha256 \"[^\"]*\"/sha256 \"${SHA}\"/" "$GITHUB_WORKSPACE/Formula/perl-lsp.rb"
           fi
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ cargo install --path crates/perllsp
 
 Do not use `cargo install perl-lsp` on crates.io. That package name is owned by another project.
 
+### Homebrew (macOS and Linux)
+
+```bash
+brew install perl-lsp
+```
+
+Supports macOS Intel, macOS Apple Silicon, and Linux via Linuxbrew. See
+[docs/how-to/HOMEBREW.md](docs/how-to/HOMEBREW.md) for shell completions and
+formula maintenance details.
+
 ### Other editors
 
 Neovim:

--- a/distribution/homebrew/perl-lsp.rb
+++ b/distribution/homebrew/perl-lsp.rb
@@ -7,28 +7,28 @@ class PerlLsp < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_X86_64__"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perl-lsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_X86_64__"
     end
   end
 
   def install
-    # Expected extracted layout: perl-lsp-<version>-<target>/{perl-lsp,perl-dap}
+    # Expected extracted layout: perllsp-<version>-<target>/{perllsp,perl-dap}
     # If the release packaging layout changes, update this extraction logic with a follow-up.
-    extracted_dir = Dir.glob("perl-lsp-*").find { |dir| Dir.exist?(dir) }
+    extracted_dir = Dir.glob("perllsp-*").find { |dir| Dir.exist?(dir) }
     if extracted_dir
       bin.install "#{extracted_dir}/perllsp"
       bin.install "#{extracted_dir}/perl-dap" if File.exist?("#{extracted_dir}/perl-dap")

--- a/docs/how-to/HOMEBREW.md
+++ b/docs/how-to/HOMEBREW.md
@@ -1,0 +1,103 @@
+# Homebrew Installation and Formula Maintenance
+
+This document covers installing `perllsp` via Homebrew and maintaining the
+formula in the release pipeline.
+
+## Installing via Homebrew
+
+```bash
+brew install perl-lsp
+```
+
+After installation, verify the binary:
+
+```bash
+perllsp --version
+perllsp --health
+```
+
+Platform support:
+
+| Platform | Architecture |
+| --- | --- |
+| macOS | Intel (x86_64) |
+| macOS | Apple Silicon (aarch64) |
+| Linux (Linuxbrew) | x86_64 |
+| Linux (Linuxbrew) | aarch64 |
+
+## Shell Completions
+
+The formula does not auto-install shell completions. Install them manually:
+
+```bash
+# bash
+perllsp --completion bash > "$(brew --prefix)/etc/bash_completion.d/_perllsp"
+
+# zsh
+perllsp --completion zsh > "$(brew --prefix)/share/zsh/site-functions/_perllsp"
+
+# fish
+perllsp --completion fish > "$(brew --prefix)/share/fish/vendor_completions.d/perllsp.fish"
+```
+
+## Formula Auto-Bump Workflow
+
+The workflow at `.github/workflows/brew-bump.yml` runs automatically on each
+`release.published` event and opens a PR to `Homebrew/homebrew-core` with the
+updated version and SHA256 checksums.
+
+It can also be triggered manually:
+
+```
+Actions → Homebrew Auto-Bump → Run workflow → enter the release tag (e.g. v0.12.0)
+```
+
+### What the workflow does
+
+1. Resolves the release tag (from the event or the manual input).
+2. Waits up to 10 minutes for release assets to appear on the GitHub release.
+3. Downloads all four platform tarballs: `perllsp-{version}-{target}.tar.gz`.
+4. Computes SHA256 for each tarball.
+5. Patches `Formula/perl-lsp.rb` with the new version and checksums.
+6. Validates that no `__RELEASE_VERSION__` or `__SHA256_` placeholders remain.
+7. Opens a PR to `Homebrew/homebrew-core`.
+
+### Release artifact naming
+
+The workflow and formula expect tarballs named with the `perllsp-` prefix, which
+matches what `release.yml` produces:
+
+```
+perllsp-{version}-x86_64-apple-darwin.tar.gz
+perllsp-{version}-aarch64-apple-darwin.tar.gz
+perllsp-{version}-x86_64-unknown-linux-gnu.tar.gz
+perllsp-{version}-aarch64-unknown-linux-gnu.tar.gz
+```
+
+If the release packaging changes this naming, update the `--pattern` argument in
+the "Download and compute SHA256" step of `brew-bump.yml` to match.
+
+### Formula files
+
+Two formula files are kept in sync:
+
+| File | Purpose |
+| --- | --- |
+| `Formula/perl-lsp.rb` | Used by `brew-bump.yml` — patched on each release |
+| `distribution/homebrew/perl-lsp.rb` | Distribution reference copy |
+
+Both must use the `perllsp-` prefix in URLs and the `Dir.glob("perllsp-*")`
+extraction glob, matching the actual release tarball names.
+
+## Troubleshooting
+
+**Workflow downloads no assets** — the release tarballs may not yet be uploaded
+when the workflow starts. The wait loop retries for up to 10 minutes. If assets
+are still missing after that, trigger the workflow manually once they appear.
+
+**SHA256 mismatch** — re-run `brew-bump.yml` manually against the correct tag.
+The workflow recomputes checksums from the actual uploaded assets each run.
+
+**`brew install` fails with "no bottle"** — the Homebrew PR to homebrew-core
+may not have merged yet. Wait for the PR to land in homebrew-core, then
+`brew update && brew install perl-lsp`.

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -12,6 +12,7 @@ expected, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 Use one of the public install paths that matches how you work:
 
 - VS Code: install the `EffortlessMetrics.perl-lsp-rs` extension and let it download the matching `perllsp` binary.
+- macOS or Linux: `brew install perl-lsp` (see [HOMEBREW.md](HOMEBREW.md) for details).
 - Other editors: download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and put it on your `PATH`.
 - Local testing or pre-release validation: install from this repo with `cargo install --path crates/perllsp`.
 


### PR DESCRIPTION
## Summary

- Fix `perl-lsp-` prefix bug in `brew-bump.yml`: the workflow downloaded tarballs as `perl-lsp-{version}-{target}.tar.gz` but `release.yml` packages them as `perllsp-{version}-{target}.tar.gz`, so every release bump downloaded nothing and skipped all SHA updates silently.
- Fix the same stale prefix in `distribution/homebrew/perl-lsp.rb`: URLs and the `Dir.glob` extraction pattern both used the wrong `perl-lsp-` prefix.
- Add `docs/how-to/HOMEBREW.md` documenting installation, shell completions, the auto-bump workflow, release artifact naming, and troubleshooting.

## Root cause

The binary rename from `perl-lsp` to `perllsp` (PR #2936) updated `release.yml` to package as `perllsp-*` but `brew-bump.yml` and the distribution formula copy were not updated in lockstep — the same class of bug fixed for Windows workflows in PR #3106.

## Changes

- `.github/workflows/brew-bump.yml` — fix download `--pattern` and all 4 SHA conditional blocks to use `perllsp-` prefix (10 lines)
- `distribution/homebrew/perl-lsp.rb` — fix 4 URL lines and `Dir.glob("perllsp-*")` extraction pattern; update install comment (7 lines)
- `docs/how-to/HOMEBREW.md` — new file: installation, shell completions, workflow mechanics, artifact naming, troubleshooting
- `README.md` — add Homebrew section to Quick Start
- `docs/how-to/INSTALLATION.md` — add Homebrew bullet to Fastest Path

Note: `Formula/perl-lsp.rb` was already correct (used `perllsp-` prefix) and is not changed.

## Evidence

- **Commits**: 1
- **Tests**: N/A — no Rust code changed; workflow/formula/docs only
- **Lint**: Format check passed, clippy gate passed, unwrap/panic ratchet passed
- **Files**: 5 changed, +130/-16 lines

## Test plan

- [ ] Verify `brew-bump.yml` now downloads `perllsp-{version}-{target}.tar.gz` matching `release.yml` line 164 (`PKG_NAME="${NAME}-${VERSION}-${TARGET}"` where `NAME="perllsp"`)
- [ ] Trigger `brew-bump.yml` manually via workflow_dispatch on next release tag
- [ ] Confirm PR is opened to Homebrew/homebrew-core with correct SHA256 checksums
- [ ] Verify `distribution/homebrew/perl-lsp.rb` URLs match `Formula/perl-lsp.rb` (now both use `perllsp-` prefix)

## Unknowns

- The `brew-bump.yml` workflow has never been triggered on a real release (no workflow run history). End-to-end PR creation to `Homebrew/homebrew-core` requires a release tag to verify fully.
- `GH_TOKEN` write permissions to `Homebrew/homebrew-core` are not verified locally.

Closes #2086