### PR TITLE
fix(parser): preserve scalar-ref hash slice targets (#3364)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/qualified_variable_subscript_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/qualified_variable_subscript_tests.rs
@@ -180,6 +180,43 @@ mod tests {
         }
     }
 
+    #[test]
+    fn scalar_ref_hash_slice_preserves_base_target() {
+        let code = "%$href{'a', 'b'};";
+        assert_no_errors(code);
+
+        let expr = first_expr(code);
+        match &expr.kind {
+            NodeKind::Binary { op, left, right } => {
+                assert_eq!(op, "{}", "Expected {{}} hash-slice operator, got: {op}");
+                match &left.kind {
+                    NodeKind::Variable { sigil, name } => {
+                        assert_eq!(sigil, "%", "Expected % sigil on hash-slice target");
+                        assert_eq!(name, "$href", "Expected scalar-ref hash target, got: {name}");
+                    }
+                    _ => panic!(
+                        "Expected Variable node as hash-slice target, got: {}",
+                        left.kind.kind_name()
+                    ),
+                }
+                match &right.kind {
+                    NodeKind::ArrayLiteral { elements } => {
+                        assert_eq!(elements.len(), 2, "Expected two hash-slice keys");
+                    }
+                    _ => panic!(
+                        "Expected ArrayLiteral slice key list, got: {}",
+                        right.kind.kind_name()
+                    ),
+                }
+            }
+            _ => panic!(
+                "Expected Binary hash-slice node, got: {} (sexp: {})",
+                expr.kind.kind_name(),
+                expr.to_sexp()
+            ),
+        }
+    }
+
     // ---------------------------------------------------------------
     // Multi-level qualified variable with hex subscript
     // Perl: $Text::Unidecode::Char[0xff]

--- a/crates/perl-parser-core/src/engine/parser/qualified_variable_subscript_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/qualified_variable_subscript_tests.rs
@@ -217,6 +217,43 @@ mod tests {
         }
     }
 
+    #[test]
+    fn scalar_ref_hash_slice_list_preserves_base_target() {
+        let code = "@$href{'a', 'b'};";
+        assert_no_errors(code);
+
+        let expr = first_expr(code);
+        match &expr.kind {
+            NodeKind::Binary { op, left, right } => {
+                assert_eq!(op, "{}", "Expected {{}} hash-slice operator, got: {op}");
+                match &left.kind {
+                    NodeKind::Variable { sigil, name } => {
+                        assert_eq!(sigil, "@", "Expected @ sigil on hash-slice target");
+                        assert_eq!(name, "$href", "Expected scalar-ref hash target, got: {name}");
+                    }
+                    _ => panic!(
+                        "Expected Variable node as hash-slice target, got: {}",
+                        left.kind.kind_name()
+                    ),
+                }
+                match &right.kind {
+                    NodeKind::ArrayLiteral { elements } => {
+                        assert_eq!(elements.len(), 2, "Expected two hash-slice keys");
+                    }
+                    _ => panic!(
+                        "Expected ArrayLiteral slice key list, got: {}",
+                        right.kind.kind_name()
+                    ),
+                }
+            }
+            _ => panic!(
+                "Expected Binary hash-slice node, got: {} (sexp: {})",
+                expr.kind.kind_name(),
+                expr.to_sexp()
+            ),
+        }
+    }
+
     // ---------------------------------------------------------------
     // Multi-level qualified variable with hex subscript
     // Perl: $Text::Unidecode::Char[0xff]

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -549,7 +549,8 @@ impl<'a> Parser<'a> {
 
         // Special handling for @, %, or $ sigil followed by { - array/hash/scalar dereference
         // e.g. @{$ref}, %{$hash}, ${"${pkg}::$sym"}
-        if (sigil == "@" || sigil == "%" || (sigil == "$" && name.is_empty()))
+        if (sigil == "@" || sigil == "%" || sigil == "$")
+            && name.is_empty()
             && self.peek_kind() == Some(TokenKind::LeftBrace)
         {
             self.tokens.next()?; // consume {

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -806,6 +806,9 @@ push @{$arrayref}, 2;
 my $hashref;
 $hashref->{k};
 
+my $hashslice_ref = { a => 1, b => 2 };
+my @vals = %$hashslice_ref{'a', 'b'};
+
 my $value = 1;
 my $scalarref = \$value;
 $$scalarref;
@@ -826,6 +829,17 @@ $arr[0];
         .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hashref"))
         .count();
     assert_eq!(unused_hashref, 0, "$hashref used via arrow dereference should not be unused");
+
+    let unused_hashslice_ref = issues
+        .iter()
+        .filter(|i| {
+            i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hashslice_ref")
+        })
+        .count();
+    assert_eq!(
+        unused_hashslice_ref, 0,
+        "$hashslice_ref used via hash slice dereference should not be unused"
+    );
 
     let unused_scalarref = issues
         .iter()

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -808,6 +808,7 @@ $hashref->{k};
 
 my $hashslice_ref = { a => 1, b => 2 };
 my @vals = %$hashslice_ref{'a', 'b'};
+my @vals_list = @$hashslice_ref{'a', 'b'};
 
 my $value = 1;
 my $scalarref = \$value;


### PR DESCRIPTION
## Summary
- preserve the base variable when parsing scalar-ref hash slices like `%$href{...}`
- replace the temporary parser probe with a real shape assertion
- extend the scope analyzer dereference regression so `%$hashslice_ref{...}` no longer leaves the scalar ref marked unused

## Validation
- cargo fmt --all
- cargo test -p perl-parser-core scalar_ref_hash_slice_preserves_base_target -- --nocapture
- cargo test -p perl-semantic-analyzer unused_variable_used_via_explicit_dereference_forms -- --nocapture