### PR TITLE
feat(symbol-surface): track declarator on SymbolDecl to distinguish our vs my (#3497)

### DIFF
--- a/crates/perl-symbol-surface/CLAUDE.md
+++ b/crates/perl-symbol-surface/CLAUDE.md
@@ -75,6 +75,7 @@ The walker tracks the innermost `package` declaration in statement order:
 | `full_span` | `(usize, usize)` | Byte range of the full declaration node |
 | `anchor_span` | `Option<(usize, usize)>` | Byte range of the name token; `None` when AST lacks `name_span` |
 | `container` | `Option<String>` | Enclosing package name; `None` at top level |
+| `declarator` | `Option<String>` | Variable scope keyword: `"my"`, `"our"`, `"local"`, `"state"`; `None` for non-variable declarations. `"our"` means package-scoped (cross-file visible). |
 
 ### Future Phases
 

--- a/crates/perl-symbol-surface/src/decl.rs
+++ b/crates/perl-symbol-surface/src/decl.rs
@@ -35,6 +35,11 @@ use perl_symbol_types::{SymbolKind, VarKind};
 ///   `class`).
 /// - `container` — unqualified name of the enclosing package, `None` at
 ///   the top level
+/// - `declarator` — the scope keyword used to declare variables (`"my"`,
+///   `"our"`, `"local"`, `"state"`), or `None` for non-variable declarations
+///   such as subroutines, packages, and constants.  `"our"` variables are
+///   package-scoped and visible across files; `"my"` variables are
+///   lexically-scoped and file-local.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SymbolDecl {
     /// Symbol classification.
@@ -49,6 +54,14 @@ pub struct SymbolDecl {
     pub anchor_span: Option<(usize, usize)>,
     /// Enclosing package name, if the declaration is inside a `package`.
     pub container: Option<String>,
+    /// Scope declarator for variable declarations: `"my"`, `"our"`, `"local"`,
+    /// or `"state"`.  `None` for non-variable declarations (subroutines,
+    /// packages, constants, classes).
+    ///
+    /// `"our"` variables are package-scoped and reachable from other files in
+    /// the same package.  `"my"` variables are lexically-scoped and invisible
+    /// outside their enclosing block.
+    pub declarator: Option<String>,
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -114,6 +127,7 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 full_span: (node.location.start, node.location.end),
                 anchor_span: anchor,
                 container,
+                declarator: None,
             });
 
             // If the package has a block, descend with package context scoped
@@ -140,6 +154,7 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 full_span: (node.location.start, node.location.end),
                 anchor_span: None, // Class has no name_span in current AST
                 container,
+                declarator: None,
             });
 
             // Walk class body with the class name as the package context.
@@ -160,6 +175,7 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 full_span: (node.location.start, node.location.end),
                 anchor_span: anchor,
                 container,
+                declarator: None,
             });
             // Walk the body — may contain nested subs or closures.
             walk(body, ctx, out);
@@ -181,13 +197,14 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                 full_span: (node.location.start, node.location.end),
                 anchor_span: None, // Method has no name_span in current AST
                 container,
+                declarator: None,
             });
             walk(body, ctx, out);
         }
 
         // ── Variable declarations ──────────────────────────────────────────
-        NodeKind::VariableDeclaration { variable, initializer, .. } => {
-            if let Some(decl) = variable_decl_from_node(variable, node, ctx) {
+        NodeKind::VariableDeclaration { declarator, variable, initializer, .. } => {
+            if let Some(decl) = variable_decl_from_node(variable, node, ctx, declarator) {
                 out.push(decl);
             }
             // Walk initializer for nested declarations (e.g. `my $x = sub { }`)
@@ -196,9 +213,9 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
             }
         }
 
-        NodeKind::VariableListDeclaration { variables, initializer, .. } => {
+        NodeKind::VariableListDeclaration { declarator, variables, initializer, .. } => {
             for var in variables {
-                if let Some(decl) = variable_decl_from_node(var, node, ctx) {
+                if let Some(decl) = variable_decl_from_node(var, node, ctx, declarator) {
                     out.push(decl);
                 }
             }
@@ -223,6 +240,7 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
                         full_span: (node.location.start, node.location.end),
                         anchor_span: None, // No precise span available from Use node
                         container,
+                        declarator: None,
                     });
                 }
             }
@@ -252,9 +270,18 @@ fn walk_statements(statements: &[Node], ctx: &mut WalkCtx, out: &mut Vec<SymbolD
 
 /// Extract a `SymbolDecl` from a `Variable` node inside a `VariableDeclaration`.
 ///
+/// `declarator` is the scope keyword (`"my"`, `"our"`, `"local"`, `"state"`)
+/// from the enclosing declaration node; it is stored on the returned `SymbolDecl`
+/// so consumers can distinguish package-scoped (`our`) from lexical (`my`) symbols.
+///
 /// Returns `None` for non-`Variable` children (e.g. `VariableWithAttributes`
 /// wrapping — in that case the caller should unwrap further).
-fn variable_decl_from_node(var_node: &Node, decl_node: &Node, ctx: &WalkCtx) -> Option<SymbolDecl> {
+fn variable_decl_from_node(
+    var_node: &Node,
+    decl_node: &Node,
+    ctx: &WalkCtx,
+    declarator: &str,
+) -> Option<SymbolDecl> {
     match &var_node.kind {
         NodeKind::Variable { sigil, name } => {
             let kind = sigil_to_symbol_kind(sigil);
@@ -267,10 +294,11 @@ fn variable_decl_from_node(var_node: &Node, decl_node: &Node, ctx: &WalkCtx) -> 
                 full_span: (decl_node.location.start, decl_node.location.end),
                 anchor_span,
                 container,
+                declarator: Some(declarator.to_owned()),
             })
         }
         NodeKind::VariableWithAttributes { variable, .. } => {
-            variable_decl_from_node(variable, decl_node, ctx)
+            variable_decl_from_node(variable, decl_node, ctx, declarator)
         }
         _ => None,
     }

--- a/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
+++ b/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
@@ -298,6 +298,210 @@ fn test_subroutine_inside_package_block() -> Result<(), String> {
     Ok(())
 }
 
+// ── Declarator tracking ───────────────────────────────────────────────────────
+
+#[test]
+fn test_our_variable_has_declarator() {
+    // our $VERSION = '1.0';
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "VERSION".to_string() },
+        loc(4, 12),
+    );
+    let decl_node = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "our".to_string(),
+            variable: Box::new(var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 12),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 12));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].declarator.as_deref(), Some("our"));
+}
+
+#[test]
+fn test_my_variable_has_declarator() {
+    // my $x = 42;
+    let var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(3, 5));
+    let decl_node = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 5),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 5));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].declarator.as_deref(), Some("my"));
+}
+
+#[test]
+fn test_state_variable_has_declarator() {
+    // state $count = 0;
+    let var = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(6, 12),
+    );
+    let decl_node = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "state".to_string(),
+            variable: Box::new(var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 12),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 12));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].declarator.as_deref(), Some("state"));
+}
+
+#[test]
+fn test_local_variable_has_declarator() {
+    // local $x = 1;
+    let var =
+        Node::new(NodeKind::Variable { sigil: "$".to_string(), name: "x".to_string() }, loc(6, 8));
+    let decl_node = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "local".to_string(),
+            variable: Box::new(var),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 8),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 8));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    assert_eq!(decls[0].declarator.as_deref(), Some("local"));
+}
+
+#[test]
+fn test_our_vs_my_declarations_are_distinguished() -> Result<(), String> {
+    // our $GLOBAL = 1; my $local = 2;
+    let var_our = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "GLOBAL".to_string() },
+        loc(4, 11),
+    );
+    let decl_our = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "our".to_string(),
+            variable: Box::new(var_our),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 11),
+    );
+
+    let var_my = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "local".to_string() },
+        loc(16, 22),
+    );
+    let decl_my = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(var_my),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(13, 22),
+    );
+
+    let program = Node::new(NodeKind::Program { statements: vec![decl_our, decl_my] }, loc(0, 22));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+
+    let our_decl = decls.iter().find(|d| d.name == "GLOBAL").ok_or("expected GLOBAL decl")?;
+    assert_eq!(our_decl.declarator.as_deref(), Some("our"), "GLOBAL should have 'our' declarator");
+
+    let my_decl = decls.iter().find(|d| d.name == "local").ok_or("expected local decl")?;
+    assert_eq!(my_decl.declarator.as_deref(), Some("my"), "local should have 'my' declarator");
+
+    Ok(())
+}
+
+#[test]
+fn test_our_variables_in_list_declaration_have_declarator() -> Result<(), String> {
+    // our ($FOO, $BAR);
+    let var_foo = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "FOO".to_string() },
+        loc(5, 9),
+    );
+    let var_bar = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "BAR".to_string() },
+        loc(11, 15),
+    );
+    let decl_node = Node::new(
+        NodeKind::VariableListDeclaration {
+            declarator: "our".to_string(),
+            variables: vec![var_foo, var_bar],
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 16),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 16));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+    for d in &decls {
+        assert_eq!(
+            d.declarator.as_deref(),
+            Some("our"),
+            "expected 'our' declarator for {} but got {:?}",
+            d.name,
+            d.declarator
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_non_variable_decls_have_no_declarator() {
+    // sub greet { }
+    let body = Node::new(NodeKind::Block { statements: vec![] }, loc(10, 13));
+    let sub_node = Node::new(
+        NodeKind::Subroutine {
+            name: Some("greet".to_string()),
+            name_span: Some(loc(4, 9)),
+            prototype: None,
+            signature: None,
+            attributes: vec![],
+            body: Box::new(body),
+        },
+        loc(0, 13),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![sub_node] }, loc(0, 13));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    assert!(
+        decls[0].declarator.is_none(),
+        "subroutines should have no declarator, got {:?}",
+        decls[0].declarator
+    );
+}
+
 // ── SymbolDecl structural properties ─────────────────────────────────────────
 
 #[test]
@@ -309,6 +513,7 @@ fn test_symbol_decl_derives() {
         full_span: (0, 10),
         anchor_span: Some((4, 7)),
         container: Some("Foo".to_string()),
+        declarator: None,
     };
     // Must be Clone, Debug, PartialEq
     let d2 = d.clone();


### PR DESCRIPTION
## Summary

- Add `declarator: Option<String>` field to `SymbolDecl` so consumers can distinguish package-scoped `our` variables from lexically-scoped `my`, `local`, and `state` variables
- Update `variable_decl_from_node()` to capture and forward the `declarator` string from the enclosing `VariableDeclaration`/`VariableListDeclaration` AST node
- Non-variable declarations (subroutines, packages, constants, classes) receive `declarator: None`

## Changes

- `crates/perl-symbol-surface/src/decl.rs` — Added `declarator: Option<String>` to `SymbolDecl`, updated `variable_decl_from_node()` signature to accept `declarator: &str`, updated all `SymbolDecl` construction sites
- `crates/perl-symbol-surface/tests/symbol_decl_tests.rs` — Added 7 new tests: `test_our_variable_has_declarator`, `test_my_variable_has_declarator`, `test_state_variable_has_declarator`, `test_local_variable_has_declarator`, `test_our_vs_my_declarations_are_distinguished`, `test_our_variables_in_list_declaration_have_declarator`, `test_non_variable_decls_have_no_declarator`
- `crates/perl-symbol-surface/CLAUDE.md` — Documented the new `declarator` field

## Evidence

- **Commits**: 1
- **Tests**: 18 passed (11 pre-existing + 7 new), 0 failed
- **Lint**: `cargo clippy -p perl-symbol-surface --tests` clean, `cargo fmt` applied
- **Files**: 3 changed, +240/-6 lines

## Test Plan

```bash
cargo test -p perl-symbol-surface
# Should show 18 tests passing
cargo clippy -p perl-symbol-surface --tests
# Should be clean
```

Verify `our` vs `my` distinction:
- `extract_symbol_decls` on `our $VERSION = 1` → `declarator = Some("our")`
- `extract_symbol_decls` on `my $x = 1` → `declarator = Some("my")`
- `extract_symbol_decls` on `sub foo {}` → `declarator = None`

## Unknowns

- Workspace-level filtering (only indexing `our` in workspace symbols) is follow-up work per the issue spec — this PR establishes the data layer prerequisite
- `VariableWithAttributes` wrapping is handled correctly (declarator is forwarded through recursive unwrap)
- No downstream consumers of `SymbolDecl` exist yet — this is a zero-breakage additive change

Closes #3497