### PR TITLE
feat(dap): implement stopOnEntry support for attach request (#3524)

### DIFF
--- a/crates/perl-dap-config/src/lib.rs
+++ b/crates/perl-dap-config/src/lib.rs
@@ -36,6 +36,7 @@
 //!     host: "localhost".to_string(),
 //!     port: 13603,
 //!     timeout_ms: Some(5000),
+//!     stop_on_entry: None,
 //! };
 //!
 //! config.validate()?;
@@ -232,11 +233,24 @@ pub struct AttachConfiguration {
     /// Connection timeout in milliseconds (optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u32>,
+
+    /// If true, pause execution at the first opportunity after attaching.
+    ///
+    /// Equivalent to the DAP `stopOnEntry` field. When set, the adapter emits a
+    /// `stopped` event with `reason = "entry"` immediately after the attach
+    /// handshake completes. Defaults to `false` when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_on_entry: Option<bool>,
 }
 
 impl Default for AttachConfiguration {
     fn default() -> Self {
-        Self { host: "localhost".to_string(), port: 13603, timeout_ms: Some(5000) }
+        Self {
+            host: "localhost".to_string(),
+            port: 13603,
+            timeout_ms: Some(5000),
+            stop_on_entry: None,
+        }
     }
 }
 
@@ -262,6 +276,7 @@ impl AttachConfiguration {
     ///     host: "localhost".to_string(),
     ///     port: 13603,
     ///     timeout_ms: Some(5000),
+    ///     stop_on_entry: None,
     /// };
     ///
     /// config.validate()?;
@@ -357,7 +372,8 @@ pub fn create_attach_json_snippet() -> String {
         "name": "Attach to Perl::LanguageServer",
         "host": "localhost",
         "port": 13603,
-        "timeout": 5000
+        "timeout": 5000,
+        "stopOnEntry": false
     });
     serde_json::to_string_pretty(&json).unwrap_or_else(|e| {
         tracing::error!(error = %e, "Failed to serialize attach.json snippet");

--- a/crates/perl-dap-config/tests/attach_config_tests.rs
+++ b/crates/perl-dap-config/tests/attach_config_tests.rs
@@ -25,6 +25,7 @@ fn test_attach_config_custom_port() -> Result<(), Box<dyn std::error::Error>> {
         host: "192.168.1.100".to_string(),
         port: 9000,
         timeout_ms: Some(10000),
+        stop_on_entry: None,
     };
 
     let json = serde_json::to_string(&config)?;
@@ -36,8 +37,12 @@ fn test_attach_config_custom_port() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_attach_config_validation_valid() {
     // Test: valid attach configuration
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
 
     assert!(config.validate().is_ok(), "Valid config should pass validation");
 }
@@ -45,7 +50,12 @@ fn test_attach_config_validation_valid() {
 #[test]
 fn test_attach_config_validation_empty_host() -> Result<(), Box<dyn std::error::Error>> {
     // Test: empty host fails validation
-    let config = AttachConfiguration { host: "".to_string(), port: 13603, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
 
     let result = config.validate();
     assert!(result.is_err(), "Empty host should fail validation");
@@ -56,8 +66,12 @@ fn test_attach_config_validation_empty_host() -> Result<(), Box<dyn std::error::
 #[test]
 fn test_attach_config_validation_whitespace_host() {
     // Test: whitespace-only host fails validation
-    let config =
-        AttachConfiguration { host: "   ".to_string(), port: 13603, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "   ".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
 
     let result = config.validate();
     assert!(result.is_err(), "Whitespace host should fail validation");
@@ -66,8 +80,12 @@ fn test_attach_config_validation_whitespace_host() {
 #[test]
 fn test_attach_config_validation_zero_port() -> Result<(), Box<dyn std::error::Error>> {
     // Test: port 0 is invalid
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 0, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 0,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
 
     let result = config.validate();
     assert!(result.is_err(), "Port 0 should fail validation");
@@ -78,8 +96,12 @@ fn test_attach_config_validation_zero_port() -> Result<(), Box<dyn std::error::E
 #[test]
 fn test_attach_config_validation_zero_timeout() -> Result<(), Box<dyn std::error::Error>> {
     // Test: zero timeout fails validation
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: Some(0) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(0),
+        stop_on_entry: None,
+    };
 
     let result = config.validate();
     assert!(result.is_err(), "Zero timeout should fail validation");
@@ -94,6 +116,7 @@ fn test_attach_config_validation_excessive_timeout() {
         host: "localhost".to_string(),
         port: 13603,
         timeout_ms: Some(400_000), // 400 seconds
+        stop_on_entry: None,
     };
 
     let result = config.validate();
@@ -103,8 +126,12 @@ fn test_attach_config_validation_excessive_timeout() {
 #[test]
 fn test_attach_config_validation_no_timeout() {
     // Test: no timeout specified is valid
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: None };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: None,
+        stop_on_entry: None,
+    };
 
     assert!(config.validate().is_ok(), "Config without timeout should be valid");
 }

--- a/crates/perl-dap-config/tests/serde_edge_case_tests.rs
+++ b/crates/perl-dap-config/tests/serde_edge_case_tests.rs
@@ -184,6 +184,7 @@ fn attach_config_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         host: "192.168.1.100".to_string(),
         port: 9229,
         timeout_ms: Some(15000),
+        stop_on_entry: None,
     };
 
     let json = serde_json::to_string(&config)?;
@@ -197,8 +198,12 @@ fn attach_config_round_trip() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn attach_config_round_trip_no_timeout() -> Result<(), Box<dyn std::error::Error>> {
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: None };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: None,
+        stop_on_entry: None,
+    };
 
     let json = serde_json::to_string(&config)?;
     assert!(!json.contains("timeoutMs"), "None timeoutMs should be omitted: {json}");
@@ -226,6 +231,7 @@ fn attach_config_validation_boundary_timeout() {
         host: "localhost".to_string(),
         port: 13603,
         timeout_ms: Some(300_000),
+        stop_on_entry: None,
     };
     assert!(config.validate().is_ok(), "Max timeout should be valid");
 
@@ -234,6 +240,7 @@ fn attach_config_validation_boundary_timeout() {
         host: "localhost".to_string(),
         port: 13603,
         timeout_ms: Some(300_001),
+        stop_on_entry: None,
     };
     assert!(config.validate().is_err(), "Over-max timeout should fail");
 }
@@ -241,20 +248,33 @@ fn attach_config_validation_boundary_timeout() {
 #[test]
 fn attach_config_validation_port_boundaries() {
     // Port 1 is valid
-    let config = AttachConfiguration { host: "localhost".to_string(), port: 1, timeout_ms: None };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 1,
+        timeout_ms: None,
+        stop_on_entry: None,
+    };
     assert!(config.validate().is_ok(), "Port 1 should be valid");
 
     // Port 65535 is valid (max u16)
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 65535, timeout_ms: None };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 65535,
+        timeout_ms: None,
+        stop_on_entry: None,
+    };
     assert!(config.validate().is_ok(), "Port 65535 should be valid");
 }
 
 #[test]
 fn attach_config_validation_timeout_1ms() {
     // Timeout of 1ms is the minimum valid timeout
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: Some(1) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(1),
+        stop_on_entry: None,
+    };
     assert!(config.validate().is_ok(), "1ms timeout should be valid");
 }
 

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -800,7 +800,12 @@ impl DebugAdapter {
                     *guard = Some(pid);
                 }
 
+                let stop_on_entry =
+                    args.get("stopOnEntry").and_then(|s| s.as_bool()).unwrap_or(false);
                 let thread_id = Self::i64_to_i32_saturating(i64::from(pid));
+
+                // Always emit the "attach" stopped event to signal the client that the
+                // debugger is connected and paused.
                 self.send_event(
                     "stopped",
                     Some(json!({
@@ -810,7 +815,25 @@ impl DebugAdapter {
                     })),
                 );
 
-                tracing::info!(pid, "Attach request: Process ID attachment (signal-control mode)");
+                // When stopOnEntry is requested, emit an additional "entry" stopped event
+                // so the IDE pauses at the first available program location.
+                if stop_on_entry {
+                    self.send_event(
+                        "stopped",
+                        Some(json!({
+                            "reason": "entry",
+                            "threadId": thread_id,
+                            "allThreadsStopped": true,
+                            "description": "Paused on entry"
+                        })),
+                    );
+                }
+
+                tracing::info!(
+                    pid,
+                    stop_on_entry,
+                    "Attach request: Process ID attachment (signal-control mode)"
+                );
 
                 DapMessage::Response {
                     seq,
@@ -844,6 +867,8 @@ impl DebugAdapter {
                 }
                 let port = raw_port as u16;
                 let timeout = args.get("timeout").and_then(|t| t.as_u64()).map(|t| t as u32);
+                let stop_on_entry =
+                    args.get("stopOnEntry").and_then(|s| s.as_bool()).unwrap_or(false);
 
                 // Validate arguments.
                 if host.trim().is_empty() {
@@ -1021,6 +1046,23 @@ impl DebugAdapter {
                                 }
                             }
                         });
+
+                        // When stopOnEntry is requested, emit a stopped event so the IDE
+                        // pauses at the first available program location after the TCP
+                        // attach handshake completes.
+                        if stop_on_entry {
+                            self.send_event(
+                                "stopped",
+                                Some(json!({
+                                    "reason": "entry",
+                                    "threadId": 1,
+                                    "allThreadsStopped": true,
+                                    "description": "Paused on entry"
+                                })),
+                            );
+                        }
+
+                        tracing::info!(host, port, stop_on_entry, "TCP attach successful");
 
                         DapMessage::Response {
                             seq,

--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -77,6 +77,7 @@
 //!     host: "localhost".to_string(),
 //!     port: 13603,
 //!     timeout_ms: Some(5000),
+//!     stop_on_entry: None,
 //! };
 //!
 //! config.validate()?;

--- a/crates/perl-dap/src/protocol.rs
+++ b/crates/perl-dap/src/protocol.rs
@@ -327,6 +327,9 @@ pub struct AttachRequestArguments {
     /// Connection timeout in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<u32>,
+    /// If true, pause at the first available program location after attaching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_on_entry: Option<bool>,
 }
 
 // ============================================================================

--- a/crates/perl-dap/tests/bridge_integration_tests.rs
+++ b/crates/perl-dap/tests/bridge_integration_tests.rs
@@ -113,8 +113,12 @@ fn test_attach_configuration_json() -> Result<()> {
     assert_eq!(config.port, 13603);
 
     // Verify custom configuration
-    let custom_config =
-        AttachConfiguration { host: "127.0.0.1".to_string(), port: 9000, timeout_ms: Some(5000) };
+    let custom_config = AttachConfiguration {
+        host: "127.0.0.1".to_string(),
+        port: 9000,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
     assert_eq!(custom_config.host, "127.0.0.1");
     assert_eq!(custom_config.port, 9000);
 
@@ -141,8 +145,12 @@ async fn test_attach_configuration_tcp() -> Result<()> {
     use perl_dap::AttachConfiguration;
 
     // Create attach configuration
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 13603, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
 
     // Verify configuration is valid
     assert_eq!(config.host, "localhost");
@@ -366,6 +374,7 @@ fn test_attach_configuration_roundtrip() -> Result<()> {
         host: "192.168.1.100".to_string(),
         port: 9000,
         timeout_ms: Some(5000),
+        stop_on_entry: None,
     };
 
     // Serialize to JSON

--- a/crates/perl-dap/tests/dap_coverage_audit_tests.rs
+++ b/crates/perl-dap/tests/dap_coverage_audit_tests.rs
@@ -1230,16 +1230,24 @@ fn test_launch_config_resolve_paths_no_cwd() -> Result<(), Box<dyn std::error::E
 
 #[test]
 fn test_attach_config_max_valid_port() -> Result<(), Box<dyn std::error::Error>> {
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 65535, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 65535,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
     config.validate()?;
     Ok(())
 }
 
 #[test]
 fn test_attach_config_min_valid_port() -> Result<(), Box<dyn std::error::Error>> {
-    let config =
-        AttachConfiguration { host: "localhost".to_string(), port: 1, timeout_ms: Some(5000) };
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 1,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    };
     config.validate()?;
     Ok(())
 }
@@ -1251,6 +1259,7 @@ fn test_attach_config_boundary_timeout() -> Result<(), Box<dyn std::error::Error
         host: "localhost".to_string(),
         port: 13603,
         timeout_ms: Some(300_000),
+        stop_on_entry: None,
     };
     config.validate()?;
 
@@ -1259,6 +1268,7 @@ fn test_attach_config_boundary_timeout() -> Result<(), Box<dyn std::error::Error
         host: "localhost".to_string(),
         port: 13603,
         timeout_ms: Some(300_001),
+        stop_on_entry: None,
     };
     assert!(config.validate().is_err());
     Ok(())
@@ -1520,6 +1530,7 @@ fn test_attach_request_arguments_round_trip() -> Result<(), Box<dyn std::error::
         host: Some("localhost".to_string()),
         port: Some(13603),
         timeout: Some(5000),
+        stop_on_entry: None,
     };
 
     let json = serde_json::to_string(&args)?;

--- a/crates/perl-dap/tests/dap_protocol_serde_tests.rs
+++ b/crates/perl-dap/tests/dap_protocol_serde_tests.rs
@@ -211,6 +211,7 @@ fn attach_request_args_tcp_mode() -> Result<(), Box<dyn std::error::Error>> {
         host: Some("localhost".to_string()),
         port: Some(13603),
         timeout: Some(5000),
+        stop_on_entry: None,
     };
     let json = serde_json::to_string(&args)?;
     let back: AttachRequestArguments = serde_json::from_str(&json)?;
@@ -223,8 +224,13 @@ fn attach_request_args_tcp_mode() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn attach_request_args_pid_mode() -> Result<(), Box<dyn std::error::Error>> {
-    let args =
-        AttachRequestArguments { process_id: Some(12345), host: None, port: None, timeout: None };
+    let args = AttachRequestArguments {
+        process_id: Some(12345),
+        host: None,
+        port: None,
+        timeout: None,
+        stop_on_entry: None,
+    };
     let json = serde_json::to_string(&args)?;
     assert!(json.contains("processId"), "camelCase: {json}");
     assert!(!json.contains("host"), "None host should be omitted: {json}");

--- a/crates/perl-dap/tests/protocol_edge_case_tests.rs
+++ b/crates/perl-dap/tests/protocol_edge_case_tests.rs
@@ -534,6 +534,7 @@ fn test_attach_args_round_trip() -> Result<()> {
         host: Some("127.0.0.1".to_string()),
         port: Some(13603),
         timeout: Some(5000),
+        stop_on_entry: None,
     };
     let json = serde_json::to_string(&args)?;
     let rt: AttachRequestArguments = serde_json::from_str(&json)?;

--- a/crates/perl-dap/tests/session_lifecycle_tests.rs
+++ b/crates/perl-dap/tests/session_lifecycle_tests.rs
@@ -1002,7 +1002,9 @@ fn test_error_handling_launch_program_is_directory() {
             assert!(message.is_some());
             let msg = must_some(message);
             assert!(
-                msg.contains("not a regular file") || msg.contains("directory"),
+                msg.contains("not a regular file")
+                    || msg.contains("directory")
+                    || msg.contains("is not a file"),
                 "Error should mention file type: {}",
                 msg
             );
@@ -1093,4 +1095,145 @@ fn test_multiple_sessions_sequential() {
         }
         let _term_event = wait_for_event(&rx, 100);
     }
+}
+
+// ============================================================================
+// AC:5.5 — DAP Attach: stopOnEntry support (#3524)
+// ============================================================================
+
+#[test]
+// AC:5.5
+fn test_attach_pid_mode_stop_on_entry_true_emits_stopped_event() {
+    // When stopOnEntry is true and attaching by PID, a stopped event with reason "entry"
+    // must be emitted after the initial "attach" stopped event.
+    let (mut adapter, rx) = create_test_adapter();
+
+    let args = json!({
+        "processId": 9999,
+        "stopOnEntry": true
+    });
+
+    let response = adapter.handle_request(1, "attach", Some(args));
+
+    match response {
+        DapMessage::Response { success, command, .. } => {
+            assert!(success, "PID attach with stopOnEntry should succeed");
+            assert_eq!(command, "attach");
+        }
+        _ => must(Err::<(), _>("Expected Response message")),
+    }
+
+    // Must receive at least one stopped event with reason "entry"
+    let mut found_entry_stop = false;
+    for _ in 0..3 {
+        if let Some(DapMessage::Event { event, body, .. }) = wait_for_event(&rx, 100) {
+            if event == "stopped" {
+                if let Some(ref b) = body {
+                    if b.get("reason").and_then(|r| r.as_str()) == Some("entry") {
+                        found_entry_stop = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    assert!(found_entry_stop, "stopOnEntry=true must emit a stopped event with reason='entry'");
+}
+
+#[test]
+// AC:5.5
+fn test_attach_pid_mode_stop_on_entry_false_no_entry_event() {
+    // When stopOnEntry is false, PID attach should emit reason "attach" but NOT "entry".
+    let (mut adapter, rx) = create_test_adapter();
+
+    let args = json!({
+        "processId": 8888,
+        "stopOnEntry": false
+    });
+
+    let response = adapter.handle_request(1, "attach", Some(args));
+
+    match response {
+        DapMessage::Response { success, command, .. } => {
+            assert!(success, "PID attach without stopOnEntry should succeed");
+            assert_eq!(command, "attach");
+        }
+        _ => must(Err::<(), _>("Expected Response message")),
+    }
+
+    let mut found_entry_stop = false;
+    let mut found_attach_stop = false;
+    for _ in 0..3 {
+        if let Some(DapMessage::Event { event, body, .. }) = wait_for_event(&rx, 100) {
+            if event == "stopped" {
+                if let Some(ref b) = body {
+                    match b.get("reason").and_then(|r| r.as_str()) {
+                        Some("entry") => found_entry_stop = true,
+                        Some("attach") => found_attach_stop = true,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    assert!(!found_entry_stop, "stopOnEntry=false must not emit an entry stop event");
+    assert!(
+        found_attach_stop,
+        "PID attach should always emit a stopped event with reason='attach'"
+    );
+}
+
+#[test]
+// AC:5.5
+fn test_attach_pid_mode_default_stop_on_entry_is_false() {
+    // When stopOnEntry is omitted it defaults to false — no entry-stop event emitted.
+    let (mut adapter, rx) = create_test_adapter();
+
+    let args = json!({ "processId": 7777 });
+    let response = adapter.handle_request(1, "attach", Some(args));
+
+    match response {
+        DapMessage::Response { success, command, .. } => {
+            assert!(success, "PID attach with omitted stopOnEntry should succeed");
+            assert_eq!(command, "attach");
+        }
+        _ => must(Err::<(), _>("Expected Response message")),
+    }
+
+    let mut found_entry_stop = false;
+    for _ in 0..3 {
+        if let Some(DapMessage::Event { event, body, .. }) = wait_for_event(&rx, 100) {
+            if event == "stopped" {
+                if let Some(ref b) = body {
+                    if b.get("reason").and_then(|r| r.as_str()) == Some("entry") {
+                        found_entry_stop = true;
+                    }
+                }
+            }
+        }
+    }
+    assert!(!found_entry_stop, "Default stopOnEntry must not emit entry-stop event");
+}
+
+#[test]
+// AC:5.5
+fn test_attach_config_stop_on_entry_field() {
+    // AttachConfiguration must expose stop_on_entry and round-trip through serde.
+    use perl_dap::configuration::AttachConfiguration;
+
+    let config = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: Some(true),
+    };
+    assert_eq!(config.stop_on_entry, Some(true));
+
+    let json_str = serde_json::to_string(&config).expect("should serialize");
+    let deserialized: AttachConfiguration =
+        serde_json::from_str(&json_str).expect("should deserialize");
+    assert_eq!(deserialized.stop_on_entry, Some(true));
+
+    let default_config = AttachConfiguration::default();
+    assert_eq!(default_config.stop_on_entry, None);
 }


### PR DESCRIPTION
## Summary

- Adds `stopOnEntry` support to the DAP `attach` request, resolving the incomplete attach implementation reported in #3524
- PID-based attach: when `stopOnEntry=true`, emits a `stopped` event with `reason="entry"` after the initial `reason="attach"` stopped event
- TCP-based attach: when `stopOnEntry=true`, emits a `stopped` event with `reason="entry"` after the TCP connection is established
- Adds `stop_on_entry: Option<bool>` field to `AttachConfiguration` (serde camelCase, `skip_serializing_if`) and `AttachRequestArguments` protocol type
- Updates `create_attach_json_snippet()` to include `"stopOnEntry": false` as an explicit default

## Changed files

- `crates/perl-dap-config/src/lib.rs` — new field on `AttachConfiguration`, updated snippet, fixed doctests
- `crates/perl-dap/src/debug_adapter/process.rs` — `handle_attach` implementation for stopOnEntry in both modes
- `crates/perl-dap/src/protocol.rs` — `stop_on_entry` field on `AttachRequestArguments`
- `crates/perl-dap/src/lib.rs` — doctest fix
- Various test files — 4 new regression tests, struct literal updates, pre-existing test assertion fix

## Test plan

- [ ] `cargo test -p perl-dap --test session_lifecycle_tests -- test_attach_pid_mode` — 3 new tests for PID mode stopOnEntry
- [ ] `cargo test -p perl-dap --test session_lifecycle_tests -- test_attach_config_stop` — 1 new serde round-trip test
- [ ] `cargo test -p perl-dap-config` — all 27 config tests pass
- [ ] `cargo clippy -p perl-dap -p perl-dap-config` — no warnings
- [ ] `cargo fmt -- --check` — clean