### PR TITLE
fix(ci): grant auto-label-prs PR write permission (#3425)

### DIFF
--- a/.github/workflows/pipeline-labels.yml
+++ b/.github/workflows/pipeline-labels.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Label PR as in-review
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary
- grant `pull-requests: write` to the `auto-label-prs` job in `pipeline-labels.yml`
- keep the existing `issues: write` permission for label mutation
- fix the 403 `Resource not accessible by integration` failure triggered on `pull_request.ready_for_review`

## Context
`#3419` and `#3420` both failed `auto-label-prs` immediately after moving out of draft. The workflow log showed GitHub accepting `issues=write; pull_requests=write` for the label mutation path.

## Validation
- inspected failing job log for run `24222568049` / job `70717028019`
- verified the workflow diff is limited to the `auto-label-prs` job permissions block