### PR TITLE
docs(marketing): GIF recording guide and asset structure (#2336)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,9 @@ rustc-ice-*
 *.orig
 *.bak
 patch.diff
+
+# Raw screen recordings (too large for version control — see docs/assets/recordings/README.md)
+docs/assets/recordings/*.mp4
+docs/assets/recordings/*.mov
+docs/assets/recordings/*.mkv
+docs/assets/recordings/*.webm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,62 @@ If a breaking change is necessary:
 
 See [STABILITY.md](docs/reference/STABILITY.md) for our API stability policy.
 
+## Updating Demo GIFs
+
+The three animated GIFs shown in `README.md` live in `docs/assets/gifs/`. They
+are produced from manual screen recordings, not generated automatically.
+
+### When to Re-Record
+
+Re-record a GIF when:
+- A menu label, key binding, or status bar message changes.
+- The workflow changes enough that the current GIF is misleading.
+- The GIF is blurry or hard to read at 960 px wide.
+
+### Recording Process
+
+1. Open `demo_workspace/` in VS Code with the `EffortlessMetrics.perl-lsp-rs`
+   extension active and the LSP server running.
+2. Set a clean theme (large font, minimal panels visible).
+3. Record the interaction using your platform screen-capture tool:
+   - Linux: `peek`, `simplescreenrecorder`, or `ffmpeg -f x11grab`
+   - macOS: QuickTime Player or ScreenFlow
+   - Windows: Xbox Game Bar, OBS Studio, or ShareX
+4. Save the raw recording to `docs/assets/recordings/` (gitignored).
+
+The full step-by-step script for each GIF is in
+[`docs/assets/gifs/README.md`](docs/assets/gifs/README.md).
+
+### Rendering
+
+After capturing, convert to a compressed GIF:
+
+```bash
+python scripts/marketing/render-walkthrough-gif.py \
+  --input docs/assets/recordings/goto-definition.mp4 \
+  --output docs/assets/gifs/goto-definition.gif \
+  --fps 12 \
+  --width 960 \
+  --max-bytes 3145728
+```
+
+Use `--start` and `--duration` to trim dead time. Run `--help` for all options.
+Requires `ffmpeg`; `gifsicle` is used automatically if available.
+
+### GIF Inventory
+
+| File | Workflow | Max size |
+|------|---------|---------|
+| `docs/assets/gifs/install-health.gif` | VS Code install, auto-download, `perllsp --health` | 3 MB |
+| `docs/assets/gifs/goto-definition.gif` | Ctrl+Click go-to-def, Find All References | 3 MB |
+| `docs/assets/gifs/extract-variable.gif` | Select, light-bulb, Extract Variable | 3 MB |
+
+### Commit Message Convention
+
+```
+docs: re-record goto-definition gif for v0.13 navigation changes
+```
+
 ## Adding New Crates
 
 1. Create the crate under `crates/` using the naming convention of its family

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,16 @@
+# docs/assets
+
+Static assets used in project documentation and marketing surfaces.
+
+| Directory | Contents |
+|-----------|---------|
+| [`gifs/`](gifs/) | Animated GIFs for README.md — recording guide and inventory |
+| [`recordings/`](recordings/) | Raw screen-capture files (gitignored, not committed) |
+
+## Adding Assets
+
+- GIF files belong in `gifs/` and must stay under 3 MB each.
+- Raw recordings belong in `recordings/` and are never committed (see
+  `.gitignore`).
+- Other static images (diagrams, screenshots) can go in subdirectories here.
+  Follow the naming convention of the nearest existing asset.

--- a/docs/assets/gifs/README.md
+++ b/docs/assets/gifs/README.md
@@ -1,0 +1,193 @@
+# Demo GIFs
+
+This directory holds the animated GIFs used in README.md and other marketing
+surfaces. Each GIF is produced from a manual screen-recording session using the
+`scripts/marketing/render-walkthrough-gif.py` helper.
+
+## Planned GIF Files
+
+| Filename | Feature | Max Size | Duration |
+|----------|---------|---------|---------|
+| `install-health.gif` | VS Code install, extension auto-download, `perllsp --health` output | 3 MB | 15 s |
+| `goto-definition.gif` | Ctrl+Click go to definition, Find All References panel | 3 MB | 15 s |
+| `extract-variable.gif` | Select expression, light-bulb, Extract Variable code action | 3 MB | 12 s |
+
+None of these files can be created by an automated agent because each requires a
+live editor session with a running LSP server. See the [recording guide](#recording-guide)
+below for instructions.
+
+## Storyboard Reference
+
+SVG storyboards for each planned GIF live in
+[`vscode-extension/media/walkthrough/`](../../../vscode-extension/media/walkthrough/).
+Use them to rehearse the flow before recording.
+
+| GIF | Storyboard |
+|-----|-----------|
+| `install-health.gif` | [`install-health.svg`](../../../vscode-extension/media/walkthrough/install-health.svg) |
+| `goto-definition.gif` | [`find-references.svg`](../../../vscode-extension/media/walkthrough/find-references.svg) |
+| `extract-variable.gif` | [`extract-variable.svg`](../../../vscode-extension/media/walkthrough/extract-variable.svg) |
+
+## Demo Workspace
+
+Record all GIFs using the files in [`demo_workspace/`](../../../demo_workspace/):
+
+```
+demo_workspace/
+  main.pl           -- entry point (calls Utils and Database)
+  lib/Utils.pm      -- process_data and load_data subs
+  lib/Database.pm   -- save sub
+```
+
+Open this workspace in VS Code before recording. The workspace provides
+realistic Perl code with cross-file symbol references so that go-to-definition
+and find-references produce visible jumps.
+
+## Recording Guide
+
+### Before You Start
+
+1. Install the VS Code extension from the Marketplace:
+   ```
+   code --install-extension EffortlessMetrics.perl-lsp-rs
+   ```
+2. Open `demo_workspace/` as a VS Code workspace folder.
+3. Verify the server is running: the status bar shows "perl-lsp" and there are
+   no red error indicators on `main.pl`.
+4. Set VS Code to a light or high-contrast dark theme with a large font size
+   (16 pt or larger) so the GIF is readable at 960 px wide.
+5. Hide panels you will not use (terminal, output, source control) to minimise
+   visual noise.
+
+### Recommended Capture Settings
+
+| Setting | Value |
+|---------|-------|
+| Resolution | 1280 x 720 or 1920 x 1080 |
+| Frame rate | 30 fps |
+| Format | MP4 (H.264) or WebM |
+| Audio | Off |
+| Cursor | Large, highlighted |
+
+**Linux:** `peek`, `simplescreenrecorder`, or:
+```bash
+ffmpeg -video_size 1280x720 -framerate 30 -f x11grab -i :0.0 recording.mp4
+```
+
+**macOS:** QuickTime Player (File > New Screen Recording) or `ScreenFlow`.
+
+**Windows:** Xbox Game Bar (`Win+G`), OBS Studio, or ShareX.
+
+### GIF #1 — Install and Health Check (`install-health.gif`)
+
+Goal: show that installing the extension is one command and the server comes up
+healthy.
+
+Steps to record:
+1. Open a fresh VS Code window (no Perl files open).
+2. Open the integrated terminal.
+3. Run `code --install-extension EffortlessMetrics.perl-lsp-rs` and let it
+   complete.
+4. Open `demo_workspace/main.pl`.
+5. Wait for the status bar to show the LSP is active (1–3 seconds).
+6. Open the terminal again and run `perllsp --health`, then wait for the output.
+7. Stop recording.
+
+Keep the terminal text large enough to read in the final GIF.
+
+### GIF #2 — Go to Definition and Find References (`goto-definition.gif`)
+
+Goal: show instant cross-file navigation.
+
+Steps to record:
+1. Open `demo_workspace/main.pl`.
+2. Hover over `Utils::process_data` so the hover tooltip appears briefly.
+3. Ctrl+Click (macOS: Cmd+Click) `Utils::process_data` to jump to the
+   definition in `lib/Utils.pm`.
+4. Pause one second at the definition.
+5. Right-click the sub name and choose "Find All References". The references
+   panel opens listing the call site in `main.pl`.
+6. Click the reference to jump back to `main.pl`.
+7. Stop recording.
+
+### GIF #3 — Extract Variable Code Action (`extract-variable.gif`)
+
+Goal: show the refactoring light-bulb workflow.
+
+Steps to record:
+1. Open `demo_workspace/main.pl`.
+2. Select the expression `Utils::process_data($data)` on the assignment line.
+3. Wait for the light-bulb icon to appear (or press `Ctrl+.`).
+4. Choose "Extract Variable" from the code action menu.
+5. Type a name for the new variable (for example `$result`) and press Enter.
+6. Pause one second on the refactored result.
+7. Stop recording.
+
+## Rendering the GIFs
+
+After capturing a recording, convert it with the render helper:
+
+```bash
+python scripts/marketing/render-walkthrough-gif.py \
+  --input recordings/install-health.mp4 \
+  --output docs/assets/gifs/install-health.gif \
+  --fps 12 \
+  --width 960 \
+  --max-bytes 3145728
+```
+
+Trim dead time at the start or end with `--start` and `--duration`:
+
+```bash
+python scripts/marketing/render-walkthrough-gif.py \
+  --input recordings/goto-definition.mp4 \
+  --output docs/assets/gifs/goto-definition.gif \
+  --start 00:00:01.5 \
+  --duration 00:00:14.0 \
+  --fps 12 \
+  --width 960 \
+  --max-bytes 3145728
+```
+
+The helper requires `ffmpeg`. If `gifsicle` is also on your PATH it will be used
+for an additional lossy compression pass.
+
+If the output exceeds the byte limit the script exits with an error. Common
+fixes:
+- Lower `--fps` to 10.
+- Lower `--width` to 800.
+- Shorten the clip with `--duration`.
+- Install `gifsicle` for a free extra compression pass.
+
+## Integrating into README.md
+
+Once all three GIFs are committed, add a Demo section to `README.md`. Place it
+between the "Why Teams Pick It" and "Quick Start" sections:
+
+```markdown
+## Demo
+
+| Install and Health Check | Go to Definition | Extract Variable |
+|:---:|:---:|:---:|
+| ![Install](docs/assets/gifs/install-health.gif) | ![Go to Def](docs/assets/gifs/goto-definition.gif) | ![Extract](docs/assets/gifs/extract-variable.gif) |
+```
+
+GitHub renders GIFs inline in Markdown so no special hosting is required.
+
+## File Naming and Versioning
+
+- Name GIF files after the feature, not the version: `goto-definition.gif` not
+  `goto-def-v1.gif`.
+- When a workflow changes enough to require a re-record, replace the file in
+  place and commit with a message like:
+  `docs: re-record goto-definition gif for v0.13 navigation changes`
+- Raw recordings are large and should not be committed. Add them to
+  `docs/assets/recordings/` which is gitignored.
+
+## Checklist for Each Release
+
+- [ ] Verify that each GIF still matches the current UI (menu labels, status
+  bar text, key bindings).
+- [ ] Re-record any GIF where the workflow has changed.
+- [ ] Confirm each GIF is under 3 MB after rendering.
+- [ ] Check that the README table links resolve correctly.

--- a/docs/assets/recordings/README.md
+++ b/docs/assets/recordings/README.md
@@ -1,0 +1,18 @@
+# Raw Recordings
+
+This directory holds raw screen-recording files used to produce the demo GIFs
+in `docs/assets/gifs/`. Raw recordings are large and are excluded from version
+control via `.gitignore`.
+
+Place your captured video files here before running
+`scripts/marketing/render-walkthrough-gif.py`.
+
+Expected files:
+
+| File | Produces |
+|------|---------|
+| `install-health.mp4` | `docs/assets/gifs/install-health.gif` |
+| `goto-definition.mp4` | `docs/assets/gifs/goto-definition.gif` |
+| `extract-variable.mp4` | `docs/assets/gifs/extract-variable.gif` |
+
+See [`../gifs/README.md`](../gifs/README.md) for the full recording guide.


### PR DESCRIPTION
## Summary

- Creates `docs/assets/gifs/README.md` — full recording guide for three planned demo GIFs (install-health, goto-definition, extract-variable) with per-platform capture instructions, exact ffmpeg render commands, storyboard cross-references, a release checklist, and README integration snippet.
- Creates `docs/assets/recordings/README.md` — drop zone doc for raw recordings (gitignored).
- Creates `docs/assets/README.md` — top-level index for the assets tree.
- Updates `CONTRIBUTING.md` — adds "Updating Demo GIFs" section with when-to-rerecord criteria, recording process summary, render command, GIF inventory table, and commit message convention.
- Updates `.gitignore` — ignores raw video files (mp4/mov/mkv/webm) under `docs/assets/recordings/`.

## Context

Issue #2336 calls for three animated GIFs in README.md. The actual recordings require a live editor session (human + display). This PR delivers:
1. The directory structure to receive GIF files once recorded.
2. A self-contained recording guide so any contributor can produce the GIFs without prior context.
3. A CONTRIBUTING.md section so future maintainers know how to update GIFs when workflows change.

The existing infrastructure (render script at `scripts/marketing/render-walkthrough-gif.py`, SVG storyboards at `vscode-extension/media/walkthrough/`, demo workspace at `demo_workspace/`) is already on master. This PR wires it together with documentation.

## Test plan

- [ ] Verify `docs/assets/gifs/README.md` exists and render commands match the script's `--help` output.
- [ ] Verify `docs/assets/recordings/` is gitignored by creating a test `.mp4` file there and confirming `git status` does not track it.
- [ ] Verify `CONTRIBUTING.md` "Updating Demo GIFs" section appears in the rendered docs.
- [ ] Confirm linked paths (storyboards, demo_workspace, render script) resolve correctly from the guide.