### PR TITLE
feat(tests): add BDD scenarios for goto-definition, hover, diagnostics, document-symbols (#3284)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -232,6 +232,64 @@ impl UxHarness {
         }
     }
 
+    /// Request document symbols (`textDocument/documentSymbol`).
+    ///
+    /// Returns the flat list of `SymbolInformation` or `DocumentSymbol` objects,
+    /// or an empty vec if the server returned null/empty.
+    pub fn document_symbols(&self, relative_path: &str) -> Result<Vec<Value>> {
+        let uri = self.workspace.uri(relative_path);
+        let resp = self.client.request(
+            "textDocument/documentSymbol",
+            json!({
+                "textDocument": { "uri": uri }
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("documentSymbol returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(syms) => Ok(syms.clone()),
+            None => {
+                if resp["result"].is_null() {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![resp["result"].clone()])
+                }
+            }
+        }
+    }
+
+    /// Wait up to `timeout` for a `textDocument/publishDiagnostics` notification
+    /// for the given file, then return all diagnostics collected for it.
+    ///
+    /// Returns an empty vec if the deadline expires with no diagnostics published.
+    pub fn wait_for_diagnostics(
+        &self,
+        relative_path: &str,
+        timeout: std::time::Duration,
+    ) -> Vec<Value> {
+        let uri = self.workspace.uri(relative_path);
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            {
+                let events = self.client.peek_events();
+                for ev in &events {
+                    if let LspEvent::Diagnostics { uri: diag_uri, diagnostics } = ev {
+                        if diag_uri == &uri {
+                            return diagnostics.clone();
+                        }
+                    }
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        Vec::new()
+    }
+
     /// Request go-to-definition.
     pub fn definition(&self, relative_path: &str, line: u32, character: u32) -> Result<Vec<Value>> {
         let uri = self.workspace.uri(relative_path);

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -1,0 +1,126 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 10 — Go-to-definition feature grid coverage.
+//!
+//! Verifies that `textDocument/definition` is wired up end-to-end for the LSP
+//! feature advertised in `features.toml`.
+//!
+//! Acceptance criteria:
+//! - `textDocument/definition` MUST NOT return a JSON-RPC error.
+//! - A definition result MAY be empty (degraded mode acceptable) but must not crash.
+//! - When a sub is defined in the same file, the server SHOULD return a location
+//!   pointing back into that file.
+//! - No crash signatures after the request.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+/// Source with a named sub defined near the top and called later.
+/// We will request go-to-definition on the call site at line 8, char 0.
+const GOTO_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub greet {\n\
+    my ($name) = @_;\n\
+    return \"Hello, $name!\";\n\
+}\n\
+\n\
+greet('World');\n\
+";
+
+#[test]
+fn scenario_10_definition_request_does_not_error() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_10: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("greet.pl", GOTO_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+
+    // Allow the server to index the file.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Request definition on the call site `greet('World')` — line 8, char 0.
+    let result = harness.definition("greet.pl", 8, 0);
+    assert!(
+        result.is_ok(),
+        "textDocument/definition must not return a JSON-RPC error — feature grid regression: {:?}",
+        result
+    );
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_10_definition_result_is_location_or_empty() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_10: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("greet.pl", GOTO_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("greet.pl", GOTO_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let defs = harness.definition("greet.pl", 8, 0).expect("definition must not error");
+
+    // If results are returned they must be well-formed Location objects.
+    for loc in &defs {
+        assert!(
+            loc.get("uri").is_some() && loc.get("range").is_some(),
+            "Definition result must have 'uri' and 'range' fields, got: {:?}",
+            loc
+        );
+        // The location must point to our file (not some unrelated URI).
+        let uri = loc["uri"].as_str().unwrap_or("");
+        assert!(
+            uri.ends_with("greet.pl"),
+            "Definition location should point to greet.pl, got uri={:?}",
+            uri
+        );
+    }
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_10_definition_on_unknown_position_returns_empty() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_10: perl-lsp binary not found");
+        return;
+    }
+
+    let source = "use strict;\nmy $x = 1;\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("simple.pl", source))
+        .expect("Failed to create UX harness");
+
+    harness.open_file("simple.pl", source).expect("didOpen should succeed");
+
+    // Position in middle of `strict` string literal — no definition expected.
+    let defs = harness
+        .definition("simple.pl", 0, 5)
+        .expect("definition must not error on arbitrary position");
+
+    // Empty is fine; what we are testing is that no crash or error occurs.
+    let _ = defs;
+
+    harness.assert_no_crash();
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -1,0 +1,135 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 11 — Hover feature grid coverage.
+//!
+//! Verifies that `textDocument/hover` is wired up end-to-end for the LSP
+//! feature advertised in `features.toml`.
+//!
+//! Acceptance criteria:
+//! - `textDocument/hover` MUST NOT return a JSON-RPC error.
+//! - When a result is returned it MUST have either `contents` (MarkupContent or
+//!   MarkedString) and optionally a `range`.
+//! - A null/empty result is acceptable (degraded mode).
+//! - No crash signatures after the request.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+/// Perl source with a clearly-named sub and variable for hover targets.
+const HOVER_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+sub calculate_sum {\n\
+    my ($a, $b) = @_;\n\
+    return $a + $b;\n\
+}\n\
+\n\
+my $result = calculate_sum(3, 7);\n\
+print $result;\n\
+";
+
+#[test]
+fn scenario_11_hover_on_variable_does_not_error() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_11: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("calc.pl", HOVER_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Hover on `$result` — line 8, char 3 (inside `$result`).
+    let hover_result = harness.hover("calc.pl", 8, 3);
+    assert!(
+        hover_result.is_ok(),
+        "textDocument/hover must not return a JSON-RPC error — feature grid regression: {:?}",
+        hover_result
+    );
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_11_hover_result_has_valid_shape_when_non_null() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_11: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("calc.pl", HOVER_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    match harness.hover("calc.pl", 8, 3) {
+        Ok(Some(result)) => {
+            // Must contain `contents` field.
+            assert!(
+                result.get("contents").is_some(),
+                "Hover result must have 'contents' field, got: {:?}",
+                result
+            );
+            let contents = &result["contents"];
+            // contents can be MarkupContent {kind, value}, MarkedString, or array.
+            let is_valid = contents.get("value").is_some()
+                || contents.get("kind").is_some()
+                || contents.is_string()
+                || contents.is_array();
+            assert!(
+                is_valid,
+                "Hover 'contents' must be MarkupContent, MarkedString, or array; got: {:?}",
+                contents
+            );
+        }
+        Ok(None) => {
+            eprintln!("INFO scenario_11: hover returned null (degraded mode acceptable)");
+        }
+        Err(e) => {
+            panic!("Hover returned a JSON-RPC error — feature grid regression: {}", e);
+        }
+    }
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_11_hover_on_sub_name_does_not_crash() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_11: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("calc.pl", HOVER_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Hover on `calculate_sum` sub declaration — line 3, char 4.
+    let hover_result = harness.hover("calc.pl", 3, 4);
+    assert!(hover_result.is_ok(), "Hover on sub declaration must not error: {:?}", hover_result);
+
+    harness.assert_no_crash();
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
@@ -1,0 +1,141 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 12 — `textDocument/publishDiagnostics` feature grid coverage.
+//!
+//! Verifies that the server emits diagnostics notifications when Perl code has
+//! known issues.  This exercises the `textDocument/publishDiagnostics`
+//! capability advertised in `features.toml`.
+//!
+//! Acceptance criteria:
+//! - After `didOpen`, the server MUST eventually send a
+//!   `textDocument/publishDiagnostics` notification (possibly empty).
+//! - The notification MUST NOT crash the server.
+//! - If diagnostics are returned they MUST be well-formed objects with at least
+//!   `range` and `message` fields.
+//! - A clean file MAY produce zero diagnostics — that is acceptable.
+
+use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+/// Source that is syntactically valid Perl — should produce no parse errors.
+const CLEAN_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+my $x = 42;\n\
+print \"$x\\n\";\n\
+";
+
+/// Source with a declared-but-unused-under-strict variable.  Some diagnostics
+/// providers flag this; others do not.  We only verify shape, not count.
+const STRICT_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+\n\
+my $unused_var = 99;\n\
+print \"done\\n\";\n\
+";
+
+#[test]
+fn scenario_12_server_does_not_crash_after_diagnostics_request() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_12: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("clean.pl", CLEAN_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("clean.pl", CLEAN_SOURCE).expect("didOpen should succeed");
+
+    // Allow diagnostics to publish (server-push; no blocking call needed).
+    std::thread::sleep(Duration::from_secs(2));
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_12_diagnostics_notification_shape_is_valid() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_12: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("strict_test.pl", STRICT_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("strict_test.pl", STRICT_SOURCE).expect("didOpen should succeed");
+
+    // Wait up to 5 seconds for diagnostics to arrive.
+    let diagnostics = harness.wait_for_diagnostics("strict_test.pl", Duration::from_secs(5));
+
+    // Validate each diagnostic has the required LSP fields.
+    for diag in &diagnostics {
+        assert!(diag.get("range").is_some(), "Diagnostic must have 'range' field, got: {:?}", diag);
+        assert!(
+            diag.get("message").is_some(),
+            "Diagnostic must have 'message' field, got: {:?}",
+            diag
+        );
+        // severity is optional but must be 1-4 when present.
+        if let Some(severity) = diag.get("severity") {
+            let s = severity.as_u64().unwrap_or(0);
+            assert!((1..=4).contains(&s), "Diagnostic severity must be 1-4, got: {}", s);
+        }
+    }
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_12_publishdiagnostics_notification_was_received() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_12: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("notify_test.pl", CLEAN_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("notify_test.pl", CLEAN_SOURCE).expect("didOpen should succeed");
+
+    // Poll for up to 5 seconds to see if the server ever fires publishDiagnostics.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut received = false;
+    while std::time::Instant::now() < deadline {
+        let events = harness.peek_notifications();
+        for ev in &events {
+            if let LspEvent::Diagnostics { .. } = ev {
+                received = true;
+                break;
+            }
+        }
+        if received {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    if !received {
+        eprintln!(
+            "INFO scenario_12: server did not publish diagnostics within 5s \
+             (may require external linter — degraded mode acceptable)"
+        );
+    }
+
+    harness.assert_no_crash();
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
@@ -1,0 +1,179 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 13 — Document symbols feature grid coverage.
+//!
+//! Verifies that `textDocument/documentSymbol` is wired up end-to-end for the
+//! LSP feature advertised in `features.toml`.
+//!
+//! Acceptance criteria:
+//! - `textDocument/documentSymbol` MUST NOT return a JSON-RPC error.
+//! - When symbols are returned they MUST have at least a `name` field.
+//! - A file with named subs and packages SHOULD return at least one symbol.
+//! - An empty result is acceptable for degraded-mode servers.
+//! - No crash signatures after the request.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+/// Source with two named subs and a package declaration — rich symbol table.
+const SYMBOLS_SOURCE: &str = "\
+package Greeter;\n\
+use strict;\n\
+use warnings;\n\
+\n\
+sub new {\n\
+    my ($class, %opts) = @_;\n\
+    return bless { name => $opts{name} // 'World' }, $class;\n\
+}\n\
+\n\
+sub greet {\n\
+    my ($self) = @_;\n\
+    return \"Hello, \" . $self->{name} . \"!\";\n\
+}\n\
+\n\
+sub farewell {\n\
+    my ($self) = @_;\n\
+    return \"Goodbye, \" . $self->{name} . \"!\";\n\
+}\n\
+\n\
+1;\n\
+";
+
+#[test]
+fn scenario_13_document_symbol_does_not_error() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_13: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("Greeter.pm", SYMBOLS_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let result = harness.document_symbols("Greeter.pm");
+    assert!(
+        result.is_ok(),
+        "textDocument/documentSymbol must not return a JSON-RPC error \
+         — feature grid regression: {:?}",
+        result
+    );
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_13_returned_symbols_have_valid_shape() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_13: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("Greeter.pm", SYMBOLS_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let symbols = harness.document_symbols("Greeter.pm").expect("documentSymbol must not error");
+
+    for sym in &symbols {
+        assert!(sym.get("name").is_some(), "Each symbol must have a 'name' field, got: {:?}", sym);
+        // kind is required by the LSP spec (1-26 SymbolKind enum).
+        if let Some(kind) = sym.get("kind") {
+            let k = kind.as_u64().unwrap_or(0);
+            assert!(k >= 1 && k <= 26, "Symbol 'kind' must be 1-26, got: {}", k);
+        }
+        // DocumentSymbol has 'range'; SymbolInformation has 'location'.
+        // Either is acceptable.
+        let has_range = sym.get("range").is_some();
+        let has_location = sym.get("location").is_some();
+        assert!(
+            has_range || has_location,
+            "Symbol must have either 'range' (DocumentSymbol) or 'location' \
+             (SymbolInformation), got: {:?}",
+            sym
+        );
+    }
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_13_rich_file_returns_known_sub_names() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_13: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+            .with_file("Greeter.pm", SYMBOLS_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let symbols = harness.document_symbols("Greeter.pm").expect("documentSymbol must not error");
+
+    if symbols.is_empty() {
+        eprintln!(
+            "INFO scenario_13: documentSymbol returned empty list \
+             (degraded mode acceptable — sub-symbol extraction may not be implemented yet)"
+        );
+        harness.assert_no_crash();
+        return;
+    }
+
+    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
+
+    // At least one of our three subs should appear.
+    let found_any = names.iter().any(|n| ["new", "greet", "farewell"].contains(n));
+    assert!(
+        found_any,
+        "Expected at least one of [new, greet, farewell] in document symbols, \
+         got: {:?}",
+        names
+    );
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_13_empty_file_returns_empty_or_null() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_13: perl-lsp binary not found");
+        return;
+    }
+
+    let source = "# empty file\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("empty.pl", source))
+        .expect("Failed to create UX harness");
+
+    harness.open_file("empty.pl", source).expect("didOpen should succeed");
+
+    let symbols =
+        harness.document_symbols("empty.pl").expect("documentSymbol on empty file must not error");
+
+    // Empty list is the correct response for a file with no symbols.
+    // We just verify no crash.
+    let _ = symbols;
+
+    harness.assert_no_crash();
+}


### PR DESCRIPTION
## Summary

- Adds four new BDD-style UX scenario files to `perl-lsp-ux-tests` (scenarios 10–13) providing end-to-end feature grid coverage for `textDocument/definition`, `textDocument/hover`, `textDocument/publishDiagnostics`, and `textDocument/documentSymbol` — all capabilities advertised in `features.toml`
- Adds two new `UxHarness` helpers: `document_symbols()` and `wait_for_diagnostics()`, following the existing patterns in `lib.rs`
- All tests are degraded-mode-safe: missing binary = skip with `eprintln!`, empty server responses are acceptable where the LSP spec allows null results

## Changed files

- `crates/perl-lsp-ux-tests/src/lib.rs` — +58 lines: `document_symbols` and `wait_for_diagnostics` helpers
- `crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs` — 3 tests: no-error, location shape validation, graceful empty
- `crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs` — 3 tests: no-error, MarkupContent/MarkedString shape, sub-declaration hover
- `crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs` — 3 tests: no crash, diagnostic field shape (range/message/severity), notification receipt
- `crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs` — 4 tests: no-error, SymbolInformation/DocumentSymbol shape, known sub names, empty file

## Pre-push note

The `hook-tests` step in the nix ci-gate fails intermittently on Windows worktrees (`swarm-metrics.jsonl` not found in the nix temp path) — unrelated to this change. Hook-tests pass correctly in the standard `CARGO_TARGET_DIR` environment (13 passed, 0 failed). Bypassed per the hook bypass policy: "The hook is failing for an environmental reason that is out of band of your change (e.g., nix store cache miss, transient toolchain issue)."

All other gate stages passed: workflow audit, format check, docs check, clippy (0 warnings on perl-lsp-ux-tests), unwrap/panic ratchet, unsafe ratchet, test-lib, corpus check, policy, v2 bundle sync, v2 parity (203/203), LSP semantic definition (16/16), LSP smoke E2E (13/13), microcrates, BDD, semantic frameworks, DAP smoke E2E, parser features, features invariants, hook-check, hook-registry-check.

## Test plan

- [ ] `cargo test -p perl-lsp-ux-tests --no-run` — compile check (verified: all 4 scenarios compile)
- [ ] `cargo test -p perl-lsp-ux-tests` — with `PERL_LSP_BIN` set, all tests run; without binary, all skip gracefully
- [ ] `cargo clippy -p perl-lsp-ux-tests` — 0 warnings (verified)
- [ ] `cargo fmt -p perl-lsp-ux-tests --check` — clean (verified)