### PR TITLE
docs: update CHANGELOG.md for v0.12.2 release (#3287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,11 +206,11 @@ the remaining 21 (including `tree-sitter-perl-c`, `tree-sitter-perl-rs`,
 - **dev-dependency stripping**: `cargo publish` now strips `[dev-dependencies]`
   before publishing to avoid version conflicts (#3254, #3256)
 - **`--allow-dirty` for publish**: added after dev-dep strip leaves the working
-  tree dirty (#3259)
+  tree dirty (#3300)
 - **HTTP 429 throttle handling**: publish workflow detects crates.io rate-limit
   responses and retries with back-off (pending)
 - **sparse index wait replaced**: replaced fixed-duration index wait with
-  sparse-index polling for faster, more reliable publish verification (#3267)
+  sparse-index polling for faster, more reliable publish verification
 - **UX regression gate**: PR check that detects regressions in user-visible LSP,
   DAP, and extension behavior on every PR touching those surfaces (#3293)
 - **post-publish smoke test**: automated verification that published crates


### PR DESCRIPTION
## Summary

Keep-a-Changelog entry for the v0.12.2 publish run, covering the work done after the original GitHub Release tag that was required to land the full crate set on crates.io.

- Updates the `[0.12.2]` date to 2026-04-08 (publish run date)
- Adds introductory prose about the publish run status (108/129 crates published, 21 pending HTTP 429 retry)
- Adds **New Crates** section: `tree-sitter-perl-rs` (v3 facade) and `tree-sitter-perl-c` (first publish)
- Adds **Quality (publish-run additions)**: eprintln→tracing, unwrap burn-down waves, error message actionability, crates.io/docs.rs metadata polish, dead build.rs removal, stale harness archival
- Adds **CI (publish-run additions)**: topo-sort, dev-dep stripping, allow-dirty, HTTP 429 throttle handling, sparse index polling, UX regression gate, post-publish smoke test, version-bump automation, `just doctor`
- Adds **UX (publish-run additions)**: settings schema polish, VS Code Marketplace punch list, test de-flake

## References

- Pre-announcement checklist: #3287
- tree-sitter-perl-rs: #3255
- tree-sitter-perl-c: #3234
- Publish pipeline: #3236, #3242, #3254, #3256, #3300, #3267, #3288
- eprintln→tracing: #3224, #3245
- UX gate: #3293

## Status

The release is in progress — the publish workflow needs to be retriggered for the remaining 21 crates after the HTTP 429 throttle fix lands. This CHANGELOG entry documents both what shipped and what is pending.

## Test plan

- [x] All PR references verified against GitHub (9 wrong refs corrected)
- [ ] Markdown renders correctly (no broken formatting)
- [ ] `[0.12.2]` date matches publish run date (2026-04-08)
- [ ] `[Unreleased]` section is untouched