### PR TITLE
fix(diagnostics): handle qw builtin imports by version (#3634)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -123,18 +123,19 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 }
 
                 for arg in args {
-                    let name = normalize_builtin_import(arg);
-                    if name.is_empty() {
-                        continue;
-                    }
+                    for name in builtin_import_names(arg) {
+                        if name.is_empty() {
+                            continue;
+                        }
 
-                    if name.starts_with(':') {
-                        builtin_bundle_declared = true;
-                        continue;
-                    }
+                        if name.starts_with(':') {
+                            builtin_bundle_declared = true;
+                            continue;
+                        }
 
-                    if !builtin_imports.contains(&name) {
-                        builtin_imports.push(name);
+                        if !builtin_imports.contains(&name) {
+                            builtin_imports.push(name);
+                        }
                     }
                 }
             }
@@ -259,20 +260,17 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 }
 
                 for arg in args {
-                    let name = normalize_builtin_import(arg);
-                    if name.is_empty() {
-                        continue;
-                    }
-
-                    let min = builtin_import_min_version(&name);
-                    if declared_version < min {
-                        let display = format!("use builtin {}", arg);
-                        diagnostics.push(make_diagnostic(
-                            n,
-                            &display,
-                            declared_version,
-                            (min.major, min.minor),
-                        ));
+                    for name in builtin_import_names(arg) {
+                        let min = builtin_import_min_version(&name);
+                        if declared_version < min {
+                            let display = format!("use builtin {}", arg);
+                            diagnostics.push(make_diagnostic(
+                                n,
+                                &display,
+                                declared_version,
+                                (min.major, min.minor),
+                            ));
+                        }
                     }
                 }
             }
@@ -347,8 +345,18 @@ fn builtin_import_min_version(name: &str) -> PerlVersion {
     builtin_min_version(name)
 }
 
-fn normalize_builtin_import(arg: &str) -> String {
-    arg.trim_matches(|c| c == '\'' || c == '"').to_string()
+fn builtin_import_names(arg: &str) -> Vec<String> {
+    let trimmed = arg.trim();
+
+    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+        return inner
+            .split_whitespace()
+            .filter(|name| !name.is_empty())
+            .map(|name| name.to_string())
+            .collect();
+    }
+
+    vec![trimmed.trim_matches(|c| c == '\'' || c == '"').to_string()]
 }
 
 /// Return `true` when a node represents the `defer { ... }` feature form.

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -1074,6 +1074,10 @@ fn use_builtin_import(import: &str) -> Node {
     )
 }
 
+fn use_builtin_qw_import(imports: &str) -> Node {
+    use_builtin_import(&format!("qw({})", imports))
+}
+
 fn isa_node() -> Node {
     Node::new(
         NodeKind::Binary {
@@ -1239,6 +1243,37 @@ fn test_builtin_imports_have_distinct_minimum_versions() -> Result<(), Box<dyn s
             diagnostics_have_code(&diagnostics, "PL900"),
             should_warn,
             "Unexpected builtin import compatibility result for {import} on {version}: {:?}",
+            diagnostics
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_builtin_qw_imports_have_distinct_minimum_versions() -> Result<(), Box<dyn std::error::Error>>
+{
+    let cases = [
+        ("floor", "v5.36", false),
+        ("is_tainted", "v5.36", true),
+        ("is_tainted", "v5.38", false),
+        ("export_lexically", "v5.36", true),
+        ("export_lexically", "v5.38", false),
+        ("load_module", "v5.38", true),
+        ("load_module", "v5.40", false),
+        (":5.40", "v5.38", true),
+        (":5.40", "v5.40", false),
+    ];
+
+    for (imports, version, should_warn) in cases {
+        let ast = program(vec![use_node(version), use_builtin_qw_import(imports)]);
+        let mut diagnostics = vec![];
+        check_version_compat(&ast, &mut diagnostics);
+
+        assert_eq!(
+            diagnostics_have_code(&diagnostics, "PL900"),
+            should_warn,
+            "Unexpected builtin qw import compatibility result for {imports} on {version}: {:?}",
             diagnostics
         );
     }


### PR DESCRIPTION
## Summary

- extend builtin version-compat import parsing to split `use builtin qw(...)` forms into individual names
- apply the existing per-function minimum-version table to each imported builtin name
- keep bundle forms like `:5.40` routed through the bundle-version logic
- add regression coverage for `qw(...)` builtin imports across 5.36, 5.38, and 5.40 thresholds

## Notes

Current `master` already has distinct minimum-version handling for direct `builtin::...` calls and quoted `use builtin ...` imports. This follow-up finishes the remaining `qw(...)` import path so it uses the same per-function rules.

## Validation

- [x] `cargo fmt --all --check`
- [x] `CARGO_TARGET_DIR=/tmp/perl-lsp-3634-target cargo test -p perl-lsp-diagnostics --test version_compat_tests`

Fixes #3634
