### PR TITLE
fix(scope): pass analysis context through foreach initialization (#3638)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -985,7 +985,7 @@ impl ScopeAnalyzer {
                 // Declare the loop variable and immediately mark it initialized — the list
                 // provides its value at runtime so there is no uninitialized window.
                 self.analyze_node(variable, &loop_scope, ancestors, issues, context);
-                self.mark_initialized(variable, &loop_scope);
+                self.mark_initialized(variable, &loop_scope, context);
                 self.analyze_node(list, &loop_scope, ancestors, issues, context);
                 self.analyze_node(body, &loop_scope, ancestors, issues, context);
                 if let Some(cb) = continue_block {


### PR DESCRIPTION
## Summary

- fixes the `Foreach` scope-analysis path to pass `AnalysisContext` into `mark_initialized`
- restores compatibility with the newer `mark_initialized(node, scope, context)` signature
- unblocks rebased branches that currently fail `PR Smoke` for an unrelated master-tip compile error

## Validation

- [x] `just clippy-core`
