### PR TITLE
fix(ci): revert xtask optional deps that broke v2_parity gate

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools"]
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 color-eyre = "0.6.5"
-similar = { version = "2.7.0", optional = true }
+similar = "2.7.0"
 duct = "1.1.1"
 walkdir = "2.5.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -28,7 +28,7 @@ console = "0.16.2"
 chrono = { version = "0.4.43", features = ["serde"] }
 perl-parser = { workspace = true }
 perl-parser-pest = { workspace = true, optional = true }
-tree-sitter = { workspace = true, optional = true }
+tree-sitter = { workspace = true }
 tree-sitter-perl = { path = "../crates/tree-sitter-perl-rs", optional = true, features = ["c-parser"] }
 regex = "1.12.2"
 serde_yaml_ng = "0.10.0"
@@ -49,6 +49,6 @@ perl-tdd-support = { workspace = true }
 
 [features]
 # Additional tasks that depend on legacy tree-sitter-perl crate
-legacy = ["tree-sitter-perl", "perl-parser-pest", "dep:similar"]
+legacy = ["tree-sitter-perl", "perl-parser-pest"]
 # Parser-related tasks
-parser-tasks = ["tree-sitter-perl", "dep:tree-sitter"]
+parser-tasks = ["tree-sitter-perl"]

--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -381,6 +381,7 @@ fn resolve_manifest_module_path(path: &str) -> Option<PathBuf> {
     resolve_manifest_module_path_impl(path, windows_manifest_module_path)
 }
 
+#[allow(unused_variables)]
 fn resolve_manifest_module_path_impl<F>(path: &str, windows_converter: F) -> Option<PathBuf>
 where
     F: Fn(&str) -> Option<PathBuf>,


### PR DESCRIPTION
## Summary
- Revert `similar` and `tree-sitter` from optional back to required in xtask
- These are used unconditionally by `corpus.rs`, `compare_parsers.rs`, and `highlight.rs`
- Making them optional caused E0432 (unresolved import) on CI
- Also suppress `unused_variables` warning for `windows_converter` on non-Windows platforms

## Test plan
- [x] `cargo check -p xtask` compiles clean
- Fixes v2_parity gate failure in CI run #23932381546