### PR TITLE
docs(dap): clarify evaluate safety boundary (#3618)

### DIFF
--- a/crates/perl-dap-eval/src/validator.rs
+++ b/crates/perl-dap-eval/src/validator.rs
@@ -1,7 +1,8 @@
-//! Expression safety validation
+//! Expression safety validation for debugger evaluate policy.
 //!
-//! This module provides the core validation logic for detecting dangerous
-//! operations in Perl expressions during debug evaluation.
+//! This module provides policy validation logic for detecting dangerous
+//! operations in Perl expressions during debug evaluation. It does not sandbox
+//! the interpreter.
 
 use crate::patterns::{ASSIGNMENT_OPERATORS, DANGEROUS_OPS_RE, REGEX_MUTATION_RE};
 
@@ -46,10 +47,11 @@ pub enum ValidationError {
 /// Result type for expression validation
 pub type ValidationResult = Result<(), ValidationError>;
 
-/// Safe expression evaluator
+/// Safe expression evaluator for policy validation.
 ///
 /// Validates that expressions are safe for evaluation during debugging,
-/// blocking operations that could mutate state or have side effects.
+/// blocking operations that could mutate state or have side effects when the
+/// caller has not opted into `allowSideEffects`.
 #[derive(Debug, Clone, Default)]
 pub struct SafeEvaluator {
     // Future: could add configuration options here

--- a/crates/perl-dap/src/debug_adapter/evaluation.rs
+++ b/crates/perl-dap/src/debug_adapter/evaluation.rs
@@ -3,10 +3,10 @@
 use super::*;
 
 impl DebugAdapter {
-    /// Handle evaluate request with safe evaluation mode and timeout enforcement
+    /// Handle evaluate request with policy validation and timeout enforcement.
     ///
     /// AC10.1: Evaluates expressions in stack frame context
-    /// AC10.2: Safe evaluation mode (non-mutating) by default
+    /// AC10.2: Policy validation for a non-mutating subset by default
     /// AC10.3: Timeout enforcement (5s default, 30s hard limit)
     pub(super) fn handle_evaluate(
         &self,
@@ -54,7 +54,8 @@ impl DebugAdapter {
                 };
             }
 
-            // AC10.2: Safe evaluation mode (non-mutating) by default
+            // AC10.2: Policy validation for a non-mutating subset by default.
+            // This is admission control, not a real sandbox.
             let allow_side_effects = args.allow_side_effects.unwrap_or(false);
 
             // Validate expression safety if side effects are not allowed

--- a/crates/perl-dap/src/debug_adapter/safe_eval.rs
+++ b/crates/perl-dap/src/debug_adapter/safe_eval.rs
@@ -1,7 +1,8 @@
-//! Safe expression evaluation validation.
+//! Safe expression policy validation for debugger evaluation.
 //!
-//! Validates that expressions sent to the Perl debugger for evaluation
-//! do not contain dangerous operations (mutations, I/O, system calls).
+//! Validates that expressions sent to the Perl debugger for evaluation do not
+//! contain dangerous operations when safe evaluation mode is active.
+//! This is admission control, not a sandboxed interpreter boundary.
 
 use super::*;
 
@@ -164,7 +165,10 @@ pub(super) fn is_package_qualified_not_core(s: &str, op_start: usize) -> bool {
     !is_core_qualified(s, op_start)
 }
 
-/// Validate that an expression is safe for evaluation (non-mutating)
+/// Validate that an expression is safe for evaluation in the policy sense.
+///
+/// This rejects dangerous operations when `allowSideEffects` is false, but it
+/// does not provide interpreter isolation or OS sandboxing.
 ///
 /// AC10.2: Safe evaluation mode validates expressions don't have side effects
 ///

--- a/crates/perl-dap/tests/security_evaluate_tests.rs
+++ b/crates/perl-dap/tests/security_evaluate_tests.rs
@@ -81,6 +81,34 @@ fn test_evaluate_detects_unsafe_qx() -> TestResult {
 }
 
 #[test]
+fn test_evaluate_defaults_to_safe_mode_without_side_effects_flag() -> TestResult {
+    let mut adapter = DebugAdapter::new();
+
+    let args = json!({
+        "expression": "system('ls')"
+    });
+
+    let response = adapter.handle_request(1, "evaluate", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(
+                !success,
+                "Evaluate should fail for dangerous ops when allowSideEffects is omitted"
+            );
+            let msg = message.ok_or("Should have error message")?;
+            assert!(
+                msg.contains("Safe evaluation mode"),
+                "Should use the safe-mode validator by default"
+            );
+        }
+        _ => return Err("Expected Response".into()),
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_evaluate_rejects_carriage_returns() -> TestResult {
     let mut adapter = DebugAdapter::new();
 
@@ -203,7 +231,7 @@ fn test_evaluate_allows_dangerous_ops_with_side_effects_enabled() -> TestResult 
 
     // These should NOT be blocked when allowSideEffects is true
     // (they may still fail for other reasons like not being in a debug session)
-    let ops_to_test = ["eval('1')", "print 'test'"];
+    let ops_to_test = ["eval('1')", "print 'test'", "system('ls')"];
 
     for expression in ops_to_test {
         let args = json!({

--- a/docs/DAP_SECURITY_SPECIFICATION.md
+++ b/docs/DAP_SECURITY_SPECIFICATION.md
@@ -344,9 +344,9 @@ sub evaluate_expression {
                 die "Side effects not allowed without allowSideEffects flag\n";
             }
 
-            # Safe.pm compartment (future enhancement)
-            # my $cpt = Safe->new;
-            # $result = $cpt->reval($expr);
+            # Future work: Safe.pm compartment or interpreter isolation.
+            # The current implementation only validates the expression
+            # policy and still evaluates in the debugger context.
 
             $result = eval $expr;
         }
@@ -371,6 +371,10 @@ sub evaluate_expression {
 ```
 
 ### 2.3 Test Coverage (AC16)
+
+Current behavior is policy validation plus timeout framing, not a sandboxed
+interpreter boundary. `allowSideEffects: true` skips the safe-mode validators
+and evaluates in the debugger context.
 
 ```rust
 // crates/perl-dap/tests/security_validation.rs


### PR DESCRIPTION
## Summary
- clarify that default evaluate mode is policy validation for a non-mutating subset, not a real sandbox
- state explicitly that `allowSideEffects: true` skips the safe-mode validators and evaluates in the debugger context
- update the security spec and evaluator comments to mark Safe.pm / interpreter isolation as future work
- add focused tests covering the omitted-flag default and the side-effects opt-in path

## Testing
- cargo fmt --all
- cargo test -p perl-dap-eval --lib
- cargo test -p perl-dap --test security_evaluate_tests -- --nocapture

Follow-up sandboxing work should be split into a separate `dap/runtime-sandbox` issue or ADR.