### PR TITLE
fix(scope): make builtin declaration consumption argument-position aware (#3345)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -851,9 +851,10 @@ impl ScopeAnalyzer {
                     let _ = scope.use_variable_parts("$", "_");
                 }
                 ancestors.push(node);
-                for arg in args {
+                let declaration_arg_positions = builtin_declaration_arg_positions(name);
+                for (arg_index, arg) in args.iter().enumerate() {
                     self.analyze_node(arg, scope, ancestors, issues, context);
-                    if is_declaration_capable_builtin(name) {
+                    if declaration_arg_positions.contains(&arg_index) {
                         self.mark_builtin_declaration_arg_consumed(arg, scope, context);
                     }
                 }
@@ -1946,10 +1947,6 @@ fn builtin_declaration_arg_positions(name: &str) -> &'static [usize] {
         "socketpair" => &[0, 1],
         _ => &[],
     }
-}
-
-fn is_declaration_capable_builtin(name: &str) -> bool {
-    !builtin_declaration_arg_positions(name).is_empty()
 }
 
 /// Builtins that operate on `$_` by default when called with zero arguments.

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2547,6 +2547,36 @@ print $buffer;
 }
 
 #[test]
+fn read_position_zero_declaration_not_consumed() -> Result<(), Box<dyn std::error::Error>> {
+    // Position 0 for `read` must not be treated as a declaration-capable output slot.
+    // If a declaration appears there, it should still be analyzed like a normal lexical
+    // declaration (and therefore may be reported as unused/uninitialized).
+    let code = r#"
+use strict;
+read my $fh, my $buffer, 1024;
+print $buffer;
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        issues.iter().any(|i| {
+            i.variable_name == "$fh"
+                && matches!(i.kind, IssueKind::UnusedVariable | IssueKind::UninitializedVariable)
+        }),
+        "read position-0 declaration should not be auto-consumed (issues: {:?})",
+        issues
+    );
+    assert!(
+        !issues.iter().any(|i| {
+            i.variable_name == "$buffer"
+                && matches!(i.kind, IssueKind::UndeclaredVariable | IssueKind::UnusedVariable)
+        }),
+        "read position-1 buffer declaration should still be consumed (issues: {:?})",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
 fn socketpair_both_positions_declared() -> Result<(), Box<dyn std::error::Error>> {
     // `socketpair my $a, my $b, ...` — positions 0 and 1 are both declarations.
     let code = r#"


### PR DESCRIPTION
### Motivation

- Declaration-capable builtins were being treated as consuming declaration-shaped arguments at any argument position, which can mask real undeclared/unused/uninitialized diagnostics.
- The goal is to make builtin declaration consumption follow the parser/Perl semantics (specific argument positions per-builtin) to reduce false negatives and improve semantic correctness.

### Description

- In `ScopeAnalyzer::NodeKind::FunctionCall` compute `declaration_arg_positions` with `builtin_declaration_arg_positions(name)` and only call `mark_builtin_declaration_arg_consumed` for arguments whose index is listed for that builtin. 
- Added and kept an explicit, conservative mapping in `builtin_declaration_arg_positions` for known builtins and their declaration positions (e.g., `read/sysread/recv/shmread` => position 1; `open/dbmopen` => position 0; `pipe/socketpair` => positions 0 and 1).
- Removed the now-unneeded `is_declaration_capable_builtin` helper and adjusted the call-site accordingly.
- Added a regression test `read_position_zero_declaration_not_consumed` ensuring `read my $fh, my $buffer, ...` does not auto-consume position 0 while still consuming position 1, alongside existing tests that cover `socketpair` and `read` behavior.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-semantic-analyzer read_position_zero -- --nocapture` which executed the relevant tests and passed (`2` tests passed: `read_position_zero_not_treated_as_declaration` and `read_position_zero_declaration_not_consumed`).
- Ran `cargo test -p perl-semantic-analyzer socketpair_both_positions_declared -- --nocapture` which executed and passed (test `socketpair_both_positions_declared` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b92cdf2c8333b99586d49a7dba6f)