### PR TITLE
feat(bench): three-way parser comparison — v3, ts-rs, ts-c (#3255)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -810,7 +810,16 @@ fn cmd_run_comparison(repo_root: &Path) -> Result<i32> {
 }
 
 fn cmd_quick_bench(repo_root: &Path) -> Result<i32> {
-    println!("=== Quick Parser Comparison ===");
+    println!("=== Three-Way Parser Comparison ===");
+    println!();
+    println!("Parsers:");
+    println!("  native-v3  : perl-parser-bench  (v3 recursive-descent, raw parser API)");
+    println!(
+        "  facade     : bench_facade        (tree-sitter-perl-rs, v3 wrapped in tree-sitter ergonomics)"
+    );
+    println!(
+        "  c-grammar  : bench_parser_c      (tree-sitter C grammar binding, requires libclang)"
+    );
     println!();
 
     let files = vec![
@@ -829,38 +838,103 @@ fn cmd_quick_bench(repo_root: &Path) -> Result<i32> {
         .collect();
     candidates.sort_by(|a, b| a.0.cmp(&b.0));
 
-    println!("File,Size,C_Time(µs),Rust_Time(µs),Speedup");
-    println!("----,----,----------,------------- ,-------");
+    // Collect results once to avoid running each parser twice per file.
+    struct Row {
+        name: String,
+        size: u64,
+        rust_time: Option<f64>,
+        facade_time: Option<f64>,
+        c_time: Option<f64>,
+    }
 
-    for (name, path) in candidates {
-        let size = fs::metadata(&path).map(|metadata| metadata.len()).unwrap_or(0);
+    let mut rows: Vec<Row> = Vec::new();
+    for (name, path) in &candidates {
+        let size = fs::metadata(path).map(|metadata| metadata.len()).unwrap_or(0);
+        let rust_time = run_rust_bench_us(repo_root, path)?;
+        let facade_time = run_facade_bench_us(repo_root, path)?;
+        let c_time = run_c_bench_us(repo_root, path)?;
+        rows.push(Row { name: name.clone(), size, rust_time, facade_time, c_time });
+    }
 
-        let c_time = run_c_bench_us(repo_root, &path)?;
-        let rust_time = run_rust_bench_us(repo_root, &path)?;
+    // --- Table 1: raw timings ---
+    let col_file = 30usize;
+    let col_num = 12usize;
+    println!(
+        "{:<col_file$} {:>8}  {:>col_num$}  {:>col_num$}  {:>col_num$}  fastest",
+        "File", "Size", "native-v3(µs)", "facade(µs)", "c-gram(µs)"
+    );
+    println!(
+        "{:<col_file$} {:>8}  {:>col_num$}  {:>col_num$}  {:>col_num$}  -------",
+        "----", "----", "-------------", "----------", "----------"
+    );
 
-        let speedup = if let (Some(c_val), Some(rust_val)) = (c_time, rust_time) {
-            if rust_val > 0.0 { Some(c_val / rust_val) } else { None }
-        } else {
-            None
+    for row in &rows {
+        let times: [(&str, Option<f64>); 3] =
+            [("native-v3", row.rust_time), ("facade", row.facade_time), ("c-grammar", row.c_time)];
+        let fastest_label = times
+            .iter()
+            .filter_map(|(label, t)| t.map(|v| (label, v)))
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(label, _)| *label)
+            .unwrap_or("N/A");
+
+        let fmt = |v: Option<f64>| -> String {
+            v.map(|us| format!("{us:.0}")).unwrap_or_else(|| "N/A".to_string())
         };
 
-        let speedup_text = if let Some(speedup) = speedup {
-            if speedup > 1.0 {
-                format!("{speedup:.2}x (Rust faster)")
-            } else {
-                format!("{:.2}x (C faster)", 1.0 / speedup.max(0.000_000_1))
+        println!(
+            "{:<col_file$} {:>8}  {:>col_num$}  {:>col_num$}  {:>col_num$}  {}",
+            row.name,
+            row.size,
+            fmt(row.rust_time),
+            fmt(row.facade_time),
+            fmt(row.c_time),
+            fastest_label,
+        );
+    }
+
+    println!();
+
+    // --- Table 2: relative-to-fastest ---
+    println!("=== Relative to fastest (per file) ===");
+    println!();
+    println!(
+        "{:<col_file$}  {:>col_num$}  {:>col_num$}  {:>col_num$}",
+        "File", "native-v3", "facade", "c-grammar"
+    );
+    println!(
+        "{:<col_file$}  {:>col_num$}  {:>col_num$}  {:>col_num$}",
+        "----", "---------", "------", "---------"
+    );
+
+    for row in &rows {
+        let available: Vec<f64> =
+            [row.rust_time, row.facade_time, row.c_time].iter().filter_map(|&t| t).collect();
+        let min = available.iter().cloned().fold(f64::INFINITY, f64::min);
+
+        let rel = |v: Option<f64>| -> String {
+            match v {
+                Some(us) if min > 0.0 => format!("{:.2}x", us / min),
+                Some(_) => "1.00x".to_string(),
+                None => "N/A".to_string(),
             }
-        } else {
-            "N/A".to_string()
         };
 
-        let c_ms = c_time.unwrap_or(0.0);
-        let rust_ms = rust_time.unwrap_or(0.0);
-        println!("{:<30} {:>8} {:>12.0} {:>12.0} {}", name, size, c_ms, rust_ms, speedup_text);
+        println!(
+            "{:<col_file$}  {:>col_num$}  {:>col_num$}  {:>col_num$}",
+            row.name,
+            rel(row.rust_time),
+            rel(row.facade_time),
+            rel(row.c_time),
+        );
     }
 
     println!();
     println!("Quick benchmark complete!");
+    println!("Note: c-grammar requires libclang; N/A means libclang was not found.");
+    println!(
+        "Note: facade overhead vs native-v3 should be near epsilon (facade wraps same v3 parser)."
+    );
     Ok(0)
 }
 
@@ -1040,6 +1114,18 @@ const C_BENCH_BIN: &str = "bench_parser_c";
 /// binary name and the crate location remain distinct from the Rust bench path.
 const C_BENCH_MANIFEST: &str = "crates/tree-sitter-perl-c/Cargo.toml";
 
+/// Crate identifier for the `tree-sitter-perl-rs` facade benchmark.
+///
+/// Lives in the normal workspace (no excluded crate dance), so it is
+/// invoked with `-p FACADE_BENCH_CRATE --bin FACADE_BENCH_BIN`.
+const FACADE_BENCH_CRATE: &str = "tree-sitter-perl-rs";
+
+/// Binary identifier for the `tree-sitter-perl-rs` facade benchmark.
+///
+/// Used by [`cmd_quick_bench`] and asserted in the unit test
+/// `three_way_bench_all_binaries_distinct`.
+const FACADE_BENCH_BIN: &str = "bench_facade";
+
 /// Run the v3 native Rust parser bench binary against `file`.
 ///
 /// Returns wall-clock duration in microseconds, or `None` if the bench
@@ -1086,6 +1172,28 @@ fn run_c_bench_us(repo_root: &Path, file: &Path) -> Result<Option<f64>> {
         C_BENCH_BIN,
         "--features",
         "test-utils",
+        "--",
+        file_arg.as_str(),
+    ];
+    let (status, elapsed) = command_timed_status(repo_root, "cargo", &args, &[])?;
+    if status == 0 { Ok(Some(elapsed.as_micros() as f64)) } else { Ok(None) }
+}
+
+/// Run the `tree-sitter-perl-rs` facade bench binary against `file`.
+///
+/// The facade crate lives in the normal workspace so it is invoked with
+/// `-p` rather than `--manifest-path`. Returns wall-clock duration in
+/// microseconds, or `None` if the bench binary exits non-zero.
+fn run_facade_bench_us(repo_root: &Path, file: &Path) -> Result<Option<f64>> {
+    let file_arg = file.to_string_lossy().into_owned();
+    let args = [
+        "run",
+        "--quiet",
+        "--release",
+        "-p",
+        FACADE_BENCH_CRATE,
+        "--bin",
+        FACADE_BENCH_BIN,
         "--",
         file_arg.as_str(),
     ];
@@ -3956,6 +4064,21 @@ mod tests {
         // the Rust bench uses a workspace package selector — they must diverge in
         // invocation style, not just binary name.
         assert!(!C_BENCH_MANIFEST.is_empty());
+    }
+
+    #[test]
+    fn three_way_bench_all_binaries_distinct() {
+        // Guard for the three-way comparison introduced after PR #3255
+        // (tree-sitter-perl-rs facade). All three parser binaries must be
+        // distinct so a future refactor can't silently collapse any pair.
+        assert_ne!(RUST_BENCH_BIN, C_BENCH_BIN, "raw Rust v3 and C binaries must differ");
+        assert_ne!(RUST_BENCH_BIN, FACADE_BENCH_BIN, "raw Rust v3 and facade binaries must differ");
+        assert_ne!(C_BENCH_BIN, FACADE_BENCH_BIN, "C and facade binaries must differ");
+        assert_eq!(FACADE_BENCH_BIN, "bench_facade");
+        assert_eq!(FACADE_BENCH_CRATE, "tree-sitter-perl-rs");
+        // Facade crate lives in the workspace, so it is invoked with -p, not
+        // --manifest-path.  Pin that it has no separate manifest string.
+        assert_ne!(FACADE_BENCH_CRATE, C_BENCH_MANIFEST);
     }
 
     #[test]

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -30,6 +30,10 @@ all-features = true
 name = "tree_sitter_perl_rs"
 doctest = true
 
+[[bin]]
+name = "bench_facade"
+path = "src/bin/bench_facade.rs"
+
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-ast = { workspace = true }

--- a/crates/tree-sitter-perl-rs/src/bin/bench_facade.rs
+++ b/crates/tree-sitter-perl-rs/src/bin/bench_facade.rs
@@ -1,0 +1,57 @@
+//! Benchmark binary for the `tree-sitter-perl-rs` facade.
+//!
+//! Measures wall-clock parse time through the tree-sitter-style ergonomic
+//! facade that wraps the v3 native Rust parser (`perl-parser-core`).
+//!
+//! # Output format
+//!
+//! ```text
+//! status=success error=false duration_us=N
+//! ```
+//!
+//! This matches the output format of `bench_parser_c` and `perl-parser-bench`
+//! so that `perl-ci-hygiene`'s `quick-bench` command can consume all three with
+//! the same parsing logic.
+//!
+//! # Usage
+//!
+//! ```text
+//! bench_facade <file>
+//! ```
+
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use tree_sitter_perl_rs::Parser;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: bench_facade <file>");
+        std::process::exit(1);
+    }
+    let file_path = &args[1];
+    let code = fs::read_to_string(file_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read file: {}", e);
+        std::process::exit(1);
+    });
+
+    let mut parser = Parser::new();
+    let start = Instant::now();
+    let result = parser.parse(&code);
+    let duration = start.elapsed().as_micros();
+
+    match result {
+        Some(_tree) => {
+            // The v3 parser is error-tolerant; a successful parse may still
+            // contain recovered error nodes. We report error=false here because
+            // the facade returned a tree (same convention as bench_parser_c).
+            println!("status=success error=false duration_us={}", duration);
+        }
+        None => {
+            println!("status=failure error=true duration_us={}", duration);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `bench_facade` binary to `crates/tree-sitter-perl-rs/src/bin/bench_facade.rs` — parses representative Perl files via `tree_sitter_perl_rs::Parser`, outputs `status=success error=false duration_us=N` matching the `bench_parser_c` format
- Extends `cmd_quick_bench` in `perl-ci-hygiene` to a **three-way comparison** (native v3, tree-sitter-rs facade, C grammar)
- Outputs two tables: raw timings (µs) and relative-to-fastest multipliers per file
- Adds regression test `three_way_bench_all_binaries_distinct` — pins all three binary identifiers so a future refactor cannot silently collapse any pair

## Comparison explained

| Parser | Binary | Crate | Use |
|--------|--------|-------|-----|
| native-v3 | `perl-parser-bench` | `perl-parser-bench` | Raw v3 API |
| facade | `bench_facade` | `tree-sitter-perl-rs` | v3 via tree-sitter ergonomics |
| c-grammar | `bench_parser_c` | `tree-sitter-perl-c` | C grammar / libclang |

**Expected results**: `facade` overhead vs `native-v3` should be near epsilon — both call the same `perl-parser-core` backend. The interesting comparison is `native-v3` + `facade` vs `c-grammar` (our full Rust stack vs C tree-sitter binding).

## How to invoke

```sh
cargo run -p perl-ci-hygiene -- quick-bench
```

c-grammar degrades gracefully to `N/A` on systems without libclang installed (no failure exit).

## Depends on

This PR depends on **#3255** (`tree-sitter-perl-rs` v3 facade crate) and **must merge after it**. The first commit in this branch is a merge of #3255's branch; once #3255 merges to master, this PR will have a clean diff showing only the benchmark additions.

## Test plan

- [x] `cargo test -p perl-ci-hygiene` — 19 tests pass (includes new `three_way_bench_all_binaries_distinct`)
- [x] `cargo test -p tree-sitter-perl-rs` — 23 tests pass
- [x] `cargo clippy -p tree-sitter-perl-rs -p perl-ci-hygiene --lib --bins` — no warnings
- [x] `cargo build -p tree-sitter-perl-rs --bin bench_facade --release` — compiles cleanly
- [ ] `cargo run -p perl-ci-hygiene -- quick-bench` — requires full environment with test corpus files present