### PR TITLE
fix(scope): add socketpair to declaration-capable builtins (#3346)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1356,7 +1356,7 @@ fn is_known_function(name: &str) -> bool {
 /// emits declaration nodes for the handle argument, and where treating that declaration as
 /// used avoids false diagnostics after the call.
 fn is_declaration_capable_builtin(name: &str) -> bool {
-    matches!(name, "open" | "opendir" | "sysopen" | "pipe" | "socket" | "accept")
+    matches!(name, "open" | "opendir" | "sysopen" | "pipe" | "socket" | "socketpair" | "accept")
 }
 
 /// Check if an identifier is a known filehandle

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -176,6 +176,39 @@ print $client;
     Ok(())
 }
 
+#[test]
+fn scope_socketpair_initializes_both_handles() -> Result<(), Box<dyn std::error::Error>> {
+    // socketpair creates a pair of connected sockets; both handles should be
+    // treated as declared and initialized, not flagged as undeclared/unused.
+    let code = r#"
+use strict;
+socketpair my $s1, my $s2, AF_UNIX, SOCK_STREAM, 0;
+print $s1;
+print $s2;
+"#;
+
+    let issues = scope_issues_strict(code);
+    let handled = ["$s1", "$s2"];
+
+    for variable_name in handled {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == variable_name
+            }),
+            "socketpair should declare and initialize both socket handles without false positives: {} (issues: {:?})",
+            variable_name,
+            issues
+        );
+    }
+
+    Ok(())
+}
+
 // ===========================================================================
 // 2. Variable Scope Resolution — our
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `socketpair` to the `is_declaration_capable_builtin()` function in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`
- Eliminates false-positive `UndeclaredVariable`, `UninitializedVariable`, and `UnusedVariable` diagnostics when both socket handles are declared inline with `my` and subsequently used
- Follows the identical pattern already used for `pipe` (two-arg declaration), since `socketpair` has the same semantics: it initializes both `$s1` and `$s2` as socket handles

## Root Cause

`socketpair my $s1, my $s2, AF_UNIX, SOCK_STREAM, 0;` creates a pair of connected sockets. The existing `mark_builtin_declaration_arg_consumed()` already handles multi-argument inline declarations (it recurses through comma-list args), but the function was never added to the `is_declaration_capable_builtin` allowlist so the declaration path was never triggered.

## Test plan

- [x] New test `scope_socketpair_initializes_both_handles` in `scope_and_symbol_tests.rs` confirms both `$s1` and `$s2` produce no diagnostics after being used via `print`
- [x] Test confirmed failing before fix, passing after
- [x] `cargo test -p perl-semantic-analyzer` passes (1 pre-existing unrelated failure: `symbol_extraction_method_preserves_attributes` exists on master)
- [x] `cargo fmt -p perl-semantic-analyzer` clean
- [x] `cargo clippy -p perl-semantic-analyzer --lib` clean

Closes #3346