### PR TITLE
fix(scope): bind try-catch variables in catch scope (#3378)

### DIFF
--- a/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
@@ -230,6 +230,34 @@ print $e;
 }
 
 #[test]
+fn test_try_catch_variable_diagnostic_range_targets_parameter()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict;
+use feature 'try';
+my $e = 1;
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+"#;
+
+    let diags = diagnostics_for(source);
+    let shadowing = diags
+        .iter()
+        .find(|d| d.message.contains("shadows") && d.message.contains("$e"))
+        .ok_or("expected catch-variable shadowing diagnostic")?;
+
+    assert_eq!(
+        &source[shadowing.range.0..shadowing.range.1],
+        "$e",
+        "catch-variable diagnostic range should target the catch parameter"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_severity_ordering_is_consistent() -> Result<(), Box<dyn std::error::Error>> {
     // Error (1) < Warning (2) < Information (3) < Hint (4)
     assert!(DiagnosticSeverity::Error < DiagnosticSeverity::Warning);

--- a/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
@@ -174,6 +174,62 @@ fn test_severity_unused_variable_is_warning() -> Result<(), Box<dyn std::error::
 }
 
 #[test]
+fn test_try_catch_variable_is_declared_inside_catch() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+"#;
+
+    let diags = diagnostics_for(source);
+    let catch_var_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| {
+            matches!(d.code.as_deref(), Some("PL102") | Some("PL103") | Some("PL110"))
+                && d.message.contains("$e")
+        })
+        .collect();
+
+    assert!(
+        catch_var_diags.is_empty(),
+        "catch variable should not produce scope diagnostics inside catch: {:?}",
+        catch_var_diags
+    );
+    Ok(())
+}
+
+#[test]
+fn test_try_catch_variable_does_not_escape_into_outer_scope()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+print $e;
+"#;
+
+    let diags = diagnostics_for(source);
+    let undeclared: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("PL103") && d.message.contains("$e"))
+        .collect();
+
+    assert!(
+        !undeclared.is_empty(),
+        "catch variable should remain undeclared outside the catch block"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_severity_ordering_is_consistent() -> Result<(), Box<dyn std::error::Error>> {
     // Error (1) < Warning (2) < Information (3) < Hint (4)
     assert!(DiagnosticSeverity::Error < DiagnosticSeverity::Warning);

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -899,13 +899,36 @@ impl ScopeAnalyzer {
                     if let Some(full_name) = catch_var.as_deref() {
                         let (sigil, name) = split_variable_name(full_name);
                         if !sigil.is_empty() && !name.is_empty() && !name.contains("::") {
-                            let _ = catch_scope.declare_variable_parts(
+                            if let Some(issue_kind) = catch_scope.declare_variable_parts(
                                 sigil,
                                 name,
                                 catch_body.location.start,
                                 false,
                                 true,
-                            );
+                            ) {
+                                let description = match issue_kind {
+                                    IssueKind::VariableShadowing => {
+                                        format!(
+                                            "Variable '{}' shadows a variable in outer scope",
+                                            full_name
+                                        )
+                                    }
+                                    IssueKind::VariableRedeclaration => {
+                                        format!(
+                                            "Variable '{}' is already declared in this scope",
+                                            full_name
+                                        )
+                                    }
+                                    _ => String::new(),
+                                };
+                                issues.push(ScopeIssue {
+                                    kind: issue_kind,
+                                    variable_name: full_name.to_string(),
+                                    line: context.get_line(catch_body.location.start),
+                                    range: (catch_body.location.start, catch_body.location.start),
+                                    description,
+                                });
+                            }
                         }
                     }
 

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -368,6 +368,26 @@ impl<'a> AnalysisContext<'a> {
             Err(idx) => idx,
         }
     }
+
+    fn find_catch_variable_range(
+        &self,
+        catch_body_start: usize,
+        full_name: &str,
+    ) -> Option<(usize, usize)> {
+        if full_name.is_empty() || catch_body_start == 0 || catch_body_start > self.code.len() {
+            return None;
+        }
+
+        let window_start = catch_body_start.saturating_sub(256);
+        let window = self.code.get(window_start..catch_body_start)?;
+        let catch_start = window.rfind("catch")?;
+        let search_start = catch_start + "catch".len();
+        let var_offset = window[search_start..].rfind(full_name)? + search_start;
+        let start = window_start + var_offset;
+        let end = start + full_name.len();
+
+        Some((start, end))
+    }
 }
 
 impl<'a> ExtractedName<'a> {
@@ -897,12 +917,15 @@ impl ScopeAnalyzer {
                     let catch_scope = Rc::new(Scope::with_parent(scope.clone()));
 
                     if let Some(full_name) = catch_var.as_deref() {
+                        let catch_var_range = context
+                            .find_catch_variable_range(catch_body.location.start, full_name)
+                            .unwrap_or((catch_body.location.start, catch_body.location.start));
                         let (sigil, name) = split_variable_name(full_name);
                         if !sigil.is_empty() && !name.is_empty() && !name.contains("::") {
                             if let Some(issue_kind) = catch_scope.declare_variable_parts(
                                 sigil,
                                 name,
-                                catch_body.location.start,
+                                catch_var_range.0,
                                 false,
                                 true,
                             ) {
@@ -924,8 +947,8 @@ impl ScopeAnalyzer {
                                 issues.push(ScopeIssue {
                                     kind: issue_kind,
                                     variable_name: full_name.to_string(),
-                                    line: context.get_line(catch_body.location.start),
-                                    range: (catch_body.location.start, catch_body.location.start),
+                                    line: context.get_line(catch_var_range.0),
+                                    range: catch_var_range,
                                     description,
                                 });
                             }

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -889,6 +889,43 @@ impl ScopeAnalyzer {
                 self.collect_unused_variables(&sub_scope, issues, context);
             }
 
+            NodeKind::Try { body, catch_blocks, finally_block } => {
+                ancestors.push(node);
+                self.analyze_node(body, scope, ancestors, issues, context);
+
+                for (catch_var, catch_body) in catch_blocks {
+                    let catch_scope = Rc::new(Scope::with_parent(scope.clone()));
+
+                    if let Some(full_name) = catch_var.as_deref() {
+                        let (sigil, name) = split_variable_name(full_name);
+                        if !sigil.is_empty() && !name.is_empty() && !name.contains("::") {
+                            let _ = catch_scope.declare_variable_parts(
+                                sigil,
+                                name,
+                                catch_body.location.start,
+                                false,
+                                true,
+                            );
+                        }
+                    }
+
+                    self.analyze_block_with_scope(
+                        catch_body,
+                        &catch_scope,
+                        ancestors,
+                        issues,
+                        context,
+                    );
+                    self.collect_unused_variables(&catch_scope, issues, context);
+                }
+
+                if let Some(finally) = finally_block {
+                    self.analyze_node(finally, scope, ancestors, issues, context);
+                }
+
+                ancestors.pop();
+            }
+
             NodeKind::FunctionCall { name, args } => {
                 // Handle function arguments, which may contain complex variable patterns.
                 // Some builtins consume declaration-capable filehandle arguments directly,
@@ -967,6 +1004,25 @@ impl ScopeAnalyzer {
                     self.mark_initialized(child, scope);
                 }
             }
+        }
+    }
+
+    fn analyze_block_with_scope<'a>(
+        &self,
+        node: &'a Node,
+        scope: &Rc<Scope>,
+        ancestors: &mut Vec<&'a Node>,
+        issues: &mut Vec<ScopeIssue>,
+        context: &AnalysisContext<'a>,
+    ) {
+        if let NodeKind::Block { statements } = &node.kind {
+            ancestors.push(node);
+            for stmt in statements {
+                self.analyze_node(stmt, scope, ancestors, issues, context);
+            }
+            ancestors.pop();
+        } else {
+            self.analyze_node(node, scope, ancestors, issues, context);
         }
     }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -176,6 +176,75 @@ print $client;
     Ok(())
 }
 
+#[test]
+fn scope_try_catch_binds_catch_variable() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues.iter().any(|i| i.kind == IssueKind::UndeclaredVariable && i.variable_name == "$e"),
+        "catch variable should be declared inside catch block: {:?}",
+        issues
+    );
+    assert!(
+        !issues.iter().any(|i| i.kind == IssueKind::UnusedVariable && i.variable_name == "$e"),
+        "used catch variable should not be reported as unused: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_try_catch_variable_does_not_escape() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+print $e;
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "$e"),
+        "catch variable should not be visible after the catch block: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_try_catch_unused_variable_reported() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    print "handled";
+}
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        issues.iter().any(|i| i.kind == IssueKind::UnusedVariable && i.variable_name == "$e"),
+        "unused catch variable should be reported: {:?}",
+        issues
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Variable Scope Resolution — our
 // ===========================================================================

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -216,10 +216,19 @@ try {
 "#;
 
     let issues = scope_issues_strict(code);
+    let shadowing = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::VariableShadowing && i.variable_name == "$e")
+        .ok_or("expected catch-variable shadowing issue")?;
     assert!(
         has_issue(&issues, IssueKind::VariableShadowing, "e"),
         "catch variable should report shadowing against outer scope: {:?}",
         issues
+    );
+    assert_eq!(
+        &code[shadowing.range.0..shadowing.range.1],
+        "$e",
+        "catch-variable shadowing range should target the catch parameter"
     );
     assert!(
         !issues.iter().any(|i| i.kind == IssueKind::UndeclaredVariable && i.variable_name == "$e"),
@@ -264,9 +273,48 @@ try {
 "#;
 
     let issues = scope_issues_strict(code);
+    let unused = issues
+        .iter()
+        .find(|i| i.kind == IssueKind::UnusedVariable && i.variable_name == "$e")
+        .ok_or("expected unused catch-variable issue")?;
     assert!(
         issues.iter().any(|i| i.kind == IssueKind::UnusedVariable && i.variable_name == "$e"),
         "unused catch variable should be reported: {:?}",
+        issues
+    );
+    assert_eq!(
+        &code[unused.range.0..unused.range.1],
+        "$e",
+        "unused catch-variable range should target the catch parameter"
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_try_catch_inner_redeclaration_stays_same_scope() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict;
+use feature 'try';
+try {
+    die "boom";
+} catch ($e) {
+    my $e = "inner";
+    print $e;
+}
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        issues
+            .iter()
+            .any(|i| i.kind == IssueKind::VariableRedeclaration && i.variable_name == "$e"),
+        "inner catch declaration should be a same-scope redeclaration: {:?}",
+        issues
+    );
+    assert!(
+        !issues.iter().any(|i| i.kind == IssueKind::VariableShadowing && i.variable_name == "$e"),
+        "inner catch declaration should not be treated as nested shadowing: {:?}",
         issues
     );
     Ok(())

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -203,6 +203,33 @@ try {
 }
 
 #[test]
+fn scope_try_catch_shadowing_is_reported() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use feature 'try';
+my $e = 1;
+try {
+    die "boom";
+} catch ($e) {
+    print $e;
+}
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        has_issue(&issues, IssueKind::VariableShadowing, "e"),
+        "catch variable should report shadowing against outer scope: {:?}",
+        issues
+    );
+    assert!(
+        !issues.iter().any(|i| i.kind == IssueKind::UndeclaredVariable && i.variable_name == "$e"),
+        "shadowed catch variable should still be bound in catch scope: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
 fn scope_try_catch_variable_does_not_escape() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict;


### PR DESCRIPTION
## Summary
- create a dedicated catch scope when analyzing `try { } catch ($e) { }`
- declare the optional catch variable in that scope before walking the catch block
- add scope regressions for binding, non-leakage, and unused catch variables

## Testing
- cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests -- --nocapture