### PR TITLE
fix(diagnostics): Perl 5.36+ auto-enables strict for signature subs (#3360)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -248,6 +248,31 @@ mod tests {
     }
 
     #[test]
+    fn v5_36_suppresses_both_strict_and_warnings_diagnostics() {
+        // use v5.36 enables both strict and warnings via the feature bundle.
+        // Neither PL100 (missing-strict) nor PL101 (missing-warnings) should fire.
+        let diags = strict_warnings_diags("use v5.36;\nsub foo ($x) { my $y = $x; }\n");
+        let has_strict_warn =
+            diags.iter().any(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")));
+        assert!(
+            !has_strict_warn,
+            "use v5.36 should suppress both missing-strict and missing-warnings diagnostics"
+        );
+    }
+
+    #[test]
+    fn v5_36_numeric_form_suppresses_both_strict_and_warnings() {
+        // use 5.036 is the numeric form of use v5.36.
+        let diags = strict_warnings_diags("use 5.036;\nmy $x = 1;\n");
+        let has_strict_warn =
+            diags.iter().any(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")));
+        assert!(
+            !has_strict_warn,
+            "use 5.036 should suppress both missing-strict and missing-warnings diagnostics"
+        );
+    }
+
+    #[test]
     fn v5_12_suppresses_strict_but_not_missing_warnings() {
         let diags = strict_warnings_diags("use v5.12;\nmy $x = 1;\n");
         assert!(

--- a/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs
@@ -502,6 +502,24 @@ fn test_version_pragma_suppresses_missing_strict_warnings() -> Result<(), Box<dy
     Ok(())
 }
 
+#[test]
+fn test_v5_36_suppresses_missing_strict_warnings() -> Result<(), Box<dyn std::error::Error>> {
+    // use v5.36 enables both strict and warnings via the Perl feature bundle.
+    // Neither PL100 (missing-strict) nor PL101 (missing-warnings) should fire.
+    let source = "use v5.36;\nmy $x = 1;\n";
+    let diags = diagnostics_for(source);
+    let lint_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code.as_deref(), Some("PL100") | Some("PL101")))
+        .collect();
+
+    assert!(
+        lint_diags.is_empty(),
+        "use v5.36 should suppress missing strict/warnings diagnostics: {lint_diags:?}"
+    );
+    Ok(())
+}
+
 // =========================================================================
 // 6. Suggestion field populated for actionable diagnostics
 // =========================================================================

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1059,6 +1059,53 @@ print FOO;
 }
 
 #[test]
+fn v5_36_auto_strict_flags_undeclared_variable_in_signature_sub()
+-> Result<(), Box<dyn std::error::Error>> {
+    // use v5.36 enables strict automatically via feature bundle.
+    // An undeclared variable $z inside a signature sub should be flagged
+    // even without an explicit 'use strict'.
+    let code = r#"
+use v5.36;
+sub foo ($x) { $z = 1; }
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "z"),
+        "use v5.36 auto-enables strict: $z inside a signature sub should be flagged as undeclared"
+    );
+    // The parameter $x should NOT be flagged as undeclared.
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "x"),
+        "signature parameter $x should not be flagged as undeclared"
+    );
+    Ok(())
+}
+
+#[test]
+fn v5_36_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
+    // use v5.36 enables both strict vars (undeclared vars) and strict subs (barewords).
+    let code = r#"
+use v5.36;
+print $unknown_var;
+print FOO;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "unknown_var"),
+        "use v5.36 should enable strict vars — $unknown_var should be flagged"
+    );
+    assert!(
+        issues
+            .iter()
+            .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
+        "use v5.36 should enable strict subs — bareword FOO should be flagged"
+    );
+    Ok(())
+}
+
+#[test]
 fn scalar_reference_dereference_uses_declared_scalar_under_strict()
 -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"


### PR DESCRIPTION
## Summary

- `use v5.36` already correctly propagates strict and warnings via `perl-pragma`'s `version_implies_strict` (>=5.12) and `version_implies_warnings` (>=5.35) functions
- The `strict_warnings` lint already defers to the shared pragma map for version pragmas
- The scope analyzer already uses `PragmaTracker::state_for_offset` to get strict mode at each variable's position
- This PR adds explicit test coverage that was missing, documenting and verifying the v5.36-specific behaviour

## Tests Added

### `crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs`
- `v5_36_suppresses_both_strict_and_warnings_diagnostics` — the exact issue scenario (use v5.36 + signature sub, no PL100/PL101)
- `v5_36_numeric_form_suppresses_both_strict_and_warnings` — `use 5.036` numeric form also suppresses both

### `crates/perl-lsp-diagnostics/tests/diagnostic_integration_test.rs`
- `test_v5_36_suppresses_missing_strict_warnings` — full pipeline integration test

### `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`
- `v5_36_auto_strict_flags_undeclared_variable_in_signature_sub` — the exact spec test case: `$z` inside `sub foo ($x)` is flagged as undeclared; `$x` (signature param) is NOT flagged
- `v5_36_enables_strict_vars_and_subs` — both strict vars (undeclared vars) and strict subs (barewords) are enabled by v5.36

## Test plan
- [x] All 5 new tests pass
- [x] `cargo test -p perl-lsp-diagnostics`: 286 passed, 0 failed
- [x] `cargo clippy -p perl-lsp-diagnostics -p perl-semantic-analyzer --lib`: no issues
- [x] `cargo fmt -p perl-lsp-diagnostics -p perl-semantic-analyzer`: no changes
- Pre-existing failure `symbol_extraction_method_preserves_attributes` in `perl-semantic-analyzer` is unrelated to this PR (pre-dates this branch)

## Knowledge artifact

The core pragma/version detection was already correct. Issue #3360 was a test coverage gap, not a code bug. The `version_implies_strict` threshold is v5.12 (not v5.36) because `use strict` has been implied by version bundles since Perl 5.12. The v5.36-specific addition is signatures becoming part of the stable bundle — but strict was already covered.