### PR TITLE
fix(analysis): align pragma and scope diagnostics (#3339)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -13,6 +13,7 @@
 
 use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::ast::{Node, NodeKind};
+use perl_pragma::PragmaTracker;
 
 use super::super::walker::walk_node;
 use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformation};
@@ -46,8 +47,11 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         return;
     }
 
-    let mut has_strict = false;
-    let mut has_warnings = false;
+    let pragma_map = PragmaTracker::build(node);
+    let mut has_strict = pragma_map
+        .iter()
+        .any(|(_, state)| state.strict_vars || state.strict_subs || state.strict_refs);
+    let mut has_warnings = pragma_map.iter().any(|(_, state)| state.warnings);
 
     // OO frameworks that implicitly provide strict+warnings
     const IMPLICIT_STRICT_MODULES: &[&str] = &[
@@ -69,6 +73,10 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 has_strict = true;
             } else if module == "warnings" {
                 has_warnings = true;
+            } else if module.starts_with('v')
+                || module.chars().next().is_some_and(|c| c.is_ascii_digit())
+            {
+                // Version pragmas are already reflected in the shared pragma map.
             } else if IMPLICIT_STRICT_MODULES.contains(&module.as_str()) {
                 has_strict = true;
                 has_warnings = true;
@@ -212,6 +220,35 @@ mod tests {
         assert!(
             !has_strict_warn,
             "file with both pragmas should get no strict/warnings diagnostic"
+        );
+    }
+
+    #[test]
+    fn version_pragma_suppresses_strict_warnings_diagnostic() {
+        let diags = strict_warnings_diags("use v5.40;\nmy $x = 1;\n");
+        let has_strict_warn =
+            diags.iter().any(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")));
+        assert!(!has_strict_warn, "use v5.40 should suppress strict/warnings diagnostics");
+    }
+
+    #[test]
+    fn numeric_version_pragma_suppresses_strict_warnings_diagnostic() {
+        let diags = strict_warnings_diags("use 5.040;\nmy $x = 1;\n");
+        let has_strict_warn =
+            diags.iter().any(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")));
+        assert!(!has_strict_warn, "use 5.040 should suppress strict/warnings diagnostics");
+    }
+
+    #[test]
+    fn v5_12_suppresses_strict_but_not_missing_warnings() {
+        let diags = strict_warnings_diags("use v5.12;\nmy $x = 1;\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL100")),
+            "use v5.12 should imply strict"
+        );
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL101")),
+            "use v5.12 should not imply warnings"
         );
     }
 

--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -240,6 +240,14 @@ mod tests {
     }
 
     #[test]
+    fn developer_version_pragma_suppresses_strict_warnings_diagnostic() {
+        let diags = strict_warnings_diags("use 5.040_001;\nmy $x = 1;\n");
+        let has_strict_warn =
+            diags.iter().any(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")));
+        assert!(!has_strict_warn, "use 5.040_001 should suppress strict/warnings diagnostics");
+    }
+
+    #[test]
     fn v5_12_suppresses_strict_but_not_missing_warnings() {
         let diags = strict_warnings_diags("use v5.12;\nmy $x = 1;\n");
         assert!(

--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -16,6 +16,7 @@
 
 use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::ast::{Node, NodeKind};
+use perl_pragma::{PerlVersion, features_enabled_by_version, parse_perl_version};
 
 use super::super::walker::walk_node;
 use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
@@ -38,47 +39,6 @@ const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     ("field", 5, 38),
 ];
 
-/// Parse a Perl version string into (major, minor).
-///
-/// Handles:
-/// - `"v5.36"`, `"v5.36.0"` → `(5, 36)`
-/// - `"5.036"` → `(5, 36)` (thousandths notation: `parse("036")` == 36)
-/// - `"5.010"` → `(5, 10)`
-/// - `"5.10"` → `(5, 10)`
-/// - `"5.8"` → `(5, 8)`
-fn parse_perl_version(module: &str) -> Option<(u32, u32)> {
-    // Strip optional 'v' prefix: "v5.36" → "5.36"
-    let s = module.strip_prefix('v').unwrap_or(module);
-
-    let parts: Vec<&str> = s.splitn(3, '.').collect();
-    let major: u32 = parts.first()?.parse().ok()?;
-    // "036" parses as 36, "10" parses as 10 — both correct for our comparison
-    let minor: u32 = parts.get(1)?.parse().ok()?;
-
-    Some((major, minor))
-}
-
-/// Returns the set of features implicitly enabled by declaring `use vM.N`.
-fn features_enabled_by_version(major: u32, minor: u32) -> Vec<&'static str> {
-    let mut features = Vec::new();
-    if (major, minor) >= (5, 10) {
-        features.extend_from_slice(&["say", "state"]);
-    }
-    if (major, minor) >= (5, 20) {
-        features.push("postfix_deref");
-    }
-    if (major, minor) >= (5, 34) {
-        features.push("try");
-    }
-    if (major, minor) >= (5, 36) {
-        features.push("signatures");
-    }
-    if (major, minor) >= (5, 38) {
-        features.extend_from_slice(&["class", "field", "method"]);
-    }
-    features
-}
-
 /// Check for Perl version compatibility issues.
 ///
 /// Walks the AST looking for uses of version-gated features and emits
@@ -90,16 +50,13 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         _ => return,
     };
 
-    let mut declared_version: Option<(u32, u32)> = None;
+    let mut declared_version: Option<PerlVersion> = None;
     let mut explicit_features: Vec<String> = Vec::new();
 
     for stmt in statements {
         if let NodeKind::Use { module, args, .. } = &stmt.kind {
             // Check for `use vN.NN` or `use N.NNN`
-            if (module.starts_with('v')
-                || module.chars().next().is_some_and(|c| c.is_ascii_digit()))
-                && let Some(version) = parse_perl_version(module)
-            {
+            if let Some(version) = parse_perl_version(module) {
                 // Take the highest declared version if multiple appear
                 match declared_version {
                     None => declared_version = Some(version),
@@ -119,13 +76,13 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     }
 
     // If no version was declared, skip all checks.
-    let (major, minor) = match declared_version {
+    let declared_version = match declared_version {
         Some(v) => v,
         None => return,
     };
 
     // Derive effective feature set from declared version.
-    let mut effective_features = features_enabled_by_version(major, minor);
+    let mut effective_features = features_enabled_by_version(declared_version);
 
     // Explicit `use feature 'X'` additions override version.
     for feat in &explicit_features {
@@ -147,7 +104,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             NodeKind::Class { .. } => {
                 if !effective_features.contains(&"class") {
                     let min = feature_min_version("class");
-                    diagnostics.push(make_diagnostic(n, "class", major, minor, min));
+                    diagnostics.push(make_diagnostic(n, "class", declared_version, min));
                 }
             }
 
@@ -155,7 +112,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             NodeKind::Try { .. } => {
                 if !effective_features.contains(&"try") {
                     let min = feature_min_version("try");
-                    diagnostics.push(make_diagnostic(n, "try/catch", major, minor, min));
+                    diagnostics.push(make_diagnostic(n, "try/catch", declared_version, min));
                 }
             }
 
@@ -163,7 +120,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             NodeKind::FunctionCall { name, .. } if name == "say" => {
                 if !effective_features.contains(&"say") {
                     let min = feature_min_version("say");
-                    diagnostics.push(make_diagnostic(n, "say", major, minor, min));
+                    diagnostics.push(make_diagnostic(n, "say", declared_version, min));
                 }
             }
 
@@ -171,7 +128,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             NodeKind::VariableDeclaration { declarator, .. } if declarator == "state" => {
                 if !effective_features.contains(&"state") {
                     let min = feature_min_version("state");
-                    diagnostics.push(make_diagnostic(n, "state", major, minor, min));
+                    diagnostics.push(make_diagnostic(n, "state", declared_version, min));
                 }
             }
 
@@ -181,7 +138,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             {
                 if !effective_features.contains(&"postfix_deref") {
                     let min = feature_min_version("postfix_deref");
-                    diagnostics.push(make_diagnostic(n, "postfix deref", major, minor, min));
+                    diagnostics.push(make_diagnostic(n, "postfix deref", declared_version, min));
                 }
             }
 
@@ -192,8 +149,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                     diagnostics.push(make_diagnostic(
                         n,
                         "subroutine signatures",
-                        major,
-                        minor,
+                        declared_version,
                         min,
                     ));
                 }
@@ -217,13 +173,12 @@ fn feature_min_version(feature: &str) -> (u32, u32) {
 fn make_diagnostic(
     node: &Node,
     display: &str,
-    declared_major: u32,
-    declared_minor: u32,
+    declared_version: PerlVersion,
     min_version: (u32, u32),
 ) -> Diagnostic {
     let message = format!(
         "'{}' requires Perl v{}.{}+; declared version is v{}.{}",
-        display, min_version.0, min_version.1, declared_major, declared_minor,
+        display, min_version.0, min_version.1, declared_version.major, declared_version.minor,
     );
 
     Diagnostic {
@@ -235,7 +190,7 @@ fn make_diagnostic(
         tags: vec![],
         suggestion: Some(format!(
             "Update 'use v{}.{}' to 'use v{}.{}' or add 'use feature \"{}\";'",
-            declared_major, declared_minor, min_version.0, min_version.1, display,
+            declared_version.major, declared_version.minor, min_version.0, min_version.1, display,
         )),
     }
 }

--- a/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
@@ -485,6 +485,23 @@ fn test_clearing_on_fix_lint_diagnostics_also_clear() -> Result<(), Box<dyn std:
     Ok(())
 }
 
+#[test]
+fn test_version_pragma_suppresses_missing_strict_warnings() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = "use v5.40;\nmy $x = 1;\n";
+    let diags = diagnostics_for(source);
+    let lint_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")))
+        .collect();
+
+    assert!(
+        lint_diags.is_empty(),
+        "use v5.40 should suppress missing strict/warnings diagnostics: {lint_diags:?}"
+    );
+    Ok(())
+}
+
 // =========================================================================
 // 6. Suggestion field populated for actionable diagnostics
 // =========================================================================

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -166,6 +166,24 @@ fn test_class_ok_on_v5_40() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // ---------------------------------------------------------------------------
+// Test 2a: class in v5.38_001 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_class_ok_on_v5_38_dev_release() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38_001"), class_node("Foo")]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'class' in v5.38_001, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3: `use feature 'class'` overrides an old version declaration -> no warn
 // ---------------------------------------------------------------------------
 //

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -148,6 +148,24 @@ fn test_class_ok_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // ---------------------------------------------------------------------------
+// Test 2b: class in v5.40 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_class_ok_on_v5_40() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40"), class_node("Foo")]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'class' in v5.40, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3: `use feature 'class'` overrides an old version declaration -> no warn
 // ---------------------------------------------------------------------------
 //

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -49,17 +49,23 @@ impl PragmaState {
 /// - `v5.36.0`
 /// - `5.036`
 /// - `5.10`
+/// - developer releases like `5.012_001`
 pub fn parse_perl_version(module: &str) -> Option<PerlVersion> {
     let s = module.strip_prefix('v').unwrap_or(module);
 
     let parts: Vec<&str> = s.splitn(3, '.').collect();
-    let major: u32 = parts.first()?.parse().ok()?;
+    let major: u32 = parse_version_component(parts.first()?)?;
     let minor: u32 = match parts.get(1) {
-        Some(part) => part.parse().ok()?,
+        Some(part) => parse_version_component(part)?,
         None => 0,
     };
 
     Some(PerlVersion { major, minor })
+}
+
+fn parse_version_component(component: &str) -> Option<u32> {
+    let component = component.split_once('_').map_or(component, |(head, _)| head);
+    component.parse().ok()
 }
 
 /// Whether `use VERSION` implies `strict` for this version.

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -6,6 +6,22 @@
 use perl_ast::ast::{Node, NodeKind};
 use std::ops::Range;
 
+/// Parsed Perl version from a lexical `use v...;` or `use 5.xxx;` pragma.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PerlVersion {
+    /// Major Perl version component.
+    pub major: u32,
+    /// Minor Perl version component.
+    pub minor: u32,
+}
+
+impl PerlVersion {
+    /// Create a new Perl version value.
+    pub const fn new(major: u32, minor: u32) -> Self {
+        Self { major, minor }
+    }
+}
+
 /// Pragma state at a given point in the code
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PragmaState {
@@ -23,6 +39,71 @@ impl PragmaState {
     /// Create a new pragma state with all strict modes enabled
     pub fn all_strict() -> Self {
         Self { strict_vars: true, strict_subs: true, strict_refs: true, warnings: false }
+    }
+}
+
+/// Parse a Perl version string into a major/minor pair.
+///
+/// Handles lexical version pragmas such as:
+/// - `v5.36`
+/// - `v5.36.0`
+/// - `5.036`
+/// - `5.10`
+pub fn parse_perl_version(module: &str) -> Option<PerlVersion> {
+    let s = module.strip_prefix('v').unwrap_or(module);
+
+    let parts: Vec<&str> = s.splitn(3, '.').collect();
+    let major: u32 = parts.first()?.parse().ok()?;
+    let minor: u32 = match parts.get(1) {
+        Some(part) => part.parse().ok()?,
+        None => 0,
+    };
+
+    Some(PerlVersion { major, minor })
+}
+
+/// Whether `use VERSION` implies `strict` for this version.
+#[must_use]
+pub fn version_implies_strict(version: PerlVersion) -> bool {
+    version >= PerlVersion::new(5, 12)
+}
+
+/// Whether `use VERSION` implies `warnings` for this version.
+#[must_use]
+pub fn version_implies_warnings(version: PerlVersion) -> bool {
+    version >= PerlVersion::new(5, 35)
+}
+
+/// Returns the language features implicitly enabled by declaring `use VERSION`.
+#[must_use]
+pub fn features_enabled_by_version(version: PerlVersion) -> Vec<&'static str> {
+    let mut features = Vec::new();
+    if version >= PerlVersion::new(5, 10) {
+        features.extend_from_slice(&["say", "state"]);
+    }
+    if version >= PerlVersion::new(5, 20) {
+        features.push("postfix_deref");
+    }
+    if version >= PerlVersion::new(5, 34) {
+        features.push("try");
+    }
+    if version >= PerlVersion::new(5, 36) {
+        features.push("signatures");
+    }
+    if version >= PerlVersion::new(5, 38) {
+        features.extend_from_slice(&["class", "field", "method"]);
+    }
+    features
+}
+
+fn enable_effective_version_semantics(state: &mut PragmaState, version: PerlVersion) {
+    if version_implies_strict(version) {
+        state.strict_vars = true;
+        state.strict_subs = true;
+        state.strict_refs = true;
+    }
+    if version_implies_warnings(version) {
+        state.warnings = true;
     }
 }
 
@@ -100,7 +181,15 @@ impl PragmaTracker {
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
-                    _ => {}
+                    _ => {
+                        if let Some(version) = parse_perl_version(module) {
+                            enable_effective_version_semantics(current_state, version);
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                        }
+                    }
                 }
             }
             NodeKind::No { module, args, .. } => {

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -234,6 +234,43 @@ fn use_warnings_enables_warnings() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn use_v5_12_enables_effective_strict_only() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.12", &[], 0, 12)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(!state.warnings, "v5.12 should not imply warnings");
+    Ok(())
+}
+
+#[test]
+fn use_v5_40_enables_effective_strict_and_warnings() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40", &[], 0, 12)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(state.warnings);
+    Ok(())
+}
+
+#[test]
+fn use_numeric_version_enables_effective_strict_and_warnings()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("5.040", &[], 0, 12)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(state.warnings);
+    Ok(())
+}
+
+#[test]
 fn no_warnings_disables_warnings() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("warnings", &[], 0, 15), no_node("warnings", &[], 16, 30)]);
     let map = PragmaTracker::build(&ast);

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -271,6 +271,18 @@ fn use_numeric_version_enables_effective_strict_and_warnings()
 }
 
 #[test]
+fn use_developer_version_enables_effective_strict_only() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("5.012_001", &[], 0, 16)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    assert!(!state.warnings, "5.012_001 should not imply warnings");
+    Ok(())
+}
+
+#[test]
 fn no_warnings_disables_warnings() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("warnings", &[], 0, 15), no_node("warnings", &[], 16, 30)]);
     let map = PragmaTracker::build(&ast);

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -931,7 +931,8 @@ impl ScopeAnalyzer {
             return None;
         };
 
-        if (sigil == "@" || sigil == "%") && name.starts_with('$') && name.len() > 1 {
+        if (sigil == "@" || sigil == "%" || sigil == "$") && name.starts_with('$') && name.len() > 1
+        {
             return Some(("$", &name[1..]));
         }
 

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -438,7 +438,8 @@ impl ScopeAnalyzer {
     ) {
         // Get effective pragma state at this node's location
         let pragma_state = PragmaTracker::state_for_offset(context.pragma_map, node.location.start);
-        let strict_mode = pragma_state.strict_subs;
+        let strict_vars_mode = pragma_state.strict_vars;
+        let strict_subs_mode = pragma_state.strict_subs;
         match &node.kind {
             NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
                 let extracted = self.extract_variable_name(variable);
@@ -588,41 +589,17 @@ impl ScopeAnalyzer {
                     return;
                 }
 
-                // Try to use the variable - allocation free!
-                let (mut variable_used, mut is_initialized) = scope.use_variable_parts(sigil, name);
-
-                // If not found as simple variable, check if this is part of a hash/array access pattern
-                if !variable_used && (sigil == "$" || sigil == "@") {
-                    // Check parent for hash/array access context
-                    if let Some(parent) = ancestors.last() {
-                        if let NodeKind::Binary { op, left, .. } = &parent.kind {
-                            // Only check if this node is the LEFT side of the access
-                            if std::ptr::eq(left.as_ref(), node) {
-                                if op == "{}" || op == "->{}" {
-                                    // Check if the corresponding hash exists
-                                    let (hash_used, hash_init) =
-                                        scope.use_variable_parts("%", name);
-                                    if hash_used {
-                                        variable_used = true;
-                                        is_initialized = hash_init;
-                                    }
-                                } else if op == "[]" || op == "->[]" {
-                                    // Check if the corresponding array exists
-                                    let (array_used, array_init) =
-                                        scope.use_variable_parts("@", name);
-                                    if array_used {
-                                        variable_used = true;
-                                        is_initialized = array_init;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                // Normalize explicit dereference/container syntax before lookup so that
+                // `@$ref` resolves to `$ref`, while direct subscripting keeps using the
+                // container sigil that the syntax implies.
+                let (lookup_sigil, lookup_name) =
+                    self.resolve_variable_use_target(node, ancestors).unwrap_or((sigil, name));
+                let (variable_used, is_initialized) =
+                    scope.use_variable_parts(lookup_sigil, lookup_name);
 
                 // Variable not found - check if we should report it
                 if !variable_used {
-                    if strict_mode {
+                    if strict_vars_mode {
                         let full_name = format!("{}{}", sigil, name);
                         issues.push(ScopeIssue {
                             kind: IssueKind::UndeclaredVariable,
@@ -720,7 +697,7 @@ impl ScopeAnalyzer {
             NodeKind::Identifier { name } => {
                 // Check for barewords under strict mode, excluding hash keys
                 // Hybrid check: Fast path for immediate hash keys (depth 1), then known functions, then deep check
-                if strict_mode
+                if strict_subs_mode
                     && !self.is_in_hash_key_context(node, ancestors, 1)
                     && !is_known_function(name)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
@@ -912,11 +889,17 @@ impl ScopeAnalyzer {
                 self.collect_unused_variables(&sub_scope, issues, context);
             }
 
-            NodeKind::FunctionCall { args, .. } => {
-                // Handle function arguments, which may contain complex variable patterns
+            NodeKind::FunctionCall { name, args } => {
+                // Handle function arguments, which may contain complex variable patterns.
+                // Some builtins consume declaration-capable filehandle arguments directly,
+                // e.g. `open my $fh, ...` or `pipe my $r, my $w;`. Those declarations should
+                // count as used and initialized by the builtin itself.
                 ancestors.push(node);
                 for arg in args {
                     self.analyze_node(arg, scope, ancestors, issues, context);
+                    if is_declaration_capable_builtin(name) {
+                        self.mark_builtin_declaration_arg_consumed(arg, scope);
+                    }
                 }
                 ancestors.pop();
             }
@@ -930,6 +913,41 @@ impl ScopeAnalyzer {
                 ancestors.pop();
             }
         }
+    }
+
+    /// Resolve the variable symbol that a syntax form should count as a use.
+    ///
+    /// This keeps explicit dereference syntax precise:
+    /// - `@$ref` and `%$ref` count as uses of `$ref`
+    /// - `$arr[0]` counts as a use of `@arr`
+    /// - `$hash{k}` counts as a use of `%hash`
+    /// - Arrow dereference forms stay on the scalar reference itself
+    fn resolve_variable_use_target<'a>(
+        &self,
+        node: &'a Node,
+        ancestors: &[&'a Node],
+    ) -> Option<(&'a str, &'a str)> {
+        let NodeKind::Variable { sigil, name } = &node.kind else {
+            return None;
+        };
+
+        if (sigil == "@" || sigil == "%") && name.starts_with('$') && name.len() > 1 {
+            return Some(("$", &name[1..]));
+        }
+
+        if sigil == "$"
+            && let Some(parent) = ancestors.last()
+            && let NodeKind::Binary { op, left, .. } = &parent.kind
+            && std::ptr::eq(left.as_ref(), node)
+        {
+            match op.as_str() {
+                "[]" => return Some(("@", name)),
+                "{}" => return Some(("%", name)),
+                _ => {}
+            }
+        }
+
+        Some((sigil, name))
     }
 
     /// Marks variables as initialized when they appear on the left-hand side of an assignment.
@@ -948,6 +966,27 @@ impl ScopeAnalyzer {
                     self.mark_initialized(child, scope);
                 }
             }
+        }
+    }
+
+    fn mark_builtin_declaration_arg_consumed(&self, node: &Node, scope: &Rc<Scope>) {
+        match &node.kind {
+            NodeKind::VariableDeclaration { variable, .. } => {
+                let extracted = self.extract_variable_name(variable);
+                let (sigil, name) = extracted.parts();
+                if !sigil.is_empty() && !name.is_empty() && !name.contains("::") {
+                    let _ = scope.initialize_and_use_variable_parts(sigil, name);
+                }
+            }
+            NodeKind::VariableListDeclaration { variables, .. } => {
+                for variable in variables {
+                    self.mark_builtin_declaration_arg_consumed(variable, scope);
+                }
+            }
+            NodeKind::VariableWithAttributes { variable, .. } => {
+                self.mark_builtin_declaration_arg_consumed(variable, scope);
+            }
+            _ => {}
         }
     }
 
@@ -1308,6 +1347,15 @@ fn is_known_function(name: &str) -> bool {
         | "state" | "scalar" | "wantarray" | "warn" => true,
         _ => false,
     }
+}
+
+/// Builtins whose declaration-capable filehandle arguments are consumed by the builtin itself.
+///
+/// Keep this list explicit and conservative. Only include builtins where the parser already
+/// emits declaration nodes for the handle argument, and where treating that declaration as
+/// used avoids false diagnostics after the call.
+fn is_declaration_capable_builtin(name: &str) -> bool {
+    matches!(name, "open" | "opendir" | "sysopen" | "pipe" | "socket" | "accept")
 }
 
 /// Check if an identifier is a known filehandle

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -806,6 +806,10 @@ push @{$arrayref}, 2;
 my $hashref;
 $hashref->{k};
 
+my $value = 1;
+my $scalarref = \$value;
+$$scalarref;
+
 my @arr = (1, 2, 3);
 $arr[0];
 "#;
@@ -822,6 +826,12 @@ $arr[0];
         .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hashref"))
         .count();
     assert_eq!(unused_hashref, 0, "$hashref used via arrow dereference should not be unused");
+
+    let unused_scalarref = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("scalarref"))
+        .count();
+    assert_eq!(unused_scalarref, 0, "$scalarref used via scalar dereference should not be unused");
 
     let unused_arr = issues
         .iter()
@@ -1044,6 +1054,34 @@ print FOO;
             .iter()
             .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
         "use v5.40 should enable strict subs"
+    );
+    Ok(())
+}
+
+#[test]
+fn scalar_reference_dereference_uses_declared_scalar_under_strict()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+my $value = 1;
+my $ref = \$value;
+print $$ref;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$$ref"),
+        "$$ref should resolve through declared $ref: {:?}",
+        issues
+    );
+    assert!(
+        !issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UnusedVariable) && i.variable_name.contains("ref")),
+        "$ref used via $$ref should not be unused: {:?}",
+        issues
     );
     Ok(())
 }

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -134,6 +134,48 @@ my ($alpha, $bravo, $charlie) = (1, 2, 3);
     Ok(())
 }
 
+#[test]
+fn scope_declaration_capable_builtins_initialize_handle_bindings()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+open my $fh, '<', 'input.txt' or die $!;
+print $fh;
+opendir my $dh, '.' or die $!;
+print $dh;
+sysopen my $sys_fh, 'sysfile.txt', 0 or die $!;
+print $sys_fh;
+pipe my $reader, my $writer;
+print $reader;
+print $writer;
+socket my $sock, PF_INET, SOCK_STREAM, getprotobyname('tcp');
+print $sock;
+accept my $client, $sock;
+print $client;
+"#;
+
+    let issues = scope_issues_strict(code);
+    let handled = ["$fh", "$dh", "$sys_fh", "$reader", "$writer", "$sock", "$client"];
+
+    for variable_name in handled {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == variable_name
+            }),
+            "builtin filehandle declaration should be declared, initialized, and consumed: {} (issues: {:?})",
+            variable_name,
+            issues
+        );
+    }
+
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Variable Scope Resolution — our
 // ===========================================================================
@@ -755,6 +797,42 @@ fn unused_variable_basic_hash() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn unused_variable_used_via_explicit_dereference_forms() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $arrayref;
+push @$arrayref, 1;
+push @{$arrayref}, 2;
+
+my $hashref;
+$hashref->{k};
+
+my @arr = (1, 2, 3);
+$arr[0];
+"#;
+    let issues = scope_issues(code);
+
+    let unused_arrayref = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("arrayref"))
+        .count();
+    assert_eq!(unused_arrayref, 0, "$arrayref used via dereference should not be unused");
+
+    let unused_hashref = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hashref"))
+        .count();
+    assert_eq!(unused_hashref, 0, "$hashref used via arrow dereference should not be unused");
+
+    let unused_arr = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("arr"))
+        .count();
+    assert_eq!(unused_arr, 0, "@arr used via direct indexing should not be unused");
+
+    Ok(())
+}
+
+#[test]
 fn unused_underscore_prefix_suppressed() -> Result<(), Box<dyn std::error::Error>> {
     // Variables prefixed with underscore should NOT be flagged as unused.
     let code = r#"
@@ -900,6 +978,72 @@ print $unknown_var;
     assert!(
         has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
         "should detect undeclared $unknown_var under strict"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_vars_only_checks_undeclared_variables() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'vars';
+print $unknown_var;
+print FOO;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
+        "strict 'vars' should flag undeclared variables"
+    );
+    assert!(
+        !issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
+        "strict 'vars' should not flag barewords"
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_only_checks_barewords() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+print $unknown_var;
+print FOO;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
+        "strict 'subs' should not flag undeclared variables"
+    );
+    assert!(
+        issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
+        "strict 'subs' should flag barewords"
+    );
+    Ok(())
+}
+
+#[test]
+fn version_pragma_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use v5.40;
+print $unknown_var;
+print FOO;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
+        "use v5.40 should enable strict vars"
+    );
+    assert!(
+        issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
+        "use v5.40 should enable strict subs"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- centralize lexical `use VERSION` semantics in `perl-pragma` and reuse them across strict/warnings checks and version compatibility (#3339)
- split scope analysis so undeclared variables follow `strict 'vars'` while barewords follow `strict 'subs'` (#3339)
- normalize dereference/container use tracking so `@$arrayref`, `@{$arrayref}`, and `$hashref->{k}` mark the right declarations as used (#3338)
- treat declaration-capable builtin handle arguments as consumed and initialized after calls like `open my $fh, ...` (#3336)

## Commentary Takeaways
- #3336 commentary was right to question parser vs analyzer, but the parser AST was already correct; the fix belongs in scope consumption.
- #3338 commentary found the right file, but the safe fix is syntax-aware normalization, not blanket cross-sigil aliasing.
- #3339 is the shared-semantics seam and leads the implementation order here.

## Validation
- `cargo fmt --all`
- `cargo test -p perl-pragma`
- `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests -- --nocapture`
- `cargo test -p perl-lsp-diagnostics --test version_compat_tests --test diagnostic_integration_test -- --nocapture`
- `cargo test -p perl-lsp-diagnostics --lib -- --nocapture`
- `just pr-fast`

Closes #3339
Related: #3336, #3338