### PR TITLE
fix(ci): include dev-deps in publish topological sort (#3236)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -60,13 +60,81 @@ jobs:
               if pkg["id"] in workspace_members:
                   packages[pkg["name"]] = pkg
 
-          # Build dependency graph (only internal deps)
-          deps = {}
+          # Build separate normal and dev dependency graphs (only internal deps).
+          # cargo publish resolves dev-deps from the registry when packaging the
+          # manifest, so a crate that dev-depends on another workspace member
+          # must be published after that member.  However, dev-dep edges can
+          # form cycles between workspace crates (e.g. crate A dev-depends on
+          # crate B while B normally depends on A).  We break those cycles by
+          # running Tarjan SCC: intra-SCC dev edges are dropped (they are the
+          # only edges that can close a cycle), while inter-SCC dev edges are
+          # kept so that the ordering constraint is honoured.
+          from collections import defaultdict
+
+          normal_deps = defaultdict(set)
+          dev_deps = defaultdict(set)
           for name, pkg in packages.items():
-              deps[name] = set()
               for dep in pkg["dependencies"]:
-                  if dep["name"] in packages and dep.get("kind") != "dev":
-                      deps[name].add(dep["name"])
+                  if dep["name"] not in packages:
+                      continue
+                  if dep.get("kind") == "dev":
+                      dev_deps[name].add(dep["name"])
+                  else:
+                      normal_deps[name].add(dep["name"])
+
+          # Tarjan SCC on the full graph (normal + dev edges).
+          def tarjan_sccs(graph, nodes):
+              index_counter = [0]
+              stack = []
+              lowlink = {}
+              index = {}
+              on_stack = {}
+              sccs = []
+
+              def strongconnect(v):
+                  index[v] = index_counter[0]
+                  lowlink[v] = index_counter[0]
+                  index_counter[0] += 1
+                  stack.append(v)
+                  on_stack[v] = True
+                  for w in graph.get(v, set()):
+                      if w not in index:
+                          strongconnect(w)
+                          lowlink[v] = min(lowlink[v], lowlink[w])
+                      elif on_stack.get(w):
+                          lowlink[v] = min(lowlink[v], index[w])
+                  if lowlink[v] == index[v]:
+                      scc = []
+                      while True:
+                          w = stack.pop()
+                          on_stack[w] = False
+                          scc.append(w)
+                          if w == v:
+                              break
+                      sccs.append(scc)
+
+              sys.setrecursionlimit(max(10000, len(nodes) * 2))
+              for v in nodes:
+                  if v not in index:
+                      strongconnect(v)
+              return sccs
+
+          full_graph = {name: normal_deps[name] | dev_deps[name] for name in packages}
+          sccs = tarjan_sccs(full_graph, list(packages.keys()))
+          node_to_scc = {}
+          for i, scc in enumerate(sccs):
+              for node in scc:
+                  node_to_scc[node] = i
+
+          # Build final dep graph: normal edges always included; dev edges only
+          # when they cross SCC boundaries (intra-SCC dev edges are dropped to
+          # break cycles).
+          deps = {}
+          for name in packages:
+              deps[name] = set(normal_deps[name])
+              for dep in dev_deps[name]:
+                  if node_to_scc.get(dep) != node_to_scc.get(name):
+                      deps[name].add(dep)
 
           # Topological sort (Kahn algorithm)
           in_degree = {name: len(d) for name, d in deps.items()}


### PR DESCRIPTION
## Summary

- `cargo publish` resolves dev-deps from the registry when packaging the crate manifest, so crates that dev-depend on other workspace members must be published after them
- The previous topo sort excluded dev-dep edges, causing `perl-corpus` (which dev-depends on `perl-tdd-support`) to be placed before `perl-tdd-support` in the publish order — reproducing the v0.12.2 publish failure
- The naive fix of including all dev-dep edges creates cycles (e.g. `perl-parser-core -[dev]-> perl-tdd-support -[normal]-> perl-parser-core`); the correct fix uses Tarjan SCC to break only intra-SCC dev-dep edges while preserving inter-SCC ordering constraints

## Changes

- `.github/workflows/publish-crates.yml`: Replace the single-pass dependency graph builder with a two-phase approach: (1) build separate normal/dev edge sets, (2) run Tarjan SCC on the full graph, (3) include all normal edges plus only inter-SCC dev edges in the final topo sort input

## Evidence

- **Commits**: 1
- **Tests**: workflow file only — no Rust tests affected; ci-gate failed due to known Windows file-lock race (#3202) unrelated to this change
- **Lint**: N/A (YAML/Python, no cargo clippy scope)
- **Files**: 1 changed, +73/-5 lines

## Test Plan

- Ran the patched Python topo-sort script against current `cargo metadata --no-deps` output (140 workspace members, 128 in publish allowlist)
- Result: valid topological order for all 140 crates, zero cycles detected
- Spot-check: `perl-tdd-support` at position 64, `perl-corpus` at position 65 — ordering is correct
- Intra-SCC dev edge (`perl-parser-core -[dev]-> perl-tdd-support`) correctly dropped; inter-SCC dev edge (`perl-corpus -[dev]-> perl-tdd-support`) correctly preserved

## Unknowns

- The workspace currently has several multi-member SCCs (perl-lsp-code-actions/perl-lsp-diagnostics/perl-parser, perl-module-token/perl-module-boundary/perl-module-import, etc.) where normal-edge cycles coexist with dev edges — these are pre-existing workspace structural issues, not introduced by this fix; the SCC approach handles them correctly
- The SCC algorithm uses recursion; `setrecursionlimit` is set to `max(10000, len(nodes)*2)` which should be sufficient for any realistic workspace size

Closes #3236
