### PR TITLE
fix(scope): position-aware builtin declaration handling for read/sysread/recv (#3345)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -891,13 +891,16 @@ impl ScopeAnalyzer {
 
             NodeKind::FunctionCall { name, args } => {
                 // Handle function arguments, which may contain complex variable patterns.
-                // Some builtins consume declaration-capable filehandle arguments directly,
-                // e.g. `open my $fh, ...` or `pipe my $r, my $w;`. Those declarations should
-                // count as used and initialized by the builtin itself.
+                // Some builtins consume declaration-capable arguments directly, but the
+                // eligible positions are builtin-specific:
+                //   - `open my $fh, ...`      — position 0 is the declaration
+                //   - `read $fh, my $buf, ...` — position 1 is the declaration
+                // Use the position-aware helper to avoid marking the wrong argument.
+                let decl_positions = builtin_declaration_arg_positions(name);
                 ancestors.push(node);
-                for arg in args {
+                for (idx, arg) in args.iter().enumerate() {
                     self.analyze_node(arg, scope, ancestors, issues, context);
-                    if is_declaration_capable_builtin(name) {
+                    if decl_positions.contains(&idx) {
                         self.mark_builtin_declaration_arg_consumed(arg, scope);
                     }
                 }
@@ -1350,13 +1353,28 @@ fn is_known_function(name: &str) -> bool {
     }
 }
 
-/// Builtins whose declaration-capable filehandle arguments are consumed by the builtin itself.
+/// Returns the argument positions (0-based) at which a builtin can accept a declaration
+/// (`my $var`) that the builtin itself initializes.
 ///
 /// Keep this list explicit and conservative. Only include builtins where the parser already
-/// emits declaration nodes for the handle argument, and where treating that declaration as
+/// emits declaration nodes for the relevant argument, and where treating that declaration as
 /// used avoids false diagnostics after the call.
-fn is_declaration_capable_builtin(name: &str) -> bool {
-    matches!(name, "open" | "opendir" | "sysopen" | "pipe" | "socket" | "accept")
+///
+/// Position semantics:
+/// - Position 0: `open`, `opendir`, `sysopen`, `socket`, `accept`, `socketpair`
+/// - Position 1: `read`, `sysread`, `recv`, `socketpair` (second handle)
+fn builtin_declaration_arg_positions(name: &str) -> &'static [usize] {
+    match name {
+        // Position 0: the first argument is the new handle/socket
+        "open" | "opendir" | "sysopen" | "socket" | "accept" => &[0],
+        // Position 1: the second argument is the buffer (first is an existing handle)
+        "read" | "sysread" | "recv" => &[1],
+        // pipe: both first arguments are new handles
+        "pipe" => &[0, 1],
+        // socketpair: both first arguments are new sockets
+        "socketpair" => &[0, 1],
+        _ => &[],
+    }
 }
 
 /// Check if an identifier is a known filehandle

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1460,3 +1460,145 @@ fn edge_scope_issue_range_within_source() -> Result<(), Box<dyn std::error::Erro
     }
     Ok(())
 }
+
+// ===========================================================================
+// 17. Position-aware builtin declaration handling (read/sysread/recv at pos 1)
+// ===========================================================================
+
+#[test]
+fn read_buffer_declaration_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // `read $fh, my $buffer, 1024` — $buffer is declared at position 1, not 0.
+    // It should not be flagged as undeclared, uninitialized, or unused.
+    let code = r#"
+use strict;
+open my $fh, '<', 'file.txt';
+read $fh, my $buffer, 1024;
+print $buffer;
+"#;
+    let issues = scope_issues_strict(code);
+    for var in ["$buffer", "$fh"] {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == var
+            }),
+            "read buffer/handle should not be flagged: {} (issues: {:?})",
+            var,
+            issues
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn sysread_buffer_declaration_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // `sysread $fh, my $buf, 512` — position 1 is the declaration.
+    let code = r#"
+use strict;
+open my $fh, '<', 'file.txt';
+sysread $fh, my $buf, 512;
+print $buf;
+"#;
+    let issues = scope_issues_strict(code);
+    for var in ["$buf", "$fh"] {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == var
+            }),
+            "sysread buffer/handle should not be flagged: {} (issues: {:?})",
+            var,
+            issues
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn recv_buffer_declaration_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // `recv $sock, my $data, 1024, 0` — position 1 is the declaration.
+    let code = r#"
+use strict;
+socket my $sock, 2, 1, 0;
+recv $sock, my $data, 1024, 0;
+print $data;
+"#;
+    let issues = scope_issues_strict(code);
+    for var in ["$data", "$sock"] {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == var
+            }),
+            "recv buffer/socket should not be flagged: {} (issues: {:?})",
+            var,
+            issues
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn read_position_zero_not_treated_as_declaration() -> Result<(), Box<dyn std::error::Error>> {
+    // Position 0 in `read` is an existing filehandle, NOT a declaration target.
+    // Passing a bare (non-declaration) variable at position 0 should not affect its
+    // declaration status — it must have been declared separately.
+    let code = r#"
+use strict;
+my $fh = \*STDIN;
+my $buffer;
+read $fh, $buffer, 1024;
+print $buffer;
+"#;
+    let issues = scope_issues_strict(code);
+    // $fh was declared with `my` — should not be flagged at all
+    assert!(
+        !issues.iter().any(|i| {
+            i.variable_name.contains("fh")
+                && matches!(i.kind, IssueKind::UndeclaredVariable | IssueKind::UnusedVariable)
+        }),
+        "existing $fh should not be flagged (issues: {:?})",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn socketpair_both_positions_declared() -> Result<(), Box<dyn std::error::Error>> {
+    // `socketpair my $a, my $b, ...` — positions 0 and 1 are both declarations.
+    let code = r#"
+use strict;
+socketpair my $a, my $b, 2, 1, 0;
+print $a;
+print $b;
+"#;
+    let issues = scope_issues_strict(code);
+    for var in ["$a", "$b"] {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(
+                    i.kind,
+                    IssueKind::UndeclaredVariable
+                        | IssueKind::UninitializedVariable
+                        | IssueKind::UnusedVariable
+                ) && i.variable_name == var
+            }),
+            "socketpair handle should not be flagged: {} (issues: {:?})",
+            var,
+            issues
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Fixes false-positive `UndeclaredVariable`/`UninitializedVariable` diagnostics for `my $buffer` in `read $fh, my $buffer, N`, `sysread $fh, my $buf, N`, and `recv $sock, my $data, N, 0`
- Replaces the flat `is_declaration_capable_builtin(name)` boolean with a position-aware `builtin_declaration_arg_positions(name) -> &'static [usize]` that returns which arg positions (0-based) can hold a `my $var` declaration
- Updates the `FunctionCall` handler to use `enumerate()` and only call `mark_builtin_declaration_arg_consumed` on the specific positions returned by the new helper

## Root cause

The previous code checked `is_declaration_capable_builtin` and called `mark_builtin_declaration_arg_consumed` on **all** args equally. `read`, `sysread`, and `recv` were absent from the list entirely, so:
- `read $fh, my $buffer, 1024` — `$buffer` was flagged as undeclared/uninitialized
- `sysread $fh, my $buf, N` — same
- `recv $sock, my $data, N, 0` — same

The position difference matters:
- `open my $fh, '<', $path` — position **0** is the declaration (no existing handle)
- `read $fh, my $buf, N` — position **1** is the declaration (position 0 is an existing handle)

## New position table

| Builtin | Declaration positions |
|---------|----------------------|
| `open`, `opendir`, `sysopen`, `socket`, `accept` | 0 |
| `read`, `sysread`, `recv` | 1 |
| `pipe`, `socketpair` | 0 and 1 |

## Tests added (5 new in `scope_and_symbol_tests.rs`)

- `read_buffer_declaration_not_flagged` — full pipeline: open + read + print $buffer
- `sysread_buffer_declaration_not_flagged` — full pipeline: open + sysread + print $buf
- `recv_buffer_declaration_not_flagged` — full pipeline: socket + recv + print $data
- `read_position_zero_not_treated_as_declaration` — position 0 must stay non-declaration
- `socketpair_both_positions_declared` — regression guard for dual-position builtins

## Verification

```
cargo test -p perl-semantic-analyzer  # 5 new tests pass; 1 pre-existing unrelated failure
cargo clippy -p perl-semantic-analyzer --lib  # 0 warnings
cargo fmt -p perl-semantic-analyzer -- --check  # clean
```

Pre-existing failure: `symbol_extraction_method_preserves_attributes` — confirmed failing on master before this branch.

Closes #3345