### PR TITLE
chore: burn down unwrap/expect in tests (Wave 3: 5 crates, 9 eliminations) (#3229)

### DIFF
--- a/crates/perl-ast-utils/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-ast-utils/tests/comprehensive_unit_tests.rs
@@ -332,12 +332,13 @@ fn get_indent_at_last_character() {
 // ============================================================================
 
 #[test]
-fn find_node_at_range_single_node_exact_match() {
+fn find_node_at_range_single_node_exact_match() -> Result<(), String> {
     let node = create_test_node(NodeKind::Number { value: "42".to_string() }, 0, 2);
     let result = find_node_at_range(&node, (0, 2));
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().location.start, 0);
-    assert_eq!(result.unwrap().location.end, 2);
+    let found = result.ok_or("expected Some node")?;
+    assert_eq!(found.location.start, 0);
+    assert_eq!(found.location.end, 2);
+    Ok(())
 }
 
 #[test]

--- a/crates/perl-dap-breakpoint/tests/extended_unit_tests.rs
+++ b/crates/perl-dap-breakpoint/tests/extended_unit_tests.rs
@@ -8,7 +8,7 @@ use perl_dap_breakpoint::{
     AstBreakpointValidator, BreakpointError, BreakpointValidation, BreakpointValidator,
     SearchDirection, ValidationReason, find_nearest_valid_line,
 };
-use perl_tdd_support::must;
+use perl_tdd_support::{must, must_some};
 
 // ---------------------------------------------------------------------------
 // Extended ValidationReason tests
@@ -647,7 +647,7 @@ fn integration_validate_then_suggest() -> Result<(), Box<dyn std::error::Error>>
     assert_eq!(nearest, Some(3));
 
     // Validate the suggested line
-    let suggested_result = v.validate(nearest.unwrap());
+    let suggested_result = v.validate(must_some(nearest));
     assert!(suggested_result.verified);
     Ok(())
 }
@@ -674,7 +674,7 @@ fn integration_find_nearest_both_then_validate() -> Result<(), Box<dyn std::erro
     let nearest = find_nearest_valid_line(&v, 2, SearchDirection::Both, None);
     assert!(nearest.is_some());
 
-    let line = nearest.unwrap();
+    let line = must_some(nearest);
     let result = v.validate(line);
     assert!(result.verified);
     Ok(())

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -760,8 +760,8 @@ fn dead_branch_has_suggestion() -> Result<(), String> {
 
     let results = detector.analyze_file(&PathBuf::from("/test_dead_suggestion.pl"))?;
     let branch = results.iter().find(|d| d.code_type == DeadCodeType::DeadBranch);
-    assert!(branch.is_some());
-    assert!(branch.unwrap().suggestion.is_some(), "DeadBranch should have a suggestion");
+    let branch = branch.ok_or("expected DeadBranch entry")?;
+    assert!(branch.suggestion.is_some(), "DeadBranch should have a suggestion");
     Ok(())
 }
 

--- a/crates/perl-lsp-code-lens/src/lib.rs
+++ b/crates/perl-lsp-code-lens/src/lib.rs
@@ -332,6 +332,7 @@ pub fn get_shebang_lens(source: &str) -> Option<CodeLens> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_tdd_support::must_some;
 
     fn extract_lenses(source: &str) -> Result<Vec<CodeLens>, String> {
         let mut parser = perl_parser::Parser::new(source);
@@ -531,7 +532,7 @@ mod tests {
         let lenses =
             CodeLensProvider::extract_subtest_lenses("subtest 'quoted name' => sub { };\n");
         assert_eq!(lenses.len(), 1);
-        let cmd = lenses[0].command.as_ref().unwrap();
+        let cmd = must_some(lenses[0].command.as_ref());
         assert_eq!(cmd.title, "\u{25b6} Run Subtest: quoted name");
     }
 

--- a/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
+++ b/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
@@ -218,7 +218,7 @@ fn test_class_produces_symbol_decl() {
 // ── Container tracking ────────────────────────────────────────────────────────
 
 #[test]
-fn test_subroutine_inside_package_has_container() {
+fn test_subroutine_inside_package_has_container() -> Result<(), String> {
     // package Foo; sub bar { }
     let body = Node::new(NodeKind::Block { statements: vec![] }, loc(18, 21));
     let sub_node = Node::new(
@@ -242,19 +242,24 @@ fn test_subroutine_inside_package_has_container() {
 
     assert_eq!(decls.len(), 2);
     // Package decl has no container
-    let pkg_decl = decls.iter().find(|d| d.kind == SymbolKind::Package).unwrap();
+    let pkg_decl =
+        decls.iter().find(|d| d.kind == SymbolKind::Package).ok_or("expected Package decl")?;
     assert!(pkg_decl.container.is_none());
 
     // Sub decl uses current package context
-    let sub_decl = decls.iter().find(|d| d.kind == SymbolKind::Subroutine).unwrap();
+    let sub_decl = decls
+        .iter()
+        .find(|d| d.kind == SymbolKind::Subroutine)
+        .ok_or("expected Subroutine decl")?;
     assert_eq!(sub_decl.container.as_deref(), Some("Foo"));
     assert_eq!(sub_decl.qualified_name, "Foo::bar");
+    Ok(())
 }
 
 // ── Nested block walking ──────────────────────────────────────────────────────
 
 #[test]
-fn test_subroutine_inside_package_block() {
+fn test_subroutine_inside_package_block() -> Result<(), String> {
     // package Foo { sub baz { } }
     let inner_body = Node::new(NodeKind::Block { statements: vec![] }, loc(20, 23));
     let inner_sub = Node::new(
@@ -283,10 +288,14 @@ fn test_subroutine_inside_package_block() {
 
     // Should include both the Package decl and the Subroutine inside
     assert_eq!(decls.len(), 2);
-    let sub_decl = decls.iter().find(|d| d.kind == SymbolKind::Subroutine).unwrap();
+    let sub_decl = decls
+        .iter()
+        .find(|d| d.kind == SymbolKind::Subroutine)
+        .ok_or("expected Subroutine decl")?;
     assert_eq!(sub_decl.name, "baz");
     assert_eq!(sub_decl.container.as_deref(), Some("Foo"));
     assert_eq!(sub_decl.qualified_name, "Foo::baz");
+    Ok(())
 }
 
 // ── SymbolDecl structural properties ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Eliminates all 9 remaining `.unwrap()`/`.expect()` occurrences in test code across 5 crates, completing the Wave 3 burn-down for issue #3229
- Where `perl-tdd-support` was already a dev-dep (perl-dap-breakpoint, perl-lsp-code-lens), uses `must_some` for consistency with the crate's existing pattern
- Where no tdd-support dep existed (perl-symbol-surface, perl-ast-utils, perl-dead-code), converts to `Result<(), String>` + `.ok_or("msg")?`

## Changes

| Crate | File | Eliminations | Strategy |
|-------|------|------|---------|
| perl-dap-breakpoint | tests/extended_unit_tests.rs | 2 | `must_some` (dep already present) |
| perl-lsp-code-lens | src/lib.rs (test module) | 1 | `must_some` (dep already present) |
| perl-symbol-surface | tests/symbol_decl_tests.rs | 3 | `Result<(), String>` + `.ok_or()?` |
| perl-ast-utils | tests/comprehensive_unit_tests.rs | 2 | `Result<(), String>` + `.ok_or()?` (also eliminates double-unwrap on same variable) |
| perl-dead-code | tests/comprehensive_unit_tests.rs | 1 | `Result<(), String>` + `.ok_or()?` (function already returned `Result`) |

## Evidence

- **Commits**: 1
- **Tests**: perl-dap-breakpoint: 205 passed; perl-lsp-code-lens: 49 passed; perl-symbol-surface: 11 passed; perl-ast-utils: 66 passed
- **Lint**: clippy clean on all 5 crates with `--tests`
- **Files**: 5 changed, +26/-15 lines
- **perl-dead-code note**: 23 pre-existing test failures exist in that crate ("file not indexed" errors unrelated to these changes — they failed before this PR too)

## Test Plan

- [ ] `cargo test -p perl-dap-breakpoint` — 205 pass
- [ ] `cargo test -p perl-lsp-code-lens` — 49 pass
- [ ] `cargo test -p perl-symbol-surface` — 11 pass
- [ ] `cargo test -p perl-ast-utils` — 66 pass
- [ ] `cargo clippy -p perl-dap-breakpoint -p perl-lsp-code-lens -p perl-dead-code -p perl-symbol-surface -p perl-ast-utils --tests` — no issues

## Closes #3229

Wave 1 (PR #3243, merged) + Wave 2 (PR #3248, in review) + Wave 3 (this PR) = full coverage. Issue #3229 should be closed once all three waves merge.

## Intentional patterns NOT changed

- `ParserContext::expect()` calls — these are method names on a parser type, not `Option::expect`
- `must(...)` calls in test bodies — these are the correct `perl-tdd-support` helper, not `.unwrap()`

## Unknowns

- The perl-dead-code pre-existing failures ("file not indexed") are unrelated to this PR but the crate's test suite was already broken — the eliminated unwrap was never reachable due to the earlier error