### PR TITLE
fix(parser): keep typed signatures off the prototype path (#3643)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -882,6 +882,26 @@ impl<'a> Parser<'a> {
                             // `$x`, `@arr`, etc. → signature
                             return Ok(false);
                         }
+                        if let Ok(third) = self.tokens.peek_third() {
+                            let third_starts_signature = match third.kind {
+                                TokenKind::Identifier => third
+                                    .text
+                                    .chars()
+                                    .next()
+                                    .is_some_and(|c| matches!(c, '$' | '@' | '%' | '*' | '&')),
+                                TokenKind::ScalarSigil
+                                | TokenKind::ArraySigil
+                                | TokenKind::HashSigil
+                                | TokenKind::SubSigil
+                                | TokenKind::GlobSigil => true,
+                                _ => false,
+                            };
+
+                            if third_starts_signature {
+                                // `Type $x`, `Role @rest`, etc. are typed signatures.
+                                return Ok(false);
+                            }
+                        }
                         // Bare alphabetic identifier with no sigil (e.g., `XYZ`, `foo`) →
                         // treat as prototype candidate; invalid chars will be warned about.
                         true
@@ -1012,6 +1032,25 @@ mod prototype_heuristic_tests {
 
         if let NodeKind::Subroutine { signature, .. } = &node.kind {
             assert!(signature.is_some(), "sub foo($x, $y) should have a signature");
+        }
+    }
+
+    #[test]
+    fn typed_signature_with_type_constraint() {
+        let node = parse_sub("sub foo(Type $x) {}");
+        assert!(node.is_some(), "expected parsed subroutine for `sub foo(Type $x) {{}}`");
+        let Some(node) = node else {
+            return;
+        };
+        assert!(
+            matches!(&node.kind, NodeKind::Subroutine { .. }),
+            "expected Subroutine node, got {}",
+            node.kind.kind_name()
+        );
+
+        if let NodeKind::Subroutine { signature, prototype, .. } = &node.kind {
+            assert!(signature.is_some(), "typed signature should keep a signature");
+            assert!(prototype.is_none(), "typed signature should not become a prototype");
         }
     }
 

--- a/crates/perl-parser-core/tests/fix_prototype_validation_3355.rs
+++ b/crates/perl-parser-core/tests/fix_prototype_validation_3355.rs
@@ -110,6 +110,11 @@ fn invalid_proto_bare_mixed() {
     assert_has_prototype_warning("sub mixed_proto (XY) { }");
 }
 
+#[test]
+fn typed_signature_type_constraint_does_not_warn() {
+    assert_no_prototype_warning("sub typed_sig (Type $x) { }");
+}
+
 // --- Structural check: invalid prototype still parses as a subroutine ---
 
 #[test]


### PR DESCRIPTION
## Summary

- keep `Type $x`-style typed signatures on the signature parse path
- only treat bare identifiers as prototype candidates when they are not followed by a signature variable
- add regressions for AST classification and prototype-warning suppression

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/perl-lsp-review-3643-target cargo test -p perl-parser-core --test fix_prototype_validation_3355 typed_signature_type_constraint_does_not_warn`
- `CARGO_TARGET_DIR=/tmp/perl-lsp-review-3643-target cargo test -p perl-parser-core prototype_heuristic_tests::typed_signature_with_type_constraint`
