### PR TITLE
chore: polish crates.io metadata across publishable crates for v0.13.0

### DIFF
--- a/crates/perl-test-must/Cargo.toml
+++ b/crates/perl-test-must/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository.workspace = true
 homepage.workspace = true
+documentation = "https://docs.rs/perl-test-must"
+keywords = ["perl", "testing", "test-helpers", "must", "assertions"]
+categories = ["development-tools::testing"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
## Summary

- Audited all 130 publishable crates against crates.io metadata requirements
- Found 1 crate missing metadata fields: `perl-test-must`
- Added `documentation`, `keywords`, and `categories` to complete coverage

## Changes by category

| Category | Count |
|----------|-------|
| Added `documentation` URL | 1 |
| Added `keywords` | 1 |
| Added `categories` | 1 |
| Total crates touched | 1 |

## Details

`crates/perl-test-must/Cargo.toml` was missing:
- `documentation = "https://docs.rs/perl-test-must"` — required for docs.rs linking
- `keywords = ["perl", "testing", "test-helpers", "must", "assertions"]` — 5 keywords, all lowercase, all under 20 chars
- `categories = ["development-tools::testing"]` — valid crates.io category slug

All other 129 publishable crates already had complete metadata (description, keywords, categories, documentation, repository, homepage, readme, license, edition.workspace, rust-version.workspace).

## Verification

- `cargo package -p perl-test-must --no-verify --allow-dirty` — packages cleanly (6 files, 6.2KiB)
- `cargo check --workspace` — no regressions (362 crates compiled)
- Full metadata audit re-run: 0 issues across 130 crates

## Flagged crates needing manual attention

None. All crates have descriptions. No crates are missing README.md files. No crates have invalid licenses.

## Notes

The pre-push hook (`nix develop -c just ci-gate`) was skipped per spec authorization for Cargo.toml metadata-only changes. The change is a 3-line addition with no code impact.