### PR TITLE
chore(release): pre-announcement cleanup (gitignore + license detection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ docs/assets/recordings/*.mp4
 docs/assets/recordings/*.mov
 docs/assets/recordings/*.mkv
 docs/assets/recordings/*.webm
+
+# Playwright MCP browser session artifacts (page state dumps)
+.playwright-mcp/

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,7 @@
 Copyright 2026 Steven Zimmerman, CPA
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
Two small pre-announcement hygiene fixes:

1. **gitignore \`.playwright-mcp/\`** — Playwright MCP browser session artifacts (page state YAML dumps) were untracked and showing up in \`git status\`. They're ephemeral session output, not project content.
2. **LICENSE-MIT smart quote → straight quote** — \`LICENSE-MIT\` had two pairs of curly quotes (\`"Software"\` and \`"AS IS"\`) where canonical MIT uses straight quotes. GitHub's [licensee](https://github.com/licensee/licensee) gem normalizes and matches against canonical license text; with smart quotes the match fails and the GitHub UI shows the repo as \`license: NOASSERTION\` even though \`Cargo.toml\` already declares \`license = "MIT OR Apache-2.0"\`. Verified via \`xxd LICENSE-MIT\` — bytes \`e2 80 9c\`/\`e2 80 9d\` (UTF-8 U+201C / U+201D) are gone after the fix. \`LICENSE-APACHE\` was already clean.

## Test plan
- [ ] CI green
- [ ] After merge: GitHub repo page shows MIT license badge instead of "Other" / no badge