### PR TITLE
docs(security): remove taint-checking overclaim (#3617)

### DIFF
--- a/docs/explanation/LSP_DOCUMENTATION.md
+++ b/docs/explanation/LSP_DOCUMENTATION.md
@@ -426,7 +426,7 @@ Example debug output:
 
 3. **Enhanced Diagnostics**
    - Type checking (where possible)
-   - Security warnings (taint checking)
+   - Security anti-pattern warnings (for example string eval, backtick execution, and unsafe open patterns)
    - Best practice suggestions
 
 4. **Multi-file Support**


### PR DESCRIPTION
## Summary\n- align the diagnostics docs with the security lints that actually ship today\n- replace the taint-checking promise with the current anti-pattern warning coverage\n\n## Validation\n- git diff --check\n\nCloses #3617