### PR TITLE
docs(economics): session 2026-04-07 — pre-announcement cleanup wave

### DIFF
--- a/docs/articles/research/SESSION_ECONOMICS_2026_04_07.md
+++ b/docs/articles/research/SESSION_ECONOMICS_2026_04_07.md
@@ -1,0 +1,327 @@
+# Session Economics: 2026-04-07 Pre-Announcement Cleanup
+
+**Session Date**: 2026-04-07
+**Model**: Claude Opus 4.6 (1M context)
+**Operator**: Steven Zimmerman (orchestrator)
+**Session type**: Pre-announcement cleanup wave for v0.13.0. Started as a "verify the v0.12.2 release shipped cleanly" check and grew into a parallel cleanup wave once hidden problems started surfacing.
+
+### Budget
+
+| Metric | Value |
+|--------|-------|
+| Single-session window consumed | **~92%** of one 5-hour session (some overage credits available) |
+| Weekly budget at session start | ~24% |
+| Weekly budget at session end | ~32% |
+| Delta on weekly budget | **+8 percentage points** |
+
+### Headline metrics
+
+| Metric | Value |
+|--------|-------|
+| PRs merged | **18** (11 release-prep + 7 dependabot) |
+| Issues filed | **9** (+1 closed by merge) |
+| Agents spawned | **~30** across 5 waves |
+| New SRP microcrates created | 2 |
+| Stale branches deleted | 17 (8 local + 9 remote) |
+| Cost per merged PR | ~0.39% weekly per PR |
+| Cost per agent spawn | ~0.23% weekly per agent |
+
+For comparison, the 2026-04-02 session 1 ran at ~2.3% weekly per PR. **This session was ~6x more efficient on a cost-per-PR basis** — see "What changed" below.
+
+---
+
+## What shipped
+
+### Release plumbing (the original mission)
+
+| PR | What |
+|----|------|
+| #3186 | README "Current release" line v0.12.1 → v0.12.2 |
+| #3190 | gitignore `.playwright-mcp/` + LICENSE-MIT smart-quote fix attempt #1 |
+| #3191 | Docker arm64 timeout 30→90 + Dockerfile MSRV pin (closes #3188) |
+| #3193 | LICENSE canonical SPDX text across all 126 files (root + 62 per-crate × 2) |
+| #3194 | `docs/project/ROADMAP.md` current-framing block refresh |
+| #3195 | Enable `perl-parser-pest` for crates.io publication |
+| #3196 | `perl-lsp-ai-provider` unblock + 3 stray LICENSE deletes + check-todos `.claude` exclusion |
+| #3198 | Extract `bench_parser` to `perl-parser-bench` SRP microcrate |
+| #3199 | Extract `anti_pattern_detector` to `perl-heredoc-anti-patterns` SRP microcrate |
+| #3200 | Top-level `ROADMAP.md` and `NOW_NEXT_LATER.md` refresh |
+| #3201 | CHANGELOG `[Unreleased]` populated with the cleanup wave |
+
+### Dependabot landed in batch
+
+7 PRs merged including 3 majors verified safe via parallel worktree investigation:
+- `eslint` 9.39.4 → 10.2.0 (#3179)
+- `actions/cache` v4 → v5 (#3181)
+- `similar` 2.7.0 → 3.0.0 (#3184)
+- `tokio` 1.50→1.51 (#3180), `tree-sitter` 0.26.7→0.26.8 (#3182), dependencies group (#3183), npm group (#3178)
+
+### Repo metadata
+
+- License badge: `NOASSERTION` → `Apache-2.0`
+- GitHub Discussions: enabled
+- Homepage URL: `https://effortlesssteven.com/`
+
+### Issues filed
+
+- #3187 vsce idempotency
+- #3189 corpus ratchet path mismatch
+- #3192 xtask Windows smoke-test backslash mangling
+- #3197 publish workflow indexing-wait + false-success
+- #3202 Windows xtask recursive race
+- #3203 hook-tests workspace scribble (safety bug)
+- #3204 broken `cmd_quick_bench` C-vs-Rust comparison
+- #3205 recurring `core.bare = true` corruption (third occurrence)
+
+Plus #3188 (Docker arm64) which was filed and closed by #3191 in the same session.
+
+---
+
+## What we found that wasn't on anyone's radar
+
+The session was supposed to verify a clean release. It surfaced **6 pre-existing bugs that nobody knew about**:
+
+1. **`perl-lsp-rs` couldn't actually publish to crates.io.** It hard-depends on `perl-lsp-ai-provider`, which had `publish = false` and had never been on crates.io. The publish workflow ran for 1h47m on the previous attempt and was eventually cancelled — the cancellation was driven by hypothesis, not by the workflow surfacing the actual blocker. The script's "indexing wait" path masked silent upload failures (issue #3197).
+
+2. **`perl-lsp-diagnostics` had the same problem** with `perl-ts-heredoc-analysis`. Both blockers existed simultaneously and both were silent — neither showed up in the workflow's normal failure annotations.
+
+3. **The `LICENSE-APACHE` file at the workspace root contained only the short header notice** (~10 lines), not the full ~200-line canonical Apache 2.0 text. GitHub's licensee couldn't match the partial text and reported the entire repo as `NOASSERTION` — even though `Cargo.toml` already declared `license = "MIT OR Apache-2.0"` correctly.
+
+4. **The `LICENSE-MIT` file had curly quotes** (`"Software"` / `"AS IS"`) instead of straight quotes, also breaking licensee. The 62 per-crate copies had drifted from the root file.
+
+5. **The `bindgen` call in `tree-sitter-perl-c/build.rs` produced dead output.** Nothing in `lib.rs` actually referenced any bindgen-generated symbol — the crate uses `tree_sitter::Language` from the upstream Rust crate plus a hand-written `extern "C" { fn tree_sitter_perl() -> Language; }`. The libclang dependency was gratuitous, blocking the crate from being publishable for no functional reason.
+
+6. **`perl-ci-hygiene` had three completely dead `cmd_*_bench` functions** referencing `--bin parse-rust` (which doesn't exist — the actual harness binary is `ts-parse-rust`). Confirmed by grep: nothing in `justfile`/workflows/scripts invokes them. They've been silently dead for a long time.
+
+Plus three Windows-specific bugs that block every Windows contributor's local CI gate:
+
+7. **`xtask.exe` recursive self-invocation race** — `cmd_check_parse_errors` spawns `cargo run -p xtask -- corpus-audit` while xtask is itself running, and Windows file-locking blocks the relink (issue #3202).
+
+8. **`hook-tests` scaffold can scribble onto real workspace files** — during one of Agent B's runs, the scaffold actually overwrote `README.md` with `# hook test repo`. The agent caught and restored it before pushing. This is a safety bug, not just a test bug (issue #3203).
+
+9. **`core.bare = true` corruption recurred** — third occurrence of this bug (first hit in v0.12.1 cleanup, twice during this session). Filed with permanent-fix proposal (issue #3205).
+
+The shape of these findings is consistent: **the project's gates and tooling have accumulated landmines that don't fire until you do something they weren't tested against** (like actually publishing every crate, or running on Windows, or using agent worktrees aggressively).
+
+---
+
+## What changed vs the 2026-04-02 session
+
+The 2026-04-02 session ran at ~2.3% weekly per merged PR. This session ran at ~0.39% per merged PR — **about 6x more efficient**. Three things drove the difference:
+
+### 1. Less code generation, more orchestration
+
+The 2026-04-02 session was building features (multi-release build-out). This session was orchestrating cleanups: identify a problem → spawn an agent → review the resulting PR → merge. The orchestrator never wrote substantial code itself, which kept the main context small and let the agents do the heavy lifting in their isolated worktrees.
+
+### 2. Aggressive scout-vs-PR split
+
+Mid-session it became clear that the local pre-push hook was a bottleneck — every PR-style agent had to fight Windows-specific gate failures (issues #3202, #3203) and resort to bypass workarounds (`--no-verify` or `git -c core.hooksPath=`). **Scouts (read-only audit agents that file a single GitHub issue and exit) routed around the bottleneck entirely.** Once that pattern was clear, the second half of the session fired ~15 scouts in parallel, none of which needed to push code.
+
+The user articulated the strategy directly: *"will open up for more fixes once Agent N lands the prepush fix."* Scout agents need zero hook bypasses; PR agents need the hook to work. So the session shifted to scouts during the bottleneck and held PR-style fixes for after Agent N (the hook fix) lands.
+
+### 3. Verify-before-build is now habitual
+
+The 2026-04-02 session learned verify-before-build during the session. This session inherited it as a starting condition. Result: zero builders found their issue was already done, zero false-start agents.
+
+### 4. Aggressive parallelism
+
+At peak, ~22 agents were in flight simultaneously. The user explicitly authorized: *"We have room for hundreds if you find things."* Constraint wasn't agent budget — it was finding legitimate work to delegate.
+
+---
+
+## Bottleneck analysis: the pre-push hook cascade
+
+The most expensive single problem in this session was the pre-push hook running `nix develop -c just ci-gate` on every push, including:
+- Branch deletions (no content to validate)
+- Doc-only changes (no code to test)
+- Pushes from worktrees that have triggered `core.bare = true` corruption (false failure)
+- Pushes that hit Windows-specific gate bugs unrelated to the actual change
+
+Each PR-style agent had to either:
+1. Wait for the gate (~10 min on Windows when it works)
+2. Hit a Windows-specific bug and bypass with `--no-verify`
+3. Fail confusingly and abandon the PR
+
+**The cascade**: every PR-style agent fights the hook → contributors learn "always bypass" → the hook stops being a safety net → the underlying bugs the hook was supposed to catch start landing in master → next contributor's experience is worse.
+
+The fix being landed by Agent N (Wave 8) addresses the hook directly:
+- Skip on deletion-only push
+- Doc-only fast path
+- Auto-detect + auto-fix `core.bare = true`
+- Better failure messages pointing at specific issues
+- Clear bypass policy documentation
+
+After Agent N lands, the queued PR-style fixes (timing test flake, vsce idempotency, etc.) become viable to fire without bypass workarounds.
+
+---
+
+## Failure modes worth flagging
+
+### What went wrong this session
+
+- **First publish run cancellation was the orchestrator's call, not the workflow's.** The publish workflow ran 1h47m on a slow indexing path, masking the actual silent upload failures behind "proceeding anyway" warnings. We don't yet know how many crates DID publish silently in that run vs failed silently.
+- **`docs/project/ROADMAP.md` and 3 sibling top-level docs were stuck at v0.12.1 framing** even though v0.12.2 had been live for 3+ days. Suggests release runs need to update version-bearing docs as part of the release process, not as a follow-up.
+- **`perl-ci-hygiene` accumulated ~150 lines of dead code** (the 3 broken `cmd_*_bench` functions + the now-obsolete `cmd_check_v2_bundle_sync`). Nothing called them. They sat unused for months.
+- **Worktree file leaks repeated** (Agent F leaked corpus-ratchet workflow files into the main checkout). Same bug as previous sessions. Restored manually.
+- **Pre-existing flaky test** (`empty_timer_reports_total` in `perl-lsp-launcher`) was hit by both Agent A and Agent B during their runs. Still hasn't been fixed (queued PR for Wave 9).
+
+### What went right this session
+
+- **License flip happened mid-session.** GitHub started showing `Apache-2.0` instead of `NOASSERTION` within minutes of PR #3193 merging. Visible win.
+- **Both SRP extractions landed cleanly** with their consumers updated in the same PR. Zero followup needed.
+- **18 PRs merged with zero rollbacks.** No PR was reverted, no production code was broken.
+- **Agent worktree investigations correctly classified all 3 dependabot majors as SAFE** with concrete evidence (lint passes for eslint v10, no schema changes for actions/cache v5, single call site uses unchanged API for similar 3.0). Zero merge-after-major regressions.
+- **8 issue follow-ups filed by agents during their work**, each of which represents a real bug they discovered while doing other things.
+
+---
+
+## Operating model insights
+
+### Scouts are the right unit when tooling is broken
+
+When the pre-push hook is broken, scouts (read-only, file-one-issue, exit) outpace PR-style agents by ~3-5x because they don't need to push. The session's late-half throughput was almost entirely scout-driven. **Lesson**: when a critical piece of tooling is in a degraded state, prefer scouts until the tooling is fixed.
+
+### Parallel agent count is bounded by *finding work*, not by agent capacity
+
+The session ran ~22 agents in parallel at peak with no resource issues. The user explicitly said "hundreds if you find things." The actual constraint is **identifying legitimate work to delegate** — busywork doesn't count. Each agent needs a specific, verifiable deliverable.
+
+### Issue filing is the cheapest unit of work
+
+A scout agent that produces ONE GitHub issue costs ~0.2% weekly. An issue is a permanent record that survives session turnover. The follow-up work (fixing what the issue describes) can happen in any future session. **Filing issues is high-leverage**: small cost now, optionality later.
+
+### Pre-existing bugs surface during verification work
+
+Of the 9 issues filed this session, 6 were pre-existing bugs nobody knew about. They surfaced because we were verifying a release shipped cleanly. **Verification isn't just confirmation — it's discovery.** Plan for verification to find ~50% net-new bugs.
+
+### Documentation drift compounds silently
+
+Multiple top-level docs were stuck at v0.12.1 framing. None of them broke anything. None of them showed up in CI. They drifted because nothing in the release process touches them. **Docs that don't have an owner or a gate get stale.** Worth automating (Agent J — version-bump centralization — is the proposed fix).
+
+---
+
+## Notes for next session
+
+Things this session left in flight:
+
+1. **Pre-push hook fix (Agent N)** — landing it unblocks the queued PR-style fixes (timing flake, vsce idempotency, future fixes)
+2. **Harness archive** — needs Agent C (xtask refactor) to land first, then a manual or agent-driven cleanup PR that also handles `perl-ci-hygiene`'s dead code (task #41)
+3. **New `tree-sitter-perl-rs` Rust facade** (queued Agent I) — needs the harness archive to free the directory name
+4. **Re-trigger Publish to crates.io** — after Agent D's workflow fix lands
+5. **10 scout findings** — issue follow-ups from the Wave 8 scouts (per-crate doc staleness, cargo-machete, naming consistency, README completeness, missing tests, dep version consistency, MSRV consistency, CI script staleness, docs/ staleness, unwrap audit)
+6. **10 more scout findings** — Wave 9 scouts in flight (cargo audit, semver-checks, missing rustdoc, release artifact integrity, features.toml drift, snapshot staleness, unsafe blocks, debug prints, vscode extension state, build.rs dead code)
+
+The session ends with **0 open PRs** and **8 open issues** (4 from Wave 6/7, plus 4 from Wave 8 audit batch already filed), all being actively worked on.
+
+---
+
+## Transferable insights (not perl-lsp specific)
+
+These are lessons that apply to any large Rust workspace + agentic-development project:
+
+### License files are subtle
+GitHub's `licensee` gem (which drives the repo license badge) does normalized text matching against canonical SPDX templates. Two failure modes that both block detection:
+1. **Smart quotes from copy-paste**. The `LICENSE-MIT` text had `"Software"` and `"AS IS"` with curly quotes (UTF-8 `e2 80 9c` / `e2 80 9d`). Looks fine in any editor; breaks licensee.
+2. **Short Apache header instead of full license**. The `LICENSE-APACHE` file had only the ~10-line header notice (the kind you put in a source file), not the ~200-line full license with TERMS AND CONDITIONS. licensee has no fallback for partial Apache text.
+
+`Cargo.toml`'s `license = "MIT OR Apache-2.0"` field is correct and shows on crates.io, but does NOT drive the GitHub badge. The GitHub badge is licensee scanning the license files at the repo root. Both must be canonical.
+
+**Lesson**: any Rust project should verify their LICENSE files survive licensee. `gh api repos/<owner>/<repo> --jq .license.spdx_id` returns the licensee verdict.
+
+### `bindgen` can produce dead output
+We found `tree-sitter-perl-c/build.rs` had ~16 lines of `bindgen::Builder` code generating `bindings.rs`, but nothing in `lib.rs` actually referenced any bindgen-generated symbol. The crate used `tree_sitter::Language` from the upstream Rust crate plus a hand-written `unsafe extern "C" { fn tree_sitter_perl() -> Language; }`. The bindgen output was pure overhead — and the libclang dependency was gratuitous.
+
+**Lesson**: any FFI crate using bindgen should verify the generated symbols are actually consumed. If not, delete bindgen and write the extern by hand. For tree-sitter-style parsers (single grammar entry point), the hand-written extern is 1-2 lines.
+
+### `publish = false` is a hidden landmine
+Marking an internal crate `publish = false` is fine. But if a published crate hard-depends on it, the published crate also becomes unpublishable: cargo packages the dep with `version = "X.Y.Z"`, and crates.io rejects because that version doesn't exist.
+
+The failure surfaces AT crates.io (not at cargo), which makes it confusing — `cargo publish --dry-run` passes locally because cargo doesn't know about the registry constraint.
+
+This session hit it twice:
+- `perl-lsp-rs` → `perl-lsp-ai-provider` (publish=false)
+- `perl-lsp-diagnostics` → `perl-ts-heredoc-analysis` (publish=false)
+
+**Lesson**: a CI check should walk the dep tree of every publishable crate and assert that all transitive deps are also publishable. The check is mechanical and catches the bug at PR time instead of at the publish workflow.
+
+### Workspace deps rewriting confuses local vs registry behavior
+When cargo packages a crate, it rewrites `[dependencies] foo = { workspace = true }` (which resolves to `path = "..." version = "X.Y.Z"`) to just `version = "X.Y.Z"` in the published manifest. The path component is dropped because crates.io can't resolve it.
+
+This means `cargo publish --dry-run` can pass even when the published version won't actually resolve on crates.io — because dry-run uses the path to find the dep locally, while real publish makes consumers resolve via the registry.
+
+**Lesson**: dry-run is necessary but not sufficient. The only way to verify "this crate can actually be consumed by downstream users" is to publish it and have a CI consumer crate that depends on the published version.
+
+### gh CLI as a git push escape hatch
+When the local pre-push hook is broken (issues #3202, #3203, #3205), `git push` fails on every push attempt — including pure branch deletions. But branch deletion via the GitHub API doesn't trigger the local hook:
+
+```
+gh api -X DELETE "repos/<owner>/<repo>/git/refs/heads/<branch>"
+```
+
+This is a useful pattern when you need to clean up remote branches and can't get past the local gate. (Not a substitute for fixing the underlying gate.)
+
+### Agent worktree branches accumulate silently
+Each `git worktree add` creates:
+1. A worktree directory (in `.claude/worktrees/agent-XXX/`)
+2. A branch ref (the worktree's HEAD)
+3. A `[branch "..."]` entry in `.git/config`
+4. Possibly a stale `worktree-agent-XXX` shadow branch in the main checkout's branch list
+
+None of these are auto-cleaned when the agent finishes. Over a session with ~22 agents, the accumulation is meaningful: ~22 worktree dirs, ~22-44 branches, dozens of config entries. `just clean-worktrees` (per CLAUDE.md) addresses some of this but not all.
+
+**Lesson**: any agent-spawning workflow needs explicit cleanup hooks. Otherwise the workspace state degrades over time.
+
+### `cargo test` doesn't surface flakiness
+The `empty_timer_reports_total` flake passed on retry but the first failure was indistinguishable from a real test failure. Cargo's test output doesn't say "this test passed on the SECOND attempt" — it just reports "ok" on the second run as if the first never happened.
+
+**Lesson**: flaky tests need their own detection (e.g., `cargo nextest --retries 1 --report-flakiness`). Otherwise they accumulate and erode confidence in the test suite.
+
+### Distribution channels drift independently
+For the same release version, this project has:
+- crates.io (per-crate, ~120 of them)
+- VSCode Marketplace
+- Open VSX
+- Docker Hub (multiple tags)
+- GitHub Releases (binary artifacts + SBOM + SHA256SUMS)
+- npm (vscode-extension package, internal)
+- Homebrew (formula)
+- winget / scoop (Windows)
+
+Each can be at a different state for the same version. The 0.12.2 release was at:
+- VSCode Marketplace ✅ 0.12.2
+- Open VSX ✅ 0.12.2
+- Docker Hub ✅ 0.12.2-perl
+- GitHub Release ✅ v0.12.2 with all binaries
+- crates.io ❌ stuck at 0.12.1 (publish workflow cancelled)
+
+A "release verification" pass needs to check ALL channels, not just one or two.
+
+### CLAUDE.md as a discoverable contract
+The project's per-directory `CLAUDE.md` files (one in the root, one in many crates, one in `xtask/`, etc.) work as discoverable contracts that agents read on entry. When an agent works in `xtask/`, it reads `xtask/CLAUDE.md` and follows the rules without being told. This is high-leverage because:
+1. Rules survive session turnover
+2. Rules apply to ALL future agents, not just the one being prompted
+3. Updates to rules propagate automatically
+
+**Lesson**: every project that uses agents should have a CLAUDE.md (or equivalent) at the root and at major subdirectories. The marginal cost is small; the marginal value is large.
+
+### Pre-existing bugs cluster around verification
+6 of the 9 issues filed this session were pre-existing bugs nobody knew about. They surfaced because we were verifying a release. Two patterns:
+1. **Tooling that's never been exercised against the failure mode** (e.g., the publish workflow against silent upload failures)
+2. **Code paths that are dead but not deleted** (the 3 broken `cmd_*_bench` functions)
+
+**Lesson**: verification is discovery. Plan for it to find net-new bugs, not just confirm what you already know.
+
+---
+
+## Self-assessment
+
+The session delivered substantial pre-announcement cleanup at much higher efficiency than the 2026-04-02 baseline (~6x cost-per-PR improvement). The key was treating it as an orchestration problem, not a coding problem. The orchestrator never wrote substantial code — it identified problems and dispatched agents to investigate or fix them, then merged the results.
+
+Three things would make the NEXT session even more efficient:
+
+1. **Agent N's pre-push hook fix landing first** — would remove the bottleneck that forced the scout-vs-PR split mid-session
+2. **`just doctor` recipe (Agent O)** — would auto-heal `core.bare` and other recurring state corruption at session start
+3. **Centralized version-bump automation (Agent J)** — would prevent the next session from having to refresh stale docs again
+
+All three are in flight at session end.
+
+<!-- Last Updated: 2026-04-07 -->


### PR DESCRIPTION
## Summary
Session economics doc for the 2026-04-07 pre-announcement cleanup wave. Pairs with the existing `SESSION_ECONOMICS_2026_04_02.md` as the second entry in this format.

## Highlights
- **~92% of one 5-hour session, +8 weekly percentage points** (24% → 32%)
- **18 PRs merged** (11 release-prep + 7 dependabot)
- **9 issues filed** (8 still open at session end)
- **~30 agents spawned** across 5 waves
- **2 SRP microcrates created** (`perl-heredoc-anti-patterns`, `perl-parser-bench`)
- **Cost per merged PR**: ~0.39% weekly per PR (vs ~2.3% for 2026-04-02 — about 6x more efficient)

## Sections
- Headline metrics
- What shipped (release plumbing + dependabot + repo metadata + issues)
- 6 pre-existing bugs the session found while verifying the v0.12.2 release
- What changed vs the 2026-04-02 session (efficiency drivers)
- Bottleneck analysis: the pre-push hook cascade
- Failure modes worth flagging
- Operating model insights
- Transferable insights (license files / dead bindgen / publish=false landmine / workspace dep rewriting / gh CLI escape hatch / agent worktree accumulation / cargo test flakiness blindness / channel drift / CLAUDE.md as discoverable contract / verification = discovery)
- Notes for next session
- Self-assessment

## Note about the push
Pushed with \`--no-verify\` because:
1. This is a doc-only PR (single new file under \`docs/articles/research/\`, zero source changes)
2. The local pre-push hook is in a degraded state mid-session: Agent N's WIP is rewriting it via a sibling worktree, and the in-progress version of the hook is producing context-dependent failures (\`cargo run -p perl-ci-hygiene -- check-unsafe-prod\` exits 0 when run directly but exits 1 when invoked from inside the hook)
3. The user authorized the bypass under session-budget pressure
4. None of the gates that matter for a doc-only change (cargo fmt, clippy on touched files, missing-docs on touched files) are relevant — there are no Rust source changes to validate

## Test plan
- [ ] CI on the PR (Linux runners, no Windows hook state issues)