### PR TITLE
ci(gitlab): add template and docs (#3590)

### DIFF
--- a/docs/project/CI.md
+++ b/docs/project/CI.md
@@ -24,6 +24,27 @@ gate.
 - `just gates`
 - receipt upload and status reporting
 
+## GitLab CI Template
+
+Use [`templates/ci/gitlab/.gitlab-ci.yml`](../../templates/ci/gitlab/.gitlab-ci.yml)
+as the starting point for GitLab-hosted repos or self-managed runners.
+
+The template keeps the GitLab jobs intentionally small:
+
+- `fmt`, `clippy`, and `test` run as separate jobs in the same stage so GitLab
+  can schedule them in parallel.
+- Cargo state is cached under `.cargo/` and `target/`, keyed by `Cargo.lock`.
+- The default image is the stock Rust image, but you can swap in a GitLab
+  Container Registry image if you want to preinstall toolchains or share a
+  custom CI environment.
+
+Example registry image override:
+
+```yaml
+default:
+  image: $CI_REGISTRY_IMAGE/ci/rust:1.92-bookworm
+```
+
 ## Local Equivalents
 
 Use these commands in the same order when iterating locally:

--- a/templates/ci/gitlab/.gitlab-ci.yml
+++ b/templates/ci/gitlab/.gitlab-ci.yml
@@ -1,0 +1,45 @@
+# Minimal GitLab CI/CD template for perl-lsp.
+#
+# This template keeps the default jobs small and parallel. If you publish a
+# custom runner image to the GitLab Container Registry, replace `image:` with
+# `$CI_REGISTRY_IMAGE/...` and keep the cache paths below.
+
+default:
+  image: rust:1.92-bookworm
+  cache:
+    key:
+      files:
+        - Cargo.lock
+    paths:
+      - target/
+      - .cargo/bin/
+      - .cargo/git/db/
+      - .cargo/registry/cache/
+      - .cargo/registry/index/
+  before_script:
+    - rustc --version
+    - cargo --version
+    - rustup component add rustfmt clippy
+
+variables:
+  CARGO_HOME: "$CI_PROJECT_DIR/.cargo"
+  CARGO_TARGET_DIR: "$CI_PROJECT_DIR/target"
+  CARGO_TERM_COLOR: "always"
+
+stages:
+  - check
+
+fmt:
+  stage: check
+  script:
+    - cargo fmt --all --check
+
+clippy:
+  stage: check
+  script:
+    - cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+test:
+  stage: check
+  script:
+    - cargo test --workspace --all-features --locked


### PR DESCRIPTION
Adds a minimal GitLab CI/CD template under templates/ci/gitlab/.gitlab-ci.yml and documents how to use it in docs/project/CI.md.

Scope is intentionally narrow:
- Rust image + cargo cache
- fmt / clippy / test jobs in one parallel stage
- GitLab Container Registry image override example

Validation:
- python3 YAML parse of the template
- git diff --check