### PR TITLE
fix(vscode): replace `any` types with proper TypeScript types

### DIFF
--- a/vscode-extension/src/debugAdapter.ts
+++ b/vscode-extension/src/debugAdapter.ts
@@ -104,14 +104,23 @@ export async function createDebugConfigWizard(): Promise<void> {
     if (workspaceFolders.length === 1) {
         workspaceRoot = workspaceFolders[0].uri.fsPath;
     } else {
-        const picked = await vscode.window.showQuickPick(
-            workspaceFolders.map(f => ({ label: f.name, description: f.uri.fsPath, fsPath: f.uri.fsPath })),
-            { placeHolder: 'Select workspace folder' }
-        );
+        interface WorkspaceFolderItem extends vscode.QuickPickItem {
+            fsPath: string;
+        }
+
+        const items: WorkspaceFolderItem[] = workspaceFolders.map(f => ({
+            label: f.name,
+            description: f.uri.fsPath,
+            fsPath: f.uri.fsPath
+        }));
+
+        const picked = await vscode.window.showQuickPick(items, {
+            placeHolder: 'Select workspace folder'
+        });
         if (!picked) {
             return;
         }
-        workspaceRoot = (picked as any).fsPath;
+        workspaceRoot = picked.fsPath;
     }
 
     const launchPath = path.join(workspaceRoot, '.vscode', 'launch.json');

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -19,6 +19,7 @@ interface ReleaseAsset {
 
 interface Release {
     tag_name: string;
+    prerelease?: boolean;
     assets: ReleaseAsset[];
 }
 
@@ -94,8 +95,8 @@ export class BinaryDownloader {
         // Download binary
         try {
             return await this.downloadWithProgress();
-        } catch (error: any) {
-            const errorMsg = error?.message || String(error);
+        } catch (error: unknown) {
+            const errorMsg = error instanceof Error ? error.message : String(error);
             this.outputChannel.appendLine(`Failed to download binary: ${errorMsg}`);
             
             // Provide helpful error messages
@@ -351,19 +352,25 @@ export class BinaryDownloader {
                 res.on('data', chunk => data += chunk);
                 res.on('end', () => {
                     try {
-                        const parsed = JSON.parse(data);
-                        if (parsed.message && parsed.message.includes('Not Found')) {
-                            reject(new Error('No releases found'));
-                        } else if (Array.isArray(parsed)) {
+                        const parsed: unknown = JSON.parse(data);
+                        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && 'message' in parsed) {
+                            const msg = parsed as { message: string };
+                            if (msg.message.includes('Not Found')) {
+                                reject(new Error('No releases found'));
+                                return;
+                            }
+                        }
+                        if (Array.isArray(parsed)) {
                             // For stable channel, find first non-prerelease
-                            const stableRelease = parsed.find((r: any) => !r.prerelease);
+                            const releases = parsed as Release[];
+                            const stableRelease = releases.find(r => !r.prerelease);
                             if (stableRelease) {
                                 resolve(stableRelease);
                             } else {
-                                resolve(parsed[0]); // Fall back to latest
+                                resolve(releases[0]); // Fall back to latest
                             }
                         } else {
-                            resolve(parsed);
+                            resolve(parsed as Release);
                         }
                     } catch (e) {
                         reject(e);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -121,7 +121,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         interface MenuAction extends vscode.QuickPickItem {
             command?: string;
-            args?: any[];
+            args?: unknown[];
             disabled?: boolean;
         }
 
@@ -938,7 +938,7 @@ async function restartServer(context: vscode.ExtensionContext) {
                 outputChannel.show();
             }
         });
-    } catch (error: any) {
+    } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         outputChannel.appendLine(`Failed to restart perl-lsp: ${message}`);
         vscode.window.showErrorMessage(`Failed to restart Perl Language Server: ${message}`, 'Show Output').then(selection => {


### PR DESCRIPTION
## Summary

- Replace all 5 `any` type annotations in VSCode extension source files with proper TypeScript types
- `debugAdapter.ts`: introduce `WorkspaceFolderItem` interface instead of `as any` cast for QuickPick items with custom `fsPath` property
- `downloader.ts`: change catch clause to `unknown` with `instanceof Error` guard; add `prerelease` field to `Release` interface; type `JSON.parse` result as `unknown` with proper narrowing for GitHub API responses
- `extension.ts`: change `MenuAction.args` from `any[]` to `unknown[]`; change catch clause to `unknown` (error handling already used `instanceof` guard)

No runtime behavior changes -- only type annotations.

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run compile` succeeds cleanly
- [x] All 390 VSCode extension tests pass (`npm test`)
- [x] Zero remaining `any` types in non-test source files (verified with grep)