### PR TITLE
fix(scope): recognize local $/ and other special variables as builtins (#3502)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -448,6 +448,25 @@ impl ScopeAnalyzer {
                 let is_our = declarator == "our";
                 let is_initialized = initializer.is_some();
 
+                // `local` of a builtin special variable (e.g. `local $/`, `local $,`) temporarily
+                // modifies the global; it does not create a new lexical binding.  Declaring it in
+                // the lexical scope would cause a spurious UnusedVariable diagnostic because all
+                // later uses of `$/` etc. are recognised by is_builtin_global and never counted as
+                // uses of the scope entry.  Skip the declaration entirely and only analyse any
+                // initialiser expression that may be present.
+                if declarator == "local" && is_builtin_global(sigil, var_name_part) {
+                    // For `local $special = expr`, the parser embeds the assignment inside
+                    // `variable` as an Assignment node rather than in `initializer`.  Walk the
+                    // variable node's children to pick up any RHS expressions.
+                    if let Some(init) = initializer {
+                        self.analyze_node(init, scope, ancestors, issues, context);
+                    }
+                    if let NodeKind::Assignment { rhs, .. } = &variable.kind {
+                        self.analyze_node(rhs, scope, ancestors, issues, context);
+                    }
+                    return;
+                }
+
                 // If checking initializer first (e.g. my $x = $x), we need to analyze initializer in
                 // current scope BEFORE declaring the variable (standard Perl behavior)
                 // Actually Perl evaluates RHS before LHS assignment, so usages in initializer refer to OUTER scope.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -280,6 +280,140 @@ sub modify_it {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// 3b. local with builtin special variables — issue #3502
+// ---------------------------------------------------------------------------
+
+#[test]
+fn local_input_record_sep_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $/` (slurp mode) must not produce a false UnusedVariable diagnostic.
+    let code = "use strict;\nlocal $/ = undef;\n";
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$/"
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $/ should produce no false UnusedVariable or UndeclaredVariable; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
+#[test]
+fn local_output_field_sep_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $,` (output field separator) must not produce a false UnusedVariable diagnostic.
+    let code = "use strict;\nlocal $, = \", \";\nprint \"a\", \"b\";\n";
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$,"
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $, should produce no false diagnostics; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
+#[test]
+fn local_output_record_sep_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $\` (output record separator) must not produce false diagnostics.
+    let code = "use strict;\nlocal $\\ = \"\\n\";\nprint \"hello\";\n";
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$\\"
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $\\ should produce no false diagnostics; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
+#[test]
+fn local_list_sep_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $"` (list separator) must not produce false diagnostics.
+    let code = "use strict;\nlocal $\" = \"-\";\nmy @arr = (1, 2);\nprint \"@arr\";\n";
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$\""
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $\" should produce no false diagnostics; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
+#[test]
+fn local_special_var_in_block_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $/` without an initializer in a block must not produce false diagnostics.
+    let code = "use strict;\n{\n    local $/;\n    my $data = <STDIN>;\n    print $data;\n}\n";
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$/"
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $/ (no initializer) should produce no false diagnostics; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
+#[test]
+fn local_special_var_in_sub_no_false_unused() -> Result<(), Box<dyn std::error::Error>> {
+    // `local $/` inside a subroutine must not produce false diagnostics.
+    let code = r#"use strict;
+use warnings;
+sub slurp {
+    my ($file) = @_;
+    open(my $fh, '<', $file) or die $!;
+    local $/ = undef;
+    my $content = <$fh>;
+    close($fh);
+    return $content;
+}
+"#;
+    let issues = scope_issues_strict(code);
+    let false_pos: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            (i.kind == IssueKind::UnusedVariable || i.kind == IssueKind::UndeclaredVariable)
+                && i.variable_name == "$/"
+        })
+        .collect();
+    assert!(
+        false_pos.is_empty(),
+        "local $/ inside sub should produce no false diagnostics; got: {:?}",
+        false_pos
+    );
+    Ok(())
+}
+
 // ===========================================================================
 // 4. Variable Scope Resolution — state
 // ===========================================================================


### PR DESCRIPTION
## Summary
- `local $/`, `local $,`, `local $\`, and `local $"` were producing spurious `UnusedVariable` diagnostics
- Root cause: the scope analyzer was adding builtin special variables to the lexical scope as ordinary lexical bindings; since all use-site paths call `is_builtin_global` and skip, the scope entry was never marked used, triggering `UnusedVariable`
- Fix: in the `NodeKind::VariableDeclaration` handler, detect `declarator == "local"` + `is_builtin_global(sigil, name)` and skip `declare_variable_parts` entirely; also analyze any RHS initializer expression embedded in the `Assignment` node that the parser places inside the `variable` field for `local $x = expr`

## Test plan
- [ ] 6 new tests in `scope_and_symbol_tests.rs` section "3b. local with builtin special variables — issue #3502" covering `$/`, `$,`, `$\`, `$"` — plain, with initializer, in a block, in a sub
- [ ] `cargo test -p perl-semantic-analyzer` — all new tests pass; only pre-existing `symbol_extraction_method_preserves_attributes` failure remains
- [ ] `cargo clippy -p perl-semantic-analyzer --lib` — clean
- [ ] `cargo fmt -p perl-semantic-analyzer` — clean
- [ ] Full workspace lib tests: 2846 passed