### PR TITLE
fix(ci): throttle crates.io publish to avoid 429 rate limit

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -421,12 +421,24 @@ jobs:
             # Use --no-verify because workspace dev-dependency cycles can fail
             # verification before all crates are indexed on crates.io.
             #
-            # Each attempt = (publish + progressive index wait + sparse-index verify).
-            # If the sparse-index verify never confirms the upload, retry the
-            # whole cycle up to 3 times before failing hard. This distinguishes
-            # slow-indexing (crate IS published, just not yet visible — confirmed
-            # by the sparse-index check) from silently-dropped uploads (cargo
-            # publish returned 0 but the crate never appeared).
+            # Each attempt = (publish + inter-publish throttle sleep + progressive
+            # index wait + sparse-index verify). If the sparse-index verify never
+            # confirms the upload, retry the whole cycle up to 3 times before
+            # failing hard. This distinguishes slow-indexing (crate IS published,
+            # just not yet visible — confirmed by the sparse-index check) from
+            # silently-dropped uploads (cargo publish returned 0 but the crate
+            # never appeared).
+            #
+            # Rate-limit context (crates.io docs: https://crates.io/docs/rate-limits):
+            #   - Update existing crate: burst 30, then 1 per 12s steady-state
+            #   - Publish new crate:     burst 5,  then 1 per 60s steady-state
+            # After the burst of 30 is exhausted (which happens fast with 129
+            # crates), each publish must wait ≥ 12s before the next one is
+            # allowed. We sleep 13s after every successful publish so the whole
+            # pipeline runs at < 5 crates/min — reliably under the rate limit.
+            # With 129 crates that is ~28 minutes total, well within the 360-min
+            # job timeout. The sleep appears BEFORE the sparse-index wait, so the
+            # inter-publish gap is at least 13s (+ however long indexing takes).
             PUBLISHED=false
             for attempt in 1 2 3; do
               echo "Attempt $attempt/3: cargo publish -p $CRATE --no-verify --allow-dirty"
@@ -439,14 +451,36 @@ jobs:
                 echo "::warning::$CRATE@$VERSION already exists on crates.io index"
                 ALREADY_EXISTS=true
               fi
+
+              # Detect HTTP 429 rate-limit responses for longer back-off.
+              IS_RATE_LIMITED=false
+              if grep -qE "429|Too Many Requests" "$PUBLISH_LOG"; then
+                IS_RATE_LIMITED=true
+              fi
               rm -f "$PUBLISH_LOG"
 
               # If cargo publish hard-failed and it wasn't the "already exists"
               # benign case, back off and retry the publish.
+              # 429 rate-limit: wait 60s (burst window + margin) before retrying.
+              # Other errors: wait 30s.
               if [ "$PUBLISH_EXIT" != "0" ] && [ "$ALREADY_EXISTS" != "true" ]; then
-                echo "Publish attempt $attempt failed (exit $PUBLISH_EXIT), waiting 30s before retry..."
-                sleep 30
+                if [ "$IS_RATE_LIMITED" = "true" ]; then
+                  echo "Publish attempt $attempt hit 429 rate limit, waiting 60s before retry..."
+                  sleep 60
+                else
+                  echo "Publish attempt $attempt failed (exit $PUBLISH_EXIT), waiting 30s before retry..."
+                  sleep 30
+                fi
                 continue
+              fi
+
+              # Inter-publish throttle: sleep 13s after a successful publish call
+              # so the next crate's publish stays under the crates.io steady-state
+              # rate limit of 1 update per 12s. This does NOT apply to the
+              # "already exists" path because that path made no API call.
+              if [ "$ALREADY_EXISTS" != "true" ]; then
+                echo "Throttle: sleeping 13s to stay under crates.io rate limit (1 update/12s steady-state)..."
+                sleep 13
               fi
 
               # Progressive sparse-index wait: probe at 5s, 15s, 45s, 90s


### PR DESCRIPTION
## Summary

- Adds a `sleep 13` after each successful `cargo publish` call (before the sparse-index wait loop), pacing the full pipeline at < 5 crates/min to stay under the crates.io steady-state rate limit of 1 update per 12 seconds
- Detects HTTP 429 "Too Many Requests" responses and uses a 60-second backoff on retry (up from 30s), giving the rate-limit burst window time to clear
- The "already published" skip path (crate found in sparse index before attempting publish) does NOT sleep — it made no API call

## Root cause

Publish run 24126423987 successfully published 108/129 crates, then the last 21 failed with:

```
error: failed to publish perl-lsp-color-provider v0.12.2 to registry at https://crates.io
  the remote server responded with an error (status 429 Too Many Requests): You have published
  too many updates to existing crates in a short period of time. Please try again after ...
```

The crates.io rate limits (https://crates.io/docs/rate-limits):
- Update existing crate: burst 30, then 1 per 12s steady-state
- Publish new crate: burst 5, then 1 per 60s steady-state

The burst of 30 is exhausted quickly with 129 crates. After that, each publish must wait 12s before the next. The previous workflow had no inter-publish throttle, so publishes piled up and hit the rate limit. The retry logic used only 30s backoff, which was insufficient to clear the rate-limit window.

## Rate limit math

- 13s sleep per crate = < 5 crates/min = reliably under the 1/12s steady-state limit
- 129 crates x 13s = ~28 minutes total publish time (well within the 360-minute job timeout)
- 60s retry backoff on 429 = burst window (30 publishes x 12s = 360s max) plus margin, so a single retry cycle clears the limit

## Test plan

- [ ] Bash syntax check of the embedded script: `bash -n <extracted-script>` passes (verified locally)
- [ ] The next publish run is the real integration test — expected ~28-30 min for a full 129-crate run
- [ ] Incremental re-runs (after partial failure) skip already-indexed crates via the sparse-index fast-path and complete much faster
