### PR TITLE
feat(config): add PERL5LIB environment variable support (#3555)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -243,6 +243,21 @@ impl ServerConfig {
     }
 }
 
+/// Controls whether PERL5LIB paths are prepended or appended to `include_paths`.
+///
+/// `Prepend` (the default) mirrors Perl's own behaviour: paths earlier in the
+/// search order shadow later ones, so PERL5LIB paths take priority over any
+/// project-level `include_paths`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Perl5LibPrecedence {
+    /// PERL5LIB entries are placed *before* `include_paths` (default).
+    #[default]
+    Prepend,
+    /// PERL5LIB entries are placed *after* `include_paths`.
+    Append,
+}
+
 /// Workspace configuration for module resolution
 ///
 /// Controls how the LSP server resolves module imports and finds
@@ -266,6 +281,14 @@ pub struct WorkspaceConfig {
     /// Resolution timeout in milliseconds
     /// Default: 50ms
     pub resolution_timeout_ms: u64,
+
+    /// Whether the `PERL5LIB` environment variable is read and merged into
+    /// the module search path.  Default: `true`.
+    pub use_perl5lib: bool,
+
+    /// Controls whether PERL5LIB entries come before or after `include_paths`.
+    /// Default: `Prepend` (mirrors Perl's own search order).
+    pub perl5lib_precedence: Perl5LibPrecedence,
 }
 
 impl Default for WorkspaceConfig {
@@ -275,11 +298,49 @@ impl Default for WorkspaceConfig {
             use_system_inc: false,
             system_inc_cache: None,
             resolution_timeout_ms: 50,
+            use_perl5lib: true,
+            perl5lib_precedence: Perl5LibPrecedence::Prepend,
         }
     }
 }
 
 impl WorkspaceConfig {
+    /// Parse a `PERL5LIB` environment variable value into a list of paths.
+    ///
+    /// Uses `:` as the separator on Unix and `;` on Windows, matching Perl's
+    /// own behaviour.  Empty components (produced by leading, trailing, or
+    /// consecutive separators) are silently dropped.
+    pub fn parse_perl5lib(value: &str) -> Vec<String> {
+        #[cfg(windows)]
+        const SEP: char = ';';
+        #[cfg(not(windows))]
+        const SEP: char = ':';
+        value.split(SEP).filter(|s| !s.is_empty()).map(|s| s.to_string()).collect()
+    }
+
+    /// Return the effective module-search-path, merging `PERL5LIB` paths with
+    /// `self.include_paths` according to `self.perl5lib_precedence`.
+    ///
+    /// If `self.use_perl5lib` is `false`, or `perl5lib_paths` is empty, the
+    /// returned list is identical to `self.include_paths`.
+    pub fn effective_include_paths(&self, perl5lib_paths: &[String]) -> Vec<String> {
+        if !self.use_perl5lib || perl5lib_paths.is_empty() {
+            return self.include_paths.clone();
+        }
+        match self.perl5lib_precedence {
+            Perl5LibPrecedence::Prepend => {
+                let mut result = perl5lib_paths.to_vec();
+                result.extend_from_slice(&self.include_paths);
+                result
+            }
+            Perl5LibPrecedence::Append => {
+                let mut result = self.include_paths.clone();
+                result.extend_from_slice(perl5lib_paths);
+                result
+            }
+        }
+    }
+
     /// Update workspace configuration from LSP settings.
     pub fn update_from_value(&mut self, settings: &serde_json::Value) {
         if let Some(workspace) = settings.get("workspace") {
@@ -295,6 +356,15 @@ impl WorkspaceConfig {
             }
             if let Some(timeout) = workspace.get("resolutionTimeout").and_then(|v| v.as_u64()) {
                 self.resolution_timeout_ms = timeout;
+            }
+            if let Some(use_p5l) = workspace.get("usePerl5lib").and_then(|v| v.as_bool()) {
+                self.use_perl5lib = use_p5l;
+            }
+            if let Some(prec) = workspace.get("perl5libPrecedence").and_then(|v| v.as_str()) {
+                self.perl5lib_precedence = match prec {
+                    "append" => Perl5LibPrecedence::Append,
+                    _ => Perl5LibPrecedence::Prepend,
+                };
             }
         }
     }
@@ -369,6 +439,12 @@ pub struct ProjectPerlConfig {
     /// Perl version string (e.g. "5.38") — parsed but not yet wired to diagnostics.
     /// Reserved for future use; ignored in this implementation.
     pub version: Option<String>,
+    /// Whether to read `PERL5LIB` from the environment and include it in the
+    /// module search path.  Unset means "leave the server default unchanged".
+    pub use_perl5lib: Option<bool>,
+    /// Whether PERL5LIB paths come before or after `include_paths`.
+    /// Unset means "leave the server default unchanged".
+    pub perl5lib_precedence: Option<Perl5LibPrecedence>,
 }
 
 /// `[diagnostics]` section of `.perl-lsp.toml`.
@@ -465,6 +541,12 @@ impl ProjectConfig {
     pub fn apply_to_workspace_config(&self, config: &mut WorkspaceConfig) {
         if !self.perl.include_paths.is_empty() {
             config.include_paths = self.perl.include_paths.clone();
+        }
+        if let Some(use_p5l) = self.perl.use_perl5lib {
+            config.use_perl5lib = use_p5l;
+        }
+        if let Some(ref prec) = self.perl.perl5lib_precedence {
+            config.perl5lib_precedence = prec.clone();
         }
     }
 }

--- a/crates/perl-lsp-config/tests/project_config.rs
+++ b/crates/perl-lsp-config/tests/project_config.rs
@@ -197,6 +197,8 @@ fn project_config_applies_include_paths_to_workspace_config() -> TestResult {
     project.perl = perl_lsp_config::ProjectPerlConfig {
         include_paths: vec!["lib".to_string(), "local/lib/perl5".to_string()],
         version: None,
+        use_perl5lib: None,
+        perl5lib_precedence: None,
     };
     project.apply_to_workspace_config(&mut config);
     assert_eq!(config.include_paths, vec!["lib", "local/lib/perl5"]);
@@ -213,6 +215,8 @@ fn project_config_empty_include_paths_leaves_workspace_defaults() -> TestResult 
     project.perl = perl_lsp_config::ProjectPerlConfig {
         include_paths: vec![], // explicitly empty
         version: None,
+        use_perl5lib: None,
+        perl5lib_precedence: None,
     };
     project.apply_to_workspace_config(&mut config);
     assert_eq!(
@@ -272,5 +276,129 @@ fn project_config_severity_negative_returns_err() -> TestResult {
     let dir = write_toml("[diagnostics]\nperlcritic_severity = -1\n")?;
     let result = load_project_config(dir.path());
     assert!(result.is_err(), "negative severity must be a parse error, got: {:?}", result);
+    Ok(())
+}
+
+// ── parse_perl5lib ────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_perl5lib_empty_string_returns_empty() {
+    let result = perl_lsp_config::WorkspaceConfig::parse_perl5lib("");
+    assert!(result.is_empty(), "empty string produces no paths");
+}
+
+#[test]
+fn parse_perl5lib_single_path() {
+    let result = perl_lsp_config::WorkspaceConfig::parse_perl5lib("/usr/lib/perl5");
+    assert_eq!(result, vec!["/usr/lib/perl5"]);
+}
+
+#[test]
+fn parse_perl5lib_multiple_paths() {
+    #[cfg(windows)]
+    let value = "/a/lib;/b/lib";
+    #[cfg(not(windows))]
+    let value = "/a/lib:/b/lib";
+
+    let result = perl_lsp_config::WorkspaceConfig::parse_perl5lib(value);
+    assert_eq!(result, vec!["/a/lib", "/b/lib"]);
+}
+
+#[test]
+fn parse_perl5lib_drops_empty_components() {
+    // Leading/trailing/consecutive separators produce empty components — they must be dropped.
+    #[cfg(windows)]
+    let value = ";/a/lib;;/b/lib;";
+    #[cfg(not(windows))]
+    let value = ":/a/lib::/b/lib:";
+
+    let result = perl_lsp_config::WorkspaceConfig::parse_perl5lib(value);
+    assert_eq!(result, vec!["/a/lib", "/b/lib"]);
+}
+
+// ── effective_include_paths ───────────────────────────────────────────────────
+
+#[test]
+fn effective_include_paths_no_perl5lib_returns_include_paths() {
+    let config = WorkspaceConfig::default();
+    let result = config.effective_include_paths(&[]);
+    assert_eq!(result, config.include_paths, "no PERL5LIB paths returns include_paths unchanged");
+}
+
+#[test]
+fn effective_include_paths_prepend_puts_perl5lib_first() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    config.perl5lib_precedence = Perl5LibPrecedence::Prepend;
+    let p5l = vec!["/p5l/lib".to_string()];
+    let result = config.effective_include_paths(&p5l);
+    assert_eq!(result.first().map(String::as_str), Some("/p5l/lib"));
+    assert!(result.contains(&"lib".to_string()));
+}
+
+#[test]
+fn effective_include_paths_append_puts_perl5lib_last() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    config.perl5lib_precedence = Perl5LibPrecedence::Append;
+    let p5l = vec!["/p5l/lib".to_string()];
+    let result = config.effective_include_paths(&p5l);
+    assert_eq!(result.last().map(String::as_str), Some("/p5l/lib"));
+    assert_eq!(result.first().map(String::as_str), Some("lib"));
+}
+
+#[test]
+fn effective_include_paths_disabled_ignores_perl5lib() {
+    let mut config = WorkspaceConfig::default();
+    config.use_perl5lib = false;
+    let p5l = vec!["/p5l/lib".to_string()];
+    let result = config.effective_include_paths(&p5l);
+    assert_eq!(result, config.include_paths, "use_perl5lib=false ignores PERL5LIB paths");
+    assert!(!result.contains(&"/p5l/lib".to_string()));
+}
+
+// ── TOML [perl] section ───────────────────────────────────────────────────────
+
+#[test]
+fn project_config_use_perl5lib_defaults_to_none() -> TestResult {
+    let dir = write_toml("[perl]\ninclude_paths = [\"lib\"]\n")?;
+    let cfg = load_project_config(dir.path())?.ok_or("expected Some")?;
+    assert!(cfg.perl.use_perl5lib.is_none(), "use_perl5lib absent in TOML must be None");
+    Ok(())
+}
+
+#[test]
+fn project_config_use_perl5lib_false_parsed() -> TestResult {
+    let dir = write_toml("[perl]\nuse_perl5lib = false\n")?;
+    let cfg = load_project_config(dir.path())?.ok_or("expected Some")?;
+    assert_eq!(cfg.perl.use_perl5lib, Some(false));
+    Ok(())
+}
+
+#[test]
+fn project_config_perl5lib_precedence_append_parsed() -> TestResult {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let dir = write_toml("[perl]\nperl5lib_precedence = \"append\"\n")?;
+    let cfg = load_project_config(dir.path())?.ok_or("expected Some")?;
+    assert_eq!(cfg.perl.perl5lib_precedence, Some(Perl5LibPrecedence::Append));
+    Ok(())
+}
+
+// ── apply_to_workspace_config propagates new fields ──────────────────────────
+
+#[test]
+fn project_config_applies_use_perl5lib_false_to_workspace_config() -> TestResult {
+    let mut config = WorkspaceConfig::default();
+    assert!(config.use_perl5lib, "use_perl5lib is true by default");
+
+    let mut project = ProjectConfig::default();
+    project.perl = perl_lsp_config::ProjectPerlConfig {
+        include_paths: vec![],
+        version: None,
+        use_perl5lib: Some(false),
+        perl5lib_precedence: None,
+    };
+    project.apply_to_workspace_config(&mut config);
+    assert!(!config.use_perl5lib, "apply_to_workspace_config must propagate use_perl5lib=false");
     Ok(())
 }

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -68,7 +68,10 @@ impl LspServer {
 
         let mut include_paths = {
             let config = self.workspace_config.lock();
-            config.include_paths.clone()
+            let perl5lib_paths = std::env::var("PERL5LIB")
+                .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
+                .unwrap_or_default();
+            config.effective_include_paths(&perl5lib_paths)
         };
 
         if let Some(text) = doc_text {
@@ -104,7 +107,10 @@ impl LspServer {
 
         let mut include_paths = {
             let config = self.workspace_config.lock();
-            config.include_paths.clone()
+            let perl5lib_paths = std::env::var("PERL5LIB")
+                .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
+                .unwrap_or_default();
+            config.effective_include_paths(&perl5lib_paths)
         };
 
         if let Some(text) = doc_text {
@@ -166,7 +172,14 @@ impl LspServer {
     ) -> Option<String> {
         let (mut include_paths, timeout_ms, use_system_inc) = {
             let config = self.workspace_config.lock();
-            (config.include_paths.clone(), config.resolution_timeout_ms, config.use_system_inc)
+            let perl5lib_paths = std::env::var("PERL5LIB")
+                .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
+                .unwrap_or_default();
+            (
+                config.effective_include_paths(&perl5lib_paths),
+                config.resolution_timeout_ms,
+                config.use_system_inc,
+            )
         };
         let timeout = Duration::from_millis(timeout_ms);
 


### PR DESCRIPTION
## Summary

- Add `Perl5LibPrecedence` enum (`prepend`/`append`) to `perl-lsp-config` with `#[serde(rename_all = "lowercase")]` for TOML and LSP settings support
- Add `use_perl5lib: bool` (default: `true`) and `perl5lib_precedence: Perl5LibPrecedence` fields to `WorkspaceConfig`; both are configurable via LSP `workspace.usePerl5lib` / `workspace.perl5libPrecedence` settings and `.perl-lsp.toml` `[perl]` section
- Add `WorkspaceConfig::parse_perl5lib` with platform-aware separator (`:` on Unix, `;` on Windows) that silently drops empty components
- Add `WorkspaceConfig::effective_include_paths` that merges PERL5LIB paths with `include_paths` respecting precedence and the `use_perl5lib` toggle
- Update all three module resolution entry points (`resolve_module_path`, `resolve_module_path_with_uri`, `resolve_module_to_path_with_doc`) to read `PERL5LIB` at resolution time and merge via `effective_include_paths`
- Add `use_perl5lib` and `perl5lib_precedence` optional fields to `ProjectPerlConfig` for `.perl-lsp.toml` support; `apply_to_workspace_config` propagates them
- Add 12 new integration tests covering: `parse_perl5lib` (empty, single, multi-path, empty-component dropping), `effective_include_paths` (no paths, prepend, append, disabled), TOML parsing of new fields, and `apply_to_workspace_config` propagation

## Test plan

- [ ] All existing `perl-lsp-config` tests pass (70 tests across 4 suites)
- [ ] 12 new PERL5LIB-specific tests pass (project_config suite grows from 14 to 26)
- [ ] `cargo clippy -p perl-lsp-config --tests` reports no issues
- [ ] `cargo fmt -p perl-lsp-config -p perl-lsp-rs` produces no changes
- [ ] CI gate on GitHub passes