### PR TITLE
feat(diagnostics): same-file Moo/Moose role conflicts (#3605)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -135,6 +135,8 @@ pub enum DiagnosticCode {
     DuplicateSubroutine,
     /// Missing explicit return statement
     MissingReturn,
+    /// Same-file Moo/Moose roles provide conflicting methods
+    RoleConflict,
     /// Invalid character(s) in a subroutine prototype
     ///
     /// Perl only allows `$`, `@`, `%`, `&`, `*`, `\`, `;`, `+`, `_`, and
@@ -248,6 +250,7 @@ impl DiagnosticCode {
             DiagnosticCode::DuplicateSubroutine => "PL300",
             DiagnosticCode::MissingReturn => "PL301",
             DiagnosticCode::InvalidPrototype => "PL302",
+            DiagnosticCode::RoleConflict => "PL303",
             DiagnosticCode::BarewordFilehandle => "PL400",
             DiagnosticCode::TwoArgOpen => "PL401",
             DiagnosticCode::ImplicitReturn => "PL402",
@@ -314,6 +317,7 @@ impl DiagnosticCode {
             "PL300" => "https://docs.perl-lsp.org/errors/PL300",
             "PL301" => "https://docs.perl-lsp.org/errors/PL301",
             "PL302" => "https://docs.perl-lsp.org/errors/PL302",
+            "PL303" => "https://docs.perl-lsp.org/errors/PL303",
             "PL400" => "https://docs.perl-lsp.org/errors/PL400",
             "PL401" => "https://docs.perl-lsp.org/errors/PL401",
             "PL402" => "https://docs.perl-lsp.org/errors/PL402",
@@ -372,6 +376,7 @@ impl DiagnosticCode {
             | DiagnosticCode::DuplicateSubroutine
             | DiagnosticCode::MissingReturn
             | DiagnosticCode::InvalidPrototype
+            | DiagnosticCode::RoleConflict
             | DiagnosticCode::BarewordFilehandle
             | DiagnosticCode::TwoArgOpen
             | DiagnosticCode::ImplicitReturn
@@ -478,6 +483,10 @@ impl DiagnosticCode {
             DiagnosticCode::MissingReturn => Some(
                 "This subroutine has no explicit `return` statement. \
                 Add `return $value;` to make the return value clear.",
+            ),
+            DiagnosticCode::RoleConflict => Some(
+                "Two or more consumed Moo/Moose roles provide the same method. \
+                Define the method in the class or remove one of the conflicting roles.",
             ),
             DiagnosticCode::InvalidPrototype => Some(
                 "The prototype contains a character that Perl does not recognise. \
@@ -691,6 +700,7 @@ impl DiagnosticCode {
             "PL300" => Some(DiagnosticCode::DuplicateSubroutine),
             "PL301" => Some(DiagnosticCode::MissingReturn),
             "PL302" => Some(DiagnosticCode::InvalidPrototype),
+            "PL303" => Some(DiagnosticCode::RoleConflict),
             "PL400" => Some(DiagnosticCode::BarewordFilehandle),
             "PL401" => Some(DiagnosticCode::TwoArgOpen),
             "PL402" => Some(DiagnosticCode::ImplicitReturn),
@@ -790,6 +800,7 @@ impl DiagnosticCode {
             DiagnosticCode::DuplicateSubroutine
             | DiagnosticCode::MissingReturn
             | DiagnosticCode::InvalidPrototype => DiagnosticCategory::Subroutine,
+            DiagnosticCode::RoleConflict => DiagnosticCategory::Subroutine,
 
             DiagnosticCode::BarewordFilehandle
             | DiagnosticCode::TwoArgOpen

--- a/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
@@ -27,6 +27,7 @@ const ALL_CODES: &[DiagnosticCode] = &[
     DiagnosticCode::DuplicatePackage,
     DiagnosticCode::DuplicateSubroutine,
     DiagnosticCode::MissingReturn,
+    DiagnosticCode::RoleConflict,
     DiagnosticCode::InvalidPrototype,
     DiagnosticCode::BarewordFilehandle,
     DiagnosticCode::TwoArgOpen,
@@ -193,6 +194,8 @@ fn code_as_str_package_module_range() -> Result<(), Box<dyn std::error::Error>> 
 fn code_as_str_subroutine_range() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(DiagnosticCode::DuplicateSubroutine.as_str(), "PL300");
     assert_eq!(DiagnosticCode::MissingReturn.as_str(), "PL301");
+    assert_eq!(DiagnosticCode::InvalidPrototype.as_str(), "PL302");
+    assert_eq!(DiagnosticCode::RoleConflict.as_str(), "PL303");
     Ok(())
 }
 
@@ -283,6 +286,7 @@ fn severity_warning_codes() -> Result<(), Box<dyn std::error::Error>> {
         DiagnosticCode::DuplicatePackage,
         DiagnosticCode::DuplicateSubroutine,
         DiagnosticCode::MissingReturn,
+        DiagnosticCode::RoleConflict,
         DiagnosticCode::BarewordFilehandle,
         DiagnosticCode::TwoArgOpen,
         DiagnosticCode::ImplicitReturn,
@@ -351,6 +355,8 @@ fn documentation_url_pl_codes_have_urls() -> Result<(), Box<dyn std::error::Erro
         (DiagnosticCode::DuplicatePackage, "PL201"),
         (DiagnosticCode::DuplicateSubroutine, "PL300"),
         (DiagnosticCode::MissingReturn, "PL301"),
+        (DiagnosticCode::InvalidPrototype, "PL302"),
+        (DiagnosticCode::RoleConflict, "PL303"),
         (DiagnosticCode::BarewordFilehandle, "PL400"),
         (DiagnosticCode::TwoArgOpen, "PL401"),
         (DiagnosticCode::ImplicitReturn, "PL402"),
@@ -479,7 +485,11 @@ fn category_package_module() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn category_subroutine() -> Result<(), Box<dyn std::error::Error>> {
-    let sub_codes = [DiagnosticCode::DuplicateSubroutine, DiagnosticCode::MissingReturn];
+    let sub_codes = [
+        DiagnosticCode::DuplicateSubroutine,
+        DiagnosticCode::MissingReturn,
+        DiagnosticCode::RoleConflict,
+    ];
     for code in &sub_codes {
         assert_eq!(
             code.category(),
@@ -882,7 +892,11 @@ fn package_module_codes_are_in_200_299_range() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn subroutine_codes_are_in_300_399_range() -> Result<(), Box<dyn std::error::Error>> {
-    let codes = [DiagnosticCode::DuplicateSubroutine, DiagnosticCode::MissingReturn];
+    let codes = [
+        DiagnosticCode::DuplicateSubroutine,
+        DiagnosticCode::MissingReturn,
+        DiagnosticCode::RoleConflict,
+    ];
     for code in &codes {
         let s = code.as_str();
         let num: u32 = s[2..].parse().map_err(|e: std::num::ParseIntError| e.to_string())?;
@@ -1177,8 +1191,8 @@ fn unused_variable_tag_is_exactly_unnecessary() {
 // --- Cross-cutting: ALL_CODES count ---
 
 #[test]
-fn all_codes_count_is_23() {
-    assert_eq!(ALL_CODES.len(), 23, "expected 23 diagnostic codes total");
+fn all_codes_count_is_24() {
+    assert_eq!(ALL_CODES.len(), 24, "expected 24 diagnostic codes total");
 }
 
 // --- DiagnosticCode: parse_code boundary values ---
@@ -1187,7 +1201,7 @@ fn all_codes_count_is_23() {
 fn parse_code_all_valid_pl_codes() {
     let valid_pl = [
         "PL001", "PL002", "PL003", "PL100", "PL101", "PL102", "PL103", "PL200", "PL201", "PL300",
-        "PL301", "PL302", "PL400", "PL401", "PL402", "PL602",
+        "PL301", "PL302", "PL303", "PL400", "PL401", "PL402", "PL602",
     ];
     for s in &valid_pl {
         assert!(DiagnosticCode::parse_code(s).is_some(), "expected valid parse for {}", s);
@@ -1205,11 +1219,11 @@ fn parse_code_all_valid_pc_codes() {
 #[test]
 fn parse_code_gaps_return_none() {
     // Codes that fall in valid ranges but aren't assigned.
-    // Note: PL104-PL111, PL403-PL404, PL500-PL501, PL600-PL602, PL700, PL800-PL806
+    // Note: PL104-PL111, PL303, PL403-PL404, PL500-PL501, PL600-PL602, PL700, PL800-PL806
     // are now assigned; only truly unassigned gaps are listed here.
     let gaps = [
-        "PL004", "PL050", "PL099", "PL150", "PL199", "PL202", "PL250", "PL303", "PL399", "PL499",
-        "PL502", "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
+        "PL004", "PL050", "PL099", "PL150", "PL199", "PL202", "PL250", "PL399", "PL499", "PL502",
+        "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
     ];
     for s in &gaps {
         assert!(DiagnosticCode::parse_code(s).is_none(), "expected None for unassigned code {}", s);

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -19,6 +19,7 @@ use crate::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
 use crate::lints::printf_format::check_printf_format;
+use crate::lints::role_conflicts::check_role_conflicts;
 use crate::lints::security::check_security;
 use crate::lints::strict_warnings::check_strict_warnings;
 use crate::lints::unreachable_code::check_unreachable_code;
@@ -141,6 +142,9 @@ impl DiagnosticsProvider {
         check_missing_package_declaration(ast, source, source_path, &mut diagnostics);
         check_duplicate_package(ast, &mut diagnostics);
         check_duplicate_subroutine(ast, &mut diagnostics);
+
+        // Moo/Moose role conflict diagnostics (same-file only)
+        check_role_conflicts(ast, &symbol_table, &mut diagnostics);
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);

--- a/crates/perl-lsp-diagnostics/src/lib.rs
+++ b/crates/perl-lsp-diagnostics/src/lib.rs
@@ -56,6 +56,8 @@ pub use lints::common_mistakes;
 pub use lints::deprecated;
 pub use lints::missing_module;
 pub use lints::package_subroutine;
+/// Same-file Moo/Moose role conflict detection.
+pub use lints::role_conflicts;
 pub use lints::security;
 pub use lints::strict_warnings;
 pub use lints::unreachable_code;

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -83,6 +83,7 @@
 //! | `PL200` | Warning | File has no package declaration |
 //! | `PL201` | Warning | Package name declared more than once |
 //! | `PL300` | Warning | Subroutine name defined more than once |
+//! | `PL303` | Warning | Same-file Moo/Moose roles provide conflicting methods |
 //!
 //! ## Dead code (`dead_code.rs`)
 //!
@@ -130,10 +131,12 @@ pub mod duplicate_hash_keys;
 pub mod eval_error_flow;
 /// Missing module detection (PL701)
 pub mod missing_module;
-/// Package and subroutine diagnostics (PL200, PL201, PL300)
+/// Package and subroutine diagnostics (PL200, PL201, PL300, PL303)
 pub mod package_subroutine;
 /// printf/sprintf format specifier arity validation (PL405)
 pub mod printf_format;
+/// Same-file Moo/Moose role conflict detection (PL303)
+pub mod role_conflicts;
 pub mod security;
 pub mod strict_warnings;
 /// Unreachable code detection (PL406)

--- a/crates/perl-lsp-diagnostics/src/lints/role_conflicts.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/role_conflicts.rs
@@ -1,0 +1,130 @@
+//! Same-file Moo/Moose role conflict diagnostics.
+//!
+//! This lint checks for roles consumed by a class in the same file that
+//! provide overlapping method names. It intentionally ignores workspace-wide
+//! indexing, Role::Tiny, and transitive role composition.
+
+use std::collections::{HashMap, HashSet};
+
+use perl_diagnostics_codes::DiagnosticCode;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
+use perl_parser_core::ast::Node;
+use perl_semantic_analyzer::{
+    class_model::{ClassModel, ClassModelBuilder},
+    symbol::{SymbolKind, SymbolTable},
+};
+
+/// Check for same-file Moo/Moose role method conflicts.
+pub fn check_role_conflicts(
+    node: &Node,
+    symbol_table: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut role_models: HashMap<String, ClassModel> = HashMap::new();
+    let mut class_models: Vec<ClassModel> = Vec::new();
+
+    for model in ClassModelBuilder::new().build(node) {
+        match package_kind(symbol_table, &model.name) {
+            Some(SymbolKind::Role) => {
+                role_models.insert(model.name.clone(), model);
+            }
+            Some(SymbolKind::Class) => {
+                class_models.push(model);
+            }
+            _ => {}
+        }
+    }
+
+    for class_model in class_models {
+        if class_model.roles.is_empty() {
+            continue;
+        }
+
+        let class_methods = provided_method_names(&class_model);
+        let mut method_providers: HashMap<String, Vec<String>> = HashMap::new();
+        let mut seen_roles = HashSet::new();
+
+        for role_name in &class_model.roles {
+            if !seen_roles.insert(role_name.clone()) {
+                continue;
+            }
+
+            let Some(role_model) = role_models.get(role_name) else {
+                continue;
+            };
+
+            for method_name in provided_method_names(role_model) {
+                method_providers.entry(method_name).or_default().push(role_name.clone());
+            }
+        }
+
+        for (method_name, providers) in method_providers {
+            if providers.len() < 2 || class_methods.contains(&method_name) {
+                continue;
+            }
+
+            let Some(location) = role_anchor_location(symbol_table, &providers) else {
+                continue;
+            };
+
+            diagnostics.push(Diagnostic {
+                range: location,
+                severity: DiagnosticSeverity::Warning,
+                code: Some(DiagnosticCode::RoleConflict.as_str().to_string()),
+                message: build_message(&class_model.name, &method_name, &providers),
+                related_information: Vec::new(),
+                tags: Vec::new(),
+                suggestion: Some(format!(
+                    "Define `{method_name}` in `{}` or remove one of the conflicting roles.",
+                    class_model.name
+                )),
+            });
+        }
+    }
+}
+
+fn package_kind(symbol_table: &SymbolTable, package_name: &str) -> Option<SymbolKind> {
+    symbol_table.symbols.get(package_name)?.iter().find_map(|symbol| match symbol.kind {
+        SymbolKind::Class | SymbolKind::Role => Some(symbol.kind),
+        _ => None,
+    })
+}
+
+fn provided_method_names(model: &ClassModel) -> HashSet<String> {
+    model.methods.iter().chain(model.adjusts.iter()).map(|method| method.name.clone()).collect()
+}
+
+fn role_anchor_location(
+    symbol_table: &SymbolTable,
+    role_names: &[String],
+) -> Option<(usize, usize)> {
+    for role_name in role_names {
+        if let Some(reference) = symbol_table.references.get(role_name).and_then(|references| {
+            references.iter().find(|reference| reference.kind == SymbolKind::Role)
+        }) {
+            return Some((reference.location.start, reference.location.end));
+        }
+    }
+
+    None
+}
+
+fn build_message(class_name: &str, method_name: &str, role_names: &[String]) -> String {
+    let role_list = format_role_list(role_names);
+    let provider_verb = if role_names.len() == 2 { "both provide" } else { "all provide" };
+    format!("Roles {role_list} {provider_verb} method `{method_name}` consumed by `{class_name}`")
+}
+
+fn format_role_list(role_names: &[String]) -> String {
+    match role_names {
+        [] => String::from(""),
+        [single] => format!("`{single}`"),
+        [first, second] => format!("`{first}` and `{second}`"),
+        many => {
+            let mut parts: Vec<String> =
+                many[..many.len() - 1].iter().map(|name| format!("`{name}`")).collect();
+            parts.push(format!("and `{}`", many[many.len() - 1]));
+            parts.join(", ")
+        }
+    }
+}

--- a/crates/perl-lsp-diagnostics/tests/role_conflicts_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/role_conflicts_tests.rs
@@ -1,0 +1,129 @@
+//! Integration tests for same-file Moo/Moose role-conflict diagnostics.
+
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl303_diags(source: &str) -> Vec<Diagnostic> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|diag| diag.code.as_deref() == Some("PL303"))
+        .collect()
+}
+
+#[test]
+fn same_file_role_conflict_emits_pl303_at_with_reference() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::Role::Printable', 'MyApp::Role::Auditable';
+
+package MyApp::Role::Printable;
+use strict;
+use warnings;
+use Moo::Role;
+sub shared { 1 }
+sub printable_only { 1 }
+
+package MyApp::Role::Auditable;
+use strict;
+use warnings;
+use Moo::Role;
+sub shared { 2 }
+sub auditable_only { 2 }
+"#;
+
+    let diags = pl303_diags(source);
+    assert_eq!(diags.len(), 1, "expected exactly one PL303 diagnostic: {diags:?}");
+    let diag = &diags[0];
+    let anchor = source.find("with 'MyApp::Role::Printable', 'MyApp::Role::Auditable'").unwrap();
+    assert_eq!(diag.range.0, anchor, "PL303 should anchor at the `with` reference");
+    assert!(diag.message.contains("shared"));
+    assert!(diag.message.contains("MyApp::Consumer"));
+}
+
+#[test]
+fn class_defining_the_method_suppresses_pl303() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::Role::Printable', 'MyApp::Role::Auditable';
+sub shared { 42 }
+
+package MyApp::Role::Printable;
+use strict;
+use warnings;
+use Moo::Role;
+sub shared { 1 }
+
+package MyApp::Role::Auditable;
+use strict;
+use warnings;
+use Moo::Role;
+sub shared { 2 }
+"#;
+
+    assert!(pl303_diags(source).is_empty(), "class-defined method should suppress PL303");
+}
+
+#[test]
+fn distinct_role_methods_do_not_conflict() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::Role::Printable', 'MyApp::Role::Auditable';
+
+package MyApp::Role::Printable;
+use strict;
+use warnings;
+use Moo::Role;
+sub printable_only { 1 }
+
+package MyApp::Role::Auditable;
+use strict;
+use warnings;
+use Moo::Role;
+sub auditable_only { 2 }
+"#;
+
+    assert!(pl303_diags(source).is_empty(), "distinct role methods should not produce PL303");
+}
+
+#[test]
+fn requires_does_not_count_as_a_provided_method() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::Role::Printable', 'MyApp::Role::Auditable';
+
+package MyApp::Role::Printable;
+use strict;
+use warnings;
+use Moo::Role;
+sub shared { 1 }
+
+package MyApp::Role::Auditable;
+use strict;
+use warnings;
+use Moo::Role;
+requires 'shared';
+"#;
+
+    assert!(pl303_diags(source).is_empty(), "`requires` should not create a role-method conflict");
+}


### PR DESCRIPTION
## Summary
- add a same-file role-conflict lint for Moo/Moose role composition
- anchor diagnostics at existing `with` role references from the symbol table
- ignore `requires` declarations and suppress the warning when the consuming class defines the method itself

## Testing
- cargo test -p perl-diagnostics-codes --test comprehensive_unit_tests -- --nocapture
- cargo test -p perl-lsp-diagnostics --test role_conflicts_tests -- --nocapture
- cargo test -p perl-lsp-diagnostics --lib -- --nocapture

This MVP is intentionally same-file only. It does not attempt workspace-wide role indexing or `Role::Tiny` support.