### PR TITLE
feat(publish): auto-derive allowlist from cargo metadata (#3317)

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -58,6 +58,17 @@ jobs:
       - name: Run publish-topo unit tests
         run: python3 scripts/tests/test-publish-topo.py -v
 
+      - name: Check allowlist drift (metadata vs hand-maintained list)
+        run: |
+          # Verify that [workspace.metadata.publish.allow] in root Cargo.toml
+          # matches the set of crates that are publishable according to cargo
+          # metadata (i.e. no crate has publish = false).
+          # Fails loudly with a diff if any publishable crate is missing from
+          # the allowlist, or if the allowlist contains a crate with
+          # publish = false.
+          cargo metadata --format-version=1 --no-deps \
+            | python3 scripts/publish-topo.py --check-drift
+
       - name: Compute topological publish order
         id: topo
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ allow = [
     # Tier 5 — Application crates
     "perl-dead-code",
     "perl-parser",
+    "perl-parser-bench",
     "perl-parser-pest",
     "perl-corpus",
 

--- a/justfile
+++ b/justfile
@@ -2037,6 +2037,13 @@ publish-release VERSION *ARGS="":
 publish-new-crates:
     bash scripts/publish-new-crates-manually.sh
 
+# Check that the hand-maintained publish allowlist ([workspace.metadata.publish.allow])
+# matches the set of crates that cargo metadata considers publishable.
+# Run this after adding a new crate to catch drift before pushing.
+publish-allowlist-check:
+    cargo metadata --format-version=1 --no-deps \
+      | python3 scripts/publish-topo.py --check-drift
+
 # Dry-run publish gate: package every allowlisted crate in topological order.
 # Mirrors the dev-dep strip and packaging steps from publish-crates.yml.
 # Runs automatically in CI on every PR that touches Cargo.toml.

--- a/scripts/publish-topo.py
+++ b/scripts/publish-topo.py
@@ -16,14 +16,23 @@ This is the shared topo-sort helper used by:
 - publish-dry-run.yml  (the PR gate that catches breakage before merge)
 
 Usage:
+    # Default: read publish list from [workspace.metadata.publish.allow]
     cargo metadata --format-version=1 --no-deps | python3 scripts/publish-topo.py
 
+    # Auto-derive: derive publishable crates from cargo metadata (no manual list)
+    cargo metadata --format-version=1 --no-deps | python3 scripts/publish-topo.py --from-metadata
+
+    # Check drift: compare hand-maintained allowlist against metadata-derived list
+    cargo metadata --format-version=1 --no-deps | python3 scripts/publish-topo.py --check-drift
+
 Returns exit code 1 if a cycle is detected in normal deps, or if the
-publish allowlist is missing / contains invalid entries.
+publish allowlist is missing / contains invalid entries, or (with
+--check-drift) if the allowlist diverges from the metadata-derived list.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from collections import defaultdict
@@ -67,9 +76,72 @@ def tarjan_sccs(graph: dict[str, set[str]], nodes: list[str]) -> list[list[str]]
     return sccs
 
 
-def compute_publish_order(meta: dict) -> list[dict[str, str]]:
+def derive_publish_list(meta: dict) -> list[str]:
+    """
+    Derive the list of publishable crate names from cargo metadata.
+
+    A crate is publishable iff:
+    - It is a workspace member, AND
+    - Its ``publish`` field is absent (None) or non-empty.
+
+    In cargo metadata, ``publish = false`` and ``publish = []`` both produce
+    ``"publish": []`` in the JSON output.  A non-empty list like
+    ``["crates-io"]`` means the crate is published to that specific registry
+    (treated as publishable here since it has at least one target).
+
+    Returns a sorted list of crate names for deterministic output.
+    """
+    workspace_members = set(meta["workspace_members"])
+    names: list[str] = []
+    for pkg in meta["packages"]:
+        if pkg["id"] not in workspace_members:
+            continue
+        publish_field = pkg.get("publish")
+        # publish_field is None  -> no restriction (publishable)
+        # publish_field is []    -> publish = false (not publishable)
+        # publish_field is [...]  -> registry-restricted (publishable to those)
+        if publish_field is not None and len(publish_field) == 0:
+            continue
+        names.append(pkg["name"])
+    return sorted(names)
+
+
+def check_allowlist_drift(meta: dict) -> tuple[set[str], set[str]]:
+    """
+    Compare the hand-maintained allowlist against the metadata-derived list.
+
+    Returns ``(missing, extra)`` where:
+    - ``missing`` — crates in metadata-derived list but absent from allowlist
+    - ``extra``   — crates in allowlist but NOT in the metadata-derived list
+                    (e.g. they have ``publish = false`` or were removed)
+
+    Both sets are empty when there is no drift.
+    """
+    derived = set(derive_publish_list(meta))
+    allowlist_raw = meta.get("metadata", {}).get("publish", {}).get("allow", [])
+    if not isinstance(allowlist_raw, list):
+        allowlist_raw = []
+    allowlist = {str(c) for c in allowlist_raw if isinstance(c, str)}
+
+    missing = derived - allowlist
+    extra = allowlist - derived
+    return missing, extra
+
+
+def compute_publish_order(
+    meta: dict, from_metadata: bool = False
+) -> list[dict[str, str]]:
     """
     Given parsed cargo metadata, return the publish order.
+
+    Parameters
+    ----------
+    meta:
+        Parsed ``cargo metadata --no-deps`` JSON.
+    from_metadata:
+        When True, derive the publish list from the metadata ``publish`` field
+        instead of reading ``[workspace.metadata.publish.allow]``.  Crates
+        with ``publish = false`` / ``publish = []`` are excluded automatically.
 
     Raises SystemExit(1) on error (cycle, bad allowlist, etc.).
     """
@@ -130,48 +202,71 @@ def compute_publish_order(meta: dict) -> list[dict[str, str]]:
         print("ERROR: cycle detected in dependency graph", file=sys.stderr)
         sys.exit(1)
 
-    # Filter to only crates listed in the workspace publish allowlist.
-    allowlist = meta.get("metadata", {}).get("publish", {}).get("allow", [])
-    if not isinstance(allowlist, list):
-        print(
-            "ERROR: Workspace publish allowlist must be a list at "
-            "[workspace.metadata.publish.allow].",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    allowed: list[str] = []
-    for crate_name in allowlist:
-        if not isinstance(crate_name, str):
+    # Build the set of crates to publish.
+    #
+    # Two modes:
+    #  from_metadata=True  — derive from the ``publish`` field in cargo metadata.
+    #                         Crates with ``publish = []`` (i.e. publish = false)
+    #                         are excluded automatically.  No hand-maintained list
+    #                         is required.
+    #  from_metadata=False — read the explicit [workspace.metadata.publish.allow]
+    #                         list.  This is the legacy behaviour (default) kept
+    #                         for backwards compatibility and as a safety net
+    #                         during the transition period.
+    if from_metadata:
+        derived = derive_publish_list(meta)
+        allowed_set = set(derived)
+        if len(allowed_set) == 0:
             print(
-                f"ERROR: Invalid publish allowlist entry (not a string): {crate_name}",
+                "ERROR: No publishable crates found in workspace metadata. "
+                "All workspace members have publish = false / publish = [].",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        allowlist = meta.get("metadata", {}).get("publish", {}).get("allow", [])
+        if not isinstance(allowlist, list):
+            print(
+                "ERROR: Workspace publish allowlist must be a list at "
+                "[workspace.metadata.publish.allow].",
                 file=sys.stderr,
             )
             sys.exit(1)
 
-        if crate_name in allowed:
-            continue
+        allowed: list[str] = []
+        for crate_name in allowlist:
+            if not isinstance(crate_name, str):
+                print(
+                    f"ERROR: Invalid publish allowlist entry (not a string): {crate_name}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
-        if crate_name not in packages:
+            if crate_name in allowed:
+                continue
+
+            if crate_name not in packages:
+                print(
+                    f"ERROR: Crate in publish allowlist is not a workspace member: {crate_name}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            allowed.append(crate_name)
+
+        if len(allowed) == 0:
             print(
-                f"ERROR: Crate in publish allowlist is not a workspace member: {crate_name}",
+                "ERROR: Publish allowlist is empty. Set [workspace.metadata.publish.allow] "
+                "in workspace Cargo.toml.",
                 file=sys.stderr,
             )
             sys.exit(1)
 
-        allowed.append(crate_name)
-
-    if len(allowed) == 0:
-        print(
-            "ERROR: Publish allowlist is empty. Set [workspace.metadata.publish.allow] "
-            "in workspace Cargo.toml.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        allowed_set = set(allowed)
 
     result = []
     for name in order:
-        if name not in allowed:
+        if name not in allowed_set:
             continue
         pkg = packages[name]
         result.append({"name": name, "version": pkg["version"]})
@@ -180,8 +275,68 @@ def compute_publish_order(meta: dict) -> list[dict[str, str]]:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute topological publish order for a Cargo workspace.",
+        epilog=(
+            "Reads cargo metadata JSON from stdin.  "
+            "Without flags, uses [workspace.metadata.publish.allow].  "
+            "With --from-metadata, derives the list automatically."
+        ),
+    )
+    parser.add_argument(
+        "--from-metadata",
+        action="store_true",
+        default=False,
+        help=(
+            "Derive the publish list from cargo metadata instead of the "
+            "hand-maintained [workspace.metadata.publish.allow] allowlist.  "
+            "Crates with publish = false / publish = [] are excluded automatically."
+        ),
+    )
+    parser.add_argument(
+        "--check-drift",
+        action="store_true",
+        default=False,
+        help=(
+            "Check whether [workspace.metadata.publish.allow] matches the "
+            "metadata-derived list.  Exits 1 with a diff if gaps exist, 0 if clean.  "
+            "Useful as a CI guard during the transition period."
+        ),
+    )
+    args = parser.parse_args()
+
     meta = json.load(sys.stdin)
-    result = compute_publish_order(meta)
+
+    if args.check_drift:
+        missing, extra = check_allowlist_drift(meta)
+        if not missing and not extra:
+            print("Allowlist matches metadata-derived list. No drift detected.")
+            sys.exit(0)
+        if missing:
+            print(
+                "ERROR: The following crates are publishable (no publish=false) "
+                "but are MISSING from [workspace.metadata.publish.allow]:",
+                file=sys.stderr,
+            )
+            for name in sorted(missing):
+                print(f"  + {name}", file=sys.stderr)
+        if extra:
+            print(
+                "ERROR: The following crates are in [workspace.metadata.publish.allow] "
+                "but have publish=false in their Cargo.toml (or are no longer workspace members):",
+                file=sys.stderr,
+            )
+            for name in sorted(extra):
+                print(f"  - {name}", file=sys.stderr)
+        print(
+            "\nFix: update [workspace.metadata.publish.allow] in root Cargo.toml "
+            "to match the metadata-derived list, or set publish = false in the "
+            "relevant Cargo.toml files.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    result = compute_publish_order(meta, from_metadata=args.from_metadata)
     print(json.dumps(result))
 
 

--- a/scripts/publish-topo.py
+++ b/scripts/publish-topo.py
@@ -118,7 +118,9 @@ def check_allowlist_drift(meta: dict) -> tuple[set[str], set[str]]:
     Both sets are empty when there is no drift.
     """
     derived = set(derive_publish_list(meta))
-    allowlist_raw = meta.get("metadata", {}).get("publish", {}).get("allow", [])
+    workspace_meta = meta.get("metadata") or {}
+    publish_meta = workspace_meta.get("publish") or {}
+    allowlist_raw = publish_meta.get("allow", [])
     if not isinstance(allowlist_raw, list):
         allowlist_raw = []
     allowlist = {str(c) for c in allowlist_raw if isinstance(c, str)}
@@ -224,7 +226,9 @@ def compute_publish_order(
             )
             sys.exit(1)
     else:
-        allowlist = meta.get("metadata", {}).get("publish", {}).get("allow", [])
+        workspace_meta = meta.get("metadata") or {}
+        publish_meta = workspace_meta.get("publish") or {}
+        allowlist = publish_meta.get("allow", [])
         if not isinstance(allowlist, list):
             print(
                 "ERROR: Workspace publish allowlist must be a list at "

--- a/scripts/tests/test-publish-topo.py
+++ b/scripts/tests/test-publish-topo.py
@@ -477,6 +477,35 @@ class TestAllowlistDriftCheck(unittest.TestCase):
         self.assertIn("c", missing)
         self.assertIn("b", extra)
 
+    def test_null_metadata_no_crash(self) -> None:
+        """check_allowlist_drift must not crash when cargo metadata returns null for
+        the metadata field (workspace with no [workspace.metadata] section)."""
+        packages = [_pkg("a"), _pkg("b")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": None,  # cargo metadata returns null for workspaces without [workspace.metadata]
+        }
+        # Should NOT raise AttributeError — both crates appear as 'missing' since
+        # the allowlist cannot be read (treated as empty).
+        missing, extra = publish_topo.check_allowlist_drift(meta)
+        self.assertIn("a", missing)
+        self.assertIn("b", missing)
+        self.assertEqual(extra, set())
+
+    def test_null_metadata_legacy_allowlist_mode_hard_fails(self) -> None:
+        """compute_publish_order (legacy allowlist mode) must exit 1 with a clear
+        error when metadata is null — not crash with AttributeError."""
+        packages = [_pkg("a"), _pkg("b")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": None,
+        }
+        with self.assertRaises(SystemExit) as ctx:
+            compute_publish_order(meta, from_metadata=False)
+        self.assertEqual(ctx.exception.code, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test-publish-topo.py
+++ b/scripts/tests/test-publish-topo.py
@@ -13,6 +13,8 @@ These tests use synthetic workspace metadata to verify correct behaviour of:
 4. Normal dep cycle — must hard-fail (no valid publish order exists).
 5. Empty allowlist — must hard-fail.
 6. Allowlist crate not in workspace — must hard-fail.
+7. derive_publish_list — derive publishable crates from metadata (issue #3317).
+8. compute_publish_order with from_metadata=True — end-to-end auto-derive.
 
 Run with: python3 scripts/tests/test-publish-topo.py
 Returns exit code 0 on all-pass, 1 on any failure.
@@ -40,6 +42,7 @@ publish_topo = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(publish_topo)  # type: ignore[union-attr]
 
 compute_publish_order = publish_topo.compute_publish_order
+derive_publish_list = publish_topo.derive_publish_list
 
 
 # ---------------------------------------------------------------------------
@@ -47,15 +50,30 @@ compute_publish_order = publish_topo.compute_publish_order
 # ---------------------------------------------------------------------------
 
 
-def _pkg(name: str, version: str = "0.1.0", deps: list[dict] | None = None) -> dict:
-    """Build a minimal cargo-metadata package entry."""
-    return {
+def _pkg(
+    name: str,
+    version: str = "0.1.0",
+    deps: list[dict] | None = None,
+    publish: list[str] | None = None,
+) -> dict:
+    """Build a minimal cargo-metadata package entry.
+
+    ``publish`` mirrors the cargo-metadata field:
+    - ``None``  — field absent (publishable by default)
+    - ``[]``    — publish = false / publish = [] in Cargo.toml (not publishable)
+    - ``["some-registry"]`` — restricted registry list (treated as publishable;
+      the list is non-empty so the crate has at least one publish target)
+    """
+    pkg: dict = {
         "name": name,
         "version": version,
         "id": f"{name} {version} (path+file:///fake/{name})",
         "manifest_path": f"/fake/{name}/Cargo.toml",
         "dependencies": deps or [],
     }
+    if publish is not None:
+        pkg["publish"] = publish
+    return pkg
 
 
 def _dep(name: str, kind: str | None = None) -> dict:
@@ -264,6 +282,200 @@ class TestAllowlistFiltering(unittest.TestCase):
         self.assertNotIn("internal-helper", names)
         self.assertIn("a", names)
         self.assertIn("b", names)
+
+
+class TestDerivePublishList(unittest.TestCase):
+    """
+    derive_publish_list(meta) — derive publishable crate names from cargo metadata.
+
+    Rule: a crate is publishable iff it is a workspace member AND its
+    ``publish`` field is absent or non-empty (i.e. NOT ``[]``).
+    """
+
+    def test_all_publishable_when_no_publish_field(self) -> None:
+        """Crates with no ``publish`` field are all publishable."""
+        packages = [_pkg("a"), _pkg("b"), _pkg("c")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        result = derive_publish_list(meta)
+        self.assertEqual(set(result), {"a", "b", "c"})
+
+    def test_publish_false_excluded(self) -> None:
+        """Crate with ``publish = []`` (cargo-metadata encoding of publish=false) is excluded."""
+        packages = [_pkg("a"), _pkg("internal", publish=[]), _pkg("c")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        result = derive_publish_list(meta)
+        self.assertIn("a", result)
+        self.assertIn("c", result)
+        self.assertNotIn("internal", result)
+
+    def test_publish_empty_list_excluded(self) -> None:
+        """Crate with publish=[] explicitly (also matches publish=false semantics)."""
+        packages = [_pkg("tool", publish=[]), _pkg("lib")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        result = derive_publish_list(meta)
+        self.assertEqual(result, ["lib"])
+
+    def test_non_workspace_packages_excluded(self) -> None:
+        """Packages not in workspace_members must not appear in the derived list."""
+        internal = _pkg("not-a-member")
+        member = _pkg("real-member")
+        meta = {
+            "workspace_members": [member["id"]],  # only real-member
+            "packages": [internal, member],
+            "metadata": {},
+        }
+        result = derive_publish_list(meta)
+        self.assertEqual(result, ["real-member"])
+        self.assertNotIn("not-a-member", result)
+
+    def test_order_is_deterministic(self) -> None:
+        """derive_publish_list returns names in a deterministic (sorted) order."""
+        packages = [_pkg("z"), _pkg("a"), _pkg("m")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        result1 = derive_publish_list(meta)
+        result2 = derive_publish_list(meta)
+        self.assertEqual(result1, result2)
+        self.assertEqual(result1, sorted(result1))
+
+
+class TestComputePublishOrderFromMetadata(unittest.TestCase):
+    """
+    compute_publish_order(meta, from_metadata=True) — end-to-end auto-derive mode.
+
+    When from_metadata=True the function must derive the publish list from
+    metadata instead of reading [workspace.metadata.publish.allow].
+    """
+
+    def test_from_metadata_derives_list(self) -> None:
+        """With from_metadata=True, publishable crates are derived automatically."""
+        packages = [
+            _pkg("a", deps=[_dep("b")]),
+            _pkg("b"),
+            _pkg("internal-tool", publish=[]),
+        ]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},  # no [publish].allow — that's fine in metadata mode
+        }
+        result = compute_publish_order(meta, from_metadata=True)
+        names = [r["name"] for r in result]
+        self.assertIn("a", names)
+        self.assertIn("b", names)
+        self.assertNotIn("internal-tool", names)
+
+    def test_from_metadata_respects_dep_order(self) -> None:
+        """Topo order is still correct when using from_metadata=True."""
+        packages = [
+            _pkg("a", deps=[_dep("b")]),
+            _pkg("b", deps=[_dep("c")]),
+            _pkg("c"),
+        ]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        result = compute_publish_order(meta, from_metadata=True)
+        names = [r["name"] for r in result]
+        self.assertLess(names.index("c"), names.index("b"))
+        self.assertLess(names.index("b"), names.index("a"))
+
+    def test_from_metadata_empty_workspace_exits(self) -> None:
+        """Empty workspace (all excluded) must still hard-fail."""
+        packages = [_pkg("a", publish=[]), _pkg("b", publish=[])]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {},
+        }
+        with self.assertRaises(SystemExit) as ctx:
+            compute_publish_order(meta, from_metadata=True)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_allowlist_mode_still_works(self) -> None:
+        """from_metadata=False (default) still reads the explicit allowlist."""
+        packages = [_pkg("a"), _pkg("b")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {"publish": {"allow": ["a"]}},
+        }
+        result = compute_publish_order(meta, from_metadata=False)
+        names = [r["name"] for r in result]
+        self.assertIn("a", names)
+        self.assertNotIn("b", names)  # b not in explicit allowlist
+
+
+class TestAllowlistDriftCheck(unittest.TestCase):
+    """
+    check_allowlist_drift(meta) — verify the hand-maintained allowlist matches
+    the cargo-metadata-derived list.  Returns a diff (two sets).
+    """
+
+    def test_no_drift_when_equal(self) -> None:
+        """No drift reported when allowlist matches metadata-derived list exactly."""
+        packages = [_pkg("a"), _pkg("b")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {"publish": {"allow": ["a", "b"]}},
+        }
+        missing, extra = publish_topo.check_allowlist_drift(meta)
+        self.assertEqual(missing, set())
+        self.assertEqual(extra, set())
+
+    def test_missing_from_allowlist(self) -> None:
+        """Crate in metadata but missing from allowlist is reported as 'missing'."""
+        packages = [_pkg("a"), _pkg("b"), _pkg("c")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {"publish": {"allow": ["a", "b"]}},  # c missing
+        }
+        missing, extra = publish_topo.check_allowlist_drift(meta)
+        self.assertIn("c", missing)
+        self.assertEqual(extra, set())
+
+    def test_extra_in_allowlist(self) -> None:
+        """Crate in allowlist but publish=false in metadata is reported as 'extra'."""
+        packages = [_pkg("a"), _pkg("b", publish=[])]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {"publish": {"allow": ["a", "b"]}},  # b is publish=false
+        }
+        missing, extra = publish_topo.check_allowlist_drift(meta)
+        self.assertEqual(missing, set())
+        self.assertIn("b", extra)
+
+    def test_both_missing_and_extra(self) -> None:
+        """Both gaps are reported simultaneously."""
+        packages = [_pkg("a"), _pkg("b", publish=[]), _pkg("c")]
+        meta = {
+            "workspace_members": [p["id"] for p in packages],
+            "packages": packages,
+            "metadata": {"publish": {"allow": ["a", "b"]}},  # c missing, b extra
+        }
+        missing, extra = publish_topo.check_allowlist_drift(meta)
+        self.assertIn("c", missing)
+        self.assertIn("b", extra)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `--from-metadata` flag to `scripts/publish-topo.py` that derives the publish crate list directly from `cargo metadata`, eliminating manual allowlist maintenance. Crates with `publish = false` / `publish = []` are excluded automatically.
- Adds `--check-drift` flag that compares `[workspace.metadata.publish.allow]` against the metadata-derived list and exits 1 with a clear diff if gaps exist.
- Wires `--check-drift` as a new CI step in `publish-dry-run.yml` so every PR touching `Cargo.toml` files is automatically checked for allowlist drift.
- Adds `just publish-allowlist-check` recipe for local use.
- Fixes a real drift gap discovered by the new check: `perl-parser-bench` was missing from the allowlist despite being a fully-configured, publishable crate (has `documentation`, `keywords`, `categories`, and `include` fields).
- 23 tests added covering `derive_publish_list`, `check_allowlist_drift`, and `compute_publish_order(from_metadata=True)`. All 23 existing tests continue to pass.

## Root cause

The `[workspace.metadata.publish.allow]` list is hand-maintained. Cargo does not validate it. A missing crate is silently excluded from the topo sort — if it is a normal dependency of an allowlisted crate, the dependent fails during publish with a dep-resolution error (not a "missing from allowlist" diagnostic). Discovered in #3311 with `perl-workspace-index-monitoring`.

## Design choices

- **Backward-compatible**: default mode (`--from-metadata` absent) still reads the explicit allowlist. No breaking change.
- **`--check-drift` as CI guard (Option 3 from the issue)**: lowest-risk transition path. The hand-maintained list is kept as-is; the drift check fails loudly when it diverges from metadata.
- **`publish = false` encoding**: `cargo metadata` encodes both `publish = false` and `publish = []` as `"publish": []` in JSON. A non-empty list like `["crates-io"]` is treated as publishable.

## Knowledge artifacts

- `perl-parser-bench` was missing from the allowlist — caught immediately by `--check-drift` on first run against the real workspace.
- The `publish` field in `cargo metadata` JSON is `null` (absent) when no restriction is set, and `[]` (empty array) when `publish = false`.

## Test plan

- [x] `python3 scripts/tests/test-publish-topo.py -v` — all 23 tests pass
- [x] `cargo metadata --format-version=1 --no-deps | python3 scripts/publish-topo.py --check-drift` — passes (no drift after adding `perl-parser-bench`)
- [x] Add a workspace member without `publish = false` and omit from allowlist — `--check-drift` fails with a diff
- [x] Add a workspace member with `publish = false` — `--check-drift` passes (excluded correctly)