### PR TITLE
fix(diagnostics): add builtin functions to version compatibility checks (#3349)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -43,6 +43,7 @@ const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     ("defer", 5, 36),
     ("class", 5, 38),
     ("field", 5, 38),
+    ("builtin", 5, 40),
 ];
 
 const GIVEN_WHEN_DEPRECATION_VERSION: PerlVersion = PerlVersion::new(5, 38);
@@ -61,6 +62,7 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
     let mut declared_version: Option<PerlVersion> = None;
     let mut explicit_features: Vec<String> = Vec::new();
+    let mut use_builtin_declared = false;
 
     for stmt in statements {
         if let NodeKind::Use { module, args, .. } = &stmt.kind {
@@ -80,6 +82,9 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                     let name = arg.trim_matches(|c| c == '\'' || c == '"');
                     explicit_features.push(name.to_string());
                 }
+            }
+            if module == "builtin" {
+                use_builtin_declared = true;
             }
         }
     }
@@ -170,6 +175,20 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 if !effective_features.contains(&"defer") {
                     let min = feature_min_version("defer");
                     diagnostics.push(make_diagnostic(n, "defer", declared_version, min));
+                }
+            }
+
+            NodeKind::FunctionCall { name, .. } if name.starts_with("builtin::") => {
+                if !effective_features.contains(&"builtin") && !use_builtin_declared {
+                    let min = feature_min_version("builtin");
+                    diagnostics.push(make_diagnostic(n, "builtin::", declared_version, min));
+                }
+            }
+
+            NodeKind::Use { module, .. } if module == "builtin" => {
+                if !effective_features.contains(&"builtin") {
+                    let min = feature_min_version("builtin");
+                    diagnostics.push(make_diagnostic(n, "use builtin", declared_version, min));
                 }
             }
 

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -1037,3 +1037,132 @@ fn test_defer_helper_call_is_not_version_feature() -> Result<(), Box<dyn std::er
     );
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Helpers for builtin:: tests
+// ---------------------------------------------------------------------------
+
+fn builtin_floor_call() -> Node {
+    Node::new(
+        NodeKind::FunctionCall {
+            name: "builtin::floor".to_string(),
+            args: vec![Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
+                loc(30, 32),
+            )],
+        },
+        loc(20, 33),
+    )
+}
+
+fn use_builtin_node() -> Node {
+    Node::new(
+        NodeKind::Use {
+            module: "builtin".to_string(),
+            args: vec!["'floor'".to_string()],
+            has_filter_risk: false,
+        },
+        loc(0, 22),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test 25: builtin::floor in v5.36 -> warns (requires v5.40+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_builtin_qualified_call_warns_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), builtin_floor_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'builtin::floor' in v5.36, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("builtin"), "Message should mention 'builtin': {}", msg.message);
+    assert!(
+        msg.message.contains("v5.40") || msg.message.contains("5.40"),
+        "Message should mention minimum version v5.40: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 26: builtin::floor in v5.40 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_builtin_qualified_call_ok_on_v5_40() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40"), builtin_floor_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'builtin::floor' in v5.40, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 27: `use builtin` pragma in v5.36 -> warns (requires v5.40+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_use_builtin_warns_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), use_builtin_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'use builtin' in v5.36, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("builtin"), "Message should mention 'builtin': {}", msg.message);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 28: `use builtin` pragma in v5.40 -> no warn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_use_builtin_ok_on_v5_40() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40"), use_builtin_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'use builtin' in v5.40, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 29: `use builtin` on old version suppresses builtin:: call warning
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_use_builtin_suppresses_qualified_call_warning() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), use_builtin_node(), builtin_floor_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let pl900_count = diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL900")).count();
+    assert!(
+        pl900_count <= 1,
+        "Expected at most one PL900 for 'use builtin' + 'builtin::floor' on v5.36, got {} warnings: {:?}",
+        pl900_count,
+        diagnostics
+    );
+    Ok(())
+}

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -1067,10 +1067,7 @@ fn use_builtin_node() -> Node {
 }
 
 fn scalar_var(name: &str) -> Node {
-    Node::new(
-        NodeKind::Variable { sigil: "$".to_string(), name: name.to_string() },
-        loc(20, 22),
-    )
+    Node::new(NodeKind::Variable { sigil: "$".to_string(), name: name.to_string() }, loc(20, 22))
 }
 
 fn given_node() -> Node {
@@ -1082,10 +1079,7 @@ fn given_node() -> Node {
 
 fn when_node() -> Node {
     Node::new(
-        NodeKind::When {
-            condition: Box::new(scalar_var("x")),
-            body: Box::new(block(vec![])),
-        },
+        NodeKind::When { condition: Box::new(scalar_var("x")), body: Box::new(block(vec![])) },
         loc(20, 40),
     )
 }

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -1066,6 +1066,38 @@ fn use_builtin_node() -> Node {
     )
 }
 
+fn scalar_var(name: &str) -> Node {
+    Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: name.to_string() },
+        loc(20, 22),
+    )
+}
+
+fn given_node() -> Node {
+    Node::new(
+        NodeKind::Given { expr: Box::new(scalar_var("x")), body: Box::new(block(vec![])) },
+        loc(20, 40),
+    )
+}
+
+fn when_node() -> Node {
+    Node::new(
+        NodeKind::When {
+            condition: Box::new(scalar_var("x")),
+            body: Box::new(block(vec![])),
+        },
+        loc(20, 40),
+    )
+}
+
+fn default_node() -> Node {
+    Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(20, 35))
+}
+
+fn defer_call() -> Node {
+    Node::new(NodeKind::FunctionCall { name: "defer".to_string(), args: vec![] }, loc(20, 27))
+}
+
 // ---------------------------------------------------------------------------
 // Test 25: builtin::floor in v5.36 -> warns (requires v5.40+)
 // ---------------------------------------------------------------------------
@@ -1162,6 +1194,90 @@ fn test_use_builtin_suppresses_qualified_call_warning() -> Result<(), Box<dyn st
         pl900_count <= 1,
         "Expected at most one PL900 for 'use builtin' + 'builtin::floor' on v5.36, got {} warnings: {:?}",
         pl900_count,
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 21: switch-family nodes in v5.8 -> each warns (requires v5.10+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_switch_family_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), given_node(), when_node(), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    let pl900: Vec<_> = diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL900")).collect();
+    assert_eq!(
+        pl900.len(),
+        3,
+        "Expected three PL900 warnings for given/when/default in v5.8, got: {:?}",
+        diagnostics
+    );
+    assert!(pl900.iter().any(|d| d.message.contains("given")));
+    assert!(pl900.iter().any(|d| d.message.contains("when")));
+    assert!(pl900.iter().any(|d| d.message.contains("default")));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 22: switch-family nodes in v5.10 -> no warnings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_switch_family_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.10"), given_node(), when_node(), default_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warnings for given/when/default in v5.10, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 23: defer in v5.34 -> warns (requires v5.36+)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_warns_on_v5_34() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.34"), defer_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for defer in v5.34, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(msg.message.contains("defer"), "Message should mention 'defer': {}", msg.message);
+    assert!(
+        msg.message.contains("v5.36") || msg.message.contains("5.36"),
+        "Message should mention minimum version v5.36: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 24: defer in v5.36 -> no warnings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defer_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), defer_call()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for defer in v5.36, got: {:?}",
         diagnostics
     );
     Ok(())


### PR DESCRIPTION
## Summary

- Adds PL900 version-compat warnings for `builtin::func()` qualified calls (requires v5.40+)
- Adds PL900 warning for `use builtin` pragma when version < v5.40
- Adds `switch` feature bundle (`given/when/default`) detection for v5.10+
- Adds `defer` block detection for v5.36+
- Updates `features_enabled_by_version` in `perl-pragma` to include "switch" (v5.10), "defer" (v5.36), and "builtin" (v5.40)
- When `use builtin` is present, per-call `builtin::*` warnings are suppressed — the pragma-level warning fires once

## Motivation

`builtin::floor($x)` with `use v5.36` was silently accepted even though `builtin::` requires v5.40+. This change makes the version-compat lint (PL900) correctly detect both `use builtin` and `builtin::*` qualified calls.

## Test plan

- [ ] `test_builtin_qualified_call_warns_on_v5_36` — warns on old version
- [ ] `test_builtin_qualified_call_ok_on_v5_40` — no warn on v5.40
- [ ] `test_use_builtin_warns_on_v5_36` — pragma warns on old version
- [ ] `test_use_builtin_ok_on_v5_40` — no warn on v5.40
- [ ] `test_use_builtin_suppresses_qualified_call_warning` — pragma deduplicates warnings
- [ ] All 17 pre-existing version_compat tests continue passing (22 total)
- [ ] `cargo test -p perl-lsp-diagnostics` and `cargo test -p perl-pragma` both pass

Closes #3349