### PR TITLE
feat(ai): promote inline completion scheduler priority and wire AI backend fallback

### DIFF
--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -62,6 +62,7 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            ai_inline_backend: Mutex::new(None),
         }
     }
 
@@ -163,6 +164,7 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            ai_inline_backend: Mutex::new(None),
         }
     }
 
@@ -227,6 +229,7 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            ai_inline_backend: Mutex::new(None),
         }
     }
 }

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -637,7 +637,11 @@ impl LspServer {
         Err(JsonRpcError { code: -32602, message: "Invalid parameters".to_string(), data: None })
     }
 
-    /// Handle textDocument/inlineCompletion request
+    /// Handle textDocument/inlineCompletion request.
+    ///
+    /// When an AI backend is registered and AI completion is enabled in config,
+    /// the handler tries the backend first. On failure or empty results, it
+    /// falls back to deterministic completions (controlled by `ai_config.fallback`).
     pub(crate) fn handle_inline_completion(
         &self,
         params: Option<Value>,
@@ -648,22 +652,102 @@ impl LspServer {
             let uri = req_uri(&params)?;
             let (line, character) = req_position(&params)?;
 
-            let documents = self.documents_guard();
-            if let Some(doc) = self.get_document(&documents, uri) {
-                let provider = InlineCompletionProvider::new();
-                let completions = provider.get_inline_completions(&doc.text, line, character);
-                return Ok(Some(serde_json::to_value(completions).map_err(|e| {
-                    crate::protocol::internal_error(&format!(
-                        "Failed to serialize inline completions: {}",
-                        e
-                    ))
-                })?));
+            // Snapshot text under document lock, then release before any slow work
+            let text = {
+                let documents = self.documents_guard();
+                match self.get_document(&documents, uri) {
+                    Some(doc) => doc.text.clone(),
+                    None => {
+                        return Ok(Some(json!({ "items": [] })));
+                    }
+                }
+            };
+
+            let provider = InlineCompletionProvider::new();
+
+            // Try AI backend if enabled
+            let ai_config = self.config.lock().ai_completion.clone();
+            if ai_config.enabled {
+                if let Some(context) = provider.prepare_context(&text, line, character) {
+                    let backend_result = self.try_ai_inline_completion(&context, &ai_config);
+                    match backend_result {
+                        Ok(ref items) if !items.is_empty() => {
+                            let list = perl_lsp_inline_completion::InlineCompletionList {
+                                items: items.clone(),
+                            };
+                            return Ok(Some(serde_json::to_value(list).map_err(|e| {
+                                crate::protocol::internal_error(&format!(
+                                    "Failed to serialize inline completions: {}",
+                                    e
+                                ))
+                            })?));
+                        }
+                        Err(ref e) => {
+                            tracing::debug!("AI inline completion failed: {}", e);
+                            if !ai_config.fallback {
+                                return Ok(Some(json!({ "items": [] })));
+                            }
+                            // Fall through to deterministic
+                        }
+                        _ => {
+                            // Ok(empty) — fall through to deterministic if fallback enabled
+                            if !ai_config.fallback {
+                                return Ok(Some(json!({ "items": [] })));
+                            }
+                        }
+                    }
+                }
             }
+
+            // Deterministic fallback
+            let completions = provider.get_inline_completions(&text, line, character);
+            return Ok(Some(serde_json::to_value(completions).map_err(|e| {
+                crate::protocol::internal_error(&format!(
+                    "Failed to serialize inline completions: {}",
+                    e
+                ))
+            })?));
         }
 
-        Ok(Some(json!({
-            "items": []
-        })))
+        Ok(Some(json!({ "items": [] })))
+    }
+
+    /// Attempt AI-backed inline completion.
+    ///
+    /// Returns `Ok(items)` on success, `Err` on any failure.
+    fn try_ai_inline_completion(
+        &self,
+        context: &perl_lsp_inline_completion::PreparedInlineCompletionContext,
+        ai_config: &perl_lsp_config::AiCompletionConfig,
+    ) -> Result<
+        Vec<perl_lsp_inline_completion::InlineCompletionItem>,
+        perl_lsp_inline_completion::BackendError,
+    > {
+        // Get the backend from server state (if registered)
+        let backend = self.ai_backend();
+        let backend = match backend.as_ref() {
+            Some(b) => b,
+            None => return Ok(vec![]),
+        };
+
+        let req = perl_lsp_inline_completion::BackendRequest {
+            context: context.clone(),
+            max_output_tokens: ai_config.max_output_tokens,
+            timeout_ms: ai_config.timeout_ms,
+        };
+
+        let texts = backend.complete(&req)?;
+        let items = texts
+            .into_iter()
+            .map(|text| perl_lsp_inline_completion::InlineCompletionItem {
+                insert_text: text,
+                filter_text: None,
+                range: None,
+                command: None,
+            })
+            .collect();
+
+        Ok(items)
     }
 
     /// Handle textDocument/inlineValue request

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -270,6 +270,13 @@ pub struct LspServer {
     /// Initialized to `false`; only the test helper methods flip this.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) skip_perlcritic_command_check: AtomicBool,
+    /// Optional AI inline-completion backend.
+    ///
+    /// When `Some`, the `handle_inline_completion` handler will attempt
+    /// AI-backed completions before falling back to deterministic rules.
+    /// Set to `None` by default; a backend can be registered later.
+    pub(crate) ai_inline_backend:
+        Mutex<Option<Arc<dyn perl_lsp_inline_completion::InlineCompletionBackend>>>,
 }
 
 // SAFETY: LspServer is not auto-Send/Sync because DocumentState contains
@@ -294,6 +301,16 @@ impl LspServer {
     /// Active feature profile for this server instance.
     pub(crate) const fn feature_profile(&self) -> FeatureProfile {
         self.feature_profile
+    }
+
+    /// Get the registered AI inline-completion backend, if any.
+    ///
+    /// Returns `None` when no backend has been registered (the default).
+    /// The returned `Arc` is a cheap clone suitable for use outside the lock.
+    pub(crate) fn ai_backend(
+        &self,
+    ) -> Option<Arc<dyn perl_lsp_inline_completion::InlineCompletionBackend>> {
+        self.ai_inline_backend.lock().clone()
     }
 
     /// Get the subprocess runtime for external tool execution (perltidy, perlcritic).

--- a/crates/perl-lsp/src/runtime/scheduler.rs
+++ b/crates/perl-lsp/src/runtime/scheduler.rs
@@ -73,7 +73,9 @@ impl RequestPriority {
 pub(crate) fn request_priority(method: &str) -> RequestPriority {
     match method {
         "textDocument/hover" => RequestPriority::Hover,
-        "textDocument/completion" | "completionItem/resolve" => RequestPriority::Completion,
+        "textDocument/completion" | "completionItem/resolve" | "textDocument/inlineCompletion" => {
+            RequestPriority::Completion
+        }
         "textDocument/references"
         | "textDocument/definition"
         | "textDocument/declaration"
@@ -800,6 +802,30 @@ mod tests {
     // =====================================================================
     // Helper constructors for tests
     // =====================================================================
+
+    #[test]
+    fn inline_completion_gets_completion_priority() {
+        assert_eq!(request_priority("textDocument/inlineCompletion"), RequestPriority::Completion);
+    }
+
+    #[test]
+    fn inline_completion_gets_dedup_key() {
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///test.pl" },
+            "position": { "line": 5, "character": 10 }
+        });
+        let key = extract_dedup_key(
+            "textDocument/inlineCompletion",
+            Some(&params),
+            RequestPriority::Completion,
+        );
+        assert!(key.is_some());
+        let key = key.unwrap();
+        assert_eq!(key.method, "textDocument/inlineCompletion");
+        assert_eq!(key.uri, "file:///test.pl");
+        assert_eq!(key.line, 5);
+        assert_eq!(key.character, 10);
+    }
 
     fn make_queued_read(method: &str, arrival_seq: u64) -> QueuedRead {
         make_queued_read_with_seq(method, 0, arrival_seq)


### PR DESCRIPTION
## Summary

- **Scheduler priority fix**: `textDocument/inlineCompletion` now maps to `RequestPriority::Completion` (was falling through to `Other`), giving inline completions the same latency treatment and stale-request deduplication as `textDocument/completion`.

- **AI backend trait**: Added `InlineCompletionBackend` trait, `BackendRequest`, and `BackendError` to `perl-lsp-inline-completion` for future pluggable AI completion backends.

- **Config support**: Added `AiCompletionConfig` (enabled, fallback, max_output_tokens, timeout_ms) to `perl-lsp-config::ServerConfig`, configurable via `didChangeConfiguration` under `aiCompletion`. Disabled by default.

- **Handler wiring**: Rewrote `handle_inline_completion` to snapshot text under the document lock then release before slow work, try an optional AI backend if enabled/registered, and fall back to deterministic completions on failure or empty results.

- **Hook point**: Added `ai_inline_backend` field and `ai_backend()` accessor to `LspServer` (returns `None` by default — backend registration is a future step).

## Changed files

| File | Change |
|------|--------|
| `crates/perl-lsp/src/runtime/scheduler.rs` | Add `textDocument/inlineCompletion` to completion priority arm + 2 tests |
| `crates/perl-lsp-inline-completion/src/lib.rs` | Add `BackendError`, `BackendRequest`, `InlineCompletionBackend` trait |
| `crates/perl-lsp-config/src/lib.rs` | Add `AiCompletionConfig` struct + `ai_completion` field on `ServerConfig` |
| `crates/perl-lsp/src/runtime/mod.rs` | Add `ai_inline_backend` field + `ai_backend()` accessor |
| `crates/perl-lsp/src/runtime/constructors.rs` | Initialize `ai_inline_backend: Mutex::new(None)` in all constructors |
| `crates/perl-lsp/src/runtime/language/misc.rs` | Rewrite handler with AI-first + deterministic fallback pattern |

## Test plan

- [x] `cargo check -p perl-lsp-rs` passes
- [x] `cargo fmt -p perl-lsp-rs -p perl-lsp-inline-completion -p perl-lsp-config` clean
- [x] `cargo clippy -p perl-lsp-rs --lib` clean (zero warnings)
- [x] New scheduler tests: `inline_completion_gets_completion_priority`, `inline_completion_gets_dedup_key`
- [x] All 23 scheduler unit tests pass
- [x] All 12 inline completion integration tests pass
- [x] All 16 inline-completion crate tests pass
- [x] All 56 config crate tests pass
- [x] All 20 wired crates integration tests pass