### PR TITLE
fix(parser): validate prototype characters and warn on invalid ones (#3355)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -133,6 +133,12 @@ pub enum DiagnosticCode {
     DuplicateSubroutine,
     /// Missing explicit return statement
     MissingReturn,
+    /// Invalid character(s) in a subroutine prototype
+    ///
+    /// Perl only allows `$`, `@`, `%`, `&`, `*`, `\`, `;`, `+`, `_`, and
+    /// spaces in old-style prototypes.  Any other character triggers Perl's
+    /// "Illegal character in prototype" warning.
+    InvalidPrototype,
 
     // Best practices (PL400-PL499)
     /// Bareword filehandle usage
@@ -228,6 +234,7 @@ impl DiagnosticCode {
             DiagnosticCode::DuplicatePackage => "PL201",
             DiagnosticCode::DuplicateSubroutine => "PL300",
             DiagnosticCode::MissingReturn => "PL301",
+            DiagnosticCode::InvalidPrototype => "PL302",
             DiagnosticCode::BarewordFilehandle => "PL400",
             DiagnosticCode::TwoArgOpen => "PL401",
             DiagnosticCode::ImplicitReturn => "PL402",
@@ -287,6 +294,7 @@ impl DiagnosticCode {
             "PL201" => "https://docs.perl-lsp.org/errors/PL201",
             "PL300" => "https://docs.perl-lsp.org/errors/PL300",
             "PL301" => "https://docs.perl-lsp.org/errors/PL301",
+            "PL302" => "https://docs.perl-lsp.org/errors/PL302",
             "PL400" => "https://docs.perl-lsp.org/errors/PL400",
             "PL401" => "https://docs.perl-lsp.org/errors/PL401",
             "PL402" => "https://docs.perl-lsp.org/errors/PL402",
@@ -339,6 +347,7 @@ impl DiagnosticCode {
             | DiagnosticCode::DuplicatePackage
             | DiagnosticCode::DuplicateSubroutine
             | DiagnosticCode::MissingReturn
+            | DiagnosticCode::InvalidPrototype
             | DiagnosticCode::BarewordFilehandle
             | DiagnosticCode::TwoArgOpen
             | DiagnosticCode::ImplicitReturn
@@ -439,6 +448,11 @@ impl DiagnosticCode {
             DiagnosticCode::MissingReturn => Some(
                 "This subroutine has no explicit `return` statement. \
                 Add `return $value;` to make the return value clear.",
+            ),
+            DiagnosticCode::InvalidPrototype => Some(
+                "The prototype contains a character that Perl does not recognise. \
+                Valid prototype characters are: $, @, %, &, *, \\, ;, +, _ and spaces. \
+                See perlsub for the full prototype syntax.",
             ),
             DiagnosticCode::BarewordFilehandle => Some(
                 "Bareword filehandles (e.g., `open FH, ...`) are global and unsafe. \
@@ -588,6 +602,10 @@ impl DiagnosticCode {
             Some(DiagnosticCode::BarewordFilehandle)
         } else if msg_lower.contains("two-argument") || msg_lower.contains("2-arg") {
             Some(DiagnosticCode::TwoArgOpen)
+        } else if msg_lower.contains("invalid prototype character")
+            || msg_lower.contains("illegal character in prototype")
+        {
+            Some(DiagnosticCode::InvalidPrototype)
         } else if msg_lower.contains("parse error") || msg_lower.contains("syntax error") {
             Some(DiagnosticCode::ParseError)
         } else {
@@ -617,6 +635,7 @@ impl DiagnosticCode {
             "PL201" => Some(DiagnosticCode::DuplicatePackage),
             "PL300" => Some(DiagnosticCode::DuplicateSubroutine),
             "PL301" => Some(DiagnosticCode::MissingReturn),
+            "PL302" => Some(DiagnosticCode::InvalidPrototype),
             "PL400" => Some(DiagnosticCode::BarewordFilehandle),
             "PL401" => Some(DiagnosticCode::TwoArgOpen),
             "PL402" => Some(DiagnosticCode::ImplicitReturn),
@@ -706,9 +725,9 @@ impl DiagnosticCode {
                 DiagnosticCategory::PackageModule
             }
 
-            DiagnosticCode::DuplicateSubroutine | DiagnosticCode::MissingReturn => {
-                DiagnosticCategory::Subroutine
-            }
+            DiagnosticCode::DuplicateSubroutine
+            | DiagnosticCode::MissingReturn
+            | DiagnosticCode::InvalidPrototype => DiagnosticCategory::Subroutine,
 
             DiagnosticCode::BarewordFilehandle
             | DiagnosticCode::TwoArgOpen

--- a/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
@@ -26,6 +26,7 @@ const ALL_CODES: &[DiagnosticCode] = &[
     DiagnosticCode::DuplicatePackage,
     DiagnosticCode::DuplicateSubroutine,
     DiagnosticCode::MissingReturn,
+    DiagnosticCode::InvalidPrototype,
     DiagnosticCode::BarewordFilehandle,
     DiagnosticCode::TwoArgOpen,
     DiagnosticCode::ImplicitReturn,
@@ -1162,8 +1163,8 @@ fn unused_variable_tag_is_exactly_unnecessary() {
 // --- Cross-cutting: ALL_CODES count ---
 
 #[test]
-fn all_codes_count_is_21() {
-    assert_eq!(ALL_CODES.len(), 21, "expected 21 diagnostic codes total");
+fn all_codes_count_is_22() {
+    assert_eq!(ALL_CODES.len(), 22, "expected 22 diagnostic codes total");
 }
 
 // --- DiagnosticCode: parse_code boundary values ---
@@ -1172,7 +1173,7 @@ fn all_codes_count_is_21() {
 fn parse_code_all_valid_pl_codes() {
     let valid_pl = [
         "PL001", "PL002", "PL003", "PL100", "PL101", "PL102", "PL103", "PL200", "PL201", "PL300",
-        "PL301", "PL400", "PL401", "PL402", "PL602",
+        "PL301", "PL302", "PL400", "PL401", "PL402", "PL602",
     ];
     for s in &valid_pl {
         assert!(DiagnosticCode::parse_code(s).is_some(), "expected valid parse for {}", s);
@@ -1193,7 +1194,7 @@ fn parse_code_gaps_return_none() {
     // Note: PL104-PL111, PL403-PL404, PL500-PL501, PL600-PL602, PL700, PL800-PL806
     // are now assigned; only truly unassigned gaps are listed here.
     let gaps = [
-        "PL004", "PL050", "PL099", "PL112", "PL150", "PL199", "PL202", "PL250", "PL302", "PL399",
+        "PL004", "PL050", "PL099", "PL112", "PL150", "PL199", "PL202", "PL250", "PL303", "PL399",
         "PL499", "PL502", "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
     ];
     for s in &gaps {

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -848,12 +848,43 @@ impl<'a> Parser<'a> {
                     TokenKind::RightParen => true,
                     // Colon indicates named parameter (:$foo), so it's a signature
                     TokenKind::Colon => false,
-                    // Identifiers usually mean signature, but could be a special case
+                    // Identifiers: The lexer produces a single Identifier token that
+                    // may include the leading sigil (e.g., `$x` → Identifier("$x")).
+                    // Signature parameters always start with a sigil followed by a name
+                    // (e.g., `$x`, `@arr`). Pure prototype characters produce either
+                    // bare sigil tokens (ScalarSigil/ArraySigil handled above) or an
+                    // Identifier token whose text contains only valid prototype chars
+                    // (`_`, `$`, `@`, `%`, `*`, `&`).
+                    //
+                    // A bare alphabetic identifier with no leading sigil (e.g., `XYZ`, `a`)
+                    // cannot be a signature parameter — treat it as a prototype candidate
+                    // so that `parse_prototype` can validate and warn on the invalid chars.
                     TokenKind::Identifier => {
-                        // Check if it's a sigil-only identifier like "$" or "@"
-                        // or the special underscore prototype
-                        &*token.text == "_"
-                            || token.text.chars().all(|c| matches!(c, '$' | '@' | '%' | '*' | '&'))
+                        let text = &*token.text;
+                        // `_` is a valid prototype character (default $_)
+                        if text == "_" {
+                            return Ok(true);
+                        }
+                        // A sigil-prefixed identifier: check if ALL chars are valid
+                        // prototype chars.  If not (e.g., `$x`), it's a signature param.
+                        let all_proto_chars = text.chars().all(is_valid_prototype_char);
+                        if all_proto_chars {
+                            // Looks like prototype-only chars → prototype
+                            return Ok(true);
+                        }
+                        // Text begins with a sigil followed by a real identifier name →
+                        // it's a signature parameter (e.g., `$x`).
+                        let starts_with_sigil = text
+                            .chars()
+                            .next()
+                            .is_some_and(|c| matches!(c, '$' | '@' | '%' | '*' | '&'));
+                        if starts_with_sigil {
+                            // `$x`, `@arr`, etc. → signature
+                            return Ok(false);
+                        }
+                        // Bare alphabetic identifier with no sigil (e.g., `XYZ`, `foo`) →
+                        // treat as prototype candidate; invalid chars will be warned about.
+                        true
                     }
                     // Anything else suggests a signature
                     _ => false,
@@ -865,6 +896,7 @@ impl<'a> Parser<'a> {
 
     /// Parse old-style prototype
     fn parse_prototype(&mut self) -> ParseResult<String> {
+        let open_paren_pos = self.current_position();
         self.expect(TokenKind::LeftParen)?; // consume (
         let mut prototype = String::new();
 
@@ -895,8 +927,40 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // Validate every character in the collected prototype string.
+        // Perl only allows: $ @ % & * \ ; + _ and ASCII space.
+        // Anything else triggers Perl's "Illegal character in prototype" warning.
+        // We emit a SyntaxError diagnostic (collected as a warning by the LSP layer
+        // via DiagnosticCode::InvalidPrototype / PL302) but do NOT abort parsing —
+        // the prototype string is preserved so the caller still gets a Subroutine node.
+        let invalid_chars: String = prototype
+            .chars()
+            .filter(|c| !is_valid_prototype_char(*c))
+            .collect::<std::collections::BTreeSet<char>>()
+            .into_iter()
+            .collect();
+
+        if !invalid_chars.is_empty() {
+            self.errors.push(ParseError::SyntaxError {
+                message: format!(
+                    "Invalid prototype character(s) '{}' — valid characters are: \
+                    $, @, %, &, *, \\, ;, +, _ (see perlsub)",
+                    invalid_chars
+                ),
+                location: open_paren_pos,
+            });
+        }
+
         Ok(prototype)
     }
+}
+
+/// Return `true` if `c` is a character that Perl permits in old-style prototypes.
+///
+/// Valid characters (from perlsub):
+/// `$` `@` `%` `&` `*` `\` `;` `+` `_` and ASCII space.
+fn is_valid_prototype_char(c: char) -> bool {
+    matches!(c, '$' | '@' | '%' | '&' | '*' | '\\' | ';' | '+' | '_' | ' ')
 }
 
 #[cfg(test)]

--- a/crates/perl-parser-core/tests/fix_prototype_validation_3355.rs
+++ b/crates/perl-parser-core/tests/fix_prototype_validation_3355.rs
@@ -1,0 +1,135 @@
+/// Tests for prototype character validation (issue #3355).
+///
+/// Perl only allows a specific set of characters in old-style prototypes:
+/// `$`, `@`, `%`, `&`, `*`, `\`, `;`, `+`, `_`, and spaces.
+/// Any other character should emit a warning-level diagnostic.
+use perl_parser_core::{NodeKind, Parser};
+use perl_tdd_support::must;
+
+/// Helper: parse code and collect diagnostic messages from `parse_with_recovery`.
+fn parse_and_get_diagnostics(code: &str) -> Vec<String> {
+    let mut parser = Parser::new(code);
+    let output = parser.parse_with_recovery();
+    output.diagnostics.iter().map(|e| e.to_string()).collect()
+}
+
+/// Helper: parse code and assert no prototype-invalid diagnostic is emitted.
+fn assert_no_prototype_warning(code: &str) {
+    let diagnostics = parse_and_get_diagnostics(code);
+    let proto_diags: Vec<_> = diagnostics.iter().filter(|m| m.contains("prototype")).collect();
+    assert!(
+        proto_diags.is_empty(),
+        "Expected no prototype diagnostics for `{}`, got: {:?}",
+        code,
+        proto_diags
+    );
+}
+
+/// Helper: parse code and assert that a prototype-invalid diagnostic IS emitted.
+fn assert_has_prototype_warning(code: &str) {
+    let diagnostics = parse_and_get_diagnostics(code);
+    let has_proto_diag = diagnostics.iter().any(|m| {
+        let lower = m.to_lowercase();
+        lower.contains("prototype") && (lower.contains("invalid") || lower.contains("character"))
+    });
+    assert!(
+        has_proto_diag,
+        "Expected a prototype-invalid diagnostic for `{}`, got diagnostics: {:?}",
+        code, diagnostics
+    );
+}
+
+// --- Valid prototype tests (no warning expected) ---
+
+#[test]
+fn valid_proto_dollar_dollar_at() {
+    // $$@ — all valid prototype characters
+    assert_no_prototype_warning("sub valid_proto ($$@) { }");
+}
+
+#[test]
+fn valid_proto_backslash_ref() {
+    // \@ \% — backslash-ref prototypes are valid
+    assert_no_prototype_warning(r"sub backslash_ref (\@\%) { }");
+}
+
+#[test]
+fn valid_proto_with_semi() {
+    // $;@ — semicolon as optional separator is valid
+    assert_no_prototype_warning("sub with_semi ($;@) { }");
+}
+
+#[test]
+fn valid_proto_empty() {
+    // () — empty prototype is valid
+    assert_no_prototype_warning("sub no_args () { }");
+}
+
+#[test]
+fn valid_proto_glob() {
+    // * — glob prototype character
+    assert_no_prototype_warning("sub glob_proto (*) { }");
+}
+
+#[test]
+fn valid_proto_ampersand() {
+    // & — coderef prototype character
+    assert_no_prototype_warning("sub code_proto (&) { }");
+}
+
+#[test]
+fn valid_proto_plus() {
+    // + — scalar or array/hash ref
+    assert_no_prototype_warning("sub plus_proto (+) { }");
+}
+
+#[test]
+fn valid_proto_underscore() {
+    // _ — default $_ prototype character
+    assert_no_prototype_warning("sub under_proto (_) { }");
+}
+
+// --- Invalid prototype tests (warning expected) ---
+
+#[test]
+fn invalid_proto_xyz() {
+    // XYZ are not valid prototype characters
+    assert_has_prototype_warning("sub invalid_proto (XYZ) { }");
+}
+
+#[test]
+fn invalid_proto_letter_a() {
+    // a single letter is not a valid prototype character
+    assert_has_prototype_warning("sub bad_proto (a) { }");
+}
+
+#[test]
+fn invalid_proto_bare_mixed() {
+    // A bare identifier with no sigil prefix: $X@Y are prototype-ish but X alone is invalid.
+    // "XY" as a bare prototype string (no leading sigil) contains only invalid chars.
+    assert_has_prototype_warning("sub mixed_proto (XY) { }");
+}
+
+// --- Structural check: invalid prototype still parses as a subroutine ---
+
+#[test]
+fn invalid_proto_still_produces_subroutine_node() {
+    // Even with an invalid prototype, the parser should produce a Subroutine node
+    // (warning, not fatal error).
+    let mut parser = Parser::new("sub bar (XYZ) { }");
+    let ast = must(parser.parse());
+    match &ast.kind {
+        NodeKind::Program { statements } => {
+            assert!(!statements.is_empty(), "expected at least one statement");
+            assert!(
+                matches!(statements[0].kind, NodeKind::Subroutine { .. }),
+                "expected Subroutine node, got: {}",
+                statements[0].kind.kind_name()
+            );
+        }
+        other => {
+            let got = other.kind_name();
+            assert_eq!("Program", got, "expected Program node at top level");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `InvalidPrototype` diagnostic code (`PL302`, Warning severity) to `perl-diagnostics-codes` for signalling invalid characters in old-style sub prototypes
- Validates prototype characters in `parse_prototype()` — valid chars are `$`, `@`, `%`, `&`, `*`, `\`, `;`, `+`, `_`, and space; anything else emits a non-fatal warning-level diagnostic
- Refines `is_likely_prototype()` heuristic to correctly classify bare alphabetic identifiers (e.g., `XYZ`) as prototype candidates (not signature parameters), enabling the new validation to fire

## Test plan

- [ ] `valid_proto_dollar_dollar_at` — `($$@)` emits no prototype warning
- [ ] `valid_proto_backslash_ref` — `(\@\%)` emits no prototype warning
- [ ] `valid_proto_with_semi` — `($;@)` emits no prototype warning
- [ ] `valid_proto_empty` — `()` emits no prototype warning
- [ ] `valid_proto_glob` — `(*)` emits no prototype warning
- [ ] `valid_proto_ampersand` — `(&)` emits no prototype warning
- [ ] `valid_proto_plus` — `(+)` emits no prototype warning
- [ ] `valid_proto_underscore` — `(_)` emits no prototype warning
- [ ] `invalid_proto_xyz` — `(XYZ)` emits an `InvalidPrototype`-style warning
- [ ] `invalid_proto_letter_a` — `(a)` emits an `InvalidPrototype`-style warning
- [ ] `invalid_proto_bare_mixed` — `(XY)` emits an `InvalidPrototype`-style warning
- [ ] `invalid_proto_still_produces_subroutine_node` — invalid prototype does NOT prevent a `Subroutine` AST node from being produced (warning, not fatal error)

Closes #3355