### PR TITLE
ci(pre-commit): add perl-lsp hooks (#3592)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,37 @@
+-   id: perl-lsp-fmt
+    name: perl-lsp fmt
+    description: Check Rust formatting for the perl-lsp workspace.
+    entry: cargo
+    args: [fmt, --all, --check]
+    language: system
+    pass_filenames: false
+    files: ^(Cargo\.(toml|lock)$|crates/|docs/|\.github/|hooks/|\.ci/|README\.md$|CONTRIBUTING\.md$|features\.toml$)
+
+-   id: perl-lsp-clippy
+    name: perl-lsp clippy
+    description: Run clippy across the perl-lsp workspace.
+    entry: cargo
+    args:
+      [
+        clippy,
+        --workspace,
+        --all-targets,
+        --locked,
+        --,
+        -D,
+        warnings,
+        -A,
+        missing_docs,
+      ]
+    language: system
+    pass_filenames: false
+    files: ^(Cargo\.(toml|lock)$|crates/|docs/|\.github/|hooks/|\.ci/|README\.md$|CONTRIBUTING\.md$|features\.toml$)
+
+-   id: perl-lsp-test
+    name: perl-lsp test
+    description: Run the perl-lsp workspace test suite.
+    entry: cargo
+    args: [test, --workspace, --locked]
+    language: system
+    pass_filenames: false
+    files: ^(Cargo\.(toml|lock)$|crates/|docs/|\.github/|hooks/|\.ci/|README\.md$|CONTRIBUTING\.md$|features\.toml$)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | If you need to... | Read this |
 | --- | --- |
 | get working fast | [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md) |
+| set up pre-commit hooks | [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md) |
 | install or upgrade | [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/UPGRADING.md](how-to/UPGRADING.md) |
 | configure an editor | [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md) |
 | troubleshoot a broken setup | [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md) |
@@ -32,7 +33,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 ## Docs by Type
 
 - Tutorial: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
-- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md)
+- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md)
 - Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md)
 - Explanation and project docs: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md)
 

--- a/docs/how-to/PRE_COMMIT.md
+++ b/docs/how-to/PRE_COMMIT.md
@@ -1,0 +1,29 @@
+# Pre-commit Integration
+
+This repository publishes a `.pre-commit-hooks.yaml` file so contributors can run the same fast checks locally before they commit.
+
+## Quick Start
+
+```yaml
+repos:
+  - repo: https://github.com/EffortlessMetrics/perl-lsp
+    rev: v0.12.3
+    hooks:
+      - id: perl-lsp-fmt
+      - id: perl-lsp-clippy
+      - id: perl-lsp-test
+```
+
+Then install and run the hooks:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+## Notes
+
+- The hooks use `cargo` from your local environment.
+- `perl-lsp-fmt` checks formatting with `cargo fmt --all --check`.
+- `perl-lsp-clippy` runs `cargo clippy --workspace --all-targets --locked -- -D warnings -A missing_docs`.
+- `perl-lsp-test` runs `cargo test --workspace --locked`.


### PR DESCRIPTION
## Summary
- add a repository-root `.pre-commit-hooks.yaml` with format, clippy, and test hooks
- document consumer setup in a short how-to page with a copy-paste `pre-commit` example
- link the new how-to from the docs front door

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.pre-commit-hooks.yaml'); puts 'pre-commit manifest ok'"`
- `git diff --check`

Fixes #3592