### PR TITLE
fix(docker): bump arm64 timeouts and pin Rust toolchain (#3188)

### DIFF
--- a/.docker/rust/Dockerfile
+++ b/.docker/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim
+FROM rust:1.92-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build builder image (${{ matrix.platform }})
     runs-on: ubuntu-24.04
     needs: init
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +162,7 @@ jobs:
     name: Publish to Docker Hub
     runs-on: ubuntu-24.04
     needs: init
-    timeout-minutes: 30
+    timeout-minutes: 90
     if: github.event.inputs.push != 'false'
 
     steps:


### PR DESCRIPTION
## Summary
Two related fixes for the Publish Docker Images workflow which kept hitting the 30-minute hard timeout on the linux/arm64 builder image and the consolidated Publish to Docker Hub job during the v0.12.2 release.

### 1. Timeout bump (\`.github/workflows/docker-publish.yml\`)
\`timeout-minutes: 30 → 90\` on the two jobs that have been failing:
- Build builder image (linux/arm64) — consistently runs 30+ min on QEMU emulation
- Publish to Docker Hub — consolidated push job

The runtime image jobs finish in <1 min and aren't affected. After this bump, the workflow should run cleanly green for the next release without manual reruns.

### 2. Rust toolchain pin (\`.docker/rust/Dockerfile\`)
\`FROM rust:slim → FROM rust:1.92-slim-bookworm\`. The workspace requires Rust 1.92.0 per \`rust-toolchain.toml\`, and \`rust:slim\` was tracking an older toolchain, which caused builder-image MSRV failures during the v0.12.2 release recovery.

## Test plan
- [ ] CI green
- [ ] Next release: Publish Docker Images workflow runs cleanly without manual reruns
- [ ] Both \`builder-arm64\` and runtime image tags publish successfully

Closes #3188.