### PR TITLE
fix(formatting): use character count instead of byte length for range positions (#3468)

### DIFF
--- a/crates/perl-lsp-formatting-types/src/lib.rs
+++ b/crates/perl-lsp-formatting-types/src/lib.rs
@@ -42,6 +42,15 @@ pub struct FormatRange {
     pub end: FormatPosition,
 }
 
+/// Count the number of UTF-16 code units in `s`.
+///
+/// LSP positions use UTF-16 code units (see Language Server Protocol spec §3.1).
+/// Characters in the Basic Multilingual Plane (U+0000–U+FFFF) count as 1 unit;
+/// supplementary-plane characters (U+10000 and above) count as 2 units.
+fn utf16_len(s: &str) -> usize {
+    s.chars().map(|c| if c as u32 >= 0x10000 { 2 } else { 1 }).sum()
+}
+
 impl FormatRange {
     /// Create a range covering the entire document.
     pub fn whole_document(content: &str) -> Self {
@@ -52,7 +61,10 @@ impl FormatRange {
             start: FormatPosition { line: 0, character: 0 },
             end: FormatPosition {
                 line: last_line,
-                character: lines.get(last_line as usize).map(|line| line.len() as u32).unwrap_or(0),
+                character: lines
+                    .get(last_line as usize)
+                    .map(|line| utf16_len(line) as u32)
+                    .unwrap_or(0),
             },
         }
     }

--- a/crates/perl-lsp-formatting-types/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-formatting-types/tests/comprehensive_unit_tests.rs
@@ -166,11 +166,15 @@ fn whole_document_multiple_lines_trailing_newline() {
 
 #[test]
 fn whole_document_unicode_content() {
-    // Each emoji is multiple bytes but .len() counts bytes
+    // LSP positions use UTF-16 code units, not byte lengths.
+    // "héllo": é (U+00E9) is 2 UTF-8 bytes but 1 UTF-16 code unit.
+    // "wörld": ö (U+00F6) is 2 UTF-8 bytes but 1 UTF-16 code unit.
+    // Both lines: 5 chars, 5 UTF-16 units, 6 bytes.
     let content = "héllo\nwörld";
     let range = FormatRange::whole_document(content);
     assert_eq!(range.end.line, 1);
-    assert_eq!(range.end.character, "wörld".len() as u32);
+    // "wörld" = 5 UTF-16 code units (ö is BMP, counts as 1 unit)
+    assert_eq!(range.end.character, 5);
 }
 
 #[test]

--- a/crates/perl-lsp-formatting/src/formatting.rs
+++ b/crates/perl-lsp-formatting/src/formatting.rs
@@ -4,6 +4,15 @@ pub use perl_lsp_formatting_types::{
     FormatPosition, FormatRange, FormatTextEdit, FormattedDocument, FormattingOptions,
 };
 
+/// Count the number of UTF-16 code units in `s`.
+///
+/// LSP positions use UTF-16 code units (see Language Server Protocol spec §3.1).
+/// Characters in the Basic Multilingual Plane (U+0000–U+FFFF) count as 1 unit;
+/// supplementary-plane characters (U+10000 and above) count as 2 units.
+fn utf16_len(s: &str) -> usize {
+    s.chars().map(|c| if c as u32 >= 0x10000 { 2 } else { 1 }).sum()
+}
+
 /// Formatting error.
 #[derive(Debug, thiserror::Error)]
 pub enum FormattingError {
@@ -110,7 +119,7 @@ impl<R: perl_lsp_tooling::SubprocessRuntime> FormattingProvider<R> {
         }
 
         let start_char = 0;
-        let end_char = lines[end_line].len() as u32;
+        let end_char = utf16_len(lines[end_line]) as u32;
 
         Ok(FormattedDocument {
             text: content.to_string(),

--- a/crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs
@@ -776,3 +776,82 @@ fn test_format_document_large_content() -> Result<(), Box<dyn std::error::Error>
     assert_eq!(doc.edits.len(), 1);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// UTF-8 / UTF-16 position encoding correctness
+// ---------------------------------------------------------------------------
+
+/// LSP positions use UTF-16 code units. A line ending with a multi-byte
+/// character like 'é' (U+00E9, 2 UTF-8 bytes, 1 UTF-16 code unit) must
+/// produce `end.character == 19` for the line, not 20 (byte length).
+#[test]
+fn test_format_range_utf8_end_character_is_utf16_count() -> Result<(), Box<dyn std::error::Error>> {
+    // Line 1: "my $café = \"hello\";"
+    // U+00E9 LATIN SMALL LETTER E WITH ACUTE: 2 UTF-8 bytes, 1 UTF-16 code unit
+    // chars().count() = 19, UTF-16 units = 19, UTF-8 bytes = 20
+    let source = "use strict;\nmy $caf\u{e9} = \"hello\";";
+    let runtime = MockSubprocessRuntime::new();
+    runtime.add_response(MockResponse::success(b"CHANGED".to_vec()));
+    let provider = make_provider(runtime);
+
+    let range = FormatRange::new(FormatPosition::new(0, 0), FormatPosition::new(1, 0));
+    let doc = must(provider.format_range(source, &range, &default_options()));
+
+    assert_eq!(doc.edits.len(), 1);
+    // 19 UTF-16 units (é is BMP, 1 unit) — not 20 (byte length)
+    assert_eq!(
+        doc.edits[0].range.end.character, 19,
+        "end.character must be UTF-16 code unit count (19), not byte length (20)"
+    );
+    Ok(())
+}
+
+/// Characters above U+FFFF (supplementary plane) count as 2 UTF-16 code
+/// units (surrogate pair). Verify the character position reflects that count,
+/// not the Rust char count (1) or byte length (4).
+#[test]
+fn test_format_range_supplementary_plane_char_is_two_utf16_units()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Line 1: "my $x = \"😀\";"
+    // U+1F600 GRINNING FACE: 4 UTF-8 bytes, 2 UTF-16 units, 1 Rust char
+    // chars().count() = 12, UTF-16 units = 13, UTF-8 bytes = 15
+    let source = "use strict;\nmy $x = \"\u{1F600}\";";
+    let runtime = MockSubprocessRuntime::new();
+    runtime.add_response(MockResponse::success(b"CHANGED".to_vec()));
+    let provider = make_provider(runtime);
+
+    let range = FormatRange::new(FormatPosition::new(0, 0), FormatPosition::new(1, 0));
+    let doc = must(provider.format_range(source, &range, &default_options()));
+
+    assert_eq!(doc.edits.len(), 1);
+    // 13 UTF-16 units: 11 BMP chars + 2 for the emoji surrogate pair
+    assert_eq!(
+        doc.edits[0].range.end.character, 13,
+        "supplementary plane char must count as 2 UTF-16 units (13 total), not 12 (char count) or 15 (bytes)"
+    );
+    Ok(())
+}
+
+/// `format_document` uses `FormatRange::whole_document` internally. The last
+/// line of a document containing multi-byte characters must produce a
+/// `end.character` that is a UTF-16 unit count, not a byte length.
+#[test]
+fn test_format_document_whole_document_range_utf16_end_char()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Last line: "café" — U+00E9 is 2 UTF-8 bytes but 1 UTF-16 unit
+    // chars().count() = 4, UTF-16 units = 4, UTF-8 bytes = 5
+    let source = "use strict;\ncaf\u{e9}";
+    let runtime = MockSubprocessRuntime::new();
+    runtime.add_response(MockResponse::success(b"CHANGED".to_vec()));
+    let provider = make_provider(runtime);
+
+    let doc = must(provider.format_document(source, &default_options()));
+
+    assert_eq!(doc.edits.len(), 1);
+    // "café": 4 UTF-16 units — not 5 (byte length)
+    assert_eq!(
+        doc.edits[0].range.end.character, 4,
+        "whole-document end.character must be UTF-16 code unit count (4), not byte length (5)"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Fixes #3468: range formatting produces incorrect edit positions for UTF-8 source files containing multi-byte characters
- LSP positions are specified in UTF-16 code units (spec §3.1), not UTF-8 byte lengths
- The previous code used `line.len()` (UTF-8 byte length) in two places, producing off-by-N positions for any line with multi-byte characters

## Changes

**`crates/perl-lsp-formatting/src/formatting.rs`**
- Add private `utf16_len(s: &str) -> usize` helper that counts UTF-16 code units (BMP = 1 unit, supplementary plane = 2 units)
- Replace `lines[end_line].len() as u32` with `utf16_len(lines[end_line]) as u32` in `format_range`

**`crates/perl-lsp-formatting-types/src/lib.rs`**
- Add same `utf16_len` helper
- Replace `line.len() as u32` with `utf16_len(line) as u32` in `FormatRange::whole_document`

**Tests added** (`crates/perl-lsp-formatting/tests/comprehensive_unit_tests.rs`):
- `test_format_range_utf8_end_character_is_utf16_count` — BMP multi-byte char `é` (U+00E9): 2 UTF-8 bytes, 1 UTF-16 unit
- `test_format_range_supplementary_plane_char_is_two_utf16_units` — emoji (U+1F600): 4 UTF-8 bytes, 2 UTF-16 units, 1 Rust char
- `test_format_document_whole_document_range_utf16_end_char` — exercises the `whole_document` path

**Test fixed** (`crates/perl-lsp-formatting-types/tests/comprehensive_unit_tests.rs`):
- `whole_document_unicode_content` was asserting the old byte-length behavior; updated to assert correct UTF-16 count

## Test plan

- [x] `cargo test -p perl-lsp-formatting` — 51 passed (3 new tests added)
- [x] `cargo test -p perl-lsp-formatting-types` — 44 passed (1 fixed test)
- [x] `cargo clippy -p perl-lsp-formatting -p perl-lsp-formatting-types --lib` — clean
- [x] `cargo fmt -p perl-lsp-formatting -p perl-lsp-formatting-types` — no changes needed

## Notes

Pre-push hook bypassed with `--no-verify`: the CI gate fails due to pre-existing unreachable pattern warnings in `crates/perl-lsp-diagnostics` (unrelated to this change; the issue exists on `origin/master` before this PR). This bypass is within the hook's stated bypass policy ("gate failing for an environmental reason out of band of your change").