### PR TITLE
chore: remove 8 unused dependencies across 6 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,7 +2537,6 @@ dependencies = [
  "perl-lsp-diagnostics",
  "perl-lsp-inlay-hints",
  "perl-lsp-navigation",
- "perl-lsp-providers",
  "perl-lsp-rename",
  "perl-lsp-semantic-tokens",
  "perl-lsp-tooling",
@@ -2738,7 +2737,6 @@ dependencies = [
 name = "perl-tdd-support"
 version = "0.12.1"
 dependencies = [
- "anyhow",
  "lsp-types",
  "perl-parser-core",
  "perl-test-must",
@@ -2823,7 +2821,6 @@ version = "0.12.1"
 dependencies = [
  "logos",
  "perl-tdd-support",
- "regex",
 ]
 
 [[package]]

--- a/crates/perl-lsp-feature-flags/Cargo.toml
+++ b/crates/perl-lsp-feature-flags/Cargo.toml
@@ -15,8 +15,10 @@ categories = ["development-tools", "development-tools::testing"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-perl-lsp-feature-contracts = { workspace = true }
 perl-lsp-feature-ids = { workspace = true }
+
+[dev-dependencies]
+perl-lsp-feature-contracts = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -33,7 +33,6 @@ perl-workspace-index = { workspace = true }
 perl-refactoring = { workspace = true }
 perl-incremental-parsing = { workspace = true, optional = true }
 perl-tdd-support = { workspace = true }
-perl-lsp-providers = { workspace = true }
 perl-lsp-code-actions = { workspace = true }
 perl-lsp-completion = { workspace = true }
 perl-lsp-diagnostics = { workspace = true }
@@ -75,7 +74,6 @@ cli = []
 incremental = ["anyhow", "perl-incremental-parsing"]
 lsp-compat = [
   "lsp-types",
-  "perl-lsp-providers/lsp-compat",
   "perl-workspace-index/lsp-compat",
   "perl-tdd-support/lsp-compat",
 ]  # LSP type compatibility shim for migration period

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -27,7 +27,6 @@ perl-parser-core = { workspace = true }
 perl-test-must = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-anyhow = "1.0.102"
 lsp-types = { version = "0.97.0", optional = true }
 url = { version = "2.5.8", optional = true }
 

--- a/crates/perl-ts-logos-lexer/Cargo.toml
+++ b/crates/perl-ts-logos-lexer/Cargo.toml
@@ -13,12 +13,8 @@ documentation = "https://docs.rs/perl-ts-logos-lexer"
 keywords = ["perl", "lexer", "logos", "tokenizer", "parser"]
 categories = ["parsing", "text-processing", "development-tools"]
 
-[package.metadata.cargo-machete]
-ignored = ["regex"]  # Used by logos #[regex(...)] proc-macro attributes
-
 [dependencies]
 logos = "0.16.0"
-regex = "1.12.2"
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -21,10 +21,9 @@ ignored = ["perl-lexer", "regex"]  # perl-lexer re-exported via perl-ts-heredoc-
 perl-lexer = { path = "../perl-lexer" }
 perl-parser = { path = "../perl-parser" }
 perl-parser-pest = { path = "../perl-parser-pest", optional = true }
-tree-sitter = "0.26.6"
+tree-sitter = { version = "0.26.6", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 postcard = { version = "1.1.3", features = ["alloc"] }
-proptest = "1.11.0"
 walkdir = "2.5.0"
 thiserror = "2.0.17"
 unicode-ident = "1.0.22"
@@ -50,6 +49,7 @@ perl-ts-advanced-parsers = { path = "../perl-ts-advanced-parsers", optional = tr
 [dev-dependencies]
 criterion = "0.8.1"
 test-case = "3.3.1"
+proptest = "1.11.0"
 
 [lints.rust]
 unused_imports = "warn"
@@ -78,7 +78,7 @@ pure-rust = [
 # Source v2 Pest modules from perl-parser-pest microcrate (enabled by default).
 v2-pest-microcrate = ["dep:perl-parser-pest"]
 bindings = ["dep:bindgen"]
-c-parser = ["dep:cc"]
+c-parser = ["dep:cc", "dep:tree-sitter"]
 pure-rust-standalone = ["pure-rust"]  # For benchmarking without perl-lexer
 token-parser = [
   "dep:perl-ts-logos-lexer",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools"]
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 color-eyre = "0.6.5"
-similar = "2.7.0"
+similar = { version = "2.7.0", optional = true }
 duct = "1.1.1"
 walkdir = "2.5.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -28,7 +28,7 @@ console = "0.16.2"
 chrono = { version = "0.4.43", features = ["serde"] }
 perl-parser = { workspace = true }
 perl-parser-pest = { workspace = true, optional = true }
-tree-sitter = { workspace = true }
+tree-sitter = { workspace = true, optional = true }
 tree-sitter-perl = { path = "../crates/tree-sitter-perl-rs", optional = true, features = ["c-parser"] }
 regex = "1.12.2"
 serde_yaml_ng = "0.10.0"
@@ -49,6 +49,6 @@ perl-tdd-support = { workspace = true }
 
 [features]
 # Additional tasks that depend on legacy tree-sitter-perl crate
-legacy = ["tree-sitter-perl", "perl-parser-pest"]
+legacy = ["tree-sitter-perl", "perl-parser-pest", "dep:similar"]
 # Parser-related tasks
-parser-tasks = ["tree-sitter-perl"]
+parser-tasks = ["tree-sitter-perl", "dep:tree-sitter"]


### PR DESCRIPTION
## Summary
- Remove unused dependencies identified by `cargo +nightly udeps`:
  - perl-lsp-feature-flags: perl-lsp-feature-contracts
  - perl-parser: perl-lsp-providers
  - perl-tdd-support: anyhow
  - perl-ts-logos-lexer: regex
  - tree-sitter-perl-rs: proptest, tree-sitter
  - xtask: similar, tree-sitter

## Test plan
- [x] `cargo build --workspace` compiles
- [x] Tests pass for affected crates