### PR TITLE
docs(config): clarify includePaths semantics (#3337)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -249,7 +249,10 @@ impl ServerConfig {
 /// Perl module files across the workspace.
 #[derive(Debug, Clone)]
 pub struct WorkspaceConfig {
-    /// Custom include paths for module resolution (relative to workspace root)
+    /// Workspace-root-relative include paths for module resolution.
+    ///
+    /// Absolute entries are only honored when they still resolve inside the
+    /// workspace boundary.
     /// Default: `["lib", ".", "local/lib/perl5"]`
     pub include_paths: Vec<String>,
 
@@ -357,7 +360,10 @@ pub struct ProjectConfig {
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default)]
 pub struct ProjectPerlConfig {
-    /// Additional include paths for module resolution (relative to workspace root).
+    /// Additional include paths for module resolution.
+    ///
+    /// Relative entries are resolved against the workspace root. Absolute
+    /// entries are still subject to workspace boundary validation.
     pub include_paths: Vec<String>,
     /// Perl version string (e.g. "5.38") — parsed but not yet wired to diagnostics.
     /// Reserved for future use; ignored in this implementation.

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -251,8 +251,8 @@ impl ServerConfig {
 pub struct WorkspaceConfig {
     /// Workspace-root-relative include paths for module resolution.
     ///
-    /// Absolute entries are only honored when they still resolve inside the
-    /// workspace boundary.
+    /// Absolute entries are accepted syntactically, but still must resolve
+    /// inside the workspace boundary.
     /// Default: `["lib", ".", "local/lib/perl5"]`
     pub include_paths: Vec<String>,
 
@@ -363,7 +363,8 @@ pub struct ProjectPerlConfig {
     /// Additional include paths for module resolution.
     ///
     /// Relative entries are resolved against the workspace root. Absolute
-    /// entries are still subject to workspace boundary validation.
+    /// entries are accepted syntactically, but still must resolve inside the
+    /// workspace boundary.
     pub include_paths: Vec<String>,
     /// Perl version string (e.g. "5.38") — parsed but not yet wired to diagnostics.
     /// Reserved for future use; ignored in this implementation.

--- a/crates/perl-lsp-diagnostics/src/lints/missing_module.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/missing_module.rs
@@ -19,7 +19,8 @@ use super::super::walker::walk_node;
 ///
 /// This list prevents false positives when `use_system_inc` is false.
 /// Conservative (under-includes) — a missed detection is better than
-/// a false positive that erodes diagnostic trust.
+/// a false positive that erodes diagnostic trust. It does not attempt to
+/// emulate Perl's full runtime `@INC` search order.
 pub const CORE_MODULES: &[&str] = &[
     // Pragmas (no-network, no-filesystem)
     "strict",

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -20,7 +20,8 @@ static WARN_ONCE_ROOT_UNDETECTED: Once = Once::new();
 
 /// Prepend `use lib` paths extracted from `doc_text` to `include_paths`.
 ///
-/// Mirrors Perl's runtime behaviour: `use lib` prepends to `@INC`.
+/// The extra paths are scoped to this resolution pass only and are searched
+/// ahead of the configured workspace paths.
 /// Paths are scoped to this call only — `workspace_config.include_paths` is never mutated.
 fn prepend_use_lib_paths(
     include_paths: &mut Vec<String>,
@@ -41,8 +42,7 @@ impl LspServer {
     /// Enhanced module path resolver using workspace configuration and optional document text.
     ///
     /// When `doc_text` is provided, `use lib` paths extracted from it are prepended to the
-    /// include path list for this call only (no global state mutation). Mirrors Perl's
-    /// runtime `@INC` prepend behaviour.
+    /// include path list for this call only (no global state mutation).
     ///
     /// Use `resolve_module_path_with_uri` when a document URI is available so that
     /// `FindBin`-relative paths are resolved against the document's directory.

--- a/crates/perl-module-resolution-path/src/lib.rs
+++ b/crates/perl-module-resolution-path/src/lib.rs
@@ -111,7 +111,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_absolute_include_path_outside_workspace() -> Result<(), Box<dyn std::error::Error>> {
+    fn falls_back_when_absolute_include_path_is_outside_workspace()
+    -> Result<(), Box<dyn std::error::Error>> {
         let workspace = tempfile::tempdir()?;
         let outside = tempfile::tempdir()?;
         let root = workspace.path().to_path_buf();

--- a/crates/perl-module-resolution-path/src/lib.rs
+++ b/crates/perl-module-resolution-path/src/lib.rs
@@ -90,4 +90,43 @@ mod tests {
         assert_eq!(resolved, Some(root.join("Local/Only.pm")));
         Ok(())
     }
+
+    #[test]
+    fn accepts_absolute_include_path_inside_workspace() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().to_path_buf();
+        let absolute_base = root.join("vendor").join("lib");
+        let module_file = absolute_base.join("Vendor").join("Tool.pm");
+
+        fs::create_dir_all(module_file.parent().ok_or("no parent")?)?;
+        fs::write(&module_file, "package Vendor::Tool; 1;")?;
+
+        let resolved = resolve_module_path(
+            &root,
+            "Vendor::Tool",
+            &[absolute_base.to_string_lossy().to_string()],
+        );
+        assert_eq!(resolved, Some(module_file));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_absolute_include_path_outside_workspace() -> Result<(), Box<dyn std::error::Error>> {
+        let workspace = tempfile::tempdir()?;
+        let outside = tempfile::tempdir()?;
+        let root = workspace.path().to_path_buf();
+        let outside_base = outside.path().join("lib");
+        let fallback = root.join("lib").join("Outside").join("Mod.pm");
+
+        fs::create_dir_all(fallback.parent().ok_or("no parent")?)?;
+        fs::write(&fallback, "package Outside::Mod; 1;")?;
+
+        let resolved = resolve_module_path(
+            &root,
+            "Outside::Mod",
+            &[outside_base.to_string_lossy().to_string()],
+        );
+        assert_eq!(resolved, Some(fallback));
+        Ok(())
+    }
 }

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -177,8 +177,12 @@ Controls module resolution and workspace scanning behaviour.
 | Default | `["lib", ".", "local/lib/perl5"]` |
 | Key | `includePaths` |
 
-Directories to search for Perl modules, relative to the workspace root. Appended
-to the internal `@INC` used for go-to-definition and hover documentation.
+Directories to search for Perl modules. Relative entries are resolved against
+the workspace root. Absolute entries are honored as provided only when they
+still stay inside the workspace boundary. These paths are searched by
+`perl-lsp` and are not appended to Perl's runtime `@INC`.
+
+Use `useSystemInc` to opt in to system `@INC` lookup.
 
 ```json
 {


### PR DESCRIPTION
## Summary
Clarifies the current `includePaths` contract instead of broadening resolver behavior implicitly.

## Changes
- documents `includePaths` as workspace-relative search roots
- makes `useSystemInc` an explicitly separate, opt-in system lookup path
- tightens resolver/config comments and tests around workspace-bounded behavior
- keeps absolute external roots out of scope for this fix

## Why
Issue #3337 is a config/contract mismatch. The current resolver is workspace-bounded by design, but the docs implied a broader `@INC` composition model. This PR aligns the docs and tests with the implementation rather than smuggling in new resolver semantics.

Closes #3337