### PR TITLE
chore(publish): unblock perl-lsp-ai-provider + cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ allow = [
     "perl-lsp-file-completion",
     "perl-lsp-completion-item",
     "perl-lsp-inline-completion",
+    "perl-lsp-ai-provider",
     "perl-lsp-inlay-hints",
     "perl-lsp-code-lens",
     "perl-lsp-color-provider",

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -3140,7 +3140,9 @@ fn cmd_check_todos(repo_root: &Path, list_mode: bool) -> Result<i32> {
     let baseline_path = repo_root.join("ci").join("todo_baseline.txt");
     // "xtask" is excluded because it is build tooling whose source code documents and implements
     // the TODO-scanner itself (unwired_scan.rs), producing unavoidable self-referential matches.
-    let exclude_dirs = ["target", ".git", ".receipts", ".runs", "archive", "xtask"];
+    // ".claude" is excluded because it contains ephemeral agent worktrees and tooling state that
+    // are gitignored — the scanner should not see them as project source.
+    let exclude_dirs = ["target", ".git", ".receipts", ".runs", "archive", "xtask", ".claude"];
     let exclude_files = [
         repo_root.join("ci").join("check_todos.sh"),
         repo_root.join("crates").join("perl-parser").join("tests").join("missing_docs_ac_tests.rs"),

--- a/crates/perl-corpus/LICENSE
+++ b/crates/perl-corpus/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2026 Steven Zimmerman, CPA
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/perl-lexer/LICENSE
+++ b/crates/perl-lexer/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2026 Steven Zimmerman, CPA
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/perl-lsp-ai-provider/Cargo.toml
+++ b/crates/perl-lsp-ai-provider/Cargo.toml
@@ -2,22 +2,29 @@
 name = "perl-lsp-ai-provider"
 version = "0.12.2"
 edition = "2024"
-description = "AI completion providers for perl-lsp"
+rust-version = "1.92"
+authors.workspace = true
+description = "AI completion providers (OpenAI-compatible streaming) for perl-lsp"
 license = "MIT OR Apache-2.0"
-publish = false
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-lsp-ai-provider"
+readme = "README.md"
+keywords = ["perl", "lsp", "ai", "completion", "openai"]
+categories = ["development-tools", "text-editors"]
 
 [lib]
 doctest = false
 
 [dependencies]
-perl-lsp-inline-completion = { path = "../perl-lsp-inline-completion" }
+perl-lsp-inline-completion = { workspace = true }
 ureq = { version = "3", features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = "0.1.44"
 
 [dev-dependencies]
-perl-tdd-support = { path = "../perl-tdd-support" }
+perl-tdd-support = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/perl-lsp-ai-provider/LICENSE-APACHE
+++ b/crates/perl-lsp-ai-provider/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Steven Zimmerman, CPA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/perl-lsp-ai-provider/LICENSE-MIT
+++ b/crates/perl-lsp-ai-provider/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/perl-lsp-ai-provider/README.md
+++ b/crates/perl-lsp-ai-provider/README.md
@@ -1,0 +1,37 @@
+# perl-lsp-ai-provider
+
+AI completion providers for the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp) Language Server.
+
+## Overview
+
+This crate plugs an OpenAI-compatible HTTP/SSE streaming backend into the LSP server's inline-completion path. It is the production AI provider behind perl-lsp's `textDocument/inlineCompletion` feature, opt-in via configuration.
+
+## Public API
+
+| Type | Description |
+|------|-------------|
+| `OpenAiProvider` | Streaming completion provider that talks to any OpenAI-compatible API |
+| `OpenAiConfig` | Endpoint, model, API key, and request-shape configuration |
+| `RateLimiter` | Token-bucket rate limiter for outbound requests |
+
+## Usage
+
+```rust
+use perl_lsp_ai_provider::{OpenAiConfig, OpenAiProvider, RateLimiter};
+use std::sync::Arc;
+
+let config = OpenAiConfig {
+    endpoint: "https://api.openai.com/v1/chat/completions".to_string(),
+    model: "gpt-4o-mini".to_string(),
+    api_key: std::env::var("OPENAI_API_KEY").ok(),
+    ..Default::default()
+};
+let limiter = Arc::new(RateLimiter::new(60, 60));  // 60 req/min
+let provider = OpenAiProvider::new(config, limiter);
+```
+
+The LSP server wires this provider when its AI inline-completion feature is enabled in the client configuration. End users do not call this crate directly; it is consumed by `perl-lsp-rs`.
+
+## License
+
+Dual-licensed under MIT or Apache-2.0 at your option. See `LICENSE-MIT` and `LICENSE-APACHE`.

--- a/crates/perl-parser/LICENSE
+++ b/crates/perl-parser/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2026 Steven Zimmerman, CPA
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
Three small release-prep blockers bundled into one PR. Each is a tiny independent fix.

### 1. perl-lsp-ai-provider publication enablement (the active blocker)
The current Publish to crates.io workflow run was hanging because **\`perl-lsp-rs\` (in the publish allow-list) hard-depends on \`perl-lsp-ai-provider\`**, which had \`publish = false\` and has never been on crates.io. Cargo packages the workspace dep as \`perl-lsp-ai-provider = "0.12.2"\` and crates.io rejects because no such version exists.

\`perl-lsp-ai-provider\` is already SRP-shaped (sole purpose: "AI completion providers (OpenAI-compatible streaming) for perl-lsp"), so no extraction was needed. Just needed to:
- Drop \`publish = false\`
- Fill out crates.io metadata: \`rust-version\`, \`authors\`, \`repository\`, \`homepage\`, \`documentation\`, \`readme\`, \`keywords\`, \`categories\`
- Switch path-only deps to workspace deps so the published manifest resolves cleanly (\`perl-lsp-inline-completion\`, \`perl-tdd-support\`)
- Add canonical \`LICENSE-APACHE\`, \`LICENSE-MIT\`, \`README.md\`
- Add to \`[workspace.metadata.publish] allow\` under the LSP feature block, after \`perl-lsp-inline-completion\` (its only workspace dep)

Verified:
- \`cargo build -p perl-lsp-ai-provider\` clean
- \`cargo package --list -p perl-lsp-ai-provider\` produces a clean package with \`Cargo.toml\`, \`README.md\`, both \`LICENSE-*\`, and all sources

After this merges, the next Publish to crates.io run should ship \`perl-lsp-rs@0.12.2\` instead of hanging on the missing dep.

### 2. Stray standalone LICENSE files
\`crates/perl-corpus/LICENSE\`, \`crates/perl-lexer/LICENSE\`, and \`crates/perl-parser/LICENSE\` were three byte-identical 1069-byte files holding the OLD pre-canonical MIT text (with smart quotes) sitting alongside the proper \`LICENSE-MIT\` and \`LICENSE-APACHE\` files in those three crates. None of the three Cargo.toml files reference \`license-file\` — pure orphans from before the project standardized on the LICENSE-MIT/LICENSE-APACHE pattern. **Deleted.**

### 3. perl-ci-hygiene check-todos: skip \`.claude/\`
The TODO scanner was walking into \`.claude/worktrees/agent-*/\`, which is gitignored ephemeral state from running Claude agents. The scanner was treating those agent working copies as project source and flagging their TODO comments. Added \`.claude\` to the \`exclude_dirs\` list alongside the existing \`xtask\` and \`archive\` exclusions. Same class of bug as scanning \`target/\`.

A more thorough fix (have the scanner respect \`.gitignore\` generally) is a separate concern.

## Test plan
- [x] \`cargo build -p perl-lsp-ai-provider\` clean locally
- [x] \`cargo package --list -p perl-lsp-ai-provider\` produces clean package
- [x] \`cargo run -p perl-ci-hygiene -- check-todos\` passes locally
- [x] \`just ci-gate\` passes locally (pre-push hook)
- [ ] CI green
- [ ] After merge: re-trigger \`Publish to crates.io\` workflow with \`version=0.12.2 dry_run=false\`; \`perl-lsp-rs@0.12.2\` and \`perl-lsp-ai-provider@0.12.2\` should both publish