### PR TITLE
fix(xtask): isolate hook-tests temp repo from inherited hooksPath and prevent workspace scribble (closes #3203)

### DIFF
--- a/xtask/src/tasks/hook_checks.rs
+++ b/xtask/src/tasks/hook_checks.rs
@@ -351,6 +351,9 @@ fn create_non_rust_test_repo(
     temp_root: &Path,
     isolated_hooks_dir: &Path,
 ) -> Result<()> {
+    // SAFETY (issue #3203): assert the repo directory path lives inside the temp
+    // root before creating it. See assert_path_inside_temp_root for full rationale.
+    assert_path_inside_temp_root(path, temp_root, "create_non_rust_test_repo dir")?;
     fs::create_dir_all(path)
         .with_context(|| format!("Failed to create temp repo {}", path.display()))?;
 


### PR DESCRIPTION
## Summary

`just hook-tests` is supposed to test git hooks in an isolated temp git repo, but every git invocation inherited `core.hooksPath` from the parent environment. On a normal dev machine that points at the parent repo's `.git/hooks`, so the parent repo's pre-commit hook fired inside the temp repo during `git commit`. The placeholder identity check rejected the seed commit, the scaffold bailed mid-flight, and during one observed run (Agent B's `perl-parser-bench` extraction wave) the temp-repo `README.md` write actually landed on the **real workspace `README.md`**. The agent caught and restored the file before pushing, but **anyone running `just hook-tests` could silently lose work** — this is a data-loss bug, not just a test isolation bug.

This PR is the two-part fix from issue #3203.

### Part 1 — Isolate the temp repo from inherited `core.hooksPath`

`run_hook_tests` now pre-creates an `empty-hooks/` directory inside the temp root and threads it through every git invocation via a new `run_git(repo, isolated_hooks_dir, args)` wrapper. The wrapper prepends `-c core.hooksPath=<isolated dir>` to every `git` call so the explicit override beats anything inherited from the environment, including hostile values set via `GIT_CONFIG_*` env vars. The parent repo's hooks can no longer fire inside the temp repo regardless of how they were inherited.

### Part 2 — Path-overlap guard at every filesystem write

`create_non_rust_test_repo` is the only place the scaffold writes a file in the temp repo today (`README.md`). It now goes through a new `assert_path_inside_temp_root` guard that canonicalizes both paths and bails loudly if a write would land outside the temp root. This both fixes the data-loss bug **and** prevents any future regression at the call site. If the scaffold ever grows a new write, the same guard should be applied.

### Regression coverage

Four new unit tests in `xtask/src/tasks/hook_checks.rs::tests`:

- `assert_path_inside_temp_root_accepts_child_path` — happy path.
- `assert_path_inside_temp_root_rejects_workspace_readme` — proves the guard refuses to scribble on a fake workspace `README.md`. Verifies the message AND that the fake workspace file is unchanged.
- `create_non_rust_test_repo_writes_only_inside_temp_root` — snapshots the **real workspace** top-level entries (with content hashes for files) before and after running `create_non_rust_test_repo` and asserts byte-for-byte equality. Also explicitly checks the workspace `README.md` was not overwritten with the placeholder content.
- `run_git_overrides_inherited_hooks_path` — plants a hostile pre-commit hook in a separate dir and exports `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0=core.hooksPath=<hostile>` env vars to simulate inheritance. Then runs the same `-c core.hooksPath=<isolated>` override the wrapper uses and verifies a real `git commit` succeeds with the hostile hook never firing (sentinel file untouched). This is the direct regression test for the inherited `core.hooksPath` leak.

Plus a snapshot integration check inside the create test that hashes every immediate child of the project root (skipping `target/`) before and after the operation and asserts exact equality.

## Test plan

- [x] `cargo check -p xtask` — clean
- [x] `cargo clippy -p xtask --tests` — clean
- [x] `cargo fmt -p xtask -- --check` — clean
- [x] `cargo test -p xtask --bin xtask hook_checks` — 4/4 new unit tests pass
- [x] `cargo xtask hook-tests` — all 13 hook tests pass with the new isolation in place
- [x] Stress test: ran `cargo xtask hook-tests` 4× back-to-back from a clean worktree; `git status` showed only the one expected file modified across all runs, no scribble on any other workspace file
- [x] Manual verification that `core.hooksPath` is overridden — the hostile-hook unit test exercises the GIT_CONFIG_* inheritance path

### Pre-push gate note

`--no-verify` was used to push because `crates/perl-lsp/tests/lsp_bdd_workflows.rs::bdd_formatting_workflow_returns_structured_edits` fails on this Windows machine for an environmental reason — `perltidy` is not installed and the test asserts the LSP error message contains the literal string `"perltidy"`, which it doesn't in this env. This failure is in a completely different crate from the change in this PR (`crates/perl-lsp/` vs `xtask/`), is pre-existing on master, and matches the project's documented bypass policy at the top of `.git/hooks/pre-push`: *"The hook is failing for an environmental reason that is out of band of your change."* Filing follow-up: this BDD test should either gate on `perltidy` availability or assert a more environment-agnostic error shape.

Closes #3203.