### PR TITLE
chore(release): audit publish allowlist for v0.13.0 — ensure all relevant crates publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ allow = [
     "perl-tdd-support",
     # Tier 2+ — Rust-native tree-sitter facade (depends on perl-parser-core + perl-ast)
     "tree-sitter-perl-rs",
+    "perl-test-generators",
     "perl-edit",
     "perl-incremental-parsing",
     "perl-symbol-types",
@@ -193,6 +194,7 @@ allow = [
     "perl-workspace-index-state-machine",
     "perl-path-normalize",
     "perl-workspace-index-slo",
+    "perl-workspace-index-monitoring",
     # Tier 3 — Analysis and indexing
     "perl-workspace-index",
     "perl-semantic-analyzer",


### PR DESCRIPTION
## Summary

Audited the `[workspace.metadata.publish] allow` list against all 133 workspace members. Found 2 crates missing from the allowlist that should be published. Adds them.

**Allowlist: 128 → 130 crates.**

---

## Publish audit

### PUBLISH list (crates that should be on crates.io)

All 130 crates in the updated allowlist are correctly included. Two were added by this PR:

| Crate | Status | Justification |
|-------|--------|---------------|
| `perl-workspace-index-monitoring` | ADDED | Normal (non-dev) dependency of `perl-workspace-index`, which is already published. Omitting it would break downstream builds that pull in `perl-workspace-index`. Has full crate metadata: docs.rs URL, keywords, categories, readme, no `publish = false`. |
| `perl-test-generators` | ADDED | Proptest strategies and Arbitrary impls for Perl domain objects. Has full crate metadata (docs.rs URL, keywords, categories, readme, no `publish = false`). Intended for external test code (consistent with `perl-test-must` and `perl-tdd-support` which are already published). |

All other 128 previously listed crates were already correct.

### INTERNAL list (crates correctly excluded)

| Crate | Status | Reason |
|-------|--------|--------|
| `xtask` | Excluded (publish=false) | Build task runner, not for distribution |
| `perl-ci-hygiene` | Excluded (publish=false) | CI-only internal tooling |
| `perl-parser-bench` | Excluded (no publish=false but benchmark-only) | Binary-only benchmark harness, no library target, no stable public API |

### UNCLEAR list

None. All 133 workspace members are classified with confidence.

---

## Ghost entries

None. Every entry in the allowlist maps to a real workspace member.

---

## Questionable existing entries (flagged for human review, NOT removed)

None found. All existing 128 entries appear intentional.

---

## Verification

- `cargo metadata` resolves cleanly with updated allowlist
- Tarjan topological sort (from `.github/workflows/publish-crates.yml`) produces a valid 130-crate publish order with no cycles
- The two added crates have no `publish = false` in their individual `Cargo.toml`
- `perl-workspace-index-monitoring` position: added immediately after `perl-workspace-index-slo` in Tier 2, before Tier 3 (where `perl-workspace-index` sits) — correct dependency order

## Test plan

- [ ] CI passes (pure metadata change, no code)
- [ ] Publish dry-run in CI will include both new crates