### PR TITLE
fix(ci): make vsce publish idempotent on re-run (#3187)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -81,6 +81,14 @@ jobs:
         if: ${{ env.VSCE_PAT != '' }}
         working-directory: vscode-extension
         run: |
+          # Idempotency guard: skip if this version is already on the marketplace.
+          PUBLISHED_VERSION=$(vsce show EffortlessMetrics.perl-lsp-rs --json 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['versions'][0]['version'])" \
+            2>/dev/null || echo "")
+          if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
+            echo "::warning::VSCode Marketplace already has version $VERSION — skipping publish."
+            exit 0
+          fi
           vsce publish --pat "$VSCE_PAT" --packagePath "${{ env.VSIX_FILE }}"
 
       - name: Verify Open VSX CLI
@@ -92,7 +100,8 @@ jobs:
         if: ${{ env.OVSX_PAT != '' }}
         working-directory: vscode-extension
         run: |
-          ovsx publish "${{ env.OPENVSX_VSIX_FILE }}" --pat "$OVSX_PAT"
+          # --skip-duplicate exits 0 with a notice if the version already exists (idempotent).
+          ovsx publish "${{ env.OPENVSX_VSIX_FILE }}" --pat "$OVSX_PAT" --skip-duplicate
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- The `Publish VSCode Extension` workflow failed noisily when re-run after a version was already on the marketplace (exit 1 with `already exists`), creating false-alarm red builds during release recovery.
- Added an idempotency guard to the **VSCode Marketplace** publish step: `vsce show EffortlessMetrics.perl-lsp-rs --json` fetches the current published version; if it matches `$VERSION`, the step emits a `::warning::` annotation and exits 0.
- Added `--skip-duplicate` to the **Open VSX** publish step — `ovsx` supports this flag natively and exits 0 with a notice when the version already exists.

## Failure mode

```
##[error]EffortlessMetrics.perl-lsp-rs v0.12.2 already exists.
##[error]Process completed with exit code 1.
```

This occurred during v0.12.2 release recovery and caused repeated misreads of "extension never published" when it had published successfully at 2026-04-04 22:34Z.

## Fix

`.github/workflows/publish-extension.yml`:

1. **VSCode Marketplace** — pre-check via `vsce show --json`, skip with `::warning::` if version matches.
2. **Open VSX** — pass `--skip-duplicate`; ovsx handles the rest.

Both publish steps now finish green on re-run for an already-published version.

## Test plan

- [ ] Trigger workflow for a version that is already on the VSCode Marketplace — expect green with warning annotation, no publish attempt.
- [ ] Trigger workflow for a new version — expect normal publish to proceed.
- [ ] Verify YAML is syntactically valid (done: `python3 -c "import yaml; yaml.safe_load(...)"` passes).

Closes #3187