### PR TITLE
fix(diagnostics): surface parse warning codes consistently (#3644)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -4,7 +4,6 @@
 
 use std::path::Path;
 
-use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::Node;
 use perl_parser_core::error::ParseError;
 use perl_pragma::PragmaTracker;
@@ -24,7 +23,7 @@ use crate::lints::strict_warnings::check_strict_warnings;
 use crate::lints::unreachable_code::check_unreachable_code;
 use crate::lints::unused_imports::check_unused_imports;
 use crate::lints::version_compat::check_version_compat;
-use crate::parse_errors::parse_error_severity;
+use crate::parse_errors::{parse_error_code, parse_error_severity};
 use crate::scope::scope_issues_to_diagnostics;
 
 // Re-export diagnostic types from the shared SRP microcrate.
@@ -107,15 +106,11 @@ impl DiagnosticsProvider {
                 })
                 .unwrap_or_default();
 
-            let code = match error {
-                ParseError::UnexpectedEof => DiagnosticCode::UnexpectedEof,
-                ParseError::SyntaxError { .. } => DiagnosticCode::SyntaxError,
-                _ => DiagnosticCode::ParseError,
-            };
+            let code = parse_error_code(error);
 
             diagnostics.push(Diagnostic {
                 range: (range_start, range_end),
-                severity: parse_error_severity(error, &message),
+                severity: parse_error_severity(error),
                 code: Some(code.as_str().to_string()),
                 message,
                 related_information,

--- a/crates/perl-lsp-diagnostics/src/lib.rs
+++ b/crates/perl-lsp-diagnostics/src/lib.rs
@@ -46,6 +46,7 @@ mod walker;
 
 pub use diagnostics::DiagnosticsProvider;
 pub use heredoc_antipatterns::detect_heredoc_antipatterns;
+pub use parse_errors::{parse_error_code, parse_error_severity};
 pub use perl_lsp_diagnostic_types::{
     Diagnostic, DiagnosticSeverity, DiagnosticTag, RelatedInformation,
 };

--- a/crates/perl-lsp-diagnostics/src/parse_errors.rs
+++ b/crates/perl-lsp-diagnostics/src/parse_errors.rs
@@ -8,9 +8,21 @@
 //! |------|----------|-------------|
 //! | `syntax-error` | Error | Generic syntax error from the parser |
 
+use perl_diagnostics_codes::DiagnosticCode;
 use perl_parser_core::error::ParseError;
 
 use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
+
+/// Derive the canonical diagnostic code for a parser error.
+pub fn parse_error_code(error: &ParseError) -> DiagnosticCode {
+    match error {
+        ParseError::UnexpectedEof => DiagnosticCode::UnexpectedEof,
+        ParseError::SyntaxError { message, .. } => {
+            DiagnosticCode::from_message(message).unwrap_or(DiagnosticCode::SyntaxError)
+        }
+        _ => DiagnosticCode::ParseError,
+    }
+}
 
 /// Convert a parse error to a diagnostic with actionable suggestions.
 ///
@@ -80,8 +92,8 @@ pub fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
 
     Diagnostic {
         range: (location, location + 1),
-        severity: parse_error_severity(error, &message),
-        code: Some("syntax-error".to_string()),
+        severity: parse_error_severity(error),
+        code: Some(parse_error_code(error).as_str().to_string()),
         message,
         related_information: Vec::new(),
         tags: Vec::new(),
@@ -89,14 +101,21 @@ pub fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
     }
 }
 
-pub(crate) fn parse_error_severity(error: &ParseError, message: &str) -> DiagnosticSeverity {
-    if matches!(error, ParseError::SyntaxError { .. })
-        && is_unknown_subroutine_attribute_warning(message)
-    {
-        DiagnosticSeverity::Warning
-    } else {
-        DiagnosticSeverity::Error
+/// Derive the user-facing severity for a parser error.
+pub fn parse_error_severity(error: &ParseError) -> DiagnosticSeverity {
+    if matches!(error, ParseError::SyntaxError { .. }) {
+        if matches!(parse_error_code(error), DiagnosticCode::InvalidPrototype)
+            || matches!(
+                error,
+                ParseError::SyntaxError { message, .. }
+                    if is_unknown_subroutine_attribute_warning(message)
+            )
+        {
+            return DiagnosticSeverity::Warning;
+        }
     }
+
+    DiagnosticSeverity::Error
 }
 
 fn is_unknown_subroutine_attribute_warning(message: &str) -> bool {

--- a/crates/perl-lsp-diagnostics/tests/unit_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/unit_tests.rs
@@ -275,6 +275,47 @@ fn provider_syntax_error() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn provider_invalid_prototype_maps_to_pl302_warning() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = Arc::new(program(vec![]));
+    let source = "sub foo (XYZ) {}";
+    let errors = vec![ParseError::SyntaxError {
+        location: 8,
+        message: "Invalid prototype character(s) 'X'".to_string(),
+    }];
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    let diagnostics = provider.get_diagnostics(&ast, &errors, source, None);
+
+    let prototype_diags: Vec<_> =
+        diagnostics.iter().filter(|d| d.code.as_deref() == Some("PL302")).collect();
+    assert!(!prototype_diags.is_empty(), "expected PL302 diagnostic, got: {:?}", diagnostics);
+
+    let first = &prototype_diags[0];
+    assert_eq!(first.severity, DiagnosticSeverity::Warning);
+    assert_eq!(first.range.0, 8);
+    Ok(())
+}
+
+#[test]
+fn provider_unknown_subroutine_attribute_stays_warning() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = Arc::new(program(vec![]));
+    let source = "sub foo :wat {}";
+    let errors = vec![ParseError::SyntaxError {
+        location: 8,
+        message: "unknown subroutine attribute ':wat'".to_string(),
+    }];
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    let diagnostics = provider.get_diagnostics(&ast, &errors, source, None);
+
+    let attr_diags: Vec<_> =
+        diagnostics.iter().filter(|d| d.message.contains("unknown subroutine attribute")).collect();
+    assert!(!attr_diags.is_empty(), "expected attribute diagnostic, got: {:?}", diagnostics);
+
+    let first = attr_diags[0];
+    assert_eq!(first.severity, DiagnosticSeverity::Warning);
+    Ok(())
+}
+
+#[test]
 fn provider_unexpected_eof_error() -> Result<(), Box<dyn std::error::Error>> {
     let ast = Arc::new(program(vec![]));
     let source = "my $x = ";

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use crate::state::DocumentState;
 use crate::util::uri::parse_uri;
 use perl_diagnostics_codes::DiagnosticCode;
+use perl_lsp_diagnostics::{parse_error_code, parse_error_severity};
 use perl_parser::Parser;
 use perl_parser::error::ParseError;
 use perl_parser::position::offset_to_utf16_line_col;
@@ -308,10 +309,11 @@ impl PullDiagnosticsProvider {
         let end_offset = offset.saturating_add(1).min(text.len());
         let range = lsp_range_from_offsets(text, offset, end_offset);
 
-        let code_str = DiagnosticCode::ParseError.as_str();
+        let code = parse_error_code(error);
+        let code_str = code.as_str();
         let data = serde_json::to_value(DiagnosticData {
             code: code_str.to_string(),
-            category: format!("{:?}", DiagnosticCode::ParseError.category()),
+            category: format!("{:?}", code.category()),
             fixable: is_fixable_diagnostic(code_str),
             tags: vec![],
         })
@@ -322,7 +324,7 @@ impl PullDiagnosticsProvider {
 
         LspDiagnostic {
             range,
-            severity: Some(LspDiagnosticSeverity::ERROR),
+            severity: Some(to_lsp_severity(parse_error_severity(error))),
             code: Some(NumberOrString::String(code_str.to_string())),
             code_description: None,
             source: Some("perl-lsp".to_string()),
@@ -534,6 +536,48 @@ mod tests {
                 assert!(data["tags"].is_array());
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_prototype_syntax_error_maps_to_pl302_warning()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let diagnostic = provider.parse_error_to_diagnostic(
+            &uri,
+            "sub foo (XYZ) {}",
+            &ParseError::SyntaxError {
+                location: 8,
+                message: "Invalid prototype character(s) 'X'".to_string(),
+            },
+        );
+
+        assert_eq!(diagnostic.code, Some(NumberOrString::String("PL302".to_string())));
+        assert_eq!(diagnostic.severity, Some(LspDiagnosticSeverity::WARNING));
+        let data = diagnostic.data.as_ref().ok_or("data should be populated")?;
+        assert_eq!(data["code"], "PL302");
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_subroutine_attribute_syntax_error_stays_warning()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let diagnostic = provider.parse_error_to_diagnostic(
+            &uri,
+            "sub foo :wat {}",
+            &ParseError::SyntaxError {
+                location: 8,
+                message: "unknown subroutine attribute ':wat'".to_string(),
+            },
+        );
+
+        assert_eq!(diagnostic.code, Some(NumberOrString::String("PL002".to_string())));
+        assert_eq!(diagnostic.severity, Some(LspDiagnosticSeverity::WARNING));
+        let data = diagnostic.data.as_ref().ok_or("data should be populated")?;
+        assert_eq!(data["code"], "PL002");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- share parse-error code/severity classification across local and pull diagnostics
- surface invalid prototype parser warnings as `PL302` in both diagnostics paths
- keep parser warnings that remain on generic syntax codes at warning severity, with regression coverage

## Testing
- cargo fmt --all --check
- CARGO_TARGET_DIR=/tmp/perl-lsp-3644-target cargo test -p perl-lsp-diagnostics --test unit_tests provider_invalid_prototype_maps_to_pl302_warning
- CARGO_TARGET_DIR=/tmp/perl-lsp-3644-target cargo test -p perl-lsp-diagnostics --test unit_tests provider_unknown_subroutine_attribute_stays_warning
- CARGO_TARGET_DIR=/tmp/perl-lsp-3644-target cargo test -p perl-lsp-rs --lib invalid_prototype_syntax_error_maps_to_pl302_warning
- CARGO_TARGET_DIR=/tmp/perl-lsp-3644-target cargo test -p perl-lsp-rs --lib unknown_subroutine_attribute_syntax_error_stays_warning

Fixes #3644