### PR TITLE
feat(lsp): surface Moo/Moose attribute metadata (#3601)

### DIFF
--- a/crates/perl-lsp-completion/src/completion/methods.rs
+++ b/crates/perl-lsp-completion/src/completion/methods.rs
@@ -213,42 +213,128 @@ pub fn infer_receiver_type(context: &CompletionContext, source: &str) -> Option<
 ///
 /// Attributes are stored as `key=value` strings (e.g. `"is=ro"`, `"isa=Str"`).
 /// This function formats them into a human-readable documentation string that
-/// surfaces the type constraint and access mode prominently.
+/// surfaces the attribute metadata prominently.
 fn moo_accessor_documentation(name: &str, attributes: &[String]) -> String {
-    let mut isa_value: Option<&str> = None;
-    let mut is_value: Option<&str> = None;
-    let mut extra_parts: Vec<&str> = Vec::new();
+    let isa = moo_accessor_value(attributes, "isa");
+    let access = moo_accessor_value(attributes, "is").map(moo_access_mode);
+    let required = moo_accessor_value(attributes, "required").map(moo_truthy);
+    let predicate = moo_accessor_method_name(name, attributes, "predicate", "has_");
+    let builder = moo_accessor_method_name(name, attributes, "builder", "_build_");
+    let clearer = moo_accessor_method_name(name, attributes, "clearer", "clear_");
+    let reader = moo_accessor_value(attributes, "reader");
+    let writer = moo_accessor_value(attributes, "writer");
+    let accessor = moo_accessor_value(attributes, "accessor");
+    let lazy = moo_accessor_value(attributes, "lazy").map(moo_truthy);
+    let default = moo_accessor_value(attributes, "default");
 
-    for attr in attributes {
-        if let Some((key, value)) = attr.split_once('=') {
-            match key {
-                "isa" => isa_value = Some(value),
-                "is" => is_value = Some(value),
-                _ => extra_parts.push(attr),
+    let mut doc = format!("Moo/Moose accessor `{name}`\n\n**Attribute**: `{name}`");
+
+    if let Some(isa) = isa {
+        doc.push_str(&format!("\n**Type**: `{isa}`"));
+    }
+    if let Some(access) = access {
+        doc.push_str(&format!("\n**Access**: {access}"));
+    }
+    if let Some(required) = required {
+        doc.push_str(&format!("\n**Required**: {required}"));
+    }
+    if let Some(predicate) = predicate {
+        doc.push_str(&format!("\n**Predicate**: `{predicate}`"));
+    }
+    if let Some(builder) = builder {
+        doc.push_str(&format!("\n**Builder**: `{builder}`"));
+    }
+    if let Some(clearer) = clearer {
+        doc.push_str(&format!("\n**Clearer**: `{clearer}`"));
+    }
+    if let Some(reader) = reader {
+        doc.push_str(&format!("\n**Reader**: `{reader}`"));
+    }
+    if let Some(writer) = writer {
+        doc.push_str(&format!("\n**Writer**: `{writer}`"));
+    }
+    if let Some(accessor) = accessor {
+        doc.push_str(&format!("\n**Accessor**: `{accessor}`"));
+    }
+    if let Some(lazy) = lazy {
+        doc.push_str(&format!("\n**Lazy**: {lazy}"));
+    }
+    if let Some(default) = default {
+        doc.push_str(&format!("\n**Default**: `{default}`"));
+    }
+
+    let extras: Vec<String> = attributes
+        .iter()
+        .filter_map(|attr| {
+            let (key, _) = attr.split_once('=')?;
+            if matches!(
+                key,
+                "isa"
+                    | "is"
+                    | "required"
+                    | "predicate"
+                    | "builder"
+                    | "clearer"
+                    | "reader"
+                    | "writer"
+                    | "accessor"
+                    | "lazy"
+                    | "default"
+            ) {
+                None
+            } else {
+                Some(attr.clone())
             }
-        }
-    }
-
-    let mut doc = format!("Moo/Moose accessor `{name}`");
-
-    if let Some(isa) = isa_value {
-        doc.push_str(&format!("\n\n**Type**: `{isa}`"));
-    }
-    if let Some(is) = is_value {
-        let mode = match is {
-            "ro" => "read-only",
-            "rw" => "read-write",
-            "rwp" => "read-write private",
-            "lazy" => "lazy",
-            other => other,
-        };
-        doc.push_str(&format!("\n\n**Access**: {mode}"));
-    }
-    if !extra_parts.is_empty() {
-        doc.push_str(&format!("\n\n**Options**: {}", extra_parts.join(", ")));
+        })
+        .collect();
+    if !extras.is_empty() {
+        doc.push_str(&format!("\n**Options**: {}", extras.join(", ")));
     }
 
     doc
+}
+
+fn moo_accessor_value<'a>(attributes: &'a [String], key: &str) -> Option<&'a str> {
+    attributes.iter().find_map(|attr| {
+        let (attr_key, value) = attr.split_once('=')?;
+        if attr_key == key { Some(value) } else { None }
+    })
+}
+
+fn moo_access_mode(value: &str) -> String {
+    match value {
+        "ro" => "read-only".to_string(),
+        "rw" => "read-write".to_string(),
+        "rwp" => "read-write private".to_string(),
+        "lazy" => "lazy".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn moo_truthy(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" => "yes".to_string(),
+        "0" | "false" | "no" => "no".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn moo_accessor_method_name(
+    name: &str,
+    attributes: &[String],
+    key: &str,
+    default_prefix: &str,
+) -> Option<String> {
+    let value = moo_accessor_value(attributes, key)?;
+    if moo_is_truthy(value) {
+        Some(format!("{default_prefix}{name}"))
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn moo_is_truthy(value: &str) -> bool {
+    matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
 }
 
 /// Add method completions

--- a/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
+++ b/crates/perl-lsp-completion/tests/completion_behavior_tests.rs
@@ -63,6 +63,10 @@ fn labels(items: &[CompletionItem]) -> Vec<String> {
     items.iter().map(|i| i.label.clone()).collect()
 }
 
+fn find_item<'a>(items: &'a [CompletionItem], label: &str) -> Option<&'a CompletionItem> {
+    items.iter().find(|item| item.label == label)
+}
+
 // ===========================================================================
 // 1. Variable completion after dollar sign
 // ===========================================================================
@@ -382,7 +386,7 @@ fn moo_accessor_completion_includes_type_documentation() {
 package Config;
 use Moo;
 
-has 'timeout' => (is => 'rw', isa => 'Int');
+has 'timeout' => (is => 'rw', isa => 'Int', required => 1, predicate => 1, builder => 1, clearer => 1);
 
 sub check {
     my $self = shift;
@@ -392,11 +396,36 @@ sub check {
     let pos = must_some(code.find("$self->")) + "$self->".len();
     let items = completions(code, pos);
 
-    let timeout_item = must_some(items.iter().find(|c| c.label == "timeout"));
+    let timeout_item = must_some(find_item(&items, "timeout"));
     let doc = must_some(timeout_item.documentation.as_deref());
     assert!(
         doc.contains("Int"),
         "accessor documentation should include the isa type, got: {:?}",
+        doc
+    );
+    assert!(
+        doc.contains("read-write"),
+        "accessor documentation should include access mode, got: {:?}",
+        doc
+    );
+    assert!(
+        doc.contains("Required"),
+        "accessor documentation should include required metadata, got: {:?}",
+        doc
+    );
+    assert!(
+        doc.contains("Predicate") && doc.contains("has_timeout"),
+        "accessor documentation should include predicate metadata, got: {:?}",
+        doc
+    );
+    assert!(
+        doc.contains("Builder") && doc.contains("_build_timeout"),
+        "accessor documentation should include builder metadata, got: {:?}",
+        doc
+    );
+    assert!(
+        doc.contains("Clearer") && doc.contains("clear_timeout"),
+        "accessor documentation should include clearer metadata, got: {:?}",
         doc
     );
 }

--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -139,20 +139,15 @@ impl LspServer {
 
         if let Some(symbol_info) = analyzer.find_definition(offset) {
             // Detect Moo/Moose attribute accessors (declaration == "has") early and
-            // render a dedicated card that shows the isa type and accessor mode clearly,
+            // render a dedicated card that shows the attribute metadata clearly,
             // instead of the generic "Subroutine" label which is misleading for accessors.
             if symbol_info.declaration.as_deref() == Some("has") {
                 let accessor_name = &symbol_info.name;
-                let doc = symbol_info
-                    .documentation
-                    .as_deref()
-                    .unwrap_or("Generated accessor from Moo/Moose `has`");
+                let doc = Self::format_moo_accessor_hover(accessor_name, &symbol_info.attributes);
                 return HoverExtracted::Complete(json!({
                     "contents": {
                         "kind": "markdown",
-                        "value": format!(
-                            "**Moo/Moose Attribute Accessor**\n\n`{accessor_name}` — {doc}"
-                        ),
+                        "value": doc,
                     },
                 }));
             }
@@ -403,6 +398,130 @@ impl LspServer {
         }
 
         HoverExtracted::None
+    }
+
+    fn format_moo_accessor_hover(name: &str, attributes: &[String]) -> String {
+        let isa = Self::moo_attribute_value(attributes, "isa");
+        let access = Self::moo_attribute_value(attributes, "is").map(Self::describe_access_mode);
+        let required = Self::moo_attribute_value(attributes, "required").map(Self::describe_truthy);
+        let predicate = Self::moo_accessor_method_name(name, attributes, "predicate", "has_");
+        let builder = Self::moo_accessor_method_name(name, attributes, "builder", "_build_");
+        let clearer = Self::moo_accessor_method_name(name, attributes, "clearer", "clear_");
+        let reader = Self::moo_attribute_value(attributes, "reader");
+        let writer = Self::moo_attribute_value(attributes, "writer");
+        let accessor = Self::moo_attribute_value(attributes, "accessor");
+        let lazy = Self::moo_attribute_value(attributes, "lazy").map(Self::describe_truthy);
+        let default = Self::moo_attribute_value(attributes, "default");
+
+        let mut lines = vec!["**Moo/Moose Attribute Accessor**".to_string(), String::new()];
+        lines.push(format!("**Attribute**: `{name}`"));
+
+        if let Some(isa) = isa {
+            lines.push(format!("**Type**: `{isa}`"));
+        }
+        if let Some(access) = access {
+            lines.push(format!("**Access**: {access}"));
+        }
+        if let Some(required) = required {
+            lines.push(format!("**Required**: {required}"));
+        }
+        if let Some(predicate) = predicate {
+            lines.push(format!("**Predicate**: `{predicate}`"));
+        }
+        if let Some(builder) = builder {
+            lines.push(format!("**Builder**: `{builder}`"));
+        }
+        if let Some(clearer) = clearer {
+            lines.push(format!("**Clearer**: `{clearer}`"));
+        }
+        if let Some(reader) = reader {
+            lines.push(format!("**Reader**: `{reader}`"));
+        }
+        if let Some(writer) = writer {
+            lines.push(format!("**Writer**: `{writer}`"));
+        }
+        if let Some(accessor) = accessor {
+            lines.push(format!("**Accessor**: `{accessor}`"));
+        }
+        if let Some(lazy) = lazy {
+            lines.push(format!("**Lazy**: {lazy}"));
+        }
+        if let Some(default) = default {
+            lines.push(format!("**Default**: `{default}`"));
+        }
+
+        let extras: Vec<String> = attributes
+            .iter()
+            .filter_map(|attr| {
+                let (key, _) = attr.split_once('=')?;
+                if matches!(
+                    key,
+                    "isa"
+                        | "is"
+                        | "required"
+                        | "predicate"
+                        | "builder"
+                        | "clearer"
+                        | "reader"
+                        | "writer"
+                        | "accessor"
+                        | "lazy"
+                        | "default"
+                ) {
+                    None
+                } else {
+                    Some(attr.clone())
+                }
+            })
+            .collect();
+        if !extras.is_empty() {
+            lines.push(format!("**Options**: {}", extras.join(", ")));
+        }
+
+        lines.join("\n")
+    }
+
+    fn moo_attribute_value<'a>(attributes: &'a [String], key: &str) -> Option<&'a str> {
+        attributes.iter().find_map(|attr| {
+            let (attr_key, value) = attr.split_once('=')?;
+            if attr_key == key { Some(value) } else { None }
+        })
+    }
+
+    fn describe_access_mode(value: &str) -> String {
+        match value {
+            "ro" => "read-only".to_string(),
+            "rw" => "read-write".to_string(),
+            "rwp" => "read-write private".to_string(),
+            "lazy" => "lazy".to_string(),
+            other => other.to_string(),
+        }
+    }
+
+    fn describe_truthy(value: &str) -> String {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" => "yes".to_string(),
+            "0" | "false" | "no" => "no".to_string(),
+            other => other.to_string(),
+        }
+    }
+
+    fn moo_accessor_method_name(
+        name: &str,
+        attributes: &[String],
+        key: &str,
+        default_prefix: &str,
+    ) -> Option<String> {
+        let value = Self::moo_attribute_value(attributes, key)?;
+        if Self::is_truthy(value) {
+            Some(format!("{default_prefix}{name}"))
+        } else {
+            Some(value.to_string())
+        }
+    }
+
+    fn is_truthy(value: &str) -> bool {
+        matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
     }
 
     /// Extract the receiver token immediately before `->` at `offset`.

--- a/crates/perl-lsp/tests/moose_class_model_navigation_tests.rs
+++ b/crates/perl-lsp/tests/moose_class_model_navigation_tests.rs
@@ -248,6 +248,38 @@ mod moose_class_model_navigation_tests {
         Ok(())
     }
 
+    /// Hovering an accessor with Moo/Moose metadata must surface the key fields
+    /// from the attribute model in the hover markdown.
+    #[test]
+    fn test_moose_accessor_hover_surfaces_full_attribute_metadata() -> TestResult {
+        let code = "package Widget;\nuse Moose;\nhas 'status' => (is => 'rw', isa => 'Str', required => 1, predicate => 1, builder => 1, clearer => 1);\nsub render { my ($self) = @_; print $self->status; }\n";
+        let uri = "file:///widget_metadata.pl";
+
+        let resp = hover_at(code, uri, "status", 3)?;
+        let content = semantic::hover_content(&resp)
+            .ok_or("Expected hover content for Moose accessor 'status'")?;
+
+        assert!(
+            content.contains("Moo/Moose Attribute Accessor"),
+            "Hover for Moose accessor should show the dedicated accessor card, got: {content}"
+        );
+        for expected in [
+            "**Attribute**: `status`",
+            "**Type**: `Str`",
+            "**Access**: read-write",
+            "**Required**: yes",
+            "**Predicate**: `has_status`",
+            "**Builder**: `_build_status`",
+            "**Clearer**: `clear_status`",
+        ] {
+            assert!(
+                content.contains(expected),
+                "Hover for Moose accessor should include `{expected}`, got: {content}"
+            );
+        }
+        Ok(())
+    }
+
     /// Hovering on a bare method call (no Moose) must NOT break — must still
     /// return some content as before.
     #[test]


### PR DESCRIPTION
Surface existing Moo/Moose attribute metadata in hover and completion without broad analyzer changes.

Changes:
- Expand Moo/Moose accessor hover cards to show attribute, type, access, required, predicate, builder, clearer, and related options.
- Expand Moo/Moose accessor completion documentation with the same metadata.
- Add regression coverage for hover and completion metadata presentation.

Tests:
- cargo test -p perl-lsp-completion --test completion_behavior_tests moo_accessor_completion_includes_type_documentation
- cargo test -p perl-lsp-rs --test moose_class_model_navigation_tests test_moose_accessor_hover