### PR TITLE
feat(capabilities): advertise typeHierarchyProvider via experimental field (#3525)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,6 +1812,7 @@ version = "0.12.3"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-ids",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -18,6 +18,9 @@ include = ["src/**", "Cargo.toml", "README.md"]
 lsp-types.workspace = true
 perl-lsp-feature-ids = { workspace = true }
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/perl-lsp-capability-map/src/lib.rs
+++ b/crates/perl-lsp-capability-map/src/lib.rs
@@ -87,7 +87,11 @@ pub fn feature_ids_from_caps(c: &ServerCapabilities) -> Vec<&'static str> {
     if c.moniker_provider.is_some() {
         v.push(LSP_MONIKER);
     }
-    // Note: type_hierarchy_provider doesn't exist in lsp-types 0.97
+    // lsp-types 0.97 lacks a `type_hierarchy_provider` field; detect it via
+    // the `experimental` object where `capabilities_for()` advertises it.
+    if c.experimental.as_ref().and_then(|e| e.get("typeHierarchyProvider")).is_some() {
+        v.push(LSP_TYPE_HIERARCHY);
+    }
     if c.inline_value_provider.is_some() {
         v.push(LSP_INLINE_VALUE);
     }
@@ -486,5 +490,31 @@ mod tests {
     fn caps_from_notebook_sync_has_selector() {
         let caps = caps_from_feature_ids(&[LSP_NOTEBOOK_DOCUMENT_SYNC]);
         assert!(caps.notebook_document_sync.is_some());
+    }
+
+    /// Verify that `feature_ids_from_caps` can detect `lsp.type_hierarchy` when
+    /// advertised via the `experimental` field (lsp-types 0.97 gap workaround).
+    #[test]
+    fn feature_ids_from_caps_detects_type_hierarchy_via_experimental() {
+        let mut caps = ServerCapabilities::default();
+        caps.experimental = Some(serde_json::json!({ "typeHierarchyProvider": true }));
+        let ids = feature_ids_from_caps(&caps);
+        assert!(
+            ids.contains(&LSP_TYPE_HIERARCHY),
+            "feature_ids_from_caps must detect lsp.type_hierarchy via experimental field; \
+             got ids={ids:?}"
+        );
+    }
+
+    /// Verify that `feature_ids_from_caps` does not report `lsp.type_hierarchy` when
+    /// the experimental field is absent.
+    #[test]
+    fn feature_ids_from_caps_no_type_hierarchy_when_experimental_absent() {
+        let caps = ServerCapabilities::default();
+        let ids = feature_ids_from_caps(&caps);
+        assert!(
+            !ids.contains(&LSP_TYPE_HIERARCHY),
+            "feature_ids_from_caps must not report lsp.type_hierarchy when not advertised"
+        );
     }
 }

--- a/crates/perl-lsp-diagnostics/src/parse_errors.rs
+++ b/crates/perl-lsp-diagnostics/src/parse_errors.rs
@@ -103,16 +103,15 @@ pub fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
 
 /// Derive the user-facing severity for a parser error.
 pub fn parse_error_severity(error: &ParseError) -> DiagnosticSeverity {
-    if matches!(error, ParseError::SyntaxError { .. }) {
-        if matches!(parse_error_code(error), DiagnosticCode::InvalidPrototype)
+    if matches!(error, ParseError::SyntaxError { .. })
+        && (matches!(parse_error_code(error), DiagnosticCode::InvalidPrototype)
             || matches!(
                 error,
                 ParseError::SyntaxError { message, .. }
                     if is_unknown_subroutine_attribute_warning(message)
-            )
-        {
-            return DiagnosticSeverity::Warning;
-        }
+            ))
+    {
+        return DiagnosticSeverity::Warning;
     }
 
     DiagnosticSeverity::Error

--- a/crates/perl-lsp-protocol/src/capabilities.rs
+++ b/crates/perl-lsp-protocol/src/capabilities.rs
@@ -294,8 +294,17 @@ pub fn capabilities_for(build: BuildFlags) -> ServerCapabilities {
         caps.call_hierarchy_provider = Some(CallHierarchyServerCapability::Simple(true));
     }
 
-    // Placeholder for type hierarchy: always add to JSON in capabilities_json
-    // Type hierarchy not directly supported in current lsp-types
+    // Type hierarchy via experimental: lsp-types 0.97 lacks a `type_hierarchy_provider`
+    // field on `ServerCapabilities`. We advertise it via `experimental` so that
+    // `capabilities_for()` users and `feature_ids_from_caps` can detect the capability.
+    // The `handle_initialize` response also injects it at the top-level for clients.
+    if build.type_hierarchy {
+        let mut experimental = caps.experimental.take().unwrap_or_else(|| serde_json::json!({}));
+        if let Some(obj) = experimental.as_object_mut() {
+            obj.insert("typeHierarchyProvider".to_string(), serde_json::json!(true));
+        }
+        caps.experimental = Some(experimental);
+    }
 
     caps
 }
@@ -371,15 +380,13 @@ mod tests {
     /// lacks the corresponding `ServerCapabilities` field.
     ///
     /// - `inline_completion`: advertised via `experimental` JSON, no typed field
-    /// - `type_hierarchy`: injected in `capabilities_json()`, not in struct
     /// - `notebook_cell_execution`: sub-feature of notebook sync, no own field
     /// - `ranges_formatting`: injected in `capabilities_json()` (LSP 3.18, not in lsp-types 0.97)
-    const KNOWN_STRUCTURAL_GAPS: &[&str] = &[
-        "lsp.inline_completion",
-        "lsp.notebook_cell_execution",
-        "lsp.ranges_formatting",
-        "lsp.type_hierarchy",
-    ];
+    ///
+    /// Note: `type_hierarchy` was previously a gap but is now advertised via
+    /// `experimental` in `capabilities_for()` and detected by `feature_ids_from_caps`.
+    const KNOWN_STRUCTURAL_GAPS: &[&str] =
+        &["lsp.inline_completion", "lsp.notebook_cell_execution", "lsp.ranges_formatting"];
 
     /// Guard: feature IDs from BuildFlags must match feature IDs extracted
     /// from the ServerCapabilities that `capabilities_for()` actually builds.

--- a/crates/perl-lsp-protocol/tests/capability_advertisement_tests.rs
+++ b/crates/perl-lsp-protocol/tests/capability_advertisement_tests.rs
@@ -894,7 +894,60 @@ fn capabilities_json_adds_type_hierarchy_beyond_struct() -> Result<(), Box<dyn s
     );
     assert!(
         from_struct.get("typeHierarchyProvider").is_none(),
-        "struct serialization should not have typeHierarchyProvider"
+        "struct serialization should not have typeHierarchyProvider at top-level \
+         (it is in experimental instead)"
+    );
+    Ok(())
+}
+
+/// Verify that `capabilities_for()` advertises `typeHierarchyProvider` via the
+/// `experimental` field when `type_hierarchy` is enabled.
+///
+/// This ensures clients that inspect `ServerCapabilities.experimental` can discover
+/// the type hierarchy capability even though lsp-types 0.97 lacks a typed field for it.
+#[test]
+fn type_hierarchy_advertised_in_experimental_when_enabled() -> Result<(), Box<dyn std::error::Error>>
+{
+    let flags = BuildFlags { type_hierarchy: true, ..BuildFlags::default() };
+    let caps = capabilities_for(flags);
+    let v = serde_json::to_value(&caps)?;
+    let type_hierarchy_in_experimental = v.pointer("/experimental/typeHierarchyProvider").is_some();
+    assert!(
+        type_hierarchy_in_experimental,
+        "capabilities_for() must advertise typeHierarchyProvider in experimental when \
+         type_hierarchy is enabled; got experimental={:?}",
+        v.get("experimental")
+    );
+    Ok(())
+}
+
+/// Verify that `typeHierarchyProvider` is absent from `experimental` when disabled.
+#[test]
+fn type_hierarchy_absent_from_experimental_when_disabled() -> Result<(), Box<dyn std::error::Error>>
+{
+    let flags = BuildFlags { type_hierarchy: false, ..BuildFlags::default() };
+    let caps = capabilities_for(flags);
+    let v = serde_json::to_value(&caps)?;
+    let type_hierarchy_in_experimental = v.pointer("/experimental/typeHierarchyProvider").is_some();
+    assert!(
+        !type_hierarchy_in_experimental,
+        "capabilities_for() must not advertise typeHierarchyProvider in experimental when \
+         type_hierarchy is disabled"
+    );
+    Ok(())
+}
+
+/// Verify that `type_hierarchy` is no longer a structural gap: `capabilities_for()`
+/// now advertises it via `experimental`, making it detectable by `feature_ids_from_caps`.
+#[test]
+fn type_hierarchy_is_not_a_structural_gap() -> Result<(), Box<dyn std::error::Error>> {
+    let flags = BuildFlags { type_hierarchy: true, ..BuildFlags::default() };
+    let caps = capabilities_for(flags);
+    let v = serde_json::to_value(&caps)?;
+    // The experimental field must be present and contain typeHierarchyProvider
+    assert!(
+        v.pointer("/experimental/typeHierarchyProvider").is_some(),
+        "type_hierarchy must be detectable via experimental — it is no longer a structural gap"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #3525

- `capabilities_for()` now inserts `typeHierarchyProvider: true` into `caps.experimental` when `build.type_hierarchy` is enabled, following the same workaround pattern used for `inline_completion`. This ensures the typed `ServerCapabilities` struct advertises type hierarchy to any code inspecting it.
- `feature_ids_from_caps()` in `perl-lsp-capability-map` now detects `lsp.type_hierarchy` by checking `experimental.typeHierarchyProvider`, closing the detection gap.
- `KNOWN_STRUCTURAL_GAPS` no longer lists `lsp.type_hierarchy` — the feature-ID alignment tests now verify it end-to-end.
- Also fixes a pre-existing `clippy::collapsible_if` warning in `perl-lsp-diagnostics/parse_errors.rs` that blocked the CI gate.

## Root cause

lsp-types 0.97 does not have a `type_hierarchy_provider` typed field on `ServerCapabilities`. Previously, `capabilities_for()` could not advertise type hierarchy in the struct at all — only `capabilities_json()` and `handle_initialize`'s direct JSON injection did so. Code using the typed struct (such as `feature_ids_from_caps`) could not detect the feature.

## Verification

Five new tests added:

**`perl-lsp-protocol`**
- `type_hierarchy_advertised_in_experimental_when_enabled` — struct has `experimental.typeHierarchyProvider` when flag is on
- `type_hierarchy_absent_from_experimental_when_disabled` — absent when flag is off
- `type_hierarchy_is_not_a_structural_gap` — detectable via experimental field

**`perl-lsp-capability-map`**
- `feature_ids_from_caps_detects_type_hierarchy_via_experimental` — `LSP_TYPE_HIERARCHY` is emitted when experimental field present
- `feature_ids_from_caps_no_type_hierarchy_when_experimental_absent` — not emitted when absent

Feature ID alignment tests (`feature_id_alignment_ga_lock`, `feature_id_alignment_production`, `feature_id_alignment_all`) now cover `lsp.type_hierarchy` without relying on `KNOWN_STRUCTURAL_GAPS`.

## Test plan

- [x] `cargo test -p perl-lsp-protocol` — 360 passed
- [x] `cargo test -p perl-lsp-capability-map` — 145 passed
- [x] `cargo clippy --workspace --lib` — no issues
- [x] `cargo fmt -p perl-lsp-protocol -p perl-lsp-capability-map -p perl-lsp-diagnostics` — clean