### PR TITLE
fix(distribution): align Linux packaging templates with perllsp binary name

### DIFF
--- a/distribution/chocolatey/tools/chocolateyuninstall.ps1
+++ b/distribution/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Remove shims
-Uninstall-BinFile -Name "perl-lsp" -ErrorAction SilentlyContinue
+Uninstall-BinFile -Name "perllsp" -ErrorAction SilentlyContinue
 Uninstall-BinFile -Name "perl-dap" -ErrorAction SilentlyContinue
 
 Write-Host "perl-lsp has been uninstalled successfully."

--- a/distribution/linux/dnf/perl-lsp.spec.in
+++ b/distribution/linux/dnf/perl-lsp.spec.in
@@ -9,7 +9,7 @@ Source0:        __SOURCE_TARBALL__
 
 %description
 perl-lsp is a native Perl language server written in Rust.
-This package installs the perl-lsp and perl-dap executables from the release artifact.
+This package installs the perllsp and perl-dap executables from the release artifact.
 
 %prep
 %autosetup -n __SOURCE_DIR__
@@ -19,13 +19,13 @@ true
 
 %install
 rm -rf %{buildroot}
-install -Dpm 0755 perl-lsp %{buildroot}%{_bindir}/perl-lsp
+install -Dpm 0755 perllsp %{buildroot}%{_bindir}/perllsp
 install -Dpm 0755 perl-dap %{buildroot}%{_bindir}/perl-dap
 
 %files
 %license LICENSE-MIT LICENSE-APACHE
 %doc README.md
-%{_bindir}/perl-lsp
+%{_bindir}/perllsp
 %{_bindir}/perl-dap
 
 %changelog

--- a/distribution/linux/pacman/PKGBUILD.in
+++ b/distribution/linux/pacman/PKGBUILD.in
@@ -11,7 +11,7 @@ sha256sums=('__DOWNLOAD_SHA256__')
 
 package() {
   cd "$srcdir/__SOURCE_DIR__"
-  install -Dm755 perl-lsp "$pkgdir/usr/bin/perl-lsp"
+  install -Dm755 perllsp "$pkgdir/usr/bin/perllsp"
   install -Dm755 perl-dap "$pkgdir/usr/bin/perl-dap"
   install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
   install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"

--- a/distribution/winget/perl-lsp.yaml
+++ b/distribution/winget/perl-lsp.yaml
@@ -13,7 +13,7 @@ Installers:
     InstallerUrl: __RELEASE_URL__
     InstallerSha256: __RELEASE_SHA256__
     Commands:
-      - perl-lsp
+      - perllsp
       - perl-dap
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Update dnf spec and pacman PKGBUILD templates to use `perllsp` binary name (not `perl-lsp`)

## Test plan
- [x] grep confirms no stale `perl-lsp` binary references in distribution/