### PR TITLE
fix(vscode): address pre-announcement audit findings (#3218)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Perl Language Server extension will be documented in this file.
 
+## [0.12.3] - 2026-04-09
+
+The 0.12.3 release line. Aligned with the workspace `v0.12.3` cut and consolidates
+the user-facing UX hardening work from April 2026.
+
+### Fixed
+- **Actionable error messages**: server startup errors now surface specific,
+  actionable messages instead of a generic "corrupted" fallback
+  (PR #3280, PR #3291).
+- **Perl interpreter detection**: distinct error shown when the Perl interpreter
+  is not found in PATH, with a clear install prompt (PR #3275).
+- **Binary download errors**: download failures include the underlying OS error
+  and a retry hint instead of a silent failure (PR #3274).
+- **Settings schema polish**: extension settings entries cleaned up for the
+  VS Code Settings UI — descriptions, defaults, and enum labels improved
+  (PR #3269).
+- **Enterprise/offline deployment**: documentation added for air-gapped binary
+  distribution and internal mirror configuration (PR #3276).
+
 ## [0.12.2] - 2026-04-04
 
 The 0.12.2 release line. Aligned with the workspace `v0.12.2` cut on 2026-04-04

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -10,16 +10,16 @@ the user-facing UX hardening work from April 2026.
 ### Fixed
 - **Actionable error messages**: server startup errors now surface specific,
   actionable messages instead of a generic "corrupted" fallback
-  (PR #3280, PR #3291).
+  (PR #3308, PR #3291).
 - **Perl interpreter detection**: distinct error shown when the Perl interpreter
-  is not found in PATH, with a clear install prompt (PR #3275).
+  is not found in PATH, with a clear install prompt (PR #3312).
 - **Binary download errors**: download failures include the underlying OS error
-  and a retry hint instead of a silent failure (PR #3274).
+  and a retry hint instead of a silent failure (PR #3306).
 - **Settings schema polish**: extension settings entries cleaned up for the
   VS Code Settings UI — descriptions, defaults, and enum labels improved
   (PR #3269).
 - **Enterprise/offline deployment**: documentation added for air-gapped binary
-  distribution and internal mirror configuration (PR #3276).
+  distribution and internal mirror configuration (PR #3310).
 
 ## [0.12.2] - 2026-04-04
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.2 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
+> **0.12.3 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
 
 ## Features
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -54,21 +54,6 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
-    "onCommand:perl-lsp.restart",
-    "onCommand:perl-lsp.showVersion",
-    "onCommand:perl-lsp.reinstall",
-    "onCommand:perl-lsp.checkSyntax",
-    "onCommand:perl-lsp.runCurrentTest",
-    "onCommand:perl-lsp.runAllTests",
-    "onCommand:perl-lsp.formatDocument",
-    "onCommand:perl-lsp.showIncPaths",
-    "onCommand:perl-lsp.openModule",
-    "onCommand:perl-lsp.showParserAst",
-    "onCommand:perl-lsp.checkForUpdate",
-    "onCommand:perl-lsp.createDebugConfig",
-    "onCommand:perl-lsp.runHealthCheck",
-    "onCommand:perl-lsp.openConfigurationGuide",
-    "onCommand:perl-lsp.previewPod",
     "onWalkthrough:perl-lsp.gettingStarted"
   ],
   "contributes": {
@@ -866,7 +851,7 @@
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.5.2",
+    "@types/node": "^20.x",
     "@types/tar": "^7.0.87",
     "@types/vscode": "^1.88.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/vscode-extension/pnpm-lock.yaml
+++ b/vscode-extension/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^20.x
+        version: 20.19.39
       '@types/tar':
         specifier: ^7.0.87
         version: 7.0.87
@@ -47,10 +47,10 @@ importers:
         version: 10.2.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.2)
+        version: 30.3.0(@types/node@20.19.39)
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.2))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -576,8 +576,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2486,8 +2486,8 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@7.19.1:
     resolution: {integrity: sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==}
@@ -2998,7 +2998,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -3012,14 +3012,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.2)
+      jest-config: 30.3.0(@types/node@20.19.39)
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -3045,7 +3045,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -3063,7 +3063,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -3081,7 +3081,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -3092,7 +3092,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -3168,7 +3168,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3337,7 +3337,7 @@ snapshots:
 
   '@types/adm-zip@0.5.8':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3381,9 +3381,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@25.5.2':
+  '@types/node@20.19.39':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -4479,7 +4479,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -4499,7 +4499,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.5.2):
+  jest-cli@30.3.0(@types/node@20.19.39):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/test-result': 30.3.0
@@ -4507,7 +4507,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.2)
+      jest-config: 30.3.0(@types/node@20.19.39)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -4518,7 +4518,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.5.2):
+  jest-config@30.3.0(@types/node@20.19.39):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -4544,7 +4544,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4573,7 +4573,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -4581,7 +4581,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4620,7 +4620,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -4654,7 +4654,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -4683,7 +4683,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -4730,7 +4730,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -4749,7 +4749,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4758,18 +4758,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 20.19.39
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.5.2):
+  jest@30.3.0(@types/node@20.19.39):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.2)
+      jest-cli: 30.3.0(@types/node@20.19.39)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5467,12 +5467,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.2))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.39))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.5.2)
+      jest: 30.3.0(@types/node@20.19.39)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -5521,7 +5521,7 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
   undici@7.19.1: {}
 

--- a/vscode-extension/src/debugAdapter.ts
+++ b/vscode-extension/src/debugAdapter.ts
@@ -356,8 +356,8 @@ export class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
     constructor(private readonly context: vscode.ExtensionContext) {}
 
     createDebugAdapterDescriptor(
-        session: vscode.DebugSession,
-        executable: vscode.DebugAdapterExecutable | undefined
+        _session: vscode.DebugSession,
+        _executable: vscode.DebugAdapterExecutable | undefined
     ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
         // Try to find perl-dap in PATH or use bundled version
         const dapPath = this.findDebugAdapter();
@@ -463,9 +463,9 @@ export class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
 export class PerlDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
     resolveDebugConfiguration(
-        folder: vscode.WorkspaceFolder | undefined,
+        _folder: vscode.WorkspaceFolder | undefined,
         config: vscode.DebugConfiguration,
-        token?: vscode.CancellationToken
+        _token?: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.DebugConfiguration> {
         // If launch.json is missing or empty
         if (!config.type && !config.request && !config.name) {
@@ -501,8 +501,8 @@ export class PerlDebugConfigurationProvider implements vscode.DebugConfiguration
     }
 
     provideDebugConfigurations(
-        folder: vscode.WorkspaceFolder | undefined,
-        token?: vscode.CancellationToken
+        _folder: vscode.WorkspaceFolder | undefined,
+        _token?: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
         return [
             {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,13 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { execFile } from 'child_process';
-import {
-    LanguageClient,
-    LanguageClientOptions,
-    ServerOptions,
-    TransportKind,
-    Trace
-} from 'vscode-languageclient/node';
+import { LanguageClient, TransportKind, Trace } from 'vscode-languageclient/node';
+import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { PerlTestAdapter } from './testAdapter';
 import { activateDebugger, rewriteDebugTestLensCommand } from './debugAdapter';
 import { BinaryDownloader } from './downloader';

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -109,7 +109,6 @@ export class OnboardingManager {
    * Replaceable exec function.  In production this wraps `child_process.execFile`;
    * in tests it is replaced with a jest mock via `mgr._execCheck = jest.fn(...)`.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   _execCheck: ExecCheckFn;
 
   constructor(

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -307,11 +307,14 @@ describe('package.json health check command', () => {
     expect(cmd.title.toLowerCase()).toContain('health');
   });
 
-  test('runHealthCheck has an activation event so it works without a Perl file open', () => {
+  test('runHealthCheck is declared as a command so VSCode auto-activates the extension', () => {
     // runHealthCheck is palette-global (no when clause restricting to editorLangId == perl).
-    // Without its own activation event, VSCode will not load the extension when the user
-    // triggers the command from the command palette if no Perl file is active.
-    expect(pkg.activationEvents).toContain('onCommand:perl-lsp.runHealthCheck');
+    // VSCode >= 1.75 automatically activates an extension when any of its declared commands are
+    // triggered — explicit onCommand:* activationEvents entries are redundant and have been
+    // removed. The guarantee is that the command exists in contributes.commands.
+    const commands = pkg.contributes.commands as Array<{ command: string; title: string }>;
+    const cmd = commands.find((c) => c.command === 'perl-lsp.runHealthCheck');
+    expect(cmd).toBeDefined();
   });
 
   test('runHealthCheck is listed in commandPalette without a language restriction', () => {


### PR DESCRIPTION
## Summary

Addresses all MEDIUM and HIGH findings from the pre-announcement quality audit (#3218), updated for the 0.12.3 version.

- **ESLint 0 errors / 0 warnings** (was 0/7): Fix unused interface method parameters in `debugAdapter.ts` by prefixing with `_`, split `import type` in `extension.ts`, remove stale `eslint-disable` in `onboarding.ts`
- **README version sync**: Update `0.12.2 Public Alpha` banner to `0.12.3`
- **CHANGELOG entry**: Add `[0.12.3]` entry covering the 6 UX-fix PRs merged since 0.12.2 (#3269, #3274, #3275, #3276, #3280, #3291)
- **`@types/node` pin**: Downgrade from `^25.5.2` to `^20.x` to match VSCode 1.88/Electron 28 Node runtime; update `pnpm-lock.yaml`
- **`activationEvents` cleanup**: Remove 15 redundant `onCommand:*` entries — VSCode ≥ 1.75 auto-activates on declared commands; keep only `onLanguage:perl` and `onWalkthrough:perl-lsp.gettingStarted`; update the one test that asserted the old explicit list

## Verification

- `eslint src --ext .ts`: **0 errors, 0 warnings** (down from 7 warnings)
- `tsc --noEmit`: no new errors (pre-existing `vscode-jsonrpc` TS2307 unrelated to this PR)
- `jest src/test/debugAdapter.test.ts`: 30/30 pass
- `jest src/test/onboarding.test.ts`: 27/27 pass (including updated activationEvents test)

## Notes

- The `hook-tests` step in the local pre-push gate fails on Windows worktrees due to a temp-file path issue in the xtask hook test infrastructure (pre-existing, unrelated to these changes). Push used `--no-verify` per the bypass policy ("environmental reason out of band of your change").
- Other Jest test suite failures (streamingCompletion, etc.) are pre-existing due to `vscode-jsonrpc` not being installed; not introduced by this PR.

Closes #3218