### PR TITLE
fix(scope): correct doc comment and strengthen position-zero test (#3423 followup)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1852,8 +1852,9 @@ fn is_known_function(name: &str) -> bool {
 /// used avoids false diagnostics after the call.
 ///
 /// Position semantics:
-/// - Position 0: `open`, `opendir`, `sysopen`, `socket`, `accept`, `socketpair`
-/// - Position 1: `read`, `sysread`, `recv`, `socketpair` (second handle)
+/// - Position 0: `open`, `opendir`, `sysopen`, `socket`, `accept`, `dbmopen`
+/// - Position 1: `read`, `sysread`, `recv`, `shmread`
+/// - Positions 0 and 1: `pipe`, `socketpair`
 fn builtin_declaration_arg_positions(name: &str) -> &'static [usize] {
     match name {
         // Position 0: the first argument is the new handle/socket

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2519,22 +2519,28 @@ print $data;
 #[test]
 fn read_position_zero_not_treated_as_declaration() -> Result<(), Box<dyn std::error::Error>> {
     // Position 0 in `read` is an existing filehandle, NOT a declaration target.
-    // Passing a bare (non-declaration) variable at position 0 should not affect its
-    // declaration status — it must have been declared separately.
+    // An undeclared handle at position 0 should still be flagged, while the
+    // position-1 buffer should be treated as the declaration/initialization target.
     let code = r#"
 use strict;
-my $fh = \*STDIN;
-my $buffer;
-read $fh, $buffer, 1024;
+read $undeclared_fh, my $buffer, 1024;
 print $buffer;
 "#;
     let issues = scope_issues_strict(code);
     assert!(
+        issues.iter().any(|i| {
+            i.variable_name.contains("undeclared_fh")
+                && matches!(i.kind, IssueKind::UndeclaredVariable)
+        }),
+        "undeclared read handle should still be flagged (issues: {:?})",
+        issues
+    );
+    assert!(
         !issues.iter().any(|i| {
-            i.variable_name.contains("fh")
+            i.variable_name.contains("buffer")
                 && matches!(i.kind, IssueKind::UndeclaredVariable | IssueKind::UnusedVariable)
         }),
-        "existing $fh should not be flagged (issues: {:?})",
+        "read buffer declaration should not be flagged (issues: {:?})",
         issues
     );
     Ok(())


### PR DESCRIPTION
## Summary

Two quality issues introduced in the squash merge of PR #3423:

- **Misleading doc comment**: `builtin_declaration_arg_positions` listed `socketpair` under "Position 0" but the code correctly returns `&[0, 1]` for it. Also `dbmopen` (pos 0) and `shmread` (pos 1) from PR #3347 were missing from the doc. The comment now accurately reflects all entries.
- **Vacuous test**: `read_position_zero_not_treated_as_declaration` tested a pre-declared `my $fh = \*STDIN` — the assertion passed regardless of whether the position-0 guard worked. Replaced with a test that passes `$undeclared_fh` at position 0 and asserts it IS flagged as UndeclaredVariable while `$buf` at position 1 is not.

No logic changes — the `builtin_declaration_arg_positions` function is correct. This PR only fixes the doc and test quality.

Closes #3345 followup quality items found during deep review.

## Test plan

- [ ] `cargo test -p perl-semantic-analyzer -- read_position_zero_not_treated_as_declaration` passes
- [ ] `cargo clippy -p perl-semantic-analyzer --lib` — 0 warnings