### PR TITLE
fix(diagnostics): flag given-when deprecation and removal (#3375)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -111,16 +111,16 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 }
             }
 
-            // `given` / `when` — deprecated in v5.38 and removed in v5.42.
-            NodeKind::Given { .. } => {
+            // `given` / `when` / `default` — deprecated in v5.38 and removed in v5.42.
+            NodeKind::Given { .. } | NodeKind::When { .. } | NodeKind::Default { .. } => {
                 if declared_version >= GIVEN_WHEN_REMOVAL_VERSION {
-                    diagnostics.push(make_given_when_diagnostic(
+                    diagnostics.push(make_given_when_default_diagnostic(
                         n,
                         declared_version,
                         DiagnosticSeverity::Error,
                     ));
                 } else if declared_version >= GIVEN_WHEN_DEPRECATION_VERSION {
-                    diagnostics.push(make_given_when_diagnostic(
+                    diagnostics.push(make_given_when_default_diagnostic(
                         n,
                         declared_version,
                         DiagnosticSeverity::Warning,
@@ -209,7 +209,7 @@ fn make_diagnostic(
     )
 }
 
-fn make_given_when_diagnostic(
+fn make_given_when_default_diagnostic(
     node: &Node,
     declared_version: PerlVersion,
     severity: DiagnosticSeverity,
@@ -217,14 +217,14 @@ fn make_given_when_diagnostic(
     let (message, min_version) = match severity {
         DiagnosticSeverity::Error => (
             format!(
-                "'given/when' was removed in Perl v5.42; declared version is v{}.{}",
+                "'given/when/default' was removed in Perl v5.42; declared version is v{}.{}",
                 declared_version.major, declared_version.minor
             ),
             (5, 42),
         ),
         _ => (
             format!(
-                "'given/when' is deprecated starting in Perl v5.38; declared version is v{}.{}",
+                "'given/when/default' is deprecated starting in Perl v5.38; declared version is v{}.{}",
                 declared_version.major, declared_version.minor
             ),
             (5, 38),
@@ -239,8 +239,10 @@ fn make_given_when_diagnostic(
         related_information: vec![],
         tags: vec![],
         suggestion: Some(format!(
-            "Refactor `given` / `when` to `if` / `elsif` or another supported control-flow form before targeting Perl v{}.{}",
-            min_version.0, min_version.1
+            "Refactor `given` / `when` / `default` to `if` / `elsif` or another supported control-flow form; this feature is {} in v{}.{}.",
+            if severity == DiagnosticSeverity::Error { "removed" } else { "deprecated" },
+            min_version.0,
+            min_version.1
         )),
     }
 }

--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -39,6 +39,9 @@ const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     ("field", 5, 38),
 ];
 
+const GIVEN_WHEN_DEPRECATION_VERSION: PerlVersion = PerlVersion::new(5, 38);
+const GIVEN_WHEN_REMOVAL_VERSION: PerlVersion = PerlVersion::new(5, 42);
+
 /// Check for Perl version compatibility issues.
 ///
 /// Walks the AST looking for uses of version-gated features and emits
@@ -105,6 +108,23 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 if !effective_features.contains(&"class") {
                     let min = feature_min_version("class");
                     diagnostics.push(make_diagnostic(n, "class", declared_version, min));
+                }
+            }
+
+            // `given` / `when` — deprecated in v5.38 and removed in v5.42.
+            NodeKind::Given { .. } => {
+                if declared_version >= GIVEN_WHEN_REMOVAL_VERSION {
+                    diagnostics.push(make_given_when_diagnostic(
+                        n,
+                        declared_version,
+                        DiagnosticSeverity::Error,
+                    ));
+                } else if declared_version >= GIVEN_WHEN_DEPRECATION_VERSION {
+                    diagnostics.push(make_given_when_diagnostic(
+                        n,
+                        declared_version,
+                        DiagnosticSeverity::Warning,
+                    ));
                 }
             }
 
@@ -176,6 +196,63 @@ fn make_diagnostic(
     declared_version: PerlVersion,
     min_version: (u32, u32),
 ) -> Diagnostic {
+    make_diagnostic_with_details(
+        node,
+        display,
+        declared_version,
+        min_version,
+        DiagnosticSeverity::Warning,
+        Some(format!(
+            "Update 'use v{}.{}' to 'use v{}.{}' or add 'use feature \"{}\";'",
+            declared_version.major, declared_version.minor, min_version.0, min_version.1, display,
+        )),
+    )
+}
+
+fn make_given_when_diagnostic(
+    node: &Node,
+    declared_version: PerlVersion,
+    severity: DiagnosticSeverity,
+) -> Diagnostic {
+    let (message, min_version) = match severity {
+        DiagnosticSeverity::Error => (
+            format!(
+                "'given/when' was removed in Perl v5.42; declared version is v{}.{}",
+                declared_version.major, declared_version.minor
+            ),
+            (5, 42),
+        ),
+        _ => (
+            format!(
+                "'given/when' is deprecated starting in Perl v5.38; declared version is v{}.{}",
+                declared_version.major, declared_version.minor
+            ),
+            (5, 38),
+        ),
+    };
+
+    Diagnostic {
+        range: (node.location.start, node.location.end),
+        severity,
+        code: Some(DiagnosticCode::VersionIncompatFeature.as_str().to_string()),
+        message,
+        related_information: vec![],
+        tags: vec![],
+        suggestion: Some(format!(
+            "Refactor `given` / `when` to `if` / `elsif` or another supported control-flow form before targeting Perl v{}.{}",
+            min_version.0, min_version.1
+        )),
+    }
+}
+
+fn make_diagnostic_with_details(
+    node: &Node,
+    display: &str,
+    declared_version: PerlVersion,
+    min_version: (u32, u32),
+    severity: DiagnosticSeverity,
+    suggestion: Option<String>,
+) -> Diagnostic {
     let message = format!(
         "'{}' requires Perl v{}.{}+; declared version is v{}.{}",
         display, min_version.0, min_version.1, declared_version.major, declared_version.minor,
@@ -183,14 +260,11 @@ fn make_diagnostic(
 
     Diagnostic {
         range: (node.location.start, node.location.end),
-        severity: DiagnosticSeverity::Warning,
+        severity,
         code: Some(DiagnosticCode::VersionIncompatFeature.as_str().to_string()),
         message,
         related_information: vec![],
         tags: vec![],
-        suggestion: Some(format!(
-            "Update 'use v{}.{}' to 'use v{}.{}' or add 'use feature \"{}\";'",
-            declared_version.major, declared_version.minor, min_version.0, min_version.1, display,
-        )),
+        suggestion,
     }
 }

--- a/crates/perl-lsp-diagnostics/src/walker.rs
+++ b/crates/perl-lsp-diagnostics/src/walker.rs
@@ -89,6 +89,17 @@ where
                 walk_node(finally, func);
             }
         }
+        NodeKind::Given { expr, body } => {
+            walk_node(expr, func);
+            walk_node(body, func);
+        }
+        NodeKind::When { condition, body } => {
+            walk_node(condition, func);
+            walk_node(body, func);
+        }
+        NodeKind::Default { body } => {
+            walk_node(body, func);
+        }
         NodeKind::Unary { operand, .. } => {
             walk_node(operand, func);
         }

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -117,6 +117,10 @@ fn default_node() -> Node {
     Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(50, 70))
 }
 
+fn default_with_class_node() -> Node {
+    Node::new(NodeKind::Default { body: Box::new(block(vec![class_node("Nested")])) }, loc(50, 90))
+}
+
 fn sub_with_signature() -> Node {
     let sig = Node::new(
         NodeKind::Signature {
@@ -341,14 +345,26 @@ fn test_default_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
         "Expected warning severity for deprecated default on v5.38, got: {:?}",
         diag
     );
-    assert!(
-        diag.message.contains("default"),
-        "Message should mention default: {}",
-        diag.message
-    );
+    assert!(diag.message.contains("default"), "Message should mention default: {}", diag.message);
     assert!(
         diag.message.contains("deprecated"),
         "Message should mention deprecation: {}",
+        diag.message
+    );
+    Ok(())
+}
+
+#[test]
+fn test_when_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38"), when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(diag.severity, DiagnosticSeverity::Warning);
+    assert!(
+        diag.message.contains("given/when/default"),
+        "Message should mention given/when/default: {}",
         diag.message
     );
     Ok(())
@@ -398,16 +414,8 @@ fn test_default_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
         "Expected error severity for removed default on v5.42, got: {:?}",
         diag
     );
-    assert!(
-        diag.message.contains("default"),
-        "Message should mention default: {}",
-        diag.message
-    );
-    assert!(
-        diag.message.contains("removed"),
-        "Message should mention removal: {}",
-        diag.message
-    );
+    assert!(diag.message.contains("default"), "Message should mention default: {}", diag.message);
+    assert!(diag.message.contains("removed"), "Message should mention removal: {}", diag.message);
     assert!(
         diag.suggestion
             .as_deref()
@@ -522,6 +530,36 @@ fn test_say_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
         "Expected no PL900 warning for 'say' in v5.10, got: {:?}",
         diagnostics
     );
+    Ok(())
+}
+
+#[test]
+fn test_say_inside_given_when_is_reached_by_walker() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), given_when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(
+        diagnostics
+            .iter()
+            .find(|d| d.code.as_deref() == Some("PL900") && d.message.contains("say")),
+    );
+    assert_eq!(diag.severity, DiagnosticSeverity::Warning);
+    Ok(())
+}
+
+#[test]
+fn test_class_inside_default_is_reached_by_walker() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), default_with_class_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(
+        diagnostics
+            .iter()
+            .find(|d| d.code.as_deref() == Some("PL900") && d.message.contains("class")),
+    );
+    assert_eq!(diag.severity, DiagnosticSeverity::Warning);
     Ok(())
 }
 

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -325,6 +325,36 @@ fn test_given_when_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 // ---------------------------------------------------------------------------
+// Test 5bb: default warns on v5.38 (deprecated)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38"), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(
+        diag.severity,
+        perl_lsp_diagnostic_types::DiagnosticSeverity::Warning,
+        "Expected warning severity for deprecated default on v5.38, got: {:?}",
+        diag
+    );
+    assert!(
+        diag.message.contains("default"),
+        "Message should mention default: {}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains("deprecated"),
+        "Message should mention deprecation: {}",
+        diag.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 5c: given/when errors on v5.42 (removed)
 // ---------------------------------------------------------------------------
 
@@ -346,6 +376,43 @@ fn test_given_when_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
             .as_deref()
             .is_some_and(|suggestion| suggestion.contains("if") && suggestion.contains("elsif")),
         "Expected migration suggestion for given/when removal, got: {:?}",
+        diag.suggestion
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5cb: default errors on v5.42 (removed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.42"), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(
+        diag.severity,
+        perl_lsp_diagnostic_types::DiagnosticSeverity::Error,
+        "Expected error severity for removed default on v5.42, got: {:?}",
+        diag
+    );
+    assert!(
+        diag.message.contains("default"),
+        "Message should mention default: {}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains("removed"),
+        "Message should mention removal: {}",
+        diag.message
+    );
+    assert!(
+        diag.suggestion
+            .as_deref()
+            .is_some_and(|suggestion| suggestion.contains("if") && suggestion.contains("elsif")),
+        "Expected migration suggestion for default removal, got: {:?}",
         diag.suggestion
     );
     Ok(())

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -3,7 +3,7 @@
 //! These tests verify that the version_compat lint correctly detects uses of
 //! Perl features that are not available in the declared Perl version.
 
-use perl_lsp_diagnostics::version_compat::check_version_compat;
+use perl_lsp_diagnostics::{DiagnosticSeverity, version_compat::check_version_compat};
 use perl_parser_core::{Node, NodeKind, SourceLocation};
 use perl_tdd_support::must_some;
 
@@ -48,9 +48,37 @@ fn class_node(name: &str) -> Node {
     )
 }
 
+fn num_node(value: &str) -> Node {
+    Node::new(NodeKind::Number { value: value.to_string() }, loc(20, 21))
+}
+
 fn try_node() -> Node {
     Node::new(
         NodeKind::Try { body: Box::new(block(vec![])), catch_blocks: vec![], finally_block: None },
+        loc(20, 60),
+    )
+}
+
+fn given_when_node() -> Node {
+    let when = Node::new(
+        NodeKind::When {
+            condition: Box::new(Node::new(
+                NodeKind::Number { value: "1".to_string() },
+                loc(34, 35),
+            )),
+            body: Box::new(block(vec![say_call()])),
+        },
+        loc(28, 52),
+    );
+
+    Node::new(
+        NodeKind::Given {
+            expr: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "value".to_string() },
+                loc(24, 30),
+            )),
+            body: Box::new(block(vec![when])),
+        },
         loc(20, 60),
     )
 }
@@ -66,6 +94,27 @@ fn say_call() -> Node {
         },
         loc(20, 32),
     )
+}
+
+fn given_node() -> Node {
+    Node::new(
+        NodeKind::Given {
+            expr: Box::new(num_node("1")),
+            body: Box::new(block(vec![when_node(), default_node()])),
+        },
+        loc(20, 80),
+    )
+}
+
+fn when_node() -> Node {
+    Node::new(
+        NodeKind::When { condition: Box::new(num_node("1")), body: Box::new(block(vec![])) },
+        loc(30, 50),
+    )
+}
+
+fn default_node() -> Node {
+    Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(50, 70))
 }
 
 fn sub_with_signature() -> Node {
@@ -247,6 +296,127 @@ fn test_try_ok_on_v5_34() -> Result<(), Box<dyn std::error::Error>> {
         "Expected no PL900 warning for 'try' in v5.34, got: {:?}",
         diagnostics
     );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5b: given/when warns on v5.38 (deprecated)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_when_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38"), given_when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(
+        diag.severity,
+        perl_lsp_diagnostic_types::DiagnosticSeverity::Warning,
+        "Expected warning severity for deprecated given/when on v5.38, got: {:?}",
+        diag
+    );
+    assert!(
+        diag.message.contains("given/when"),
+        "Message should mention given/when: {}",
+        diag.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5c: given/when errors on v5.42 (removed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_when_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.42"), given_when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let diag = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(
+        diag.severity,
+        perl_lsp_diagnostic_types::DiagnosticSeverity::Error,
+        "Expected error severity for removed given/when on v5.42, got: {:?}",
+        diag
+    );
+    assert!(
+        diag.suggestion
+            .as_deref()
+            .is_some_and(|suggestion| suggestion.contains("if") && suggestion.contains("elsif")),
+        "Expected migration suggestion for given/when removal, got: {:?}",
+        diag.suggestion
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5b: given/when in v5.36 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'given/when' in v5.36, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5c: given/when in v5.38 -> warns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'given/when' in v5.38, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(msg.severity, DiagnosticSeverity::Warning);
+    assert!(
+        msg.message.contains("v5.38") || msg.message.contains("5.38"),
+        "Message should mention minimum version v5.38: {}",
+        msg.message
+    );
+    assert!(
+        msg.message.contains("deprecated"),
+        "Message should mention deprecation: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 5d: given/when in v5.42 -> error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.42"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert_eq!(msg.severity, DiagnosticSeverity::Error);
+    assert!(
+        msg.message.contains("v5.42") || msg.message.contains("5.42"),
+        "Message should mention removal version v5.42: {}",
+        msg.message
+    );
+    assert!(msg.message.contains("removed"), "Message should mention removal: {}", msg.message);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- warn on `given/when` for declared Perl v5.38-v5.41
- error on `given/when` for declared Perl v5.42+
- add focused regression coverage for the new version-compat behavior

## Testing
- cargo test -p perl-lsp-diagnostics --test version_compat_tests -- --nocapture
