### PR TITLE
fix(ci): regenerate stale LSP capability snapshots

### DIFF
--- a/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
+++ b/crates/perl-lsp/tests/lsp_capabilities_snapshot.rs
@@ -146,6 +146,15 @@ fn write_snapshots(snapshots_dir: &Path) -> Result<(), Box<dyn std::error::Error
 fn regenerate_snapshots() -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
 
+    // If UPDATE_SNAPSHOTS=1, write to the real snapshots directory
+    if std::env::var("UPDATE_SNAPSHOTS").as_deref() == Ok("1") {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let snapshots_dir = manifest_dir.join("tests").join("snapshots");
+        write_snapshots(&snapshots_dir)?;
+        eprintln!("Snapshots updated in {:?}", snapshots_dir);
+        return Ok(());
+    }
+
     let temp_dir = tempfile::tempdir()?;
     write_snapshots(temp_dir.path())?;
 

--- a/crates/perl-lsp/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/all_capabilities.json
@@ -129,7 +129,9 @@
         "number",
         "regexp",
         "operator",
-        "sql_string"
+        "sql_string",
+        "sql_heredoc_keyword",
+        "json_heredoc_key"
       ]
     },
     "range": true

--- a/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/ga_lock_capabilities.json
@@ -128,7 +128,9 @@
         "number",
         "regexp",
         "operator",
-        "sql_string"
+        "sql_string",
+        "sql_heredoc_keyword",
+        "json_heredoc_key"
       ]
     },
     "range": true

--- a/crates/perl-lsp/tests/snapshots/production_capabilities.json
+++ b/crates/perl-lsp/tests/snapshots/production_capabilities.json
@@ -126,7 +126,9 @@
         "number",
         "regexp",
         "operator",
-        "sql_string"
+        "sql_string",
+        "sql_heredoc_keyword",
+        "json_heredoc_key"
       ]
     },
     "range": true


### PR DESCRIPTION
## Summary
- Regenerated 3 stale LSP capability snapshot files (`production_capabilities.json`, `ga_lock_capabilities.json`, `all_capabilities.json`) to include two new semantic token types: `sql_heredoc_keyword` and `json_heredoc_key`
- Added `UPDATE_SNAPSHOTS=1` env var support to the `regenerate_snapshots` test for easier future snapshot updates: `UPDATE_SNAPSHOTS=1 cargo test -p perl-lsp-rs --test lsp_capabilities_snapshot regenerate_snapshots -- --exact`

## Test plan
- [x] All 5 snapshot tests pass: `cargo test -p perl-lsp-rs --test lsp_capabilities_snapshot` (5 passed, 0 failed)
- [x] Format check clean for perl-lsp-rs
- [ ] CI gate validates on GitHub