### PR TITLE
docs(testing): add continuous testing guide and examples (#3593)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ Choose the path that matches what you are trying to do:
 | Integrate perl-lsp into GitHub Actions | [GitHub Actions Integration](how-to/GITHUB_ACTIONS.md) |
 | Upgrade an existing installation | [Upgrading](how-to/UPGRADING.md) |
 | Get a working editor setup quickly | [Getting Started](tutorials/GETTING_STARTED.md) |
+| Set up continuous testing and watch loops | [Continuous Testing](how-to/CONTINUOUS_TESTING.md) |
 | Configure editor or workspace settings | [Configuration Reference](reference/CONFIG.md) |
 | Share project settings with my team | [Project Configuration File (.perl-lsp.toml)](reference/CONFIG.md#project-configuration-file-perl-lsptoml) |
 | Troubleshoot startup, indexing, or editor issues | [Troubleshooting](how-to/TROUBLESHOOTING.md) |
@@ -40,6 +41,7 @@ Task-focused instructions for common operational and development workflows.
 - [Upgrading](how-to/UPGRADING.md)
 - [Editor Setup](how-to/EDITOR_SETUP.md)
 - [Troubleshooting](how-to/TROUBLESHOOTING.md)
+- [Continuous Testing](how-to/CONTINUOUS_TESTING.md)
 - [Contributing LSP Features](how-to/CONTRIBUTING_LSP.md)
 - [Threading Configuration Guide](how-to/THREADING_CONFIGURATION_GUIDE.md)
 - [Performance Tuning](how-to/PERFORMANCE_TUNING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | If you need to... | Read this |
 | --- | --- |
 | get working fast | [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md) |
+| set up continuous testing | [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md) |
 | set up pre-commit hooks | [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md) |
 | install or upgrade | [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/UPGRADING.md](how-to/UPGRADING.md) |
 | set up `perllsp` in GitHub Actions | [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md) |
@@ -34,7 +35,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 ## Docs by Type
 
 - Tutorial: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
-- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md)
+- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md)
 - Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md)
 - Explanation and project docs: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md)
 

--- a/docs/examples/vscode/tasks.json
+++ b/docs/examples/vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "perl-lsp: watch tests with bacon",
+      "type": "shell",
+      "command": "just dev-watch-tests",
+      "group": "test",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "perl-lsp: nextest local-fast",
+      "type": "shell",
+      "command": "cargo nextest run --profile local-fast --workspace",
+      "group": "test",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/docs/how-to/CONTINUOUS_TESTING.md
+++ b/docs/how-to/CONTINUOUS_TESTING.md
@@ -1,0 +1,62 @@
+# Continuous Testing
+
+Use this guide when you want tests to rerun automatically while you edit. The
+repo already has the pieces you need:
+
+- `bacon.toml` for interactive watch loops
+- `just dev-watch*` wrappers around the common local loops
+- `cargo nextest` for faster targeted test execution
+
+## Recommended Loops
+
+Start with the repo-native watch commands:
+
+```bash
+just dev-watch
+just dev-watch-clippy
+just dev-watch-tests
+```
+
+Those recipes use `bacon.toml` when `bacon` is installed, and they fall back
+cleanly when it is not.
+
+If you want a narrower test runner loop, use `nextest` directly:
+
+```bash
+cargo nextest run --profile local-fast --workspace
+```
+
+You can combine that with `cargo-watch` if you prefer a shell-driven file
+watcher:
+
+```bash
+cargo watch -s "cargo nextest run --profile local-fast --workspace"
+```
+
+## VS Code Example
+
+The repository keeps a reusable task file at
+[docs/examples/vscode/tasks.json](../examples/vscode/tasks.json). Copy it into
+your workspace `.vscode/tasks.json` and adjust the command you want on save.
+
+The example includes two tasks:
+
+- run the bacon-backed watch loop through `just dev-watch-tests`
+- run the `cargo nextest` local-fast profile directly
+
+## IntelliJ Rust Plugin
+
+IntelliJ and the Rust plugin do not need a perl-lsp-specific integration point
+for this workflow. Configure an external tool or file watcher that runs one of
+the commands above.
+
+Use `just dev-watch-tests` if you want the repo defaults, or run
+`cargo nextest run --profile local-fast --workspace` when you want the smaller
+test loop.
+
+## When To Use Each Tool
+
+- Use `bacon` when you want a fast feedback loop while editing.
+- Use `nextest` when you want a quicker targeted test run than `cargo test`.
+- Use `cargo-watch` when your editor or shell workflow already expects a
+  watch-and-rerun command.

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -638,6 +638,7 @@ just dev-watch-tests      # core test loop
 ```
 
 The watch recipes use `bacon.toml` with project-tuned jobs for faster local feedback loops.
+For a walkthrough and editor task example, see [Continuous Testing](../how-to/CONTINUOUS_TESTING.md).
 
 ## Dual-Scanner Corpus Comparison (*Diataxis: How-to Guide* - Testing procedures)
 

--- a/docs/reference/TEST_INFRASTRUCTURE_GUIDE.md
+++ b/docs/reference/TEST_INFRASTRUCTURE_GUIDE.md
@@ -482,6 +482,8 @@ cargo nextest run --profile local-fast --workspace
 
 **Purpose**: Rapid iteration during development with balanced parallelization.
 
+For a practical editor/watch walkthrough, see [Continuous Testing](../how-to/CONTINUOUS_TESTING.md).
+
 ---
 
 ## Known Flaky Tests


### PR DESCRIPTION
Add a focused how-to for continuous local testing workflows.

Includes:
- a new continuous testing guide that reuses the existing bacon, just, and nextest commands
- a repo-side VS Code tasks example under docs/examples
- front-door links from docs/README.md and docs/INDEX.md
- short references from the commands and test infrastructure docs

Validation:
- git diff --check
- python3 -m json.tool docs/examples/vscode/tasks.json