### PR TITLE
fix(diagnostics): flag global SIG handlers (#3379)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -161,6 +161,8 @@ pub enum DiagnosticCode {
     SecurityStringEval,
     /// Backtick/qx command execution detected
     SecurityBacktickExec,
+    /// Global assignment to `$SIG{__DIE__}` / `$SIG{__WARN__}`
+    SecuritySignalHandler,
 
     // Import (PL700-PL799)
     /// Module appears to be unused
@@ -235,6 +237,7 @@ impl DiagnosticCode {
             DiagnosticCode::DeprecatedArrayBase => "PL501",
             DiagnosticCode::SecurityStringEval => "PL600",
             DiagnosticCode::SecurityBacktickExec => "PL601",
+            DiagnosticCode::SecuritySignalHandler => "PL602",
             DiagnosticCode::UnusedImport => "PL700",
             DiagnosticCode::ModuleNotFound => "PL701",
             DiagnosticCode::HeredocInFormat => "PL800",
@@ -292,6 +295,7 @@ impl DiagnosticCode {
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
             "PL600" => "https://docs.perl-lsp.org/errors/PL600",
             "PL601" => "https://docs.perl-lsp.org/errors/PL601",
+            "PL602" => "https://docs.perl-lsp.org/errors/PL602",
             "PL700" => "https://docs.perl-lsp.org/errors/PL700",
             "PL701" => "https://docs.perl-lsp.org/errors/PL701",
             "PL800" => "https://docs.perl-lsp.org/errors/PL800",
@@ -341,6 +345,7 @@ impl DiagnosticCode {
             | DiagnosticCode::DeprecatedArrayBase
             | DiagnosticCode::SecurityStringEval
             | DiagnosticCode::SecurityBacktickExec
+            | DiagnosticCode::SecuritySignalHandler
             | DiagnosticCode::ModuleNotFound
             | DiagnosticCode::VersionIncompatFeature
             | DiagnosticCode::CriticSeverity1
@@ -506,6 +511,10 @@ impl DiagnosticCode {
                 "Backticks/`qx()` execute shell commands and can be exploited. \
                 Use `system()` with a list form or IPC::Run for safer execution.",
             ),
+            DiagnosticCode::SecuritySignalHandler => Some(
+                "Assigning to $SIG{__DIE__} or $SIG{__WARN__} globally changes exception \
+                and warning handling for the whole process. Use `local` to scope the handler.",
+            ),
             DiagnosticCode::UnusedImport => Some(
                 "This module is imported but none of its exports appear to be used. \
                 Remove the `use` statement to reduce unnecessary dependencies.",
@@ -610,6 +619,7 @@ impl DiagnosticCode {
             "PL501" => Some(DiagnosticCode::DeprecatedArrayBase),
             "PL600" => Some(DiagnosticCode::SecurityStringEval),
             "PL601" => Some(DiagnosticCode::SecurityBacktickExec),
+            "PL602" => Some(DiagnosticCode::SecuritySignalHandler),
             "PL700" => Some(DiagnosticCode::UnusedImport),
             "PL701" => Some(DiagnosticCode::ModuleNotFound),
             "PL800" => Some(DiagnosticCode::HeredocInFormat),
@@ -706,6 +716,7 @@ impl DiagnosticCode {
             DiagnosticCode::SecurityStringEval | DiagnosticCode::SecurityBacktickExec => {
                 DiagnosticCategory::Security
             }
+            DiagnosticCode::SecuritySignalHandler => DiagnosticCategory::Security,
 
             DiagnosticCode::UnusedImport | DiagnosticCode::ModuleNotFound => {
                 DiagnosticCategory::Import
@@ -739,6 +750,7 @@ mod tests {
         assert_eq!(DiagnosticCode::ParseError.as_str(), "PL001");
         assert_eq!(DiagnosticCode::MissingStrict.as_str(), "PL100");
         assert_eq!(DiagnosticCode::CriticSeverity1.as_str(), "PC001");
+        assert_eq!(DiagnosticCode::SecuritySignalHandler.as_str(), "PL602");
     }
 
     #[test]
@@ -763,6 +775,10 @@ mod tests {
     #[test]
     fn test_from_str() {
         assert_eq!(DiagnosticCode::parse_code("PL001"), Some(DiagnosticCode::ParseError));
+        assert_eq!(
+            DiagnosticCode::parse_code("PL602"),
+            Some(DiagnosticCode::SecuritySignalHandler)
+        );
         assert_eq!(DiagnosticCode::parse_code("INVALID"), None);
     }
 
@@ -770,6 +786,7 @@ mod tests {
     fn test_category() {
         assert_eq!(DiagnosticCode::ParseError.category(), DiagnosticCategory::Parser);
         assert_eq!(DiagnosticCode::MissingStrict.category(), DiagnosticCategory::StrictWarnings);
+        assert_eq!(DiagnosticCode::SecuritySignalHandler.category(), DiagnosticCategory::Security);
         assert_eq!(DiagnosticCode::CriticSeverity1.category(), DiagnosticCategory::PerlCritic);
     }
 

--- a/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
@@ -30,6 +30,7 @@ const ALL_CODES: &[DiagnosticCode] = &[
     DiagnosticCode::TwoArgOpen,
     DiagnosticCode::ImplicitReturn,
     DiagnosticCode::PrintfFormatMismatch,
+    DiagnosticCode::SecuritySignalHandler,
     DiagnosticCode::CriticSeverity1,
     DiagnosticCode::CriticSeverity2,
     DiagnosticCode::CriticSeverity3,
@@ -1128,7 +1129,7 @@ fn category_inequality_across_variants() {
 // --- DiagnosticCategory: coverage of all codes ---
 
 #[test]
-fn all_six_categories_are_represented() {
+fn all_seven_categories_are_represented() {
     use std::collections::HashSet;
     let categories: HashSet<DiagnosticCategory> = ALL_CODES.iter().map(|c| c.category()).collect();
     assert!(categories.contains(&DiagnosticCategory::Parser));
@@ -1136,8 +1137,9 @@ fn all_six_categories_are_represented() {
     assert!(categories.contains(&DiagnosticCategory::PackageModule));
     assert!(categories.contains(&DiagnosticCategory::Subroutine));
     assert!(categories.contains(&DiagnosticCategory::BestPractices));
+    assert!(categories.contains(&DiagnosticCategory::Security));
     assert!(categories.contains(&DiagnosticCategory::PerlCritic));
-    assert_eq!(categories.len(), 6);
+    assert_eq!(categories.len(), 7);
 }
 
 // --- DiagnosticCode: tags exhaustive check ---
@@ -1160,8 +1162,8 @@ fn unused_variable_tag_is_exactly_unnecessary() {
 // --- Cross-cutting: ALL_CODES count ---
 
 #[test]
-fn all_codes_count_is_20() {
-    assert_eq!(ALL_CODES.len(), 20, "expected 20 diagnostic codes total");
+fn all_codes_count_is_21() {
+    assert_eq!(ALL_CODES.len(), 21, "expected 21 diagnostic codes total");
 }
 
 // --- DiagnosticCode: parse_code boundary values ---
@@ -1170,7 +1172,7 @@ fn all_codes_count_is_20() {
 fn parse_code_all_valid_pl_codes() {
     let valid_pl = [
         "PL001", "PL002", "PL003", "PL100", "PL101", "PL102", "PL103", "PL200", "PL201", "PL300",
-        "PL301", "PL400", "PL401", "PL402",
+        "PL301", "PL400", "PL401", "PL402", "PL602",
     ];
     for s in &valid_pl {
         assert!(DiagnosticCode::parse_code(s).is_some(), "expected valid parse for {}", s);
@@ -1188,11 +1190,11 @@ fn parse_code_all_valid_pc_codes() {
 #[test]
 fn parse_code_gaps_return_none() {
     // Codes that fall in valid ranges but aren't assigned.
-    // Note: PL104-PL111, PL403-PL404, PL500-PL501, PL600-PL601, PL700, PL800-PL806
+    // Note: PL104-PL111, PL403-PL404, PL500-PL501, PL600-PL602, PL700, PL800-PL806
     // are now assigned; only truly unassigned gaps are listed here.
     let gaps = [
         "PL004", "PL050", "PL099", "PL112", "PL150", "PL199", "PL202", "PL250", "PL302", "PL399",
-        "PL499", "PL502", "PL599", "PL602", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006",
+        "PL499", "PL502", "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006",
         "PC010",
     ];
     for s in &gaps {

--- a/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
@@ -1194,8 +1194,7 @@ fn parse_code_gaps_return_none() {
     // are now assigned; only truly unassigned gaps are listed here.
     let gaps = [
         "PL004", "PL050", "PL099", "PL112", "PL150", "PL199", "PL202", "PL250", "PL302", "PL399",
-        "PL499", "PL502", "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006",
-        "PC010",
+        "PL499", "PL502", "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
     ];
     for s in &gaps {
         assert!(DiagnosticCode::parse_code(s).is_none(), "expected None for unassigned code {}", s);

--- a/crates/perl-diagnostics-codes/tests/diagnostic_code_completeness.rs
+++ b/crates/perl-diagnostics-codes/tests/diagnostic_code_completeness.rs
@@ -180,6 +180,24 @@ fn security_backtick_exec_code_exists() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
+#[test]
+fn security_signal_handler_code_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let code = DiagnosticCode::SecuritySignalHandler;
+    assert_eq!(code.as_str(), "PL602", "SecuritySignalHandler should have code PL602");
+    assert_eq!(
+        code.severity(),
+        perl_diagnostics_codes::DiagnosticSeverity::Warning,
+        "SecuritySignalHandler should have Warning severity"
+    );
+    assert!(code.context_hint().is_some(), "SecuritySignalHandler should have a context hint");
+    assert_eq!(
+        DiagnosticCode::parse_code("PL602"),
+        Some(DiagnosticCode::SecuritySignalHandler),
+        "parse_code('PL602') should return SecuritySignalHandler"
+    );
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Import diagnostic codes
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -11,7 +11,7 @@
 //! - **strict_warnings**: Missing `use strict` / `use warnings` advisories and
 //!   misspelled pragma detection
 //! - **common_mistakes**: Frequent programming errors (assignment in conditions, etc.)
-//! - **security**: Security anti-patterns (two-arg open, string eval, backtick execution)
+//! - **security**: Security anti-patterns (two-arg open, string eval, backtick execution, global signal handlers)
 //!
 //! # Diagnostic Code Reference
 //!
@@ -67,6 +67,7 @@
 //! | `security-two-arg-open` | Warning | `open(FH, ">file")` -- use 3-arg open |
 //! | `security-string-eval` | Warning | `eval "$string"` is a security risk |
 //! | `security-backtick-exec` | Information | Backtick/qx command execution detected |
+//! | `security-signal-handler` | Warning | Global `$SIG{__DIE__}` / `$SIG{__WARN__}` assignment |
 //!
 //! ## Package / subroutine (`package_subroutine.rs`)
 //!

--- a/crates/perl-lsp-diagnostics/src/lints/security.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/security.rs
@@ -353,7 +353,7 @@ fn check_global_signal_handler_assignment(
         severity: DiagnosticSeverity::Warning,
         code: Some(DiagnosticCode::SecuritySignalHandler.as_str().to_string()),
         message: format!(
-            "Global assignment to ${}{{{}}} changes process-wide behavior. Use local $SIG{{...}} to scope the handler.",
+            "Global assignment to {}{{{}}} changes process-wide behavior. Use local $SIG{{...}} to scope the handler.",
             signal_table_display(&signal_handler.access),
             signal_handler.signal_name
         ),

--- a/crates/perl-lsp-diagnostics/src/lints/security.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/security.rs
@@ -16,7 +16,6 @@
 use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::ast::{Node, NodeKind};
 
-use super::super::walker::walk_node;
 use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformation};
 
 /// Check for security anti-patterns
@@ -27,47 +26,311 @@ use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformati
 /// - Backtick/qx command execution (ensure input is sanitized)
 /// - Global signal-handler assignment to `$SIG{__DIE__}` / `$SIG{__WARN__}`
 pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
-    walk_node(node, &mut |n| {
-        match &n.kind {
-            NodeKind::FunctionCall { name, args } => {
-                check_two_arg_open(name, args, n, diagnostics);
-                check_string_eval(name, args, n, diagnostics);
-            }
+    walk_security_node(node, diagnostics, false);
+}
 
-            NodeKind::Assignment { lhs, .. } => {
-                check_global_signal_handler_assignment(lhs, n, diagnostics);
-            }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SignalTableAccess {
+    Bare,
+    MainQualified,
+}
 
-            // The parser produces Eval { block } for both `eval { ... }` and
-            // `eval "string"`.  Block evals are safe (exception handling);
-            // string/variable evals are a security risk.
-            NodeKind::Eval { block } => {
-                check_eval_node(block, n, diagnostics);
-            }
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SignalHandlerTarget {
+    access: SignalTableAccess,
+    signal_name: String,
+}
 
-            // Backtick strings: the parser stores `cmd` and qx(cmd) as
-            // String { value: "`cmd`", interpolated: true }
-            NodeKind::String { value, interpolated: true } if is_backtick_string(value) => {
-                diagnostics.push(Diagnostic {
-                    range: (n.location.start, n.location.end),
-                    severity: DiagnosticSeverity::Information,
-                    code: Some(DiagnosticCode::SecurityBacktickExec.as_str().to_string()),
-                    message: "Command execution detected. Ensure input is sanitized.".to_string(),
-                    related_information: vec![RelatedInformation {
-                        location: (n.location.start, n.location.end),
-                        message: "Consider using open() with a pipe, or IPC::Run for safer command execution with proper input validation".to_string(),
-                    }],
-                    tags: Vec::new(),
-                    suggestion: Some(
-                        "Use open(my $fh, '-|', @cmd) or IPC::Run for safer command execution"
-                            .to_string(),
-                    ),
-                });
+fn walk_security_node(
+    node: &Node,
+    diagnostics: &mut Vec<Diagnostic>,
+    signal_shadowed: bool,
+) -> bool {
+    match &node.kind {
+        NodeKind::Program { statements } => {
+            let mut current_shadowed = signal_shadowed;
+            for stmt in statements {
+                current_shadowed = walk_security_node(stmt, diagnostics, current_shadowed);
             }
-
-            _ => {}
+            current_shadowed
         }
-    });
+        NodeKind::Block { statements } => {
+            let mut block_shadowed = signal_shadowed;
+            for stmt in statements {
+                block_shadowed = walk_security_node(stmt, diagnostics, block_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::ExpressionStatement { expression } => {
+            walk_security_node(expression, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Assignment { lhs, rhs, .. } => {
+            check_global_signal_handler_assignment(lhs, node, diagnostics, signal_shadowed);
+            walk_security_node(lhs, diagnostics, signal_shadowed);
+            walk_security_node(rhs, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
+            if let Some(init) = initializer {
+                walk_security_node(init, diagnostics, signal_shadowed);
+            }
+
+            let mut updated_shadowed = signal_shadowed;
+            if matches!(declarator.as_str(), "my" | "state") && shadows_signal_table(variable) {
+                updated_shadowed = true;
+            }
+
+            if declarator != "local" {
+                walk_security_node(variable, diagnostics, signal_shadowed);
+            }
+            updated_shadowed
+        }
+        NodeKind::VariableListDeclaration { declarator, variables, initializer, .. } => {
+            if let Some(init) = initializer {
+                walk_security_node(init, diagnostics, signal_shadowed);
+            }
+
+            if declarator != "local" {
+                for variable in variables {
+                    walk_security_node(variable, diagnostics, signal_shadowed);
+                }
+            }
+
+            if matches!(declarator.as_str(), "my" | "state")
+                && variables.iter().any(shadows_signal_table)
+            {
+                true
+            } else {
+                signal_shadowed
+            }
+        }
+        NodeKind::If { condition, then_branch, elsif_branches, else_branch } => {
+            walk_security_node(condition, diagnostics, signal_shadowed);
+            walk_security_node(then_branch, diagnostics, signal_shadowed);
+            for (condition, branch) in elsif_branches {
+                walk_security_node(condition, diagnostics, signal_shadowed);
+                walk_security_node(branch, diagnostics, signal_shadowed);
+            }
+            if let Some(branch) = else_branch {
+                walk_security_node(branch, diagnostics, signal_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::While { condition, body, .. } => {
+            walk_security_node(condition, diagnostics, signal_shadowed);
+            walk_security_node(body, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::For { init, condition, update, body, continue_block } => {
+            let mut loop_shadowed = signal_shadowed;
+            if let Some(init) = init {
+                loop_shadowed = walk_security_node(init, diagnostics, loop_shadowed);
+            }
+            if let Some(condition) = condition {
+                walk_security_node(condition, diagnostics, loop_shadowed);
+            }
+            if let Some(update) = update {
+                walk_security_node(update, diagnostics, loop_shadowed);
+            }
+            walk_security_node(body, diagnostics, loop_shadowed);
+            if let Some(continue_block) = continue_block {
+                walk_security_node(continue_block, diagnostics, loop_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::Foreach { variable, list, body, continue_block } => {
+            let mut loop_shadowed = walk_security_node(variable, diagnostics, signal_shadowed);
+            if shadows_signal_table(variable) {
+                loop_shadowed = true;
+            }
+            walk_security_node(list, diagnostics, signal_shadowed);
+            walk_security_node(body, diagnostics, loop_shadowed);
+            if let Some(continue_block) = continue_block {
+                walk_security_node(continue_block, diagnostics, loop_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::Given { expr, body } => {
+            walk_security_node(expr, diagnostics, signal_shadowed);
+            walk_security_node(body, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::When { condition, body } => {
+            walk_security_node(condition, diagnostics, signal_shadowed);
+            walk_security_node(body, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Default { body } => {
+            walk_security_node(body, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::StatementModifier { statement, condition, .. } => {
+            walk_security_node(statement, diagnostics, signal_shadowed);
+            walk_security_node(condition, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Subroutine { signature, body, .. } => {
+            let mut sub_shadowed = signal_shadowed;
+            if let Some(signature) = signature {
+                sub_shadowed = walk_security_node(signature, diagnostics, sub_shadowed);
+            }
+            walk_security_node(body, diagnostics, sub_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Method { signature, body, .. } => {
+            let mut method_shadowed = signal_shadowed;
+            if let Some(signature) = signature {
+                method_shadowed = walk_security_node(signature, diagnostics, method_shadowed);
+            }
+            walk_security_node(body, diagnostics, method_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Signature { parameters } => {
+            let mut signature_shadowed = signal_shadowed;
+            for parameter in parameters {
+                signature_shadowed = walk_security_node(parameter, diagnostics, signature_shadowed);
+            }
+            signature_shadowed
+        }
+        NodeKind::MandatoryParameter { variable }
+        | NodeKind::SlurpyParameter { variable }
+        | NodeKind::NamedParameter { variable } => {
+            let updated_shadowed =
+                if shadows_signal_table(variable) { true } else { signal_shadowed };
+            walk_security_node(variable, diagnostics, signal_shadowed);
+            updated_shadowed
+        }
+        NodeKind::OptionalParameter { variable, default_value } => {
+            walk_security_node(default_value, diagnostics, signal_shadowed);
+            let updated_shadowed =
+                if shadows_signal_table(variable) { true } else { signal_shadowed };
+            walk_security_node(variable, diagnostics, signal_shadowed);
+            updated_shadowed
+        }
+        NodeKind::Package { block: Some(block), .. }
+        | NodeKind::PhaseBlock { block, .. }
+        | NodeKind::Class { body: block, .. } => {
+            walk_security_node(block, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Try { body, catch_blocks, finally_block } => {
+            walk_security_node(body, diagnostics, signal_shadowed);
+            for (_, catch_body) in catch_blocks {
+                walk_security_node(catch_body, diagnostics, signal_shadowed);
+            }
+            if let Some(finally_block) = finally_block {
+                walk_security_node(finally_block, diagnostics, signal_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::Binary { left, right, .. } => {
+            walk_security_node(left, diagnostics, signal_shadowed);
+            walk_security_node(right, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Ternary { condition, then_expr, else_expr } => {
+            walk_security_node(condition, diagnostics, signal_shadowed);
+            walk_security_node(then_expr, diagnostics, signal_shadowed);
+            walk_security_node(else_expr, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Unary { operand, .. } => {
+            walk_security_node(operand, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::VariableWithAttributes { variable, .. } => {
+            walk_security_node(variable, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::FunctionCall { name, args } => {
+            check_two_arg_open(name, args, node, diagnostics);
+            check_string_eval(name, args, node, diagnostics);
+            for arg in args {
+                walk_security_node(arg, diagnostics, signal_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::IndirectCall { object, args, .. } | NodeKind::MethodCall { object, args, .. } => {
+            walk_security_node(object, diagnostics, signal_shadowed);
+            for arg in args {
+                walk_security_node(arg, diagnostics, signal_shadowed);
+            }
+            signal_shadowed
+        }
+        NodeKind::Eval { block } => {
+            check_eval_node(block, node, diagnostics);
+            walk_security_node(block, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        // Backtick strings: the parser stores `cmd` and qx(cmd) as
+        // String { value: "`cmd`", interpolated: true }
+        NodeKind::String { value, interpolated: true } if is_backtick_string(value) => {
+            diagnostics.push(Diagnostic {
+                range: (node.location.start, node.location.end),
+                severity: DiagnosticSeverity::Information,
+                code: Some(DiagnosticCode::SecurityBacktickExec.as_str().to_string()),
+                message: "Command execution detected. Ensure input is sanitized.".to_string(),
+                related_information: vec![RelatedInformation {
+                    location: (node.location.start, node.location.end),
+                    message: "Consider using open() with a pipe, or IPC::Run for safer command execution with proper input validation".to_string(),
+                }],
+                tags: Vec::new(),
+                suggestion: Some(
+                    "Use open(my $fh, '-|', @cmd) or IPC::Run for safer command execution"
+                        .to_string(),
+                ),
+            });
+            signal_shadowed
+        }
+        NodeKind::Return { value: Some(value) } => {
+            walk_security_node(value, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Return { value: None } => signal_shadowed,
+        NodeKind::LabeledStatement { statement, .. } => {
+            walk_security_node(statement, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Error { partial: Some(partial), .. } => {
+            walk_security_node(partial, diagnostics, signal_shadowed);
+            signal_shadowed
+        }
+        NodeKind::Heredoc { .. }
+        | NodeKind::Tie { .. }
+        | NodeKind::Untie { .. }
+        | NodeKind::Format { .. } => signal_shadowed,
+        NodeKind::Package { block: None, .. }
+        | NodeKind::Use { .. }
+        | NodeKind::No { .. }
+        | NodeKind::DataSection { .. }
+        | NodeKind::Number { .. }
+        | NodeKind::String { .. }
+        | NodeKind::Regex { .. }
+        | NodeKind::Match { .. }
+        | NodeKind::Substitution { .. }
+        | NodeKind::Transliteration { .. }
+        | NodeKind::Identifier { .. }
+        | NodeKind::Variable { .. }
+        | NodeKind::Typeglob { .. }
+        | NodeKind::Diamond
+        | NodeKind::Ellipsis
+        | NodeKind::Undef
+        | NodeKind::Readline { .. }
+        | NodeKind::Glob { .. }
+        | NodeKind::ArrayLiteral { .. }
+        | NodeKind::HashLiteral { .. }
+        | NodeKind::Do { .. }
+        | NodeKind::LoopControl { .. }
+        | NodeKind::Goto { .. }
+        | NodeKind::Prototype { .. }
+        | NodeKind::MissingExpression
+        | NodeKind::MissingStatement
+        | NodeKind::MissingIdentifier
+        | NodeKind::MissingBlock
+        | NodeKind::Error { .. }
+        | NodeKind::UnknownRest => signal_shadowed,
+    }
 }
 
 /// Detect a global assignment to `$SIG{__DIE__}` or `$SIG{__WARN__}`.
@@ -75,17 +338,24 @@ fn check_global_signal_handler_assignment(
     lhs: &Node,
     node: &Node,
     diagnostics: &mut Vec<Diagnostic>,
+    signal_shadowed: bool,
 ) {
-    let Some(signal_name) = signal_handler_name(lhs) else {
+    let Some(signal_handler) = signal_handler_name(lhs) else {
         return;
     };
+
+    if signal_handler.access == SignalTableAccess::Bare && signal_shadowed {
+        return;
+    }
 
     diagnostics.push(Diagnostic {
         range: (node.location.start, node.location.end),
         severity: DiagnosticSeverity::Warning,
         code: Some(DiagnosticCode::SecuritySignalHandler.as_str().to_string()),
         message: format!(
-            "Global assignment to $SIG{{{signal_name}}} changes process-wide behavior. Use local $SIG{{...}} to scope the handler."
+            "Global assignment to ${}{{{}}} changes process-wide behavior. Use local $SIG{{...}} to scope the handler.",
+            signal_table_display(&signal_handler.access),
+            signal_handler.signal_name
         ),
         related_information: vec![RelatedInformation {
             location: (node.location.start, node.location.end),
@@ -93,13 +363,21 @@ fn check_global_signal_handler_assignment(
         }],
         tags: Vec::new(),
         suggestion: Some(format!(
-            "Use `local $SIG{{{signal_name}}} = ...` if the handler should be scoped"
+            "Use `local $SIG{{{}}} = ...` if the handler should be scoped",
+            signal_handler.signal_name
         )),
     });
 }
 
+fn signal_table_display(access: &SignalTableAccess) -> &'static str {
+    match access {
+        SignalTableAccess::Bare => "$SIG",
+        SignalTableAccess::MainQualified => "$main::SIG",
+    }
+}
+
 /// Extract the signal-handler key if the node targets `$SIG{__DIE__}` or `$SIG{__WARN__}`.
-fn signal_handler_name(node: &Node) -> Option<&str> {
+fn signal_handler_name(node: &Node) -> Option<SignalHandlerTarget> {
     let NodeKind::Binary { op, left, right } = &node.kind else {
         return None;
     };
@@ -108,21 +386,29 @@ fn signal_handler_name(node: &Node) -> Option<&str> {
         return None;
     }
 
-    let is_sig_hash = matches!(
-        &left.kind,
-        NodeKind::Variable { sigil, name } if (sigil == "$" || sigil == "%") && name == "SIG"
-    );
-    if !is_sig_hash {
-        return None;
-    }
+    let access = match &left.kind {
+        NodeKind::Variable { sigil, name } if (sigil == "$" || sigil == "%") && name == "SIG" => {
+            SignalTableAccess::Bare
+        }
+        NodeKind::Variable { sigil, name }
+            if (sigil == "$" || sigil == "%") && (name == "main::SIG" || name == "::SIG") =>
+        {
+            SignalTableAccess::MainQualified
+        }
+        _ => return None,
+    };
 
     match &right.kind {
         NodeKind::Identifier { name } if name == "__DIE__" || name == "__WARN__" => {
-            Some(name.as_str())
+            Some(SignalHandlerTarget { access, signal_name: name.to_string() })
         }
         NodeKind::String { value, .. } => {
             let trimmed = value.trim_matches(['"', '\'']);
-            if trimmed == "__DIE__" || trimmed == "__WARN__" { Some(trimmed) } else { None }
+            if trimmed == "__DIE__" || trimmed == "__WARN__" {
+                Some(SignalHandlerTarget { access, signal_name: trimmed.to_string() })
+            } else {
+                None
+            }
         }
         _ => None,
     }
@@ -232,6 +518,25 @@ fn is_backtick_string(value: &str) -> bool {
     value.starts_with('`') && value.ends_with('`') && value.len() >= 2
 }
 
+fn shadows_signal_table(node: &Node) -> bool {
+    match &node.kind {
+        NodeKind::Variable { sigil, name } => sigil == "%" && name == "SIG",
+        NodeKind::VariableWithAttributes { variable, .. } => shadows_signal_table(variable),
+        NodeKind::VariableDeclaration { declarator, variable, .. } => {
+            matches!(declarator.as_str(), "my" | "state") && shadows_signal_table(variable)
+        }
+        NodeKind::VariableListDeclaration { declarator, variables, .. } => {
+            matches!(declarator.as_str(), "my" | "state")
+                && variables.iter().any(shadows_signal_table)
+        }
+        NodeKind::MandatoryParameter { variable }
+        | NodeKind::SlurpyParameter { variable }
+        | NodeKind::NamedParameter { variable } => shadows_signal_table(variable),
+        NodeKind::OptionalParameter { variable, .. } => shadows_signal_table(variable),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,11 +560,38 @@ mod tests {
     }
 
     #[test]
+    fn quoted_global_sig_warn_handler_is_flagged() {
+        let diags = security_diags("$SIG{'__WARN__'} = sub { };");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL602")),
+            "quoted __WARN__ handler should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
     fn global_sig_die_handler_is_flagged() {
         let diags = security_diags("%SIG{__DIE__} = sub { };");
         assert!(
             diags.iter().any(|d| d.code.as_deref() == Some("PL602")),
             "global __DIE__ handler should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn main_qualified_sig_warn_handler_is_flagged() {
+        let diags = security_diags("$main::SIG{__WARN__} = sub { };");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL602")),
+            "main-qualified __WARN__ handler should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn lexical_sig_shadow_is_not_flagged() {
+        let diags = security_diags("my %SIG; $SIG{__WARN__} = sub { };");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL602")),
+            "lexical %SIG shadow should not be flagged: {diags:?}"
         );
     }
 

--- a/crates/perl-lsp-diagnostics/src/lints/security.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/security.rs
@@ -11,6 +11,7 @@
 //! | `security-two-arg-open` | Warning | `open(FH, ">file")` -- use 3-arg open for safety |
 //! | `security-string-eval` | Warning | `eval "$string"` -- string eval is a security risk |
 //! | `security-backtick-exec` | Information | Backtick/qx command execution detected |
+//! | `security-signal-handler` | Warning | Global `$SIG{__DIE__}` / `$SIG{__WARN__}` assignment |
 
 use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::ast::{Node, NodeKind};
@@ -24,12 +25,21 @@ use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformati
 /// - Two-argument `open` calls (should use 3-arg form)
 /// - String `eval` (security risk vs. block `eval`)
 /// - Backtick/qx command execution (ensure input is sanitized)
+/// - Global signal-handler assignment to `$SIG{__DIE__}` / `$SIG{__WARN__}`
 pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     walk_node(node, &mut |n| {
         match &n.kind {
             NodeKind::FunctionCall { name, args } => {
                 check_two_arg_open(name, args, n, diagnostics);
                 check_string_eval(name, args, n, diagnostics);
+            }
+
+            NodeKind::Assignment { lhs, .. } => {
+                check_global_signal_handler_assignment(lhs, n, diagnostics);
+            }
+
+            NodeKind::VariableDeclaration { declarator, variable, .. } if declarator == "local" => {
+                let _ = signal_handler_name(variable);
             }
 
             // The parser produces Eval { block } for both `eval { ... }` and
@@ -62,6 +72,64 @@ pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             _ => {}
         }
     });
+}
+
+/// Detect a global assignment to `$SIG{__DIE__}` or `$SIG{__WARN__}`.
+fn check_global_signal_handler_assignment(
+    lhs: &Node,
+    node: &Node,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(signal_name) = signal_handler_name(lhs) else {
+        return;
+    };
+
+    diagnostics.push(Diagnostic {
+        range: (node.location.start, node.location.end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(DiagnosticCode::SecuritySignalHandler.as_str().to_string()),
+        message: format!(
+            "Global assignment to $SIG{{{signal_name}}} changes process-wide behavior. Use local $SIG{{...}} to scope the handler."
+        ),
+        related_information: vec![RelatedInformation {
+            location: (node.location.start, node.location.end),
+            message: "Localized signal handlers avoid leaking exception or warning hooks across unrelated code.".to_string(),
+        }],
+        tags: Vec::new(),
+        suggestion: Some(format!(
+            "Use `local $SIG{{{signal_name}}} = ...` if the handler should be scoped"
+        )),
+    });
+}
+
+/// Extract the signal-handler key if the node targets `$SIG{__DIE__}` or `$SIG{__WARN__}`.
+fn signal_handler_name(node: &Node) -> Option<&str> {
+    let NodeKind::Binary { op, left, right } = &node.kind else {
+        return None;
+    };
+
+    if op != "{}" {
+        return None;
+    }
+
+    let is_sig_hash = matches!(
+        &left.kind,
+        NodeKind::Variable { sigil, name } if (sigil == "$" || sigil == "%") && name == "SIG"
+    );
+    if !is_sig_hash {
+        return None;
+    }
+
+    match &right.kind {
+        NodeKind::Identifier { name } if name == "__DIE__" || name == "__WARN__" => {
+            Some(name.as_str())
+        }
+        NodeKind::String { value, .. } => {
+            let trimmed = value.trim_matches(['"', '\'']);
+            if trimmed == "__DIE__" || trimmed == "__WARN__" { Some(trimmed) } else { None }
+        }
+        _ => None,
+    }
 }
 
 /// Detect string `eval` from `NodeKind::Eval` nodes.
@@ -166,4 +234,51 @@ fn check_string_eval(name: &str, args: &[Node], node: &Node, diagnostics: &mut V
 /// `String { value: "`cmd`", interpolated: true }`.
 fn is_backtick_string(value: &str) -> bool {
     value.starts_with('`') && value.ends_with('`') && value.len() >= 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn security_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        check_security(&ast, &mut diags);
+        diags
+    }
+
+    #[test]
+    fn global_sig_warn_handler_is_flagged() {
+        let diags = security_diags("$SIG{__WARN__} = sub { };");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL602")),
+            "global __WARN__ handler should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn global_sig_die_handler_is_flagged() {
+        let diags = security_diags("%SIG{__DIE__} = sub { };");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL602")),
+            "global __DIE__ handler should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn local_sig_handlers_are_not_flagged() {
+        let warn_diags = security_diags("local $SIG{__WARN__} = sub { };");
+        let die_diags = security_diags("local $SIG{__DIE__} = sub { };");
+
+        assert!(
+            warn_diags.iter().all(|d| d.code.as_deref() != Some("PL602")),
+            "localized __WARN__ handler should not be flagged: {warn_diags:?}"
+        );
+        assert!(
+            die_diags.iter().all(|d| d.code.as_deref() != Some("PL602")),
+            "localized __DIE__ handler should not be flagged: {die_diags:?}"
+        );
+    }
 }

--- a/crates/perl-lsp-diagnostics/src/lints/security.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/security.rs
@@ -38,10 +38,6 @@ pub fn check_security(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 check_global_signal_handler_assignment(lhs, n, diagnostics);
             }
 
-            NodeKind::VariableDeclaration { declarator, variable, .. } if declarator == "local" => {
-                let _ = signal_handler_name(variable);
-            }
-
             // The parser produces Eval { block } for both `eval { ... }` and
             // `eval "string"`.  Block evals are safe (exception handling);
             // string/variable evals are a security risk.

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -257,7 +257,7 @@ fn lint_pipeline_string_eval_emits_pl600() {
 
 #[test]
 fn lint_pipeline_global_sig_handler_emits_pl602() {
-    let source = "use strict;\nuse warnings;\n$SIG{__WARN__} = sub { warn \"caught\" };\n";
+    let source = "use strict;\nuse warnings;\n$main::SIG{'__WARN__'} = sub { warn \"caught\" };\n";
     let diags = diagnostics_for(source);
 
     let signal: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL602")).collect();
@@ -271,6 +271,19 @@ fn lint_pipeline_global_sig_handler_emits_pl602() {
     );
     assert_eq!(signal[0].severity, DiagnosticSeverity::Warning);
     assert!(signal[0].suggestion.is_some(), "security-signal-handler should carry a suggestion");
+}
+
+#[test]
+fn lint_pipeline_lexical_sig_shadow_does_not_emit_pl602() {
+    let source =
+        "use strict;\nuse warnings;\nmy %SIG;\n$SIG{__WARN__} = sub { warn \"caught\" };\n";
+    let diags = diagnostics_for(source);
+
+    assert!(
+        diags.iter().all(|d| d.code.as_deref() != Some("PL602")),
+        "lexical %SIG shadow should not emit PL602 from get_diagnostics(), got {:?}",
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
 }
 
 // =========================================================================

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -252,7 +252,29 @@ fn lint_pipeline_string_eval_emits_pl600() {
 }
 
 // =========================================================================
-// 11. Unused imports lint fires through the full pipeline (#2694)
+// 11. Security lint: global SIG handlers fire through the full pipeline
+// =========================================================================
+
+#[test]
+fn lint_pipeline_global_sig_handler_emits_pl602() {
+    let source = "use strict;\nuse warnings;\n$SIG{__WARN__} = sub { warn \"caught\" };\n";
+    let diags = diagnostics_for(source);
+
+    let signal: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL602")).collect();
+
+    assert!(
+        !signal.is_empty(),
+        "Expected security-signal-handler (PL602) diagnostic from get_diagnostics(), \
+         got {} total diags with codes: {:?}",
+        diags.len(),
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+    assert_eq!(signal[0].severity, DiagnosticSeverity::Warning);
+    assert!(signal[0].suggestion.is_some(), "security-signal-handler should carry a suggestion");
+}
+
+// =========================================================================
+// 12. Unused imports lint fires through the full pipeline (#2694)
 // =========================================================================
 
 #[test]
@@ -282,7 +304,7 @@ fn lint_pipeline_unused_import_emits_pl700() {
 }
 
 // =========================================================================
-// 12. Used import does NOT fire PL700 (#2694)
+// 13. Used import does NOT fire PL700 (#2694)
 // =========================================================================
 
 #[test]
@@ -302,7 +324,7 @@ fn lint_pipeline_used_import_no_pl700() {
 }
 
 // =========================================================================
-// 13. Dedup removes duplicate diagnostics (#2696)
+// 14. Dedup removes duplicate diagnostics (#2696)
 // =========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary
- add a narrow security diagnostic for global `$SIG{__DIE__}` and `$SIG{__WARN__}` assignment
- suppress localized `local $SIG{...}` forms
- register PL602 in the diagnostics code registry and completeness tests

## Why
Global signal-handler assignment changes process-wide exception and warning behavior. The parser already distinguishes localized forms, but diagnostics had no rule for the risky global case.

## User impact
Users now get a targeted warning when they assign process-wide `__DIE__` or `__WARN__` hooks, with guidance to use `local` when the handler is intended to be scoped.

## Validation
- `cargo test -p perl-diagnostics-codes`
- `cargo test -p perl-lsp-diagnostics security -- --nocapture`
- `cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests -- --nocapture`