### PR TITLE
fix(scope): mark variables in print comma-separated arguments as used (#3503)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2855,3 +2855,60 @@ my $a = 42;
     assert!(!undeclared, "a lexically declared $a must never be flagged as undeclared");
     Ok(())
 }
+
+// ===========================================================================
+// Print with comma-separated arguments (#3503)
+// ===========================================================================
+
+/// Regression test for issue #3503: variables passed to `print` as a comma-separated
+/// list must be marked as used by the scope analyzer and must not produce
+/// `UnusedVariable` diagnostics.
+#[test]
+fn scope_many_variables_in_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+my $a = 1;
+my $b = 2;
+my $c = 3;
+my $d = 4;
+my $e = 5;
+print $a, $b, $c, $d, $e;
+"#;
+    let issues = scope_issues(code);
+    let unused = count_issues(&issues, IssueKind::UnusedVariable);
+    assert_eq!(unused, 0, "all variables used in print should not be unused");
+    Ok(())
+}
+
+#[test]
+fn scope_print_comma_args_with_strict() -> Result<(), Box<dyn std::error::Error>> {
+    // Same pattern but with `use strict` enabled — reproducer from issue #3503.
+    let code = r#"
+use strict;
+my $name = "world";
+my $greeting = "hello";
+print $greeting, " ", $name, "\n";
+"#;
+    let issues = scope_issues_strict(code);
+    let unused: Vec<_> = issues.iter().filter(|i| i.kind == IssueKind::UnusedVariable).collect();
+    assert!(
+        unused.is_empty(),
+        "variables used in print comma-arg list must not be flagged as unused (strict); got: {:?}",
+        unused.iter().map(|i| &i.variable_name).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_say_comma_separated_args_marked_used() -> Result<(), Box<dyn std::error::Error>> {
+    // `say` uses the same indirect-object / FunctionCall path as `print`.
+    let code = r#"
+my $a = "first";
+my $b = "second";
+my $c = "third";
+say $a, $b, $c;
+"#;
+    let issues = scope_issues(code);
+    let unused = count_issues(&issues, IssueKind::UnusedVariable);
+    assert_eq!(unused, 0, "all variables used in say should not be unused");
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/tests/scope_golden_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_golden_tests.rs
@@ -501,3 +501,48 @@ print $result;
     );
     Ok(())
 }
+
+// ===========================================================================
+// Pattern: print with comma-separated argument list
+// ===========================================================================
+
+#[test]
+fn golden_print_comma_separated_args_all_marked_used() -> Result<(), Box<dyn std::error::Error>> {
+    // Variables that appear as comma-separated arguments to `print` must be marked as used.
+    // Regression test for issue #3503: print $greeting, " ", $name, "\n" was producing
+    // UnusedVariable diagnostics for $greeting and $name.
+    let code = r#"
+use strict;
+my $name = "world";
+my $greeting = "hello";
+print $greeting, " ", $name, "\n";
+"#;
+    let issues = scope_issues_strict(code);
+    let fp = false_positive_issues(&issues);
+    assert!(
+        fp.is_empty(),
+        "variables in print comma-separated arg list must be marked as used; got: {:?}",
+        fp.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn golden_say_comma_separated_args_all_marked_used() -> Result<(), Box<dyn std::error::Error>> {
+    // Same as above but for `say` (adds newline automatically).
+    let code = r#"
+use strict;
+my $a = "first";
+my $b = "second";
+my $c = "third";
+say $a, $b, $c;
+"#;
+    let issues = scope_issues_strict(code);
+    let fp = false_positive_issues(&issues);
+    assert!(
+        fp.is_empty(),
+        "variables in say comma-separated arg list must be marked as used; got: {:?}",
+        fp.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds regression tests confirming that variables used as comma-separated arguments to `print`/`say` are correctly marked as used by the scope analyzer
- Investigation revealed the behavior is already correct: `FunctionCall` args are fully traversed in `analyze_node`; these tests lock that behavior against future regression
- Tests cover: bare `print $a, $b, $c, $d, $e`, strict-mode variant with `use strict`, and `say` equivalent

## Changes

- `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` — 3 new tests: `scope_many_variables_in_scope` (exact spec test), `scope_print_comma_args_with_strict`, `scope_say_comma_separated_args_marked_used`
- `crates/perl-semantic-analyzer/tests/scope_golden_tests.rs` — 2 new golden (zero-false-positive) tests for `print` and `say` comma-arg patterns

## Evidence

- **Commits**: 1
- **Tests**: 128/128 pass in `scope_and_symbol_tests`, 19/19 pass in `scope_golden_tests`
- **Lint**: clippy clean (`cargo clippy -p perl-semantic-analyzer --tests` — zero warnings)
- **Format**: `cargo fmt -p perl-semantic-analyzer` applied, no drift
- **Files**: 2 changed, +102 lines (test-only, no production code changes)
- **Pre-existing failure**: `symbol_extraction_method_preserves_attributes` in `comprehensive_unit_tests` — confirmed present on master, unrelated to this PR

## Test Plan

- [ ] `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests -- scope_many_variables_in_scope --exact` passes
- [ ] `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests -- scope_print_comma scope_say_comma` passes
- [ ] `cargo test -p perl-semantic-analyzer --test scope_golden_tests` all 19 pass
- [ ] `cargo clippy -p perl-semantic-analyzer --tests` clean

## Unknowns

- **Root cause not patched**: Investigation showed the code path (`FunctionCall` arg traversal in `analyze_node`) was already correct. The issue spec's root cause analysis was inaccurate. No production code was changed.
- **printf not covered**: `printf` uses a different argument structure (format string first) and was not added to this regression suite; could be a follow-up.
- **`symbol_extraction_method_preserves_attributes` pre-existing failure**: Present on master, out of scope.