### PR TITLE
fix(diagnostics): wire PL302 prototype warnings through LSP pipeline (#3644)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -107,15 +107,45 @@ impl DiagnosticsProvider {
                 })
                 .unwrap_or_default();
 
+            // Derive the most specific diagnostic code available.
+            //
+            // For SyntaxError variants, `from_message` may match a named code
+            // such as `InvalidPrototype` (PL302) — use it when available so that
+            // the LSP client sees the intended code and severity instead of the
+            // generic PL002.  Other parse-error variants stay as-is.
             let code = match error {
                 ParseError::UnexpectedEof => DiagnosticCode::UnexpectedEof,
-                ParseError::SyntaxError { .. } => DiagnosticCode::SyntaxError,
+                ParseError::SyntaxError { .. } => {
+                    DiagnosticCode::from_message(&message).unwrap_or(DiagnosticCode::SyntaxError)
+                }
                 _ => DiagnosticCode::ParseError,
+            };
+
+            // When `from_message` promoted the code to a named diagnostic (e.g.
+            // `InvalidPrototype`), honour the canonical severity from the code
+            // catalogue rather than the generic parse-error severity.
+            let severity = if matches!(error, ParseError::SyntaxError { .. })
+                && code != DiagnosticCode::SyntaxError
+            {
+                // Convert from perl_diagnostics_codes severity to the LSP internal type.
+                // DiagnosticSeverity is re-exported from perl_lsp_diagnostic_types above.
+                match code.severity() {
+                    perl_diagnostics_codes::DiagnosticSeverity::Error => DiagnosticSeverity::Error,
+                    perl_diagnostics_codes::DiagnosticSeverity::Warning => {
+                        DiagnosticSeverity::Warning
+                    }
+                    perl_diagnostics_codes::DiagnosticSeverity::Information => {
+                        DiagnosticSeverity::Information
+                    }
+                    perl_diagnostics_codes::DiagnosticSeverity::Hint => DiagnosticSeverity::Hint,
+                }
+            } else {
+                parse_error_severity(error, &message)
             };
 
             diagnostics.push(Diagnostic {
                 range: (range_start, range_end),
-                severity: parse_error_severity(error, &message),
+                severity,
                 code: Some(code.as_str().to_string()),
                 message,
                 related_information,

--- a/crates/perl-lsp-diagnostics/tests/prototype_warning_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/prototype_warning_tests.rs
@@ -1,0 +1,98 @@
+//! Regression tests for PL302 invalid-prototype warning pipeline (issue #3644)
+//!
+//! The parser emits `ParseError::SyntaxError` with an "Invalid prototype character(s)"
+//! message.  The diagnostics layer must:
+//!
+//! 1. Promote the code from the generic `PL002` (SyntaxError) to `PL302` (InvalidPrototype)
+//!    via `DiagnosticCode::from_message`.
+//! 2. Surface the diagnostic with `Warning` severity (not `Error`).
+//!
+//! These tests are the regression guard for that wiring.
+
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn find_code(diags: &[Diagnostic], code: &str) -> Option<Diagnostic> {
+    diags.iter().find(|d| d.code.as_deref() == Some(code)).cloned()
+}
+
+// =========================================================================
+// PL302 — InvalidPrototype
+// =========================================================================
+
+/// PL302 appears when the prototype contains invalid characters.
+///
+/// `sub foo (XYZ) { }` — X, Y, Z are not valid prototype characters.
+#[test]
+fn pl302_fires_for_invalid_prototype_chars() {
+    let source = "sub foo (XYZ) { }\n";
+    let diags = diagnostics_for(source);
+    let codes: Vec<_> = diags.iter().filter_map(|d| d.code.as_deref()).collect();
+    assert!(
+        codes.contains(&"PL302"),
+        "Expected PL302 (InvalidPrototype) for 'sub foo (XYZ)'. Got codes: {codes:?}"
+    );
+}
+
+/// PL302 must not appear for a valid prototype string.
+#[test]
+fn pl302_absent_for_valid_prototype() {
+    let source = "sub foo ($@) { }\n";
+    let diags = diagnostics_for(source);
+    let codes: Vec<_> = diags.iter().filter_map(|d| d.code.as_deref()).collect();
+    assert!(
+        !codes.contains(&"PL302"),
+        "PL302 should NOT fire for valid prototype '$@'. Got codes: {codes:?}"
+    );
+}
+
+/// PL302 carries Warning severity, not Error — invalid prototypes do not
+/// prevent Perl from running the code, they are merely Perl-level warnings.
+#[test]
+fn pl302_has_warning_severity() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "sub foo (XYZ) { }\n";
+    let diags = diagnostics_for(source);
+    let pl302 = find_code(&diags, "PL302")
+        .ok_or_else(|| format!("Expected PL302 in diagnostics for 'sub foo (XYZ)'. Got: {diags:?}"))?;
+    assert_eq!(
+        pl302.severity,
+        DiagnosticSeverity::Warning,
+        "PL302 must be Warning severity, got {:?}",
+        pl302.severity
+    );
+    Ok(())
+}
+
+/// PL302 must not collide with PL002 (generic SyntaxError) — the code
+/// should be promoted to PL302, not left as PL002.
+#[test]
+fn pl302_not_emitted_as_pl002() {
+    let source = "sub foo (XYZ) { }\n";
+    let diags = diagnostics_for(source);
+    // PL302 present
+    let has_302 = diags.iter().any(|d| d.code.as_deref() == Some("PL302"));
+    // PL002 must NOT be present for this prototype warning
+    let prototype_pl002 = diags.iter().any(|d| {
+        d.code.as_deref() == Some("PL002") && d.message.to_lowercase().contains("invalid prototype")
+    });
+    assert!(has_302, "PL302 must appear for invalid prototype");
+    assert!(!prototype_pl002, "The prototype warning must NOT be emitted as PL002");
+}
+
+/// Multiple invalid characters all produce exactly one PL302, not one per character.
+#[test]
+fn pl302_single_diagnostic_for_multiple_invalid_chars() {
+    let source = "sub bar (XYZ) { }\n";
+    let diags = diagnostics_for(source);
+    let count = diags.iter().filter(|d| d.code.as_deref() == Some("PL302")).count();
+    assert_eq!(count, 1, "Expected exactly one PL302 for 'XYZ' prototype, got {count}");
+}

--- a/crates/perl-lsp-diagnostics/tests/prototype_warning_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/prototype_warning_tests.rs
@@ -61,8 +61,9 @@ fn pl302_absent_for_valid_prototype() {
 fn pl302_has_warning_severity() -> Result<(), Box<dyn std::error::Error>> {
     let source = "sub foo (XYZ) { }\n";
     let diags = diagnostics_for(source);
-    let pl302 = find_code(&diags, "PL302")
-        .ok_or_else(|| format!("Expected PL302 in diagnostics for 'sub foo (XYZ)'. Got: {diags:?}"))?;
+    let pl302 = find_code(&diags, "PL302").ok_or_else(|| {
+        format!("Expected PL302 in diagnostics for 'sub foo (XYZ)'. Got: {diags:?}")
+    })?;
     assert_eq!(
         pl302.severity,
         DiagnosticSeverity::Warning,


### PR DESCRIPTION
## Summary

- The parser emits `ParseError::SyntaxError` with `"Invalid prototype character(s)"` messages for subroutines with bad prototype strings (e.g., `sub foo (XYZ) { }`)
- The diagnostics layer was mapping all `SyntaxError` variants to the generic `PL002` code at `Error` severity, silently swallowing the specific `PL302` (InvalidPrototype) code and its `Warning` severity
- Fix: use `DiagnosticCode::from_message(&message)` in the `SyntaxError` branch to promote to the most specific code, then use that code's canonical severity from the catalogue

## Root cause

In `crates/perl-lsp-diagnostics/src/diagnostics.rs`, the code assignment for `ParseError::SyntaxError` was a hard-coded `DiagnosticCode::SyntaxError` with no message inspection. `DiagnosticCode::from_message` already knew how to detect prototype messages and return `InvalidPrototype`, but was never called.

## Changes

- `crates/perl-lsp-diagnostics/src/diagnostics.rs` — call `from_message` for `SyntaxError` variants; use resolved code's `severity()` when promoted beyond generic `SyntaxError`
- `crates/perl-lsp-diagnostics/tests/prototype_warning_tests.rs` (new) — 5 regression tests

## Test plan

- [ ] `cargo test -p perl-lsp-diagnostics` — all 356 tests pass
- [ ] `cargo clippy -p perl-lsp-diagnostics --tests` — clean
- [ ] `cargo fmt -p perl-lsp-diagnostics -- --check` — clean
- [ ] New tests: pl302_fires_for_invalid_prototype_chars, pl302_absent_for_valid_prototype, pl302_has_warning_severity, pl302_not_emitted_as_pl002, pl302_single_diagnostic_for_multiple_invalid_chars

## Knowledge artifacts

- `from_message` already handled prototype detection — the gap was purely in calling it
- The severity promotion pattern (`from_message` → `code.severity()`) is now a reusable approach for future named SyntaxError promotions
- Pre-push gate hit flaky debounce timer tests in `perl-lsp-rs` (pre-existing, unrelated to this change, timing-sensitive on Windows)