### PR TITLE
fix(lsp): replace silently swallowed errors with tracing log calls

### DIFF
--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -571,7 +571,9 @@ impl ExecuteCommandProvider {
     fn find_workspace_root(&self, path: &std::path::Path) -> Option<std::path::PathBuf> {
         // Tier 1: explicit workspace roots registered with the provider.
         if !self.workspace_roots.is_empty() {
-            let canonical_path = path.canonicalize().ok();
+            let canonical_path = path.canonicalize().map_err(|e| {
+                tracing::debug!(path = %path.display(), error = %e, "workspace root: failed to canonicalize path");
+            }).ok();
             for root in &self.workspace_roots {
                 let Ok(canonical_root) = root.canonicalize() else { continue };
                 if canonical_path.as_ref().is_some_and(|p| p.starts_with(&canonical_root)) {

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -116,9 +116,17 @@ impl PullDiagnosticsProvider {
                 let parse_errors: Vec<ParseError> = parser.errors().to_vec();
                 let ast = std::sync::Arc::new(ast);
                 let provider = DiagnosticsProvider::new(&ast, content.to_string());
-                let source_path = url::Url::parse(&uri.to_string())
+                let uri_str = uri.to_string();
+                let source_path = url::Url::parse(&uri_str)
+                    .map_err(|e| {
+                        tracing::warn!(uri = %uri_str, error = %e, "pull diagnostics: failed to parse URI");
+                    })
                     .ok()
-                    .and_then(|value| value.to_file_path().ok());
+                    .and_then(|value| {
+                        value.to_file_path().map_err(|()| {
+                            tracing::warn!(uri = %uri_str, "pull diagnostics: URI is not a file path");
+                        }).ok()
+                    });
                 provider
                     .get_diagnostics_with_path(
                         &ast,
@@ -306,6 +314,9 @@ impl PullDiagnosticsProvider {
             category: format!("{:?}", DiagnosticCode::ParseError.category()),
             fixable: is_fixable_diagnostic(code_str),
             tags: vec![],
+        })
+        .map_err(|e| {
+            tracing::warn!(error = %e, "pull diagnostics: failed to serialize diagnostic data");
         })
         .ok();
 

--- a/crates/perl-lsp/src/features/lsp_document_link.rs
+++ b/crates/perl-lsp/src/features/lsp_document_link.rs
@@ -65,8 +65,13 @@ pub fn collect_document_links(text: &str, uri: &Url) -> Result<Vec<DocumentLink>
                 links.push(DocumentLink {
                     range: to_range(text, s, e),
                     target: Url::parse(&format!("https://metacpan.org/pod/{}", name))
+                        .map_err(|e| {
+                            tracing::debug!(module = %name, error = %e, "document link: failed to build MetaCPAN URL");
+                        })
                         .ok()
-                        .and_then(|url| url.to_string().parse::<Uri>().ok()),
+                        .and_then(|url| url.to_string().parse::<Uri>().map_err(|e| {
+                            tracing::debug!(module = %name, error = %e, "document link: failed to parse MetaCPAN URI");
+                        }).ok()),
                     tooltip: Some(format!("Open {} on MetaCPAN", name)),
                     data: None,
                 });
@@ -90,8 +95,13 @@ pub fn collect_document_links(text: &str, uri: &Url) -> Result<Vec<DocumentLink>
                     links.push(DocumentLink {
                         range: to_range(text, s, e),
                         target: Url::parse(&format!("https://metacpan.org/pod/{}", name))
+                            .map_err(|e| {
+                                tracing::debug!(module = %name, error = %e, "document link: failed to build MetaCPAN URL");
+                            })
                             .ok()
-                            .and_then(|url| url.to_string().parse::<Uri>().ok()),
+                            .and_then(|url| url.to_string().parse::<Uri>().map_err(|e| {
+                                tracing::debug!(module = %name, error = %e, "document link: failed to parse MetaCPAN URI");
+                            }).ok()),
                         tooltip: Some(format!("Open {} on MetaCPAN", name)),
                         data: None,
                     });
@@ -115,14 +125,25 @@ pub fn collect_document_links(text: &str, uri: &Url) -> Result<Vec<DocumentLink>
                         // Try to resolve relative to current file
                         let target = if PathBuf::from(path).is_absolute() {
                             // Absolute path - works on both Unix and Windows
-                            Url::from_file_path(path).ok()
+                            Url::from_file_path(path)
+                                .map_err(|()| {
+                                    tracing::debug!(
+                                        path,
+                                        "document link: failed to convert absolute path to URL"
+                                    );
+                                })
+                                .ok()
                         } else {
                             // Relative to current file's directory
-                            uri.to_file_path().ok().and_then(|base_path| {
+                            uri.to_file_path().map_err(|()| {
+                                tracing::debug!(uri = %uri, "document link: URI is not a file path");
+                            }).ok().and_then(|base_path| {
                                 base_path.parent().and_then(|parent| {
                                     let resolved = parent.join(path);
                                     // Normalize the path for the current OS
-                                    Url::from_file_path(&resolved).ok()
+                                    Url::from_file_path(&resolved).map_err(|()| {
+                                        tracing::debug!(path = %resolved.display(), "document link: failed to convert resolved path to URL");
+                                    }).ok()
                                 })
                             })
                         };
@@ -135,7 +156,9 @@ pub fn collect_document_links(text: &str, uri: &Url) -> Result<Vec<DocumentLink>
                             };
                             links.push(DocumentLink {
                                 range: to_range(text, s, e),
-                                target: target_url.to_string().parse::<Uri>().ok(),
+                                target: target_url.to_string().parse::<Uri>().map_err(|e| {
+                                    tracing::debug!(error = %e, "document link: failed to parse file URI");
+                                }).ok(),
                                 tooltip: Some(format!("Open {}", display_path)),
                                 data: None,
                             });

--- a/crates/perl-lsp/src/runtime/diagnostic_debounce.rs
+++ b/crates/perl-lsp/src/runtime/diagnostic_debounce.rs
@@ -41,13 +41,17 @@ impl DiagnosticDebouncer {
     }
 
     pub(crate) fn schedule(&self, uri: &str) {
-        let _ = self.tx.send(DebounceMsg::Schedule(uri.to_string()));
+        if let Err(e) = self.tx.send(DebounceMsg::Schedule(uri.to_string())) {
+            tracing::debug!(error = %e, "diagnostic debounce: channel closed on schedule");
+        }
     }
 }
 
 impl Drop for DiagnosticDebouncer {
     fn drop(&mut self) {
-        let _ = self.tx.send(DebounceMsg::Shutdown);
+        if let Err(e) = self.tx.send(DebounceMsg::Shutdown) {
+            tracing::debug!(error = %e, "diagnostic debounce: channel closed on shutdown");
+        }
     }
 }
 

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -775,9 +775,18 @@ impl LspServer {
         }
 
         // Convert URI to file system path; skip non-file URIs
-        let file_path = match url::Url::parse(uri).ok().and_then(|u| u.to_file_path().ok()) {
-            Some(p) => p,
-            None => return,
+        let file_path = match url::Url::parse(uri) {
+            Ok(u) => match u.to_file_path() {
+                Ok(p) => p,
+                Err(()) => {
+                    tracing::warn!(uri, "perlcritic: URI is not a file path");
+                    return;
+                }
+            },
+            Err(e) => {
+                tracing::warn!(uri, error = %e, "perlcritic: failed to parse URI");
+                return;
+            }
         };
 
         // Silently skip if perlcritic is not installed.

--- a/crates/perl-lsp/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp/src/runtime/dispatch/mod.rs
@@ -131,14 +131,22 @@ impl LspServer {
                     ProviderCleanupContext::new(request.method.clone(), request.params.clone());
 
                 // Batch registration to reduce lock overhead
-                let _ = GLOBAL_CANCELLATION_REGISTRY.register_token(token);
-                let _ = GLOBAL_CANCELLATION_REGISTRY.register_cleanup(request_id, cleanup_context);
+                if let Err(e) = GLOBAL_CANCELLATION_REGISTRY.register_token(token) {
+                    tracing::trace!(error = %e, "cancellation: failed to register token");
+                }
+                if let Err(e) =
+                    GLOBAL_CANCELLATION_REGISTRY.register_cleanup(request_id, cleanup_context)
+                {
+                    tracing::trace!(error = %e, "cancellation: failed to register cleanup");
+                }
 
                 // Quick cancellation check after registration
                 if GLOBAL_CANCELLATION_REGISTRY.is_cancelled(request_id) {
                     if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
                         let cleanup_context =
-                            GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).ok().flatten();
+                            GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).map_err(|e| {
+                                tracing::trace!(error = %e, "cancellation: failed to cancel request (early)");
+                            }).ok().flatten();
                         return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
                     }
                     return Some(cancelled_response_with_method(request_id, &request.method));
@@ -331,7 +339,9 @@ impl LspServer {
             if let Some(token) = GLOBAL_CANCELLATION_REGISTRY.get_token(request_id) {
                 if token.is_cancelled() {
                     let cleanup_context =
-                        GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).ok().flatten();
+                        GLOBAL_CANCELLATION_REGISTRY.cancel_request(request_id).map_err(|e| {
+                            tracing::trace!(error = %e, "cancellation: failed to cancel request (post-dispatch)");
+                        }).ok().flatten();
                     return Some(enhanced_cancelled_response(&token, cleanup_context.as_ref()));
                 }
             }

--- a/crates/perl-lsp/src/runtime/file_watcher_debounce.rs
+++ b/crates/perl-lsp/src/runtime/file_watcher_debounce.rs
@@ -59,13 +59,17 @@ impl FileWatcherDebouncer {
     ///
     /// Repeated schedules of the same URI within the window reset its deadline.
     pub fn schedule(&self, uri: &str) {
-        let _ = self.tx.send(WatcherMsg::Schedule(uri.to_string()));
+        if let Err(e) = self.tx.send(WatcherMsg::Schedule(uri.to_string())) {
+            tracing::debug!(error = %e, "file watcher debounce: channel closed on schedule");
+        }
     }
 }
 
 impl Drop for FileWatcherDebouncer {
     fn drop(&mut self) {
-        let _ = self.tx.send(WatcherMsg::Shutdown);
+        if let Err(e) = self.tx.send(WatcherMsg::Shutdown) {
+            tracing::debug!(error = %e, "file watcher debounce: channel closed on shutdown");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `.ok()` and `let _ =` patterns in the LSP runtime with structured `tracing` log calls, making previously invisible failures visible in logs
- 7 files changed across diagnostics, dispatch, debounce, document links, and execute-command subsystems
- No control flow or return type changes -- only logging visibility added

### Log levels chosen by context

| Pattern | Level | Rationale |
|---------|-------|-----------|
| URI parse/conversion in diagnostics | `warn` | Actionable: indicates bad input reaching the server |
| Path canonicalize, channel closed | `debug` | Expected in some scenarios (shutdown, missing paths) |
| Cancellation registry ops | `trace` | High-frequency hot path, only useful for deep debugging |
| Document link URL construction | `debug` | Benign failures from unusual module names or paths |
| Diagnostic data serialization | `warn` | Should never fail, indicates a real bug if it does |

### Files changed

- `crates/perl-lsp/src/runtime/diagnostics.rs` -- perlcritic URI parse
- `crates/perl-lsp/src/features/diagnostics/pull.rs` -- pull diagnostics URI + serialization
- `crates/perl-lsp/src/execute_command/provider.rs` -- workspace root canonicalize
- `crates/perl-lsp/src/runtime/dispatch/mod.rs` -- cancellation registry operations
- `crates/perl-lsp/src/features/lsp_document_link.rs` -- document link URL construction
- `crates/perl-lsp/src/runtime/diagnostic_debounce.rs` -- channel send on schedule/shutdown
- `crates/perl-lsp/src/runtime/file_watcher_debounce.rs` -- channel send on schedule/shutdown

## Test plan

- [x] `cargo clippy -p perl-lsp-rs --lib` passes clean (no warnings)
- [x] `cargo test -p perl-lsp-rs --lib` passes (306 tests, 0 failures)
- [x] `cargo fmt -p perl-lsp-rs` applied
- [ ] CI gate runs on PR