### PR TITLE
fix(pragma): add missing features field to PragmaState struct literals (#3647)

### DIFF
--- a/crates/perl-parser/benches/scope_benchmark.rs
+++ b/crates/perl-parser/benches/scope_benchmark.rs
@@ -73,7 +73,13 @@ fn benchmark_strict_barewords(c: &mut Criterion) {
     // Enable strict subs to force is_known_function checks
     let pragma_map = vec![(
         0..script.len(),
-        PragmaState { strict_subs: true, strict_vars: true, strict_refs: true, warnings: true },
+        PragmaState {
+            strict_subs: true,
+            strict_vars: true,
+            strict_refs: true,
+            warnings: true,
+            features: Vec::new(),
+        },
     )];
 
     c.bench_function("scope_analysis_strict_barewords", |b| {

--- a/crates/perl-parser/tests/scope_analysis_test.rs
+++ b/crates/perl-parser/tests/scope_analysis_test.rs
@@ -24,7 +24,13 @@ fn analyze_strict(code: &str) -> Vec<ScopeIssue> {
     // Create a pragma map with strict enabled for the whole file
     let pragma_map = vec![(
         0..code.len(),
-        PragmaState { strict_refs: true, strict_subs: true, strict_vars: true, warnings: true },
+        PragmaState {
+            strict_refs: true,
+            strict_subs: true,
+            strict_vars: true,
+            warnings: true,
+            features: Vec::new(),
+        },
     )];
 
     analyzer.analyze(&ast, code, &pragma_map)

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -747,12 +747,12 @@ fn v5_40_enables_builtin() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn v5_12_does_not_have_switch() -> Result<(), Box<dyn std::error::Error>> {
-    // switch was removed/deprecated in v5.38
+fn v5_12_retains_switch_from_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    // switch was inherited from v5.10 and not removed until v5.38
     let features_v12 = features_enabled_by_version(PerlVersion::new(5, 12));
     assert!(
         features_v12.contains(&"switch"),
-        "v5.12 should include 'switch' (inherited from v5.10)"
+        "v5.12 should include 'switch' (inherited from v5.10, removed at v5.38)"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

- PR #3544 added `features: Vec<&'static str>` to `PragmaState` but two call sites that construct `PragmaState` with struct literal syntax were not updated, causing `E0063: missing field 'features'` compile errors in `cargo test -p perl-parser` and `cargo bench -p perl-parser`
- Rename test `v5_12_does_not_have_switch` to `v5_12_retains_switch_from_v5_10` — the name was inverted relative to the assertion (test correctly checks switch IS present at v5.12)

## Test plan

- [x] `cargo test -p perl-parser --test scope_analysis_test` — was failing E0063, now passes
- [x] `cargo bench -p perl-parser --no-run` — was failing E0063, now compiles
- [x] `cargo test -p perl-pragma` — 61 tests pass including renamed test

Closes #3647