### PR TITLE
fix(ci): restore clippy-core green for parse errors (#3669)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/parse_errors.rs
+++ b/crates/perl-lsp-diagnostics/src/parse_errors.rs
@@ -103,16 +103,15 @@ pub fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
 
 /// Derive the user-facing severity for a parser error.
 pub fn parse_error_severity(error: &ParseError) -> DiagnosticSeverity {
-    if matches!(error, ParseError::SyntaxError { .. }) {
-        if matches!(parse_error_code(error), DiagnosticCode::InvalidPrototype)
+    if matches!(error, ParseError::SyntaxError { .. })
+        && (matches!(parse_error_code(error), DiagnosticCode::InvalidPrototype)
             || matches!(
                 error,
                 ParseError::SyntaxError { message, .. }
                     if is_unknown_subroutine_attribute_warning(message)
-            )
-        {
-            return DiagnosticSeverity::Warning;
-        }
+            ))
+    {
+        return DiagnosticSeverity::Warning;
     }
 
     DiagnosticSeverity::Error


### PR DESCRIPTION
## Summary
- collapse the nested condition in `parse_error_severity()` to satisfy `clippy::collapsible_if`
- preserve the existing warning behavior for invalid prototypes and unknown subroutine attributes
- unblock PR Smoke on master-derived branches

## Testing
- cargo fmt --all --check
- cargo clippy -p perl-parser -p perl-lexer --locked -- -D warnings -A missing_docs
- CARGO_TARGET_DIR=/tmp/perl-lsp-3669-target cargo test -p perl-lsp-diagnostics unknown_subroutine_attribute -- --nocapture

Fixes #3669