### PR TITLE
docs(hover): add file test operator docs (#3516)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -291,6 +291,24 @@ impl LspServer {
             }
         }
 
+        // Handle file test operators (`-e`, `-f`, `-M`, etc.) before the
+        // general token fallback, because the token scanner does not include
+        // the leading `-`.
+        if let Some(op) = Self::extract_file_test_operator(text, offset) {
+            if let Some(op_doc) = crate::semantic::get_operator_documentation(&op) {
+                return HoverExtracted::Complete(json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": format!(
+                            "**File Test Operator**\n\n```\n{}\n```\n\n{}",
+                            op_doc.signature,
+                            op_doc.description
+                        ),
+                    },
+                }));
+            }
+        }
+
         // Fall back to simple token display, with builtin docs
         let hover_text = self.get_token_at_position(text, offset);
 
@@ -1504,6 +1522,32 @@ impl LspServer {
                 '!' | '@' | '?' | '/' | '\\' | '$' | ';' | ',' | '.' | '&' | '\'' | '`' | '+' | '|'
             ) {
                 return Some(format!("${}", punct));
+            }
+        }
+
+        None
+    }
+
+    /// Extract a file test operator at the given byte offset.
+    ///
+    /// Recognizes operators like `-e`, `-f`, and `-M` when the cursor is on
+    /// either the `-` or the operator letter.
+    fn extract_file_test_operator(text: &str, offset: usize) -> Option<String> {
+        let bytes = text.as_bytes();
+        if bytes.is_empty() || offset >= bytes.len() {
+            return None;
+        }
+
+        for start in [offset, offset.saturating_sub(1)] {
+            if bytes.get(start) != Some(&b'-') {
+                continue;
+            }
+
+            if let Some(op_char) = bytes.get(start + 1) {
+                let op = format!("-{}", *op_char as char);
+                if crate::semantic::SemanticAnalyzer::is_file_test_operator(&op) {
+                    return Some(op);
+                }
             }
         }
 

--- a/crates/perl-lsp/tests/lsp_hover_tests.rs
+++ b/crates/perl-lsp/tests/lsp_hover_tests.rs
@@ -23,6 +23,7 @@
 mod support;
 
 use serde_json::json;
+use std::time::Duration;
 use support::lsp_harness::LspHarness;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -193,6 +194,62 @@ push @items, 9;
             "If hover is returned for builtin, it must have contents"
         );
     }
+
+    Ok(())
+}
+
+/// Tests feature spec: navigation.rs#hover-file-test-operators
+///
+/// Validates that hovering over Perl file test operators returns documentation.
+#[test]
+fn test_hover_on_file_test_operators() -> TestResult {
+    let doc = r#"
+my $file = "test.txt";
+-e $file;
+-M $file;
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///file_tests.pl", doc)?;
+
+    let result = harness
+        .request_with_timeout(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///file_tests.pl"},
+                "position": {"line": 2, "character": 1}
+            }),
+            Duration::from_secs(10),
+        )
+        .unwrap_or(json!(null));
+
+    assert!(!result.is_null(), "Expected hover response for -e");
+    let value =
+        result.get("contents").and_then(|c| c.get("value")).and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        value.contains("exists"),
+        "File test hover should explain -e existence checks, got: {value}"
+    );
+
+    let result = harness
+        .request_with_timeout(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///file_tests.pl"},
+                "position": {"line": 3, "character": 1}
+            }),
+            Duration::from_secs(10),
+        )
+        .unwrap_or(json!(null));
+
+    assert!(!result.is_null(), "Expected hover response for -M");
+    let value =
+        result.get("contents").and_then(|c| c.get("value")).and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        value.contains("days"),
+        "Related file test hover should explain -M age semantics, got: {value}"
+    );
 
     Ok(())
 }

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -102,6 +102,122 @@ pub(super) fn is_file_test_operator(op: &str) -> bool {
     )
 }
 
+/// Get documentation for a Perl file test operator.
+///
+/// Returns signature and description for known file test operators,
+/// or `None` if documentation is not available.
+pub fn get_operator_documentation(op: &str) -> Option<BuiltinDoc> {
+    macro_rules! doc {
+        ($signature:expr, $description:expr) => {
+            Some(BuiltinDoc { signature: $signature, description: $description })
+        };
+    }
+
+    match op {
+        "-e" => doc!("-e FILE\n-e", "Returns true if FILE exists. If FILE is omitted, tests `$_`."),
+        "-f" => doc!(
+            "-f FILE\n-f",
+            "Returns true if FILE is a plain file. If FILE is omitted, tests `$_`."
+        ),
+        "-d" => doc!(
+            "-d FILE\n-d",
+            "Returns true if FILE is a directory. If FILE is omitted, tests `$_`."
+        ),
+        "-r" => doc!(
+            "-r FILE\n-r",
+            "Returns true if FILE is readable by the effective user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-w" => doc!(
+            "-w FILE\n-w",
+            "Returns true if FILE is writable by the effective user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-x" => doc!(
+            "-x FILE\n-x",
+            "Returns true if FILE is executable by the effective user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-o" => doc!(
+            "-o FILE\n-o",
+            "Returns true if FILE is owned by the effective user ID. If FILE is omitted, tests `$_`."
+        ),
+        "-R" => doc!(
+            "-R FILE\n-R",
+            "Returns true if FILE is readable by the real user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-W" => doc!(
+            "-W FILE\n-W",
+            "Returns true if FILE is writable by the real user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-X" => doc!(
+            "-X FILE\n-X",
+            "Returns true if FILE is executable by the real user or group ID. If FILE is omitted, tests `$_`."
+        ),
+        "-O" => doc!(
+            "-O FILE\n-O",
+            "Returns true if FILE is owned by the real user ID. If FILE is omitted, tests `$_`."
+        ),
+        "-z" => doc!(
+            "-z FILE\n-z",
+            "Returns true if FILE exists and has zero size. If FILE is omitted, tests `$_`."
+        ),
+        "-s" => doc!(
+            "-s FILE\n-s",
+            "Returns the file size in bytes in scalar context, or true if FILE has nonzero size. If FILE is omitted, tests `$_`."
+        ),
+        "-l" => doc!(
+            "-l FILE\n-l",
+            "Returns true if FILE is a symbolic link. If FILE is omitted, tests `$_`."
+        ),
+        "-p" => doc!(
+            "-p FILE\n-p",
+            "Returns true if FILE is a named pipe (FIFO). If FILE is omitted, tests `$_`."
+        ),
+        "-S" => {
+            doc!("-S FILE\n-S", "Returns true if FILE is a socket. If FILE is omitted, tests `$_`.")
+        }
+        "-u" => doc!(
+            "-u FILE\n-u",
+            "Returns true if FILE has the setuid bit set. If FILE is omitted, tests `$_`."
+        ),
+        "-g" => doc!(
+            "-g FILE\n-g",
+            "Returns true if FILE has the setgid bit set. If FILE is omitted, tests `$_`."
+        ),
+        "-k" => doc!(
+            "-k FILE\n-k",
+            "Returns true if FILE has the sticky bit set. If FILE is omitted, tests `$_`."
+        ),
+        "-t" => doc!(
+            "-t FILEHANDLE\n-t",
+            "Returns true if FILEHANDLE is connected to a tty. If FILEHANDLE is omitted, tests `STDIN`."
+        ),
+        "-T" => doc!(
+            "-T FILE\n-T",
+            "Returns true if FILE looks like a text file. If FILE is omitted, tests `$_`."
+        ),
+        "-B" => doc!(
+            "-B FILE\n-B",
+            "Returns true if FILE looks like a binary file. If FILE is omitted, tests `$_`."
+        ),
+        "-M" => doc!(
+            "-M FILE\n-M",
+            "Returns the file age in days at program start, based on the file's modification time."
+        ),
+        "-A" => doc!("-A FILE\n-A", "Returns the file age in days based on the last access time."),
+        "-C" => {
+            doc!("-C FILE\n-C", "Returns the file age in days based on the last inode change time.")
+        }
+        "-b" => doc!(
+            "-b FILE\n-b",
+            "Returns true if FILE is a block special file. If FILE is omitted, tests `$_`."
+        ),
+        "-c" => doc!(
+            "-c FILE\n-c",
+            "Returns true if FILE is a character special file. If FILE is omitted, tests `$_`."
+        ),
+        _ => None,
+    }
+}
+
 /// Get documentation for a Perl built-in function.
 ///
 /// Returns signature and description for known built-in functions,

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -25,7 +25,8 @@ mod tokens;
 // Public re-exports — downstream consumers see exactly the same surface.
 pub use builtins::{
     BuiltinDoc, ExceptionContext, get_attribute_documentation, get_builtin_documentation,
-    get_exception_context, get_moose_type_documentation, is_exception_function,
+    get_exception_context, get_moose_type_documentation, get_operator_documentation,
+    is_exception_function,
 };
 pub use hover::HoverInfo;
 pub use model::SemanticModel;

--- a/crates/perl-semantic-analyzer/tests/builtin_context_docs_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/builtin_context_docs_tests.rs
@@ -5,7 +5,9 @@
 //! so failures are immediate and pinpoint the exact string, not a
 //! hover-position-lookup that can silently pass when hover returns null.
 
-use perl_semantic_analyzer::analysis::semantic::get_builtin_documentation;
+use perl_semantic_analyzer::analysis::semantic::{
+    get_builtin_documentation, get_operator_documentation,
+};
 use perl_tdd_support::must_some;
 
 // ---------------------------------------------------------------------------
@@ -107,6 +109,34 @@ fn test_wantarray_void_context_doc() {
         "wantarray description must mention undef for void context: {}",
         doc.description
     );
+}
+
+// ---------------------------------------------------------------------------
+// file test operators
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_file_test_operator_docs() {
+    let cases = [
+        ("-e", "exists"),
+        ("-f", "plain file"),
+        ("-d", "directory"),
+        ("-r", "readable"),
+        ("-w", "writable"),
+        ("-M", "program start"),
+        ("-A", "last access"),
+        ("-C", "inode change"),
+    ];
+
+    for (op, expected) in cases {
+        let doc = must_some(get_operator_documentation(op));
+        assert!(
+            doc.description.contains(expected),
+            "{op} description should mention {expected}: {}",
+            doc.description
+        );
+        assert!(!doc.signature.is_empty(), "{op} should have a non-empty signature");
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add dedicated documentation entries for Perl file test operators
- extract file test operators in the hover path before generic token fallback
- add semantic-doc and LSP hover regressions for file test operators

## Validation
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test builtin_context_docs_tests test_file_test_operator_docs -- --nocapture
- cargo test -p perl-lsp-rs --test lsp_hover_tests test_hover_on_file_test_operators -- --nocapture