### PR TITLE
fix(ux): make user-visible error messages actionable for v0.13.0 launch

### DIFF
--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -169,7 +169,12 @@ impl DebugAdapter {
                     success: false,
                     command: "launch".to_string(),
                     body: None,
-                    message: Some(format!("Failed to launch debugger: {}", e)),
+                    message: Some(format!(
+                        "Cannot start Perl debugger: {}. \
+                         Check that 'perl' is on your PATH and that the file exists. \
+                         You can set a custom interpreter path in your launch.json.",
+                        e
+                    )),
                 },
             }
         } else {
@@ -179,7 +184,11 @@ impl DebugAdapter {
                 success: false,
                 command: "launch".to_string(),
                 body: None,
-                message: Some("Missing launch arguments".to_string()),
+                message: Some(
+                    "Debugger launch failed: no launch configuration was provided. \
+                     Add a launch.json with a 'program' field pointing to your Perl script."
+                        .to_string(),
+                ),
             }
         }
     }
@@ -200,7 +209,11 @@ impl DebugAdapter {
 
         // Reject empty or whitespace-only paths
         if program.is_empty() {
-            return Err("Program path cannot be empty".to_string());
+            return Err(
+                "No Perl script was specified. Set the 'program' field in your launch.json \
+                 to the path of the script you want to debug."
+                    .to_string(),
+            );
         }
 
         // Validate that the program is a regular file (not a directory, device, etc.)
@@ -212,11 +225,19 @@ impl DebugAdapter {
         match std::fs::metadata(path) {
             Ok(metadata) => {
                 if !metadata.is_file() {
-                    return Err(format!("Program path is not a regular file: {}", program));
+                    return Err(format!(
+                        "'{}' is not a file. Update the 'program' field in your launch.json \
+                         to point to a Perl script (.pl or .t).",
+                        program
+                    ));
                 }
             }
             Err(e) => {
-                return Err(format!("Could not access program file '{}': {}", program, e));
+                return Err(format!(
+                    "Cannot find '{}': {}. \
+                     Check that the 'program' path in your launch.json is correct.",
+                    program, e
+                ));
             }
         }
 
@@ -225,8 +246,14 @@ impl DebugAdapter {
         let workspace_root =
             lock_or_recover(&self.workspace_root, "debug_adapter.workspace_root").clone();
         if let Some(root) = workspace_root.as_ref() {
-            security::validate_path(path, root)
-                .map_err(|e| format!("Security check failed: {}", e))?;
+            security::validate_path(path, root).map_err(|e| {
+                format!(
+                    "The script '{}' is outside your workspace folder. \
+                     Only scripts within the open workspace can be debugged. \
+                     Details: {}",
+                    program, e
+                )
+            })?;
         }
 
         let mut cmd = Command::new("perl");
@@ -271,7 +298,11 @@ impl DebugAdapter {
                 if let Ok(mut guard) = self.session.lock() {
                     *guard = Some(session);
                 } else {
-                    return Err("Failed to lock session".to_string());
+                    return Err(
+                        "Debugger could not be started: an internal state error occurred. \
+                         Try stopping the debug session and relaunching."
+                            .to_string(),
+                    );
                 }
 
                 // Apply any function breakpoints configured before launch.
@@ -1007,11 +1038,16 @@ impl DebugAdapter {
                         command: "attach".to_string(),
                         body: None,
                         message: Some(format!(
-                            "Failed to connect to {}:{} ({}ms timeout): {}",
+                            "Cannot attach to Perl debugger at {}:{} ({}ms timeout): {}. \
+                             Make sure the Perl process was started with \
+                             'PERLDB_OPTS=\"RemotePort={}:{}\"' \
+                             and is still running before attaching.",
                             config.host,
                             config.port,
                             config.timeout_ms.unwrap_or(30000),
-                            e
+                            e,
+                            config.host,
+                            config.port,
                         )),
                     },
                 }
@@ -1407,7 +1443,9 @@ impl DebugAdapter {
                         command: "restart".to_string(),
                         body: None,
                         message: Some(
-                            "No previous launch configuration available for restart".to_string(),
+                            "Cannot restart: no previous launch configuration found. \
+                             Start a debug session first, then use Restart."
+                                .to_string(),
                         ),
                     };
                 }

--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -95,7 +95,7 @@ fn test_dap_launch_with_invalid_program() {
             assert!(!success);
             assert_eq!(command, "launch");
             assert!(message.is_some());
-            assert!(must_some(message).contains("Failed to launch debugger"));
+            assert!(must_some(message).contains("Cannot start Perl debugger"));
         }
         _ => must(Err::<(), _>("Expected response message")),
     }
@@ -114,7 +114,7 @@ fn test_dap_launch_missing_arguments() {
             assert!(!success);
             assert_eq!(command, "launch");
             assert!(message.is_some());
-            assert_eq!(must_some(message), "Missing launch arguments");
+            assert!(must_some(message).contains("no launch configuration was provided"));
         }
         _ => must(Err::<(), _>("Expected response message")),
     }

--- a/crates/perl-dap/tests/dap_launch_security_test.rs
+++ b/crates/perl-dap/tests/dap_launch_security_test.rs
@@ -34,10 +34,10 @@ fn test_launch_rejects_path_traversal() -> Result<(), Box<dyn std::error::Error>
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should have failed due to path traversal/workspace escape");
             let msg = must_some(message);
-            assert!(msg.contains("Security check failed"), "Unexpected error message: {}", msg);
             assert!(
-                msg.contains("outside workspace"),
-                "Error should indicate path is outside workspace"
+                msg.contains("outside your workspace folder") || msg.contains("outside workspace"),
+                "Unexpected error message: {}",
+                msg
             );
         }
         _ => return Err("Expected Response message".into()),
@@ -73,7 +73,7 @@ fn test_launch_allows_valid_path() -> Result<(), Box<dyn std::error::Error>> {
             if !success {
                 let msg = message.clone().unwrap_or_default();
                 assert!(
-                    !msg.contains("outside workspace") && !msg.contains("Security check failed"),
+                    !msg.contains("outside workspace") && !msg.contains("outside your workspace"),
                     "Valid path rejected by security check: {msg}"
                 );
             }

--- a/crates/perl-dap/tests/security_regression_tests.rs
+++ b/crates/perl-dap/tests/security_regression_tests.rs
@@ -31,11 +31,7 @@ fn test_command_injection_via_program_argument() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail because file '-e' does not exist");
             let msg = message.ok_or("Expected error message")?;
-            assert!(
-                msg.contains("Could not access program file"),
-                "Should fail with access error: {}",
-                msg
-            );
+            assert!(msg.contains("Cannot find"), "Should fail with access error: {}", msg);
         }
         _ => return Err("Expected Response".into()),
     }
@@ -78,11 +74,7 @@ fn test_launch_with_nonexistent_file_errors_gracefully() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail for nonexistent file");
             let msg = message.ok_or("Expected error message")?;
-            assert!(
-                msg.contains("Could not access program file"),
-                "Should return meaningful error: {}",
-                msg
-            );
+            assert!(msg.contains("Cannot find"), "Should return meaningful error: {}", msg);
         }
         _ => return Err("Expected Response".into()),
     }
@@ -107,7 +99,11 @@ fn test_launch_with_empty_program_rejected() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail for empty program");
             let msg = message.ok_or("Expected error message")?;
-            assert!(msg.contains("cannot be empty"), "Should indicate empty path: {}", msg);
+            assert!(
+                msg.contains("No Perl script was specified"),
+                "Should indicate empty path: {}",
+                msg
+            );
         }
         _ => return Err("Expected Response".into()),
     }
@@ -133,7 +129,7 @@ fn test_launch_with_whitespace_program_rejected() -> TestResult {
             assert!(!success, "Launch should fail for whitespace-only program");
             let msg = message.ok_or("Expected error message")?;
             assert!(
-                msg.contains("cannot be empty"),
+                msg.contains("No Perl script was specified"),
                 "Should indicate empty path after trimming: {}",
                 msg
             );
@@ -165,11 +161,7 @@ fn test_launch_with_directory_rejected() -> TestResult {
         DapMessage::Response { success, message, .. } => {
             assert!(!success, "Launch should fail for directory path");
             let msg = message.ok_or("Expected error message")?;
-            assert!(
-                msg.contains("not a regular file"),
-                "Should indicate path is not a file: {}",
-                msg
-            );
+            assert!(msg.contains("is not a file"), "Should indicate path is not a file: {}", msg);
         }
         _ => return Err("Expected Response".into()),
     }

--- a/crates/perl-dap/tests/session_lifecycle_tests.rs
+++ b/crates/perl-dap/tests/session_lifecycle_tests.rs
@@ -201,7 +201,7 @@ fn test_session_lifecycle_launch_missing_arguments() {
             assert!(!success, "Launch should fail without arguments");
             assert_eq!(command, "launch");
             assert!(message.is_some());
-            assert!(must_some(message).contains("Missing launch arguments"));
+            assert!(must_some(message).contains("no launch configuration was provided"));
         }
         _ => must(Err::<(), _>("Expected Response message".to_string())),
     }
@@ -228,7 +228,7 @@ fn test_session_lifecycle_launch_empty_program() {
             assert!(message.is_some());
             let msg = must_some(message);
             assert!(
-                msg.contains("empty") || msg.contains("cannot be empty"),
+                msg.contains("No Perl script was specified") || msg.contains("empty"),
                 "Error should mention empty path: {}",
                 msg
             );
@@ -258,7 +258,7 @@ fn test_session_lifecycle_launch_nonexistent_program() {
             assert!(message.is_some());
             let msg = must_some(message);
             assert!(
-                msg.contains("Could not access") || msg.contains("not a regular file"),
+                msg.contains("Cannot find") || msg.contains("is not a file"),
                 "Error should mention access issue: {}",
                 msg
             );

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -408,10 +408,14 @@ pub fn load_project_config(
     let path = workspace_root.join(".perl-lsp.toml");
     match std::fs::read_to_string(&path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(format!("Failed to read .perl-lsp.toml: {}", e)),
+        Err(e) => Err(format!(
+            "Could not read .perl-lsp.toml: {}. \
+             Check that the file is readable and not locked by another process.",
+            e
+        )),
         Ok(content) => toml::from_str::<ProjectConfig>(&content)
             .map(Some)
-            .map_err(|e| format!(".perl-lsp.toml parse error: {}", e)),
+            .map_err(|e| format!(".perl-lsp.toml has a syntax error: {}", e)),
     }
 }
 

--- a/crates/perl-lsp/src/cli.rs
+++ b/crates/perl-lsp/src/cli.rs
@@ -346,7 +346,11 @@ fn run_server(command_name: &str, launch_config: LaunchConfig) {
             let rt = match Runtime::new() {
                 Ok(rt) => rt,
                 Err(e) => {
-                    eprintln!("Failed to create Tokio runtime: {e}");
+                    eprintln!(
+                        "Perl Language Server failed to start: could not initialize the async \
+                         runtime ({e}). This is usually caused by system resource limits. \
+                         Try restarting VS Code or increasing your OS thread limits."
+                    );
                     process::exit(1);
                 }
             };
@@ -380,7 +384,11 @@ fn run_server(command_name: &str, launch_config: LaunchConfig) {
             let rt = match Runtime::new() {
                 Ok(rt) => rt,
                 Err(e) => {
-                    eprintln!("Failed to create Tokio runtime: {e}");
+                    eprintln!(
+                        "Perl Language Server failed to start: could not initialize the async \
+                         runtime ({e}). This is usually caused by system resource limits. \
+                         Try restarting VS Code or increasing your OS thread limits."
+                    );
                     process::exit(1);
                 }
             };
@@ -395,7 +403,10 @@ fn run_server(command_name: &str, launch_config: LaunchConfig) {
                                 port_in_use_message(port).replace("perl-lsp", &command_name)
                             );
                         } else {
-                            eprintln!("Failed to bind to {addr}: {e}");
+                            eprintln!(
+                                "Perl Language Server could not listen on {addr}: {e}. \
+                                 Try a different port with --port or check firewall settings."
+                            );
                         }
                         process::exit(1);
                     }
@@ -403,7 +414,10 @@ fn run_server(command_name: &str, launch_config: LaunchConfig) {
                 let local_addr = match listener.local_addr() {
                     Ok(a) => a,
                     Err(e) => {
-                        eprintln!("Failed to get local address: {e}");
+                        eprintln!(
+                            "Perl Language Server started but could not determine its \
+                             listening address: {e}."
+                        );
                         process::exit(1);
                     }
                 };

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -1570,7 +1570,12 @@ impl LspServer {
                         Err(e) => {
                             return Err(JsonRpcError {
                                 code: -32603,
-                                message: format!("Failed to launch debugger: {}", e),
+                                message: format!(
+                                    "Cannot start Perl debugger for '{}': {}. \
+                                     Check that 'perl' is on your PATH and that the file exists.",
+                                    resolved.display(),
+                                    e
+                                ),
                                 data: Some(json!({"file": resolved.display().to_string()})),
                             });
                         }

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -49,13 +49,18 @@ impl LspServer {
                 }
             }
             Err(msg) => {
-                tracing::warn!(message = msg, "Project config warning");
+                let user_msg = format!(
+                    "perl-lsp: {msg} \
+                     Fix the error in .perl-lsp.toml and reload the window \
+                     (Ctrl+Shift+P \u{2192} Developer: Reload Window) to apply your settings.",
+                );
+                tracing::warn!(message = %user_msg, "Project config warning");
                 // Emit user-visible warning so devs can fix a broken .perl-lsp.toml
                 if let Err(e) = self.notify(
                     "window/showMessage",
                     serde_json::json!({
                         "type": 2, // Warning
-                        "message": format!("perl-lsp: {}", msg)
+                        "message": user_msg
                     }),
                 ) {
                     tracing::warn!(error = %e, "Failed to send showMessage warning");

--- a/vscode-extension/src/debugAdapter.ts
+++ b/vscode-extension/src/debugAdapter.ts
@@ -364,8 +364,15 @@ export class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
         if (!dapPath) {
             vscode.window.showErrorMessage(
-                'Perl Debug Adapter (perl-dap) not found. It ships with perl-lsp — re-download from the release page or install via: cargo install perl-dap'
-            );
+                'Perl Debug Adapter (perl-dap) not found. ' +
+                'Use "Perl LSP: Reinstall" from the Command Palette to re-download it, ' +
+                'or install it manually with: cargo install perl-dap',
+                'Reinstall'
+            ).then(sel => {
+                if (sel === 'Reinstall') {
+                    void vscode.commands.executeCommand('perl-lsp.reinstall');
+                }
+            });
             return undefined;
         }
 
@@ -552,7 +559,10 @@ export function activateDebugger(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(VSCODE_DEBUG_TEST_COMMAND, (test: unknown) => {
             const target = parseDebugTestLaunchTarget(test);
             if (!target) {
-                void vscode.window.showErrorMessage('Unable to resolve the Perl test to debug.');
+                void vscode.window.showErrorMessage(
+                    'Cannot debug this test: the test location could not be resolved. ' +
+                    'Save the file and try again, or launch the debugger manually via the Run and Debug panel.'
+                );
                 return undefined;
             }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -96,13 +96,24 @@ export async function activate(context: vscode.ExtensionContext) {
     
     const showVersionCommand = vscode.commands.registerCommand('perl-lsp.showVersion', async () => {
         if (!currentServerPath) {
-            vscode.window.showErrorMessage('Perl LSP server path is unavailable.');
+            vscode.window.showErrorMessage(
+                'Perl Language Server is not running. Restart the server or check the Output panel for startup errors.',
+                'Restart Server', 'Show Output'
+            ).then(sel => {
+                if (sel === 'Restart Server') { void vscode.commands.executeCommand('perl-lsp.restart'); }
+                if (sel === 'Show Output') { outputChannel.show(); }
+            });
             return;
         }
 
         execFile(currentServerPath, ['--version'], (error: Error | null, stdout: string) => {
             if (error) {
-                vscode.window.showErrorMessage(`Failed to get version: ${error.message}`);
+                vscode.window.showErrorMessage(
+                    `Could not get Perl LSP version: ${error.message}. The server binary may be missing or corrupt — try reinstalling.`,
+                    'Reinstall'
+                ).then(sel => {
+                    if (sel === 'Reinstall') { void vscode.commands.executeCommand('perl-lsp.reinstall'); }
+                });
                 return;
             }
 
@@ -1124,7 +1135,10 @@ async function showIncPaths(): Promise<void> {
     return new Promise(resolve => {
         execFile('perl', ['-e', 'print join("\\n", @INC)'], { timeout: 5000 }, (error, stdout) => {
             if (error) {
-                vscode.window.showErrorMessage(`Failed to get @INC: ${error.message}`).then(() => {
+                vscode.window.showErrorMessage(
+                    `Could not read Perl @INC paths: ${error.message}. ` +
+                    `Make sure 'perl' is installed and on your PATH, or set perl-lsp.includePaths in settings.`
+                ).then(() => {
                     resolve();
                 });
                 return;
@@ -1226,9 +1240,13 @@ async function reinstallServerBinary(context: vscode.ExtensionContext) {
     const downloadedPath = await downloader.ensureBinary(true);
 
     if (!downloadedPath) {
-        vscode.window.showErrorMessage('Failed to reinstall perl-lsp. See output for details.', 'Show Output').then(selection => {
-            if (selection === 'Show Output') {
-                outputChannel.show();
+        vscode.window.showErrorMessage(
+            'Could not reinstall perl-lsp. Check your internet connection and proxy settings, then try again.',
+            'Show Output', 'Open Settings'
+        ).then(selection => {
+            if (selection === 'Show Output') { outputChannel.show(); }
+            if (selection === 'Open Settings') {
+                void vscode.commands.executeCommand('workbench.action.openSettings', 'http.proxy');
             }
         });
         return;
@@ -1237,9 +1255,13 @@ async function reinstallServerBinary(context: vscode.ExtensionContext) {
     currentServerPath = downloadedPath;
     const healthOk = await runHealthCheck(downloadedPath);
     if (!healthOk) {
-        vscode.window.showErrorMessage('Downloaded perllsp failed its health check.', 'Show Output').then(selection => {
-            if (selection === 'Show Output') {
-                outputChannel.show();
+        vscode.window.showErrorMessage(
+            'The downloaded perl-lsp binary failed its health check — it may be corrupted or incompatible with your platform.',
+            'Show Output', 'Report Issue'
+        ).then(selection => {
+            if (selection === 'Show Output') { outputChannel.show(); }
+            if (selection === 'Report Issue') {
+                void vscode.env.openExternal(vscode.Uri.parse('https://github.com/EffortlessMetrics/perl-lsp/issues'));
             }
         });
         return;

--- a/vscode-extension/src/formattingErrors.ts
+++ b/vscode-extension/src/formattingErrors.ts
@@ -38,7 +38,8 @@ export function handleFormattingError(
     const isNotFound = message.includes('perltidy not found');
     const label = isNotFound ? 'Run Health Check' : 'Show Output';
     const msg = isNotFound
-        ? `Perl formatting failed: perltidy is not installed. ${truncated}`
+        ? `Perl formatting requires perltidy, which was not found on PATH. ` +
+          `Install it via: cpan Perl::Tidy  (or set perl-lsp.perltidyConfig to your config path)`
         : `Perl formatting failed: ${truncated}`;
 
     vscode.window.showErrorMessage(msg, label).then(sel => {

--- a/vscode-extension/src/test/formatting.test.ts
+++ b/vscode-extension/src/test/formatting.test.ts
@@ -48,7 +48,7 @@ describe('handleFormattingError', () => {
         const ch = makeOutputChannel();
         handleFormattingError('perltidy not found: /usr/bin/perltidy', ch as any);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            expect.stringContaining('perltidy is not installed'),
+            expect.stringContaining('perltidy, which was not found on PATH'),
             'Run Health Check'
         );
     });


### PR DESCRIPTION
## Summary

Audited ~45 user-visible error surfaces across the LSP/DAP stack and the VS Code extension. Rewrote every message rated cryptic (✗) and the worst unactionable (⚠) ones. All rewrites follow the pattern: WHAT went wrong + WHAT to do, with exact setting names and install commands where applicable.

**Audit result:** 45 messages reviewed — 18 GOOD, 16 understandable but unactionable, 11 cryptic. Fixed 11 of the worst.

## Before/After Examples

**DAP launch with missing file:**
- Before: `Could not access program file '/path/to/script.pl': No such file or directory`
- After: `Cannot find '/path/to/script.pl': No such file or directory. Check that the 'program' path in your launch.json is correct.`

**DAP launch with no config:**
- Before: `Missing launch arguments`
- After: `Debugger launch failed: no launch configuration was provided. Add a launch.json with a 'program' field pointing to your Perl script.`

**Server startup failure:**
- Before: `Failed to create Tokio runtime: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }`
- After: `Perl Language Server failed to start: could not initialize the async runtime (...). This is usually caused by system resource limits. Try restarting VS Code or increasing your OS thread limits.`

**Config file error:**
- Before: `.perl-lsp.toml parse error: expected . at line 5 column 3`
- After: `.perl-lsp.toml has a syntax error: expected . at line 5 column 3 Fix the error in .perl-lsp.toml and reload the window (Ctrl+Shift+P → Developer: Reload Window) to apply your settings.`

**perltidy not found:**
- Before: `Perl formatting failed: perltidy is not installed.`
- After: `Perl formatting requires perltidy, which was not found on PATH. Install it via: cpan Perl::Tidy  (or set perl-lsp.perltidyConfig to your config path)`

## Files Changed

- `crates/perl-dap/src/debug_adapter/process.rs` — DAP launch, attach, restart, path validation errors
- `crates/perl-lsp/src/cli.rs` — server startup (Tokio runtime, TCP bind) errors
- `crates/perl-lsp/src/runtime/lifecycle/workspace.rs` — `.perl-lsp.toml` config error notification
- `crates/perl-lsp/src/runtime/language/misc.rs` — LSP debugger launch JSON-RPC error
- `crates/perl-lsp-config/src/lib.rs` — config file read/parse error strings
- `vscode-extension/src/extension.ts` — server path unavailable, version, @INC, reinstall errors
- `vscode-extension/src/formattingErrors.ts` — perltidy not installed message with install command
- `vscode-extension/src/debugAdapter.ts` — perl-dap not found + test debug resolve errors
- Test files updated to match new message substrings (4 Rust test files, 1 TS test file)

## Test Plan

- [x] `cargo test -p perl-dap -p perllsp -p perl-lsp-config -p perl-lsp-launcher` — all pass (1 pre-existing unrelated failure in README content test)
- [x] `cargo clippy` — no issues
- [x] `cargo fmt --check` — clean
- [ ] TS tests via `npm test` in vscode-extension (need Node environment)