### PR TITLE
feat(ai): add OpenAI-compatible provider with SSE streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +446,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +638,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -822,6 +866,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -918,6 +973,22 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
@@ -1217,6 +1288,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1817,6 +1894,18 @@ name = "perl-line-index"
 version = "0.12.1"
 dependencies = [
  "perl-tdd-support",
+]
+
+[[package]]
+name = "perl-lsp-ai-provider"
+version = "0.1.0"
+dependencies = [
+ "perl-lsp-inline-completion",
+ "perl-tdd-support",
+ "serde",
+ "serde_json",
+ "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -3381,6 +3470,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ropey"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +3554,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3775,6 +3913,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4240,6 +4384,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,6 +4432,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4429,6 +4617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4525,6 +4722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4899,6 +5105,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "crates/perl-lsp-file-completion",
     "crates/perl-lsp-completion-item",
     "crates/perl-lsp-inline-completion",
+    "crates/perl-lsp-ai-provider",
     "crates/perl-lsp-code-actions",
     "crates/perl-lsp-document-highlight",
     "crates/perl-lsp-folding",

--- a/crates/perl-lsp-ai-provider/Cargo.toml
+++ b/crates/perl-lsp-ai-provider/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "perl-lsp-ai-provider"
+version = "0.1.0"
+edition = "2024"
+description = "AI completion providers for perl-lsp"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+perl-lsp-inline-completion = { path = "../perl-lsp-inline-completion" }
+ureq = { version = "3", features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = "0.1.44"
+
+[dev-dependencies]
+perl-tdd-support = { path = "../perl-tdd-support" }
+
+[lints]
+workspace = true

--- a/crates/perl-lsp-ai-provider/src/lib.rs
+++ b/crates/perl-lsp-ai-provider/src/lib.rs
@@ -1,0 +1,13 @@
+//! AI completion providers for perl-lsp.
+//!
+//! This crate provides pluggable AI backends for inline code completion.
+//! The primary provider is OpenAI-compatible, supporting any endpoint that
+//! implements the OpenAI chat completions API with SSE streaming.
+
+pub mod openai;
+pub mod prompt;
+pub mod rate_limiter;
+pub mod sse;
+
+pub use openai::{OpenAiConfig, OpenAiProvider};
+pub use rate_limiter::RateLimiter;

--- a/crates/perl-lsp-ai-provider/src/openai.rs
+++ b/crates/perl-lsp-ai-provider/src/openai.rs
@@ -1,0 +1,132 @@
+//! OpenAI-compatible completion provider.
+
+use crate::prompt::build_fim_prompt;
+use crate::rate_limiter::RateLimiter;
+use crate::sse::SseParser;
+use perl_lsp_inline_completion::{
+    BackendError, BackendRequest, InlineCompletionBackend, StreamChunk, StreamControl,
+};
+use std::io::BufReader;
+use std::sync::Arc;
+
+/// Configuration for the OpenAI-compatible provider.
+#[derive(Debug, Clone)]
+pub struct OpenAiConfig {
+    /// The API endpoint URL (e.g. `https://api.openai.com/v1/chat/completions`).
+    pub endpoint: String,
+    /// The model name to use (e.g. `gpt-4o`).
+    pub model: String,
+    /// API key for authentication.
+    pub api_key: String,
+    /// Global timeout in milliseconds.
+    pub timeout_ms: u64,
+}
+
+/// An OpenAI-compatible completion provider using ureq for HTTP.
+pub struct OpenAiProvider {
+    config: OpenAiConfig,
+    limiter: Arc<RateLimiter>,
+}
+
+impl OpenAiProvider {
+    /// Create a new provider with the given config and rate limiter.
+    pub fn new(config: OpenAiConfig, limiter: Arc<RateLimiter>) -> Self {
+        Self { config, limiter }
+    }
+
+    fn build_request_body(&self, req: &BackendRequest) -> serde_json::Value {
+        let (system, user) = build_fim_prompt(&req.context);
+
+        serde_json::json!({
+            "model": self.config.model,
+            "max_tokens": req.max_output_tokens,
+            "stream": true,
+            "messages": [
+                { "role": "system", "content": system },
+                { "role": "user", "content": user }
+            ]
+        })
+    }
+
+    fn extract_content_delta(data: &str) -> Option<String> {
+        let parsed: serde_json::Value = serde_json::from_str(data).ok()?;
+        let choices = parsed.get("choices")?.as_array()?;
+        let delta = choices.first()?.get("delta")?.get("content")?.as_str()?;
+        Some(delta.to_string())
+    }
+
+    fn extract_finish_reason(data: &str) -> Option<String> {
+        let parsed: serde_json::Value = serde_json::from_str(data).ok()?;
+        let choices = parsed.get("choices")?.as_array()?;
+        choices.first()?.get("finish_reason")?.as_str().map(|s| s.to_string())
+    }
+}
+
+impl InlineCompletionBackend for OpenAiProvider {
+    fn stream(
+        &self,
+        req: &BackendRequest,
+        sink: &mut dyn FnMut(StreamChunk) -> StreamControl,
+    ) -> Result<(), BackendError> {
+        if !self.limiter.try_acquire() {
+            return Err(BackendError::RateLimited);
+        }
+
+        let body = self.build_request_body(req);
+        let timeout = std::time::Duration::from_millis(req.timeout_ms);
+
+        let config = ureq::Agent::config_builder().timeout_global(Some(timeout)).build();
+        let agent = ureq::Agent::new_with_config(config);
+
+        let response = agent
+            .post(&self.config.endpoint)
+            .header("Authorization", &format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json")
+            .send_json(&body)
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("timed out") || msg.contains("timeout") {
+                    BackendError::Timeout
+                } else if msg.contains("401") || msg.contains("403") {
+                    BackendError::Auth(msg)
+                } else {
+                    BackendError::Transport(msg)
+                }
+            })?;
+
+        let reader = BufReader::new(response.into_body().into_reader());
+        let mut parser = SseParser::new(reader);
+        let mut cumulative = String::new();
+
+        loop {
+            match parser.next_event() {
+                Ok(Some(event)) => {
+                    if let Some(delta) = Self::extract_content_delta(&event.data) {
+                        cumulative.push_str(&delta);
+
+                        let is_final = Self::extract_finish_reason(&event.data)
+                            .is_some_and(|r| r == "stop" || r == "length");
+
+                        let control = sink(StreamChunk { text: cumulative.clone(), is_final });
+
+                        if control == StreamControl::Stop || is_final {
+                            break;
+                        }
+                    }
+                }
+                Ok(None) => {
+                    // Stream ended -- emit final chunk if we have content
+                    if !cumulative.is_empty() {
+                        sink(StreamChunk { text: cumulative, is_final: true });
+                    }
+                    break;
+                }
+                Err(e) => {
+                    return Err(BackendError::Transport(e.to_string()));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/perl-lsp-ai-provider/src/prompt.rs
+++ b/crates/perl-lsp-ai-provider/src/prompt.rs
@@ -1,0 +1,60 @@
+//! Prompt construction from inline completion context.
+
+use perl_lsp_inline_completion::PreparedInlineCompletionContext;
+
+/// Build an OpenAI-compatible prompt from the prepared context.
+///
+/// Returns a `(system, user)` message pair suitable for the chat completions API.
+pub fn build_fim_prompt(context: &PreparedInlineCompletionContext) -> (String, String) {
+    let mut system = String::from(
+        "You are a Perl code completion assistant. Complete the code at the cursor position. \
+         Return ONLY the completion text, no explanation, no markdown.",
+    );
+
+    // Add context about the current scope
+    if let Some(ref pkg) = context.current_package {
+        system.push_str(&format!("\nCurrent package: {pkg}"));
+    }
+    if let Some(ref func) = context.current_function {
+        system.push_str(&format!("\nInside subroutine: {func}"));
+    }
+    if !context.imports.is_empty() {
+        system.push_str(&format!("\nImported modules: {}", context.imports.join(", ")));
+    }
+
+    // Build the user message with the code context
+    let mut user = String::new();
+    if let Some(ref prev) = context.previous_non_empty_line {
+        user.push_str(prev);
+        user.push('\n');
+    }
+    user.push_str(&context.prefix);
+    user.push_str("<CURSOR>");
+
+    (system, user)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_prompt_includes_prefix() {
+        let ctx = PreparedInlineCompletionContext {
+            prefix: "my $x = ".to_string(),
+            current_line: "my $x = ".to_string(),
+            previous_non_empty_line: Some("use strict;".to_string()),
+            current_function: Some("new".to_string()),
+            current_package: Some("MyClass".to_string()),
+            variables: vec!["$self".to_string()],
+            imports: vec!["strict".to_string()],
+        };
+        let (system, user) = build_fim_prompt(&ctx);
+        assert!(system.contains("Perl"));
+        assert!(system.contains("MyClass"));
+        assert!(system.contains("new"));
+        assert!(user.contains("my $x = "));
+        assert!(user.contains("<CURSOR>"));
+        assert!(user.contains("use strict;"));
+    }
+}

--- a/crates/perl-lsp-ai-provider/src/rate_limiter.rs
+++ b/crates/perl-lsp-ai-provider/src/rate_limiter.rs
@@ -1,0 +1,73 @@
+//! Simple token-bucket rate limiter for AI API calls.
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// A simple rate limiter using token bucket algorithm.
+pub struct RateLimiter {
+    state: Mutex<RateLimiterState>,
+}
+
+struct RateLimiterState {
+    tokens: f64,
+    max_tokens: f64,
+    refill_rate: f64, // tokens per second
+    last_refill: Instant,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter.
+    ///
+    /// `rps` is the maximum requests per second.
+    /// `burst` is the maximum burst size.
+    pub fn new(rps: f64, burst: u32) -> Self {
+        Self {
+            state: Mutex::new(RateLimiterState {
+                tokens: f64::from(burst),
+                max_tokens: f64::from(burst),
+                refill_rate: rps,
+                last_refill: Instant::now(),
+            }),
+        }
+    }
+
+    /// Try to acquire a token. Returns true if allowed, false if rate-limited.
+    pub fn try_acquire(&self) -> bool {
+        let mut state = match self.state.lock() {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        let now = Instant::now();
+        let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+        state.tokens = (state.tokens + elapsed * state.refill_rate).min(state.max_tokens);
+        state.last_refill = now;
+
+        if state.tokens >= 1.0 {
+            state.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_within_burst() {
+        let limiter = RateLimiter::new(1.0, 3);
+        assert!(limiter.try_acquire());
+        assert!(limiter.try_acquire());
+        assert!(limiter.try_acquire());
+    }
+
+    #[test]
+    fn blocks_after_burst() {
+        let limiter = RateLimiter::new(1.0, 1);
+        assert!(limiter.try_acquire());
+        assert!(!limiter.try_acquire());
+    }
+}

--- a/crates/perl-lsp-ai-provider/src/sse.rs
+++ b/crates/perl-lsp-ai-provider/src/sse.rs
@@ -1,0 +1,160 @@
+//! Server-Sent Events frame parser for streaming AI responses.
+
+/// A parsed SSE event.
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    /// Event type (from `event:` field). Defaults to "message".
+    pub event: String,
+    /// Event data (from `data:` field(s), joined by newlines).
+    pub data: String,
+}
+
+/// Parse SSE frames from a byte stream reader.
+///
+/// Yields events one at a time. Handles:
+/// - Multi-line `data:` fields (joined by newline)
+/// - Comment lines (`:` prefix, ignored)
+/// - Keepalive empty lines
+/// - `[DONE]` sentinel
+pub struct SseParser<R: std::io::BufRead> {
+    reader: R,
+    done: bool,
+}
+
+impl<R: std::io::BufRead> SseParser<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader, done: false }
+    }
+
+    /// Read the next SSE event. Returns None when stream is done.
+    pub fn next_event(&mut self) -> Result<Option<SseEvent>, std::io::Error> {
+        if self.done {
+            return Ok(None);
+        }
+
+        let mut event_type = String::from("message");
+        let mut data_lines: Vec<String> = Vec::new();
+        let mut has_data = false;
+
+        loop {
+            let mut line = String::new();
+            let bytes_read = self.reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                self.done = true;
+                if has_data {
+                    break;
+                }
+                return Ok(None);
+            }
+
+            let line = line.trim_end_matches(['\r', '\n']);
+
+            // Empty line = event boundary
+            if line.is_empty() {
+                if has_data {
+                    break;
+                }
+                continue;
+            }
+
+            // Comment line
+            if line.starts_with(':') {
+                continue;
+            }
+
+            // Parse field
+            if let Some(value) = line.strip_prefix("event:") {
+                event_type = value.trim().to_string();
+            } else if let Some(value) = line.strip_prefix("data:") {
+                let value = value.trim();
+                if value == "[DONE]" {
+                    self.done = true;
+                    if has_data {
+                        break;
+                    }
+                    return Ok(None);
+                }
+                data_lines.push(value.to_string());
+                has_data = true;
+            }
+            // Ignore unknown fields (id:, retry:, etc.)
+        }
+
+        Ok(Some(SseEvent { event: event_type, data: data_lines.join("\n") }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn parse_simple_event() {
+        let input = "data: {\"test\": true}\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let event = parser.next_event().ok().flatten();
+        assert!(event.is_some());
+        let event = event.as_ref();
+        assert_eq!(event.map(|e| e.event.as_str()), Some("message"));
+        assert_eq!(event.map(|e| e.data.as_str()), Some("{\"test\": true}"));
+    }
+
+    #[test]
+    fn parse_done_sentinel() {
+        let input = "data: [DONE]\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let result = parser.next_event();
+        assert!(result.is_ok());
+        assert!(result.ok().flatten().is_none());
+    }
+
+    #[test]
+    fn skip_comments() {
+        let input = ": keepalive\ndata: hello\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let event = parser.next_event().ok().flatten();
+        assert_eq!(event.map(|e| e.data), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn multi_data_lines_joined() {
+        let input = "data: line1\ndata: line2\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let event = parser.next_event().ok().flatten();
+        assert_eq!(event.map(|e| e.data), Some("line1\nline2".to_string()));
+    }
+
+    #[test]
+    fn custom_event_type() {
+        let input = "event: custom\ndata: payload\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let event = parser.next_event().ok().flatten();
+        assert!(event.is_some());
+        let event = event.as_ref();
+        assert_eq!(event.map(|e| e.event.as_str()), Some("custom"));
+        assert_eq!(event.map(|e| e.data.as_str()), Some("payload"));
+    }
+
+    #[test]
+    fn multiple_events() {
+        let input = "data: first\n\ndata: second\n\n";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let e1 = parser.next_event().ok().flatten();
+        assert_eq!(e1.map(|e| e.data), Some("first".to_string()));
+        let e2 = parser.next_event().ok().flatten();
+        assert_eq!(e2.map(|e| e.data), Some("second".to_string()));
+        let e3 = parser.next_event();
+        assert!(e3.is_ok());
+        assert!(e3.ok().flatten().is_none());
+    }
+
+    #[test]
+    fn empty_stream() {
+        let input = "";
+        let mut parser = SseParser::new(Cursor::new(input));
+        let result = parser.next_event();
+        assert!(result.is_ok());
+        assert!(result.ok().flatten().is_none());
+    }
+}

--- a/crates/perl-lsp-inline-completion/src/lib.rs
+++ b/crates/perl-lsp-inline-completion/src/lib.rs
@@ -6,8 +6,80 @@
 
 use perl_position_tracking::utf16_line_col_to_offset;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 const MAX_INLINE_COMPLETION_ITEMS: usize = 5;
+
+// ---------------------------------------------------------------------------
+// Backend trait for pluggable AI completion providers
+// ---------------------------------------------------------------------------
+
+/// A streaming chunk emitted by an AI backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamChunk {
+    /// Cumulative completion text so far.
+    pub text: String,
+    /// Whether this is the final chunk.
+    pub is_final: bool,
+}
+
+/// Flow-control signal returned by the streaming sink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamControl {
+    /// Continue receiving chunks.
+    Continue,
+    /// Stop the stream early (e.g. user cancelled).
+    Stop,
+}
+
+/// Errors that a backend may surface.
+#[derive(Debug)]
+pub enum BackendError {
+    /// HTTP/network transport failure.
+    Transport(String),
+    /// Authentication or authorization failure.
+    Auth(String),
+    /// The request exceeded its timeout.
+    Timeout,
+    /// The backend is rate-limiting requests.
+    RateLimited,
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport(msg) => write!(f, "transport error: {msg}"),
+            Self::Auth(msg) => write!(f, "auth error: {msg}"),
+            Self::Timeout => write!(f, "request timed out"),
+            Self::RateLimited => write!(f, "rate limited"),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+/// A request to an AI backend for inline completion.
+pub struct BackendRequest {
+    /// The prepared context from the editor.
+    pub context: PreparedInlineCompletionContext,
+    /// Maximum number of tokens to generate.
+    pub max_output_tokens: u32,
+    /// Timeout in milliseconds for the request.
+    pub timeout_ms: u64,
+}
+
+/// Trait for AI backends that produce inline completions via streaming.
+pub trait InlineCompletionBackend: Send + Sync {
+    /// Stream a completion for the given request.
+    ///
+    /// The `sink` callback is invoked for each streaming chunk. Return
+    /// [`StreamControl::Stop`] to cancel early.
+    fn stream(
+        &self,
+        req: &BackendRequest,
+        sink: &mut dyn FnMut(StreamChunk) -> StreamControl,
+    ) -> Result<(), BackendError>;
+}
 
 /// Prepared context for inline completion suggestions and future AI handoff.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Add new `perl-lsp-ai-provider` crate with OpenAI-compatible completion provider, SSE frame parser, token-bucket rate limiter, and prompt construction from `PreparedInlineCompletionContext`
- Add `InlineCompletionBackend` trait, `BackendRequest`, `BackendError`, `StreamChunk`, and `StreamControl` types to `perl-lsp-inline-completion` to define the pluggable backend interface
- Uses ureq 3 for HTTP with streaming SSE support; no `unwrap`/`expect`/`panic` in production code

## Test plan

- [x] `cargo check -p perl-lsp-ai-provider` -- compiles cleanly
- [x] `cargo test -p perl-lsp-ai-provider` -- all 10 tests pass (7 SSE parser, 2 rate limiter, 1 prompt)
- [x] `cargo test -p perl-lsp-inline-completion` -- all 16 existing tests still pass
- [x] `cargo clippy -p perl-lsp-ai-provider --lib` -- clean
- [x] `cargo clippy -p perl-lsp-inline-completion --lib` -- clean
- [x] `cargo check -p perl-lsp-rs` -- downstream LSP server still compiles
- [x] `cargo fmt -p perl-lsp-ai-provider -p perl-lsp-inline-completion` -- formatted