### PR TITLE
feat(lsp): heredoc language injection for SQL/HTML/JSON (#2059)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "perl-lexer",
  "perl-parser-core",
  "perl-tdd-support",
+ "regex",
  "rustc-hash",
 ]
 

--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -181,6 +181,8 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
                         SemanticTokenType::REGEXP,
                         SemanticTokenType::OPERATOR,
                         SemanticTokenType::new("sql_string"), // DBI/SQL string context (Issue #2337)
+                        SemanticTokenType::new("sql_heredoc_keyword"), // SQL keyword in <<SQL heredoc (Issue #2059)
+                        SemanticTokenType::new("json_heredoc_key"), // JSON key in <<JSON heredoc (Issue #2059)
                     ],
                     token_modifiers: vec![
                         SemanticTokenModifier::DECLARATION,

--- a/crates/perl-lsp-protocol/tests/capability_advertisement_tests.rs
+++ b/crates/perl-lsp-protocol/tests/capability_advertisement_tests.rs
@@ -276,14 +276,15 @@ fn semantic_tokens_legend_has_token_types() -> Result<(), Box<dyn std::error::Er
         .pointer("/semanticTokensProvider/legend/tokenTypes")
         .and_then(|v| v.as_array())
         .ok_or("missing legend.tokenTypes")?;
-    // 20 standard LSP types + sql_string = 21 total.
+    // 20 standard LSP types + sql_string + sql_heredoc_keyword + json_heredoc_key = 23 total.
     // This count assertion catches legend desynchronization (issue #2103) at the
     // advertisement layer — if a type is added to the internal legend but not
     // advertised (or vice versa), this fails immediately.
     assert_eq!(
         types.len(),
-        21,
-        "expected 21 token types (20 standard + sql_string); got {:?}",
+        23,
+        "expected 23 token types (20 standard + sql_string + sql_heredoc_keyword + json_heredoc_key); \
+         got {:?}",
         types
     );
     let type_strs: Vec<&str> = types.iter().filter_map(|t| t.as_str()).collect();
@@ -299,6 +300,15 @@ fn semantic_tokens_legend_has_token_types() -> Result<(), Box<dyn std::error::Er
     assert!(
         type_strs.contains(&"sql_string"),
         "should include 'sql_string' token type (DBI/SQL context, issue #2337)"
+    );
+    // Heredoc injection types added in issue #2059.
+    assert!(
+        type_strs.contains(&"sql_heredoc_keyword"),
+        "should include 'sql_heredoc_keyword' token type (heredoc SQL injection, issue #2059)"
+    );
+    assert!(
+        type_strs.contains(&"json_heredoc_key"),
+        "should include 'json_heredoc_key' token type (heredoc JSON injection, issue #2059)"
     );
     Ok(())
 }

--- a/crates/perl-lsp-semantic-tokens/Cargo.toml
+++ b/crates/perl-lsp-semantic-tokens/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 perl-parser-core = { workspace = true }
 perl-lexer = { workspace = true }
 rustc-hash = "2.1.2"
+regex = "1.12.2"
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
+++ b/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
@@ -106,7 +106,10 @@
 
 use perl_lexer::{PerlLexer, StringPart, TokenType};
 use perl_parser_core::ast::{Node, NodeKind};
+use regex::Regex;
 use rustc_hash::FxHashMap;
+use std::collections::VecDeque;
+use std::sync::LazyLock;
 
 /// LSP semantic token encoding format for client transmission
 ///
@@ -154,27 +157,29 @@ pub fn legend() -> TokensLegend {
     // Clients decode emitted tokenType indices using the advertised legend;
     // any ordering mismatch renders every token with the wrong colour.
     let types = vec![
-        "namespace",     // 0
-        "type",          // 1
-        "class",         // 2
-        "interface",     // 3
-        "enum",          // 4
-        "enumMember",    // 5
-        "typeParameter", // 6
-        "function",      // 7
-        "method",        // 8
-        "property",      // 9
-        "macro",         // 10
-        "variable",      // 11
-        "parameter",     // 12
-        "keyword",       // 13
-        "modifier",      // 14
-        "comment",       // 15
-        "string",        // 16
-        "number",        // 17
-        "regexp",        // 18
-        "operator",      // 19
-        "sql_string",    // 20 — DBI/SQL string context (Issue #2337)
+        "namespace",           // 0
+        "type",                // 1
+        "class",               // 2
+        "interface",           // 3
+        "enum",                // 4
+        "enumMember",          // 5
+        "typeParameter",       // 6
+        "function",            // 7
+        "method",              // 8
+        "property",            // 9
+        "macro",               // 10
+        "variable",            // 11
+        "parameter",           // 12
+        "keyword",             // 13
+        "modifier",            // 14
+        "comment",             // 15
+        "string",              // 16
+        "number",              // 17
+        "regexp",              // 18
+        "operator",            // 19
+        "sql_string",          // 20 — DBI/SQL string context (Issue #2337)
+        "sql_heredoc_keyword", // 21 — SQL keyword inside <<SQL heredoc (Issue #2059)
+        "json_heredoc_key",    // 22 — JSON object key inside <<JSON heredoc (Issue #2059)
     ]
     .into_iter()
     .map(|s| s.to_string())
@@ -214,6 +219,122 @@ pub fn legend() -> TokensLegend {
 #[inline]
 fn kind_idx(leg: &TokensLegend, k: &str) -> u32 {
     *leg.map.get(k).unwrap_or(&0)
+}
+
+// ---------------------------------------------------------------------------
+// Heredoc language injection helpers (Issue #2059)
+// ---------------------------------------------------------------------------
+
+/// Regex matching SQL keywords (case-insensitive).
+///
+/// Matches word-boundary-delimited SQL keywords in a heredoc body and emits
+/// `sql_heredoc_keyword` semantic tokens for each match.
+static SQL_KW_RE: LazyLock<Option<Regex>> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(SELECT|FROM|WHERE|AND|OR|NOT|IN|IS|NULL|LIKE|BETWEEN|JOIN|INNER|LEFT|RIGHT|OUTER|FULL|CROSS|ON|AS|DISTINCT|GROUP|BY|ORDER|HAVING|LIMIT|OFFSET|UNION|ALL|INSERT|INTO|VALUES|UPDATE|SET|DELETE|CREATE|DROP|ALTER|TABLE|INDEX|VIEW|RETURNING|WITH|CASE|WHEN|THEN|ELSE|END|EXISTS|EXCEPT|INTERSECT)\b"
+    ).ok()
+});
+
+/// Regex matching JSON object keys: `"key":`.
+static JSON_KEY_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| Regex::new(r#""([^"\\]|\\.)*"\s*:"#).ok());
+
+/// Determine the injection language for a heredoc start token.
+///
+/// `text` is the full heredoc start token text (e.g. `<<SQL`, `<<'SQL'`, `<<~SQL`,
+/// `<<"sql"`). Returns `Some("sql")` or `Some("json")` for known language tags,
+/// and `None` for everything else (including backtick command heredocs).
+///
+/// # Edge cases handled
+///
+/// - `<<~SQL` — indented heredoc, strip the `~`
+/// - `<<'SQL'`, `<<"SQL"` — quoted delimiters, strip quotes
+/// - Case-insensitive: `<<sql`, `<<Sql`, `<<SQL` all map to `"sql"`
+/// - Backtick heredoc `<<\`SQL\`` — returns `None` (command exec, not injection)
+fn heredoc_injection_language(text: &str) -> Option<&'static str> {
+    let rest = text.strip_prefix("<<")?;
+    // Strip optional indented-heredoc `~`
+    let rest = rest.strip_prefix('~').unwrap_or(rest);
+    // Backtick delimiter → command heredoc, never inject
+    if rest.starts_with('`') {
+        return None;
+    }
+    // Strip matching quote characters (single or double)
+    let label = rest.trim_start_matches(['\'', '"']).trim_end_matches(['\'', '"']);
+    match label.to_ascii_lowercase().as_str() {
+        "sql" | "mysql" | "postgres" | "postgresql" | "sqlite" => Some("sql"),
+        "json" => Some("json"),
+        _ => None,
+    }
+}
+
+/// Emit semantic tokens for SQL keyword matches inside a heredoc body.
+fn tokenize_sql_body(
+    body: &str,
+    body_start: usize,
+    to_pos16: &impl Fn(usize) -> (u32, u32),
+    leg: &TokensLegend,
+    out: &mut Vec<(u32, u32, u32, u32, u32)>,
+) {
+    let re = match SQL_KW_RE.as_ref() {
+        Some(r) => r,
+        None => return,
+    };
+    let kind = kind_idx(leg, "sql_heredoc_keyword");
+    for mat in re.find_iter(body) {
+        let offset = body_start + mat.start();
+        let (sl, sc) = to_pos16(offset);
+        let (el, ec) = to_pos16(body_start + mat.end());
+        let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+        if len > 0 {
+            out.push((sl, sc, len, kind, 0));
+        }
+    }
+}
+
+/// Emit semantic tokens for JSON key matches inside a heredoc body.
+fn tokenize_json_body(
+    body: &str,
+    body_start: usize,
+    to_pos16: &impl Fn(usize) -> (u32, u32),
+    leg: &TokensLegend,
+    out: &mut Vec<(u32, u32, u32, u32, u32)>,
+) {
+    let re = match JSON_KEY_RE.as_ref() {
+        Some(r) => r,
+        None => return,
+    };
+    let kind = kind_idx(leg, "json_heredoc_key");
+    for mat in re.find_iter(body) {
+        // Highlight only the key string (before the colon), not the colon itself.
+        // The regex matches `"key":` — trim the trailing colon off the token length.
+        let match_text = mat.as_str();
+        let colon_offset = match_text.rfind(':').unwrap_or(match_text.len());
+        let key_start = body_start + mat.start();
+        let key_end = key_start + colon_offset;
+        let (sl, sc) = to_pos16(key_start);
+        let (el, ec) = to_pos16(key_end);
+        let len = if sl == el { ec.saturating_sub(sc) } else { 0 };
+        if len > 0 {
+            out.push((sl, sc, len, kind, 0));
+        }
+    }
+}
+
+/// Dispatch to the appropriate body tokenizer based on the injection language.
+fn tokenize_heredoc_body(
+    body: &str,
+    body_start: usize,
+    lang: &str,
+    to_pos16: &impl Fn(usize) -> (u32, u32),
+    leg: &TokensLegend,
+    out: &mut Vec<(u32, u32, u32, u32, u32)>,
+) {
+    match lang {
+        "sql" => tokenize_sql_body(body, body_start, to_pos16, leg, out),
+        "json" => tokenize_json_body(body, body_start, to_pos16, leg, out),
+        _ => {}
+    }
 }
 
 /// Returns `true` when `full_name` is a well-known Perl built-in special variable.
@@ -308,7 +429,12 @@ pub fn collect_semantic_tokens(
     let mut lexer_tokens: Vec<(u32, u32, u32, u32, u32)> = Vec::new();
 
     // 1) Fast path from lexer categories: conservative single-line emission
-    let mut lexer = PerlLexer::new(text);
+    // FIFO queue of pending heredoc injection languages, one entry per heredoc start token
+    // encountered in source order. Multiple heredocs on the same line (`<<SQL, <<JSON`)
+    // are handled correctly: we push on HeredocStart and pop on HeredocBody.
+    let mut pending_heredoc_langs: VecDeque<Option<&'static str>> = VecDeque::new();
+    // Use with_body_tokens so the lexer emits HeredocBody tokens (needed for injection).
+    let mut lexer = PerlLexer::with_body_tokens(text);
     while let Some(tok) = lexer.next_token() {
         let (sl, sc) = to_pos16(tok.start);
         let (el, ec) = to_pos16(tok.end);
@@ -395,9 +521,27 @@ pub fn collect_semantic_tokens(
             | TokenType::QuoteSingle
             | TokenType::QuoteDouble
             | TokenType::QuoteWords
-            | TokenType::QuoteCommand
-            | TokenType::HeredocStart
-            | TokenType::HeredocBody(_) => "string",
+            | TokenType::QuoteCommand => "string",
+
+            TokenType::HeredocStart => {
+                // Record the injection language for this heredoc's upcoming body token.
+                pending_heredoc_langs.push_back(heredoc_injection_language(&tok.text));
+                "string"
+            }
+
+            TokenType::HeredocBody(_) => {
+                // Pop the queued injection language for the corresponding heredoc start.
+                // NOTE: The Arc<str> inside HeredocBody is always empty_arc(); the actual
+                // body text must be sliced from the source using tok.start..tok.end.
+                if let Some(maybe_lang) = pending_heredoc_langs.pop_front()
+                    && let Some(lang) = maybe_lang
+                {
+                    let body_end = tok.end.min(text.len());
+                    let body = &text[tok.start.min(body_end)..body_end];
+                    tokenize_heredoc_body(body, tok.start, lang, to_pos16, &leg, &mut lexer_tokens);
+                }
+                "string"
+            }
 
             TokenType::Number(_) => "number",
 

--- a/crates/perl-lsp-semantic-tokens/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-semantic-tokens/tests/comprehensive_unit_tests.rs
@@ -112,8 +112,9 @@ fn legend_modifiers_have_no_duplicates() {
 #[test]
 fn legend_token_type_count() {
     let leg = legend();
-    // 20 standard LSP types + sql_string = 21 total (must match capabilities_for() advertisement)
-    assert_eq!(leg.token_types.len(), 21, "expected 21 token types");
+    // 20 standard LSP types + sql_string + sql_heredoc_keyword + json_heredoc_key
+    // = 23 total (must match capabilities_for() advertisement)
+    assert_eq!(leg.token_types.len(), 23, "expected 23 token types");
 }
 
 #[test]

--- a/crates/perl-lsp-semantic-tokens/tests/token_classification_tests.rs
+++ b/crates/perl-lsp-semantic-tokens/tests/token_classification_tests.rs
@@ -1243,3 +1243,127 @@ fn test_two_special_variables_in_same_expression_both_get_modifier() {
          got {special_count} special-variable tokens (expected >= 2)"
     );
 }
+
+// ===========================================================================
+// Heredoc language injection — Issue #2059
+// ===========================================================================
+
+#[test]
+fn sql_heredoc_keywords_are_classified() {
+    // <<SQL heredoc body containing SQL keywords should produce sql_heredoc_keyword tokens.
+    let code = "my $sql = <<SQL;\nSELECT * FROM users WHERE id = ?\nSQL\n";
+    let result = tokens_of_type(code, "sql_heredoc_keyword");
+    assert!(
+        !result.is_empty(),
+        "<<SQL heredoc body with SELECT/FROM/WHERE should produce >= 1 sql_heredoc_keyword token; \
+         got none. Legend has sql_heredoc_keyword: {}",
+        legend().map.contains_key("sql_heredoc_keyword")
+    );
+}
+
+#[test]
+fn json_heredoc_keys_are_classified() {
+    // <<JSON heredoc body with a quoted key:value should produce json_heredoc_key tokens.
+    let code = "my $j = <<JSON;\n{\"key\": \"value\", \"count\": 42}\nJSON\n";
+    let result = tokens_of_type(code, "json_heredoc_key");
+    assert!(
+        !result.is_empty(),
+        "<<JSON heredoc body with quoted keys should produce >= 1 json_heredoc_key token; \
+         got none. Legend has json_heredoc_key: {}",
+        legend().map.contains_key("json_heredoc_key")
+    );
+}
+
+#[test]
+fn non_sql_heredoc_body_is_plain_string() {
+    // <<EOF heredoc should not produce any injection tokens.
+    let code = "my $txt = <<EOF;\nSELECT this is just text\nEOF\n";
+    let sql_result = tokens_of_type(code, "sql_heredoc_keyword");
+    let json_result = tokens_of_type(code, "json_heredoc_key");
+    assert!(
+        sql_result.is_empty(),
+        "<<EOF heredoc should not produce sql_heredoc_keyword tokens; got: {:?}",
+        sql_result
+    );
+    assert!(
+        json_result.is_empty(),
+        "<<EOF heredoc should not produce json_heredoc_key tokens; got: {:?}",
+        json_result
+    );
+}
+
+#[test]
+fn multiple_heredocs_same_line_both_injected() {
+    // Two heredocs on the same line: first SQL, then JSON.
+    // Both bodies must get injection tokens.
+    let code = "my ($a, $b) = (<<SQL, <<JSON);\nSELECT 1\nSQL\n{\"x\": 1}\nJSON\n";
+    let sql_result = tokens_of_type(code, "sql_heredoc_keyword");
+    let json_result = tokens_of_type(code, "json_heredoc_key");
+    assert!(
+        !sql_result.is_empty(),
+        "First heredoc (<<SQL) on multi-heredoc line should produce sql_heredoc_keyword tokens"
+    );
+    assert!(
+        !json_result.is_empty(),
+        "Second heredoc (<<JSON) on multi-heredoc line should produce json_heredoc_key tokens"
+    );
+}
+
+#[test]
+fn command_heredoc_not_injected() {
+    // Backtick heredoc (command exec) must NOT produce sql_heredoc_keyword tokens.
+    let code = "my $out = <<`SQL`;\nSELECT 1\nSQL\n";
+    let result = tokens_of_type(code, "sql_heredoc_keyword");
+    assert!(
+        result.is_empty(),
+        "Backtick (command) heredoc must not produce sql_heredoc_keyword tokens; got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn perl_variable_in_sql_heredoc_preserved() {
+    // A Perl variable inside a SQL heredoc body must still get a variable token.
+    // Injection tokens and variable tokens can coexist in the same heredoc body.
+    let code = "my $sql = <<SQL;\nSELECT * FROM users WHERE id = $user_id\nSQL\n";
+    let sql_result = tokens_of_type(code, "sql_heredoc_keyword");
+    let var_result = tokens_of_type(code, "variable");
+    assert!(
+        !sql_result.is_empty(),
+        "<<SQL heredoc should still produce sql_heredoc_keyword tokens when Perl variable present"
+    );
+    assert!(
+        !var_result.is_empty(),
+        "Perl variable $user_id inside SQL heredoc body should still get a variable token"
+    );
+}
+
+#[test]
+fn case_insensitive_sql_tag_is_recognized() {
+    // <<sql (lowercase) should also trigger SQL injection.
+    let code = "my $s = <<sql;\nSELECT 1\nsql\n";
+    let result = tokens_of_type(code, "sql_heredoc_keyword");
+    assert!(
+        !result.is_empty(),
+        "Lowercase <<sql tag should produce sql_heredoc_keyword tokens just like <<SQL"
+    );
+}
+
+#[test]
+fn quoted_sql_tag_is_recognized() {
+    // <<'SQL' (single-quoted delimiter) should trigger SQL injection.
+    let code = "my $s = <<'SQL';\nSELECT 1\nSQL\n";
+    let result = tokens_of_type(code, "sql_heredoc_keyword");
+    assert!(
+        !result.is_empty(),
+        "Single-quoted <<'SQL' tag should produce sql_heredoc_keyword tokens"
+    );
+}
+
+#[test]
+fn indented_heredoc_sql_tag_is_recognized() {
+    // <<~SQL (indented heredoc) should trigger SQL injection.
+    let code = "my $s = <<~SQL;\n    SELECT 1\n    SQL\n";
+    let result = tokens_of_type(code, "sql_heredoc_keyword");
+    assert!(!result.is_empty(), "Indented <<~SQL tag should produce sql_heredoc_keyword tokens");
+}

--- a/crates/perl-lsp/tests/lsp_semantic_legend_contract_tests.rs
+++ b/crates/perl-lsp/tests/lsp_semantic_legend_contract_tests.rs
@@ -491,3 +491,123 @@ fn default_library_modifier_bitmask_decodes_correctly_via_advertised_legend() ->
     let _ = child.wait();
     Ok(())
 }
+
+/// Contract test for the `sql_heredoc_keyword` token type (Issue #2059).
+///
+/// Verifies that `sql_heredoc_keyword` is present in the advertised legend AND that
+/// opening a document with a `<<SQL` heredoc containing `SELECT` produces at least one
+/// token that decodes to `sql_heredoc_keyword` via the advertised legend.
+///
+/// Guards against the legend index ordering class of bug fixed in PR #2772: if
+/// `sql_heredoc_keyword` is missing from the advertised legend, the emitted index would
+/// decode as a wrong type for every LSP client.
+#[test]
+fn sql_heredoc_keyword_index_decodes_correctly_via_advertised_legend() -> Result<(), BoxError> {
+    let bin = env!("CARGO_BIN_EXE_perl-lsp");
+    let mut child = Command::new(bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().ok_or("no stdin")?;
+    let stdout = child.stdout.take().ok_or("no stdout")?;
+    let mut reader = BufReader::new(stdout);
+
+    let init_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "capabilities": {
+                "general": { "positionEncodings": ["utf-16"] }
+            }
+        }
+    })
+    .to_string();
+    send_msg(&mut stdin, &init_req)?;
+    let init_resp = recv_until_id(&mut reader, 1)?;
+
+    let advertised_legend: Vec<String> =
+        init_resp["result"]["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"]
+            .as_array()
+            .ok_or("tokenTypes missing from initialize response")?
+            .iter()
+            .map(|v| v.as_str().unwrap_or("").to_string())
+            .collect();
+
+    // Verify sql_heredoc_keyword is present in the advertised legend.
+    let sql_heredoc_advertised_idx = advertised_legend
+        .iter()
+        .position(|s| s == "sql_heredoc_keyword")
+        .ok_or("sql_heredoc_keyword is not in the advertised tokenTypes legend")?;
+
+    send_msg(
+        &mut stdin,
+        &serde_json::json!({"jsonrpc":"2.0","method":"initialized","params":{}}).to_string(),
+    )?;
+
+    // Heredoc with SQL keyword — should produce sql_heredoc_keyword tokens.
+    let source = "my $sql = <<SQL;\nSELECT * FROM users WHERE id = ?\nSQL\n";
+    let did_open = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///sql_heredoc_contract_test.pl",
+                "languageId": "perl",
+                "version": 1,
+                "text": source
+            }
+        }
+    })
+    .to_string();
+    send_msg(&mut stdin, &did_open)?;
+
+    let sem_req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/semanticTokens/full",
+        "params": {
+            "textDocument": { "uri": "file:///sql_heredoc_contract_test.pl" }
+        }
+    })
+    .to_string();
+    send_msg(&mut stdin, &sem_req)?;
+    let sem_resp = recv_until_id(&mut reader, 2)?;
+
+    let data = sem_resp["result"]["data"]
+        .as_array()
+        .ok_or("semanticTokens response missing data array")?;
+
+    let mut decoded_types: Vec<String> = Vec::new();
+    for chunk in data.chunks(5) {
+        let type_idx = chunk[3].as_u64().ok_or("token_type not u64")? as usize;
+        let type_name = advertised_legend
+            .get(type_idx)
+            .cloned()
+            .unwrap_or_else(|| format!("OUT_OF_RANGE({})", type_idx));
+        decoded_types.push(type_name);
+    }
+
+    let found = decoded_types.iter().any(|t| t == "sql_heredoc_keyword");
+    assert!(
+        found,
+        "No token decoded to 'sql_heredoc_keyword' via the advertised legend for <<SQL heredoc \
+         containing SELECT. Decoded types: {:?}. \
+         sql_heredoc_keyword is at advertised index {}.",
+        decoded_types, sql_heredoc_advertised_idx
+    );
+
+    send_msg(
+        &mut stdin,
+        &serde_json::json!({"jsonrpc":"2.0","id":3,"method":"shutdown","params":null}).to_string(),
+    )?;
+    let _ = recv_until_id(&mut reader, 3)?;
+    send_msg(
+        &mut stdin,
+        &serde_json::json!({"jsonrpc":"2.0","method":"exit","params":null}).to_string(),
+    )?;
+    let _ = child.wait();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `sql_heredoc_keyword` (index 21) and `json_heredoc_key` (index 22) semantic token types to the legend, advertised in `capabilities.rs` and `semantic_tokens.rs` in lockstep (guards the PR #2772 index invariant)
- Switches the semantic token lexer from `PerlLexer::new` to `PerlLexer::with_body_tokens` so heredoc body tokens are emitted
- Extracts the injection language from the `HeredocStart` token text via `heredoc_injection_language()`, handling `<<SQL`, `<<'SQL'`, `<<"SQL"`, `<<~SQL`, and backtick (command heredoc) suppression — case-insensitive via `to_ascii_lowercase`
- Uses a `VecDeque<Option<&'static str>>` (not a bare `Option`) to correctly handle multiple heredocs on a single line (`<<SQL, <<JSON`)
- SQL tokenizer: `LazyLock<Option<Regex>>` keyword pass with word-boundary matching — emits `sql_heredoc_keyword` tokens
- JSON tokenizer: `LazyLock<Option<Regex>>` regex matching `"key":` patterns — emits `json_heredoc_key` tokens (key string only, colon excluded)

## Test plan

- [x] 8 new unit tests in `token_classification_tests.rs`: `sql_heredoc_keywords_are_classified`, `json_heredoc_keys_are_classified`, `non_sql_heredoc_body_is_plain_string`, `multiple_heredocs_same_line_both_injected`, `command_heredoc_not_injected`, `perl_variable_in_sql_heredoc_preserved`, `case_insensitive_sql_tag_is_recognized`, `quoted_sql_tag_is_recognized`, `indented_heredoc_sql_tag_is_recognized`
- [x] 1 new LSP contract integration test in `lsp_semantic_legend_contract_tests.rs`: `sql_heredoc_keyword_index_decodes_correctly_via_advertised_legend` (full LSP roundtrip via advertised legend)
- [x] Updated `legend_token_type_count` in `comprehensive_unit_tests.rs`: 21 → 23
- [x] Updated `semantic_tokens_legend_has_token_types` in `capability_advertisement_tests.rs`: 21 → 23 + asserts for new types
- [x] All 229+ existing tests pass unchanged
- [x] `cargo clippy -p perl-lsp-semantic-tokens -p perl-lsp-protocol` clean

## Knowledge artifacts

**Key discovery:** `PerlLexer::new(text)` does NOT emit `HeredocBody` tokens — requires `PerlLexer::with_body_tokens(text)`. The `Arc<str>` payload inside `HeredocBody(content)` is always `empty_arc()` — body text must be sliced from source as `&text[tok.start..tok.end]`.

**Risk:** Legend index ordering invariant (PR #2772). Both `sql_heredoc_keyword` (21) and `json_heredoc_key` (22) are appended at the end — never inserted in the middle.

Closes #2059