### PR TITLE
fix(ci): restore completion clippy green (#3698)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -1171,13 +1171,8 @@ impl CompletionProvider {
         }
 
         let segment = options_text[segment_start..].trim_start();
-        let Some(option_prefix) = segment.strip_prefix(option_name) else {
-            return None;
-        };
-
-        let Some(option_prefix) = option_prefix.trim_start().strip_prefix("=>") else {
-            return None;
-        };
+        let option_prefix = segment.strip_prefix(option_name)?;
+        let option_prefix = option_prefix.trim_start().strip_prefix("=>")?;
 
         Some(option_prefix.trim_start().to_string())
     }


### PR DESCRIPTION
## Summary
- rewrite the two  sites in completion option parsing to use 
- restore  compliance on current 
- keep PR smoke from failing on this unrelated pre-existing lint

## Testing
- cargo clippy -p perl-lsp-completion --locked -- -D warnings -A missing_docs
- cargo test -p perl-lsp-completion --lib --locked
