### PR TITLE
ci(jenkins): add template and guide (#3591)

### DIFF
--- a/docs/how-to/JENKINS.md
+++ b/docs/how-to/JENKINS.md
@@ -1,0 +1,24 @@
+# Jenkins Pipeline
+
+`perl-lsp` ships a Jenkins template at [templates/ci/jenkins/Jenkinsfile](../../templates/ci/jenkins/Jenkinsfile).
+Use it as a starting point for a multibranch pipeline or copy it to the repository root as `Jenkinsfile`.
+
+## Recommended Setup
+
+1. Create a Jenkins multibranch pipeline job for the repository.
+2. Prefer a Docker-backed agent so the Rust toolchain stays reproducible.
+3. Point the job at the repository root `Jenkinsfile`, or copy the template into your repo if you want to customize it.
+4. Open the build in Blue Ocean to view the parallel `Format`, `Clippy`, and `Tests` stages clearly.
+
+## What The Template Does
+
+- Runs inside the official `rust:1.92-bookworm` container.
+- Executes the repository fast path in parallel: formatting, clippy, and library tests.
+- Publishes per-stage JUnit records and log artifacts under `target/jenkins-*`.
+- Keeps the implementation declarative so Jenkins can visualize stage flow cleanly.
+
+## Customization Notes
+
+- If your Jenkins environment needs extra system packages, add them to the Docker image or bootstrap them in the `Checkout` stage.
+- If you prefer a bare agent instead of Docker, swap the `agent { docker { ... } }` block for your own Rust bootstrap logic.
+- If you want full-gate validation, extend the `Fast Gates` parallel block with the repo's heavier checks.

--- a/templates/ci/jenkins/Jenkinsfile
+++ b/templates/ci/jenkins/Jenkinsfile
@@ -1,0 +1,99 @@
+def escapeXml(String text) {
+    return text
+        .replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
+        .replace('"', '&quot;')
+        .replace("'", '&apos;')
+}
+
+def writeStageReport(String name, boolean success, String message = '') {
+    def reportDir = 'target/jenkins-reports'
+    sh "mkdir -p '${reportDir}'"
+    def escaped = escapeXml(message)
+    def failureBlock = success ? '' : "    <failure message=\"${escaped}\"><![CDATA[${message}]]></failure>\n"
+    def xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="perl-lsp:${name}" tests="1" failures="${success ? 0 : 1}" errors="0" skipped="0">
+  <testcase classname="perl-lsp" name="${name}">
+${failureBlock}  </testcase>
+</testsuite>
+"""
+    writeFile file: "${reportDir}/${name}.xml", text: xml
+}
+
+def runGate(String name, String command) {
+    def logDir = 'target/jenkins-logs'
+    def reportDir = 'target/jenkins-reports'
+    sh "mkdir -p '${logDir}' '${reportDir}'"
+
+    def logFile = "${logDir}/${name}.log"
+    try {
+        sh """#!/usr/bin/env bash
+set -euo pipefail
+${command} 2>&1 | tee '${logFile}'
+"""
+        writeStageReport(name, true)
+    } catch (err) {
+        writeStageReport(name, false, err.toString())
+        throw err
+    }
+}
+
+pipeline {
+    agent {
+        docker {
+            image 'rust:1.92-bookworm'
+            args '-u root:root'
+            reuseNode true
+        }
+    }
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+    }
+    environment {
+        CARGO_HOME = "${WORKSPACE}/.cargo"
+        CARGO_TARGET_DIR = "${WORKSPACE}/target"
+        RUST_BACKTRACE = '1'
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                sh 'rustc --version'
+                sh 'cargo --version'
+            }
+        }
+        stage('Fast Gates') {
+            parallel {
+                stage('Format') {
+                    steps {
+                        script {
+                            runGate('format', 'cargo fmt --all --check')
+                        }
+                    }
+                }
+                stage('Clippy') {
+                    steps {
+                        script {
+                            runGate('clippy', 'cargo clippy -p perl-parser -p perl-lexer --locked -- -D warnings -A missing_docs')
+                        }
+                    }
+                }
+                stage('Tests') {
+                    steps {
+                        script {
+                            runGate('tests', 'cargo test -p perl-parser -p perl-lexer --lib --locked')
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            junit allowEmptyResults: true, testResults: 'target/jenkins-reports/*.xml'
+            archiveArtifacts artifacts: 'target/jenkins-logs/**/*.log, target/jenkins-reports/*.xml', allowEmptyArchive: true
+        }
+    }
+}


### PR DESCRIPTION
Adds a focused Jenkins pipeline template under templates/ci/jenkins and a dedicated how-to page for consumers.\n\nValidation:\n- git diff --check\n- targeted content checks for the Jenkinsfile and docs page