### PR TITLE
ci(travis): add template and docs (#3596)

### DIFF
--- a/docs/how-to/TRAVIS.md
+++ b/docs/how-to/TRAVIS.md
@@ -1,0 +1,26 @@
+# Travis CI
+
+This repository prefers GitHub Actions for new CI setups. Use the Travis
+template here only when you are maintaining a legacy consumer repository that
+still depends on Travis.
+
+Template path:
+
+- [`templates/ci/travis/.travis.yml`](../../templates/ci/travis/.travis.yml)
+
+The template is intentionally minimal:
+
+- Rust stable, beta, and nightly are checked
+- `cargo fmt --all --check` runs first
+- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` runs next
+- `cargo test --workspace --all-features --locked` runs last
+- nightly is allowed to fail so the stable lanes stay the signal
+
+If you need extra Travis jobs for old consumers, add them in the consumer
+repository rather than expanding this template. Keep multi-arch or
+project-specific jobs local to the repository that actually needs them. For
+example, add `arch: arm64` or `arch: ppc64le` jobs only in the consumer repo
+when you specifically need that coverage.
+
+For new projects, prefer the GitHub Actions workflow in
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).

--- a/templates/ci/travis/.travis.yml
+++ b/templates/ci/travis/.travis.yml
@@ -1,0 +1,24 @@
+# Travis CI is legacy support for consumer repositories that still need it.
+# Prefer GitHub Actions for new projects and keep Travis as a migration bridge.
+
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+cache: cargo
+
+before_script:
+  - rustup component add rustfmt clippy
+
+script:
+  - cargo fmt --all --check
+  - cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+  - cargo test --workspace --all-features --locked
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
Adds a minimal Travis CI template under templates/ci/travis/.travis.yml plus a dedicated legacy-support note in docs/how-to/TRAVIS.md.

GitHub Actions remains the preferred CI path for new projects; Travis is provided as a migration bridge for consumers that still need it.