### PR TITLE
chore(devex): drop #3203 workaround from pre-push hook (post-#3246)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -2019,12 +2019,6 @@ if [ "$GATE_STATUS" -ne 0 ]; then
         echo "     your change is unrelated to xtask/parser-features."
         HINTED=true
     fi
-    if grep -q 'hook-tests' "$GATE_LOG" 2>/dev/null; then
-        echo "   • Known: hook-tests can scribble on real workspace files (#3203)"
-        echo "     Workaround: re-run, or skip with --no-verify if your change"
-        echo "     is unrelated to crates/perl-ci-hygiene."
-        HINTED=true
-    fi
     if grep -qE 'cargo (xtask )?fmt.*--check' "$GATE_LOG" 2>/dev/null && \
        grep -qE 'Diff in|rustfmt' "$GATE_LOG" 2>/dev/null; then
         echo "   • Formatting drift — run \`cargo xtask fmt\` (or \`cargo fmt --all\`) to auto-fix"
@@ -4230,10 +4224,6 @@ mod tests {
         // When the gate fails, the hook should hint at known issues so
         // contributors can recognize them instead of bypassing in confusion.
         assert!(hook.contains("#3202"), "hook must mention issue #3202 (Windows file-lock race)");
-        assert!(
-            hook.contains("#3203"),
-            "hook must mention issue #3203 (hook-tests isolation leak)"
-        );
         assert!(
             hook.contains("cargo xtask fmt") || hook.contains("cargo fmt"),
             "hook must suggest the fmt fix command on fmt failures"


### PR DESCRIPTION
## Summary

- PR #3246 fixed the root cause of the hook-tests scribble bug (#3203): `xtask` tests now use an isolated temp repo and cannot scribble on real workspace files
- The failure-mode hint added in PR #3238 (smart pre-push hook) is now obsolete — contributors no longer need the `--no-verify` workaround for that pattern
- Removes the `hook-tests`/`#3203` matcher from the gate failure hint scanner and drops the corresponding test assertion

## Changes

- `crates/perl-ci-hygiene/src/main.rs` — remove 6-line `hook-tests` hint block from `pre_push_hook_script()` and remove 4-line `#3203` assertion from `pre_push_hook_explains_known_failure_modes` test

## Evidence

- **Commits**: 1
- **Tests**: 18 passed, 0 failed (`cargo test -p perl-ci-hygiene`)
- **Lint**: fmt clean (no diff)
- **Files**: 1 changed, -10 lines

## Test Plan

- `cargo test -p perl-ci-hygiene` — all 18 tests pass including `pre_push_hook_explains_known_failure_modes` which now only asserts `#3202`
- `cargo run -p perl-ci-hygiene -- install-githooks` then inspect `.git/hooks/pre-push` — no mention of `#3203`

## Unknowns

- `#3202` (Windows file-lock race in `ci-parser-features-check`) is intentionally preserved — that bug is tracked separately and still active