### PR TITLE
feat(srp): extract anti_pattern_detector to perl-heredoc-anti-patterns microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,6 +1855,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "perl-heredoc-anti-patterns"
+version = "0.12.2"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "perl-incremental-parsing"
 version = "0.12.2"
 dependencies = [
@@ -2019,13 +2026,13 @@ name = "perl-lsp-diagnostics"
 version = "0.12.2"
 dependencies = [
  "perl-diagnostics-codes",
+ "perl-heredoc-anti-patterns",
  "perl-lsp-diagnostic-types",
  "perl-parser",
  "perl-parser-core",
  "perl-pragma",
  "perl-semantic-analyzer",
  "perl-tdd-support",
- "perl-ts-heredoc-analysis",
  "perl-workspace-index",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/perl-builtins-phf",
     "crates/perl-regex",
     "crates/perl-heredoc",
+    "crates/perl-heredoc-anti-patterns",
     "crates/perl-error",
     "crates/perl-tokenizer",
     "crates/perl-lexer",
@@ -162,6 +163,7 @@ allow = [
     "perl-regex",
     "perl-quote",
     "perl-pod",
+    "perl-heredoc-anti-patterns",
 
     # Tier 1b — Depend only on Tier 1 crates
     "perl-ast",
@@ -320,6 +322,7 @@ perl-pragma = { path = "crates/perl-pragma", version = "0.12.2" }
 perl-lexer = { path = "crates/perl-lexer", version = "0.12.2" }
 perl-ast = { path = "crates/perl-ast", version = "0.12.2" }
 perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.2" }
+perl-heredoc-anti-patterns = { path = "crates/perl-heredoc-anti-patterns", version = "0.12.2" }
 perl-error = { path = "crates/perl-error", version = "0.12.2" }
 perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.2" }
 perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.2" }

--- a/crates/perl-heredoc-anti-patterns/Cargo.toml
+++ b/crates/perl-heredoc-anti-patterns/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "perl-heredoc-anti-patterns"
+version = "0.12.2"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perl-heredoc-anti-patterns"
+description = "Anti-pattern detection for problematic Perl heredoc patterns (format blocks, BEGIN-time heredocs, dynamic delimiters, source filters, etc.)"
+readme = "README.md"
+keywords = ["perl", "heredoc", "lint", "static-analysis", "parser"]
+categories = ["parsing", "development-tools"]
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
+
+[dependencies]
+regex.workspace = true
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/perl-heredoc-anti-patterns/LICENSE-APACHE
+++ b/crates/perl-heredoc-anti-patterns/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Steven Zimmerman, CPA
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/perl-heredoc-anti-patterns/LICENSE-MIT
+++ b/crates/perl-heredoc-anti-patterns/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steven Zimmerman, CPA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/perl-heredoc-anti-patterns/README.md
+++ b/crates/perl-heredoc-anti-patterns/README.md
@@ -1,0 +1,36 @@
+# perl-heredoc-anti-patterns
+
+Anti-pattern detection for problematic Perl heredoc constructs.
+
+This crate scans Perl source code for seven categories of heredoc-related
+anti-patterns that make static parsing difficult or impossible, and produces
+structured diagnostics describing each finding with severity, explanation,
+suggested fix, and documentation references. Detected patterns include
+heredocs inside `format` declarations, heredocs declared inside `BEGIN`
+blocks, dynamic (variable-expanded) heredoc delimiters, source filter
+modules (`Filter::Simple`, etc.), heredocs inside regex code blocks, heredocs
+inside `eval` strings, and heredocs written to tied handles.
+
+Part of the [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp)
+workspace. Used by `perl-lsp-diagnostics` to surface these patterns as LSP
+diagnostics in editors.
+
+## Usage
+
+```rust
+use perl_heredoc_anti_patterns::AntiPatternDetector;
+
+let detector = AntiPatternDetector::new();
+let diagnostics = detector.detect_all(perl_source_code);
+let report = detector.format_report(&diagnostics);
+println!("{}", report);
+```
+
+## License
+
+Dual-licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.

--- a/crates/perl-heredoc-anti-patterns/src/lib.rs
+++ b/crates/perl-heredoc-anti-patterns/src/lib.rs
@@ -1,0 +1,663 @@
+//! Anti-pattern detection for heredoc edge cases
+//!
+//! This crate provides detection and analysis of problematic Perl patterns
+//! that make static parsing difficult or impossible, particularly around heredocs.
+//!
+//! The [`AntiPatternDetector`] scans Perl source for seven categories of
+//! heredoc-related anti-patterns and produces [`Diagnostic`]s describing each
+//! finding, with severity, explanation, suggested fix, and documentation
+//! references.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Location {
+    pub line: usize,
+    pub column: usize,
+    pub offset: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Severity {
+    Error,   // Code will likely fail
+    Warning, // Code works but is problematic
+    Info,    // Code could be improved
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AntiPattern {
+    FormatHeredoc { location: Location, format_name: String, heredoc_delimiter: String },
+    BeginTimeHeredoc { location: Location, heredoc_content: String, side_effects: Vec<String> },
+    DynamicHeredocDelimiter { location: Location, expression: String },
+    SourceFilterHeredoc { location: Location, module: String },
+    RegexCodeBlockHeredoc { location: Location },
+    EvalStringHeredoc { location: Location },
+    TiedHandleHeredoc { location: Location, handle_name: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub pattern: AntiPattern,
+    pub message: String,
+    pub explanation: String,
+    pub suggested_fix: Option<String>,
+    pub references: Vec<String>,
+}
+
+pub struct AntiPatternDetector {
+    patterns: Vec<Box<dyn PatternDetector>>,
+}
+
+trait PatternDetector: Send + Sync {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)>;
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic>;
+}
+
+// Format heredoc detector
+struct FormatHeredocDetector;
+
+/// Pattern for identifying format declarations
+static FORMAT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"(?m)^\s*format\s+(\w+)\s*=\s*$") {
+        Ok(re) => re,
+        Err(_) => unreachable!("FORMAT_PATTERN regex failed to compile"),
+    });
+
+impl PatternDetector for FormatHeredocDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in FORMAT_PATTERN.captures_iter(code) {
+            if let (Some(match_pos), Some(name_match)) = (cap.get(0), cap.get(1)) {
+                let format_name = name_match.as_str().to_string();
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                // Look for heredoc marker inside format body (simplified)
+                let body_start = match_pos.end();
+                let body_end = code[body_start..].find("\n.").unwrap_or(code.len() - body_start);
+                let body = &code[body_start..body_start + body_end];
+
+                if body.contains("<<") {
+                    results.push((
+                        AntiPattern::FormatHeredoc {
+                            location: location.clone(),
+                            format_name,
+                            heredoc_delimiter: "UNKNOWN".to_string(), // Would need better extraction
+                        },
+                        location,
+                    ));
+                }
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        let AntiPattern::FormatHeredoc { format_name, .. } = pattern else {
+            return None;
+        };
+
+        Some(Diagnostic {
+            severity: Severity::Warning,
+            pattern: pattern.clone(),
+            message: format!("Heredoc declared inside format '{}'", format_name),
+            explanation: "Heredocs inside format declarations are often handled specially by the Perl interpreter and can be difficult to parse statically.".to_string(),
+            suggested_fix: Some("Consider moving the heredoc outside the format or using a simple string if possible.".to_string()),
+            references: vec!["perldoc perlform".to_string()],
+        })
+    }
+}
+
+// BEGIN-time heredoc detector
+struct BeginTimeHeredocDetector;
+
+/// Pattern for identifying BEGIN blocks with heredocs
+static BEGIN_BLOCK_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"(?s)\bBEGIN\s*\{([^}]*<<[^}]*)\}") {
+        Ok(re) => re,
+        Err(_) => unreachable!("BEGIN_BLOCK_PATTERN regex failed to compile"),
+    });
+
+impl PatternDetector for BeginTimeHeredocDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in BEGIN_BLOCK_PATTERN.captures_iter(code) {
+            if let (Some(match_pos), Some(content_match)) = (cap.get(0), cap.get(1)) {
+                let block_content = content_match.as_str();
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                results.push((
+                    AntiPattern::BeginTimeHeredoc {
+                        location: location.clone(),
+                        heredoc_content: block_content.to_string(),
+                        side_effects: vec!["Phase-dependent parsing".to_string()],
+                    },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        if let AntiPattern::BeginTimeHeredoc { .. } = pattern {
+            Some(Diagnostic {
+                severity: Severity::Error,
+                pattern: pattern.clone(),
+                message: "Heredoc declared during BEGIN-time".to_string(),
+                explanation: "Heredocs declared inside BEGIN blocks are evaluated during the compilation phase. This can lead to complex side effects that are difficult to track statically.".to_string(),
+                suggested_fix: Some("Move the heredoc declaration out of the BEGIN block if it doesn't need to be evaluated during compilation.".to_string()),
+                references: vec!["perldoc perlmod".to_string()],
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// Dynamic delimiter detector
+struct DynamicDelimiterDetector;
+
+/// Pattern for identifying dynamic heredoc delimiters
+static DYNAMIC_DELIMITER_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"<<\s*\$\{[^}]+\}|<<\s*\$\w+|<<\s*`[^`]+`") {
+        Ok(re) => re,
+        Err(_) => unreachable!("DYNAMIC_DELIMITER_PATTERN regex failed to compile"),
+    });
+
+impl PatternDetector for DynamicDelimiterDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in DYNAMIC_DELIMITER_PATTERN.captures_iter(code) {
+            if let Some(match_pos) = cap.get(0) {
+                let expression = match_pos.as_str().to_string();
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                results.push((
+                    AntiPattern::DynamicHeredocDelimiter { location: location.clone(), expression },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        let AntiPattern::DynamicHeredocDelimiter { expression, .. } = pattern else {
+            return None;
+        };
+
+        Some(Diagnostic {
+            severity: Severity::Warning,
+            pattern: pattern.clone(),
+            message: format!("Dynamic heredoc delimiter: {}", expression),
+            explanation: "Using variables or expressions as heredoc delimiters makes it impossible to know the terminator without executing the code.".to_string(),
+            suggested_fix: Some("Use a literal string as the heredoc terminator.".to_string()),
+            references: vec!["perldoc perlop".to_string()],
+        })
+    }
+}
+
+// Source filter detector
+struct SourceFilterDetector;
+
+/// Pattern for identifying common source filter modules
+static SOURCE_FILTER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    match Regex::new(r"use\s+Filter::(Simple|Util::Call|cpp|exec|sh|decrypt|tee)") {
+        Ok(re) => re,
+        Err(_) => unreachable!("SOURCE_FILTER_PATTERN regex failed to compile"),
+    }
+});
+
+impl PatternDetector for SourceFilterDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in SOURCE_FILTER_PATTERN.captures_iter(code) {
+            if let (Some(match_pos), Some(module_match)) = (cap.get(0), cap.get(1)) {
+                let filter_module = module_match.as_str().to_string();
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                results.push((
+                    AntiPattern::SourceFilterHeredoc {
+                        location: location.clone(),
+                        module: filter_module,
+                    },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        let AntiPattern::SourceFilterHeredoc { module, .. } = pattern else {
+            return None;
+        };
+
+        Some(Diagnostic {
+            severity: Severity::Error,
+            pattern: pattern.clone(),
+            message: format!("Source filter detected: Filter::{}", module),
+            explanation: "Source filters rewrite the source code before it's parsed. Static analysis cannot reliably predict the state of the code after filtering.".to_string(),
+            suggested_fix: Some("Avoid using source filters. They are considered problematic and often replaced by better alternatives like Devel::Declare or modern Perl features.".to_string()),
+            references: vec!["perldoc Filter::Simple".to_string()],
+        })
+    }
+}
+
+// Regex heredoc detector
+struct RegexHeredocDetector;
+
+/// Pattern for identifying heredocs inside regex code blocks
+static REGEX_HEREDOC_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"\(\?\{[^}]*<<[^}]*\}") {
+        Ok(re) => re,
+        Err(_) => unreachable!("REGEX_HEREDOC_PATTERN regex failed to compile"),
+    });
+
+impl PatternDetector for RegexHeredocDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in REGEX_HEREDOC_PATTERN.captures_iter(code) {
+            if let Some(match_pos) = cap.get(0) {
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                results.push((
+                    AntiPattern::RegexCodeBlockHeredoc { location: location.clone() },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        if let AntiPattern::RegexCodeBlockHeredoc { .. } = pattern {
+            Some(Diagnostic {
+                severity: Severity::Warning,
+                pattern: pattern.clone(),
+                message: "Heredoc inside regex code block".to_string(),
+                explanation: "Declaring heredocs inside (?{ ... }) or (??{ ... }) blocks is extremely rare and difficult to parse correctly.".to_string(),
+                suggested_fix: None,
+                references: vec!["perldoc perlre".to_string()],
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// Eval heredoc detector
+struct EvalHeredocDetector;
+
+/// Pattern for identifying heredocs inside eval strings
+static EVAL_HEREDOC_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r#"eval\s+(?:'[^']*<<[^']*'|"[^"]*<<[^"]*")"#) {
+        Ok(re) => re,
+        Err(_) => unreachable!("EVAL_HEREDOC_PATTERN regex failed to compile"),
+    });
+
+impl PatternDetector for EvalHeredocDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        for cap in EVAL_HEREDOC_PATTERN.captures_iter(code) {
+            if let Some(match_pos) = cap.get(0) {
+                let location = Location {
+                    line: code[..match_pos.start()].lines().count(),
+                    column: match_pos.start() - code[..match_pos.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + match_pos.start(),
+                };
+
+                results.push((
+                    AntiPattern::EvalStringHeredoc { location: location.clone() },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        if let AntiPattern::EvalStringHeredoc { .. } = pattern {
+            Some(Diagnostic {
+                severity: Severity::Warning,
+                pattern: pattern.clone(),
+                message: "Heredoc inside eval string".to_string(),
+                explanation: "Heredocs declared inside strings passed to eval require double parsing and can hide malicious or complex code.".to_string(),
+                suggested_fix: Some("Consider using a block eval or moving the heredoc outside the eval string.".to_string()),
+                references: vec!["perldoc -f eval".to_string()],
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// Tied handle detector
+struct TiedHandleDetector;
+
+/// Pattern for identifying tie statements
+static TIE_PATTERN: LazyLock<Regex> = LazyLock::new(|| match Regex::new(r"tie\s+([*$]\w+)") {
+    Ok(re) => re,
+    Err(_) => unreachable!("TIE_PATTERN regex failed to compile"),
+});
+
+impl PatternDetector for TiedHandleDetector {
+    fn detect(&self, code: &str, offset: usize) -> Vec<(AntiPattern, Location)> {
+        let mut results = Vec::new();
+
+        // First find tied handles
+        let mut tied_handles = Vec::new();
+        for cap in TIE_PATTERN.captures_iter(code) {
+            if let Some(handle_match) = cap.get(1) {
+                tied_handles.push(handle_match.as_str());
+            }
+        }
+
+        for raw_handle in tied_handles {
+            // If it's a glob (*FH), we typically print to the bare handle (FH).
+            // If it's a scalar ($fh), we print to the scalar ($fh).
+            let handle_to_search = raw_handle.strip_prefix('*').unwrap_or(raw_handle);
+
+            // Look for usage of this handle with heredoc
+            let usage_pattern = format!(r"print\s+{}\s+<<", regex::escape(handle_to_search));
+            if let Ok(re) = Regex::new(&usage_pattern)
+                && let Some(usage_match) = re.find(code)
+            {
+                let location = Location {
+                    line: code[..usage_match.start()].lines().count(),
+                    column: usage_match.start()
+                        - code[..usage_match.start()].rfind('\n').unwrap_or(0),
+                    offset: offset + usage_match.start(),
+                };
+
+                results.push((
+                    AntiPattern::TiedHandleHeredoc {
+                        location: location.clone(),
+                        handle_name: handle_to_search.to_string(),
+                    },
+                    location,
+                ));
+            }
+        }
+
+        results
+    }
+
+    fn diagnose(&self, pattern: &AntiPattern) -> Option<Diagnostic> {
+        let AntiPattern::TiedHandleHeredoc { handle_name, .. } = pattern else {
+            return None;
+        };
+
+        Some(Diagnostic {
+            severity: Severity::Info,
+            pattern: pattern.clone(),
+            message: format!("Heredoc written to tied handle '{}'", handle_name),
+            explanation: "Writing to a tied handle invokes custom code. The behavior of heredoc output depends on the tied class implementation.".to_string(),
+            suggested_fix: None,
+            references: vec!["perldoc -f tie".to_string()],
+        })
+    }
+}
+
+impl Default for AntiPatternDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AntiPatternDetector {
+    pub fn new() -> Self {
+        Self {
+            patterns: vec![
+                Box::new(FormatHeredocDetector),
+                Box::new(BeginTimeHeredocDetector),
+                Box::new(DynamicDelimiterDetector),
+                Box::new(SourceFilterDetector),
+                Box::new(RegexHeredocDetector),
+                Box::new(EvalHeredocDetector),
+                Box::new(TiedHandleDetector),
+            ],
+        }
+    }
+
+    pub fn detect_all(&self, code: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        for detector in &self.patterns {
+            let patterns = detector.detect(code, 0);
+            for (pattern, _) in patterns {
+                if let Some(diagnostic) = detector.diagnose(&pattern) {
+                    diagnostics.push(diagnostic);
+                }
+            }
+        }
+
+        diagnostics.sort_by_key(|d| match &d.pattern {
+            AntiPattern::FormatHeredoc { location, .. }
+            | AntiPattern::BeginTimeHeredoc { location, .. }
+            | AntiPattern::DynamicHeredocDelimiter { location, .. }
+            | AntiPattern::SourceFilterHeredoc { location, .. }
+            | AntiPattern::RegexCodeBlockHeredoc { location, .. }
+            | AntiPattern::EvalStringHeredoc { location, .. }
+            | AntiPattern::TiedHandleHeredoc { location, .. } => location.offset,
+        });
+
+        diagnostics
+    }
+
+    pub fn format_report(&self, diagnostics: &[Diagnostic]) -> String {
+        let mut report = String::from("Anti-Pattern Analysis Report\n");
+        report.push_str("============================\n\n");
+
+        if diagnostics.is_empty() {
+            report.push_str("No problematic patterns detected.\n");
+            return report;
+        }
+
+        report.push_str(&format!("Found {} problematic patterns:\n\n", diagnostics.len()));
+
+        for (i, diag) in diagnostics.iter().enumerate() {
+            report.push_str(&format!(
+                "{}. {} ({})\n",
+                i + 1,
+                diag.message,
+                match diag.severity {
+                    Severity::Error => "ERROR",
+                    Severity::Warning => "WARNING",
+                    Severity::Info => "INFO",
+                }
+            ));
+
+            report.push_str(&format!(
+                "   Location: {}\n",
+                match &diag.pattern {
+                    AntiPattern::FormatHeredoc { location, .. }
+                    | AntiPattern::BeginTimeHeredoc { location, .. }
+                    | AntiPattern::DynamicHeredocDelimiter { location, .. }
+                    | AntiPattern::SourceFilterHeredoc { location, .. }
+                    | AntiPattern::RegexCodeBlockHeredoc { location, .. }
+                    | AntiPattern::EvalStringHeredoc { location, .. }
+                    | AntiPattern::TiedHandleHeredoc { location, .. } =>
+                        format!("line {}, column {}", location.line, location.column),
+                }
+            ));
+
+            report.push_str(&format!("   Explanation: {}\n", diag.explanation));
+
+            if let Some(fix) = &diag.suggested_fix {
+                report.push_str(&format!(
+                    "   Suggested fix:\n     {}\n",
+                    fix.lines().collect::<Vec<_>>().join("\n     ")
+                ));
+            }
+
+            if !diag.references.is_empty() {
+                report.push_str(&format!("   References: {}\n", diag.references.join(", ")));
+            }
+
+            report.push('\n');
+        }
+
+        report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_heredoc_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r#"
+format REPORT =
+<<'END'
+Name: @<<<<<<<<<<<<
+$name
+END
+.
+"#;
+
+        let diagnostics = detector.detect_all(code);
+        // Note: DynamicDelimiterDetector might also flag the << inside the format body as a false positive.
+        // But FormatHeredoc should appear first because it starts at 'format'.
+        // So diagnostics[0] should be FormatHeredoc.
+        assert!(!diagnostics.is_empty());
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::FormatHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_begin_heredoc_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+BEGIN {
+    $config = <<'END';
+    server = localhost
+END
+}
+"###;
+
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::BeginTimeHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_dynamic_delimiter_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+my $delimiter = "EOF";
+my $content = <<$delimiter;
+This is dynamic
+EOF
+"###;
+
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::DynamicHeredocDelimiter { .. }));
+    }
+
+    #[test]
+    fn test_source_filter_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+use Filter::Simple;
+print <<EOF;
+Filtered content
+EOF
+"###;
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::SourceFilterHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_regex_heredoc_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+m/pattern(?{
+    print <<'MATCH';
+    Match text
+MATCH
+})/
+"###;
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::RegexCodeBlockHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_eval_heredoc_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+eval 'print <<"EVAL";
+Eval content
+EVAL';
+"###;
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::EvalStringHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_tied_handle_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+tie *FH, 'Tie::Handle';
+print FH <<'DATA';
+Tied output
+DATA
+"###;
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::TiedHandleHeredoc { .. }));
+    }
+
+    #[test]
+    fn test_tied_scalar_handle_detection() {
+        let detector = AntiPatternDetector::new();
+        let code = r###"
+tie $fh, 'Tie::Handle';
+print $fh <<'DATA';
+Tied output
+DATA
+"###;
+        let diagnostics = detector.detect_all(code);
+        assert_eq!(diagnostics.len(), 1);
+        assert!(matches!(diagnostics[0].pattern, AntiPattern::TiedHandleHeredoc { .. }));
+    }
+}

--- a/crates/perl-lsp-diagnostics/Cargo.toml
+++ b/crates/perl-lsp-diagnostics/Cargo.toml
@@ -23,7 +23,7 @@ perl-parser-core = { workspace = true }
 perl-semantic-analyzer = { workspace = true }
 perl-workspace-index = { workspace = true }
 perl-pragma = { workspace = true }
-perl-ts-heredoc-analysis = { workspace = true }
+perl-heredoc-anti-patterns = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-lsp-diagnostics/src/heredoc_antipatterns.rs
+++ b/crates/perl-lsp-diagnostics/src/heredoc_antipatterns.rs
@@ -1,8 +1,8 @@
 //! Heredoc anti-pattern detection diagnostics
 
 use perl_diagnostics_codes::DiagnosticCode;
+use perl_heredoc_anti_patterns::{AntiPattern, AntiPatternDetector, Severity};
 use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
-use perl_ts_heredoc_analysis::anti_pattern_detector::{AntiPattern, AntiPatternDetector, Severity};
 
 /// Detect heredoc anti-patterns in Perl source code.
 ///


### PR DESCRIPTION
## Problem

`perl-lsp-diagnostics` is a published LSP crate (in the Tier 3 publish allow-list) but it can't currently be cleanly published because it hard-depends on `perl-ts-heredoc-analysis`, which is:

- `publish = false` in its `Cargo.toml`
- Stuck at a stale `0.12.1` on crates.io (incidentally published; we own the name)
- Being archived along with the rest of the unused harness ecosystem

The workspace dep `perl-ts-heredoc-analysis = { workspace = true, version = "0.12.2" }` does not resolve on crates.io, so `cargo publish -p perl-lsp-diagnostics` fails at resolution. Yet `perl-lsp-diagnostics` only uses three types from one module of that crate:

```rust
use perl_ts_heredoc_analysis::anti_pattern_detector::{AntiPattern, AntiPatternDetector, Severity};
```

## Solution

Extract `anti_pattern_detector` into its own Single-Responsibility leaf microcrate, `perl-heredoc-anti-patterns`, and rewire `perl-lsp-diagnostics` to depend on the new crate instead.

The extraction is trivial: the source file has zero internal workspace dependencies (only `regex` and `std::sync::LazyLock`), so the new crate is a clean Tier 1 leaf. The module becomes the crate root with the same public API.

## Changes

- **New crate** `crates/perl-heredoc-anti-patterns/`:
  - `src/lib.rs` — verbatim copy of `perl-ts-heredoc-analysis::anti_pattern_detector`, promoted from module to crate root, with crate-level doc comment. All 8 inline tests preserved.
  - `Cargo.toml` — full crates.io metadata (keywords, categories, description, readme, include list, docs.rs link).
  - `LICENSE-APACHE` / `LICENSE-MIT` — canonical SPDX text (same as the files being normalized in #3193).
  - `README.md` — brief description and usage example.
- **Workspace root `Cargo.toml`**:
  - Add `"crates/perl-heredoc-anti-patterns"` to `[workspace.members]`.
  - Register workspace dep `perl-heredoc-anti-patterns = { path = ..., version = "0.12.2" }`.
  - Add `"perl-heredoc-anti-patterns"` to `[workspace.metadata.publish].allow` under Tier 1 (Leaf crates).
- **`crates/perl-lsp-diagnostics/Cargo.toml`**: replace `perl-ts-heredoc-analysis = { workspace = true }` with `perl-heredoc-anti-patterns = { workspace = true }`.
- **`crates/perl-lsp-diagnostics/src/heredoc_antipatterns.rs`**: change `use perl_ts_heredoc_analysis::anti_pattern_detector::{...}` to `use perl_heredoc_anti_patterns::{...}`.

## Scope

This PR only **adds** the new microcrate and rewires the single consumer. The old file at `crates/perl-ts-heredoc-analysis/src/anti_pattern_detector.rs` is intentionally left in place — the archival of `perl-ts-heredoc-analysis` and the rest of the harness crates is a separate follow-up PR.

## Verification

- `cargo build -p perl-heredoc-anti-patterns` — clean
- `cargo test -p perl-heredoc-anti-patterns` — 8 passed
- `cargo clippy -p perl-heredoc-anti-patterns -p perl-lsp-diagnostics -- -D warnings` — clean
- `cargo build -p perl-lsp-diagnostics` — clean
- `cargo test -p perl-lsp-diagnostics` — 276 passed
- `cargo package --list -p perl-heredoc-anti-patterns --allow-dirty` — clean package (src/lib.rs, Cargo.toml, LICENSE-*, README.md)
- `cargo check -p perl-ts-heredoc-analysis` — still builds (old module untouched)

## Test Plan

- [x] New crate builds and all inline tests pass
- [x] New crate is clippy-clean
- [x] `perl-lsp-diagnostics` builds and tests pass against the new dep
- [x] `cargo package --list` produces the expected file set
- [x] Old `perl-ts-heredoc-analysis` still builds (no breakage of incidental consumers)
- [ ] Full CI gate on Linux passes

## Notes

Pre-push local gate was bypassed due to a pre-existing Windows-only file-lock race in `just ci-parser-features-check` (the `xtask corpus-audit` subprocess tries to relink `xtask.exe` while it's running — unrelated to this change). Linux CI on GitHub will exercise the full gate.
