### PR TITLE
fix(limits): consolidate file size limits to single source of truth (#3582)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ name = "perl-lsp-input-validation"
 version = "0.12.3"
 dependencies = [
  "anyhow",
+ "perl-lsp-limits",
  "perl-path-security",
  "perl-tdd-support",
  "serde_json",

--- a/crates/perl-lsp-input-validation/Cargo.toml
+++ b/crates/perl-lsp-input-validation/Cargo.toml
@@ -17,6 +17,7 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 anyhow.workspace = true
 serde_json = { workspace = true }
+perl-lsp-limits = { workspace = true }
 perl-path-security = { workspace = true }
 
 [dev-dependencies]

--- a/crates/perl-lsp-input-validation/src/lib.rs
+++ b/crates/perl-lsp-input-validation/src/lib.rs
@@ -6,9 +6,6 @@ use perl_path_security::validate_workspace_path;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-/// Maximum allowed file size for parsing (10MB).
-const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
-
 /// Maximum allowed path length.
 const MAX_PATH_LENGTH: usize = 4096;
 
@@ -40,13 +37,17 @@ pub fn validate_file_path<P: AsRef<Path>>(path: P, workspace_root: &Path) -> Res
 }
 
 /// Validates file content before parsing to prevent resource exhaustion.
+///
+/// The file size limit is sourced from [`perl_lsp_limits::max_file_size_bytes`],
+/// which defaults to 1MB and is configurable via `perl.limits.maxFileSizeBytes`.
 pub fn validate_file_content(content: &str, file_path: &Path) -> Result<()> {
-    if content.len() > MAX_FILE_SIZE {
+    let max_file_size = perl_lsp_limits::max_file_size_bytes();
+    if content.len() > max_file_size {
         return Err(anyhow!(
-            "File {} too large: {} bytes (max: {})",
+            "File {} too large: {} bytes (max: {} bytes) — adjust perl.limits.maxFileSizeBytes to increase",
             file_path.display(),
             content.len(),
-            MAX_FILE_SIZE
+            max_file_size
         ));
     }
 
@@ -224,9 +225,10 @@ mod tests {
 
     #[test]
     fn test_validate_file_content_too_large() {
+        let max = perl_lsp_limits::max_file_size_bytes();
         let mut content = String::new();
-        content.reserve(MAX_FILE_SIZE + 1);
-        content.extend(std::iter::repeat_n('x', MAX_FILE_SIZE + 1));
+        content.reserve(max + 1);
+        content.extend(std::iter::repeat_n('x', max + 1));
         let file_path = Path::new("large.pl");
 
         let result = validate_file_content(&content, file_path);
@@ -296,5 +298,18 @@ mod tests {
 
         let result = validate_lsp_request(method, &params);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_file_size_limit_sourced_from_lsp_limits() {
+        // The file size limit must come from perl-lsp-limits, not a local constant.
+        // This test documents the expected single source of truth.
+        let expected_limit = perl_lsp_limits::max_file_size_bytes();
+        // Default is 1MB per LspLimits::default()
+        assert_eq!(
+            expected_limit,
+            1_024 * 1_024,
+            "default file size limit must be 1MB from perl-lsp-limits"
+        );
     }
 }

--- a/crates/perl-lsp-input-validation/tests/boundary_cases.rs
+++ b/crates/perl-lsp-input-validation/tests/boundary_cases.rs
@@ -1,13 +1,14 @@
 //! Boundary and mutation-killing tests for perl-lsp-input-validation.
 //!
 //! Complements the inline happy-path tests in lib.rs by targeting:
-//! - Exact boundary values (MAX_FILE_SIZE, MAX_PATH_LENGTH, line length 100_000)
+//! - Exact boundary values (max_file_size_bytes from perl-lsp-limits, MAX_PATH_LENGTH, line length 100_000)
 //! - Every disallowed condition in validate_file_content and validate_lsp_request
 //! - All suspicious patterns in the content filter
 //! - sanitize_string: exactly which characters are kept vs removed
 //! - validate_file_path: extension filtering
 
 use perl_lsp_input_validation::{sanitize_string, validate_file_content, validate_lsp_request};
+use perl_lsp_limits::max_file_size_bytes;
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
@@ -16,9 +17,9 @@ use std::path::Path;
 
 #[test]
 fn validate_file_content_at_exactly_max_size_is_ok() -> anyhow::Result<()> {
-    // 10 * 1024 * 1024 bytes exactly must pass (> not >=).
+    // max_file_size_bytes() bytes exactly must pass (> not >=).
     // Use many short lines to avoid triggering the per-line length check.
-    let max = 10 * 1024 * 1024;
+    let max = max_file_size_bytes();
     // Each "x\n" = 2 bytes; max / 2 lines avoids the 100_000 char line check
     let line = "x\n";
     let lines = max / line.len();
@@ -30,7 +31,7 @@ fn validate_file_content_at_exactly_max_size_is_ok() -> anyhow::Result<()> {
 
 #[test]
 fn validate_file_content_one_byte_over_max_errors() {
-    let max = 10 * 1024 * 1024;
+    let max = max_file_size_bytes();
     // Use short lines spread across many rows so only the total size limit is hit
     let line = "x\n"; // 2 bytes each
     let lines = (max / line.len()) + 1;
@@ -38,7 +39,7 @@ fn validate_file_content_one_byte_over_max_errors() {
     // content.len() > max here
     assert!(content.len() > max);
     let result = validate_file_content(&content, Path::new("test.pl"));
-    assert!(result.is_err(), "content over MAX_FILE_SIZE must be rejected");
+    assert!(result.is_err(), "content over max_file_size_bytes must be rejected");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp/src/security/mod.rs
+++ b/crates/perl-lsp/src/security/mod.rs
@@ -19,7 +19,10 @@ pub use sandbox::{SafeExecutor, Sandbox, SandboxConfig, SandboxResult};
 /// Security configuration for the LSP server
 #[derive(Debug, Clone)]
 pub struct SecurityConfig {
-    /// Maximum file size for parsing (bytes)
+    /// Maximum file size for parsing (bytes).
+    ///
+    /// Defaults to the value from [`perl_lsp_limits::LspLimits`] (1MB).
+    /// Adjust via `perl.limits.maxFileSizeBytes` in LSP settings.
     pub max_file_size: usize,
     /// Maximum path length
     pub max_path_length: usize,
@@ -34,7 +37,7 @@ pub struct SecurityConfig {
 impl Default for SecurityConfig {
     fn default() -> Self {
         Self {
-            max_file_size: 10 * 1024 * 1024, // 10MB
+            max_file_size: perl_lsp_limits::max_file_size_bytes(),
             max_path_length: 4096,
             allowed_extensions: vec![
                 "pl".to_string(),
@@ -113,7 +116,9 @@ mod tests {
     #[test]
     fn test_security_config_default() {
         let config = SecurityConfig::default();
-        assert_eq!(config.max_file_size, 10 * 1024 * 1024);
+        // max_file_size must match the single source of truth in perl-lsp-limits
+        assert_eq!(config.max_file_size, perl_lsp_limits::max_file_size_bytes());
+        assert_eq!(config.max_file_size, 1_024 * 1_024, "default must be 1MB from LspLimits");
         assert_eq!(config.max_path_length, 4096);
         assert!(config.strict_mode);
         assert_eq!(config.allowed_extensions.len(), 4);


### PR DESCRIPTION
## Summary

- Removes the hardcoded `MAX_FILE_SIZE = 10MB` constant from `perl-lsp-input-validation` and replaces it with `perl_lsp_limits::max_file_size_bytes()` (default 1MB)
- Fixes `SecurityConfig::default()` in `perl-lsp` to use the shared limit instead of its own hardcoded 10MB value
- Eliminates the 10x inconsistency where workspace discovery could attempt to index 9MB files that the LSP handler would subsequently reject
- Improves error message to include the settings key (`perl.limits.maxFileSizeBytes`) so users know how to adjust the limit

## Changes

- `crates/perl-lsp-input-validation/Cargo.toml`: Add `perl-lsp-limits` as a dependency
- `crates/perl-lsp-input-validation/src/lib.rs`: Remove local `MAX_FILE_SIZE` constant; use `perl_lsp_limits::max_file_size_bytes()` at call site; add `test_file_size_limit_sourced_from_lsp_limits` test
- `crates/perl-lsp-input-validation/tests/boundary_cases.rs`: Replace hardcoded `10 * 1024 * 1024` with `max_file_size_bytes()` calls
- `crates/perl-lsp/src/security/mod.rs`: Replace hardcoded `10 * 1024 * 1024` in `SecurityConfig::default()` with `perl_lsp_limits::max_file_size_bytes()`; update test assertion accordingly

## Test plan

- [x] `cargo test -p perl-lsp-input-validation` — 43 tests pass (3 suites)
- [x] `cargo test -p perl-lsp-limits` — 4 tests pass
- [x] `cargo test -p perl-lsp-rs --lib security` — 15 security tests pass
- [x] `cargo clippy -p perl-lsp-input-validation --lib` — no issues
- [x] `cargo clippy -p perl-lsp-rs --lib` — no issues
- [x] `cargo fmt` on affected crates — clean

Closes #3582