### PR TITLE
fix(workspace): exclude blib/, local/, vendor/ from file discovery (#3493)

### DIFF
--- a/crates/perl-workspace-ignore/src/lib.rs
+++ b/crates/perl-workspace-ignore/src/lib.rs
@@ -10,7 +10,8 @@
 
 use std::path::{Component, Path};
 
-const SKIPPED_DIRS: [&str; 6] = [".git", ".hg", ".svn", "target", "node_modules", ".cache"];
+const SKIPPED_DIRS: [&str; 9] =
+    [".git", ".hg", ".svn", "target", "node_modules", ".cache", "blib", "local", "vendor"];
 
 /// Returns true when `name` matches one of the canonical workspace noise directories.
 #[must_use]
@@ -71,6 +72,21 @@ mod tests {
     }
 
     #[test]
+    fn test_skipped_dir_name_blib_matches() {
+        assert!(is_skipped_dir_name("blib"));
+    }
+
+    #[test]
+    fn test_skipped_dir_name_local_matches() {
+        assert!(is_skipped_dir_name("local"));
+    }
+
+    #[test]
+    fn test_skipped_dir_name_vendor_matches() {
+        assert!(is_skipped_dir_name("vendor"));
+    }
+
+    #[test]
     fn test_skipped_dir_name_all_canonical_patterns() {
         // Verify every entry in the constant is recognized
         for name in &SKIPPED_DIRS {
@@ -80,14 +96,14 @@ mod tests {
 
     #[test]
     fn test_skipped_dir_name_constant_has_expected_count() {
-        assert_eq!(SKIPPED_DIRS.len(), 6);
+        assert_eq!(SKIPPED_DIRS.len(), 9);
     }
 
     // ── is_skipped_dir_name: non-matching names ────────────────────────
 
     #[test]
     fn test_skipped_dir_name_rejects_common_directories() {
-        for name in ["src", "lib", "blib", "tmp", "vendor", "dist", "build"] {
+        for name in ["src", "lib", "tmp", "dist", "build"] {
             assert!(!is_skipped_dir_name(name), "'{name}' should not be skipped");
         }
     }


### PR DESCRIPTION
## Summary

- Adds `blib`, `local`, and `vendor` to the `SKIPPED_DIRS` constant in `perl-workspace-ignore`
- These are standard Perl build/install artifact directories that cause duplicate symbol noise during workspace discovery
- Array size constant updated from 6 to 9
- Tests updated: count assertion bumped; `blib`/`vendor` removed from the "should not be skipped" negative test; three new positive tests added

## Replaces

Closes #3546 (mislabeled — pushed to wrong branch). This is the clean reimplementation.

Fixes #3493

## Scope

`git diff --stat` shows exactly 1 file changed: `crates/perl-workspace-ignore/src/lib.rs`

## Test plan

- [x] `cargo test -p perl-workspace-ignore` — 46 tests pass
- [x] `cargo fmt -p perl-workspace-ignore` — no changes needed
- [x] `cargo clippy -p perl-workspace-ignore` — no issues
- [x] `is_skipped_dir_name("blib")` returns true
- [x] `is_skipped_dir_name("local")` returns true
- [x] `is_skipped_dir_name("vendor")` returns true
- [x] `test_skipped_dir_name_constant_has_expected_count` asserts 9
- [x] `test_skipped_dir_name_rejects_common_directories` no longer tests blib/vendor