### PR TITLE
feat(publish): enable perl-parser-pest publication to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ allow = [
     # Tier 5 — Application crates
     "perl-dead-code",
     "perl-parser",
+    "perl-parser-pest",
     "perl-corpus",
 
     # Tier 5 — DAP components

--- a/crates/perl-parser-pest/Cargo.toml
+++ b/crates/perl-parser-pest/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "perl-parser-pest"
 version = "0.12.2"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
The legacy v2 Pest-based Perl parser is a useful learning tool and reference implementation for anyone working with Perl in pest. Currently it has \`publish = false\` and is excluded from the workspace publish allow-list, so it never reaches crates.io. This PR enables publication.

## Why publish it
- It's a real-world example of parsing a notoriously irregular language with a PEG library — there's value to the broader pest/Rust parsing community
- Full crates.io metadata is already in place: description, keywords (\`perl, parser, pest, peg, ast\`), categories (\`parsing, development-tools\`), README, license, repository, homepage
- Zero workspace dependencies — true leaf crate, no transitive complexity
- Already documented as "maintained as a learning tool, compatibility reference, and benchmark baseline" in the crate's CLAUDE.md
- Frozen, no new features expected — low ongoing maintenance cost
- The crate's own README points to \`perl-parser\` (v3) for production use, so there's no risk of confusing users about which to pick

## Changes
1. Drop \`publish = false\` from \`crates/perl-parser-pest/Cargo.toml\`
2. Add \`"perl-parser-pest"\` to \`[workspace.metadata.publish] allow\` under Tier 5 (Application crates), grouped with the other parser crates

## Verification
\`\`\`
$ cargo package --list -p perl-parser-pest --no-verify
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE-APACHE
LICENSE-MIT
README.md
src\error.rs
src\grammar.pest
src\lib.rs
src\pratt_parser.rs
src\pure_rust_parser.rs
src\sexp_formatter.rs
\`\`\`
Clean package with all sources, the \`.pest\` grammar, both LICENSE files, and the README.

## Test plan
- [ ] CI green
- [ ] After merge: re-run \`Publish to crates.io\` workflow with \`version=0.12.2 dry_run=false\`
- [ ] Verify \`perl-parser-pest@0.12.2\` appears at https://crates.io/crates/perl-parser-pest
- [ ] Confirm docs build at https://docs.rs/perl-parser-pest/0.12.2/

## Notes
- The current Publish to crates.io run (24062337060) is still in flight and will not include this crate. After this PR merges and the current run finishes, a separate publish run is needed to ship perl-parser-pest. The "skip already published" guard in the workflow will skip the 124 crates already at 0.12.2 and only publish this one.