### PR TITLE
fix(diagnostics): flag stale eval error reads (#3380)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -149,6 +149,8 @@ pub enum DiagnosticCode {
     PrintfFormatMismatch,
     /// Statement that cannot be reached due to preceding unconditional exit
     UnreachableCode,
+    /// `$@` / `$EVAL_ERROR` reads that are not paired with a nearby `eval`/`try`
+    EvalErrorFlow,
 
     // Deprecated syntax (PL500-PL599)
     /// Use of deprecated defined(@array) / defined(%hash)
@@ -233,6 +235,7 @@ impl DiagnosticCode {
             DiagnosticCode::NumericComparisonWithUndef => "PL404",
             DiagnosticCode::PrintfFormatMismatch => "PL405",
             DiagnosticCode::UnreachableCode => "PL406",
+            DiagnosticCode::EvalErrorFlow => "PL407",
             DiagnosticCode::DeprecatedDefined => "PL500",
             DiagnosticCode::DeprecatedArrayBase => "PL501",
             DiagnosticCode::SecurityStringEval => "PL600",
@@ -291,6 +294,7 @@ impl DiagnosticCode {
             "PL404" => "https://docs.perl-lsp.org/errors/PL404",
             "PL405" => "https://docs.perl-lsp.org/errors/PL405",
             "PL406" => "https://docs.perl-lsp.org/errors/PL406",
+            "PL407" => "https://docs.perl-lsp.org/errors/PL407",
             "PL500" => "https://docs.perl-lsp.org/errors/PL500",
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
             "PL600" => "https://docs.perl-lsp.org/errors/PL600",
@@ -348,6 +352,7 @@ impl DiagnosticCode {
             | DiagnosticCode::SecuritySignalHandler
             | DiagnosticCode::ModuleNotFound
             | DiagnosticCode::VersionIncompatFeature
+            | DiagnosticCode::EvalErrorFlow
             | DiagnosticCode::CriticSeverity1
             | DiagnosticCode::CriticSeverity2 => DiagnosticSeverity::Warning,
 
@@ -454,6 +459,10 @@ impl DiagnosticCode {
             DiagnosticCode::NumericComparisonWithUndef => Some(
                 "Comparing a potentially undefined value with a numeric operator \
                 produces a warning at runtime. Check for definedness first with `defined()`.",
+            ),
+            DiagnosticCode::EvalErrorFlow => Some(
+                "Read `$@` or `$EVAL_ERROR` immediately after an `eval` or `try` \
+                block; intervening statements can clobber the exception state.",
             ),
             DiagnosticCode::UnreachableCode => Some(
                 "This statement cannot be executed because a preceding statement \
@@ -707,7 +716,8 @@ impl DiagnosticCode {
             | DiagnosticCode::AssignmentInCondition
             | DiagnosticCode::NumericComparisonWithUndef
             | DiagnosticCode::PrintfFormatMismatch
-            | DiagnosticCode::UnreachableCode => DiagnosticCategory::BestPractices,
+            | DiagnosticCode::UnreachableCode
+            | DiagnosticCode::EvalErrorFlow => DiagnosticCategory::BestPractices,
 
             DiagnosticCode::DeprecatedDefined | DiagnosticCode::DeprecatedArrayBase => {
                 DiagnosticCategory::Deprecated
@@ -749,6 +759,7 @@ mod tests {
     fn test_code_strings() {
         assert_eq!(DiagnosticCode::ParseError.as_str(), "PL001");
         assert_eq!(DiagnosticCode::MissingStrict.as_str(), "PL100");
+        assert_eq!(DiagnosticCode::EvalErrorFlow.as_str(), "PL407");
         assert_eq!(DiagnosticCode::CriticSeverity1.as_str(), "PC001");
         assert_eq!(DiagnosticCode::SecuritySignalHandler.as_str(), "PL602");
     }
@@ -757,6 +768,7 @@ mod tests {
     fn test_severity() {
         assert_eq!(DiagnosticCode::ParseError.severity(), DiagnosticSeverity::Error);
         assert_eq!(DiagnosticCode::UnusedVariable.severity(), DiagnosticSeverity::Warning);
+        assert_eq!(DiagnosticCode::EvalErrorFlow.severity(), DiagnosticSeverity::Warning);
         assert_eq!(DiagnosticCode::CriticSeverity5.severity(), DiagnosticSeverity::Hint);
     }
 
@@ -787,6 +799,7 @@ mod tests {
         assert_eq!(DiagnosticCode::ParseError.category(), DiagnosticCategory::Parser);
         assert_eq!(DiagnosticCode::MissingStrict.category(), DiagnosticCategory::StrictWarnings);
         assert_eq!(DiagnosticCode::SecuritySignalHandler.category(), DiagnosticCategory::Security);
+        assert_eq!(DiagnosticCode::EvalErrorFlow.category(), DiagnosticCategory::BestPractices);
         assert_eq!(DiagnosticCode::CriticSeverity1.category(), DiagnosticCategory::PerlCritic);
     }
 

--- a/crates/perl-lsp-diagnostic-catalog/src/lib.rs
+++ b/crates/perl-lsp-diagnostic-catalog/src/lib.rs
@@ -123,6 +123,12 @@ pub fn implicit_return() -> DiagnosticMeta {
     diagnostic_meta(DiagnosticCode::ImplicitReturn)
 }
 
+/// Eval / try error-flow diagnostic (PL407).
+#[must_use]
+pub fn eval_error_flow() -> DiagnosticMeta {
+    diagnostic_meta(DiagnosticCode::EvalErrorFlow)
+}
+
 /// Perl::Critic severity-5 violation diagnostic (PC005).
 #[must_use]
 pub fn critic_severity_5() -> DiagnosticMeta {
@@ -161,7 +167,7 @@ pub fn from_message(msg: &str) -> Option<DiagnosticMeta> {
 
 #[cfg(test)]
 mod tests {
-    use super::{from_message, parse_error};
+    use super::{eval_error_flow, from_message, parse_error};
 
     #[test]
     fn parse_error_includes_stable_code_and_docs_url() {
@@ -178,6 +184,16 @@ mod tests {
         let meta = super::critic_severity_1();
         assert_eq!(meta.code, "PC001");
         assert!(meta.desc.is_none());
+    }
+
+    #[test]
+    fn eval_error_flow_has_stable_code_and_docs_url() {
+        let meta = eval_error_flow();
+        assert_eq!(meta.code, "PL407");
+        assert_eq!(
+            meta.desc,
+            Some(serde_json::json!({ "href": "https://docs.perl-lsp.org/errors/PL407" }))
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -14,6 +14,7 @@ use perl_semantic_analyzer::symbol::SymbolExtractor;
 use crate::dedup::deduplicate_diagnostics;
 use crate::lints::common_mistakes::check_common_mistakes;
 use crate::lints::deprecated::check_deprecated_syntax;
+use crate::lints::eval_error_flow::check_eval_error_flow;
 use crate::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -147,6 +148,7 @@ impl DiagnosticsProvider {
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);
+        check_eval_error_flow(ast, &mut diagnostics);
 
         // Unused import detection
         check_unused_imports(ast, source, &mut diagnostics);

--- a/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
@@ -209,7 +209,7 @@ fn make_diagnostic(node: &Node, has_prior_source: bool) -> Diagnostic {
         }],
         tags: Vec::new(),
         suggestion: Some(
-            "Check `$@` or `$EVAL_ERROR` immediately after the `eval` or `try` statement."
+            "Move the exception check immediately after the `eval` or `try` block."
                 .to_string(),
         ),
     }

--- a/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
@@ -97,9 +97,8 @@ fn check_statement_list(
 
         // Handler blocks need the outer exception-flow state so the body can
         // still report stale reads after an intervening statement.
-        if is_handler_block {
-            visit_node(statement, diagnostics, entry_state);
-        } else if !facts.reads_error_var
+        if is_handler_block
+            || !facts.reads_error_var
             || matches!(&statement.kind, NodeKind::LabeledStatement { .. })
         {
             visit_node(statement, diagnostics, entry_state);
@@ -179,15 +178,17 @@ fn inspect_node(node: &Node, facts: &mut StatementFacts) {
         NodeKind::ExpressionStatement { expression } => {
             inspect_node(expression, facts);
         }
-        NodeKind::VariableDeclaration { initializer, .. } => {
-            if let Some(init) = initializer {
-                inspect_node(init, facts);
-            }
+        NodeKind::VariableDeclaration {
+            initializer: Some(init),
+            ..
+        } => {
+            inspect_node(init, facts);
         }
-        NodeKind::VariableListDeclaration { initializer, .. } => {
-            if let Some(init) = initializer {
-                inspect_node(init, facts);
-            }
+        NodeKind::VariableListDeclaration {
+            initializer: Some(init),
+            ..
+        } => {
+            inspect_node(init, facts);
         }
         NodeKind::Return { value: Some(value) } => {
             inspect_node(value, facts);

--- a/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
@@ -178,16 +178,10 @@ fn inspect_node(node: &Node, facts: &mut StatementFacts) {
         NodeKind::ExpressionStatement { expression } => {
             inspect_node(expression, facts);
         }
-        NodeKind::VariableDeclaration {
-            initializer: Some(init),
-            ..
-        } => {
+        NodeKind::VariableDeclaration { initializer: Some(init), .. } => {
             inspect_node(init, facts);
         }
-        NodeKind::VariableListDeclaration {
-            initializer: Some(init),
-            ..
-        } => {
+        NodeKind::VariableListDeclaration { initializer: Some(init), .. } => {
             inspect_node(init, facts);
         }
         NodeKind::Return { value: Some(value) } => {

--- a/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
@@ -12,52 +12,58 @@ use perl_parser_core::ast::{Node, NodeKind};
 
 /// Warn on stale or context-free reads of `$@` / `$EVAL_ERROR`.
 pub fn check_eval_error_flow(root: &Node, diagnostics: &mut Vec<Diagnostic>) {
-    visit_node(root, diagnostics);
+    visit_node(root, diagnostics, FlowState::default());
 }
 
-fn visit_node(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
+#[derive(Clone, Copy, Default)]
+struct FlowState {
+    source_seen: bool,
+    immediate_after_source: bool,
+}
+
+fn visit_node(node: &Node, diagnostics: &mut Vec<Diagnostic>, state: FlowState) {
     match &node.kind {
         NodeKind::Program { statements } | NodeKind::Block { statements } => {
-            check_statement_list(statements, diagnostics);
+            check_statement_list(statements, diagnostics, state);
         }
         NodeKind::Subroutine { body, .. } | NodeKind::Method { body, .. } => {
-            visit_node(body, diagnostics);
+            visit_node(body, diagnostics, FlowState::default());
         }
         NodeKind::Class { body, .. } => {
-            visit_node(body, diagnostics);
+            visit_node(body, diagnostics, FlowState::default());
         }
         NodeKind::Package { block: Some(block), .. } => {
-            visit_node(block, diagnostics);
+            visit_node(block, diagnostics, FlowState::default());
         }
         NodeKind::PhaseBlock { block, .. } => {
-            visit_node(block, diagnostics);
+            visit_node(block, diagnostics, FlowState::default());
         }
         NodeKind::If { then_branch, elsif_branches, else_branch, .. } => {
-            visit_node(then_branch, diagnostics);
+            visit_node(then_branch, diagnostics, state);
             for (_, branch) in elsif_branches {
-                visit_node(branch, diagnostics);
+                visit_node(branch, diagnostics, FlowState::default());
             }
             if let Some(branch) = else_branch {
-                visit_node(branch, diagnostics);
+                visit_node(branch, diagnostics, FlowState::default());
             }
         }
         NodeKind::While { body, continue_block, .. } => {
-            visit_node(body, diagnostics);
+            visit_node(body, diagnostics, state);
             if let Some(block) = continue_block {
-                visit_node(block, diagnostics);
+                visit_node(block, diagnostics, state);
             }
         }
         NodeKind::For { body, .. } | NodeKind::Foreach { body, .. } => {
-            visit_node(body, diagnostics);
+            visit_node(body, diagnostics, FlowState::default());
         }
         NodeKind::Given { body, .. } | NodeKind::When { body, .. } | NodeKind::Default { body } => {
-            visit_node(body, diagnostics);
+            visit_node(body, diagnostics, FlowState::default());
         }
         NodeKind::Do { block } => {
-            visit_node(block, diagnostics);
+            visit_node(block, diagnostics, FlowState::default());
         }
         NodeKind::LabeledStatement { statement, .. } => {
-            visit_node(statement, diagnostics);
+            visit_node(statement, diagnostics, state);
         }
         // `eval` and `try` are statement-level sources; their nested blocks are
         // intentionally not walked in this conservative pass.
@@ -66,28 +72,37 @@ fn visit_node(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
     }
 }
 
-fn check_statement_list(statements: &[Node], diagnostics: &mut Vec<Diagnostic>) {
-    let mut last_exception_source: Option<usize> = None;
-
-    for (idx, statement) in statements.iter().enumerate() {
+fn check_statement_list(
+    statements: &[Node],
+    diagnostics: &mut Vec<Diagnostic>,
+    mut state: FlowState,
+) {
+    for statement in statements {
+        let entry_state = state;
         let facts = inspect_statement(statement);
-        let immediate_after_source =
-            last_exception_source == Some(idx.saturating_sub(1)) && idx > 0;
+        let is_handler_block =
+            matches!(&statement.kind, NodeKind::If { .. } | NodeKind::While { .. })
+                && facts.reads_error_var;
 
-        if facts.reads_error_var && !facts.has_source && !immediate_after_source {
-            diagnostics.push(make_diagnostic(statement, last_exception_source.is_some()));
+        if facts.reads_error_var && !facts.has_source && !entry_state.immediate_after_source {
+            diagnostics.push(make_diagnostic(statement, entry_state.source_seen));
         }
 
         if facts.has_source {
-            last_exception_source = Some(idx);
+            state.source_seen = true;
+            state.immediate_after_source = true;
+        } else {
+            state.immediate_after_source = false;
         }
 
-        // If this statement already reads `$@` / `$EVAL_ERROR`, treat it as the
-        // current exception check/handler and do not immediately recurse into its
-        // nested blocks as fresh scopes. That keeps `if ($@) { warn $@; }`
-        // from warning on the handler body one statement later.
-        if !facts.reads_error_var {
-            visit_node(statement, diagnostics);
+        // Handler blocks need the outer exception-flow state so the body can
+        // still report stale reads after an intervening statement.
+        if is_handler_block {
+            visit_node(statement, diagnostics, entry_state);
+        } else if !facts.reads_error_var
+            || matches!(&statement.kind, NodeKind::LabeledStatement { .. })
+        {
+            visit_node(statement, diagnostics, entry_state);
         }
     }
 }
@@ -111,6 +126,10 @@ fn inspect_node(node: &Node, facts: &mut StatementFacts) {
         }
         NodeKind::Variable { sigil, name } if is_error_variable(sigil, name) => {
             facts.reads_error_var = true;
+        }
+        NodeKind::StatementModifier { statement, condition, .. } => {
+            inspect_node(statement, facts);
+            inspect_node(condition, facts);
         }
         NodeKind::Program { .. }
         | NodeKind::Block { .. }
@@ -141,7 +160,9 @@ fn inspect_node(node: &Node, facts: &mut StatementFacts) {
             inspect_node(else_expr, facts);
         }
         NodeKind::Assignment { lhs, rhs, .. } => {
-            inspect_node(lhs, facts);
+            if !matches!(lhs.kind, NodeKind::Variable { .. }) {
+                inspect_node(lhs, facts);
+            }
             inspect_node(rhs, facts);
         }
         NodeKind::FunctionCall { args, .. } | NodeKind::MethodCall { args, .. } => {
@@ -158,16 +179,12 @@ fn inspect_node(node: &Node, facts: &mut StatementFacts) {
         NodeKind::ExpressionStatement { expression } => {
             inspect_node(expression, facts);
         }
-        NodeKind::VariableDeclaration { variable, initializer, .. } => {
-            inspect_node(variable, facts);
+        NodeKind::VariableDeclaration { initializer, .. } => {
             if let Some(init) = initializer {
                 inspect_node(init, facts);
             }
         }
-        NodeKind::VariableListDeclaration { variables, initializer, .. } => {
-            for variable in variables {
-                inspect_node(variable, facts);
-            }
+        NodeKind::VariableListDeclaration { initializer, .. } => {
             if let Some(init) = initializer {
                 inspect_node(init, facts);
             }

--- a/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/eval_error_flow.rs
@@ -1,0 +1,216 @@
+//! Diagnostics for `$@` / `$EVAL_ERROR` exception-flow mistakes.
+//!
+//! The rule is intentionally conservative:
+//! - only same-block statement order is considered
+//! - `eval` / `try` in the same statement are treated as valid sources
+//! - nested blocks are analyzed independently
+//! - no attempt is made to model interprocedural dataflow
+
+use perl_diagnostics_codes::DiagnosticCode;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformation};
+use perl_parser_core::ast::{Node, NodeKind};
+
+/// Warn on stale or context-free reads of `$@` / `$EVAL_ERROR`.
+pub fn check_eval_error_flow(root: &Node, diagnostics: &mut Vec<Diagnostic>) {
+    visit_node(root, diagnostics);
+}
+
+fn visit_node(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            check_statement_list(statements, diagnostics);
+        }
+        NodeKind::Subroutine { body, .. } | NodeKind::Method { body, .. } => {
+            visit_node(body, diagnostics);
+        }
+        NodeKind::Class { body, .. } => {
+            visit_node(body, diagnostics);
+        }
+        NodeKind::Package { block: Some(block), .. } => {
+            visit_node(block, diagnostics);
+        }
+        NodeKind::PhaseBlock { block, .. } => {
+            visit_node(block, diagnostics);
+        }
+        NodeKind::If { then_branch, elsif_branches, else_branch, .. } => {
+            visit_node(then_branch, diagnostics);
+            for (_, branch) in elsif_branches {
+                visit_node(branch, diagnostics);
+            }
+            if let Some(branch) = else_branch {
+                visit_node(branch, diagnostics);
+            }
+        }
+        NodeKind::While { body, continue_block, .. } => {
+            visit_node(body, diagnostics);
+            if let Some(block) = continue_block {
+                visit_node(block, diagnostics);
+            }
+        }
+        NodeKind::For { body, .. } | NodeKind::Foreach { body, .. } => {
+            visit_node(body, diagnostics);
+        }
+        NodeKind::Given { body, .. } | NodeKind::When { body, .. } | NodeKind::Default { body } => {
+            visit_node(body, diagnostics);
+        }
+        NodeKind::Do { block } => {
+            visit_node(block, diagnostics);
+        }
+        NodeKind::LabeledStatement { statement, .. } => {
+            visit_node(statement, diagnostics);
+        }
+        // `eval` and `try` are statement-level sources; their nested blocks are
+        // intentionally not walked in this conservative pass.
+        NodeKind::Eval { .. } | NodeKind::Try { .. } => {}
+        _ => {}
+    }
+}
+
+fn check_statement_list(statements: &[Node], diagnostics: &mut Vec<Diagnostic>) {
+    let mut last_exception_source: Option<usize> = None;
+
+    for (idx, statement) in statements.iter().enumerate() {
+        let facts = inspect_statement(statement);
+        let immediate_after_source =
+            last_exception_source == Some(idx.saturating_sub(1)) && idx > 0;
+
+        if facts.reads_error_var && !facts.has_source && !immediate_after_source {
+            diagnostics.push(make_diagnostic(statement, last_exception_source.is_some()));
+        }
+
+        if facts.has_source {
+            last_exception_source = Some(idx);
+        }
+
+        // If this statement already reads `$@` / `$EVAL_ERROR`, treat it as the
+        // current exception check/handler and do not immediately recurse into its
+        // nested blocks as fresh scopes. That keeps `if ($@) { warn $@; }`
+        // from warning on the handler body one statement later.
+        if !facts.reads_error_var {
+            visit_node(statement, diagnostics);
+        }
+    }
+}
+
+#[derive(Default)]
+struct StatementFacts {
+    has_source: bool,
+    reads_error_var: bool,
+}
+
+fn inspect_statement(node: &Node) -> StatementFacts {
+    let mut facts = StatementFacts::default();
+    inspect_node(node, &mut facts);
+    facts
+}
+
+fn inspect_node(node: &Node, facts: &mut StatementFacts) {
+    match &node.kind {
+        NodeKind::Eval { .. } | NodeKind::Try { .. } => {
+            facts.has_source = true;
+        }
+        NodeKind::Variable { sigil, name } if is_error_variable(sigil, name) => {
+            facts.reads_error_var = true;
+        }
+        NodeKind::Program { .. }
+        | NodeKind::Block { .. }
+        | NodeKind::Subroutine { .. }
+        | NodeKind::Method { .. }
+        | NodeKind::Class { .. }
+        | NodeKind::Package { .. }
+        | NodeKind::PhaseBlock { .. } => {}
+        NodeKind::If { condition, .. } => {
+            inspect_node(condition, facts);
+        }
+        NodeKind::While { condition, .. } => {
+            inspect_node(condition, facts);
+        }
+        NodeKind::Given { expr, .. } => {
+            inspect_node(expr, facts);
+        }
+        NodeKind::Binary { left, right, .. } => {
+            inspect_node(left, facts);
+            inspect_node(right, facts);
+        }
+        NodeKind::Unary { operand, .. } => {
+            inspect_node(operand, facts);
+        }
+        NodeKind::Ternary { condition, then_expr, else_expr } => {
+            inspect_node(condition, facts);
+            inspect_node(then_expr, facts);
+            inspect_node(else_expr, facts);
+        }
+        NodeKind::Assignment { lhs, rhs, .. } => {
+            inspect_node(lhs, facts);
+            inspect_node(rhs, facts);
+        }
+        NodeKind::FunctionCall { args, .. } | NodeKind::MethodCall { args, .. } => {
+            for arg in args {
+                inspect_node(arg, facts);
+            }
+        }
+        NodeKind::IndirectCall { object, args, .. } => {
+            inspect_node(object, facts);
+            for arg in args {
+                inspect_node(arg, facts);
+            }
+        }
+        NodeKind::ExpressionStatement { expression } => {
+            inspect_node(expression, facts);
+        }
+        NodeKind::VariableDeclaration { variable, initializer, .. } => {
+            inspect_node(variable, facts);
+            if let Some(init) = initializer {
+                inspect_node(init, facts);
+            }
+        }
+        NodeKind::VariableListDeclaration { variables, initializer, .. } => {
+            for variable in variables {
+                inspect_node(variable, facts);
+            }
+            if let Some(init) = initializer {
+                inspect_node(init, facts);
+            }
+        }
+        NodeKind::Return { value: Some(value) } => {
+            inspect_node(value, facts);
+        }
+        NodeKind::LabeledStatement { statement, .. } => {
+            inspect_node(statement, facts);
+        }
+        // Nested block-like nodes are handled by `visit_node` as independent
+        // same-block scopes, so they do not contribute to the current statement.
+        NodeKind::For { .. } | NodeKind::Foreach { .. } | NodeKind::Do { .. } => {}
+        _ => {}
+    }
+}
+
+fn is_error_variable(sigil: &str, name: &str) -> bool {
+    sigil == "$" && matches!(name, "@" | "EVAL_ERROR")
+}
+
+fn make_diagnostic(node: &Node, has_prior_source: bool) -> Diagnostic {
+    let message = if has_prior_source {
+        "Reading `$@` or `$EVAL_ERROR` after an intervening statement can see stale exception state. Check it immediately after the `eval` or `try`."
+            .to_string()
+    } else {
+        "Reading `$@` or `$EVAL_ERROR` without a preceding `eval` or `try` in this block may see stale exception state."
+            .to_string()
+    };
+
+    Diagnostic {
+        range: (node.location.start, node.location.end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(DiagnosticCode::EvalErrorFlow.as_str().to_string()),
+        message,
+        related_information: vec![RelatedInformation {
+            location: (node.location.start, node.location.end),
+            message: "Move the exception check immediately after the `eval { ... }` or `try { ... }` statement.".to_string(),
+        }],
+        tags: Vec::new(),
+        suggestion: Some(
+            "Check `$@` or `$EVAL_ERROR` immediately after the `eval` or `try` statement."
+                .to_string(),
+        ),
+    }
+}

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -12,6 +12,7 @@
 //!   misspelled pragma detection
 //! - **common_mistakes**: Frequent programming errors (assignment in conditions, etc.)
 //! - **security**: Security anti-patterns (two-arg open, string eval, backtick execution, global signal handlers)
+//! - **eval_error_flow**: Conservative `$@` / `$EVAL_ERROR` flow checks after `eval` / `try`
 //!
 //! # Diagnostic Code Reference
 //!
@@ -59,6 +60,12 @@
 //! |------|----------|-------------|
 //! | `assignment-in-condition` | Warning | `=` used where `==` likely intended |
 //! | `numeric-undef` | Warning | `==`/`!=` with potentially undef value |
+//!
+//! ## Eval / try flow (`eval_error_flow.rs`)
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL407` | Warning | `$@` / `$EVAL_ERROR` read without a nearby `eval` / `try` |
 //!
 //! ## Security (`security.rs`)
 //!
@@ -111,6 +118,8 @@
 
 pub mod common_mistakes;
 pub mod deprecated;
+/// Conservative `$@` / `$EVAL_ERROR` flow checks after `eval` / `try`
+pub mod eval_error_flow;
 /// Missing module detection (PL701)
 pub mod missing_module;
 /// Package and subroutine diagnostics (PL200, PL201, PL300)

--- a/crates/perl-lsp-diagnostics/tests/eval_error_flow_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/eval_error_flow_tests.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl407_messages(source: &str) -> Vec<String> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("PL407"))
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn reading_error_without_prior_eval_or_try_warns() {
+    let source = "use v5.40;\nmy $err = $@;\n";
+    let messages = pl407_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("without a preceding `eval` or `try`")),
+        "expected PL407 for bare $@ read, got: {messages:?}"
+    );
+}
+
+#[test]
+fn immediate_check_after_eval_is_allowed() {
+    let source = "use v5.40;\neval { risky() };\nif ($@) { warn $@; }\n";
+    let messages = pl407_messages(source);
+    assert!(messages.is_empty(), "immediate check after eval should not warn, got: {messages:?}");
+}
+
+#[test]
+fn intervening_statement_before_check_warns() {
+    let source = "use v5.40;\neval { risky() };\nmy $marker = 1;\nif ($@) { warn $@; }\n";
+    let messages = pl407_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("after an intervening statement")),
+        "expected PL407 for stale $@ read, got: {messages:?}"
+    );
+}
+
+#[test]
+fn immediate_check_after_try_is_allowed_for_eval_error() {
+    let source =
+        "use v5.40;\ntry { risky() } catch { warn $_ };\nif ($EVAL_ERROR) { warn $EVAL_ERROR; }\n";
+    let messages = pl407_messages(source);
+    assert!(messages.is_empty(), "immediate check after try should not warn, got: {messages:?}");
+}

--- a/crates/perl-lsp-diagnostics/tests/eval_error_flow_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/eval_error_flow_tests.rs
@@ -52,3 +52,40 @@ fn immediate_check_after_try_is_allowed_for_eval_error() {
     let messages = pl407_messages(source);
     assert!(messages.is_empty(), "immediate check after try should not warn, got: {messages:?}");
 }
+
+#[test]
+fn localizing_error_variable_is_not_treated_as_a_read() {
+    let source = "use v5.40;\nlocal $@ = undef;\nlocal $EVAL_ERROR = undef;\n";
+    let messages = pl407_messages(source);
+    assert!(messages.is_empty(), "localizing $@ / $EVAL_ERROR should not warn, got: {messages:?}");
+}
+
+#[test]
+fn assignment_targets_do_not_count_as_reads() {
+    let source = "use v5.40;\n($@, $EVAL_ERROR) = (1, 2);\n";
+    let messages = pl407_messages(source);
+    assert!(
+        messages.is_empty(),
+        "assignment targets for $@ / $EVAL_ERROR should not warn, got: {messages:?}"
+    );
+}
+
+#[test]
+fn statement_modifier_reads_are_visible() {
+    let source = "use v5.40;\nwarn $@ if $@;\n";
+    let messages = pl407_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("without a preceding `eval` or `try`")),
+        "expected PL407 for a statement-modifier read, got: {messages:?}"
+    );
+}
+
+#[test]
+fn stale_read_inside_handler_body_is_reported() {
+    let source = "use v5.40;\neval { risky() };\nif ($@) {\n    my $marker = 1;\n    warn $@;\n}\n";
+    let messages = pl407_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("after an intervening statement")),
+        "expected PL407 for a stale read inside the handler body, got: {messages:?}"
+    );
+}

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -252,7 +252,28 @@ fn lint_pipeline_string_eval_emits_pl600() {
 }
 
 // =========================================================================
-// 11. Security lint: global SIG handlers fire through the full pipeline
+// 11. Eval error flow lint fires through the full pipeline (#3380)
+// =========================================================================
+
+#[test]
+fn lint_pipeline_eval_error_flow_emits_pl407() {
+    let source = "use v5.40;\neval { risky() };\nmy $marker = 1;\nif ($@) { warn $@; }\n";
+    let diags = diagnostics_for(source);
+
+    let flow: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL407")).collect();
+
+    assert!(
+        !flow.is_empty(),
+        "Expected eval-error-flow (PL407) diagnostic from get_diagnostics(), \
+         got {} total diags with codes: {:?}",
+        diags.len(),
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+    assert_eq!(flow[0].severity, DiagnosticSeverity::Warning);
+}
+
+// =========================================================================
+// 12. Security lint: global SIG handlers fire through the full pipeline
 // =========================================================================
 
 #[test]
@@ -287,7 +308,7 @@ fn lint_pipeline_lexical_sig_shadow_does_not_emit_pl602() {
 }
 
 // =========================================================================
-// 12. Unused imports lint fires through the full pipeline (#2694)
+// 13. Unused imports lint fires through the full pipeline (#2694)
 // =========================================================================
 
 #[test]
@@ -317,7 +338,7 @@ fn lint_pipeline_unused_import_emits_pl700() {
 }
 
 // =========================================================================
-// 13. Used import does NOT fire PL700 (#2694)
+// 14. Used import does NOT fire PL700 (#2694)
 // =========================================================================
 
 #[test]
@@ -337,7 +358,7 @@ fn lint_pipeline_used_import_no_pl700() {
 }
 
 // =========================================================================
-// 14. Dedup removes duplicate diagnostics (#2696)
+// 15. Dedup removes duplicate diagnostics (#2696)
 // =========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary
- add a conservative PL407 diagnostic for `$@` / `$EVAL_ERROR` flow in the diagnostics layer
- warn on reads with no preceding `eval` / `try` in the same block
- warn on reads after an intervening statement, while allowing the immediate `if ($@) { ... }` / `if ($EVAL_ERROR) { ... }` check pattern

## Why
Diagnostics already understood `eval` and `try` syntax, but they had no rule for stale or context-free reads of `$@` / `$EVAL_ERROR`. That left a common Perl footgun invisible.

## User impact
Users now get a bounded flow warning for the obvious same-block exception-handling mistakes without pretending to do full dataflow.

## Validation
- `cargo test -p perl-diagnostics-codes`
- `cargo test -p perl-lsp-diagnostic-catalog`
- `cargo test -p perl-lsp-diagnostics --test eval_error_flow_tests -- --nocapture`
- `cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests -- --nocapture`