### PR TITLE
fix(scope): array/hash subscript access marks parent variable as used (#3504)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -948,6 +948,25 @@ impl ScopeAnalyzer {
             }
         }
 
+        // When the parser interprets `print $arr[0]` as indirect-object syntax, it produces
+        // `IndirectCall { object: Variable($, "arr"), args: [ArrayLiteral([0])] }`.
+        // Similarly, `print $hash{a}` produces
+        // `IndirectCall { object: Variable($, "hash"), args: [Block([a])] }`.
+        // Bridge the sigil so that `@arr` / `%hash` are marked as used, not `$arr` / `$hash`.
+        if sigil == "$"
+            && let Some(parent) = ancestors.last()
+            && let NodeKind::IndirectCall { object, args, .. } = &parent.kind
+            && std::ptr::eq(object.as_ref(), node)
+        {
+            if let Some(first_arg) = args.first() {
+                match &first_arg.kind {
+                    NodeKind::ArrayLiteral { .. } => return Some(("@", name)),
+                    NodeKind::Block { .. } => return Some(("%", name)),
+                    _ => {}
+                }
+            }
+        }
+
         Some((sigil, name))
     }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -871,8 +871,7 @@ print $hash{a};
         .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hash"))
         .count();
     assert_eq!(
-        unused_hash,
-        0,
+        unused_hash, 0,
         "%hash should not be flagged as unused when accessed via $hash{{a}}"
     );
     Ok(())

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -843,6 +843,61 @@ $arr[0];
 }
 
 #[test]
+fn subscript_access_marks_array_parent_used() -> Result<(), Box<dyn std::error::Error>> {
+    // $arr[0] passed to a function should mark @arr as used — no unused-variable diagnostic.
+    let code = r#"
+my @arr = (1, 2, 3);
+print $arr[0];
+"#;
+    let issues = scope_issues(code);
+    let unused_arr = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("arr"))
+        .count();
+    assert_eq!(unused_arr, 0, "@arr should not be flagged as unused when accessed via $arr[0]");
+    Ok(())
+}
+
+#[test]
+fn subscript_access_marks_hash_parent_used() -> Result<(), Box<dyn std::error::Error>> {
+    // $hash{key} passed to a function should mark %hash as used — no unused-variable diagnostic.
+    let code = r#"
+my %hash = (a => 1);
+print $hash{a};
+"#;
+    let issues = scope_issues(code);
+    let unused_hash = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("hash"))
+        .count();
+    assert_eq!(
+        unused_hash,
+        0,
+        "%hash should not be flagged as unused when accessed via $hash{{a}}"
+    );
+    Ok(())
+}
+
+#[test]
+fn subscript_access_does_not_suppress_truly_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // A %hash or @array that is truly never accessed should still be flagged as unused.
+    let code = r#"
+my %unused_hash = (a => 1);
+my @unused_arr = (1, 2, 3);
+"#;
+    let issues = scope_issues(code);
+    let unused_hash = issues
+        .iter()
+        .any(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("unused_hash"));
+    let unused_arr = issues
+        .iter()
+        .any(|i| i.kind == IssueKind::UnusedVariable && i.variable_name.contains("unused_arr"));
+    assert!(unused_hash, "%unused_hash with no subscripts should still be flagged as unused");
+    assert!(unused_arr, "@unused_arr with no subscripts should still be flagged as unused");
+    Ok(())
+}
+
+#[test]
 fn unused_underscore_prefix_suppressed() -> Result<(), Box<dyn std::error::Error>> {
     // Variables prefixed with underscore should NOT be flagged as unused.
     let code = r#"

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 2843 lib tests (discovered), 3 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2846 lib tests (discovered), 3 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 2843 lib tests (Tier A), 3 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2846 lib tests (Tier A), 3 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->


### PR DESCRIPTION
## Summary

- **Bug**: `print $arr[0]` and `print $hash{a}` caused false "unused variable" diagnostics for `@arr` and `%hash`
- **Root cause**: The parser represents `print $arr[0]` as `IndirectCall { object: Variable($, "arr"), args: [ArrayLiteral([0])] }` (indirect-object syntax). The `resolve_variable_use_target` helper only bridged `$` → `@`/`%` for `Binary { op: "[]" }` and `Binary { op: "{}" }` parents, not for `IndirectCall` parents.
- **Fix**: Added an `IndirectCall` case to `resolve_variable_use_target` — when the variable is the `object` of an `IndirectCall` and the first arg is `ArrayLiteral` (array subscript), bridge to `@`; if first arg is `Block` (hash subscript), bridge to `%`.

## Test plan

- [x] `subscript_access_marks_array_parent_used` — `print $arr[0]` no longer flags `@arr` as unused
- [x] `subscript_access_marks_hash_parent_used` — `print $hash{a}` no longer flags `%hash` as unused  
- [x] `subscript_access_does_not_suppress_truly_unused` — truly unused `@arr`/`%hash` are still flagged
- [x] All 75 existing `scope_and_symbol_tests` continue to pass
- [x] `cargo clippy -p perl-semantic-analyzer --lib` — no new warnings
- [x] `rustfmt --check` — no formatting drift

## Knowledge artifacts

- The parser parses `print $var[idx]` and `print $var{key}` as `IndirectCall` (indirect-object syntax: `print FILEHANDLE LIST`). The parser treats `$var` as the filehandle and `[idx]`/`{key}` as the argument list — `ArrayLiteral` for array subscripts, `Block` for hash subscripts.
- The bare `$arr[0];` case (not inside a function call) was already correctly handled via the `Binary { op: "[]" }` parent check. Only the `IndirectCall` wrapper was missing.