### PR TITLE
ci(pre-commit): add framework hooks (#3592)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,23 @@
+- id: perl-lsp-fmt
+  name: perl-lsp format check
+  description: Run the repository format gate.
+  entry: cargo xtask fmt --check
+  language: system
+  pass_filenames: false
+  files: '(\.rs$|\.toml$|^Cargo\.lock$|^justfile$|^rust-toolchain\.toml$)'
+
+- id: perl-lsp-clippy
+  name: perl-lsp clippy check
+  description: Run the repository clippy gate for the fast PR path.
+  entry: cargo clippy -p perl-parser -p perl-lexer --locked -- -D warnings -A missing_docs
+  language: system
+  pass_filenames: false
+  files: '(\.rs$|\.toml$|^Cargo\.lock$|^justfile$|^rust-toolchain\.toml$)'
+
+- id: perl-lsp-test
+  name: perl-lsp fast test check
+  description: Run the repository fast library test gate.
+  entry: cargo test -p perl-parser -p perl-lexer --lib --locked
+  language: system
+  pass_filenames: false
+  files: '(\.rs$|\.toml$|^Cargo\.lock$|^justfile$|^rust-toolchain\.toml$)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,9 @@ Install the pre-push git hook so the gate runs automatically before every push:
 bash scripts/install-githooks.sh
 ```
 
+If you prefer the [pre-commit framework](docs/how-to/PRE_COMMIT.md) in a downstream repo,
+use the root-level `.pre-commit-hooks.yaml` manifest and pin the repo by tag.
+
 ### Build and Test
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | --- | --- |
 | get working fast | [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md) |
 | install or upgrade | [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/UPGRADING.md](how-to/UPGRADING.md) |
+| use the pre-commit framework | [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md) |
 | configure an editor | [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md) |
 | troubleshoot a broken setup | [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md) |
 | see what is true now | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) |

--- a/docs/how-to/PRE_COMMIT.md
+++ b/docs/how-to/PRE_COMMIT.md
@@ -1,0 +1,31 @@
+# Pre-commit Framework
+
+`perl-lsp` publishes a root-level [`.pre-commit-hooks.yaml`](../../.pre-commit-hooks.yaml) so downstream repos can reuse the same fast local gates.
+
+Use a pinned release tag in your consumer repo. `rev` should point at a tag, not a branch, so the hook set stays reproducible:
+
+```yaml
+# .pre-commit-config.yaml in a consumer repo
+repos:
+  - repo: https://github.com/EffortlessMetrics/perl-lsp
+    rev: v0.12.3
+    hooks:
+      - id: perl-lsp-fmt
+      - id: perl-lsp-clippy
+      - id: perl-lsp-test
+```
+
+Install and run it once from the consumer repo:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+These hooks are intentionally fast and map to the repo's PR-fast path:
+
+- `perl-lsp-fmt` runs the format check
+- `perl-lsp-clippy` runs the core clippy gate
+- `perl-lsp-test` runs the fast library test gate
+
+For the full merge gate, keep using the repo's normal CI gate or pre-push hook flow.


### PR DESCRIPTION
## Summary
- add a root-level `.pre-commit-hooks.yaml` for the repo
- expose fast format, clippy, and test hooks for downstream pre-commit users
- add a short consumer how-to with a pinned tag example and install commands
- link the new pre-commit guide from the docs front door and contributor guide

## Validation
- git diff --check
- pre-commit validate-manifest
- python3 YAML parse check for `.pre-commit-hooks.yaml`

Fixes #3592