### PR TITLE
docs(readme): bump current release line to v0.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 
 ## Status
 
-**Current release: v0.12.1** — public alpha. The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
+**Current release: v0.12.2** — public alpha. The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- README.md status section still said `v0.12.1` even though `v0.12.2` has been live across all channels since 2026-04-04.
- One-line bump to match the GitHub Release widget, VSCode Marketplace (0.12.2 published 2026-04-04 22:34Z), and Docker Hub (`0.12.2-perl` last_updated 2026-04-06).

## Test plan
- [ ] CI green