### PR TITLE
docs: refresh stale per-crate ROADMAP.md headers (#3212)

### DIFF
--- a/crates/perl-ast-utils/ROADMAP.md
+++ b/crates/perl-ast-utils/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared AST range-lookup, insertion-position, and indentation helpers for Perl LSP features.
 
-## Current Status (v0.12.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-ast/ROADMAP.md
+++ b/crates/perl-ast/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 AST node definitions for Perl parsing, providing typed representations of Perl syntax constructs
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-builtins/ROADMAP.md
+++ b/crates/perl-builtins/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Builtin symbol metadata for Perl parser and LSP tooling
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-content-length-framing/ROADMAP.md
+++ b/crates/perl-content-length-framing/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared Content-Length frame parsing and encoding for LSP and DAP transports
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-corpus/ROADMAP.md
+++ b/crates/perl-corpus/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Test corpus management and generators for Perl parsers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-dap-breakpoint/ROADMAP.md
+++ b/crates/perl-dap-breakpoint/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Breakpoint validation for Perl DAP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-dap-eval/ROADMAP.md
+++ b/crates/perl-dap-eval/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Safe expression evaluation validation for Perl DAP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-dap-stack/ROADMAP.md
+++ b/crates/perl-dap-stack/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Stack trace parsing and frame classification for the Perl Debug Adapter Protocol
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-dap-variables/ROADMAP.md
+++ b/crates/perl-dap-variables/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Variable rendering for Perl DAP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-dap/ROADMAP.md
+++ b/crates/perl-dap/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Debug Adapter Protocol server for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-diagnostics-codes/ROADMAP.md
+++ b/crates/perl-diagnostics-codes/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Stable diagnostic codes and severity levels for Perl LSP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-edit/ROADMAP.md
+++ b/crates/perl-edit/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Text edit representation and helpers for incremental Perl parsing
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-error/ROADMAP.md
+++ b/crates/perl-error/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Error types, classification, and recovery strategies for the Perl parser ecosystem
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-feature-catalog/ROADMAP.md
+++ b/crates/perl-feature-catalog/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared feature catalog model and code-generation helpers for capability-driven features.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-heredoc/ROADMAP.md
+++ b/crates/perl-heredoc/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Heredoc collector and processor for Perl — handles multi-line heredoc syntax including indentation stripping and CRLF normalization
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-incremental-parsing/ROADMAP.md
+++ b/crates/perl-incremental-parsing/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Incremental parsing support for Perl with subtree reuse and LSP integration
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-keywords/ROADMAP.md
+++ b/crates/perl-keywords/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Canonical Perl keyword inventories and classification helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lexer/ROADMAP.md
+++ b/crates/perl-lexer/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 High-performance Perl lexer with context-aware tokenization
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-cancellation/ROADMAP.md
+++ b/crates/perl-lsp-cancellation/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Enhanced LSP cancellation infrastructure with token/registry support
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-code-actions/ROADMAP.md
+++ b/crates/perl-lsp-code-actions/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP code actions provider for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-completion/ROADMAP.md
+++ b/crates/perl-lsp-completion/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Context-aware LSP completion engine for Perl — variables, functions, methods, packages, and file paths
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-diagnostics/ROADMAP.md
+++ b/crates/perl-lsp-diagnostics/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP diagnostics provider for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-contracts/ROADMAP.md
+++ b/crates/perl-lsp-feature-contracts/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared LSP feature contract model with SRP-friendly capability mapping helpers.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-flags/ROADMAP.md
+++ b/crates/perl-lsp-feature-flags/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared feature-flag and advertised-feature models for LSP capability negotiation.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-governance/ROADMAP.md
+++ b/crates/perl-lsp-feature-governance/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Feature profile governance façade for Perl LSP (parsing, policies, and grid interoperability).
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-grid/ROADMAP.md
+++ b/crates/perl-lsp-feature-grid/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 BDD-aware feature-grid payload and profile-aware advertized feature APIs for Perl LSP.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-ids/ROADMAP.md
+++ b/crates/perl-lsp-feature-ids/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Canonical feature identifiers for LSP/DAP capability interoperability.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-policy/ROADMAP.md
+++ b/crates/perl-lsp-feature-policy/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Policy and profile helpers for LSP capability selection.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-feature-profile/ROADMAP.md
+++ b/crates/perl-lsp-feature-profile/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Canonical feature profile contract and parsing for perl-lsp CLI/profile interoperability.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-formatting/ROADMAP.md
+++ b/crates/perl-lsp-formatting/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP formatting provider for Perl with perltidy integration
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-inlay-hints/ROADMAP.md
+++ b/crates/perl-lsp-inlay-hints/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP inlay hints provider for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-input-validation/ROADMAP.md
+++ b/crates/perl-lsp-input-validation/ROADMAP.md
@@ -5,6 +5,6 @@
 ## Purpose
 LSP request and file-input validation helpers.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Shared by `perl-lsp`.

--- a/crates/perl-lsp-launcher/ROADMAP.md
+++ b/crates/perl-lsp-launcher/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Typed CLI launch configuration for the Perl LSP runtime.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-navigation/ROADMAP.md
+++ b/crates/perl-lsp-navigation/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP navigation providers for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-protocol/ROADMAP.md
+++ b/crates/perl-lsp-protocol/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 JSON-RPC/LSP protocol types and capability configuration for perl-lsp
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-providers/ROADMAP.md
+++ b/crates/perl-lsp-providers/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP provider aggregation and tooling integrations for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-rename/ROADMAP.md
+++ b/crates/perl-lsp-rename/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP rename provider for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-semantic-tokens/ROADMAP.md
+++ b/crates/perl-lsp-semantic-tokens/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP semantic tokens provider for Perl — token classification and delta encoding
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-tooling/ROADMAP.md
+++ b/crates/perl-lsp-tooling/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Tooling integration for Perl LSP (perltidy, perlcritic, subprocess abstraction)
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp-transport/ROADMAP.md
+++ b/crates/perl-lsp-transport/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 LSP transport layer with Content-Length message framing for perl-lsp
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-lsp/ROADMAP.md
+++ b/crates/perl-lsp/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl Language Server (LSP) — Tree-sitter-compatible with comprehensive IDE features
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-boundary/ROADMAP.md
+++ b/crates/perl-module-boundary/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Standalone Perl module-token boundary matching for single-line scanners
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-import-match/ROADMAP.md
+++ b/crates/perl-module-import-match/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Import-line module match predicates for deterministic Perl module rename workflows
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-import/ROADMAP.md
+++ b/crates/perl-module-import/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Single-line Perl use/require import head parsing and classification
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-name/ROADMAP.md
+++ b/crates/perl-module-name/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl module-name separator normalization and canonical/legacy variant helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-path/ROADMAP.md
+++ b/crates/perl-module-path/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl module name/path conversion utilities
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-reference/ROADMAP.md
+++ b/crates/perl-module-reference/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Cursor-aware Perl module reference extraction for use/require statements
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-rename/ROADMAP.md
+++ b/crates/perl-module-rename/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Deterministic module-import line edit planning for file rename workflows
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-resolution-path/ROADMAP.md
+++ b/crates/perl-module-resolution-path/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Deterministic Perl module path resolution within workspace roots
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-resolution-uri/ROADMAP.md
+++ b/crates/perl-module-resolution-uri/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Deterministic Perl module URI resolution with workspace-safe search behavior
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-resolution/ROADMAP.md
+++ b/crates/perl-module-resolution/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Deterministic and secure Perl module resolution for workspace and @INC search
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-token-core/ROADMAP.md
+++ b/crates/perl-module-token-core/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared parser and boundary primitives for Perl module tokens
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-token-parser/ROADMAP.md
+++ b/crates/perl-module-token-parser/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Single-responsibility Perl module token parsing for import/reference workflows
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-module-token/ROADMAP.md
+++ b/crates/perl-module-token/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Boundary-safe Perl module token replacement and variant helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-parser-core/ROADMAP.md
+++ b/crates/perl-parser-core/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Core parser engine for perl-parser
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-parser-pest/ROADMAP.md
+++ b/crates/perl-parser-pest/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Legacy Pest-based Perl parser (v2) — maintained as a learning tool and compatibility layer
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-parser/ROADMAP.md
+++ b/crates/perl-parser/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Native Perl parser (v3) — recursive descent with Tree-sitter-compatible AST, semantic analysis, and LSP provider engine
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-path-normalize/ROADMAP.md
+++ b/crates/perl-path-normalize/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Secure component-wise path normalization for workspace-relative paths.
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Shared by workspace-bound path security crates.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Add additional platform-focused tests for path component behavior.
 - Refine error messages for invalid relative path inputs.
 

--- a/crates/perl-path-security/ROADMAP.md
+++ b/crates/perl-path-security/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Workspace-bound path validation and traversal prevention for Perl tooling
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-position-tracking/ROADMAP.md
+++ b/crates/perl-position-tracking/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 UTF-8/UTF-16 position tracking and conversion for Perl LSP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-pragma/ROADMAP.md
+++ b/crates/perl-pragma/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl pragma extraction and analysis primitives
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-qualified-name/ROADMAP.md
+++ b/crates/perl-qualified-name/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl qualified-name parsing, splitting, and validation helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-quote/ROADMAP.md
+++ b/crates/perl-quote/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Perl quote-like operator parsing helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-refactoring/ROADMAP.md
+++ b/crates/perl-refactoring/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Refactoring and modernization utilities for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-regex/ROADMAP.md
+++ b/crates/perl-regex/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Regex parsing and validation helpers for Perl syntax
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-semantic-analyzer/ROADMAP.md
+++ b/crates/perl-semantic-analyzer/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Semantic analysis and symbol extraction for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-source-file/ROADMAP.md
+++ b/crates/perl-source-file/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Shared Perl source file classification helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-symbol-types/ROADMAP.md
+++ b/crates/perl-symbol-types/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Unified Perl symbol taxonomy for LSP tooling
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-tdd-support/ROADMAP.md
+++ b/crates/perl-tdd-support/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Test-driven development helpers and test generation for the Perl LSP ecosystem
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-text-line/ROADMAP.md
+++ b/crates/perl-text-line/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Text-line cursor and boundary helpers
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-token/ROADMAP.md
+++ b/crates/perl-token/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Token definitions for Perl parser
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-tokenizer/ROADMAP.md
+++ b/crates/perl-tokenizer/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Token stream and utilities for Perl parser
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-uri/ROADMAP.md
+++ b/crates/perl-uri/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 URI ↔ filesystem path conversion and normalization utilities for Perl LSP
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-workspace-discovery/ROADMAP.md
+++ b/crates/perl-workspace-discovery/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Git-aware Perl workspace file discovery with WalkDir fallback
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-workspace-folder/ROADMAP.md
+++ b/crates/perl-workspace-folder/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Parse Perl workspace folder declarations into filesystem paths
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-workspace-index-slo/ROADMAP.md
+++ b/crates/perl-workspace-index-slo/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Service-level objective (SLO) tracking primitives for workspace index operations
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/perl-workspace-index/ROADMAP.md
+++ b/crates/perl-workspace-index/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Workspace indexing and refactoring orchestration for Perl
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.

--- a/crates/tree-sitter-perl-c/ROADMAP.md
+++ b/crates/tree-sitter-perl-c/ROADMAP.md
@@ -5,13 +5,13 @@
 ## Purpose
 Tree-sitter Perl grammar with C scanner (legacy implementation)
 
-## Current Status (v0.10.0)
+## Current Status (workspace version)
 - **Status:** Initial Public Alpha
 - **Integration:** Part of the `perl-lsp` workspace.
 
 ## Future Milestones
 
-### v0.10.x Hardening
+### Hardening
 - Address early adopter feedback.
 - Refine API contracts and error handling.
 - Improve test coverage and documentation.


### PR DESCRIPTION
## Summary

- Swept 78 crate `ROADMAP.md` files with hardcoded version strings (v0.10.0, v0.12.0)
- Applied consistent workspace-agnostic wording matching the Agent U pattern from PR #3240
- No roadmap content was rewritten — surgical header-only changes

## Changes applied

| Old text | New text |
|---|---|
| `## Current Status (v0.10.0)` | `## Current Status (workspace version)` |
| `## Current Status (v0.12.0)` | `## Current Status (workspace version)` |
| `### v0.10.x Hardening` | `### Hardening` |

78 files changed, 155 insertions(+), 155 deletions(-) — each file has exactly 2 line changes.

## Scope

Touches only `crates/*/ROADMAP.md`. No source, test, or CI files modified.

## Test plan

- [ ] Doc-only PR — no functional changes, no tests required
- [ ] Verify grep for `v0.10` in `crates/**/ROADMAP.md` returns 0 matches after merge