### PR TITLE
fix(ux): integrate probeStartupFailure with runStartupDiagnostics (#3329)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -19,7 +19,7 @@ import { handleFormattingError } from './formattingErrors';
 import { HealthWidget, ClientState } from './healthWidget';
 import { registerPodPreview } from './podPreview';
 import { StreamingCompletionController } from './streamingCompletion';
-import { classifyStartupError } from './startupDiagnosis';
+import { classifyStartupError, selectBestDiagnosis, StartupErrorKind } from './startupDiagnosis';
 import type { StartupErrorDiagnosis } from './startupDiagnosis';
 
 let client: LanguageClient | undefined;
@@ -730,11 +730,19 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
         healthWidget?.onStateChange(ClientState.Stopped);
 
         // Probe the binary to get an actionable OS-level diagnosis (#3280).
+        // If the probe result is Unknown (binary gave no useful output), fall
+        // back to the health check (#3312) which can detect missing Perl etc.
         // lastStartupDiagnostic is updated so that serverNotRunningMessage() in
         // command handlers surfaces the specific root cause rather than a generic prompt.
-        const diagnosis = currentServerPath
+        const probeResult = currentServerPath
             ? await probeStartupFailure(currentServerPath)
             : classifyStartupError('');
+        let healthMsg: string | undefined;
+        if (probeResult.kind === StartupErrorKind.Unknown) {
+            const onboarding = new OnboardingManager(context, outputChannel);
+            healthMsg = await onboarding.runStartupDiagnostics(currentServerPath ?? null);
+        }
+        const diagnosis = selectBestDiagnosis(probeResult, healthMsg);
         lastStartupDiagnostic = `${diagnosis.hint} Suggestion: ${diagnosis.remediation}`;
         const dialogMessage =
             `Perl Language Server failed to start.\n\n${diagnosis.hint}\n\nSuggestion: ${diagnosis.remediation}`;

--- a/vscode-extension/src/startupDiagnosis.ts
+++ b/vscode-extension/src/startupDiagnosis.ts
@@ -106,3 +106,39 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
         remediation: 'Try "Run Health Check" to diagnose, or "Reinstall" to fetch a fresh binary.',
     };
 }
+
+/**
+ * Choose the most informative startup diagnosis to surface to the user.
+ *
+ * Strategy (#3329): OS-level probe results are preferred when they classify a
+ * specific error (glibc mismatch, wrong arch, permission error, etc.).  When
+ * the probe returns `Unknown` — meaning execFile gave no useful output — fall
+ * back to the health-check string from `runStartupDiagnostics`, which can
+ * detect environment issues like a missing Perl interpreter.
+ *
+ * @param probe      Result of `probeStartupFailure`.
+ * @param healthMsg  Result of `onboardingManager.runStartupDiagnostics`, or
+ *                   `undefined` if that call was skipped / not yet awaited.
+ * @returns          The best available diagnosis, with `hint` and `remediation`
+ *                   ready for display.
+ */
+export function selectBestDiagnosis(
+    probe: StartupErrorDiagnosis,
+    healthMsg: string | undefined,
+): StartupErrorDiagnosis {
+    if (probe.kind !== StartupErrorKind.Unknown) {
+        // Probe classified the error specifically — trust it.
+        return probe;
+    }
+    if (!healthMsg) {
+        // Nothing better available — return the probe as-is.
+        return probe;
+    }
+    // Probe was inconclusive; promote the health-check string as the hint so
+    // the user sees "Perl interpreter not found" instead of the generic message.
+    return {
+        kind: StartupErrorKind.Unknown,
+        hint: healthMsg,
+        remediation: probe.remediation,
+    };
+}

--- a/vscode-extension/src/test/startupError.test.ts
+++ b/vscode-extension/src/test/startupError.test.ts
@@ -15,7 +15,7 @@
  * "corrupted or incompatible") and a specific remediation step.
  */
 
-import { classifyStartupError, StartupErrorKind } from '../startupDiagnosis';
+import { classifyStartupError, StartupErrorKind, selectBestDiagnosis } from '../startupDiagnosis';
 
 // ---------------------------------------------------------------------------
 // classifyStartupError — pure classification of stderr/stdout text
@@ -196,5 +196,49 @@ describe('classifyStartupError', () => {
       const result = classifyStartupError(stderr);
       expect(result.hint.length).toBeLessThanOrEqual(200);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectBestDiagnosis — fallback chaining for #3329
+//
+// When probeStartupFailure returns Unknown (binary probe was inconclusive),
+// selectBestDiagnosis must prefer the health-check string from
+// runStartupDiagnostics so the user gets the specific "Perl interpreter not
+// found" message instead of a generic hint.
+// ---------------------------------------------------------------------------
+
+describe('selectBestDiagnosis', () => {
+  test('returns probe diagnosis unchanged when kind is not Unknown', () => {
+    const probe = classifyStartupError(
+      '/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.35` not found',
+    );
+    // probe.kind === GlibcMismatch — health msg should be ignored
+    const result = selectBestDiagnosis(probe, 'Perl interpreter not found. Install Perl 5.10+');
+    expect(result.kind).toBe(StartupErrorKind.GlibcMismatch);
+    expect(result.hint).toContain('glibc');
+  });
+
+  test('falls back to health-check message when probe kind is Unknown', () => {
+    const probe = classifyStartupError('');  // Unknown
+    const healthMsg = 'Perl interpreter not found. Install Perl 5.10+ and reload the window.';
+    const result = selectBestDiagnosis(probe, healthMsg);
+    expect(result.hint).toContain('Perl');
+    expect(result.hint).toContain('Install');
+    // The fallback should not be the generic Unknown hint
+    expect(result.hint).not.toContain('LSP binary failed to start');
+  });
+
+  test('returns probe Unknown unchanged when no health message is provided', () => {
+    const probe = classifyStartupError('');  // Unknown
+    const result = selectBestDiagnosis(probe, undefined);
+    expect(result.kind).toBe(StartupErrorKind.Unknown);
+    expect(result.hint).toBeTruthy();
+  });
+
+  test('returns probe Unknown unchanged when health message is empty string', () => {
+    const probe = classifyStartupError('');  // Unknown
+    const result = selectBestDiagnosis(probe, '');
+    expect(result.kind).toBe(StartupErrorKind.Unknown);
   });
 });


### PR DESCRIPTION
## Summary
- Restores the lost `runStartupDiagnostics()` call that was dropped during the rebase of #3308 onto post-#3312 master
- Adds `selectBestDiagnosis()` pure function that chains OS-level probe → health-check fallback so users get "Perl interpreter not found" instead of a generic message
- When `probeStartupFailure` returns `Unknown` (no useful stderr), the catch block now calls `runStartupDiagnostics` and uses its result as the hint

## Changes
- `vscode-extension/src/startupDiagnosis.ts`: adds `selectBestDiagnosis(probe, healthMsg)` — pure function, no vscode or I/O deps, fully unit-tested
- `vscode-extension/src/extension.ts`: updates catch block in `initializeLanguageClient` to probe first, fall back to health check when probe is `Unknown`, then select best diagnosis
- `vscode-extension/src/test/startupError.test.ts`: adds 4 unit tests for the new fallback logic

## Evidence
- **Commits**: 1
- **Tests**: 433 passed, 0 failed (22/22 in startupError.test.ts including 4 new selectBestDiagnosis tests)
- **Lint**: 0 errors, 7 pre-existing warnings (none in changed files)
- **Files**: 3 changed, +91/-3 lines

## Test Plan
- `cd vscode-extension && pnpm test` — all 433 tests pass
- Manual: start VS Code without Perl installed; LSP binary probe returns Unknown → health check detects missing Perl → user sees "Perl interpreter not found. Install Perl 5.10+..." instead of generic message

## Unknowns
- The `PERL_MISSING_MESSAGE` used as `hint` already contains remediation text; `lastStartupDiagnostic` will append `Suggestion: Try "Run Health Check"...` which is slightly redundant but harmless at tier-2 severity
- The 3 pre-existing test suite failures (arrowCompletion, languageClientArgs, streamingCompletion) are due to missing `vscode-jsonrpc` module — unrelated to this change, pre-existed before the fix
- E2E validation (real Perl-missing environment) is out of scope for this PR