### PR TITLE
fix(diagnostics): per-function builtin version thresholds (#3634)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -49,6 +49,36 @@ const FEATURE_VERSIONS: &[(&str, u32, u32)] = &[
     ("builtin", 5, 40),
 ];
 
+/// `builtin` bundle and import minimums.
+///
+/// The namespace-level bundle still gates at 5.40, but individual functions
+/// were introduced across multiple releases.
+const BUILTIN_BUNDLE_MIN_VERSION: PerlVersion = PerlVersion::new(5, 40);
+
+const BUILTIN_FUNCTION_VERSIONS: &[(&str, u32, u32)] = &[
+    ("true", 5, 36),
+    ("false", 5, 36),
+    ("is_bool", 5, 36),
+    ("inf", 5, 40),
+    ("nan", 5, 40),
+    ("weaken", 5, 36),
+    ("unweaken", 5, 36),
+    ("is_weak", 5, 36),
+    ("blessed", 5, 36),
+    ("refaddr", 5, 36),
+    ("reftype", 5, 36),
+    ("created_as_string", 5, 36),
+    ("created_as_number", 5, 36),
+    ("stringify", 5, 36),
+    ("ceil", 5, 36),
+    ("floor", 5, 36),
+    ("indexed", 5, 36),
+    ("trim", 5, 36),
+    ("is_tainted", 5, 38),
+    ("export_lexically", 5, 38),
+    ("load_module", 5, 40),
+];
+
 const GIVEN_WHEN_DEPRECATION_VERSION: PerlVersion = PerlVersion::new(5, 38);
 const GIVEN_WHEN_REMOVAL_VERSION: PerlVersion = PerlVersion::new(5, 42);
 
@@ -65,7 +95,8 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 
     let mut declared_version: Option<PerlVersion> = None;
     let mut explicit_features: Vec<String> = Vec::new();
-    let mut use_builtin_declared = false;
+    let mut builtin_imports: Vec<String> = Vec::new();
+    let mut builtin_bundle_declared = false;
 
     for stmt in statements {
         if let NodeKind::Use { module, args, .. } = &stmt.kind {
@@ -87,7 +118,25 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 }
             }
             if module == "builtin" {
-                use_builtin_declared = true;
+                if args.is_empty() {
+                    builtin_bundle_declared = true;
+                }
+
+                for arg in args {
+                    let name = normalize_builtin_import(arg);
+                    if name.is_empty() {
+                        continue;
+                    }
+
+                    if name.starts_with(':') {
+                        builtin_bundle_declared = true;
+                        continue;
+                    }
+
+                    if !builtin_imports.contains(&name) {
+                        builtin_imports.push(name);
+                    }
+                }
             }
         }
     }
@@ -182,16 +231,49 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             }
 
             NodeKind::FunctionCall { name, .. } if name.starts_with("builtin::") => {
-                if !effective_features.contains(&"builtin") && !use_builtin_declared {
-                    let min = feature_min_version("builtin");
-                    diagnostics.push(make_diagnostic(n, "builtin::", declared_version, min));
+                let builtin_name = name.trim_start_matches("builtin::");
+                let min = builtin_min_version(builtin_name);
+                let imported = builtin_imports.iter().any(|import| import == builtin_name);
+
+                if declared_version < min && !builtin_bundle_declared && !imported {
+                    diagnostics.push(make_diagnostic(
+                        n,
+                        name,
+                        declared_version,
+                        (min.major, min.minor),
+                    ));
                 }
             }
 
-            NodeKind::Use { module, .. } if module == "builtin" => {
-                if !effective_features.contains(&"builtin") {
-                    let min = feature_min_version("builtin");
-                    diagnostics.push(make_diagnostic(n, "use builtin", declared_version, min));
+            NodeKind::Use { module, args, .. } if module == "builtin" => {
+                if args.is_empty() {
+                    if declared_version < BUILTIN_BUNDLE_MIN_VERSION {
+                        diagnostics.push(make_diagnostic(
+                            n,
+                            "use builtin",
+                            declared_version,
+                            (BUILTIN_BUNDLE_MIN_VERSION.major, BUILTIN_BUNDLE_MIN_VERSION.minor),
+                        ));
+                    }
+                    return;
+                }
+
+                for arg in args {
+                    let name = normalize_builtin_import(arg);
+                    if name.is_empty() {
+                        continue;
+                    }
+
+                    let min = builtin_import_min_version(&name);
+                    if declared_version < min {
+                        let display = format!("use builtin {}", arg);
+                        diagnostics.push(make_diagnostic(
+                            n,
+                            &display,
+                            declared_version,
+                            (min.major, min.minor),
+                        ));
+                    }
                 }
             }
 
@@ -246,6 +328,27 @@ fn feature_min_version(feature: &str) -> (u32, u32) {
         .find(|(name, _, _)| *name == feature)
         .map(|(_, maj, min)| (*maj, *min))
         .unwrap_or((5, 0))
+}
+
+/// Return the minimum Perl version for a `builtin::name` call or named import.
+fn builtin_min_version(name: &str) -> PerlVersion {
+    BUILTIN_FUNCTION_VERSIONS
+        .iter()
+        .find(|(builtin_name, _, _)| *builtin_name == name)
+        .map(|(_, maj, min)| PerlVersion::new(*maj, *min))
+        .unwrap_or(BUILTIN_BUNDLE_MIN_VERSION)
+}
+
+fn builtin_import_min_version(name: &str) -> PerlVersion {
+    if let Some(bundle) = name.strip_prefix(':') {
+        return parse_perl_version(bundle).unwrap_or(BUILTIN_BUNDLE_MIN_VERSION);
+    }
+
+    builtin_min_version(name)
+}
+
+fn normalize_builtin_import(arg: &str) -> String {
+    arg.trim_matches(|c| c == '\'' || c == '"').to_string()
 }
 
 /// Return `true` when a node represents the `defer { ... }` feature form.

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -1043,9 +1043,13 @@ fn test_defer_helper_call_is_not_version_feature() -> Result<(), Box<dyn std::er
 // ---------------------------------------------------------------------------
 
 fn builtin_floor_call() -> Node {
+    builtin_call("builtin::floor")
+}
+
+fn builtin_call(name: &str) -> Node {
     Node::new(
         NodeKind::FunctionCall {
-            name: "builtin::floor".to_string(),
+            name: name.to_string(),
             args: vec![Node::new(
                 NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() },
                 loc(30, 32),
@@ -1056,63 +1060,51 @@ fn builtin_floor_call() -> Node {
 }
 
 fn use_builtin_node() -> Node {
+    use_builtin_import("'floor'")
+}
+
+fn use_builtin_import(import: &str) -> Node {
     Node::new(
         NodeKind::Use {
             module: "builtin".to_string(),
-            args: vec!["'floor'".to_string()],
+            args: vec![import.to_string()],
             has_filter_risk: false,
         },
         loc(0, 22),
     )
 }
 
-fn scalar_var(name: &str) -> Node {
-    Node::new(NodeKind::Variable { sigil: "$".to_string(), name: name.to_string() }, loc(20, 22))
-}
-
-fn given_node() -> Node {
+fn isa_node() -> Node {
     Node::new(
-        NodeKind::Given { expr: Box::new(scalar_var("x")), body: Box::new(block(vec![])) },
-        loc(20, 40),
+        NodeKind::Binary {
+            op: "isa".to_string(),
+            left: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "obj".to_string() },
+                loc(24, 28),
+            )),
+            right: Box::new(Node::new(
+                NodeKind::String { value: "MyClass".to_string(), interpolated: false },
+                loc(29, 38),
+            )),
+        },
+        loc(20, 38),
     )
-}
-
-fn when_node() -> Node {
-    Node::new(
-        NodeKind::When { condition: Box::new(scalar_var("x")), body: Box::new(block(vec![])) },
-        loc(20, 40),
-    )
-}
-
-fn default_node() -> Node {
-    Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(20, 35))
-}
-
-fn defer_call() -> Node {
-    Node::new(NodeKind::FunctionCall { name: "defer".to_string(), args: vec![] }, loc(20, 27))
 }
 
 // ---------------------------------------------------------------------------
-// Test 25: builtin::floor in v5.36 -> warns (requires v5.40+)
+// Test 25: builtin::floor in v5.36 -> ok (available since v5.36)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_builtin_qualified_call_warns_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+fn test_builtin_qualified_call_floor_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("v5.36"), builtin_floor_call()]);
     let mut diagnostics = vec![];
     check_version_compat(&ast, &mut diagnostics);
 
     assert!(
-        diagnostics_have_code(&diagnostics, "PL900"),
-        "Expected PL900 warning for 'builtin::floor' in v5.36, got: {:?}",
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'builtin::floor' in v5.36, got: {:?}",
         diagnostics
-    );
-    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
-    assert!(msg.message.contains("builtin"), "Message should mention 'builtin': {}", msg.message);
-    assert!(
-        msg.message.contains("v5.40") || msg.message.contains("5.40"),
-        "Message should mention minimum version v5.40: {}",
-        msg.message
     );
     Ok(())
 }
@@ -1136,166 +1128,122 @@ fn test_builtin_qualified_call_ok_on_v5_40() -> Result<(), Box<dyn std::error::E
 }
 
 // ---------------------------------------------------------------------------
-// Test 27: `use builtin` pragma in v5.36 -> warns (requires v5.40+)
+// Test 27: `use builtin 'floor'` in v5.36 -> ok (available since v5.36)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_use_builtin_warns_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+fn test_use_builtin_floor_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("v5.36"), use_builtin_node()]);
     let mut diagnostics = vec![];
     check_version_compat(&ast, &mut diagnostics);
 
     assert!(
-        diagnostics_have_code(&diagnostics, "PL900"),
-        "Expected PL900 warning for 'use builtin' in v5.36, got: {:?}",
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for 'use builtin \"floor\"' in v5.36, got: {:?}",
         diagnostics
     );
-    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
-    assert!(msg.message.contains("builtin"), "Message should mention 'builtin': {}", msg.message);
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Test 28: `use builtin` pragma in v5.40 -> no warn
+// Test 28: builtin bundle import in v5.36 -> warns (requires v5.40+)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_use_builtin_ok_on_v5_40() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.40"), use_builtin_node()]);
+fn test_use_builtin_bundle_warns_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.36"), use_builtin_import("':5.40'")]);
     let mut diagnostics = vec![];
     check_version_compat(&ast, &mut diagnostics);
 
     assert!(
-        no_compat_warnings(&diagnostics),
-        "Expected no PL900 warning for 'use builtin' in v5.40, got: {:?}",
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for 'use builtin \":5.40\"' in v5.36, got: {:?}",
         diagnostics
     );
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Test 29: `use builtin` on old version suppresses builtin:: call warning
+// Test 29: builtin import on old version suppresses duplicate qualified-call warning
 // ---------------------------------------------------------------------------
 
 #[test]
 fn test_use_builtin_suppresses_qualified_call_warning() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.36"), use_builtin_node(), builtin_floor_call()]);
+    let ast = program(vec![
+        use_node("v5.38"),
+        use_builtin_import("'load_module'"),
+        builtin_call("builtin::load_module"),
+    ]);
     let mut diagnostics = vec![];
     check_version_compat(&ast, &mut diagnostics);
 
     let pl900_count = diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL900")).count();
     assert!(
         pl900_count <= 1,
-        "Expected at most one PL900 for 'use builtin' + 'builtin::floor' on v5.36, got {} warnings: {:?}",
+        "Expected at most one PL900 for 'use builtin load_module' + 'builtin::load_module' on v5.38, got {} warnings: {:?}",
         pl900_count,
         diagnostics
     );
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Test 21: switch-family nodes in v5.8 -> each warns (requires v5.10+)
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_switch_family_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.8"), given_node(), when_node(), default_node()]);
-    let mut diagnostics = vec![];
-    check_version_compat(&ast, &mut diagnostics);
+fn test_builtin_qualified_calls_have_distinct_minimum_versions()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        ("builtin::floor", "v5.36", false),
+        ("builtin::is_tainted", "v5.36", true),
+        ("builtin::is_tainted", "v5.38", false),
+        ("builtin::export_lexically", "v5.36", true),
+        ("builtin::export_lexically", "v5.38", false),
+        ("builtin::load_module", "v5.38", true),
+        ("builtin::load_module", "v5.40", false),
+    ];
 
-    let pl900: Vec<_> = diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL900")).collect();
-    assert_eq!(
-        pl900.len(),
-        3,
-        "Expected three PL900 warnings for given/when/default in v5.8, got: {:?}",
-        diagnostics
-    );
-    assert!(pl900.iter().any(|d| d.message.contains("given")));
-    assert!(pl900.iter().any(|d| d.message.contains("when")));
-    assert!(pl900.iter().any(|d| d.message.contains("default")));
+    for (name, version, should_warn) in cases {
+        let ast = program(vec![use_node(version), builtin_call(name)]);
+        let mut diagnostics = vec![];
+        check_version_compat(&ast, &mut diagnostics);
+
+        assert_eq!(
+            diagnostics_have_code(&diagnostics, "PL900"),
+            should_warn,
+            "Unexpected builtin:: compatibility result for {name} on {version}: {:?}",
+            diagnostics
+        );
+    }
+
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Test 22: switch-family nodes in v5.10 -> no warnings
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_switch_family_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.10"), given_node(), when_node(), default_node()]);
-    let mut diagnostics = vec![];
-    check_version_compat(&ast, &mut diagnostics);
+fn test_builtin_imports_have_distinct_minimum_versions() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = [
+        ("'floor'", "v5.36", false),
+        ("'is_tainted'", "v5.36", true),
+        ("'is_tainted'", "v5.38", false),
+        ("'export_lexically'", "v5.36", true),
+        ("'export_lexically'", "v5.38", false),
+        ("'load_module'", "v5.38", true),
+        ("'load_module'", "v5.40", false),
+        ("':5.40'", "v5.38", true),
+        ("':5.40'", "v5.40", false),
+    ];
 
-    assert!(
-        no_compat_warnings(&diagnostics),
-        "Expected no PL900 warnings for given/when/default in v5.10, got: {:?}",
-        diagnostics
-    );
+    for (import, version, should_warn) in cases {
+        let ast = program(vec![use_node(version), use_builtin_import(import)]);
+        let mut diagnostics = vec![];
+        check_version_compat(&ast, &mut diagnostics);
+
+        assert_eq!(
+            diagnostics_have_code(&diagnostics, "PL900"),
+            should_warn,
+            "Unexpected builtin import compatibility result for {import} on {version}: {:?}",
+            diagnostics
+        );
+    }
+
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Test 23: defer in v5.34 -> warns (requires v5.36+)
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_defer_warns_on_v5_34() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.34"), defer_call()]);
-    let mut diagnostics = vec![];
-    check_version_compat(&ast, &mut diagnostics);
-
-    assert!(
-        diagnostics_have_code(&diagnostics, "PL900"),
-        "Expected PL900 warning for defer in v5.34, got: {:?}",
-        diagnostics
-    );
-    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
-    assert!(msg.message.contains("defer"), "Message should mention 'defer': {}", msg.message);
-    assert!(
-        msg.message.contains("v5.36") || msg.message.contains("5.36"),
-        "Message should mention minimum version v5.36: {}",
-        msg.message
-    );
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Test 24: defer in v5.36 -> no warnings
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_defer_ok_on_v5_36() -> Result<(), Box<dyn std::error::Error>> {
-    let ast = program(vec![use_node("v5.36"), defer_call()]);
-    let mut diagnostics = vec![];
-    check_version_compat(&ast, &mut diagnostics);
-
-    assert!(
-        no_compat_warnings(&diagnostics),
-        "Expected no PL900 warning for defer in v5.36, got: {:?}",
-        diagnostics
-    );
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Helper: build an `isa` binary operator node
-// ---------------------------------------------------------------------------
-
-fn isa_node() -> Node {
-    Node::new(
-        NodeKind::Binary {
-            op: "isa".to_string(),
-            left: Box::new(Node::new(
-                NodeKind::Variable { sigil: "$".to_string(), name: "obj".to_string() },
-                loc(24, 28),
-            )),
-            right: Box::new(Node::new(
-                NodeKind::String { value: "MyClass".to_string(), interpolated: false },
-                loc(29, 38),
-            )),
-        },
-        loc(20, 38),
-    )
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Split builtin version checks so qualified calls and named `use builtin` imports use per-function minimum versions. Leaves bare imported-call resolution out of scope.\n\nValidation:\n- cargo fmt --all --check\n- cargo test -p perl-lsp-diagnostics --test version_compat_tests