### PR TITLE
fix(pragma): auto-enable strict for `use feature 'signatures'` (#3360)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -272,6 +272,35 @@ impl PragmaTracker {
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
+                    "feature" => {
+                        // `use feature 'signatures'` implicitly enables strict
+                        // (same effective behavior as `use v5.36` for strictness).
+                        // Accept quoted and unquoted args, and qw(...) bundles.
+                        let enables_signatures = args.iter().any(|arg| {
+                            let normalized = arg.trim_matches('\'').trim_matches('"');
+                            if normalized == "signatures" {
+                                return true;
+                            }
+
+                            if let Some(inner) =
+                                normalized.strip_prefix("qw(").and_then(|s| s.strip_suffix(')'))
+                            {
+                                return inner.split_whitespace().any(|item| item == "signatures");
+                            }
+
+                            false
+                        });
+
+                        if enables_signatures {
+                            current_state.strict_vars = true;
+                            current_state.strict_subs = true;
+                            current_state.strict_refs = true;
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                        }
+                    }
                     _ => {
                         if let Some(version) = parse_perl_version(module) {
                             enable_effective_version_semantics(current_state, version);

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -220,6 +220,32 @@ fn no_strict_quoted_double() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn use_feature_signatures_enables_all_strict_categories() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![use_node("feature", &["'signatures'"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn use_feature_qw_signatures_enables_all_strict_categories()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["qw(signatures say)"], 0, 34)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
 // ===========================================================================
 // use warnings / no warnings
 // ===========================================================================

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1724,6 +1724,29 @@ sub foo ($x) { $z = 1; }
 }
 
 #[test]
+fn feature_signatures_auto_strict_flags_undeclared_variable_in_signature_sub()
+-> Result<(), Box<dyn std::error::Error>> {
+    // `use feature 'signatures'` should enable strict semantics automatically.
+    // An undeclared variable $z inside a signature sub should be flagged even
+    // without explicit `use strict`.
+    let code = r#"
+use feature 'signatures';
+sub foo ($x) { $z = 1; }
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "z"),
+        "use feature 'signatures' should auto-enable strict: $z should be flagged as undeclared"
+    );
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "x"),
+        "signature parameter $x should not be flagged as undeclared"
+    );
+    Ok(())
+}
+
+#[test]
 fn v5_36_enables_strict_vars_and_subs() -> Result<(), Box<dyn std::error::Error>> {
     // use v5.36 enables both strict vars (undeclared vars) and strict subs (barewords).
     let code = r#"


### PR DESCRIPTION
### Motivation
- Treat `use feature 'signatures'` as enabling the same strict semantics as the v5.36 feature bundle so signature-bearing subs get the expected `strict` behavior.

### Description
- Update `PragmaTracker` to recognize `use feature 'signatures'` (including quoted and `qw(...)` forms) and set `strict_vars`, `strict_subs`, and `strict_refs` accordingly (`crates/perl-pragma/src/lib.rs`).
- Add two pragma-level unit tests that verify `'signatures'` and `qw(signatures ...)` imports enable strict (`crates/perl-pragma/tests/comprehensive_unit_tests.rs`).
- Add a semantic-analyzer regression test that verifies an undeclared variable inside a signature sub is flagged when only `use feature 'signatures'` is present while signature parameters remain valid (`crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`).

### Testing
- Ran `cargo fmt --all` to format the workspace and it completed successfully.
- Ran `cargo test -p perl-pragma --test comprehensive_unit_tests use_feature_signatures` and `use_feature_qw_signatures` and both targeted tests passed.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests feature_signatures_auto_strict_flags_undeclared_variable_in_signature_sub` and the targeted semantic test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b92cdf2c8333b99586d49a7dba6f)