### PR TITLE
fix(semantic): recognize PL_sv_yes/no internal specials (#3542)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -1512,10 +1512,42 @@ impl LspServer {
 
     /// Return educational hover documentation for Perl special variables.
     ///
-    /// Covers the 20 most common special variables that every Perl developer
-    /// encounters.  Returns a JSON hover response with markdown content, or
-    /// `None` if the variable is not in the known set.
+    /// Covers the common special variables every Perl developer encounters,
+    /// plus a few internal `PL_sv_*` constants used by XS/C code. Returns a
+    /// JSON hover response with markdown content, or `None` if the variable is
+    /// not in the known set.
+    fn get_internal_special_variable_hover(name: &str) -> Option<Value> {
+        let (heading, description) = match name {
+            "PL_sv_yes" => (
+                "Internal Special Variable",
+                "The canonical true scalar used by Perl internals and XS/C code. It is an immutable shared value, so extensions can return or compare against it without allocating a fresh true scalar.",
+            ),
+            "PL_sv_no" => (
+                "Internal Special Variable",
+                "The canonical false scalar used by Perl internals and XS/C code. It is an immutable shared value representing Perl's shared false value.",
+            ),
+            "PL_sv_undef" => (
+                "Internal Special Variable",
+                "The canonical undefined scalar used by Perl internals and XS/C code. It represents Perl's shared `undef` value.",
+            ),
+            _ => return None,
+        };
+
+        Some(json!({
+            "contents": {
+                "kind": "markdown",
+                "value": format!(
+                    "**`{name}` \u{2014} {heading}**\n\n{description}\n\n```perl\n# XS/C internals typically treat this as a shared value\n```"
+                ),
+            },
+        }))
+    }
+
     fn get_special_variable_hover(name: &str) -> Option<Value> {
+        if let Some(hover) = Self::get_internal_special_variable_hover(name) {
+            return Some(hover);
+        }
+
         // Handle $1-$9 capture group variables with dynamic content.
         if let Some(digit) = name
             .strip_prefix('$')

--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -20,6 +20,30 @@ enum HoverExtracted {
     None,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::LspServer;
+
+    #[test]
+    fn test_internal_pl_sv_yes_hover_from_sigiled_token() {
+        let text = "print $PL_sv_yes;\n";
+        let offset = text.find('$').expect("sigil should exist");
+
+        assert_eq!(
+            LspServer::extract_special_variable(text, offset).as_deref(),
+            Some("$PL_sv_yes")
+        );
+
+        let hover = LspServer::get_special_variable_hover("$PL_sv_yes")
+            .expect("hover should exist for $PL_sv_yes");
+        let value = hover["contents"]["value"].as_str().expect("markdown hover text");
+        assert!(
+            value.contains("true scalar"),
+            "hover should describe the shared true scalar: {value}"
+        );
+    }
+}
+
 impl LspServer {
     /// Handle textDocument/hover request for symbol information display
     ///
@@ -1496,6 +1520,15 @@ impl LspServer {
             }
         }
 
+        // Internal Perl values used by XS/C code, e.g. $PL_sv_yes.
+        if sigil == '$' && bytes[next_pos..].starts_with(b"PL_sv_") {
+            let mut end = next_pos + "PL_sv_".len();
+            while end < len && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+                end += 1;
+            }
+            return Some(text[sigil_pos..end].to_string());
+        }
+
         // Single punctuation character after $ (e.g. $!, $?, $/, $\, $$, $;, etc.)
         if sigil == '$' && !next_ch.is_ascii_alphanumeric() && next_ch != b'_' {
             let punct = next_ch as char;
@@ -1518,15 +1551,15 @@ impl LspServer {
     /// not in the known set.
     fn get_internal_special_variable_hover(name: &str) -> Option<Value> {
         let (heading, description) = match name {
-            "PL_sv_yes" => (
+            "$PL_sv_yes" | "PL_sv_yes" => (
                 "Internal Special Variable",
                 "The canonical true scalar used by Perl internals and XS/C code. It is an immutable shared value, so extensions can return or compare against it without allocating a fresh true scalar.",
             ),
-            "PL_sv_no" => (
+            "$PL_sv_no" | "PL_sv_no" => (
                 "Internal Special Variable",
                 "The canonical false scalar used by Perl internals and XS/C code. It is an immutable shared value representing Perl's shared false value.",
             ),
-            "PL_sv_undef" => (
+            "$PL_sv_undef" | "PL_sv_undef" => (
                 "Internal Special Variable",
                 "The canonical undefined scalar used by Perl internals and XS/C code. It represents Perl's shared `undef` value.",
             ),

--- a/crates/perl-lsp/tests/special_variable_hover_tests.rs
+++ b/crates/perl-lsp/tests/special_variable_hover_tests.rs
@@ -140,6 +140,39 @@ fn test_hover_special_variables_return_markdown() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_hover_internal_pl_sv_special_variables() -> TestResult {
+    let doc = "print PL_sv_yes; print PL_sv_no; print PL_sv_undef;\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///pl_sv_internal.pl", doc)?;
+
+    for (needle, expected) in [
+        ("PL_sv_yes", "true scalar"),
+        ("PL_sv_no", "false scalar"),
+        ("PL_sv_undef", "undefined scalar"),
+    ] {
+        let character = doc.find(needle).ok_or("needle not found")?;
+        let result = harness
+            .request(
+                "textDocument/hover",
+                json!({
+                    "textDocument": {"uri": "file:///pl_sv_internal.pl"},
+                    "position": {"line": 0, "character": character}
+                }),
+            )
+            .unwrap_or(json!(null));
+        let val = hover_value(&result).ok_or("Expected hover content for PL_sv_*")?;
+        let lower = val.to_lowercase();
+        assert!(
+            lower.contains(expected) || lower.contains("internal special variable"),
+            "{needle} hover should mention {expected}, got: {val}"
+        );
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // New tests for issue #2347 – extended special variable hover coverage
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp/tests/special_variable_hover_tests.rs
+++ b/crates/perl-lsp/tests/special_variable_hover_tests.rs
@@ -142,15 +142,15 @@ fn test_hover_special_variables_return_markdown() -> TestResult {
 
 #[test]
 fn test_hover_internal_pl_sv_special_variables() -> TestResult {
-    let doc = "print PL_sv_yes; print PL_sv_no; print PL_sv_undef;\n";
+    let doc = "print $PL_sv_yes; print $PL_sv_no; print $PL_sv_undef;\n";
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
     harness.open_document("file:///pl_sv_internal.pl", doc)?;
 
     for (needle, expected) in [
-        ("PL_sv_yes", "true scalar"),
-        ("PL_sv_no", "false scalar"),
-        ("PL_sv_undef", "undefined scalar"),
+        ("$PL_sv_yes", "true scalar"),
+        ("$PL_sv_no", "false scalar"),
+        ("$PL_sv_undef", "undefined scalar"),
     ] {
         let character = doc.find(needle).ok_or("needle not found")?;
         let result = harness

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1573,6 +1573,9 @@ fn is_known_function(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
+    if matches!(name, "PL_sv_yes" | "PL_sv_no" | "PL_sv_undef") {
+        return true;
+    }
     // Optimization: All known functions are lowercase or start with non-uppercase chars
     if name.as_bytes()[0].is_ascii_uppercase() {
         return false;

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1299,6 +1299,9 @@ fn strict_subs_only_checks_barewords() -> Result<(), Box<dyn std::error::Error>>
 use strict 'subs';
 print $unknown_var;
 print FOO;
+print PL_sv_yes;
+print PL_sv_no;
+print PL_sv_undef;
 "#;
     let issues = scope_issues_strict(code);
 
@@ -1312,6 +1315,14 @@ print FOO;
             .any(|i| { matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "FOO" }),
         "strict 'subs' should flag barewords"
     );
+    for internal in ["PL_sv_yes", "PL_sv_no", "PL_sv_undef"] {
+        assert!(
+            !issues.iter().any(|i| {
+                matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == internal
+            }),
+            "strict 'subs' should not flag internal special constant {internal}"
+        );
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- treat PL_sv_yes / PL_sv_no / PL_sv_undef as known internal specials for strict-subs analysis
- add hover support for sigiled PL_sv_* internal values used by XS/C-style code
- add focused scope and hover regressions for the internal specials

## Validation
- cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests strict_subs_only_checks_barewords -- --nocapture
- cargo test -p perl-lsp-rs --test special_variable_hover_tests test_hover_internal_pl_sv_special_variables -- --nocapture
- cargo fmt --all