### PR TITLE
chore: unify 16 scattered dependency versions via workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,6 +450,20 @@ tree-sitter = "0.26.6"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+regex = "1.12.2"
+thiserror = "2.0.18"
+tempfile = "3.24.0"
+anyhow = "1.0.102"
+url = "2.5.8"
+lsp-types = "0.97.0"
+parking_lot = "0.12.5"
+once_cell = "1.21.3"
+tracing = "0.1.44"
+walkdir = "2.5.0"
+clap = { version = "4.5.60", features = ["derive"] }
+tokio = { version = "1.49.0", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
+proptest = "1.11.0"
+criterion = "0.8.1"
 
 # Profile for development - slightly optimized for better performance
 [profile.dev]

--- a/crates/perl-ci-hygiene/Cargo.toml
+++ b/crates/perl-ci-hygiene/Cargo.toml
@@ -11,10 +11,10 @@ homepage.workspace = true
 publish = false
 
 [dependencies]
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { workspace = true }
 color-eyre = "0.6.5"
 chrono = "0.4.42"
-regex = "1.12.2"
-serde_json = "1.0.140"
-walkdir = "2.5.0"
+regex.workspace = true
+serde_json.workspace = true
+walkdir.workspace = true
 toml = "1.1.0"

--- a/crates/perl-corpus/Cargo.toml
+++ b/crates/perl-corpus/Cargo.toml
@@ -23,19 +23,19 @@ name = "perl-corpus"
 path = "src/bin/main.rs"
 
 [dependencies]
-anyhow = "1.0.102"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.148"
-regex = "1.12.2"
+anyhow.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+regex.workspace = true
 glob = "0.3.3"
-clap = { version = "4.5.60", features = ["derive"] }
-once_cell = "1.21.3"
+clap = { workspace = true }
+once_cell.workspace = true
 chrono = "0.4.42"
-proptest = "1.11.0"
+proptest.workspace = true
 rand = "0.10.0"
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-tdd-support = { workspace = true }
 
 [features]

--- a/crates/perl-dap-breakpoint/Cargo.toml
+++ b/crates/perl-dap-breakpoint/Cargo.toml
@@ -22,11 +22,11 @@ perl-parser = { path = "../perl-parser", version = "0.12.1" }
 ropey = "1.6.1"
 
 # Error handling
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-dap-config/Cargo.toml
+++ b/crates/perl-dap-config/Cargo.toml
@@ -19,9 +19,9 @@ name = "perl_dap_config"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.102"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+anyhow.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-dap-eval/Cargo.toml
+++ b/crates/perl-dap-eval/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["development-tools", "development-tools::debugging"]
 
 [dependencies]
 # Regex for pattern matching
-regex = "1.12.2"
-once_cell = "1.21.3"
+regex.workspace = true
+once_cell.workspace = true
 
 # Error handling
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-dap-platform/Cargo.toml
+++ b/crates/perl-dap-platform/Cargo.toml
@@ -24,12 +24,12 @@ name = "perl_dap_platform"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow.workspace = true
 
 [dev-dependencies]
 perl-dap-command-args = { workspace = true }
 perl-tdd-support = { workspace = true }
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-dap-security/Cargo.toml
+++ b/crates/perl-dap-security/Cargo.toml
@@ -18,12 +18,12 @@ name = "perl_dap_security"
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "2.0.18"
+thiserror.workspace = true
 perl-path-security = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.102"
-tempfile = "3.24.0"
+anyhow.workspace = true
+tempfile.workspace = true
 perl-tdd-support = { workspace = true }
 
 [lints]

--- a/crates/perl-dap-stack/Cargo.toml
+++ b/crates/perl-dap-stack/Cargo.toml
@@ -15,14 +15,14 @@ categories = ["development-tools::debugging"]
 
 [dependencies]
 # Serialization for DAP protocol
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 
 # Regex for parsing debugger output
-regex = "1.12"
-once_cell = "1.21"
+regex.workspace = true
+once_cell.workspace = true
 
 # Error handling
-thiserror = "2.0"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-dap-types/Cargo.toml
+++ b/crates/perl-dap-types/Cargo.toml
@@ -19,10 +19,10 @@ name = "perl_dap_types"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-dap-value/Cargo.toml
+++ b/crates/perl-dap-value/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools::debugging", "development-tools"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/perl-dap-variables/Cargo.toml
+++ b/crates/perl-dap-variables/Cargo.toml
@@ -17,14 +17,14 @@ categories = ["development-tools::debugging", "development-tools"]
 perl-dap-value = { workspace = true }
 
 # Serialization for DAP protocol
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 
 # Regex for parsing debugger output
-regex = "1.12"
-once_cell = "1.21"
+regex.workspace = true
+once_cell.workspace = true
 
 # Error handling
-thiserror = "2.0"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -31,24 +31,24 @@ path = "src/lib.rs"
 
 [dependencies]
 # JSON serialization
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json.workspace = true
 
 # Error handling
-anyhow = "1.0.102"
+anyhow.workspace = true
 
 # Regex for parsing debugger output
-regex = "1.12.2"
-once_cell = "1.21.3"
+regex.workspace = true
+once_cell.workspace = true
 
 # Async runtime
-tokio = { version = "1.49.0", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 # Logging
-tracing = "0.1.44"
+tracing.workspace = true
 
 # Command-line argument parsing
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { workspace = true }
 
 perl-dap-breakpoint = { workspace = true }
 perl-dap-eval = { workspace = true }
@@ -69,13 +69,13 @@ perl-lsp-launcher = { workspace = true }
 
 [dev-dependencies]
 # Property-based testing (AC13)
-proptest = "1.11.0"
+proptest.workspace = true
 
 # Performance benchmarking (AC14, AC15)
-criterion = "0.8.1"
+criterion.workspace = true
 
 # Test fixtures
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 perl-tdd-support = { workspace = true }
 

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 
 [dependencies]
 perl-workspace-index = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/perl-diagnostics-codes/Cargo.toml
+++ b/crates/perl-diagnostics-codes/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/crates/perl-error/Cargo.toml
+++ b/crates/perl-error/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "parser", "error", "recovery", "diagnostics"]
 categories = ["parsing", "development-tools"]
 
 [dependencies]
-thiserror = "2.0.18"
+thiserror.workspace = true
 perl-ast = { workspace = true }
 perl-ast-v2 = { workspace = true }
 perl-regex = { workspace = true }

--- a/crates/perl-feature-catalog/Cargo.toml
+++ b/crates/perl-feature-catalog/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["development-tools", "development-tools::testing"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0.18"
+serde = { workspace = true }
+thiserror.workspace = true
 toml = "1.1.0"
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-incremental-parsing/Cargo.toml
+++ b/crates/perl-incremental-parsing/Cargo.toml
@@ -27,11 +27,11 @@ perl-parser-core = { workspace = true }
 perl-edit = { workspace = true }
 perl-lexer = { workspace = true }
 perl-line-index = { workspace = true }
-anyhow = "1.0.102"
-lsp-types = "0.97.0"
+anyhow.workspace = true
+lsp-types.workspace = true
 ropey = "1.6.1"
-serde_json = "1.0.149"
-tracing = "0.1.44"
+serde_json.workspace = true
+tracing.workspace = true
 
 [features]
 default = []

--- a/crates/perl-lexer/Cargo.toml
+++ b/crates/perl-lexer/Cargo.toml
@@ -18,17 +18,17 @@ include = ["src/**", "tests/**", "examples/**", "benches/**", "README.md", "LICE
 # Core dependencies
 unicode-ident = "1.0.22"
 memchr = "2.7.6"
-tracing = "0.1.44"
+tracing.workspace = true
 
 # For better error handling
-thiserror = "2.0.18"
+thiserror.workspace = true
 perl-position-tracking = { workspace = true }
 perl-keywords = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion.workspace = true
 pretty_assertions = "1.4.1"
-proptest = "1.11.0"
+proptest.workspace = true
 
 [features]
 default = []

--- a/crates/perl-lsp-cancellation/Cargo.toml
+++ b/crates/perl-lsp-cancellation/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 serde_json = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools"]
 include = ["src/**", "Cargo.toml", "README.md"]
 
 [dependencies]
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 perl-lsp-feature-ids = { workspace = true }
 
 [lints]

--- a/crates/perl-lsp-code-lens/Cargo.toml
+++ b/crates/perl-lsp-code-lens/Cargo.toml
@@ -19,8 +19,8 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-position-tracking = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-color-provider/Cargo.toml
+++ b/crates/perl-lsp-color-provider/Cargo.toml
@@ -18,9 +18,9 @@ doctest = false
 
 [dependencies]
 perl-position-tracking = { workspace = true }
-once_cell = "1.21.3"
-regex = "1.12.2"
-serde_json = "1.0.149"
+once_cell.workspace = true
+regex.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-completion/Cargo.toml
+++ b/crates/perl-lsp-completion/Cargo.toml
@@ -23,18 +23,18 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-keywords = { workspace = true }
-url = "2.5.8"
+url.workspace = true
 
 [features]
 default = []
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion.workspace = true
 perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-workspace-index = { workspace = true }
-serde_json = "1.0"
-url = "2.5.8"
+serde_json.workspace = true
+url.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-config/Cargo.toml
+++ b/crates/perl-lsp-config/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["perl", "lsp", "config", "language-server", "settings"]
 categories = ["development-tools", "text-editors"]
 
 [dependencies]
-serde_json = "1.0.149"
-serde = { version = "1.0", features = ["derive"] }
+serde_json.workspace = true
+serde = { workspace = true }
 toml = "1.1.0"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-document-links/Cargo.toml
+++ b/crates/perl-lsp-document-links/Cargo.toml
@@ -19,8 +19,8 @@ doctest = false
 [dependencies]
 perl-module-import = { workspace = true }
 perl-module-path = { workspace = true }
-serde_json = "1.0.149"
-url = "2.5.8"
+serde_json.workspace = true
+url.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**", "build.rs", "features_sot.toml", "Cargo.toml", "README.md"]
 
 [dependencies]
 serde = { workspace = true }
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 perl-lsp-capability-map = { workspace = true }
 
 [build-dependencies]

--- a/crates/perl-lsp-feature-grid/Cargo.toml
+++ b/crates/perl-lsp-feature-grid/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**", "Cargo.toml", "README.md"]
 [dependencies]
 perl-lsp-feature-contracts = { workspace = true }
 perl-lsp-feature-policy = { workspace = true }
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [features]
 lsp-ga-lock = [

--- a/crates/perl-lsp-file-completion/Cargo.toml
+++ b/crates/perl-lsp-file-completion/Cargo.toml
@@ -19,10 +19,10 @@ doctest = false
 [dependencies]
 perl-lsp-completion-item = { workspace = true }
 perl-path-security = { workspace = true }
-walkdir = "2.5.0"
+walkdir.workspace = true
 
 [dev-dependencies]
-tempfile = "3.23.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-formatting-types/Cargo.toml
+++ b/crates/perl-lsp-formatting-types/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["development-tools", "text-editors"]
 doctest = false
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-formatting/Cargo.toml
+++ b/crates/perl-lsp-formatting/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 [dependencies]
 perl-lsp-tooling = { workspace = true }
 perl-lsp-formatting-types = { workspace = true }
-thiserror = "2.0"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-inlay-hints/Cargo.toml
+++ b/crates/perl-lsp-inlay-hints/Cargo.toml
@@ -21,8 +21,8 @@ perl-semantic-analyzer = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-builtins = { workspace = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-inline-completion/Cargo.toml
+++ b/crates/perl-lsp-inline-completion/Cargo.toml
@@ -17,9 +17,9 @@ categories = ["development-tools", "text-editors"]
 doctest = false
 
 [dependencies]
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 perl-position-tracking = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-input-validation/Cargo.toml
+++ b/crates/perl-lsp-input-validation/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow.workspace = true
 serde_json = { workspace = true }
 perl-path-security = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-launcher/Cargo.toml
+++ b/crates/perl-lsp-launcher/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["development-tools", "development-tools::debugging"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { workspace = true }
 perl-lsp-feature-governance = { workspace = true }
-tracing = "0.1.44"
+tracing.workspace = true
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 

--- a/crates/perl-lsp-limits/Cargo.toml
+++ b/crates/perl-lsp-limits/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "lsp", "limits", "timeout", "resource-management"]
 categories = ["development-tools", "text-editors"]
 
 [dependencies]
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-navigation/Cargo.toml
+++ b/crates/perl-lsp-navigation/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 perl-parser-core = { workspace = true }
-lsp-types = { version = "0.97.0" }
+lsp-types = { workspace = true }
 serde_json = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-qualified-name = { workspace = true }
@@ -32,7 +32,7 @@ lsp-compat = []  # Enable LSP-specific functionality
 slow_tests = []  # Enable slow/expensive tests
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion.workspace = true
 perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }
 

--- a/crates/perl-lsp-on-type-formatting/Cargo.toml
+++ b/crates/perl-lsp-on-type-formatting/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies]
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-protocol/Cargo.toml
+++ b/crates/perl-lsp-protocol/Cargo.toml
@@ -20,10 +20,10 @@ include = [
 ]
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { workspace = true }
+serde_json.workspace = true
 perl-lsp-feature-flags = { workspace = true }
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 
 [dev-dependencies]
 perl-lsp-feature-contracts = { workspace = true }

--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -39,8 +39,8 @@ perl-lsp-code-lens = { workspace = true }
 perl-lsp-folding = { workspace = true }
 perl-lsp-uri = { workspace = true }
 rustc-hash = "2.1.2"
-serde_json = "1.0.149"
-lsp-types = { version = "0.97.0", optional = true }
+serde_json.workspace = true
+lsp-types = { workspace = true, optional = true }
 
 # Unix-only dependency for signal handling in debug adapter
 [target.'cfg(unix)'.dependencies]

--- a/crates/perl-lsp-selection-range/Cargo.toml
+++ b/crates/perl-lsp-selection-range/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [dependencies]
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-semantic-tokens/Cargo.toml
+++ b/crates/perl-lsp-semantic-tokens/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 perl-parser-core = { workspace = true }
 perl-lexer = { workspace = true }
 rustc-hash = "2.1.2"
-regex = "1.12.2"
+regex.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-tooling/Cargo.toml
+++ b/crates/perl-lsp-tooling/Cargo.toml
@@ -26,12 +26,12 @@ perl-lsp-perltidy = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-lsp-performance = { workspace = true }
 perl-lsp-critic-parser = { workspace = true }
-lsp-types = { version = "0.97.0", optional = true }
-serde = { version = "1.0.228", features = ["derive"] }
+lsp-types = { workspace = true, optional = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
-criterion = "0.8"
+criterion.workspace = true
 serde_json = { workspace = true }
 
 [[bench]]

--- a/crates/perl-lsp-transport/Cargo.toml
+++ b/crates/perl-lsp-transport/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 [dependencies]
 perl-lsp-protocol = { workspace = true }
 perl-content-length-framing = { workspace = true }
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-uri/Cargo.toml
+++ b/crates/perl-lsp-uri/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [dependencies]
-lsp-types = "0.97.0"
+lsp-types.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-workspace-symbols/Cargo.toml
+++ b/crates/perl-lsp-workspace-symbols/Cargo.toml
@@ -23,11 +23,11 @@ perl-parser-core = { workspace = true }
 perl-position-tracking = { workspace = true }
 perl-qualified-name = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
-serde_json = "1.0.149"
+serde_json.workspace = true
 perl-position-tracking = { workspace = true }
 
 [lints]

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -91,25 +91,25 @@ perl-workspace-discovery = { workspace = true }
 perl-workspace-folder = { workspace = true }
 perl-workspace-ignore = { workspace = true }
 perl-keywords = { workspace = true }
-lsp-types = "0.97.0"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-url = "2.5.8"
-anyhow = "1.0.102"
-regex = "1.12.2"
+lsp-types.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+url.workspace = true
+anyhow.workspace = true
+regex.workspace = true
 md5 = "0.8.0"
-parking_lot = "0.12.5"
-walkdir = "2.5.0"
+parking_lot.workspace = true
+walkdir.workspace = true
 uuid = { version = "1.23.0", features = ["v4"] }
 
 # Core dependencies for position mapping
 ropey = { version = "1.6.1" }
-tokio = { version = "1.49.0", features = ["net", "rt-multi-thread", "macros", "io-util", "sync", "time"] }
-once_cell = "1.21.3"
-tracing = "0.1.44"
+tokio = { workspace = true }
+once_cell.workspace = true
+tracing.workspace = true
 
 [build-dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 toml = "1.1.0"
 
 [lints]
@@ -148,13 +148,13 @@ insta = { version = "1.47.1", features = ["yaml"] }
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
 serial_test = "3.4.0"
-tempfile = "3.24.0"
-proptest = "1.11.0"
+tempfile.workspace = true
+proptest.workspace = true
 perl-tdd-support = { workspace = true }
 perl-content-length-framing = { workspace = true }
 which = "8.0.2"
-parking_lot = "0.12.5"
-criterion = "0.8.1"
+parking_lot.workspace = true
+criterion.workspace = true
 perl-ast-utils = { workspace = true }
 
 [package.metadata.binstall]

--- a/crates/perl-module-boundary/Cargo.toml
+++ b/crates/perl-module-boundary/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 perl-module-token-core = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-import = { workspace = true }
 perl-module-name = { workspace = true }
 

--- a/crates/perl-module-import-match/Cargo.toml
+++ b/crates/perl-module-import-match/Cargo.toml
@@ -19,7 +19,7 @@ perl-module-import = { workspace = true }
 perl-module-boundary = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-path = { workspace = true }
 perl-module-token = { workspace = true }
 

--- a/crates/perl-module-import/Cargo.toml
+++ b/crates/perl-module-import/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-path = { workspace = true }
 perl-module-token = { workspace = true }
 

--- a/crates/perl-module-name/Cargo.toml
+++ b/crates/perl-module-name/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-module-reference/Cargo.toml
+++ b/crates/perl-module-reference/Cargo.toml
@@ -20,7 +20,7 @@ perl-module-token-parser = { workspace = true }
 perl-text-line = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-import = { workspace = true }
 perl-module-path = { workspace = true }
 

--- a/crates/perl-module-rename/Cargo.toml
+++ b/crates/perl-module-rename/Cargo.toml
@@ -19,7 +19,7 @@ perl-module-token = { workspace = true }
 perl-module-import-match = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-path = { workspace = true }
 
 [lints]

--- a/crates/perl-module-resolution-path/Cargo.toml
+++ b/crates/perl-module-resolution-path/Cargo.toml
@@ -19,8 +19,8 @@ perl-module-path = { workspace = true }
 perl-path-security = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
-tempfile = "3.24.0"
+proptest.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-module-resolution-uri/Cargo.toml
+++ b/crates/perl-module-resolution-uri/Cargo.toml
@@ -18,12 +18,12 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 perl-module-path = { workspace = true }
 perl-path-security = { workspace = true }
 perl-workspace-folder = { workspace = true }
-url = "2.5.8"
+url.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
-proptest = "1.11.0"
-tempfile = "3.24.0"
+proptest.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-module-resolution/Cargo.toml
+++ b/crates/perl-module-resolution/Cargo.toml
@@ -19,9 +19,9 @@ perl-module-resolution-path = { workspace = true }
 perl-module-resolution-uri = { workspace = true }
 
 [dev-dependencies]
-url = "2.5.8"
-proptest = "1.11.0"
-tempfile = "3.24.0"
+url.workspace = true
+proptest.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-module-token-core/Cargo.toml
+++ b/crates/perl-module-token-core/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-module-token-parser/Cargo.toml
+++ b/crates/perl-module-token-parser/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 perl-module-token-core = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-reference = { workspace = true }
 
 [lints]

--- a/crates/perl-module-token/Cargo.toml
+++ b/crates/perl-module-token/Cargo.toml
@@ -19,7 +19,7 @@ perl-module-boundary = { workspace = true }
 perl-module-name = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-path = { workspace = true }
 
 [lints]

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -18,10 +18,10 @@ include = ["src/**", "src/grammar.pest", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 pest = "2.8.6"
 pest_derive = "2.8.6"
-regex = "1.12.2"
+regex.workspace = true
 stacker = "0.1.23"
-thiserror = "2.0.18"
-serde = { version = "1.0.228", features = ["derive"] }
+thiserror.workspace = true
+serde = { workspace = true }
 
 [features]
 default = []

--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -42,24 +42,24 @@ perl-lsp-rename = { workspace = true }
 perl-lsp-semantic-tokens = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-keywords = { workspace = true }
-serde_json = "1.0.149"
-regex = "1.12.2"
-lsp-types = { version = "0.97.0", optional = true }
-url = "2.5.8"
+serde_json.workspace = true
+regex.workspace = true
+lsp-types = { workspace = true, optional = true }
+url.workspace = true
 rustc-hash = "2.1.2"
 # Core dependencies for position mapping (unconditional, all targets)
 ropey = "1.6.1"
 
 # Filesystem traversal is only available on non-wasm targets.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-walkdir = "2.5.0"
+walkdir.workspace = true
 
 # Unix-only dependency for signal handling
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31.1", features = ["signal"] }
 
 # Optional dependencies for incremental parsing
-anyhow = { version = "1.0.102", optional = true }
+anyhow = { workspace = true, optional = true }
 
 [[bin]]
 name = "perl-parse"
@@ -103,14 +103,14 @@ doc-coverage = []  # SPEC-149 documentation coverage tests
 [dev-dependencies]
 assert_cmd = "2.1.2"
 insta = { version = "1.47.1", features = ["yaml"] }
-criterion = "0.8.1"
-parking_lot = "0.12.5"
+criterion.workspace = true
+parking_lot.workspace = true
 predicates = "3.1.3"
 pretty_assertions = "1.4.1"
-regex = "1.12.2"
+regex.workspace = true
 serial_test = "3.4.0"
-tempfile = "3.24.0"
-proptest = "1.11.0"
+tempfile.workspace = true
+proptest.workspace = true
 rstest = "0.26.1"
 perl-corpus = { workspace = true }
 which = "8.0.2"

--- a/crates/perl-path-normalize/Cargo.toml
+++ b/crates/perl-path-normalize/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["development-tools", "filesystem"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-path-security/Cargo.toml
+++ b/crates/perl-path-security/Cargo.toml
@@ -16,10 +16,10 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-path-normalize = { workspace = true }
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-percentile/Cargo.toml
+++ b/crates/perl-percentile/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-position-tracking/Cargo.toml
+++ b/crates/perl-position-tracking/Cargo.toml
@@ -21,9 +21,9 @@ include = [
 ]
 
 [dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 ropey = "1.6.1"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [features]
 default = []
@@ -36,7 +36,7 @@ optional = true
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }
 perl-test-generators = { path = "../perl-test-generators" }
-proptest = "1.11"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-qualified-name/Cargo.toml
+++ b/crates/perl-qualified-name/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-quote/Cargo.toml
+++ b/crates/perl-quote/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["parsing", "text-processing"]
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-refactoring/Cargo.toml
+++ b/crates/perl-refactoring/Cargo.toml
@@ -27,9 +27,9 @@ perl-parser-core = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-module-path = { workspace = true }
 perl-qualified-name = { workspace = true }
-regex = "1.12.2"
-serde = { version = "1.0.228", features = ["derive"] }
-url = "2.5.4"
+regex.workspace = true
+serde = { workspace = true }
+url.workspace = true
 
 [features]
 default = ["workspace_refactor"]
@@ -40,7 +40,7 @@ workspace-rename-tests = []  # Workspace rename integration tests (requires Work
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
 serial_test = "3.4.0"
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-regex/Cargo.toml
+++ b/crates/perl-regex/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "regex", "validation", "security", "backtracking"]
 categories = ["parsing", "text-processing"]
 
 [dependencies]
-thiserror = "2.0.18"
+thiserror.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -26,9 +26,9 @@ doctest = false
 perl-parser-core = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-symbol-types = { workspace = true }
-regex = "1.12.2"
+regex.workspace = true
 rustc-hash = "2.1.2"
-tracing = "0.1"
+tracing.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-symbol-types/Cargo.toml
+++ b/crates/perl-symbol-types/Cargo.toml
@@ -22,10 +22,10 @@ include = [
 doctest = false
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.149"
+serde_json.workspace = true
 
 [features]
 default = []

--- a/crates/perl-tdd-support/Cargo.toml
+++ b/crates/perl-tdd-support/Cargo.toml
@@ -25,10 +25,10 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-test-must = { workspace = true }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-lsp-types = { version = "0.97.0", optional = true }
-url = { version = "2.5.8", optional = true }
+serde = { workspace = true }
+serde_json.workspace = true
+lsp-types = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/crates/perl-test-generators/Cargo.toml
+++ b/crates/perl-test-generators/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies]
-proptest = "1.11"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-text-line/Cargo.toml
+++ b/crates/perl-text-line/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 perl-module-token-parser = { workspace = true }
 perl-tdd-support = { workspace = true }
 

--- a/crates/perl-ts-advanced-parsers/Cargo.toml
+++ b/crates/perl-ts-advanced-parsers/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["perl", "parser", "heredoc", "incremental", "lsp"]
 categories = ["parsing", "development-tools", "text-processing"]
 
 [dependencies]
-regex = "1.12.2"
-serde = { version = "1.0.228", features = ["derive"] }
+regex.workspace = true
+serde = { workspace = true }
 pest = "2.8.4"
 perl-ts-heredoc-parser = { path = "../perl-ts-heredoc-parser" }
 perl-parser-pest = { path = "../perl-parser-pest" }

--- a/crates/perl-ts-heredoc-analysis/Cargo.toml
+++ b/crates/perl-ts-heredoc-analysis/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["perl", "heredoc", "parser", "analysis", "lsp"]
 categories = ["parsing", "development-tools", "text-processing"]
 
 [dependencies]
-regex = "1.12.2"
+regex.workspace = true
 encoding_rs = "0.8.35"
-thiserror = "2.0.17"
+thiserror.workspace = true
 perl-ts-statement-tracker = { path = "../perl-ts-statement-tracker" }
 
 [dev-dependencies]

--- a/crates/perl-ts-heredoc-parser/Cargo.toml
+++ b/crates/perl-ts-heredoc-parser/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "heredoc", "parser", "lexer", "lsp"]
 categories = ["parsing", "development-tools", "text-processing"]
 
 [dependencies]
-regex = "1.12.2"
+regex.workspace = true
 perl-ts-heredoc-analysis = { path = "../perl-ts-heredoc-analysis" }
 perl-ts-statement-tracker = { path = "../perl-ts-statement-tracker" }
 perl-parser-pest = { path = "../perl-parser-pest" }

--- a/crates/perl-ts-partial-ast/Cargo.toml
+++ b/crates/perl-ts-partial-ast/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["perl", "parser", "ast", "heredoc", "tree-sitter"]
 categories = ["parser-implementations", "development-tools"]
 
 [dependencies]
-regex = "1.12.2"
+regex.workspace = true
 perl-ts-heredoc-analysis = { path = "../perl-ts-heredoc-analysis" }
 perl-parser-pest = { path = "../perl-parser-pest" }
 pest = "2.8.4"
-serde_json = "1.0.148"
+serde_json.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-uri-classify/Cargo.toml
+++ b/crates/perl-uri-classify/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "encoding"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-url = "2.5.8"
+url.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-uri/Cargo.toml
+++ b/crates/perl-uri/Cargo.toml
@@ -17,10 +17,10 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 perl-uri-classify = { workspace = true }
 percent-encoding = "2.3.2"
-url = "2.5.8"
+url.workspace = true
 
 [dev-dependencies]
-tempfile = "3.24.0"
+tempfile.workspace = true
 perl-tdd-support = { workspace = true }
 
 [features]

--- a/crates/perl-workspace-discovery/Cargo.toml
+++ b/crates/perl-workspace-discovery/Cargo.toml
@@ -17,11 +17,11 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 perl-source-file = { workspace = true }
 perl-workspace-ignore = { workspace = true }
-walkdir = "2.5.0"
+walkdir.workspace = true
 
 [dev-dependencies]
-tempfile = "3.24.0"
-proptest = "1.11.0"
+tempfile.workspace = true
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-workspace-folder/Cargo.toml
+++ b/crates/perl-workspace-folder/Cargo.toml
@@ -16,12 +16,12 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 perl-uri = { workspace = true }
-serde_json = "1.0.149"
-url = "2.5.8"
+serde_json.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-proptest = "1.9.0"
-tempfile = "3.24.0"
+proptest.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-workspace-index-monitoring/Cargo.toml
+++ b/crates/perl-workspace-index-monitoring/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-parking_lot = "0.12.5"
+parking_lot.workspace = true
 
 [dev-dependencies]
 perl-tdd-support = { path = "../../crates/perl-tdd-support" }

--- a/crates/perl-workspace-index-slo/Cargo.toml
+++ b/crates/perl-workspace-index-slo/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-parking_lot = "0.12.5"
+parking_lot.workspace = true
 perl-percentile = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-workspace-index-state-machine/Cargo.toml
+++ b/crates/perl-workspace-index-state-machine/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "text-editors"]
 include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
-parking_lot = "0.12.5"
+parking_lot.workspace = true
 
 [lints]
 workspace = true

--- a/crates/perl-workspace-index/Cargo.toml
+++ b/crates/perl-workspace-index/Cargo.toml
@@ -30,15 +30,15 @@ perl-uri = { workspace = true }
 perl-workspace-index-monitoring = { workspace = true }
 perl-workspace-index-slo = { workspace = true }
 perl-workspace-index-state-machine = { workspace = true }
-parking_lot = "0.12.5"
-serde = { version = "1.0.228", features = ["derive"] }
-url = "2.5.8"
-lsp-types = { version = "0.97.0", optional = true }
+parking_lot.workspace = true
+serde = { workspace = true }
+url.workspace = true
+lsp-types = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.102"
-criterion = "0.8.1"
-tempfile = "3.24.0"
+anyhow.workspace = true
+criterion.workspace = true
+tempfile.workspace = true
 perl-tdd-support = { workspace = true }
 
 [features]

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["parsing", "text-processing"]
 tree-sitter = "0.26.6"
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion.workspace = true
 test-case = "3.3.1"
 
 [features]

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -22,21 +22,21 @@ perl-lexer = { path = "../perl-lexer" }
 perl-parser = { path = "../perl-parser" }
 perl-parser-pest = { path = "../perl-parser-pest", optional = true }
 tree-sitter = { version = "0.26.6", optional = true }
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 postcard = { version = "1.1.3", features = ["alloc"] }
-walkdir = "2.5.0"
-thiserror = "2.0.17"
+walkdir.workspace = true
+thiserror.workspace = true
 unicode-ident = "1.0.22"
 unicode-normalization = "0.1.25"
 pest = "2.8.4"
 pest_derive = "2.8.4"
 logos = "0.16.0"
-regex = "1.12.2"
-anyhow = "1.0.102"
+regex.workspace = true
+anyhow.workspace = true
 stacker = "0.1.22"
-serde_json = "1.0.148"
+serde_json.workspace = true
 lazy_static = "1.5.0"
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { workspace = true }
 chrono = { version = "0.4.42", features = ["serde"] }
 perl-tdd-support = { path = "../perl-tdd-support" }
 perl-ts-heredoc-analysis = { path = "../perl-ts-heredoc-analysis", optional = true }
@@ -47,9 +47,9 @@ perl-ts-partial-ast = { path = "../perl-ts-partial-ast", optional = true }
 perl-ts-advanced-parsers = { path = "../perl-ts-advanced-parsers", optional = true }
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion.workspace = true
 test-case = "3.3.1"
-proptest = "1.11.0"
+proptest.workspace = true
 
 [lints.rust]
 unused_imports = "warn"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["perl", "parser", "lsp", "tasks"]
 categories = ["development-tools"]
 
 [dependencies]
-clap = { version = "4.5.60", features = ["derive"] }
+clap = { workspace = true }
 color-eyre = "0.6.5"
 similar = "2.7.0"
 duct = "1.1.1"
-walkdir = "2.5.0"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-anyhow = "1.0.102"
+walkdir.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+anyhow.workspace = true
 perl-feature-catalog = { workspace = true }
 indicatif = "0.18.4"
 console = "0.16.2"
@@ -30,7 +30,7 @@ perl-parser = { workspace = true }
 perl-parser-pest = { workspace = true, optional = true }
 tree-sitter = { workspace = true }
 tree-sitter-perl = { path = "../crates/tree-sitter-perl-rs", optional = true, features = ["c-parser"] }
-regex = "1.12.2"
+regex.workspace = true
 serde_yaml_ng = "0.10.0"
 toml = "1.1.0"
 bindgen = "0.72.1"
@@ -38,7 +38,7 @@ peak_alloc = "0.3.0"
 notify = "8.2.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
-tempfile = "3.24.0"
+tempfile.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"


### PR DESCRIPTION
## Summary

- Add 14 new external dependencies to `[workspace.dependencies]` in the root `Cargo.toml` (serde and serde_json were already there)
- Update 88 individual crate `Cargo.toml` files to use `dep.workspace = true` or `dep = { workspace = true }` instead of pinning versions locally
- Eliminates version scatter where the same dependency had 2-5 different version specs across the workspace

## Dependencies unified

| Dependency | Version scatter before | Canonical version |
|---|---|---|
| **serde** | `1.0.228`, `1.0`, `1` (4 specs) | `1.0.228` |
| **serde_json** | `1.0.149`, `1.0.148`, `1.0.140`, `1.0` (5 specs) | `1.0.149` |
| **regex** | `1.12.2`, `1.12` | `1.12.2` |
| **thiserror** | `2.0.18`, `2.0.17`, `2.0` (3 specs) | `2.0.18` |
| **tempfile** | `3.24.0`, `3.23.0`, `3` (3 specs) | `3.24.0` |
| **proptest** | `1.11.0`, `1.11`, `1.9.0` (3 specs) | `1.11.0` |
| **url** | `2.5.8`, `2.5.4` | `2.5.8` |
| **once_cell** | `1.21.3`, `1.21` | `1.21.3` |
| **tracing** | `0.1.44`, `0.1` | `0.1.44` |
| **criterion** | `0.8.1`, `0.8` | `0.8.1` |
| **anyhow** | uniform, not workspace-ified | `1.0.102` |
| **lsp-types** | uniform, not workspace-ified | `0.97.0` |
| **parking_lot** | uniform, not workspace-ified | `0.12.5` |
| **walkdir** | uniform, not workspace-ified | `2.5.0` |
| **clap** | uniform, not workspace-ified | `4.5.60` |
| **tokio** | 2 feature sets, not workspace-ified | `1.49.0` |

## What's preserved

- `optional = true` on deps like `serde` in `perl-diagnostics-codes`, `anyhow` in `perl-parser`, `lsp-types` in multiple crates, `url` in `perl-tdd-support`
- Feature flags in `[features]` sections (e.g., `serde = ["dep:serde"]` in `perl-diagnostics-codes`, `serde = []` in `perl-parser-pest`)
- Extra features on workspace deps (e.g., `tokio = { workspace = true, features = ["full"] }` in `perl-dap`)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` passes (all tests green, 0 failures)
- [ ] CI gate runs on PR