### PR TITLE
ci(circleci): add template and docs (#3594)

### DIFF
--- a/docs/how-to/CIRCLECI.md
+++ b/docs/how-to/CIRCLECI.md
@@ -1,0 +1,32 @@
+# CircleCI
+
+This repository publishes a CircleCI template under [`templates/ci/circleci/config.yml`](../../templates/ci/circleci/config.yml).
+
+The template is intentionally minimal and follows the repo's fast PR path with a single matrix job over three checks:
+
+- `cargo fmt --all --check`
+- `cargo clippy -p perl-parser -p perl-lexer --locked -- -D warnings -A missing_docs`
+- `cargo test -p perl-parser -p perl-lexer --lib --locked`
+
+To use it in a consumer repo:
+
+1. Copy the template into `.circleci/config.yml`, or adapt the jobs to your own workflow.
+2. Pin your Rust image or toolchain version if you need reproducible builds.
+3. Keep Cargo caches enabled so registry and git dependencies stay warm across runs.
+
+Example consumer workflow:
+
+```yaml
+version: 2.1
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - check:
+          matrix:
+            parameters:
+              kind: [fmt, clippy, test]
+```
+
+If you need custom artifact collection, store `target/` or a narrower subdirectory in your own project after the fast checks complete.

--- a/templates/ci/circleci/config.yml
+++ b/templates/ci/circleci/config.yml
@@ -1,0 +1,57 @@
+version: 2.1
+
+jobs:
+  check:
+    parameters:
+      kind:
+        type: enum
+        enum: [fmt, clippy, test]
+    docker:
+      - image: cimg/rust:1.85
+    working_directory: ~/project
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-cargo-registry-{{ checksum "Cargo.lock" }}
+            - v1-cargo-registry-
+      - restore_cache:
+          keys:
+            - v1-cargo-git-{{ checksum "Cargo.lock" }}
+            - v1-cargo-git-
+      - run:
+          name: Install rustfmt and clippy
+          command: rustup component add rustfmt clippy
+      - run:
+          name: Run << parameters.kind >>
+          command: |
+            case "<< parameters.kind >>" in
+              fmt)
+                cargo fmt --all --check
+                ;;
+              clippy)
+                cargo clippy -p perl-parser -p perl-lexer --locked -- -D warnings -A missing_docs
+                ;;
+              test)
+                cargo test -p perl-parser -p perl-lexer --lib --locked
+                ;;
+            esac
+      - store_artifacts:
+          path: target
+      - save_cache:
+          key: v1-cargo-registry-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/registry
+      - save_cache:
+          key: v1-cargo-git-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo/git
+
+workflows:
+  version: 2
+  perl_lsp_fast:
+    jobs:
+      - check:
+          matrix:
+            parameters:
+              kind: [fmt, clippy, test]


### PR DESCRIPTION
Adds a focused CircleCI template under templates/ci/circleci/config.yml plus a dedicated docs/how-to/CIRCLECI.md page for consumers.

Scope stays off semantic/LSP runtime files and avoids the active GitHub Actions and GitLab lanes.

Validation:
- git diff --check
- YAML parse check for templates/ci/circleci/config.yml