### PR TITLE
feat(ai): add InlineCompletionBackend trait and AI config surface

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -55,6 +55,73 @@ pub struct ServerConfig {
     /// When `Some`, passes `--profile=<path>` to perlcritic. When `None`,
     /// the auto-discovery logic looks for `.perlcriticrc` in the workspace root.
     pub perlcritic_profile: Option<String>,
+
+    /// AI-powered inline completion configuration.
+    pub ai_completion: AiCompletionConfig,
+}
+
+/// Configuration for AI-powered inline completions.
+///
+/// Disabled by default. When enabled, the server calls an external AI provider
+/// for inline completion suggestions, falling back to deterministic rules on
+/// timeout, error, or when AI is disabled.
+#[derive(Debug, Clone)]
+pub struct AiCompletionConfig {
+    /// Whether AI completions are enabled. Default: false.
+    pub enabled: bool,
+    /// Provider type. Currently only "openai_compat" is supported.
+    pub provider: String,
+    /// API endpoint URL.
+    pub endpoint: String,
+    /// Model identifier (e.g., "gpt-4o-mini").
+    pub model: String,
+    /// Environment variable name containing the API key.
+    pub api_key_env: String,
+    /// Request timeout in milliseconds. Default: 1800.
+    pub timeout_ms: u64,
+    /// Maximum output tokens per request. Default: 64.
+    pub max_output_tokens: u32,
+    /// Maximum requests per second. Default: 1.
+    pub rate_limit_rps: f64,
+    /// Maximum concurrent in-flight requests. Default: 1.
+    pub max_inflight: u32,
+    /// Whether to fall back to deterministic completions on AI failure. Default: true.
+    pub fallback: bool,
+    /// Streaming-specific configuration.
+    pub streaming: AiStreamingConfig,
+}
+
+/// Streaming sub-configuration for AI completions.
+#[derive(Debug, Clone)]
+pub struct AiStreamingConfig {
+    /// Whether streaming mode is enabled. Default: true.
+    pub enabled: bool,
+    /// Minimum milliseconds between emitted updates. Default: 60.
+    pub update_debounce_ms: u64,
+}
+
+impl Default for AiCompletionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: "openai_compat".to_string(),
+            endpoint: String::new(),
+            model: "gpt-4o-mini".to_string(),
+            api_key_env: "OPENAI_API_KEY".to_string(),
+            timeout_ms: 1800,
+            max_output_tokens: 64,
+            rate_limit_rps: 1.0,
+            max_inflight: 1,
+            fallback: true,
+            streaming: AiStreamingConfig::default(),
+        }
+    }
+}
+
+impl Default for AiStreamingConfig {
+    fn default() -> Self {
+        Self { enabled: true, update_debounce_ms: 60 }
+    }
 }
 
 impl Default for ServerConfig {
@@ -73,6 +140,7 @@ impl Default for ServerConfig {
             perlcritic_enabled: false,
             perlcritic_severity: 3,
             perlcritic_profile: None,
+            ai_completion: AiCompletionConfig::default(),
         }
     }
 }
@@ -129,6 +197,47 @@ impl ServerConfig {
             }
             if let Some(profile) = critic.get("profile").and_then(|v| v.as_str()) {
                 self.perlcritic_profile = Some(profile.to_string());
+            }
+        }
+
+        if let Some(ai) = settings.get("aiCompletion") {
+            if let Some(enabled) = ai.get("enabled").and_then(|v| v.as_bool()) {
+                self.ai_completion.enabled = enabled;
+            }
+            if let Some(provider) = ai.get("provider").and_then(|v| v.as_str()) {
+                self.ai_completion.provider = provider.to_string();
+            }
+            if let Some(endpoint) = ai.get("endpoint").and_then(|v| v.as_str()) {
+                self.ai_completion.endpoint = endpoint.to_string();
+            }
+            if let Some(model) = ai.get("model").and_then(|v| v.as_str()) {
+                self.ai_completion.model = model.to_string();
+            }
+            if let Some(key_env) = ai.get("apiKeyEnv").and_then(|v| v.as_str()) {
+                self.ai_completion.api_key_env = key_env.to_string();
+            }
+            if let Some(timeout) = ai.get("timeoutMs").and_then(|v| v.as_u64()) {
+                self.ai_completion.timeout_ms = timeout;
+            }
+            if let Some(tokens) = ai.get("maxOutputTokens").and_then(|v| v.as_u64()) {
+                self.ai_completion.max_output_tokens = tokens as u32;
+            }
+            if let Some(rps) = ai.get("rateLimitRps").and_then(|v| v.as_f64()) {
+                self.ai_completion.rate_limit_rps = rps;
+            }
+            if let Some(inflight) = ai.get("maxInflight").and_then(|v| v.as_u64()) {
+                self.ai_completion.max_inflight = inflight as u32;
+            }
+            if let Some(fallback) = ai.get("fallback").and_then(|v| v.as_bool()) {
+                self.ai_completion.fallback = fallback;
+            }
+            if let Some(streaming) = ai.get("streaming") {
+                if let Some(enabled) = streaming.get("enabled").and_then(|v| v.as_bool()) {
+                    self.ai_completion.streaming.enabled = enabled;
+                }
+                if let Some(debounce) = streaming.get("updateDebounceMs").and_then(|v| v.as_u64()) {
+                    self.ai_completion.streaming.update_debounce_ms = debounce;
+                }
             }
         }
     }
@@ -240,6 +349,8 @@ pub struct ProjectConfig {
     pub diagnostics: ProjectDiagnosticsConfig,
     /// `[features]` section: LSP feature toggles.
     pub features: ProjectFeaturesConfig,
+    /// `[ai_completion]` section: AI completion settings.
+    pub ai_completion: ProjectAiCompletionConfig,
 }
 
 /// `[perl]` section of `.perl-lsp.toml`.
@@ -269,6 +380,22 @@ pub struct ProjectDiagnosticsConfig {
 pub struct ProjectFeaturesConfig {
     /// Whether inlay hints are enabled globally. Maps to `ServerConfig.inlay_hints_enabled`.
     pub inlay_hints: Option<bool>,
+}
+
+/// `[ai_completion]` section of `.perl-lsp.toml`.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct ProjectAiCompletionConfig {
+    /// Whether AI completions are enabled.
+    pub enabled: Option<bool>,
+    /// Provider type.
+    pub provider: Option<String>,
+    /// API endpoint URL.
+    pub endpoint: Option<String>,
+    /// Model identifier.
+    pub model: Option<String>,
+    /// Environment variable name for API key.
+    pub api_key_env: Option<String>,
 }
 
 /// Load project config from `<workspace_root>/.perl-lsp.toml`.
@@ -302,6 +429,21 @@ impl ProjectConfig {
         }
         if let Some(hints) = self.features.inlay_hints {
             config.inlay_hints_enabled = hints;
+        }
+        if let Some(enabled) = self.ai_completion.enabled {
+            config.ai_completion.enabled = enabled;
+        }
+        if let Some(ref provider) = self.ai_completion.provider {
+            config.ai_completion.provider = provider.clone();
+        }
+        if let Some(ref endpoint) = self.ai_completion.endpoint {
+            config.ai_completion.endpoint = endpoint.clone();
+        }
+        if let Some(ref model) = self.ai_completion.model {
+            config.ai_completion.model = model.clone();
+        }
+        if let Some(ref key_env) = self.ai_completion.api_key_env {
+            config.ai_completion.api_key_env = key_env.clone();
         }
     }
 
@@ -525,5 +667,52 @@ mod tests {
         // use_system_inc = false (default)
         let inc = config.get_system_inc();
         assert!(inc.is_empty(), "system inc is empty when use_system_inc=false");
+    }
+
+    // ── AiCompletionConfig ──────────────────────────────────────
+
+    #[test]
+    fn server_config_default_ai_completion_disabled() {
+        let config = ServerConfig::default();
+        assert!(!config.ai_completion.enabled, "AI completion disabled by default");
+        assert_eq!(config.ai_completion.provider, "openai_compat");
+        assert!(config.ai_completion.endpoint.is_empty());
+        assert_eq!(config.ai_completion.timeout_ms, 1800);
+        assert_eq!(config.ai_completion.max_output_tokens, 64);
+        assert!(config.ai_completion.fallback);
+        assert!(config.ai_completion.streaming.enabled);
+        assert_eq!(config.ai_completion.streaming.update_debounce_ms, 60);
+    }
+
+    #[test]
+    fn server_config_ai_completion_updated_via_settings() {
+        let mut config = ServerConfig::default();
+        config.update_from_value(&json!({
+            "aiCompletion": {
+                "enabled": true,
+                "provider": "openai_compat",
+                "endpoint": "https://api.openai.com/v1/chat/completions",
+                "model": "gpt-4o",
+                "apiKeyEnv": "MY_KEY",
+                "timeoutMs": 3000,
+                "maxOutputTokens": 128,
+                "rateLimitRps": 2.0,
+                "maxInflight": 2,
+                "fallback": false,
+                "streaming": {
+                    "enabled": false,
+                    "updateDebounceMs": 100
+                }
+            }
+        }));
+        assert!(config.ai_completion.enabled);
+        assert_eq!(config.ai_completion.endpoint, "https://api.openai.com/v1/chat/completions");
+        assert_eq!(config.ai_completion.model, "gpt-4o");
+        assert_eq!(config.ai_completion.api_key_env, "MY_KEY");
+        assert_eq!(config.ai_completion.timeout_ms, 3000);
+        assert_eq!(config.ai_completion.max_output_tokens, 128);
+        assert!(!config.ai_completion.fallback);
+        assert!(!config.ai_completion.streaming.enabled);
+        assert_eq!(config.ai_completion.streaming.update_debounce_ms, 100);
     }
 }

--- a/crates/perl-lsp-inline-completion/src/lib.rs
+++ b/crates/perl-lsp-inline-completion/src/lib.rs
@@ -1,8 +1,8 @@
-//! Inline completions provider with deterministic rules
+//! Inline completions provider with deterministic rules and AI backend support.
 //!
 //! This crate provides context-aware inline completions that appear as
-//! ghost text. These are deterministic completions based on patterns,
-//! not AI-powered suggestions.
+//! ghost text. Deterministic completions are based on patterns; AI-powered
+//! suggestions use the `InlineCompletionBackend` trait for pluggable providers.
 
 use perl_position_tracking::utf16_line_col_to_offset;
 use serde::{Deserialize, Serialize};
@@ -55,6 +55,101 @@ pub struct InlineCompletionItem {
 pub struct InlineCompletionList {
     /// The inline completion items.
     pub items: Vec<InlineCompletionItem>,
+}
+
+// ── AI backend interface ─────────────────────────────────────────────────────
+
+/// Error type for backend operations.
+#[derive(Debug)]
+pub enum BackendError {
+    /// Network or IO error.
+    Transport(String),
+    /// Authentication failure (bad key, expired token).
+    Auth(String),
+    /// Provider returned an error response.
+    Provider(String),
+    /// Request timed out.
+    Timeout,
+    /// Rate limit exceeded.
+    RateLimited,
+    /// Request was cancelled.
+    Cancelled,
+}
+
+impl std::fmt::Display for BackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(msg) => write!(f, "transport error: {}", msg),
+            Self::Auth(msg) => write!(f, "auth error: {}", msg),
+            Self::Provider(msg) => write!(f, "provider error: {}", msg),
+            Self::Timeout => write!(f, "request timed out"),
+            Self::RateLimited => write!(f, "rate limit exceeded"),
+            Self::Cancelled => write!(f, "request cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+/// Request payload sent to an AI completion backend.
+#[derive(Debug, Clone)]
+pub struct BackendRequest {
+    /// Prepared context from the current buffer.
+    pub context: PreparedInlineCompletionContext,
+    /// Maximum tokens to generate.
+    pub max_output_tokens: u32,
+    /// Timeout in milliseconds.
+    pub timeout_ms: u64,
+}
+
+/// A chunk emitted by a streaming backend.
+#[derive(Debug, Clone)]
+pub struct StreamChunk {
+    /// Cumulative candidate text so far (NOT a delta).
+    pub text: String,
+    /// Whether this is the final chunk.
+    pub is_final: bool,
+}
+
+/// Control signal returned by the stream sink callback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamControl {
+    /// Continue receiving chunks.
+    Continue,
+    /// Stop the stream early.
+    Stop,
+}
+
+/// Trait for AI inline completion backends.
+///
+/// Implementations provide streaming token generation. The default `complete()`
+/// method buffers the stream into a one-shot result, so backends only need to
+/// implement `stream()`.
+///
+/// The trait is sync and callback-based to keep this crate dependency-light
+/// and runtime-agnostic. Network I/O happens in the provider crate.
+pub trait InlineCompletionBackend: Send + Sync {
+    /// One-shot completion: returns the final candidate texts.
+    ///
+    /// Default implementation buffers the stream.
+    fn complete(&self, req: &BackendRequest) -> Result<Vec<String>, BackendError> {
+        let mut final_text = String::new();
+        self.stream(req, &mut |chunk| {
+            final_text = chunk.text.clone();
+            if chunk.is_final { StreamControl::Stop } else { StreamControl::Continue }
+        })?;
+        Ok(if final_text.is_empty() { vec![] } else { vec![final_text] })
+    }
+
+    /// Stream completion chunks to a callback sink.
+    ///
+    /// Each `StreamChunk.text` is **cumulative** — the full candidate so far,
+    /// not a delta. The sink returns `StreamControl::Stop` to cancel early.
+    fn stream(
+        &self,
+        req: &BackendRequest,
+        sink: &mut dyn FnMut(StreamChunk) -> StreamControl,
+    ) -> Result<(), BackendError>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- Add `InlineCompletionBackend` trait with streaming + buffered completion to `perl-lsp-inline-completion`, along with `BackendError`, `BackendRequest`, `StreamChunk`, and `StreamControl` types
- Add `AiCompletionConfig` / `AiStreamingConfig` to `perl-lsp-config` with JSON settings parsing (`aiCompletion` key) and `.perl-lsp.toml` support (`[ai_completion]` section via `ProjectAiCompletionConfig`)
- AI completions disabled by default; deterministic fallback enabled by default

## Test plan
- [x] `cargo check -p perl-lsp-inline-completion` -- compiles clean
- [x] `cargo check -p perl-lsp-config` -- compiles clean
- [x] `cargo test -p perl-lsp-inline-completion` -- 16 tests pass
- [x] `cargo test -p perl-lsp-config` -- 24 unit + 20 behavioral + 14 project config tests pass
- [x] `cargo fmt -p perl-lsp-inline-completion -p perl-lsp-config` -- no changes
- [x] `cargo clippy -p perl-lsp-inline-completion -p perl-lsp-config --lib` -- no warnings
- [x] `cargo test --workspace --lib` -- 138 tests pass (full workspace)