### PR TITLE
fix(ci): sync post-release docs and CPAN ratchet (#2026)

### DIFF
--- a/.github/workflows/post-merge-corpus-ratchet.yml
+++ b/.github/workflows/post-merge-corpus-ratchet.yml
@@ -43,7 +43,7 @@ jobs:
   corpus-ratchet:
     name: Refresh CPAN corpus receipts
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v6

--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -8,14 +8,15 @@ evidence-backed status and release facts.
 ## DONE — v0.12.2 through v0.12.8 (consolidated and shipped)
 
 - Work consolidated and merged 2026-04-02 (~70 PRs): CI gates, error handling, test coverage, parser confidence, performance, distribution, AI inline completion, packaging, announcement polish
-- `v0.12.2` cut as a GitHub Release on 2026-04-04 with binaries, SBOM, and SHA256SUMS
-- Editor channels (VSCode Marketplace, Open VSX) and Docker Hub: published 2026-04-04
+- `v0.12.3` is the live GitHub/editor release line as of 2026-04-09 with binaries, SBOM, SHA256SUMS, VS Code Marketplace, and Open VSX published
+- crates.io intentionally remains on `v0.12.2` while the registry window is deferred
 
-## NOW — pre-announcement cleanup
+## NOW — post-v0.12.3 / pre-announcement cleanup
 
 - License badge fixed (canonical SPDX text in all 126 LICENSE files), GitHub now reports `Apache-2.0` instead of `NOASSERTION`
 - Docker arm64 timeout fix landed (Dockerfile MSRV pin + workflow timeout bump)
 - Dependency triage complete: 7 dependabot PRs merged including 3 majors (eslint v10, actions/cache v5, similar 3.0.0)
+- Keep public guidance explicit about the current channel split: GitHub Releases plus editor marketplaces are on `v0.12.3`; crates.io remains on `v0.12.2`
 - SRP microcrate extractions in flight (anti_pattern_detector, bench_parser) to free the dead `tree-sitter-perl-rs` harness for archival
 - Publishing the modern parsers as `tree-sitter-perl-c` (C tree-sitter FFI) and a new `tree-sitter-perl-rs` (Rust v3 facade with tree-sitter-compatible output)
 - Per-crate publish blockers cleared (perl-lsp-ai-provider unblocked, perl-heredoc-anti-patterns extraction in progress)
@@ -36,7 +37,7 @@ evidence-backed status and release facts.
 
 ## Working Rules
 
-- Last updated: `2026-04-07`
+- Last updated: `2026-04-09`
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,12 +13,13 @@ project docs when you need exact release facts, receipts, or milestone detail.
 - Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
 - Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
-## Now (pre-announcement cleanup)
+## Now (post-v0.12.3 ship / pre-announcement cleanup)
 
-- `v0.12.2` shipped to GitHub Releases on 2026-04-04 (work consolidated 2026-04-02; v0.12.2 through v0.12.8 milestones merged into a single release)
+- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09
+- crates.io intentionally remains on `0.12.2` while the registry window is still deferred
 - Pre-announcement plumbing: license badge fix, Docker arm64 timeout fix, dependency triage, harness archival, SRP microcrate extractions
-- Distribution channel verification across crates.io, VSCode Marketplace, Open VSX, Docker Hub, GitHub Releases
-- See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) "Now (0.12.x quality tail)" for the active item list
+- Distribution channel verification across GitHub Releases, VS Code Marketplace, Open VSX, Docker Hub, and the delayed crates.io line
+- See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) "Now (post-v0.12.3 / pre-v0.13.0)" for the active item list
 
 ## Next (v0.13.0 — public alpha announcement)
 

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -21,9 +21,10 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.12.2` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest published release** | `v0.12.2`, 2026-04-07 | GitHub Releases |
-| **Active milestone** | `v0.12.3` pipeline-rehearsal release prep | [status/index.md](status/index.md) |
+| **Workspace version line** | `v0.12.3` | [`Cargo.toml`](../../Cargo.toml) |
+| **Latest GitHub/editor release** | `v0.12.3`, 2026-04-09 | GitHub Releases, VS Code Marketplace, Open VSX |
+| **crates.io line** | `v0.12.2`, 2026-04-07 | crates.io |
+| **Active milestone** | `v0.13.0` public alpha announcement | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |
 | **Test counts** | See [status/tests.md](status/tests.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -9,12 +9,12 @@
 ## Current Framing
 
 - Workspace version line: `v0.12.3`
-- Latest published release: `v0.12.2` (GitHub Releases public line, shipped 2026-04-07)
-- 0.12.x public release line: currently stops at `v0.12.2`; `v0.12.3` is the active pipeline-rehearsal prep line and is not yet a published GitHub release
-- Active work: finish the `v0.12.3` readiness pass (status/docs alignment, parser baseline receipts, distribution-surface verification), then move to the `v0.13.0` public alpha announcement
+- Latest published GitHub/editor release: `v0.12.3` (GitHub Releases, VS Code Marketplace, and Open VSX public line, shipped 2026-04-09)
+- crates.io published line: `v0.12.2` (registry line, shipped 2026-04-07)
+- Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.3` line stable across GitHub Releases and the editor marketplaces
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: milestone sections below can describe the intended `0.12.x` breakdown on the prep track, but the public GitHub release truth remains `v0.12.2` until a new tag is cut.
+Publication discipline: public release truth is intentionally split right now. GitHub Releases and the editor marketplaces are on `v0.12.3`; crates.io remains on `v0.12.2` until the registry window reopens. Milestone sections below can describe the intended `0.12.x` breakdown, but they must not blur that channel split.
 
 ## How To Read This File
 
@@ -41,7 +41,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - All 7 Tier 1 parser blockers confirmed fixed via scouts (#3085, #3096)
 - 10 PRs merged total
 
-## Prepared Scope: v0.12.3 Diagnostic & Refactoring Hardening
+## Completed: v0.12.3 Diagnostic & Refactoring Hardening (GitHub/editor release shipped 2026-04-09)
 
 - Dead code highlighting with DiagnosticTag::Unnecessary (#2060, PR #3092)
 - Perlcritic integration hardened: cached analyzer, walk-up discovery (#2018, PR #3097)
@@ -90,7 +90,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - End-to-end LSP feature development guide (#3027, PR #3115)
 - GIF recording guide and asset structure (#2336, PR #3130)
 
-## Active: Quality Cleanup (0.12.x tail)
+## Active: Quality Cleanup (post-v0.12.3 / pre-v0.13.0)
 
 - Debug println removal from library code (in progress)
 - Unused dependency removal across 6 crates (in progress)
@@ -99,15 +99,16 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 
 ## Now / Next / Later
 
-### Now (0.12.x quality tail)
+### Now (post-v0.12.3 / pre-v0.13.0)
 
+- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09; crates.io remains on `v0.12.2`
 - Pre-announcement license badge fix (PR #3193): canonical SPDX text in all 126 LICENSE files
 - Pre-announcement Docker arm64 timeout fix (#3188 → PR #3191, merged)
 - Per-release dependency triage: 7 dependabot PRs merged 2026-04-07 (#3178–#3184)
 - Code quality cleanup: debug prints (only `crates/perl-corpus/src/bin/main.rs` CLI output remains, library code clean), unused deps, remaining `unwrap()`/`expect()` audit in production code
 - Test coverage gaps and broken integration tests
 - VSCode extension lint/quality audit (eslint v10 landed in #3179)
-- AI inline completion (#3018) shipped in v0.12.2 — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
+- AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
 
 ### Next (v0.13.0 — public alpha announcement)
 
@@ -139,8 +140,8 @@ corpus confidence ratchet, and error-handling hygiene.
 
 ### v0.12.3
 
-Pipeline-rehearsal release prep: status regeneration, corpus receipts, version-surface alignment,
-and readiness verification ahead of the public alpha announcement.
+GitHub/editor release line: status regeneration, corpus receipts, version-surface alignment,
+and readiness verification shipped on 2026-04-09 ahead of the public alpha announcement.
 
 ### v0.12.4
 
@@ -149,7 +150,7 @@ Follow-on diagnostics and semantics scope retained on the prep track, not yet a 
 ### v0.12.5–v0.12.8
 
 Parser confidence, performance, distribution, and announcement-polish scopes retained on the prep track.
-Treat these as internal milestone slices until a new public GitHub release is actually cut.
+Treat these as internal milestone slices until the next public GitHub release beyond `v0.12.3` is actually cut.
 
 ### v0.13.0
 
@@ -187,9 +188,9 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Topic | Source |
 | --- | --- |
 | Workspace version line | [`../../Cargo.toml`](../../Cargo.toml) |
-| Latest published release | GitHub Releases |
+| Latest published release | GitHub Releases (`v0.12.3`) + crates.io API (`0.12.2` when channel split matters) |
 | Capability catalog | [`../../features.toml`](../../features.toml) |
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |
 
-<!-- Last Updated: 2026-04-07 -->
+<!-- Last Updated: 2026-04-09 -->

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: the latest published GitHub release is `v0.12.2` (2026-04-07), the workspace version line is `v0.12.3`, and the active milestone is `v0.12.3` pipeline-rehearsal release prep (the last launch gate before `v0.13.0` public alpha)
+- **Release posture**: GitHub Releases plus the editor channels (VS Code Marketplace and Open VSX) are live on `v0.12.3` as of 2026-04-09, the workspace version line is `v0.12.3`, crates.io intentionally remains on `v0.12.2`, and the active milestone is the `v0.13.0` public alpha announcement
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 58 user-visible features at 100% coverage (102/102 including plumbing protocol methods) — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `cargo xtask ignored-tests` is the tracked-test-debt source
@@ -26,12 +26,12 @@
 
 ## What's Next
 
-**Now (active milestone: v0.12.3 pipeline-rehearsal release prep)**
-- Close out `#3302` demo-asset recording — the only remaining human-owned blocker before the `v0.13.0` public alpha announcement
-- Tag `v0.12.3` against the green master at `a5680401` once assets land (CHANGELOG entry already on master from #3287)
+**Now (active milestone: v0.13.0 public alpha announcement)**
+- Close out `#3302` demo-asset recording — the main remaining human-owned blocker before the `v0.13.0` public alpha announcement
+- Keep the public release split explicit: GitHub Releases, VS Code Marketplace, and Open VSX are on `v0.12.3`, while crates.io remains on `v0.12.2` until the registry window reopens
 - Keep the three parser verification lanes explicit and green: `just corpus-sweep-check`, `just cpan-corpus-check`, and `just parser-audit`, with `just common-corpus-check` covering the pinned strict-clean subset
-- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` VS Code package, and the crates.io publish surface
-- Resume parser, corpus, and semantic hardening immediately after the `v0.13.0` tag
+- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the delayed crates.io surface
+- Resume parser, corpus, and semantic hardening while the `v0.13.0` announcement pass stays open
 
 **Next (v0.13.0 public alpha)**
 - Keep all three parser corpus lanes current: Ubuntu system Perl, the cached CPAN top 1000 install, and the repo-owned corpus audit

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -5,21 +5,23 @@
 
 ## Current Release Call
 
-**Latest published release**: `v0.12.2` (2026-04-07)
-**Release target**: `v0.12.3` pipeline-rehearsal cut
-**Ship readiness**: the 11-PR launch-prep drain merged cleanly on 2026-04-08, master carries the full publish/UX/CI hardening wave, and the only remaining explicit launch gate is the `#3302` demo-assets recording before the `v0.13.0` public alpha announcement
+**Latest GitHub/editor release**: `v0.12.3` (2026-04-09)
+**crates.io line**: `v0.12.2` (2026-04-07)
+**Release target**: `v0.13.0` public alpha announcement
+**Ship readiness**: `v0.12.3` is live on GitHub Releases, VS Code Marketplace, and Open VSX; the remaining launch work is announcement-path cleanup, with `#3302` demo assets still the main human-owned blocker before the `v0.13.0` public alpha announcement
 
 ## Active Blockers
 
-- `#3302` demo GIFs are the only human-owned blocker before the `v0.13.0` public alpha announcement
-- Public install guidance must stay tied to the crates.io truth at release time, not just the local workspace version line
+- `#3302` demo GIFs remain the main human-owned blocker before the `v0.13.0` public alpha announcement
+- Public install guidance must keep the channel split explicit while crates.io remains on `v0.12.2`
 
-## 0.12.3 Pipeline-Rehearsal Receipts (2026-04-08)
+## 0.12.3 Ship Receipts (2026-04-09)
 
-- `v0.12.2` is live on GitHub Releases and crates.io as of 2026-04-07, post-publish smoke test green
-- 11 launch-prep PRs merged in a controlled drain sequence on 2026-04-08 (master green at `a5680401`)
-- workspace version line bumped to `v0.12.3`; `check-version-sync` reports all 140 sites in agreement
-- `CHANGELOG.md` already carries the `[0.12.3]` entry; tagging is a `git tag` away
+- GitHub release `v0.12.3` published 2026-04-09 against `cc801735`
+- `Release` workflow completed successfully and attached the cross-platform `perllsp` archives plus `SHA256SUMS`
+- `Publish VSCode Extension` completed successfully; `perl-lsp-rs` `0.12.3` is live on both VS Code Marketplace and Open VSX
+- workspace version line is `v0.12.3`; `check-version-sync` still expects all 140 version sites to agree with it
+- crates.io intentionally remains on `v0.12.2` as of 2026-04-09, so docs and install guidance must keep that split explicit
 
 ## Component Summary
 
@@ -38,11 +40,11 @@ Native + Bridge preview. Harden preview flows is active work.
 ## Corpus Tracking Receipts
 
 - **Compatibility baseline (`just corpus-sweep-check`)**: Ubuntu system Perl in `.ci/parser-corpus-baseline.json` is the "does this still parse what ships on a stock Linux box?" receipt. Current committed floor: `6890/7095` clean (`97.1%`) on Perl `5.038002`, refreshed 2026-04-09 after the parser regression fixes.
-- **Ecosystem-breadth baseline (`just cpan-corpus-check`)**: `.ci/cpan-corpus-baseline.json` tracks the cached CPAN top-1000 install as the broad ecosystem receipt. Current committed floor: `3717/4355` clean (`85.4%`), baseline dated 2026-03-20. The install lane reuses `target/cpan-corpus/.cpanm` so reruns ratchet instead of redownloading from scratch.
+- **Ecosystem-breadth baseline (`just cpan-corpus-check`)**: `.ci/cpan-corpus-baseline.json` tracks the cached CPAN top-1000 install as the broad ecosystem receipt. Current committed floor: `8931/9372` clean (`95.3%`), baseline dated 2026-04-09. The install lane reuses `target/cpan-corpus/.cpanm` so reruns ratchet instead of redownloading from scratch.
 - **Deterministic regression baseline (`just parser-audit`)**: the repo-owned corpus stays at `91/91` clean, `64/68` NodeKinds covered, `12/12` GA features covered across `test_corpus/` plus `crates/perl-corpus/src/gen`.
-- **Strict-clean subsets**: `just common-corpus-check` enforces the pinned common manifest, and `.ci/cpan-corpus-manifest.txt` currently carries `4337` CPAN modules that must stay clean inside `just cpan-corpus-check`.
+- **Strict-clean subsets**: `just common-corpus-check` enforces the pinned common manifest, and `.ci/cpan-corpus-manifest.txt` currently carries `4488` CPAN modules that must stay clean inside `just cpan-corpus-check`.
 - **Automation discipline**: the post-merge CPAN workflow now refreshes both the full baseline receipt and the ratcheted manifest, then reruns the CPAN gate before attempting to commit either artifact.
-- **Cadence discipline**: the three baselines do not need identical refresh dates. The system-Perl receipt was rerun on 2026-04-09 after parser fixes; the CPAN top-1000 floor remains the committed 2026-03-20 snapshot until the full install lane is rerun end-to-end.
+- **Cadence discipline**: the three baselines do not need identical refresh dates, but the committed system-Perl and CPAN top-1000 receipts are now both refreshed through 2026-04-09 after the `v0.12.3` parser/corpus fixes.
 
 ## Coverage Baseline Receipts (2026-03-17)
 

--- a/xtask/src/tasks/cpan_corpus.rs
+++ b/xtask/src/tasks/cpan_corpus.rs
@@ -34,9 +34,13 @@ const CPANM_CACHE_DIR: &str = ".cpanm";
 const CPANM_STANDALONE_URL: &str = "https://cpanmin.us";
 /// MetaCPAN API endpoint for distribution search (sorted by river.immediate)
 const METACPAN_API: &str = "https://fastapi.metacpan.org/v1/distribution/_search";
-/// Hard timeout for a single cpanm invocation. Batch installs fall back to
-/// per-distribution retries when a distribution wedges inside configure/build.
-const CPANM_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+/// Hard timeout for a batch cpanm invocation. Batch installs fall back to
+/// per-distribution retries when one distribution wedges inside configure/build.
+const CPANM_BATCH_TIMEOUT: Duration = Duration::from_secs(120);
+/// Hard timeout for a single-distribution retry. Native-heavy distributions
+/// such as `PDL` legitimately need more wall-clock time than a whole batch
+/// should get before we split it apart.
+const CPANM_SINGLE_DIST_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Return the workspace root path, anchored at compile time to the xtask
 /// crate's manifest directory. This makes every relative CPAN corpus path
@@ -286,12 +290,12 @@ pub fn install(config: &CpanCorpusConfig) -> Result<()> {
             cmd.arg(dist);
         }
 
-        let output = run_command_with_timeout(cmd, CPANM_COMMAND_TIMEOUT)?;
+        let output = run_command_with_timeout(cmd, CPANM_BATCH_TIMEOUT)?;
         let stderr = String::from_utf8_lossy(&output.output.stderr);
         if output.timed_out {
             println!(
                 "cpanm batch {batch_num} timed out after {}s; retrying distributions individually",
-                CPANM_COMMAND_TIMEOUT.as_secs()
+                CPANM_BATCH_TIMEOUT.as_secs()
             );
             let (batch_installed, batch_failed) =
                 install_distributions_individually(&cpanm, &cpanm_home, &local_lib, chunk, config)?;
@@ -430,11 +434,11 @@ fn install_distributions_individually(
         cmd.arg("--quiet");
         cmd.arg(dist);
 
-        let output = run_command_with_timeout(cmd, CPANM_COMMAND_TIMEOUT)?;
+        let output = run_command_with_timeout(cmd, CPANM_SINGLE_DIST_TIMEOUT)?;
         let stderr = String::from_utf8_lossy(&output.output.stderr);
         if output.timed_out {
             failed += 1;
-            println!("  timed out after {}s: {}", CPANM_COMMAND_TIMEOUT.as_secs(), dist);
+            println!("  timed out after {}s: {}", CPANM_SINGLE_DIST_TIMEOUT.as_secs(), dist);
             continue;
         }
 


### PR DESCRIPTION
## Summary
- sync roadmap and status docs to the live v0.12.3 GitHub/editor release while keeping the crates.io v0.12.2 split explicit
- give post-merge CPAN installs a longer single-distribution timeout and more workflow headroom for slow native dists like PDL
- keep the release truth, version sync, and cached CPAN gate aligned after the 0.12.3 rollout

## Validation
- cargo fmt --all
- bash scripts/check-version-sync.sh
- just status-check
- cargo test -p xtask -- --nocapture
- just cpan-corpus-check