### PR TITLE
fix(semantic): model `use builtin` in strict bareword analysis (#3349)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -272,6 +272,13 @@ impl PragmaTracker {
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
+                    "builtin" => {
+                        if !current_state.features.contains(&"builtin") {
+                            current_state.features.push("builtin");
+                        }
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
                     _ => {
                         if let Some(version) = parse_perl_version(module) {
                             enable_effective_version_semantics(current_state, version);
@@ -311,6 +318,11 @@ impl PragmaTracker {
                         }
 
                         // Record the state change at this location
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "builtin" => {
+                        current_state.features.retain(|feature| *feature != "builtin");
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -920,6 +920,25 @@ fn use_v5_40_state_has_builtin() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn use_builtin_adds_builtin_feature() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("builtin", &["'true'"], 0, 19)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.has_feature("builtin"), "use builtin must enable builtin feature");
+    Ok(())
+}
+
+#[test]
+fn no_builtin_removes_builtin_feature() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40", &[], 0, 12), no_node("builtin", &[], 13, 24)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2, "expected one state per pragma");
+    assert!(map[0].1.has_feature("builtin"), "v5.40 must enable builtin feature");
+    assert!(!map[1].1.has_feature("builtin"), "no builtin must disable builtin feature");
+    Ok(())
+}
+
+#[test]
 fn no_version_declaration_has_no_features() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("strict", &[], 0, 12)]);
     let map = PragmaTracker::build(&ast);

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -958,6 +958,7 @@ impl ScopeAnalyzer {
                 if strict_subs_mode
                     && !self.is_in_hash_key_context(node, ancestors, 1)
                     && !is_known_function(name)
+                    && !is_feature_builtin_function(name, &pragma_state)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
                 {
                     issues.push(ScopeIssue {
@@ -1950,6 +1951,26 @@ fn builtin_declaration_arg_positions(name: &str) -> &'static [usize] {
 
 fn is_declaration_capable_builtin(name: &str) -> bool {
     !builtin_declaration_arg_positions(name).is_empty()
+}
+
+fn is_feature_builtin_function(name: &str, pragma_state: &PragmaState) -> bool {
+    if !pragma_state.has_feature("builtin") {
+        return false;
+    }
+
+    matches!(
+        name,
+        "true"
+            | "false"
+            | "is_bool"
+            | "blessed"
+            | "refaddr"
+            | "reftype"
+            | "ceil"
+            | "floor"
+            | "indexed"
+            | "trim"
+    )
 }
 
 /// Builtins that operate on `$_` by default when called with zero arguments.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1747,6 +1747,44 @@ print FOO;
 }
 
 #[test]
+fn use_builtin_true_not_flagged_as_bareword_under_strict_subs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+use builtin 'true';
+print true;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "true"
+        }),
+        "'true' imported via use builtin should not be flagged as bareword: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn strict_subs_true_without_builtin_is_flagged_as_bareword()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+print true;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "true"
+        }),
+        "'true' should be flagged as bareword under strict subs when builtin feature is not enabled"
+    );
+    Ok(())
+}
+
+#[test]
 fn scalar_reference_dereference_uses_declared_scalar_under_strict()
 -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"


### PR DESCRIPTION
### Motivation

- Reduce false-positive bareword diagnostics when `use builtin` is present by honoring explicit `builtin` pragmas in the pragma state.

### Description

- Teach the pragma tracker to recognize `use builtin` and `no builtin` by toggling the `"builtin"` entry in `PragmaState.features` in `crates/perl-pragma/src/lib.rs`.
- Update scope analysis in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` to consult effective pragma state and treat a curated set of builtin functions as valid barewords only when `PragmaState.has_feature("builtin")` is true by adding `is_feature_builtin_function` and integrating it into the `NodeKind::Identifier` bareword check.
- Add regression tests in `crates/perl-pragma/tests/comprehensive_unit_tests.rs` for `use builtin` / `no builtin` behavior and in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` to verify that `true` is accepted under `use builtin 'true'` and still flagged without it.
- Run `cargo fmt --all` to normalize formatting.

### Testing

- Ran `cargo test -p perl-pragma --test comprehensive_unit_tests use_builtin_adds_builtin_feature` and it passed.
- Ran `cargo test -p perl-pragma --test comprehensive_unit_tests no_builtin_removes_builtin_feature` and it passed.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests use_builtin_true_not_flagged_as_bareword_under_strict_subs` and it passed.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests strict_subs_true_without_builtin_is_flagged_as_bareword` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b92cdf2c8333b99586d49a7dba6f)