### PR TITLE
chore(perl-ci-hygiene): fix or remove broken cmd_benchmark_* references

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -74,10 +74,6 @@ enum CliCommand {
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Benchmark pure-Rust and C parser implementations (multi-file, timed runs).
-    BenchmarkPureRustVsC,
-    /// Run simple benchmark comparison between pure-Rust and C parser implementations.
-    BenchmarkRustVsCSimple,
     /// Compare modern, C legacy, and parser outputs across sample snippets.
     RunComparison,
     /// Run quick parser benchmarks across preselected fixture files.
@@ -219,8 +215,6 @@ fn run() -> Result<i32> {
         CliCommand::TestIterativeParser => cmd_test_iterative_parser(&repo_root)?,
         CliCommand::CheckV2BundleSync => cmd_check_v2_bundle_sync(&repo_root)?,
         CliCommand::CompareBenchmarks { args } => cmd_compare_benchmarks(&repo_root, &args)?,
-        CliCommand::BenchmarkPureRustVsC => cmd_benchmark_pure_rust_vs_c(&repo_root)?,
-        CliCommand::BenchmarkRustVsCSimple => cmd_benchmark_rust_vs_c_simple(&repo_root)?,
         CliCommand::RunComparison => cmd_run_comparison(&repo_root)?,
         CliCommand::QuickBench => cmd_quick_bench(&repo_root)?,
         CliCommand::SimpleBench => cmd_simple_bench(&repo_root)?,
@@ -745,168 +739,6 @@ fn cmd_check_v2_bundle_sync(repo_root: &Path) -> Result<i32> {
     Ok(0)
 }
 
-fn cmd_benchmark_pure_rust_vs_c(repo_root: &Path) -> Result<i32> {
-    println!("=== Pure Rust (Pest) vs C Parser Benchmark ===");
-    println!("Building both implementations...");
-
-    let rust_parser =
-        repo_root.join("archive/crates/tree-sitter-perl-rs/target/release/parse-rust");
-    let c_parser = repo_root.join("crates/tree-sitter-perl-c/target/release/parse_c");
-
-    command_status_strict(
-        repo_root,
-        "cargo",
-        &["build", "--release", "-p", "tree-sitter-perl-rs", "--bin", "parse-rust"],
-        &[],
-    )?;
-    command_status_strict(
-        repo_root,
-        "cargo",
-        &["build", "--release", "-p", "tree-sitter-perl-c", "--bin", "parse_c"],
-        &[],
-    )?;
-
-    let workspace =
-        repo_root.join("target").join("perl-ci-hygiene").join("benchmark_pure_rust_vs_c");
-    fs::create_dir_all(&workspace).with_context(|| format!("creating {}", workspace.display()))?;
-
-    let test_simple = workspace.join("test_simple.pl");
-    let test_medium = workspace.join("test_medium.pl");
-    fs::write(&test_simple, "print \"Hello, World!\\n\";\n")?;
-    fs::write(
-        &test_medium,
-        r#"#!/usr/bin/env perl
-use strict;
-use warnings;
-
-my $scalar = "test";
-my @array = (1, 2, 3, 4, 5);
-my %hash = (a => 1, b => 2);
-
-my $ref = \$scalar;
-my $aref = \@array;
-my $href = \%hash;
-
-my $octal = 0o755;
-print "..." if $scalar;
-
-my $π = 3.14159;
-my $café = "coffee";
-
-sub process {
-    my ($x, $y) = @_;
-    return $x + $y;
-}
-
-for my $i (1..10) {
-    print "$i\\n" if $i % 2 == 0;
-}
-"#,
-    )?;
-
-    println!();
-    println!("Running benchmarks...");
-    println!("File,Pure_Rust_Time(ms),C_Time(ms),Rust/C_Ratio");
-
-    let files = vec![
-        ("test_simple.pl", test_simple),
-        ("test_medium.pl", test_medium),
-        ("examples/hello.pl", repo_root.join("examples/hello.pl")),
-    ];
-    for (name, file) in files {
-        if !file.is_file() {
-            continue;
-        }
-        let rust_ms = benchmark_average_ms(repo_root, &rust_parser, &file, 10)?;
-        let c_ms = benchmark_average_ms(repo_root, &c_parser, &file, 10)?;
-        let ratio = if c_ms > 0.0 { rust_ms / c_ms } else { f64::INFINITY };
-        println!("{},{rust_ms:.3},{c_ms:.3},{ratio:.2}", name);
-    }
-
-    Ok(0)
-}
-
-fn cmd_benchmark_rust_vs_c_simple(repo_root: &Path) -> Result<i32> {
-    println!("=== Pure Rust (Pest) vs C Parser Benchmark ===");
-    println!();
-
-    let rust_parser =
-        repo_root.join("archive/crates/tree-sitter-perl-rs/target/release/parse-rust");
-    let c_parser = repo_root.join("crates/tree-sitter-perl-c/target/release/parse_c");
-    let workspace =
-        repo_root.join("target").join("perl-ci-hygiene").join("benchmark_rust_vs_c_simple");
-    fs::create_dir_all(&workspace)?;
-
-    command_status_strict(
-        repo_root,
-        "cargo",
-        &["build", "--release", "-p", "tree-sitter-perl-rs", "--bin", "parse-rust"],
-        &[],
-    )?;
-    command_status_strict(
-        repo_root,
-        "cargo",
-        &["build", "--release", "-p", "tree-sitter-perl-c", "--bin", "parse_c"],
-        &[],
-    )?;
-
-    let benchmark_file = workspace.join("test_benchmark.pl");
-    fs::write(
-        &benchmark_file,
-        r#"#!/usr/bin/env perl
-use strict;
-use warnings;
-
-my $scalar = "Hello, World!";
-my @array = (1..10);
-my %hash = map { $_ => $_ * 2 } 1..5;
-
-my $sref = \$scalar;
-my $aref = \@array;
-my $href = \%hash;
-
-my $perms = 0o755;
-my $old_perms = 0755;
-
-sub todo {
-    ...
-}
-
-my $π = 3.14159;
-my $café = "coffee shop";
-sub 日本語 { return "Japanese" }
-
-for my $i (@array) {
-    print "$i\\n" if $i % 2 == 0;
-}
-
-my $text = "foo bar baz";
-$text =~ s/foo/FOO/g;
-
-1;
-"#,
-    )?;
-
-    println!("Running 5 iterations each...");
-    println!();
-    println!("Pure Rust (Pest) Parser:");
-    for i in 1..=5 {
-        let time_ms = timed_file_run_ms(repo_root, &rust_parser, &benchmark_file)?;
-        println!("  Run {i}: {:.3}s", time_ms / 1000.0);
-    }
-
-    println!();
-    println!("C Parser:");
-    for i in 1..=5 {
-        let time_ms = timed_file_run_ms(repo_root, &c_parser, &benchmark_file)?;
-        println!("  Run {i}: {:.3}s", time_ms / 1000.0);
-    }
-
-    println!();
-    println!("Note: Times include process startup overhead");
-    Ok(0)
-}
-
 fn cmd_run_comparison(repo_root: &Path) -> Result<i32> {
     println!("=== Three-Way Parser Comparison ===");
     println!("Comparing: Pure Rust vs Legacy C vs Modern Parser");
@@ -1274,20 +1106,6 @@ fn timed_file_run_ms(repo_root: &Path, parser: &Path, file: &Path) -> Result<f64
             file.display()
         ))
     }
-}
-
-fn benchmark_average_ms(
-    repo_root: &Path,
-    parser: &Path,
-    file: &Path,
-    iterations: usize,
-) -> Result<f64> {
-    let mut total_ms = 0.0;
-    for _ in 0..iterations {
-        let elapsed_ms = timed_file_run_ms(repo_root, parser, file)?;
-        total_ms += elapsed_ms;
-    }
-    Ok(total_ms / iterations as f64)
 }
 
 fn cmd_cargo_package_workspace_dry_run(repo_root: &Path, crates: &[String]) -> Result<i32> {


### PR DESCRIPTION
## Summary

- `cmd_benchmark_pure_rust_vs_c` and `cmd_benchmark_rust_vs_c_simple` both called `cargo build -p tree-sitter-perl-rs`, which fails at runtime because `crates/tree-sitter-perl-rs/` was moved to `archive/` by PR #3244 (merged) and removed from workspace members
- Chose **Option B (delete)**: the archived Pest-based parser (`tree-sitter-perl-rs`) is dead code; benchmarking it against the C parser is no longer meaningful
- Also removed the `benchmark_average_ms` helper that was exclusively called by these two functions (now dead code)

## Changes

| Item | Decision | Reason |
|------|----------|--------|
| `BenchmarkPureRustVsC` enum variant + `cmd_benchmark_pure_rust_vs_c` | Deleted | Called `-p tree-sitter-perl-rs`, no longer a workspace member |
| `BenchmarkRustVsCSimple` enum variant + `cmd_benchmark_rust_vs_c_simple` | Deleted | Same — called `-p tree-sitter-perl-rs` |
| `benchmark_average_ms` helper | Deleted | Only called by the two removed functions, now orphaned |

**Considered alternatives:**
- Option A (update to `--manifest-path archive/...`): Rejected — building and benching an archived dead crate has no practical value
- Option C (switch to new `crates/tree-sitter-perl-rs` via PR #3255): Not yet merged; if that lands and a Rust-vs-C benchmark is wanted, it can be re-added then

## Evidence

- **Commits**: 1
- **Tests**: 18 passed, 0 failed (`cargo test -p perl-ci-hygiene`)
- **Lint**: Clean (`cargo clippy -p perl-ci-hygiene`)
- **Files**: 1 changed, +0/-182 lines

## Test Plan

- `cargo check -p perl-ci-hygiene` — confirms clean compile
- `cargo test -p perl-ci-hygiene` — 18/18 pass
- `cargo clippy -p perl-ci-hygiene` — no warnings

## Unknowns

- If PR #3255 (`crates/tree-sitter-perl-rs` new version) lands, a new benchmark command could be added pointing at the new crate. That's out of scope here and can be done as a follow-up.
- The remaining `cmd_run_comparison`, `cmd_quick_bench`, and `cmd_simple_bench` commands do not reference `tree-sitter-perl-rs` and were left untouched.