### PR TITLE
fix(workspace): add .cgi and .psgi to recognized Perl file extensions (#3492)

### DIFF
--- a/crates/perl-source-file/src/lib.rs
+++ b/crates/perl-source-file/src/lib.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 /// Canonical Perl source file extensions.
-pub const PERL_SOURCE_EXTENSIONS: [&str; 4] = ["pl", "pm", "t", "psgi"];
+pub const PERL_SOURCE_EXTENSIONS: [&str; 5] = ["pl", "pm", "t", "psgi", "cgi"];
 
 /// Returns `true` if `extension` is a recognized Perl source extension.
 ///
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn exposes_expected_extension_set() {
-        assert_eq!(PERL_SOURCE_EXTENSIONS, ["pl", "pm", "t", "psgi"]);
+        assert_eq!(PERL_SOURCE_EXTENSIONS, ["pl", "pm", "t", "psgi", "cgi"]);
     }
 
     #[test]
@@ -55,6 +55,8 @@ mod tests {
         assert!(is_perl_source_extension(".pm"));
         assert!(is_perl_source_extension("T"));
         assert!(is_perl_source_extension("PsGi"));
+        assert!(is_perl_source_extension("cgi"));
+        assert!(is_perl_source_extension(".CGI"));
         assert!(!is_perl_source_extension("txt"));
     }
 
@@ -63,6 +65,8 @@ mod tests {
         assert!(is_perl_source_path(Path::new("/workspace/script.pl")));
         assert!(is_perl_source_path(Path::new("/workspace/lib/Foo/Bar.PM")));
         assert!(is_perl_source_path(Path::new("/workspace/app.psgi")));
+        assert!(is_perl_source_path(Path::new("/var/www/cgi-bin/form.cgi")));
+        assert!(is_perl_source_path(Path::new("/var/www/cgi-bin/upload.CGI")));
         assert!(!is_perl_source_path(Path::new("/workspace/README.md")));
         assert!(!is_perl_source_path(Path::new("/workspace/no_extension")));
     }
@@ -73,7 +77,28 @@ mod tests {
         assert!(is_perl_source_uri("file:///workspace/lib/Foo/Bar.pm"));
         assert!(is_perl_source_uri("file:///workspace/app.psgi"));
         assert!(is_perl_source_uri("file:///workspace/app.psgi?version=1#section"));
+        assert!(is_perl_source_uri("file:///var/www/cgi-bin/form.cgi"));
+        assert!(is_perl_source_uri("file:///var/www/cgi-bin/search.cgi?q=perl#results"));
         assert!(!is_perl_source_uri("file:///workspace/README.md"));
+    }
+
+    #[test]
+    fn cgi_and_psgi_are_recognized() {
+        // CGI scripts (.cgi) — web projects, Apache/Nginx CGI handlers
+        assert!(is_perl_source_extension("cgi"));
+        assert!(is_perl_source_extension("CGI"));
+        assert!(is_perl_source_path(Path::new("/var/www/cgi-bin/form.cgi")));
+        assert!(is_perl_source_uri("file:///var/www/cgi-bin/form.cgi"));
+
+        // PSGI apps (.psgi) — Plack/PSGI applications
+        assert!(is_perl_source_extension("psgi"));
+        assert!(is_perl_source_extension("PSGI"));
+        assert!(is_perl_source_path(Path::new("/workspace/app.psgi")));
+        assert!(is_perl_source_uri("file:///workspace/app.psgi"));
+
+        // Non-Perl extensions remain unrecognized
+        assert!(!is_perl_source_extension("sh"));
+        assert!(!is_perl_source_extension("py"));
     }
 
     #[test]

--- a/crates/perl-source-file/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-source-file/tests/comprehensive_unit_tests.rs
@@ -11,16 +11,16 @@ use perl_source_file::{
 // ---------------------------------------------------------------------------
 
 #[test]
-fn extensions_constant_has_exactly_four_entries() -> Result<(), String> {
-    if PERL_SOURCE_EXTENSIONS.len() != 4 {
-        return Err(format!("expected 4 extensions, got {}", PERL_SOURCE_EXTENSIONS.len()));
+fn extensions_constant_has_exactly_five_entries() -> Result<(), String> {
+    if PERL_SOURCE_EXTENSIONS.len() != 5 {
+        return Err(format!("expected 5 extensions, got {}", PERL_SOURCE_EXTENSIONS.len()));
     }
     Ok(())
 }
 
 #[test]
 fn extensions_constant_contains_expected_values() -> Result<(), String> {
-    let expected = ["pl", "pm", "t", "psgi"];
+    let expected = ["pl", "pm", "t", "psgi", "cgi"];
     if PERL_SOURCE_EXTENSIONS != expected {
         return Err(format!("expected {expected:?}, got {:?}", PERL_SOURCE_EXTENSIONS));
     }

--- a/crates/perl-source-file/tests/edge_cases_and_consistency.rs
+++ b/crates/perl-source-file/tests/edge_cases_and_consistency.rs
@@ -68,8 +68,8 @@ fn uri_agrees_with_path_for_all_canonical() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn extension_rejects_cgi() {
-    assert!(!is_perl_source_extension("cgi"), "cgi is not a canonical Perl source extension");
+fn extension_recognises_cgi() {
+    assert!(is_perl_source_extension("cgi"), "cgi is a recognized Perl source extension");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `"cgi"` to `PERL_SOURCE_EXTENSIONS` in `crates/perl-source-file/src/lib.rs`, fixing file discovery for CGI scripts in web projects
- `.psgi` was already present; `.cgi` was the missing extension causing Apache/Nginx CGI handlers to be excluded from workspace indexing
- Updates all hardcoded extension-count assertions and negative tests that previously rejected `.cgi`

## Changes

- `crates/perl-source-file/src/lib.rs`: `[&str; 4]` → `[&str; 5]`, adds `"cgi"` to the array; updates existing tests and adds `cgi_and_psgi_are_recognized` test
- `crates/perl-source-file/tests/comprehensive_unit_tests.rs`: updates `extensions_constant_has_exactly_four_entries` → five, and `extensions_constant_contains_expected_values`
- `crates/perl-source-file/tests/edge_cases_and_consistency.rs`: flips `extension_rejects_cgi` → `extension_recognises_cgi`

## Test plan

- [ ] `cargo test -p perl-source-file` passes (124 tests)
- [ ] `cargo clippy --workspace --lib` — no issues
- [ ] `cargo fmt -p perl-source-file` — no formatting drift
- [ ] Verify `.cgi` and `.psgi` files are recognized by `is_perl_source_extension`, `is_perl_source_path`, and `is_perl_source_uri`

Fixes #3492