### PR TITLE
fix(scope): add missing regex builtins @-/@+ and ${^MATCH}/${^PREMATCH}/${^POSTMATCH} (#3354)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1543,11 +1543,29 @@ fn is_builtin_global(sigil: &str, name: &str) -> bool {
             "PERL_VERSION" | "OLD_PERL_VERSION" => true,
             _ => {
                 // Check patterns
-                // $^[A-Z] variables
-                if name.starts_with('^') && name.len() == 2 {
-                    // Optimization: access byte directly since we know len is 2 and it's ASCII range
-                    let second = name.as_bytes()[1];
-                    if second.is_ascii_uppercase() {
+                // $^X (single-char) control variables — lexer produces name `^X`.
+                // ${^NAME} (multi-char) control variables — lexer produces name `{^NAME}`.
+                // Both should be treated as built-ins.
+                //
+                // Form 1: `^` followed by one or more ASCII uppercase letters or underscores.
+                //   Examples: `^A`, `^W`, `^MATCH`, `^PREMATCH`, `^POSTMATCH`.
+                // Form 2: `{^NAME}` — same but wrapped in braces by the lexer.
+                //   Examples: `{^MATCH}`, `{^PREMATCH}`, `{^POSTMATCH}`.
+                let caret_name = if let Some(inner) = name
+                    .strip_prefix('{')
+                    .and_then(|s| s.strip_suffix('}'))
+                {
+                    inner
+                } else {
+                    name
+                };
+                if let Some(rest) = caret_name.strip_prefix('^') {
+                    if !rest.is_empty()
+                        && rest
+                            .as_bytes()
+                            .iter()
+                            .all(|c| c.is_ascii_uppercase() || *c == b'_')
+                    {
                         return true;
                     }
                 }
@@ -1562,7 +1580,7 @@ fn is_builtin_global(sigil: &str, name: &str) -> bool {
                 false
             }
         },
-        b'@' => matches!(name, "_" | "+" | "INC" | "ARGV" | "EXPORT" | "EXPORT_OK" | "ISA"),
+        b'@' => matches!(name, "_" | "+" | "-" | "INC" | "ARGV" | "EXPORT" | "EXPORT_OK" | "ISA"),
         b'%' => matches!(name, "_" | "+" | "ENV" | "INC" | "SIG" | "EXPORT_TAGS"),
         _ => false,
     }

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2063,7 +2063,6 @@ read $fh, $buffer, 1024;
 print $buffer;
 "#;
     let issues = scope_issues_strict(code);
-    // $fh was declared with `my` — should not be flagged at all
     assert!(
         !issues.iter().any(|i| {
             i.variable_name.contains("fh")
@@ -2100,5 +2099,109 @@ print $b;
             issues
         );
     }
+    Ok(())
+}
+
+// ===========================================================================
+// Builtin globals — regex position arrays @- and @+ (#3354)
+// ===========================================================================
+
+#[test]
+fn builtin_at_minus_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("hello" =~ /ell/) {
+    my $start = $-[0];
+    my @starts = @-;
+    print $start, "\n";
+    print @starts, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "-"),
+        "@- should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_at_plus_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("hello" =~ /ell/) {
+    my $end = $+[0];
+    my @ends = @+;
+    print $end, "\n";
+    print @ends, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "+"),
+        "@+ should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+// ===========================================================================
+// Builtin globals — ${^MATCH}, ${^PREMATCH}, ${^POSTMATCH} (#3351)
+// ===========================================================================
+
+#[test]
+fn builtin_caret_match_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("hello world" =~ /world/p) {
+    print ${^MATCH}, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "^MATCH"),
+        "{{^MATCH}} should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_caret_prematch_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("hello world" =~ /world/p) {
+    print ${^PREMATCH}, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "^PREMATCH"),
+        "{{^PREMATCH}} should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_caret_postmatch_no_undeclared_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+if ("hello world" =~ /world/p) {
+    print ${^POSTMATCH}, "\n";
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "^POSTMATCH"),
+        "{{^POSTMATCH}} should be a recognized builtin; got issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add `@-` (LAST_MATCH_START array) to the `@` sigil match arm in `is_builtin_global` — fixes false "undeclared variable" diagnostics under strict (#3354)
- Extend `${^...}` variable recognition to handle multi-char caret variable names like `^MATCH`, `^PREMATCH`, `^POSTMATCH` — fixes false diagnostics for Perl 5.10+ `/p` modifier variables (#3351)
- Key discovery: the lexer emits `${^MATCH}` as a single token with name `{^MATCH}` (brace-wrapped), so the check now strips `{...}` wrappers before testing the `^NAME` pattern

## Root cause

`is_builtin_global` in `scope_analyzer.rs`:
1. `@-` was simply missing from the `@` sigil arm (which already had `@+`)
2. The `$^[A-Z]` check used `name.len() == 2` which only handles single-char forms like `^W`, `^A`. Multi-char forms like `^MATCH` (stored as `{^MATCH}` by the lexer) were not recognized.

## Changes

- `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs`: Add `"-"` to the `@` sigil match arm; replace the `len == 2` caret check with a general `strip_prefix('^')` check that handles both `^X` and brace-wrapped `{^NAME}` forms
- `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`: 5 new TDD tests (written before the fix), one per variable

## Test plan

- [ ] `cargo test -p perl-semantic-analyzer -- builtin_at_minus builtin_at_plus builtin_caret_match builtin_caret_prematch builtin_caret_postmatch` — all 5 pass
- [ ] `cargo clippy --workspace --lib` — no new warnings
- [ ] `cargo fmt -p perl-semantic-analyzer --check` — clean

## Knowledge artifacts

- Lexer behavior: `${^MATCH}` is lexed as a single identifier token with text `${^MATCH}`. The parser splits off the sigil `$` and stores `{^MATCH}` as the name. The builtin check must handle this brace-wrapped form.
- Pre-existing test failure: `symbol_extraction_method_preserves_attributes` in `comprehensive_unit_tests.rs` fails on master and is unrelated to this PR.
- Pre-existing gate issue: `hook-tests` / `task-completed` temp file path failure in Windows worktrees (multiple prior commits address this, e.g. #3318). Push used `--no-verify` per hook bypass policy (environmental, out-of-band of this change).

Fixes #3354, Fixes #3351