### PR TITLE
fix(diagnostics): add given/when and defer to version compatibility checks (#3344)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -38,8 +38,8 @@ const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     // experimental pragma (`use feature 'signatures'`).
     ("signatures", 5, 36),
     // defer block: experimental since v5.36.
-    // Currently detected via FunctionCall { name: "defer" } as the lexer/parser
-    // do not yet have a dedicated Defer keyword token.
+    // Detected only when the AST matches the parser's `defer { ... }` shape,
+    // not for arbitrary helpers/imports named `defer`.
     ("defer", 5, 36),
     ("class", 5, 38),
     ("field", 5, 38),
@@ -131,9 +131,10 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             }
 
             // `defer { }` block — requires v5.36 (`use feature 'defer'`).
-            // The lexer does not yet have a Defer keyword token so defer is
-            // currently parsed as a function call.  Gate on name == "defer".
-            NodeKind::FunctionCall { name, .. } if name == "defer" => {
+            // The parser currently models this as a FunctionCall with a single
+            // block argument. Ordinary helper calls named `defer` should not
+            // trigger PL900.
+            NodeKind::FunctionCall { name, args } if is_defer_feature_usage(name, args) => {
                 if !effective_features.contains(&"defer") {
                     let min = feature_min_version("defer");
                     diagnostics.push(make_diagnostic(n, "defer", declared_version, min));
@@ -207,6 +208,15 @@ fn feature_min_version(feature: &str) -> (u32, u32) {
         .find(|(name, _, _)| *name == feature)
         .map(|(_, maj, min)| (*maj, *min))
         .unwrap_or((5, 0))
+}
+
+/// Return `true` when a node represents the `defer { ... }` feature form.
+fn is_defer_feature_usage(name: &str, args: &[Node]) -> bool {
+    if name != "defer" || args.len() != 1 {
+        return false;
+    }
+
+    matches!(args.first().map(|arg| &arg.kind), Some(NodeKind::Block { .. }))
 }
 
 /// Build a PL900 diagnostic for a version-incompatible feature use.

--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -28,13 +28,19 @@ use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
 const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     ("say", 5, 10),
     ("state", 5, 10),
+    // switch: the feature bundle name for given/when/default constructs (Perl 5.10+)
+    ("switch", 5, 10),
     ("postfix_deref", 5, 20),
+    ("try", 5, 34),
     // signatures: experimental since v5.20 but only stable-bundled at v5.36.
     // We use 5.36 as the effective minimum to match features_enabled_by_version,
     // preventing false-positive warnings on `use v5.20` files that rely on the
     // experimental pragma (`use feature 'signatures'`).
     ("signatures", 5, 36),
-    ("try", 5, 34),
+    // defer block: experimental since v5.36.
+    // Currently detected via FunctionCall { name: "defer" } as the lexer/parser
+    // do not yet have a dedicated Defer keyword token.
+    ("defer", 5, 36),
     ("class", 5, 38),
     ("field", 5, 38),
 ];
@@ -121,6 +127,40 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 if !effective_features.contains(&"say") {
                     let min = feature_min_version("say");
                     diagnostics.push(make_diagnostic(n, "say", declared_version, min));
+                }
+            }
+
+            // `defer { }` block — requires v5.36 (`use feature 'defer'`).
+            // The lexer does not yet have a Defer keyword token so defer is
+            // currently parsed as a function call.  Gate on name == "defer".
+            NodeKind::FunctionCall { name, .. } if name == "defer" => {
+                if !effective_features.contains(&"defer") {
+                    let min = feature_min_version("defer");
+                    diagnostics.push(make_diagnostic(n, "defer", declared_version, min));
+                }
+            }
+
+            // `given ($x) { ... }` — requires v5.10 (`use feature 'switch'`)
+            NodeKind::Given { .. } => {
+                if !effective_features.contains(&"switch") {
+                    let min = feature_min_version("switch");
+                    diagnostics.push(make_diagnostic(n, "given", declared_version, min));
+                }
+            }
+
+            // `when ($pat) { ... }` — requires v5.10 (`use feature 'switch'`)
+            NodeKind::When { .. } => {
+                if !effective_features.contains(&"switch") {
+                    let min = feature_min_version("switch");
+                    diagnostics.push(make_diagnostic(n, "when", declared_version, min));
+                }
+            }
+
+            // `default { ... }` — requires v5.10 (`use feature 'switch'`)
+            NodeKind::Default { .. } => {
+                if !effective_features.contains(&"switch") {
+                    let min = feature_min_version("switch");
+                    diagnostics.push(make_diagnostic(n, "default", declared_version, min));
                 }
             }
 

--- a/crates/perl-lsp-diagnostics/src/walker.rs
+++ b/crates/perl-lsp-diagnostics/src/walker.rs
@@ -118,6 +118,18 @@ where
         NodeKind::LabeledStatement { statement, .. } => {
             walk_node(statement, func);
         }
+        // given ($x) { when (...) { } default { } } — switch feature (v5.10+)
+        NodeKind::Given { expr, body } => {
+            walk_node(expr, func);
+            walk_node(body, func);
+        }
+        NodeKind::When { condition, body } => {
+            walk_node(condition, func);
+            walk_node(body, func);
+        }
+        NodeKind::Default { body } => {
+            walk_node(body, func);
+        }
         _ => {} // Other nodes don't have children or are handled differently
     }
 }

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -527,14 +527,27 @@ fn default_node() -> Node {
 }
 
 fn defer_call() -> Node {
-    // `defer` is currently parsed as a FunctionCall (the lexer has no Defer
-    // keyword token yet).  Model it the same way the parser would produce it.
+    // `defer` is currently parsed as a FunctionCall with a single block
+    // argument (the lexer has no Defer keyword token yet).
     Node::new(
         NodeKind::FunctionCall {
             name: "defer".to_string(),
             args: vec![Node::new(NodeKind::Block { statements: vec![] }, loc(26, 40))],
         },
         loc(20, 41),
+    )
+}
+
+fn defer_helper_call() -> Node {
+    Node::new(
+        NodeKind::FunctionCall {
+            name: "defer".to_string(),
+            args: vec![Node::new(
+                NodeKind::String { value: "cleanup".to_string(), interpolated: false },
+                loc(26, 35),
+            )],
+        },
+        loc(20, 36),
     )
 }
 
@@ -727,6 +740,24 @@ fn test_defer_ok_with_use_feature_defer() -> Result<(), Box<dyn std::error::Erro
     assert!(
         no_compat_warnings(&diagnostics),
         "Expected no PL900 warning when 'use feature 'defer'' is present on v5.34, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 24: ordinary helper call named defer is not treated as the feature
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_helper_call_is_not_version_feature() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.34"), defer_helper_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for ordinary helper call named 'defer', got: {:?}",
         diagnostics
     );
     Ok(())

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -491,3 +491,243 @@ fn test_say_in_return_value_detected() -> Result<(), Box<dyn std::error::Error>>
     );
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Tests for given/when/default (#3344) and defer (#3350)
+// ---------------------------------------------------------------------------
+
+fn given_node() -> Node {
+    Node::new(
+        NodeKind::Given {
+            expr: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+                loc(26, 28),
+            )),
+            body: Box::new(block(vec![])),
+        },
+        loc(20, 50),
+    )
+}
+
+fn when_node() -> Node {
+    Node::new(
+        NodeKind::When {
+            condition: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+                loc(26, 28),
+            )),
+            body: Box::new(block(vec![])),
+        },
+        loc(20, 50),
+    )
+}
+
+fn default_node() -> Node {
+    Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(20, 40))
+}
+
+fn defer_call() -> Node {
+    // `defer` is currently parsed as a FunctionCall (the lexer has no Defer
+    // keyword token yet).  Model it the same way the parser would produce it.
+    Node::new(
+        NodeKind::FunctionCall {
+            name: "defer".to_string(),
+            args: vec![Node::new(NodeKind::Block { statements: vec![] }, loc(26, 40))],
+        },
+        loc(20, 41),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: given in v5.8 -> warns (requires v5.10+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'given' in v5.8, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("given"), "Message should mention 'given': {}", msg.message);
+    assert!(
+        msg.message.contains("v5.10") || msg.message.contains("5.10"),
+        "Message should mention minimum version v5.10: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 17: when in v5.8 -> warns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_when_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'when' in v5.8, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("when"), "Message should mention 'when': {}", msg.message);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 18: default in v5.8 -> warns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'default' in v5.8, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("default"), "Message should mention 'default': {}", msg.message);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 19: given/when/default in v5.10 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_given_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.10"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'given' in v5.10, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+#[test]
+fn test_when_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.10"), when_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'when' in v5.10, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+#[test]
+fn test_default_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.10"), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'default' in v5.10, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 20: explicit `use feature 'switch'` suppresses given/when warning
+// ---------------------------------------------------------------------------
+//
+// In Perl, given/when/default are enabled by `use feature 'switch'`.  An
+// explicit `use feature 'switch'` on an old-version file must suppress
+// the PL900 warning.
+
+#[test]
+fn test_given_ok_with_use_feature_switch() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), use_feature("switch"), given_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning when 'use feature 'switch'' is present on v5.8, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 21: defer (as FunctionCall) in v5.34 -> warns (requires v5.36+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_warns_on_v5_34() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.34"), defer_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'defer' in v5.34, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("defer"), "Message should mention 'defer': {}", msg.message);
+    assert!(
+        msg.message.contains("v5.36") || msg.message.contains("5.36"),
+        "Message should mention minimum version v5.36: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 22: defer in v5.36 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), defer_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'defer' in v5.36, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 23: explicit `use feature 'defer'` suppresses warning on old version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_ok_with_use_feature_defer() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.34"), use_feature("defer"), defer_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning when 'use feature 'defer'' is present on v5.34, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -85,7 +85,8 @@ pub fn version_implies_warnings(version: PerlVersion) -> bool {
 pub fn features_enabled_by_version(version: PerlVersion) -> Vec<&'static str> {
     let mut features = Vec::new();
     if version >= PerlVersion::new(5, 10) {
-        features.extend_from_slice(&["say", "state"]);
+        // say, state, switch (given/when/default)
+        features.extend_from_slice(&["say", "state", "switch"]);
     }
     if version >= PerlVersion::new(5, 20) {
         features.push("postfix_deref");
@@ -94,7 +95,8 @@ pub fn features_enabled_by_version(version: PerlVersion) -> Vec<&'static str> {
         features.push("try");
     }
     if version >= PerlVersion::new(5, 36) {
-        features.push("signatures");
+        // signatures stable-bundled at 5.36; defer experimental since 5.36
+        features.extend_from_slice(&["signatures", "defer"]);
     }
     if version >= PerlVersion::new(5, 38) {
         features.extend_from_slice(&["class", "field", "method"]);


### PR DESCRIPTION
## Summary

- Add `given`/`when`/`default` (Perl 5.10+) version gating to the PL900 version-compat lint
- Add `defer` (Perl 5.36+) version gating using FunctionCall name matching (lexer has no Defer keyword token yet)
- Extend the AST walker to traverse `Given`/`When`/`Default` children so nested version-gated constructs are detected
- Update `features_enabled_by_version` in `perl-pragma` to include `switch` (v5.10+) and `defer` (v5.36+) bundles

## Fixes

Fixes #3344, Fixes #3350

## Implementation Notes

**given/when/default**: The `NodeKind::Given`, `NodeKind::When`, `NodeKind::Default` variants already exist in the AST (`perl-ast`). They map to the `switch` feature bundle (`use feature 'switch'`), available since Perl 5.10.

**defer**: `NodeKind::Defer` does not exist yet — the lexer has no `Defer` token kind (see comment in `perl-parser/src/lib.rs`). As a pragmatic fallback, `defer` is detected via `NodeKind::FunctionCall { name: "defer" }`. This is documented in both the FEATURE_VERSIONS comment and the walker match arm. When the parser gains a proper `Defer` keyword, this can be upgraded to `NodeKind::Defer`.

**`use feature 'switch'` / `use feature 'defer'` suppression**: The existing explicit-feature override mechanism handles both — `use feature 'switch'` on an old-version file suppresses given/when/default warnings; `use feature 'defer'` suppresses defer warnings.

## Test Plan

- [ ] `cargo test -p perl-lsp-diagnostics` — all 27 version_compat tests pass (15 original + 12 new)
- [ ] `cargo test -p perl-pragma` — all 48 tests pass
- [ ] `cargo clippy -p perl-lsp-diagnostics -p perl-pragma --lib` — no warnings
- [ ] Tests 16-23 cover: given warns on v5.8, when warns on v5.8, default warns on v5.8, no warn on v5.10, `use feature 'switch'` suppression, defer warns on v5.34, no warn on v5.36, `use feature 'defer'` suppression

## Files Changed

- `crates/perl-lsp-diagnostics/src/lints/version_compat.rs` — feature table + detection
- `crates/perl-lsp-diagnostics/src/walker.rs` — Given/When/Default traversal
- `crates/perl-lsp-diagnostics/tests/version_compat_tests.rs` — 12 new tests
- `crates/perl-pragma/src/lib.rs` — switch and defer in version bundles