### PR TITLE
feat(semantic-analyzer): add IO::Async framework symbols (#3609)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -340,6 +340,13 @@ pub enum WebFrameworkKind {
     MojoliciousLite,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Async framework variant detected via `use` statements during Parse/Analyze workflows.
+pub enum AsyncFrameworkKind {
+    /// `use IO::Async;`
+    IOAsync,
+}
+
 #[derive(Debug, Clone, Default)]
 /// Per-package framework detection flags used in Parse/Analyze workflows.
 pub struct FrameworkFlags {
@@ -351,6 +358,8 @@ pub struct FrameworkFlags {
     pub kind: Option<FrameworkKind>,
     /// Web framework variant, if any (Dancer2, Mojolicious::Lite).
     pub web_framework: Option<WebFrameworkKind>,
+    /// Async framework variant, if any (IO::Async).
+    pub async_framework: Option<AsyncFrameworkKind>,
 }
 
 /// Extract symbols from an AST for Parse/Index workflows.
@@ -650,6 +659,7 @@ impl SymbolExtractor {
                     is_write: false,
                 });
 
+                self.synthesize_io_async_class_symbol(object);
                 self.visit_node(object);
                 for arg in args {
                     self.visit_node(arg);
@@ -1587,6 +1597,46 @@ impl SymbolExtractor {
         true
     }
 
+    /// Synthesize class symbols for IO::Async namespaces used in method-call form.
+    fn synthesize_io_async_class_symbol(&mut self, object: &Node) -> bool {
+        let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
+            return false;
+        };
+        if !matches!(flags.async_framework, Some(AsyncFrameworkKind::IOAsync)) {
+            return false;
+        }
+
+        let Some(name) = Self::single_symbol_name(object) else {
+            return false;
+        };
+        if !name.starts_with("IO::Async::") {
+            return false;
+        }
+
+        let already_synthesized = self.table.symbols.get(&name).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Class
+                    && symbol.declaration.as_deref() == Some("framework=IO::Async")
+            })
+        });
+        if already_synthesized {
+            return true;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: name.clone(),
+            qualified_name: name.clone(),
+            kind: SymbolKind::Class,
+            location: object.location,
+            scope_id: self.table.current_scope(),
+            declaration: Some("framework=IO::Async".to_string()),
+            documentation: Some("Synthetic IO::Async class".to_string()),
+            attributes: vec!["framework=IO::Async".to_string()],
+        });
+
+        true
+    }
+
     /// Update framework detection state from `use` statements.
     fn update_framework_context(&mut self, module: &str, args: &[String]) {
         let pkg = self.table.current_package.clone();
@@ -1618,6 +1668,12 @@ impl SymbolExtractor {
         };
         if let Some(kind) = web_kind {
             self.framework_flags.entry(pkg).or_default().web_framework = Some(kind);
+            return;
+        }
+
+        if module == "IO::Async" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::IOAsync);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -1671,7 +1671,7 @@ impl SymbolExtractor {
             return;
         }
 
-        if module == "IO::Async" {
+        if module == "IO::Async" || module.starts_with("IO::Async::") {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::IOAsync);
             return;

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -715,6 +715,7 @@ impl SymbolExtractor {
 
             NodeKind::Use { module, args, .. } => {
                 self.update_framework_context(module, args);
+                self.synthesize_io_async_use_symbol(module, node.location);
             }
 
             NodeKind::No { module: _, args: _, .. } => {
@@ -1613,7 +1614,20 @@ impl SymbolExtractor {
             return false;
         }
 
-        let already_synthesized = self.table.symbols.get(&name).is_some_and(|symbols| {
+        self.add_io_async_class_symbol(&name, object.location)
+    }
+
+    /// Synthesize a class symbol directly from `use IO::Async::Namespace`.
+    fn synthesize_io_async_use_symbol(&mut self, module: &str, location: SourceLocation) -> bool {
+        if !module.starts_with("IO::Async::") {
+            return false;
+        }
+
+        self.add_io_async_class_symbol(module, location)
+    }
+
+    fn add_io_async_class_symbol(&mut self, name: &str, location: SourceLocation) -> bool {
+        let already_synthesized = self.table.symbols.get(name).is_some_and(|symbols| {
             symbols.iter().any(|symbol| {
                 symbol.kind == SymbolKind::Class
                     && symbol.declaration.as_deref() == Some("framework=IO::Async")
@@ -1624,10 +1638,10 @@ impl SymbolExtractor {
         }
 
         self.table.add_symbol(Symbol {
-            name: name.clone(),
-            qualified_name: name.clone(),
+            name: name.to_string(),
+            qualified_name: name.to_string(),
             kind: SymbolKind::Class,
-            location: object.location,
+            location,
             scope_id: self.table.current_scope(),
             declaration: Some("framework=IO::Async".to_string()),
             documentation: Some("Synthetic IO::Async class".to_string()),

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -51,6 +51,22 @@ my $handle = IO::Async::Handle->new;
 }
 
 #[test]
+fn io_async_namespace_import_enables_symbol_synthesis() {
+    let code = r#"
+use IO::Async::Loop;
+
+my $loop = IO::Async::Loop->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "IO::Async::Loop", SymbolKind::Class),
+        "expected namespace import to enable IO::Async class synthesis"
+    );
+}
+
+#[test]
 fn io_async_names_are_not_synthesized_without_framework_use() {
     let code = r#"
 my $loop = IO::Async::Loop->new;

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -1,0 +1,65 @@
+//! Framework semantic extraction tests for IO::Async.
+
+use perl_semantic_analyzer::{
+    Parser,
+    symbol::{SymbolExtractor, SymbolKind, SymbolTable},
+};
+use perl_tdd_support::must;
+
+fn extract_symbols(code: &str) -> SymbolTable {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    SymbolExtractor::new_with_source(code).extract(&ast)
+}
+
+fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
+    table.symbols.get(name).is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == kind))
+}
+
+fn symbol_attrs(table: &SymbolTable, name: &str, kind: SymbolKind) -> Vec<String> {
+    table
+        .symbols
+        .get(name)
+        .and_then(|symbols| symbols.iter().find(|symbol| symbol.kind == kind))
+        .map(|symbol| symbol.attributes.clone())
+        .unwrap_or_default()
+}
+
+#[test]
+fn io_async_use_synthesizes_class_symbols_for_common_namespaces() {
+    let code = r#"
+use IO::Async;
+
+my $loop = IO::Async::Loop->new;
+my $stream = IO::Async::Stream->new;
+my $handle = IO::Async::Handle->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in ["IO::Async::Loop", "IO::Async::Stream", "IO::Async::Handle"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Class),
+            "expected synthetic IO::Async class symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Class);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=IO::Async"),
+            "expected `framework=IO::Async` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
+fn io_async_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $loop = IO::Async::Loop->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "IO::Async::Loop", SymbolKind::Class),
+        "did not expect IO::Async class synthesis without `use IO::Async`"
+    );
+}


### PR DESCRIPTION
## Summary
- detect IO::Async framework usage in the symbol extractor
- synthesize IO::Async class symbols from common namespace method calls
- honor direct namespace imports such as `use IO::Async::Loop;`
- add focused async framework regression tests

## Testing
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
- cargo test -p perl-semantic-analyzer --test frameworks_web -- --nocapture