### PR TITLE
feat(navigation): support Moose type constraints (#3604)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -113,6 +113,7 @@ pub use self::test_more::get_test_more_documentation;
 
 use perl_parser_core::ast::Node;
 use perl_parser_core::ast::NodeKind;
+use perl_semantic_analyzer::semantic::{BuiltinDoc, get_moose_type_documentation};
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
 use perl_workspace_index::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
@@ -125,6 +126,37 @@ use std::sync::Arc;
 /// - Entry with EMPTY set: `use Module qw()` (explicit empty qw import) — nothing in namespace.
 /// - Entry with non-empty set: `use Module qw(a b)` — only those symbols are imported.
 type ImportMap = HashMap<String, HashSet<String>>;
+
+const MOOSE_TYPE_CANDIDATES: &[&str] = &[
+    "Any",
+    "Item",
+    "Undef",
+    "Defined",
+    "Value",
+    "Bool",
+    "Str",
+    "Num",
+    "Int",
+    "ClassName",
+    "RoleName",
+    "Ref",
+    "ScalarRef",
+    "ArrayRef",
+    "HashRef",
+    "CodeRef",
+    "RegexpRef",
+    "GlobRef",
+    "FileHandle",
+    "Object",
+    "Maybe",
+    "InstanceOf",
+    "ConsumerOf",
+    "HasMethods",
+    "Dict",
+    "Tuple",
+    "Map",
+    "Enum",
+];
 
 /// Completion provider
 pub struct CompletionProvider {
@@ -223,6 +255,48 @@ impl CompletionProvider {
     fn extract_import_map(ast: &Node) -> ImportMap {
         let mut map: ImportMap = HashMap::new();
 
+        fn collect_import_symbols(arg: &str, symbols: &mut HashSet<String>) -> bool {
+            let trimmed = arg.trim();
+            if trimmed.is_empty() {
+                return false;
+            }
+            if matches!(trimmed, "=>" | "," | "(" | ")" | "[" | "]" | "{" | "}") {
+                return false;
+            }
+
+            let mut content = trimmed;
+            if let Some(inner) = content.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                content = inner.trim();
+            }
+
+            if content.starts_with("qw") {
+                content = content
+                    .trim_start_matches("qw")
+                    .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                    .trim_end_matches(|c: char| ")]}/|!>".contains(c))
+                    .trim();
+
+                for word in content.split_whitespace() {
+                    if !word.is_empty() {
+                        symbols.insert(word.to_string());
+                    }
+                }
+                return !content.is_empty();
+            }
+
+            let cleaned = content.trim_matches(|c: char| c == '\'' || c == '"');
+            if cleaned.is_empty() {
+                return false;
+            }
+
+            for word in cleaned.split_whitespace() {
+                if !word.is_empty() {
+                    symbols.insert(word.to_string());
+                }
+            }
+            true
+        }
+
         fn collect(node: &Node, map: &mut ImportMap) {
             match &node.kind {
                 NodeKind::Use { module, args, .. } => {
@@ -250,29 +324,8 @@ impl CompletionProvider {
                         if arg.starts_with('-') {
                             continue;
                         }
-                        // Skip hash-ref style args
-                        if arg.starts_with('{') {
-                            continue;
-                        }
-
-                        if arg.starts_with("qw") {
-                            let content = arg
-                                .trim_start_matches("qw")
-                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                            for word in content.split_whitespace() {
-                                if !word.is_empty() {
-                                    symbols.insert(word.to_string());
-                                    has_symbol_args = true;
-                                }
-                            }
-                        } else {
-                            // Bare string arg (possibly quoted): 'func' or "func"
-                            let cleaned = arg.trim_matches(|c: char| c == '\'' || c == '"');
-                            if !cleaned.is_empty() {
-                                symbols.insert(cleaned.to_string());
-                                has_symbol_args = true;
-                            }
+                        if collect_import_symbols(arg, &mut symbols) {
+                            has_symbol_args = true;
                         }
                     }
 
@@ -513,6 +566,8 @@ impl CompletionProvider {
                 &context,
                 &self.workspace_index,
             );
+        } else if self.is_has_type_value_context(source, position) {
+            self.add_has_type_completions(&mut completions, &context);
         } else if self.is_has_options_key_context(source, position) {
             self.add_has_option_completions(&mut completions, &context);
         } else if (context.trigger_character == Some('>') || context.trigger_character == Some('-'))
@@ -1058,6 +1113,138 @@ impl CompletionProvider {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch.is_ascii_whitespace())
     }
 
+    /// Check whether the cursor is inside the value position of a Moo/Moose `isa => ...`
+    /// attribute inside a `has(...)` declaration.
+    fn is_has_type_value_context(&self, source: &str, position: usize) -> bool {
+        self.has_option_value_prefix(source, position, "isa").is_some()
+    }
+
+    /// Return the current value prefix for a `has(...)` option if the cursor is in that
+    /// option's value position.
+    fn has_option_value_prefix(
+        &self,
+        source: &str,
+        position: usize,
+        option_name: &str,
+    ) -> Option<String> {
+        if position > source.len() {
+            return None;
+        }
+
+        let prefix = &source[..position];
+        let statement_start = prefix.rfind(';').map(|idx| idx + 1).unwrap_or(0);
+        let statement = &prefix[statement_start..];
+
+        let has_idx = Self::find_keyword(statement, "has")?;
+        let after_has = &statement[has_idx + 3..];
+
+        let arrow_idx = after_has.find("=>")?;
+        let after_arrow = &after_has[arrow_idx + 2..];
+
+        let open_idx = after_arrow.find('(')?;
+        let options_text = &after_arrow[open_idx + 1..];
+
+        // Must still be inside the `(` ... `)` option list.
+        let mut paren_depth = 1i32;
+        for ch in options_text.chars() {
+            if ch == '(' {
+                paren_depth += 1;
+            } else if ch == ')' {
+                paren_depth -= 1;
+                if paren_depth <= 0 {
+                    return None;
+                }
+            }
+        }
+
+        // Find the current top-level option segment (after last comma).
+        let mut depth = 1i32;
+        let mut segment_start = 0usize;
+        for (idx, ch) in options_text.char_indices() {
+            if ch == '(' {
+                depth += 1;
+            } else if ch == ')' {
+                depth -= 1;
+            } else if ch == ',' && depth == 1 {
+                segment_start = idx + 1;
+            }
+        }
+
+        let segment = options_text[segment_start..].trim_start();
+        let Some(option_prefix) = segment.strip_prefix(option_name) else {
+            return None;
+        };
+
+        let Some(option_prefix) = option_prefix.trim_start().strip_prefix("=>") else {
+            return None;
+        };
+
+        Some(option_prefix.trim_start().to_string())
+    }
+
+    /// Add completions for Moo/Moose type constraint values inside `isa => ...`.
+    fn add_has_type_completions(
+        &self,
+        completions: &mut Vec<CompletionItem>,
+        context: &CompletionContext,
+    ) {
+        let prefix = context.prefix.trim();
+        let mut seen: HashSet<String> = completions.iter().map(|item| item.label.clone()).collect();
+
+        let mut push_completion =
+            |label: &str, detail: String, documentation: String, kind: CompletionItemKind| {
+                if !seen.insert(label.to_string()) {
+                    return;
+                }
+
+                completions.push(CompletionItem {
+                    label: label.to_string(),
+                    kind,
+                    detail: Some(detail),
+                    documentation: Some(documentation),
+                    insert_text: Some(label.to_string()),
+                    sort_text: Some(format!("0_{label}")),
+                    filter_text: Some(label.to_string()),
+                    additional_edits: vec![],
+                    text_edit_range: Some((context.prefix_start, context.position)),
+                    commit_characters: None,
+                });
+            };
+
+        for type_name in MOOSE_TYPE_CANDIDATES {
+            if !prefix.is_empty() && !type_name.starts_with(prefix) {
+                continue;
+            }
+
+            if let Some(doc) = get_moose_type_documentation(type_name) {
+                push_completion(
+                    type_name,
+                    "Built-in Moose type".to_string(),
+                    Self::format_type_documentation(&doc),
+                    CompletionItemKind::Module,
+                );
+            }
+        }
+
+        for (module_name, symbols) in &self.import_map {
+            for symbol in symbols {
+                if !Self::looks_like_type_name(symbol) {
+                    continue;
+                }
+                if !prefix.is_empty() && !symbol.starts_with(prefix) {
+                    continue;
+                }
+
+                push_completion(
+                    symbol,
+                    format!("Imported type from {module_name}"),
+                    format!("Imported from `{module_name}`."),
+                    CompletionItemKind::Module,
+                );
+            }
+        }
+    }
+
     /// Find a keyword in source text using ASCII identifier boundaries.
     fn find_keyword(text: &str, keyword: &str) -> Option<usize> {
         let mut start = 0usize;
@@ -1075,6 +1262,16 @@ impl CompletionProvider {
             start = idx + keyword.len();
         }
         None
+    }
+
+    /// Convert Moose type documentation into a concise completion tooltip.
+    fn format_type_documentation(doc: &BuiltinDoc) -> String {
+        format!("{}\n\n{}", doc.signature, doc.description)
+    }
+
+    /// Return `true` when the label looks like a type name rather than a function.
+    fn looks_like_type_name(label: &str) -> bool {
+        label.chars().next().is_some_and(|c| c.is_ascii_uppercase()) || label.contains("::")
     }
 
     /// Add common Moo/Moose `has` option-key completions.
@@ -1675,6 +1872,38 @@ has 'name' => (re
         assert!(
             completions.iter().any(|item| item.label == "reader"),
             "expected `reader` option completion inside has(...) context"
+        );
+    }
+
+    #[test]
+    fn test_moo_isa_type_completion_includes_builtins_and_imports() {
+        let code = r#"
+use MyApp::Types qw(UserID PositiveInt);
+use Moose;
+
+has 'id' => (
+    is => 'ro',
+    isa => 
+"#;
+
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        let provider = CompletionProvider::new_with_index_and_source(&ast, code, None);
+
+        let completions = provider.get_completions(code, code.len());
+
+        assert!(
+            completions.iter().any(|item| item.label == "Str"),
+            "expected built-in Moose type `Str` in isa completion, got: {:?}",
+            completions.iter().map(|item| &item.label).collect::<Vec<_>>()
+        );
+        assert!(
+            completions.iter().any(|item| item.label == "ArrayRef"),
+            "expected built-in Moose type `ArrayRef` in isa completion"
+        );
+        assert!(
+            completions.iter().any(|item| item.label == "UserID"),
+            "expected imported custom type `UserID` in isa completion"
         );
     }
 

--- a/crates/perl-lsp-navigation/src/type_definition.rs
+++ b/crates/perl-lsp-navigation/src/type_definition.rs
@@ -41,8 +41,22 @@ impl TypeDefinitionProvider {
         // Find the node at the given position
         let target_node = self.find_node_at_position(ast, line, character, source_text)?;
 
-        // Get the type name from the node
-        let type_name = self.extract_type_name(&target_node)?;
+        // First try Moose/Moo `has(... isa => Type)` attribute forms.
+        let type_name = self
+            .extract_has_type_constraint_name(
+                ast,
+                target_node.location.start,
+                target_node.location.end,
+            )
+            // Fall back to generic class / object / `isa` expression handling.
+            .or_else(|| self.extract_type_name(&target_node))?;
+
+        // Try to resolve custom type declarations before package/class names.
+        if let Some(locations) =
+            self.find_custom_type_definition_in_docs(&type_name, uri, documents)
+        {
+            return Some(locations);
+        }
 
         // Find the package/class definition — search all open documents
         self.find_package_definition_in_docs(&type_name, uri, documents)
@@ -65,6 +79,39 @@ impl TypeDefinitionProvider {
         for (doc_uri, source_text) in documents {
             if let Ok(ast) = perl_parser_core::Parser::new(source_text).parse() {
                 self.find_package_in_node(&ast, package_name, doc_uri, source_text, &mut locations);
+            }
+        }
+
+        if !locations.is_empty() { Some(locations) } else { None }
+    }
+
+    /// Find a custom Moose/Type::Tiny type declaration across all open documents.
+    ///
+    /// Supports bounded type-declaration forms such as `type UserID, ...` and
+    /// `subtype PositiveInt, ...`, which are sufficient for MooseX::Types and
+    /// Type::Tiny libraries used by the editor-facing provider path.
+    #[cfg(feature = "lsp-compat")]
+    fn find_custom_type_definition_in_docs(
+        &self,
+        type_name: &str,
+        _origin_uri: &str,
+        documents: &HashMap<String, String>,
+    ) -> Option<Vec<LocationLink>> {
+        let mut locations = Vec::new();
+
+        for (doc_uri, source_text) in documents {
+            if let Ok(ast) = perl_parser_core::Parser::new(source_text).parse() {
+                self.find_custom_type_in_node(
+                    &ast,
+                    type_name,
+                    doc_uri,
+                    source_text,
+                    &mut locations,
+                );
+            }
+
+            if locations.is_empty() {
+                self.find_custom_type_in_source(type_name, doc_uri, source_text, &mut locations);
             }
         }
 
@@ -174,6 +221,179 @@ impl TypeDefinitionProvider {
         }
     }
 
+    /// Extract the type name from a Moose/Moo `has(... isa => Type)` attribute.
+    #[cfg(feature = "lsp-compat")]
+    fn extract_has_type_constraint_name(
+        &self,
+        node: &Node,
+        target_start: usize,
+        target_end: usize,
+    ) -> Option<String> {
+        match &node.kind {
+            NodeKind::FunctionCall { name, args } if name == "has" => {
+                for arg in args {
+                    if let Some(type_name) = self.extract_has_type_constraint_name_from_node(
+                        arg,
+                        target_start,
+                        target_end,
+                    ) {
+                        return Some(type_name);
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        let mut found = None;
+        self.visit_children(node, |child| {
+            if found.is_none() {
+                found = self.extract_has_type_constraint_name(child, target_start, target_end);
+            }
+        });
+        found
+    }
+
+    /// Search a node for the `isa => Type` value that encloses the cursor.
+    #[cfg(feature = "lsp-compat")]
+    fn extract_has_type_constraint_name_from_node(
+        &self,
+        node: &Node,
+        target_start: usize,
+        target_end: usize,
+    ) -> Option<String> {
+        match &node.kind {
+            NodeKind::HashLiteral { pairs } => {
+                for (key, pair_value) in pairs {
+                    if matches!(&key.kind, NodeKind::String { value: key_name, .. } if key_name == "isa")
+                        && target_start >= pair_value.location.start
+                        && target_end <= pair_value.location.end
+                    {
+                        return match &pair_value.kind {
+                            NodeKind::Identifier { name } => Some(name.clone()),
+                            NodeKind::String { value, .. } => Some(value.clone()),
+                            NodeKind::Variable { name, .. } => Some(name.clone()),
+                            _ => None,
+                        };
+                    }
+                }
+            }
+            NodeKind::Binary { op, left, right } if op == "=>" => {
+                if matches!(&left.kind, NodeKind::Identifier { name } if name == "isa")
+                    && target_start >= right.location.start
+                    && target_end <= right.location.end
+                {
+                    return match &right.kind {
+                        NodeKind::Identifier { name } => Some(name.clone()),
+                        NodeKind::String { value, .. } => Some(value.clone()),
+                        NodeKind::Variable { name, .. } => Some(name.clone()),
+                        _ => None,
+                    };
+                }
+            }
+            _ => {}
+        }
+
+        let mut found = None;
+        self.visit_children(node, |child| {
+            if found.is_none() {
+                found = self.extract_has_type_constraint_name_from_node(
+                    child,
+                    target_start,
+                    target_end,
+                );
+            }
+        });
+        found
+    }
+
+    /// Return `true` when a function call looks like a type declaration.
+    #[cfg(feature = "lsp-compat")]
+    fn is_type_declaration_call(name: &str) -> bool {
+        matches!(name, "type" | "subtype" | "class_type" | "role_type" | "enum" | "declare")
+    }
+
+    /// Extract a declared type name from the arguments of a type declaration call.
+    #[cfg(feature = "lsp-compat")]
+    fn declared_type_name(args: &[Node]) -> Option<String> {
+        args.first().and_then(|arg| match &arg.kind {
+            NodeKind::Identifier { name } => Some(name.clone()),
+            NodeKind::String { value, .. } => Some(value.clone()),
+            NodeKind::Variable { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+    }
+
+    /// Fallback textual scan for custom type declarations when the AST does not
+    /// expose the MooseX::Types DSL shape directly.
+    #[cfg(feature = "lsp-compat")]
+    fn find_custom_type_in_source(
+        &self,
+        type_name: &str,
+        uri: &str,
+        source_text: &str,
+        locations: &mut Vec<LocationLink>,
+    ) {
+        let mut offset = 0usize;
+
+        for line in source_text.split_inclusive('\n') {
+            let line_end = offset + line.len();
+            let body = line.strip_suffix('\n').unwrap_or(line);
+            let body = body.strip_suffix('\r').unwrap_or(body);
+            let trimmed = body.trim_start();
+            let leading_ws = body.len().saturating_sub(trimmed.len());
+            let start_offset = offset + leading_ws;
+
+            if Self::line_declares_custom_type(trimmed, type_name) {
+                self.push_location_link_from_offsets(
+                    start_offset,
+                    line_end,
+                    uri,
+                    source_text,
+                    locations,
+                );
+                return;
+            }
+
+            offset = line_end;
+        }
+    }
+
+    /// Return `true` when a source line looks like a supported custom type declaration.
+    #[cfg(feature = "lsp-compat")]
+    fn line_declares_custom_type(line: &str, type_name: &str) -> bool {
+        let keywords = ["type", "subtype", "class_type", "role_type", "enum", "declare"];
+
+        keywords.iter().any(|keyword| {
+            let Some(rest) = line.strip_prefix(keyword) else {
+                return false;
+            };
+
+            Self::first_declared_name(rest).as_deref().is_some_and(|declared| declared == type_name)
+        })
+    }
+
+    /// Extract the first declared identifier or string from a type declaration tail.
+    #[cfg(feature = "lsp-compat")]
+    fn first_declared_name(text: &str) -> Option<String> {
+        let mut rest = text.trim_start();
+        while rest.starts_with([',', '(', ')']) {
+            rest = rest[1..].trim_start();
+        }
+
+        if let Some(quoted) = rest.strip_prefix('"').or_else(|| rest.strip_prefix('\'')) {
+            let quote = rest.chars().next()?;
+            let value_end = quoted.find(quote)?;
+            return Some(quoted[..value_end].to_string());
+        }
+
+        let name: String = rest
+            .chars()
+            .take_while(|ch| ch.is_alphanumeric() || matches!(ch, '_' | ':' | '-'))
+            .collect();
+
+        if name.is_empty() { None } else { Some(name) }
+    }
+
     /// Try to infer the type of an object from its declaration or assignment
     #[cfg(feature = "lsp-compat")]
     fn infer_object_type(&self, object: &Node) -> Option<String> {
@@ -225,36 +445,7 @@ impl TypeDefinitionProvider {
     ) {
         match &node.kind {
             NodeKind::Package { name, .. } if name == package_name => {
-                // Convert byte offsets to LSP range using perl-parser-core utilities
-                let (target_start_line, target_start_char) =
-                    perl_parser_core::engine::position::offset_to_utf16_line_col(
-                        source_text,
-                        node.location.start,
-                    );
-                let (target_end_line, target_end_char) =
-                    perl_parser_core::engine::position::offset_to_utf16_line_col(
-                        source_text,
-                        node.location.end,
-                    );
-
-                let target_range = lsp_types::Range {
-                    start: lsp_types::Position {
-                        line: target_start_line,
-                        character: target_start_char,
-                    },
-                    end: lsp_types::Position { line: target_end_line, character: target_end_char },
-                };
-
-                // Create typed LocationLink for better UI experience
-                // Parse URI - if invalid, skip this location
-                if let Ok(target_uri) = lsp_types::Uri::from_str(uri) {
-                    locations.push(LocationLink {
-                        origin_selection_range: None, // Could be filled with the reference range
-                        target_uri,
-                        target_range,
-                        target_selection_range: target_range,
-                    });
-                }
+                self.push_location_link(node, uri, source_text, locations);
             }
             _ => {}
         }
@@ -263,6 +454,95 @@ impl TypeDefinitionProvider {
         self.visit_children(node, |child| {
             self.find_package_in_node(child, package_name, uri, source_text, locations);
         });
+    }
+
+    /// Recursively find type declarations by matching the declared name.
+    #[cfg(feature = "lsp-compat")]
+    fn find_custom_type_in_node(
+        &self,
+        node: &Node,
+        type_name: &str,
+        uri: &str,
+        source_text: &str,
+        locations: &mut Vec<LocationLink>,
+    ) {
+        match &node.kind {
+            NodeKind::FunctionCall { name, args } if Self::is_type_declaration_call(name) => {
+                if Self::declared_type_name(args).as_deref() == Some(type_name) {
+                    self.push_location_link(node, uri, source_text, locations);
+                }
+            }
+            _ => {}
+        }
+
+        self.visit_children(node, |child| {
+            self.find_custom_type_in_node(child, type_name, uri, source_text, locations);
+        });
+    }
+
+    /// Convert the current node range into an LSP `LocationLink` and push it.
+    #[cfg(feature = "lsp-compat")]
+    fn push_location_link(
+        &self,
+        node: &Node,
+        uri: &str,
+        source_text: &str,
+        locations: &mut Vec<LocationLink>,
+    ) {
+        let (target_start_line, target_start_char) =
+            perl_parser_core::engine::position::offset_to_utf16_line_col(
+                source_text,
+                node.location.start,
+            );
+        let (target_end_line, target_end_char) =
+            perl_parser_core::engine::position::offset_to_utf16_line_col(
+                source_text,
+                node.location.end,
+            );
+
+        let target_range = lsp_types::Range {
+            start: lsp_types::Position { line: target_start_line, character: target_start_char },
+            end: lsp_types::Position { line: target_end_line, character: target_end_char },
+        };
+
+        if let Ok(target_uri) = lsp_types::Uri::from_str(uri) {
+            locations.push(LocationLink {
+                origin_selection_range: None,
+                target_uri,
+                target_range,
+                target_selection_range: target_range,
+            });
+        }
+    }
+
+    /// Convert raw byte offsets into an LSP `LocationLink` and push it.
+    #[cfg(feature = "lsp-compat")]
+    fn push_location_link_from_offsets(
+        &self,
+        start_offset: usize,
+        end_offset: usize,
+        uri: &str,
+        source_text: &str,
+        locations: &mut Vec<LocationLink>,
+    ) {
+        let (target_start_line, target_start_char) =
+            perl_parser_core::engine::position::offset_to_utf16_line_col(source_text, start_offset);
+        let (target_end_line, target_end_char) =
+            perl_parser_core::engine::position::offset_to_utf16_line_col(source_text, end_offset);
+
+        let target_range = lsp_types::Range {
+            start: lsp_types::Position { line: target_start_line, character: target_start_char },
+            end: lsp_types::Position { line: target_end_line, character: target_end_char },
+        };
+
+        if let Ok(target_uri) = lsp_types::Uri::from_str(uri) {
+            locations.push(LocationLink {
+                origin_selection_range: None,
+                target_uri,
+                target_range,
+                target_selection_range: target_range,
+            });
+        }
     }
 
     /// Helper to visit children of a node
@@ -303,6 +583,12 @@ impl TypeDefinitionProvider {
             NodeKind::FunctionCall { args, .. } => {
                 for arg in args {
                     f(arg);
+                }
+            }
+            NodeKind::HashLiteral { pairs } => {
+                for (key, value) in pairs {
+                    f(key);
+                    f(value);
                 }
             }
             NodeKind::Subroutine { body, .. } => {

--- a/crates/perl-lsp/tests/lsp_type_definition_tests.rs
+++ b/crates/perl-lsp/tests/lsp_type_definition_tests.rs
@@ -211,6 +211,67 @@ if ($pet isa Animal) {
 }
 
 #[test]
+fn test_type_definition_moose_type_library_resolves_custom_type()
+-> Result<(), Box<dyn std::error::Error>> {
+    let types_uri = "file:///lib/MyApp/Types.pm";
+    let types_code = r#"
+package MyApp::Types;
+use MooseX::Types -declare => [qw(UserID)];
+type UserID, where { /\A\d+\z/ };
+
+1;
+"#;
+    let _types_ast = perl_parser::Parser::new(types_code).parse()?;
+
+    let user_uri = "file:///lib/MyApp/User.pm";
+    let user_code = r#"
+package MyApp::User;
+use Moose;
+use MyApp::Types qw(UserID);
+
+has 'id' => (is => 'ro', isa => UserID);
+
+1;
+"#;
+    let user_ast = perl_parser::Parser::new(user_code).parse()?;
+
+    let line = user_code
+        .lines()
+        .position(|line| line.contains("isa => UserID"))
+        .ok_or("type use line not found")?;
+    let character = user_code
+        .lines()
+        .nth(line)
+        .and_then(|line| line.find("UserID"))
+        .ok_or("type use column not found")?;
+
+    let mut documents = std::collections::HashMap::new();
+    documents.insert(types_uri.to_string(), types_code.to_string());
+    documents.insert(user_uri.to_string(), user_code.to_string());
+
+    let provider = perl_lsp_navigation::TypeDefinitionProvider::new();
+    let locations = provider
+        .find_type_definition(&user_ast, line as u32, character as u32, user_uri, &documents)
+        .ok_or("Expected array from type definition")?;
+    assert!(
+        !locations.is_empty(),
+        "Expected custom Moose type definition to resolve, got: {locations:?}"
+    );
+
+    let target_uri = locations[0].target_uri.as_str();
+    assert_eq!(target_uri, types_uri, "type definition should resolve into the type library");
+
+    let target_line = locations[0].target_range.start.line as u64;
+    let expected_line = types_code
+        .lines()
+        .position(|line| line.contains("type UserID"))
+        .ok_or("type declaration line missing")? as u64;
+    assert_eq!(target_line, expected_line, "type definition should land on `type UserID`");
+
+    Ok(())
+}
+
+#[test]
 fn test_type_definition_no_type() -> Result<(), Box<dyn std::error::Error>> {
     let mut harness = LspHarness::new();
     let _init = harness.initialize(None)?;


### PR DESCRIPTION
Adds bounded Moose type-constraint support in the completion and type-definition provider paths:\n\n- built-in Moose type completion coverage\n- imported custom type name completion coverage\n- type-definition resolution for MooseX::Types declarations and has(... isa => ...) values\n- targeted regression tests for completion and type-definition lookup\n\nTests run:\n- cargo test -p perl-lsp-completion test_moo_isa_type_completion_includes_builtins_and_imports -- --nocapture\n- cargo test -p perl-lsp-rs --test lsp_type_definition_tests test_type_definition_moose_type_library_resolves_custom_type -- --nocapture