### PR TITLE
test(dap): add 147 tests across 4 DAP crates for serde and edge cases

### DIFF
--- a/crates/perl-dap-config/tests/serde_edge_case_tests.rs
+++ b/crates/perl-dap-config/tests/serde_edge_case_tests.rs
@@ -1,0 +1,289 @@
+//! Serde round-trip and deserialization edge-case tests for perl-dap-config.
+//!
+//! These tests verify that LaunchConfiguration and AttachConfiguration
+//! serialize/deserialize correctly and handle edge cases.
+
+use perl_dap_config::{AttachConfiguration, LaunchConfiguration};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// ── LaunchConfiguration serde ──────────────────────────────────────
+
+#[test]
+fn launch_config_round_trip_all_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = HashMap::new();
+    env.insert("PERL5LIB".to_string(), "lib".to_string());
+    env.insert("DEBUG".to_string(), "1".to_string());
+
+    let config = LaunchConfiguration {
+        program: PathBuf::from("/path/to/script.pl"),
+        args: vec!["--verbose".to_string(), "-n".to_string()],
+        cwd: Some(PathBuf::from("/workspace")),
+        env,
+        perl_path: Some(PathBuf::from("/usr/local/bin/perl")),
+        include_paths: vec![PathBuf::from("lib"), PathBuf::from("local/lib/perl5")],
+    };
+
+    let json = serde_json::to_string(&config)?;
+    let back: LaunchConfiguration = serde_json::from_str(&json)?;
+
+    assert_eq!(back.program, config.program);
+    assert_eq!(back.args, config.args);
+    assert_eq!(back.cwd, config.cwd);
+    assert_eq!(back.perl_path, config.perl_path);
+    assert_eq!(back.include_paths, config.include_paths);
+    assert_eq!(back.env.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn launch_config_round_trip_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let config = LaunchConfiguration {
+        program: PathBuf::from("test.pl"),
+        args: vec![],
+        cwd: None,
+        env: HashMap::new(),
+        perl_path: None,
+        include_paths: vec![],
+    };
+
+    let json = serde_json::to_string(&config)?;
+    let back: LaunchConfiguration = serde_json::from_str(&json)?;
+
+    assert_eq!(back.program, PathBuf::from("test.pl"));
+    assert!(back.cwd.is_none());
+    assert!(back.perl_path.is_none());
+    assert!(back.args.is_empty());
+    assert!(back.include_paths.is_empty());
+    Ok(())
+}
+
+#[test]
+fn launch_config_deserialize_camel_case() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{
+        "program": "script.pl",
+        "args": ["--debug"],
+        "cwd": "/work",
+        "env": {},
+        "perlPath": "/usr/bin/perl",
+        "includePaths": ["/lib"]
+    }"#;
+
+    let config: LaunchConfiguration = serde_json::from_str(json)?;
+    assert_eq!(config.program, PathBuf::from("script.pl"));
+    assert_eq!(config.args, vec!["--debug".to_string()]);
+    assert_eq!(config.cwd, Some(PathBuf::from("/work")));
+    assert_eq!(config.perl_path, Some(PathBuf::from("/usr/bin/perl")));
+    assert_eq!(config.include_paths, vec![PathBuf::from("/lib")]);
+    Ok(())
+}
+
+#[test]
+fn launch_config_deserialize_optional_fields_missing() -> Result<(), Box<dyn std::error::Error>> {
+    // Only required field is program; other fields have defaults via serde
+    let json = r#"{"program": "minimal.pl"}"#;
+    let config: LaunchConfiguration = serde_json::from_str(json)?;
+    assert_eq!(config.program, PathBuf::from("minimal.pl"));
+    assert!(config.args.is_empty());
+    assert!(config.cwd.is_none());
+    assert!(config.env.is_empty());
+    assert!(config.perl_path.is_none());
+    assert!(config.include_paths.is_empty());
+    Ok(())
+}
+
+#[test]
+fn launch_config_serializes_camel_case_field_names() -> Result<(), Box<dyn std::error::Error>> {
+    let config = LaunchConfiguration {
+        program: PathBuf::from("x.pl"),
+        args: vec![],
+        cwd: None,
+        env: HashMap::new(),
+        perl_path: Some(PathBuf::from("/usr/bin/perl")),
+        include_paths: vec![PathBuf::from("lib")],
+    };
+
+    let json = serde_json::to_string(&config)?;
+    assert!(json.contains("perlPath"), "Should use camelCase: {json}");
+    assert!(json.contains("includePaths"), "Should use camelCase: {json}");
+    assert!(!json.contains("perl_path"), "Should not use snake_case: {json}");
+    assert!(!json.contains("include_paths"), "Should not use snake_case: {json}");
+    Ok(())
+}
+
+#[test]
+fn launch_config_omits_none_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let config = LaunchConfiguration {
+        program: PathBuf::from("x.pl"),
+        args: vec![],
+        cwd: None,
+        env: HashMap::new(),
+        perl_path: None,
+        include_paths: vec![],
+    };
+
+    let json = serde_json::to_string(&config)?;
+    assert!(!json.contains("perlPath"), "None perlPath should be omitted: {json}");
+    assert!(!json.contains("cwd"), "None cwd should be omitted: {json}");
+    Ok(())
+}
+
+#[test]
+fn launch_config_resolve_paths_no_cwd() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = LaunchConfiguration {
+        program: PathBuf::from("script.pl"),
+        args: vec![],
+        cwd: None,
+        env: HashMap::new(),
+        perl_path: None,
+        include_paths: vec![PathBuf::from("lib")],
+    };
+
+    let workspace = PathBuf::from("/workspace");
+    config.resolve_paths(&workspace)?;
+
+    assert_eq!(config.program, workspace.join("script.pl"));
+    assert!(config.cwd.is_none(), "cwd should remain None after resolve_paths");
+    assert_eq!(config.include_paths[0], workspace.join("lib"));
+    Ok(())
+}
+
+#[test]
+fn launch_config_resolve_paths_multiple_include_paths() -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = LaunchConfiguration {
+        program: PathBuf::from("app.pl"),
+        args: vec![],
+        cwd: None,
+        env: HashMap::new(),
+        perl_path: None,
+        include_paths: vec![
+            PathBuf::from("lib"),
+            PathBuf::from("/absolute/lib"),
+            PathBuf::from("local/lib"),
+        ],
+    };
+
+    let workspace = PathBuf::from("/ws");
+    config.resolve_paths(&workspace)?;
+
+    assert_eq!(config.include_paths[0], PathBuf::from("/ws/lib"));
+    assert_eq!(
+        config.include_paths[1],
+        PathBuf::from("/absolute/lib"),
+        "Absolute include path should be preserved"
+    );
+    assert_eq!(config.include_paths[2], PathBuf::from("/ws/local/lib"));
+    Ok(())
+}
+
+// ── AttachConfiguration serde ──────────────────────────────────────
+
+#[test]
+fn attach_config_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let config = AttachConfiguration {
+        host: "192.168.1.100".to_string(),
+        port: 9229,
+        timeout_ms: Some(15000),
+    };
+
+    let json = serde_json::to_string(&config)?;
+    let back: AttachConfiguration = serde_json::from_str(&json)?;
+
+    assert_eq!(back.host, "192.168.1.100");
+    assert_eq!(back.port, 9229);
+    assert_eq!(back.timeout_ms, Some(15000));
+    Ok(())
+}
+
+#[test]
+fn attach_config_round_trip_no_timeout() -> Result<(), Box<dyn std::error::Error>> {
+    let config =
+        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: None };
+
+    let json = serde_json::to_string(&config)?;
+    assert!(!json.contains("timeoutMs"), "None timeoutMs should be omitted: {json}");
+
+    let back: AttachConfiguration = serde_json::from_str(&json)?;
+    assert!(back.timeout_ms.is_none());
+    Ok(())
+}
+
+#[test]
+fn attach_config_deserialize_camel_case() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"host": "myhost", "port": 5555, "timeoutMs": 3000}"#;
+    let config: AttachConfiguration = serde_json::from_str(json)?;
+
+    assert_eq!(config.host, "myhost");
+    assert_eq!(config.port, 5555);
+    assert_eq!(config.timeout_ms, Some(3000));
+    Ok(())
+}
+
+#[test]
+fn attach_config_validation_boundary_timeout() {
+    // Exactly at maximum (300_000) should succeed
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(300_000),
+    };
+    assert!(config.validate().is_ok(), "Max timeout should be valid");
+
+    // One over maximum should fail
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(300_001),
+    };
+    assert!(config.validate().is_err(), "Over-max timeout should fail");
+}
+
+#[test]
+fn attach_config_validation_port_boundaries() {
+    // Port 1 is valid
+    let config = AttachConfiguration { host: "localhost".to_string(), port: 1, timeout_ms: None };
+    assert!(config.validate().is_ok(), "Port 1 should be valid");
+
+    // Port 65535 is valid (max u16)
+    let config =
+        AttachConfiguration { host: "localhost".to_string(), port: 65535, timeout_ms: None };
+    assert!(config.validate().is_ok(), "Port 65535 should be valid");
+}
+
+#[test]
+fn attach_config_validation_timeout_1ms() {
+    // Timeout of 1ms is the minimum valid timeout
+    let config =
+        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: Some(1) };
+    assert!(config.validate().is_ok(), "1ms timeout should be valid");
+}
+
+// ── launch.json / attach.json snippet cross-checks ─────────────────
+
+#[test]
+fn launch_snippet_deserialization_produces_valid_config() -> Result<(), Box<dyn std::error::Error>>
+{
+    let snippet = perl_dap_config::create_launch_json_snippet();
+    let parsed: serde_json::Value = serde_json::from_str(&snippet)?;
+
+    // Verify it has all the required fields for VS Code DAP
+    assert!(parsed.get("type").is_some(), "Must have 'type' field");
+    assert!(parsed.get("request").is_some(), "Must have 'request' field");
+    assert!(parsed.get("name").is_some(), "Must have 'name' field");
+    assert!(parsed.get("program").is_some(), "Must have 'program' field");
+    Ok(())
+}
+
+#[test]
+fn attach_snippet_deserialization_produces_valid_config() -> Result<(), Box<dyn std::error::Error>>
+{
+    let snippet = perl_dap_config::create_attach_json_snippet();
+    let parsed: serde_json::Value = serde_json::from_str(&snippet)?;
+
+    assert!(parsed.get("type").is_some(), "Must have 'type' field");
+    assert!(parsed.get("request").is_some(), "Must have 'request' field");
+    assert!(parsed.get("name").is_some(), "Must have 'name' field");
+    assert!(parsed.get("host").is_some(), "Must have 'host' field");
+    assert!(parsed.get("port").is_some(), "Must have 'port' field");
+    Ok(())
+}

--- a/crates/perl-dap-types/tests/edge_case_tests.rs
+++ b/crates/perl-dap-types/tests/edge_case_tests.rs
@@ -1,0 +1,264 @@
+//! Edge-case and additional coverage tests for perl-dap-types.
+//!
+//! Covers: Source with tricky paths, StackFrame builder chaining,
+//! Variable deserialization from real DAP JSON, and serde compliance.
+
+use perl_dap_types::{Source, StackFrame, Variable};
+
+// ── Source edge cases ──────────────────────────────────────────────
+
+#[test]
+fn source_with_bare_filename_has_same_name_and_path() {
+    let src = Source::new("script.pl");
+    assert_eq!(src.name, Some("script.pl".to_string()));
+    assert_eq!(src.path, "script.pl");
+}
+
+#[test]
+fn source_with_windows_path() {
+    let src = Source::new("C:\\Users\\dev\\project\\lib\\Module.pm");
+    assert_eq!(src.name, Some("Module.pm".to_string()));
+    assert_eq!(src.path, "C:\\Users\\dev\\project\\lib\\Module.pm");
+}
+
+#[test]
+fn source_with_empty_path() {
+    let src = Source::new("");
+    assert_eq!(src.path, "");
+    // Empty path produces None for the name since file_name() returns None
+    assert!(src.name.is_none());
+}
+
+#[test]
+fn source_with_path_ending_in_separator() {
+    // Trailing separator means no file_name on Unix.
+    // On Windows, Path::new("/path/to/dir/").file_name() may return Some("dir").
+    let src = Source::new("/path/to/dir/");
+    assert_eq!(src.path, "/path/to/dir/");
+    // Behavior is platform-dependent; just verify it does not panic
+    // and produces a consistent result
+    let _ = src.name;
+}
+
+#[test]
+fn source_with_dotfile() {
+    let src = Source::new("/home/user/.perldb");
+    assert_eq!(src.name, Some(".perldb".to_string()));
+}
+
+#[test]
+fn source_with_deep_nested_path() {
+    let src = Source::new("/a/b/c/d/e/f/deeply/nested/Module.pm");
+    assert_eq!(src.name, Some("Module.pm".to_string()));
+}
+
+// ── Source serde ────────────────────────────────────────────────────
+
+#[test]
+fn source_serialization_omits_none_source_reference() -> Result<(), serde_json::Error> {
+    let src = Source::new("/script.pl");
+    let json = serde_json::to_string(&src)?;
+    // Source uses snake_case field names (no rename_all = "camelCase")
+    assert!(!json.contains("source_reference"), "None source_reference should be omitted: {json}");
+    Ok(())
+}
+
+#[test]
+fn source_deserialization_from_dap_json() -> Result<(), serde_json::Error> {
+    // Simulating a source object as it would arrive from a DAP client
+    let json = r#"{"name": "test.pl", "path": "/workspace/test.pl"}"#;
+    let src: Source = serde_json::from_str(json)?;
+    assert_eq!(src.name, Some("test.pl".to_string()));
+    assert_eq!(src.path, "/workspace/test.pl");
+    assert!(src.source_reference.is_none());
+    Ok(())
+}
+
+#[test]
+fn source_deserialization_with_source_reference() -> Result<(), serde_json::Error> {
+    // Note: Source struct does NOT use rename_all = "camelCase",
+    // so the JSON field name is "source_reference" (snake_case)
+    let json = r#"{"name": "eval", "path": "(eval 1)", "source_reference": 42}"#;
+    let src: Source = serde_json::from_str(json)?;
+    assert_eq!(src.source_reference, Some(42));
+    Ok(())
+}
+
+// ── StackFrame edge cases ──────────────────────────────────────────
+
+#[test]
+fn stack_frame_builder_chaining_order_independent() {
+    let src = Source::new("/a.pl");
+    // with_end then with_column
+    let f1 = StackFrame::new(1, "main", src.clone(), 10).with_end(20, 30).with_column(5);
+
+    let src2 = Source::new("/a.pl");
+    // with_column then with_end
+    let f2 = StackFrame::new(1, "main", src2, 10).with_column(5).with_end(20, 30);
+
+    assert_eq!(f1.column, f2.column);
+    assert_eq!(f1.end_line, f2.end_line);
+    assert_eq!(f1.end_column, f2.end_column);
+}
+
+#[test]
+fn stack_frame_negative_line_preserved() {
+    // DAP protocol uses signed integers; negative values are technically possible
+    let src = Source::new("/a.pl");
+    let frame = StackFrame::new(1, "test", src, -1);
+    assert_eq!(frame.line, -1);
+}
+
+#[test]
+fn stack_frame_zero_id() {
+    let src = Source::new("/a.pl");
+    let frame = StackFrame::new(0, "frame0", src, 1);
+    assert_eq!(frame.id, 0);
+}
+
+#[test]
+fn stack_frame_empty_name() {
+    let src = Source::new("/a.pl");
+    let frame = StackFrame::new(1, "", src, 1);
+    assert_eq!(frame.name, "");
+}
+
+#[test]
+fn stack_frame_unicode_name() {
+    let src = Source::new("/a.pl");
+    let frame = StackFrame::new(1, "日本語::関数", src, 42);
+    assert_eq!(frame.name, "日本語::関数");
+}
+
+#[test]
+fn stack_frame_serde_with_all_fields() -> Result<(), serde_json::Error> {
+    let src = Source::new("/script.pl");
+    let frame = StackFrame::new(5, "Foo::bar", src, 100).with_column(10).with_end(105, 20);
+
+    let json = serde_json::to_string(&frame)?;
+    assert!(json.contains("\"endLine\":105"), "endLine should be present: {json}");
+    assert!(json.contains("\"endColumn\":20"), "endColumn should be present: {json}");
+
+    let back: StackFrame = serde_json::from_str(&json)?;
+    assert_eq!(back, frame);
+    Ok(())
+}
+
+#[test]
+fn stack_frame_deserialization_from_dap_json() -> Result<(), serde_json::Error> {
+    let json = r#"{
+        "id": 3,
+        "name": "main::run",
+        "source": {"name": "app.pl", "path": "/ws/app.pl"},
+        "line": 42,
+        "column": 1
+    }"#;
+    let frame: StackFrame = serde_json::from_str(json)?;
+    assert_eq!(frame.id, 3);
+    assert_eq!(frame.name, "main::run");
+    assert_eq!(frame.line, 42);
+    assert_eq!(frame.column, 1);
+    assert!(frame.end_line.is_none());
+    assert!(frame.end_column.is_none());
+    Ok(())
+}
+
+// ── Variable edge cases ────────────────────────────────────────────
+
+#[test]
+fn variable_with_all_optional_fields() -> Result<(), serde_json::Error> {
+    let var = Variable {
+        name: "@data".to_string(),
+        value: "(10 elements)".to_string(),
+        type_: Some("ARRAY".to_string()),
+        variables_reference: 5,
+        named_variables: Some(0),
+        indexed_variables: Some(10),
+    };
+
+    let json = serde_json::to_string(&var)?;
+    assert!(json.contains("\"namedVariables\":0"), "namedVariables present: {json}");
+    assert!(json.contains("\"indexedVariables\":10"), "indexedVariables present: {json}");
+
+    let back: Variable = serde_json::from_str(&json)?;
+    assert_eq!(back, var);
+    Ok(())
+}
+
+#[test]
+fn variable_deserialization_from_dap_json() -> Result<(), serde_json::Error> {
+    // Simulating what a DAP client would send
+    let json = r#"{
+        "name": "$count",
+        "value": "42",
+        "type": "SCALAR",
+        "variablesReference": 0
+    }"#;
+    let var: Variable = serde_json::from_str(json)?;
+    assert_eq!(var.name, "$count");
+    assert_eq!(var.value, "42");
+    assert_eq!(var.type_, Some("SCALAR".to_string()));
+    assert_eq!(var.variables_reference, 0);
+    assert!(var.named_variables.is_none());
+    assert!(var.indexed_variables.is_none());
+    Ok(())
+}
+
+#[test]
+fn variable_type_field_deserialization_uses_type_not_type_underscore()
+-> Result<(), serde_json::Error> {
+    // The JSON field must be "type", not "type_"
+    let json = r#"{
+        "name": "$x",
+        "value": "1",
+        "type": "int",
+        "variablesReference": 0
+    }"#;
+    let var: Variable = serde_json::from_str(json)?;
+    assert_eq!(var.type_, Some("int".to_string()));
+
+    // Verify "type_" in JSON does NOT populate the field
+    let json_wrong = r#"{
+        "name": "$x",
+        "value": "1",
+        "type_": "int",
+        "variablesReference": 0
+    }"#;
+    let var2: Variable = serde_json::from_str(json_wrong)?;
+    assert!(var2.type_.is_none(), "type_ key in JSON should not populate type_ field");
+    Ok(())
+}
+
+#[test]
+fn variable_empty_name_and_value() -> Result<(), serde_json::Error> {
+    let var = Variable {
+        name: String::new(),
+        value: String::new(),
+        type_: None,
+        variables_reference: 0,
+        named_variables: None,
+        indexed_variables: None,
+    };
+    let json = serde_json::to_string(&var)?;
+    let back: Variable = serde_json::from_str(&json)?;
+    assert_eq!(back.name, "");
+    assert_eq!(back.value, "");
+    Ok(())
+}
+
+#[test]
+fn variable_large_variables_reference() -> Result<(), serde_json::Error> {
+    let var = Variable {
+        name: "$big".to_string(),
+        value: "complex structure".to_string(),
+        type_: Some("HASH".to_string()),
+        variables_reference: i32::MAX,
+        named_variables: Some(i32::MAX),
+        indexed_variables: None,
+    };
+    let json = serde_json::to_string(&var)?;
+    let back: Variable = serde_json::from_str(&json)?;
+    assert_eq!(back.variables_reference, i32::MAX);
+    assert_eq!(back.named_variables, Some(i32::MAX));
+    Ok(())
+}

--- a/crates/perl-dap-value/tests/serde_round_trip_tests.rs
+++ b/crates/perl-dap-value/tests/serde_round_trip_tests.rs
@@ -1,0 +1,388 @@
+//! Serde round-trip tests for all PerlValue variants.
+//!
+//! Ensures every variant serializes and deserializes correctly,
+//! including nested structures and edge cases.
+
+use perl_dap_value::PerlValue;
+
+// ── Simple variant round-trips ─────────────────────────────────────
+
+#[test]
+fn undef_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Undef;
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, PerlValue::Undef);
+    Ok(())
+}
+
+#[test]
+fn scalar_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Scalar("hello world".to_string());
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn scalar_empty_string_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Scalar(String::new());
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn number_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Number(7.125);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn number_negative_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Number(-42.5);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn integer_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Integer(9_999_999);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn integer_negative_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Integer(-1);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn integer_zero_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Integer(0);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Collection variant round-trips ─────────────────────────────────
+
+#[test]
+fn array_empty_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Array(vec![]);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn array_with_mixed_elements_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Array(vec![
+        PerlValue::Integer(1),
+        PerlValue::Scalar("two".to_string()),
+        PerlValue::Undef,
+        PerlValue::Number(4.0),
+    ]);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn hash_empty_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Hash(vec![]);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn hash_with_entries_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Hash(vec![
+        ("name".to_string(), PerlValue::Scalar("Alice".to_string())),
+        ("age".to_string(), PerlValue::Integer(30)),
+        ("active".to_string(), PerlValue::Integer(1)),
+    ]);
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Reference variant round-trips ──────────────────────────────────
+
+#[test]
+fn reference_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Reference(Box::new(PerlValue::Integer(42)));
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn reference_to_array_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Reference(Box::new(PerlValue::Array(vec![
+        PerlValue::Integer(1),
+        PerlValue::Integer(2),
+    ])));
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Object variant round-trips ─────────────────────────────────────
+
+#[test]
+fn object_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Object {
+        class: "My::Class".to_string(),
+        value: Box::new(PerlValue::Hash(vec![(
+            "field".to_string(),
+            PerlValue::Scalar("value".to_string()),
+        )])),
+    };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn object_with_array_base_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Object {
+        class: "Array::Based".to_string(),
+        value: Box::new(PerlValue::Array(vec![PerlValue::Integer(1)])),
+    };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Code variant round-trips ───────────────────────────────────────
+
+#[test]
+fn code_named_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Code { name: Some("main::handler".to_string()) };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn code_anonymous_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Code { name: None };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Glob variant round-trip ────────────────────────────────────────
+
+#[test]
+fn glob_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Glob("*main::STDOUT".to_string());
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Regex variant round-trip ───────────────────────────────────────
+
+#[test]
+fn regex_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Regex("^foo\\d+bar$".to_string());
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Tied variant round-trips ───────────────────────────────────────
+
+#[test]
+fn tied_with_value_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Tied {
+        class: "Tie::StdHash".to_string(),
+        value: Some(Box::new(PerlValue::Hash(vec![(
+            "key".to_string(),
+            PerlValue::Scalar("val".to_string()),
+        )]))),
+    };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn tied_without_value_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Tied { class: "Tie::File".to_string(), value: None };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Truncated variant round-trips ──────────────────────────────────
+
+#[test]
+fn truncated_with_count_round_trip() -> Result<(), serde_json::Error> {
+    let val =
+        PerlValue::Truncated { summary: "Array too large".to_string(), total_count: Some(50000) };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+#[test]
+fn truncated_without_count_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Truncated { summary: "Deep nesting".to_string(), total_count: None };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Error variant round-trip ───────────────────────────────────────
+
+#[test]
+fn error_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Error("Cannot inspect: variable optimized away".to_string());
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Deeply nested round-trip ───────────────────────────────────────
+
+#[test]
+fn deeply_nested_structure_round_trip() -> Result<(), serde_json::Error> {
+    let val = PerlValue::Object {
+        class: "App::Config".to_string(),
+        value: Box::new(PerlValue::Hash(vec![
+            (
+                "db".to_string(),
+                PerlValue::Object {
+                    class: "DBI::db".to_string(),
+                    value: Box::new(PerlValue::Hash(vec![
+                        ("host".to_string(), PerlValue::Scalar("localhost".to_string())),
+                        ("port".to_string(), PerlValue::Integer(5432)),
+                    ])),
+                },
+            ),
+            (
+                "items".to_string(),
+                PerlValue::Reference(Box::new(PerlValue::Array(vec![
+                    PerlValue::Scalar("first".to_string()),
+                    PerlValue::Undef,
+                    PerlValue::Number(9.81),
+                ]))),
+            ),
+        ])),
+    };
+    let json = serde_json::to_string(&val)?;
+    let back: PerlValue = serde_json::from_str(&json)?;
+    assert_eq!(back, val);
+    Ok(())
+}
+
+// ── Behavioral edge cases ──────────────────────────────────────────
+
+#[test]
+fn tied_is_expandable() {
+    let val = PerlValue::Tied {
+        class: "Tie::Hash".to_string(),
+        value: Some(Box::new(PerlValue::Hash(vec![]))),
+    };
+    assert!(val.is_expandable());
+    assert_eq!(val.type_name(), "TIED");
+    assert_eq!(val.child_count(), None);
+}
+
+#[test]
+fn regex_is_not_expandable() {
+    let val = PerlValue::Regex("pattern".to_string());
+    assert!(!val.is_expandable());
+    assert_eq!(val.type_name(), "Regexp");
+    assert_eq!(val.child_count(), None);
+}
+
+#[test]
+fn glob_is_not_expandable() {
+    let val = PerlValue::Glob("*main::STDERR".to_string());
+    assert!(!val.is_expandable());
+    assert_eq!(val.type_name(), "GLOB");
+    assert_eq!(val.child_count(), None);
+}
+
+#[test]
+fn error_is_not_expandable() {
+    let val = PerlValue::Error("inspection failed".to_string());
+    assert!(!val.is_expandable());
+    assert_eq!(val.type_name(), "ERROR");
+    assert_eq!(val.child_count(), None);
+}
+
+#[test]
+fn truncated_child_count_returns_total() {
+    let val = PerlValue::Truncated { summary: "big array".to_string(), total_count: Some(10000) };
+    assert_eq!(val.child_count(), Some(10000));
+
+    let val_none = PerlValue::Truncated { summary: "unknown".to_string(), total_count: None };
+    assert_eq!(val_none.child_count(), None);
+}
+
+#[test]
+fn number_and_integer_share_scalar_type_name() {
+    assert_eq!(PerlValue::Number(1.0).type_name(), "SCALAR");
+    assert_eq!(PerlValue::Integer(1).type_name(), "SCALAR");
+    assert_eq!(PerlValue::Scalar("1".to_string()).type_name(), "SCALAR");
+}
+
+#[test]
+fn code_type_name_is_code() {
+    assert_eq!(PerlValue::Code { name: None }.type_name(), "CODE");
+    assert_eq!(PerlValue::Code { name: Some("f".to_string()) }.type_name(), "CODE");
+}
+
+#[test]
+fn object_child_count_is_none() {
+    // Objects delegate to their inner value in the renderer, but
+    // PerlValue::child_count() only returns Some for Array/Hash/Truncated
+    let val = PerlValue::Object {
+        class: "My::Obj".to_string(),
+        value: Box::new(PerlValue::Hash(vec![("k".to_string(), PerlValue::Undef)])),
+    };
+    assert_eq!(val.child_count(), None);
+}
+
+#[test]
+fn reference_child_count_is_none() {
+    let val = PerlValue::Reference(Box::new(PerlValue::Array(vec![PerlValue::Undef])));
+    assert_eq!(val.child_count(), None);
+}

--- a/crates/perl-dap/tests/dap_protocol_serde_tests.rs
+++ b/crates/perl-dap/tests/dap_protocol_serde_tests.rs
@@ -1,0 +1,764 @@
+//! Protocol type serde compliance tests.
+//!
+//! Verifies that DAP protocol message types serialize/deserialize
+//! correctly with proper camelCase field naming, optional field omission,
+//! and round-trip fidelity for all request/response argument types.
+
+use perl_dap::protocol::*;
+use serde_json::json;
+
+// ── Request / Response / Event base types ──────────────────────────
+
+#[test]
+fn request_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let req = Request {
+        seq: 1,
+        msg_type: "request".to_string(),
+        command: "initialize".to_string(),
+        arguments: Some(json!({"clientId": "vscode"})),
+    };
+    let json = serde_json::to_string(&req)?;
+    let back: Request = serde_json::from_str(&json)?;
+    assert_eq!(back.seq, 1);
+    assert_eq!(back.command, "initialize");
+    assert!(back.arguments.is_some());
+    Ok(())
+}
+
+#[test]
+fn request_without_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let req = Request {
+        seq: 5,
+        msg_type: "request".to_string(),
+        command: "configurationDone".to_string(),
+        arguments: None,
+    };
+    let json = serde_json::to_string(&req)?;
+    assert!(!json.contains("arguments"), "None arguments should be omitted: {json}");
+    let back: Request = serde_json::from_str(&json)?;
+    assert!(back.arguments.is_none());
+    Ok(())
+}
+
+#[test]
+fn response_success_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let resp = Response {
+        seq: 1,
+        msg_type: "response".to_string(),
+        request_seq: 1,
+        success: true,
+        command: "initialize".to_string(),
+        message: None,
+        body: Some(json!({"supportsConfigurationDoneRequest": true})),
+    };
+    let json = serde_json::to_string(&resp)?;
+    assert!(json.contains("requestSeq"), "Should use camelCase: {json}");
+    let back: Response = serde_json::from_str(&json)?;
+    assert_eq!(back.request_seq, 1);
+    assert!(back.success);
+    assert!(back.message.is_none());
+    Ok(())
+}
+
+#[test]
+fn response_error_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let resp = Response {
+        seq: 2,
+        msg_type: "response".to_string(),
+        request_seq: 2,
+        success: false,
+        command: "launch".to_string(),
+        message: Some("Script not found".to_string()),
+        body: None,
+    };
+    let json = serde_json::to_string(&resp)?;
+    let back: Response = serde_json::from_str(&json)?;
+    assert!(!back.success);
+    assert_eq!(back.message.as_deref(), Some("Script not found"));
+    assert!(back.body.is_none());
+    Ok(())
+}
+
+#[test]
+fn event_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let evt = Event {
+        seq: 10,
+        msg_type: "event".to_string(),
+        event: "stopped".to_string(),
+        body: Some(json!({"reason": "breakpoint", "threadId": 1})),
+    };
+    let json = serde_json::to_string(&evt)?;
+    let back: Event = serde_json::from_str(&json)?;
+    assert_eq!(back.event, "stopped");
+    assert!(back.body.is_some());
+    Ok(())
+}
+
+#[test]
+fn event_without_body() -> Result<(), Box<dyn std::error::Error>> {
+    let evt = Event {
+        seq: 11,
+        msg_type: "event".to_string(),
+        event: "initialized".to_string(),
+        body: None,
+    };
+    let json = serde_json::to_string(&evt)?;
+    assert!(!json.contains("body"), "None body should be omitted: {json}");
+    Ok(())
+}
+
+// ── Initialize types ───────────────────────────────────────────────
+
+#[test]
+fn initialize_request_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = InitializeRequestArguments {
+        client_id: Some("vscode".to_string()),
+        client_name: Some("Visual Studio Code".to_string()),
+        adapter_id: "perl-rs".to_string(),
+        locale: Some("en-US".to_string()),
+        lines_start_at1: Some(true),
+        columns_start_at1: Some(true),
+        path_format: Some("path".to_string()),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("clientId"), "camelCase: {json}");
+    assert!(json.contains("clientName"), "camelCase: {json}");
+    assert!(json.contains("adapterId"), "camelCase: {json}");
+    assert!(json.contains("linesStartAt1"), "camelCase: {json}");
+    assert!(json.contains("columnsStartAt1"), "camelCase: {json}");
+    assert!(json.contains("pathFormat"), "camelCase: {json}");
+
+    let back: InitializeRequestArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.adapter_id, "perl-rs");
+    assert_eq!(back.client_id.as_deref(), Some("vscode"));
+    Ok(())
+}
+
+#[test]
+fn initialize_request_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"adapterId": "perl-rs"}"#;
+    let args: InitializeRequestArguments = serde_json::from_str(json)?;
+    assert_eq!(args.adapter_id, "perl-rs");
+    assert!(args.client_id.is_none());
+    assert!(args.lines_start_at1.is_none());
+    Ok(())
+}
+
+#[test]
+fn capabilities_omits_none_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let caps = Capabilities {
+        supports_configuration_done_request: Some(true),
+        supports_evaluate_for_hovers: None,
+        supports_conditional_breakpoints: None,
+        supports_hit_conditional_breakpoints: None,
+        supports_log_points: None,
+        supports_exception_options: None,
+        supports_exception_filter_options: None,
+        supports_terminate_request: None,
+        supports_inline_values: None,
+        supports_function_breakpoints: None,
+        supports_set_variable: None,
+        supports_value_formatting_options: None,
+        support_terminate_debuggee: None,
+        supports_step_back: None,
+        supports_data_breakpoints: None,
+        exception_breakpoint_filters: None,
+    };
+    let json = serde_json::to_string(&caps)?;
+    assert!(json.contains("supportsConfigurationDoneRequest"));
+    assert!(!json.contains("supportsEvaluateForHovers"), "None should be omitted: {json}");
+    assert!(!json.contains("exceptionBreakpointFilters"), "None should be omitted: {json}");
+    Ok(())
+}
+
+// ── Launch / Attach arguments ──────────────────────────────────────
+
+#[test]
+fn launch_request_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = LaunchRequestArguments {
+        program: "/workspace/script.pl".to_string(),
+        args: Some(vec!["--verbose".to_string()]),
+        cwd: Some("/workspace".to_string()),
+        env: None,
+        perl_path: Some("/usr/bin/perl".to_string()),
+        stop_on_entry: Some(true),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("stopOnEntry"), "camelCase: {json}");
+    assert!(json.contains("perlPath"), "camelCase: {json}");
+
+    let back: LaunchRequestArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.program, "/workspace/script.pl");
+    assert_eq!(back.stop_on_entry, Some(true));
+    Ok(())
+}
+
+#[test]
+fn launch_request_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"program": "test.pl"}"#;
+    let args: LaunchRequestArguments = serde_json::from_str(json)?;
+    assert_eq!(args.program, "test.pl");
+    assert!(args.args.is_none());
+    assert!(args.cwd.is_none());
+    assert!(args.stop_on_entry.is_none());
+    Ok(())
+}
+
+#[test]
+fn attach_request_args_tcp_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let args = AttachRequestArguments {
+        process_id: None,
+        host: Some("localhost".to_string()),
+        port: Some(13603),
+        timeout: Some(5000),
+    };
+    let json = serde_json::to_string(&args)?;
+    let back: AttachRequestArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.host.as_deref(), Some("localhost"));
+    assert_eq!(back.port, Some(13603));
+    assert_eq!(back.timeout, Some(5000));
+    assert!(back.process_id.is_none());
+    Ok(())
+}
+
+#[test]
+fn attach_request_args_pid_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let args =
+        AttachRequestArguments { process_id: Some(12345), host: None, port: None, timeout: None };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("processId"), "camelCase: {json}");
+    assert!(!json.contains("host"), "None host should be omitted: {json}");
+
+    let back: AttachRequestArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.process_id, Some(12345));
+    Ok(())
+}
+
+// ── Control flow arguments ─────────────────────────────────────────
+
+#[test]
+fn continue_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = ContinueArguments { thread_id: 1 };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("threadId"), "camelCase: {json}");
+    let back: ContinueArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 1);
+    Ok(())
+}
+
+#[test]
+fn next_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = NextArguments { thread_id: 2 };
+    let json = serde_json::to_string(&args)?;
+    let back: NextArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 2);
+    Ok(())
+}
+
+#[test]
+fn step_in_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = StepInArguments { thread_id: 3 };
+    let json = serde_json::to_string(&args)?;
+    let back: StepInArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 3);
+    Ok(())
+}
+
+#[test]
+fn step_out_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = StepOutArguments { thread_id: 4 };
+    let json = serde_json::to_string(&args)?;
+    let back: StepOutArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 4);
+    Ok(())
+}
+
+#[test]
+fn pause_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = PauseArguments { thread_id: 5 };
+    let json = serde_json::to_string(&args)?;
+    let back: PauseArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 5);
+    Ok(())
+}
+
+// ── Stack / Scope / Variable arguments ─────────────────────────────
+
+#[test]
+fn stack_trace_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = StackTraceArguments { thread_id: 1, start_frame: Some(0), levels: Some(20) };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("threadId"), "camelCase: {json}");
+    assert!(json.contains("startFrame"), "camelCase: {json}");
+
+    let back: StackTraceArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.thread_id, 1);
+    assert_eq!(back.start_frame, Some(0));
+    assert_eq!(back.levels, Some(20));
+    Ok(())
+}
+
+#[test]
+fn stack_trace_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"threadId": 1}"#;
+    let args: StackTraceArguments = serde_json::from_str(json)?;
+    assert_eq!(args.thread_id, 1);
+    assert!(args.start_frame.is_none());
+    assert!(args.levels.is_none());
+    Ok(())
+}
+
+#[test]
+fn scopes_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = ScopesArguments { frame_id: 42 };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("frameId"), "camelCase: {json}");
+    let back: ScopesArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.frame_id, 42);
+    Ok(())
+}
+
+#[test]
+fn variables_args_full_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = VariablesArguments {
+        variables_reference: 100,
+        filter: Some("indexed".to_string()),
+        start: Some(0),
+        count: Some(50),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("variablesReference"), "camelCase: {json}");
+
+    let back: VariablesArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.variables_reference, 100);
+    assert_eq!(back.filter.as_deref(), Some("indexed"));
+    assert_eq!(back.start, Some(0));
+    assert_eq!(back.count, Some(50));
+    Ok(())
+}
+
+#[test]
+fn variables_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"variablesReference": 7}"#;
+    let args: VariablesArguments = serde_json::from_str(json)?;
+    assert_eq!(args.variables_reference, 7);
+    assert!(args.filter.is_none());
+    assert!(args.start.is_none());
+    assert!(args.count.is_none());
+    Ok(())
+}
+
+// ── Evaluate arguments ─────────────────────────────────────────────
+
+#[test]
+fn evaluate_args_hover_context() -> Result<(), Box<dyn std::error::Error>> {
+    let args = EvaluateArguments {
+        expression: "$x + 1".to_string(),
+        frame_id: Some(0),
+        context: Some("hover".to_string()),
+        allow_side_effects: Some(false),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("allowSideEffects"), "camelCase: {json}");
+    assert!(json.contains("frameId"), "camelCase: {json}");
+
+    let back: EvaluateArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.expression, "$x + 1");
+    assert_eq!(back.context.as_deref(), Some("hover"));
+    assert_eq!(back.allow_side_effects, Some(false));
+    Ok(())
+}
+
+#[test]
+fn evaluate_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"expression": "$_"}"#;
+    let args: EvaluateArguments = serde_json::from_str(json)?;
+    assert_eq!(args.expression, "$_");
+    assert!(args.frame_id.is_none());
+    assert!(args.context.is_none());
+    Ok(())
+}
+
+// ── Disconnect / Terminate arguments ───────────────────────────────
+
+#[test]
+fn disconnect_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = DisconnectArguments { restart: Some(false), terminate_debuggee: Some(true) };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("terminateDebuggee"), "camelCase: {json}");
+    let back: DisconnectArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.terminate_debuggee, Some(true));
+    assert_eq!(back.restart, Some(false));
+    Ok(())
+}
+
+#[test]
+fn terminate_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = TerminateArguments { restart: Some(true) };
+    let json = serde_json::to_string(&args)?;
+    let back: TerminateArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.restart, Some(true));
+    Ok(())
+}
+
+// ── Breakpoint types ───────────────────────────────────────────────
+
+#[test]
+fn source_breakpoint_full_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let bp = SourceBreakpoint {
+        line: 42,
+        column: Some(10),
+        condition: Some("$x > 5".to_string()),
+        hit_condition: Some(">= 3".to_string()),
+        log_message: Some("Value of x: {$x}".to_string()),
+    };
+    let json = serde_json::to_string(&bp)?;
+    assert!(json.contains("hitCondition"), "camelCase: {json}");
+    assert!(json.contains("logMessage"), "camelCase: {json}");
+
+    let back: SourceBreakpoint = serde_json::from_str(&json)?;
+    assert_eq!(back.line, 42);
+    assert_eq!(back.column, Some(10));
+    assert_eq!(back.condition.as_deref(), Some("$x > 5"));
+    assert_eq!(back.hit_condition.as_deref(), Some(">= 3"));
+    assert_eq!(back.log_message.as_deref(), Some("Value of x: {$x}"));
+    Ok(())
+}
+
+#[test]
+fn source_breakpoint_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"line": 10}"#;
+    let bp: SourceBreakpoint = serde_json::from_str(json)?;
+    assert_eq!(bp.line, 10);
+    assert!(bp.column.is_none());
+    assert!(bp.condition.is_none());
+    assert!(bp.hit_condition.is_none());
+    assert!(bp.log_message.is_none());
+    Ok(())
+}
+
+#[test]
+fn function_breakpoint_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let bp = FunctionBreakpoint {
+        name: "main::process_data".to_string(),
+        condition: Some("$count > 100".to_string()),
+        hit_condition: None,
+    };
+    let json = serde_json::to_string(&bp)?;
+    let back: FunctionBreakpoint = serde_json::from_str(&json)?;
+    assert_eq!(back.name, "main::process_data");
+    assert_eq!(back.condition.as_deref(), Some("$count > 100"));
+    assert!(back.hit_condition.is_none());
+    Ok(())
+}
+
+#[test]
+fn set_breakpoints_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = SetBreakpointsArguments {
+        source: Source { path: Some("/ws/test.pl".to_string()), name: Some("test.pl".to_string()) },
+        breakpoints: Some(vec![
+            SourceBreakpoint {
+                line: 10,
+                column: None,
+                condition: None,
+                hit_condition: None,
+                log_message: None,
+            },
+            SourceBreakpoint {
+                line: 20,
+                column: None,
+                condition: Some("$x".to_string()),
+                hit_condition: None,
+                log_message: None,
+            },
+        ]),
+        source_modified: Some(false),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("sourceModified"), "camelCase: {json}");
+
+    let back: SetBreakpointsArguments = serde_json::from_str(&json)?;
+    let bps = back.breakpoints.as_ref().ok_or("Expected breakpoints")?;
+    assert_eq!(bps.len(), 2);
+    assert_eq!(bps[0].line, 10);
+    assert_eq!(bps[1].condition.as_deref(), Some("$x"));
+    Ok(())
+}
+
+// ── Exception breakpoints ──────────────────────────────────────────
+
+#[test]
+fn set_exception_breakpoints_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = SetExceptionBreakpointsArguments {
+        filters: vec!["die".to_string()],
+        filter_options: Some(vec![ExceptionFilterOption {
+            filter_id: "die".to_string(),
+            condition: Some("$_ =~ /fatal/".to_string()),
+        }]),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("filterOptions"), "camelCase: {json}");
+    assert!(json.contains("filterId"), "camelCase: {json}");
+
+    let back: SetExceptionBreakpointsArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.filters, vec!["die"]);
+    let opts = back.filter_options.as_ref().ok_or("Expected filter_options")?;
+    assert_eq!(opts[0].filter_id, "die");
+    Ok(())
+}
+
+#[test]
+fn exception_breakpoint_filter_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let filter = ExceptionBreakpointFilter {
+        filter: "die".to_string(),
+        label: "Break on die/croak".to_string(),
+        default: Some(false),
+    };
+    let json = serde_json::to_string(&filter)?;
+    let back: ExceptionBreakpointFilter = serde_json::from_str(&json)?;
+    assert_eq!(back.filter, "die");
+    assert_eq!(back.label, "Break on die/croak");
+    assert_eq!(back.default, Some(false));
+    Ok(())
+}
+
+// ── Response body types ────────────────────────────────────────────
+
+#[test]
+fn threads_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = ThreadsResponseBody {
+        threads: vec![
+            Thread { id: 1, name: "main".to_string() },
+            Thread { id: 2, name: "worker".to_string() },
+        ],
+    };
+    let json = serde_json::to_string(&body)?;
+    let back: ThreadsResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.threads.len(), 2);
+    assert_eq!(back.threads[0].name, "main");
+    Ok(())
+}
+
+#[test]
+fn continue_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = ContinueResponseBody { all_threads_continued: true };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("allThreadsContinued"), "camelCase: {json}");
+    let back: ContinueResponseBody = serde_json::from_str(&json)?;
+    assert!(back.all_threads_continued);
+    Ok(())
+}
+
+#[test]
+fn evaluate_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = EvaluateResponseBody {
+        result: "42".to_string(),
+        type_: Some("SCALAR".to_string()),
+        variables_reference: 0,
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("\"type\":"), "type field should use 'type' not 'type_': {json}");
+    assert!(!json.contains("type_"), "type_ should not leak: {json}");
+
+    let back: EvaluateResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.result, "42");
+    assert_eq!(back.type_, Some("SCALAR".to_string()));
+    Ok(())
+}
+
+#[test]
+fn set_variable_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = SetVariableResponseBody {
+        value: "new_value".to_string(),
+        type_: Some("SCALAR".to_string()),
+        variables_reference: 0,
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("variablesReference"), "camelCase: {json}");
+    let back: SetVariableResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.value, "new_value");
+    Ok(())
+}
+
+#[test]
+fn scopes_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = ScopesResponseBody {
+        scopes: vec![
+            Scope {
+                name: "Locals".to_string(),
+                presentation_hint: Some("locals".to_string()),
+                variables_reference: 1,
+                expensive: false,
+            },
+            Scope {
+                name: "Globals".to_string(),
+                presentation_hint: Some("globals".to_string()),
+                variables_reference: 2,
+                expensive: true,
+            },
+        ],
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("presentationHint"), "camelCase: {json}");
+    assert!(json.contains("variablesReference"), "camelCase: {json}");
+    let back: ScopesResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.scopes.len(), 2);
+    assert!(!back.scopes[0].expensive);
+    assert!(back.scopes[1].expensive);
+    Ok(())
+}
+
+#[test]
+fn stack_trace_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = StackTraceResponseBody {
+        stack_frames: vec![ProtocolStackFrame {
+            id: 0,
+            name: "main::run".to_string(),
+            source: Some(Source {
+                path: Some("/a.pl".to_string()),
+                name: Some("a.pl".to_string()),
+            }),
+            line: 10,
+            column: 1,
+            end_line: None,
+            end_column: None,
+        }],
+        total_frames: Some(1),
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("stackFrames"), "camelCase: {json}");
+    assert!(json.contains("totalFrames"), "camelCase: {json}");
+    let back: StackTraceResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.stack_frames.len(), 1);
+    assert_eq!(back.total_frames, Some(1));
+    Ok(())
+}
+
+// ── Exception info ─────────────────────────────────────────────────
+
+#[test]
+fn exception_info_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = ExceptionInfoResponseBody {
+        exception_id: "die".to_string(),
+        description: Some("Died at script.pl line 42".to_string()),
+        break_mode: "always".to_string(),
+        details: Some(ExceptionDetails {
+            message: Some("Cannot open file".to_string()),
+            type_name: Some("IO::Error".to_string()),
+            stack_trace: Some(
+                "  at main::open_file (script.pl:42)\n  at main (script.pl:10)".to_string(),
+            ),
+        }),
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("exceptionId"), "camelCase: {json}");
+    assert!(json.contains("breakMode"), "camelCase: {json}");
+    assert!(json.contains("typeName"), "camelCase: {json}");
+    assert!(json.contains("stackTrace"), "camelCase: {json}");
+
+    let back: ExceptionInfoResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.exception_id, "die");
+    let details = back.details.as_ref().ok_or("Expected details")?;
+    assert_eq!(details.type_name.as_deref(), Some("IO::Error"));
+    Ok(())
+}
+
+#[test]
+fn exception_info_minimal() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"{"exceptionId": "warn", "breakMode": "never"}"#;
+    let body: ExceptionInfoResponseBody = serde_json::from_str(json)?;
+    assert_eq!(body.exception_id, "warn");
+    assert_eq!(body.break_mode, "never");
+    assert!(body.description.is_none());
+    assert!(body.details.is_none());
+    Ok(())
+}
+
+// ── Goto / Source / StepInTargets ──────────────────────────────────
+
+#[test]
+fn goto_target_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let target = GotoTarget {
+        id: 1,
+        label: "line 42".to_string(),
+        line: 42,
+        column: Some(1),
+        end_line: Some(42),
+        end_column: Some(80),
+    };
+    let json = serde_json::to_string(&target)?;
+    assert!(json.contains("endLine"), "camelCase: {json}");
+    let back: GotoTarget = serde_json::from_str(&json)?;
+    assert_eq!(back.id, 1);
+    assert_eq!(back.line, 42);
+    Ok(())
+}
+
+#[test]
+fn step_in_target_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let target = StepInTarget { id: 5, label: "Foo::bar()".to_string() };
+    let json = serde_json::to_string(&target)?;
+    let back: StepInTarget = serde_json::from_str(&json)?;
+    assert_eq!(back.id, 5);
+    assert_eq!(back.label, "Foo::bar()");
+    Ok(())
+}
+
+#[test]
+fn source_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = SourceResponseBody {
+        content: "#!/usr/bin/perl\nprint 'hello';\n".to_string(),
+        mime_type: Some("text/x-perl".to_string()),
+    };
+    let json = serde_json::to_string(&body)?;
+    assert!(json.contains("mimeType"), "camelCase: {json}");
+    let back: SourceResponseBody = serde_json::from_str(&json)?;
+    assert!(back.content.contains("print 'hello'"));
+    assert_eq!(back.mime_type.as_deref(), Some("text/x-perl"));
+    Ok(())
+}
+
+// ── SetVariable arguments ──────────────────────────────────────────
+
+#[test]
+fn set_variable_args_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let args = SetVariableArguments {
+        variables_reference: 10,
+        name: "$count".to_string(),
+        value: "42".to_string(),
+    };
+    let json = serde_json::to_string(&args)?;
+    assert!(json.contains("variablesReference"), "camelCase: {json}");
+    let back: SetVariableArguments = serde_json::from_str(&json)?;
+    assert_eq!(back.name, "$count");
+    assert_eq!(back.value, "42");
+    Ok(())
+}
+
+// ── BreakpointLocation types ───────────────────────────────────────
+
+#[test]
+fn breakpoint_location_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let loc =
+        BreakpointLocation { line: 15, column: Some(1), end_line: Some(15), end_column: Some(40) };
+    let json = serde_json::to_string(&loc)?;
+    let back: BreakpointLocation = serde_json::from_str(&json)?;
+    assert_eq!(back.line, 15);
+    assert_eq!(back.column, Some(1));
+    assert_eq!(back.end_line, Some(15));
+    Ok(())
+}
+
+#[test]
+fn breakpoint_locations_response_body_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let body = BreakpointLocationsResponseBody {
+        breakpoints: vec![
+            BreakpointLocation { line: 10, column: None, end_line: None, end_column: None },
+            BreakpointLocation { line: 15, column: Some(5), end_line: None, end_column: None },
+        ],
+    };
+    let json = serde_json::to_string(&body)?;
+    let back: BreakpointLocationsResponseBody = serde_json::from_str(&json)?;
+    assert_eq!(back.breakpoints.len(), 2);
+    Ok(())
+}

--- a/crates/perl-dap/tests/dap_server_and_adapter_tests.rs
+++ b/crates/perl-dap/tests/dap_server_and_adapter_tests.rs
@@ -1,0 +1,243 @@
+//! Tests for DapMode, DapConfig, DapServer, TcpAttachConfig,
+//! TcpAttachSession, DapEvent, and BridgeAdapter.
+//!
+//! These tests verify the public API surfaces of the top-level DAP server
+//! types and supporting adapter infrastructure without requiring a live
+//! Perl debugger process.
+
+use perl_dap::tcp_attach::{DapEvent, TcpAttachConfig, TcpAttachSession};
+use perl_dap::{BridgeAdapter, DapConfig, DapMode, DapServer};
+use std::time::Duration;
+
+// ── DapMode ────────────────────────────────────────────────────────
+
+#[test]
+fn dap_mode_default_is_native() {
+    assert_eq!(DapMode::default(), DapMode::Native);
+}
+
+#[test]
+fn dap_mode_clone_and_eq() {
+    let mode = DapMode::Bridge;
+    let cloned = mode.clone();
+    assert_eq!(mode, cloned);
+    assert_ne!(DapMode::Native, DapMode::Bridge);
+}
+
+#[test]
+fn dap_mode_debug_format() {
+    let debug_str = format!("{:?}", DapMode::Native);
+    assert!(debug_str.contains("Native"));
+    let debug_str = format!("{:?}", DapMode::Bridge);
+    assert!(debug_str.contains("Bridge"));
+}
+
+// ── DapServer ──────────────────────────────────────────────────────
+
+#[test]
+fn dap_server_creation_native() -> Result<(), Box<dyn std::error::Error>> {
+    let config =
+        DapConfig { log_level: "info".to_string(), mode: DapMode::Native, workspace_root: None };
+    let server = DapServer::new(config)?;
+    assert_eq!(server.config.mode, DapMode::Native);
+    assert_eq!(server.config.log_level, "info");
+    assert!(server.config.workspace_root.is_none());
+    Ok(())
+}
+
+#[test]
+fn dap_server_creation_bridge() -> Result<(), Box<dyn std::error::Error>> {
+    let config = DapConfig {
+        log_level: "debug".to_string(),
+        mode: DapMode::Bridge,
+        workspace_root: Some(std::path::PathBuf::from("/workspace")),
+    };
+    let server = DapServer::new(config)?;
+    assert_eq!(server.config.mode, DapMode::Bridge);
+    assert_eq!(server.config.workspace_root, Some(std::path::PathBuf::from("/workspace")));
+    Ok(())
+}
+
+#[test]
+fn dap_server_socket_rejects_bridge_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let config =
+        DapConfig { log_level: "info".to_string(), mode: DapMode::Bridge, workspace_root: None };
+    let mut server = DapServer::new(config)?;
+    let result = server.run_socket(9999);
+    assert!(result.is_err(), "Socket transport should be rejected in bridge mode");
+    let err_msg = result.err().ok_or("Expected error")?.to_string();
+    assert!(err_msg.contains("not supported"), "Error should mention lack of support: {err_msg}");
+    Ok(())
+}
+
+// ── TcpAttachConfig ────────────────────────────────────────────────
+
+#[test]
+fn tcp_attach_config_builder_pattern() {
+    let config = TcpAttachConfig::new("192.168.1.1".to_string(), 9000).with_timeout(10000);
+    assert_eq!(config.host, "192.168.1.1");
+    assert_eq!(config.port, 9000);
+    assert_eq!(config.timeout_ms, Some(10000));
+}
+
+#[test]
+fn tcp_attach_config_default_timeout_duration() {
+    let config = TcpAttachConfig::new("localhost".to_string(), 13603);
+    assert_eq!(config.timeout_duration(), Duration::from_millis(5000));
+}
+
+#[test]
+fn tcp_attach_config_custom_timeout_duration() {
+    let config = TcpAttachConfig::new("localhost".to_string(), 13603).with_timeout(15000);
+    assert_eq!(config.timeout_duration(), Duration::from_millis(15000));
+}
+
+#[test]
+fn tcp_attach_config_validate_whitespace_host() {
+    let config = TcpAttachConfig::new("   ".to_string(), 13603);
+    assert!(config.validate().is_err(), "Whitespace-only host should be rejected");
+}
+
+#[test]
+fn tcp_attach_config_validate_port_1_is_valid() {
+    let config = TcpAttachConfig::new("localhost".to_string(), 1);
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn tcp_attach_config_validate_max_port_is_valid() {
+    let config = TcpAttachConfig::new("localhost".to_string(), 65535);
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn tcp_attach_config_validate_boundary_timeout() {
+    // At 300_000 (5 min) should be valid
+    let config = TcpAttachConfig::new("localhost".to_string(), 13603).with_timeout(300_000);
+    assert!(config.validate().is_ok());
+
+    // At 300_001 should fail
+    let config = TcpAttachConfig::new("localhost".to_string(), 13603).with_timeout(300_001);
+    assert!(config.validate().is_err());
+}
+
+#[test]
+fn tcp_attach_config_validate_1ms_timeout() {
+    let config = TcpAttachConfig::new("localhost".to_string(), 13603).with_timeout(1);
+    assert!(config.validate().is_ok());
+}
+
+// ── TcpAttachSession ───────────────────────────────────────────────
+
+#[test]
+fn tcp_attach_session_default_is_disconnected() {
+    let session = TcpAttachSession::default();
+    assert!(!session.is_connected());
+}
+
+#[test]
+fn tcp_attach_session_send_message_without_connection_fails() {
+    let mut session = TcpAttachSession::new();
+    let result = session.send_message(r#"{"seq":1,"type":"request","command":"initialize"}"#);
+    assert!(result.is_err(), "Should fail when not connected");
+}
+
+#[test]
+fn tcp_attach_session_disconnect_when_not_connected_is_ok() {
+    let mut session = TcpAttachSession::new();
+    let result = session.disconnect();
+    assert!(result.is_ok(), "Disconnecting when not connected should be fine");
+}
+
+#[test]
+fn tcp_attach_session_start_reader_without_connection_fails() {
+    let mut session = TcpAttachSession::new();
+    let result = session.start_reader();
+    assert!(result.is_err(), "Starting reader without connection should fail");
+}
+
+#[test]
+fn tcp_attach_session_connect_to_invalid_host_fails() {
+    let mut session = TcpAttachSession::new();
+    // Use a very short timeout to fail fast
+    let config = TcpAttachConfig::new("192.0.2.1".to_string(), 59999).with_timeout(100);
+    let result = session.connect(&config);
+    assert!(result.is_err(), "Connecting to unreachable host should fail");
+}
+
+#[test]
+fn tcp_attach_session_connect_with_invalid_config_fails() {
+    let mut session = TcpAttachSession::new();
+    let config = TcpAttachConfig::new("".to_string(), 0);
+    let result = session.connect(&config);
+    assert!(result.is_err(), "Should fail validation before attempting connection");
+}
+
+// ── DapEvent ───────────────────────────────────────────────────────
+
+#[test]
+fn dap_event_output_debug_format() {
+    let event =
+        DapEvent::Output { category: "stdout".to_string(), output: "Hello World\n".to_string() };
+    let debug = format!("{:?}", event);
+    assert!(debug.contains("Output"));
+    assert!(debug.contains("stdout"));
+}
+
+#[test]
+fn dap_event_stopped_debug_format() {
+    let event = DapEvent::Stopped { reason: "breakpoint".to_string(), thread_id: 1 };
+    let debug = format!("{:?}", event);
+    assert!(debug.contains("Stopped"));
+    assert!(debug.contains("breakpoint"));
+}
+
+#[test]
+fn dap_event_continued_debug_format() {
+    let event = DapEvent::Continued { thread_id: 1 };
+    let debug = format!("{:?}", event);
+    assert!(debug.contains("Continued"));
+}
+
+#[test]
+fn dap_event_terminated_debug_format() {
+    let event = DapEvent::Terminated { reason: "exited".to_string() };
+    let debug = format!("{:?}", event);
+    assert!(debug.contains("Terminated"));
+    assert!(debug.contains("exited"));
+}
+
+#[test]
+fn dap_event_error_debug_format() {
+    let event = DapEvent::Error { message: "connection lost".to_string() };
+    let debug = format!("{:?}", event);
+    assert!(debug.contains("Error"));
+    assert!(debug.contains("connection lost"));
+}
+
+#[test]
+fn dap_event_clone() {
+    let event = DapEvent::Stopped { reason: "step".to_string(), thread_id: 2 };
+    let cloned = event.clone();
+    let debug_original = format!("{:?}", event);
+    let debug_cloned = format!("{:?}", cloned);
+    assert_eq!(debug_original, debug_cloned);
+}
+
+// ── BridgeAdapter ──────────────────────────────────────────────────
+
+#[test]
+fn bridge_adapter_creation() {
+    let adapter = BridgeAdapter::new();
+    // BridgeAdapter::new() should succeed without panicking
+    let debug = format!("{:?}", "BridgeAdapter created");
+    assert!(!debug.is_empty());
+    drop(adapter);
+}
+
+#[test]
+fn bridge_adapter_default_creation() {
+    let adapter = BridgeAdapter::default();
+    // Default should be equivalent to new()
+    drop(adapter);
+}


### PR DESCRIPTION
## Summary

- Adds **147 new tests** across 4 DAP crates targeting previously untested public API surfaces
- Covers serde round-trip fidelity, camelCase field naming compliance, optional field omission, deserialization from real DAP JSON, error paths, and boundary validation
- No production code changes -- test-only

## New test files

| Crate | File | Tests | Coverage area |
|-------|------|-------|---------------|
| `perl-dap-config` | `serde_edge_case_tests.rs` | 16 | Round-trip, camelCase, optional field omission, path resolution, snippet validation |
| `perl-dap-types` | `edge_case_tests.rs` | 21 | Source edge cases (empty/Windows/dotfile paths), StackFrame builder chaining, Variable DAP JSON deserialization |
| `perl-dap-value` | `serde_round_trip_tests.rs` | 35 | Every PerlValue variant (Tied, Regex, Glob, Code, Truncated, Error), nested structures, behavioral properties |
| `perl-dap` | `dap_protocol_serde_tests.rs` | 47 | All protocol types: Request/Response/Event, Capabilities, Launch/Attach args, control flow, exception info, goto targets, breakpoint locations |
| `perl-dap` | `dap_server_and_adapter_tests.rs` | 28 | DapMode/DapConfig/DapServer, TcpAttachConfig builder/validation, TcpAttachSession error paths, DapEvent variants, BridgeAdapter creation |

## Test plan

- [x] All 147 new tests pass
- [x] All existing DAP tests unchanged (110 lib + integration tests verified green)
- [x] `cargo fmt` clean
- [x] `cargo clippy --tests` clean for all 4 crates