### PR TITLE
feat(inline-completion): use version-aware stream cancellation (#3018)

### DIFF
--- a/crates/perl-lsp/src/runtime/stream_session.rs
+++ b/crates/perl-lsp/src/runtime/stream_session.rs
@@ -100,7 +100,6 @@ impl StreamSessionManager {
 
     /// Cancel all sessions for a given URI where the document version is older
     /// than the supplied version (on document version change).
-    #[allow(dead_code)] // Reserved for future version-aware cancellation
     pub fn cancel_for_uri_version(&self, uri: &str, version: i64) {
         let sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
         for (key, session) in sessions.iter() {

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -386,8 +386,9 @@ impl LspServer {
                 params.pointer("/textDocument/version").and_then(|v| v.as_i64()).unwrap_or(0);
             let version = i32::try_from(version_i64).unwrap_or(0);
 
-            // Cancel any active streaming inline completion sessions for this URI.
-            self.stream_sessions().cancel_for_uri(uri);
+            // Cancel any active streaming inline completion sessions for this URI
+            // that are older than the new document version.
+            self.stream_sessions().cancel_for_uri_version(uri, version_i64);
 
             if let Some(changes) = params["contentChanges"].as_array() {
                 // Get current document state or create new one


### PR DESCRIPTION
## Summary
- Changes `didChange` handler from `cancel_for_uri(uri)` to `cancel_for_uri_version(uri, version)` for more precise stream session cancellation
- `didClose` keeps unconditional `cancel_for_uri(uri)` (correct: close should cancel all)
- Removes `#[allow(dead_code)]` from `cancel_for_uri_version` since it's now used

## Test plan
- [ ] `cargo test -p perl-lsp-rs --lib` passes (314 tests)
- [ ] `cargo clippy -p perl-lsp-rs --lib` clean
- [ ] Existing stream session tests pass
- [ ] didChange cancels only older-version sessions
- [ ] didClose cancels all sessions for URI