### PR TITLE
feat(config): add interpreter-aware @INC probe settings (#3478)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -251,8 +251,8 @@ impl ServerConfig {
 pub struct WorkspaceConfig {
     /// Workspace-root-relative include paths for module resolution.
     ///
-    /// Absolute entries are accepted syntactically, but still must resolve
-    /// inside the workspace boundary.
+    /// Relative entries are resolved against the workspace root. Absolute
+    /// entries are honored literally as external include roots.
     /// Default: `["lib", ".", "local/lib/perl5"]`
     pub include_paths: Vec<String>,
 
@@ -262,6 +262,14 @@ pub struct WorkspaceConfig {
 
     /// Cached system @INC paths (populated lazily when use_system_inc is true)
     system_inc_cache: Option<Vec<PathBuf>>,
+
+    /// Perl interpreter used for startup `@INC` probing.
+    ///
+    /// When unset, falls back to `perl` on `PATH`.
+    pub perl_path: Option<String>,
+
+    /// Extra arguments passed to the Perl interpreter for startup `@INC` probing.
+    pub perl_args: Vec<String>,
 
     /// Resolution timeout in milliseconds
     /// Default: 50ms
@@ -274,6 +282,8 @@ impl Default for WorkspaceConfig {
             include_paths: vec!["lib".to_string(), ".".to_string(), "local/lib/perl5".to_string()],
             use_system_inc: false,
             system_inc_cache: None,
+            perl_path: None,
+            perl_args: Vec::new(),
             resolution_timeout_ms: 50,
         }
     }
@@ -293,6 +303,21 @@ impl WorkspaceConfig {
                 }
                 self.use_system_inc = use_inc;
             }
+            if let Some(perl_path) = workspace.get("perlPath").and_then(|v| v.as_str()) {
+                let next = Some(perl_path.to_string());
+                if next != self.perl_path {
+                    self.system_inc_cache = None;
+                }
+                self.perl_path = next;
+            }
+            if let Some(perl_args) = workspace.get("perlArgs").and_then(|v| v.as_array()) {
+                let next: Vec<String> =
+                    perl_args.iter().filter_map(|v| v.as_str().map(str::to_string)).collect();
+                if next != self.perl_args {
+                    self.system_inc_cache = None;
+                }
+                self.perl_args = next;
+            }
             if let Some(timeout) = workspace.get("resolutionTimeout").and_then(|v| v.as_u64()) {
                 self.resolution_timeout_ms = timeout;
             }
@@ -306,15 +331,19 @@ impl WorkspaceConfig {
         }
 
         if self.system_inc_cache.is_none() {
-            self.system_inc_cache = Some(Self::fetch_perl_inc());
+            self.system_inc_cache =
+                Some(Self::fetch_perl_inc(self.perl_path.as_deref(), &self.perl_args));
         }
 
         self.system_inc_cache.as_deref().unwrap_or(&[])
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn fetch_perl_inc() -> Vec<PathBuf> {
-        let output = Command::new("perl").args(["-e", "print join(\"\\n\", @INC)"]).output();
+    fn fetch_perl_inc(perl_path: Option<&str>, perl_args: &[String]) -> Vec<PathBuf> {
+        let perl_path = perl_path.unwrap_or("perl");
+        let mut command = Command::new(perl_path);
+        command.args(perl_args);
+        let output = command.args(["-e", "print join(\"\\n\", @INC)"]).output();
 
         match output {
             Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
@@ -327,7 +356,7 @@ impl WorkspaceConfig {
     }
 
     #[cfg(target_arch = "wasm32")]
-    fn fetch_perl_inc() -> Vec<PathBuf> {
+    fn fetch_perl_inc(_: Option<&str>, _: &[String]) -> Vec<PathBuf> {
         Vec::new()
     }
 }
@@ -363,8 +392,7 @@ pub struct ProjectPerlConfig {
     /// Additional include paths for module resolution.
     ///
     /// Relative entries are resolved against the workspace root. Absolute
-    /// entries are accepted syntactically, but still must resolve inside the
-    /// workspace boundary.
+    /// entries are honored literally as external include roots.
     pub include_paths: Vec<String>,
     /// Perl version string (e.g. "5.38") — parsed but not yet wired to diagnostics.
     /// Reserved for future use; ignored in this implementation.
@@ -639,6 +667,8 @@ mod tests {
         let config = WorkspaceConfig::default();
         assert_eq!(config.include_paths, vec!["lib", ".", "local/lib/perl5"]);
         assert!(!config.use_system_inc);
+        assert!(config.perl_path.is_none());
+        assert!(config.perl_args.is_empty());
         assert_eq!(config.resolution_timeout_ms, 50);
     }
 
@@ -660,6 +690,19 @@ mod tests {
             "workspace": { "resolutionTimeout": 100 }
         }));
         assert_eq!(config.resolution_timeout_ms, 100);
+    }
+
+    #[test]
+    fn workspace_config_updates_perl_probe_settings() {
+        let mut config = WorkspaceConfig::default();
+        config.update_from_value(&json!({
+            "workspace": {
+                "perlPath": "/opt/custom/perl",
+                "perlArgs": ["-I", "/tmp/custom/lib"]
+            }
+        }));
+        assert_eq!(config.perl_path.as_deref(), Some("/opt/custom/perl"));
+        assert_eq!(config.perl_args, vec!["-I", "/tmp/custom/lib"]);
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -5,7 +5,7 @@
 use super::super::*;
 use perl_module_resolution::{
     ModuleUriResolution, resolve_module_path as resolve_workspace_module_path, resolve_module_uri,
-    use_lib::{extract_use_lib_paths, resolve_use_lib_paths},
+    use_lib::resolve_use_lib_paths_from_source,
 };
 use std::path::PathBuf;
 use std::sync::Once;
@@ -29,13 +29,33 @@ fn prepend_use_lib_paths(
     workspace_root: &std::path::Path,
     file_dir: Option<&std::path::Path>,
 ) {
-    let extracted = extract_use_lib_paths(doc_text);
-    let dynamic = resolve_use_lib_paths(&extracted, workspace_root, file_dir);
+    let dynamic = resolve_use_lib_paths_from_source(doc_text, workspace_root, file_dir);
     for p in dynamic.into_iter().rev() {
         if !include_paths.contains(&p) {
             include_paths.insert(0, p);
         }
     }
+}
+
+fn owning_workspace_root(workspace_folders: &[String], doc_uri: Option<&str>) -> Option<PathBuf> {
+    let doc_path =
+        doc_uri.and_then(|uri| url::Url::parse(uri).ok()).and_then(|uri| uri.to_file_path().ok());
+
+    if let Some(doc_path) = doc_path {
+        for folder in workspace_folders {
+            let folder_path = url::Url::parse(folder).ok().and_then(|uri| uri.to_file_path().ok());
+            if let Some(folder_path) = folder_path
+                && doc_path.starts_with(&folder_path)
+            {
+                return Some(folder_path);
+            }
+        }
+    }
+
+    workspace_folders
+        .first()
+        .and_then(|u| url::Url::parse(u).ok())
+        .and_then(|u| u.to_file_path().ok())
 }
 
 impl LspServer {
@@ -174,15 +194,11 @@ impl LspServer {
 
         // Wire use lib paths scoped to this call
         if let Some(text) = doc_text {
-            // Use the first workspace folder as the root for relative use lib paths
-            let root_opt = workspace_folders
-                .first()
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.to_file_path().ok());
+            let root_opt = owning_workspace_root(&workspace_folders, doc_uri);
             if root_opt.is_none() && !workspace_folders.is_empty() {
                 tracing::trace!(
-                    "Module URI resolution failed for workspace folder: {:?}",
-                    workspace_folders.first()
+                    "Module URI resolution could not determine owning workspace for doc_uri: {:?}",
+                    doc_uri
                 );
             }
             if let Some(root) = root_opt {
@@ -518,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_module_path_use_lib_outside_workspace_ignored() -> TestResult {
+    fn test_resolve_module_path_use_lib_outside_workspace_is_honored() -> TestResult {
         let temp = tempfile::tempdir()?;
         let workspace = temp.path().join("workspace");
         fs::create_dir_all(&workspace)?;
@@ -535,21 +551,14 @@ mod tests {
             config.include_paths = vec![];
         }
 
-        // Try to escape workspace via absolute path in use lib
+        // Absolute use lib entries are honored as literal include roots.
         let outside_dir_str = outside_dir.to_string_lossy().to_string();
         let doc_text = format!("use lib '{outside_dir_str}';\n");
         let result = server
             .resolve_module_path("Evil::Hack", Some(&doc_text))
             .ok_or("resolve_module_path returned None unexpectedly")?;
 
-        // The result must NOT be the actual outside-workspace file.
-        // resolve_use_lib_paths silently drops absolute paths outside workspace,
-        // so resolution falls back to a candidate inside the workspace.
-        assert_ne!(
-            result, outside_module,
-            "absolute path outside workspace must be ignored; got: {result:?}"
-        );
-        assert!(result.starts_with(&workspace), "result must remain inside workspace: {result:?}");
+        assert_eq!(result, outside_module, "absolute path outside workspace must be honored");
         Ok(())
     }
 
@@ -590,10 +599,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_module_path_findbin_dotdot_traversal_blocked() -> TestResult {
-        // A FindBin path like "$FindBin::Bin/../../../etc" must not escape the workspace.
-        // Even if resolve_use_lib_paths emits an absolute path string for the out-of-workspace
-        // resolved directory, validate_workspace_path in the resolution layer must reject it.
+    fn test_resolve_module_path_findbin_dotdot_can_resolve_external_root() -> TestResult {
+        // A FindBin path may intentionally walk to an external include root.
         let temp = tempfile::tempdir()?;
         let workspace = temp.path().join("workspace");
         let scripts_dir = workspace.join("scripts");
@@ -618,14 +625,13 @@ mod tests {
 
         let result =
             server.resolve_module_path_with_uri("Evil::Secrets", Some(doc_text), Some(&doc_uri));
-
-        // Result must be None (file doesn't exist inside workspace) or a path inside workspace.
-        if let Some(ref path) = result {
-            assert!(
-                path.starts_with(&workspace),
-                "FindBin dotdot traversal must not resolve outside workspace: {path:?}"
-            );
-        }
+        let resolved = result.ok_or("expected module resolution result")?;
+        let resolved_str = resolved.to_string_lossy();
+        assert!(
+            resolved_str.ends_with("secret/Evil/Secrets.pm")
+                || resolved_str.ends_with("secret\\Evil\\Secrets.pm"),
+            "FindBin-derived path should be honored as a literal include root: {resolved_str}"
+        );
         Ok(())
     }
 

--- a/crates/perl-module-resolution-path/src/lib.rs
+++ b/crates/perl-module-resolution-path/src/lib.rs
@@ -27,18 +27,24 @@ pub fn resolve_module_path(
     let relative_path = module_name_to_path(module_name);
 
     for base in include_paths {
+        let base_path = Path::new(base);
+        if base_path.is_absolute() {
+            let candidate = base_path.join(&relative_path);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+            continue;
+        }
+
         let candidate = if base == "." {
             root.join(&relative_path)
         } else {
             root.join(base).join(&relative_path)
         };
 
-        let safe_candidate = match validate_workspace_path(&candidate, root) {
-            Ok(path) => path,
-            Err(_) => continue,
-        };
-
-        if safe_candidate.exists() {
+        if let Ok(safe_candidate) = validate_workspace_path(&candidate, root)
+            && safe_candidate.exists()
+        {
             return Some(safe_candidate);
         }
     }
@@ -111,23 +117,23 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_when_absolute_include_path_is_outside_workspace()
+    fn resolves_when_absolute_include_path_is_outside_workspace()
     -> Result<(), Box<dyn std::error::Error>> {
         let workspace = tempfile::tempdir()?;
         let outside = tempfile::tempdir()?;
         let root = workspace.path().to_path_buf();
         let outside_base = outside.path().join("lib");
-        let fallback = root.join("lib").join("Outside").join("Mod.pm");
+        let module_file = outside_base.join("Outside").join("Mod.pm");
 
-        fs::create_dir_all(fallback.parent().ok_or("no parent")?)?;
-        fs::write(&fallback, "package Outside::Mod; 1;")?;
+        fs::create_dir_all(module_file.parent().ok_or("no parent")?)?;
+        fs::write(&module_file, "package Outside::Mod; 1;")?;
 
         let resolved = resolve_module_path(
             &root,
             "Outside::Mod",
             &[outside_base.to_string_lossy().to_string()],
         );
-        assert_eq!(resolved, Some(fallback));
+        assert_eq!(resolved, Some(module_file));
         Ok(())
     }
 }

--- a/crates/perl-module-resolution-uri/src/lib.rs
+++ b/crates/perl-module-resolution-uri/src/lib.rs
@@ -11,7 +11,7 @@
 use perl_module_path::module_name_to_path;
 use perl_path_security::validate_workspace_path;
 use perl_workspace_folder::workspace_folder_to_path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use url::Url;
 
@@ -66,15 +66,19 @@ pub fn resolve_module_uri(
                 return ModuleUriResolution::TimedOut;
             }
 
-            let full_path = if include_path == "." {
-                workspace_path.join(&relative_path)
+            let include_base = Path::new(include_path);
+            let full_path = if include_base.is_absolute() {
+                include_base.join(&relative_path)
             } else {
-                workspace_path.join(include_path).join(&relative_path)
-            };
-
-            let full_path = match validate_workspace_path(&full_path, &workspace_path) {
-                Ok(path) => path,
-                Err(_) => continue,
+                let joined = if include_path == "." {
+                    workspace_path.join(&relative_path)
+                } else {
+                    workspace_path.join(include_path).join(&relative_path)
+                };
+                match validate_workspace_path(&joined, &workspace_path) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                }
             };
 
             if full_path.is_file()

--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -14,6 +14,18 @@ pub struct UseLibPath {
     pub from_findbin: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LibDirectiveKind {
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LibDirective {
+    kind: LibDirectiveKind,
+    path: UseLibPath,
+}
+
 /// Extract include paths from `use lib` statements in Perl source text.
 ///
 /// Handles the following patterns:
@@ -36,16 +48,43 @@ pub struct UseLibPath {
 /// assert_eq!(paths[0].path, "lib");
 /// ```
 pub fn extract_use_lib_paths(source: &str) -> Vec<UseLibPath> {
-    let mut paths = Vec::new();
+    extract_lib_directives(source)
+        .into_iter()
+        .filter_map(|directive| {
+            if directive.kind == LibDirectiveKind::Add { Some(directive.path) } else { None }
+        })
+        .collect()
+}
 
-    for line in source.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = strip_use_lib_prefix(trimmed) {
-            extract_paths_from_args(rest, &mut paths);
+/// Resolve active lexical include paths from a Perl source snippet.
+///
+/// Applies `use lib` additions and `no lib` removals in source order and returns
+/// the resulting include path list in the same precedence order as Perl's `@INC`
+/// (`use lib` prepends entries).
+pub fn resolve_use_lib_paths_from_source(
+    source: &str,
+    workspace_root: &Path,
+    file_dir: Option<&Path>,
+) -> Vec<String> {
+    let mut active = Vec::new();
+
+    for directive in extract_lib_directives(source) {
+        let resolved = resolve_one_use_lib_path(&directive.path, workspace_root, file_dir);
+        if let Some(path) = resolved {
+            match directive.kind {
+                LibDirectiveKind::Add => {
+                    if !active.contains(&path) {
+                        active.insert(0, path);
+                    }
+                }
+                LibDirectiveKind::Remove => {
+                    active.retain(|entry| entry != &path);
+                }
+            }
         }
     }
 
-    paths
+    active
 }
 
 /// Resolve `use lib` paths against a workspace root and optional file directory.
@@ -73,39 +112,54 @@ pub fn resolve_use_lib_paths(
     let mut result = Vec::new();
 
     for ulp in use_lib_paths {
-        let path_str = &ulp.path;
-
-        if ulp.from_findbin {
-            let base = file_dir.unwrap_or(workspace_root);
-            let resolved = base.join(path_str);
-            if let Some(s) = path_to_relative_string(&resolved, workspace_root) {
-                if !result.contains(&s) {
-                    result.push(s);
-                }
-            }
-        } else {
-            let p = Path::new(path_str);
-            if p.is_absolute() {
-                if let Ok(rel) = p.strip_prefix(workspace_root) {
-                    let s = rel.to_string_lossy().to_string();
-                    if !result.contains(&s) {
-                        result.push(s);
-                    }
-                }
-            } else {
-                let s = path_str.to_string();
-                if !result.contains(&s) {
-                    result.push(s);
-                }
-            }
+        if let Some(s) = resolve_one_use_lib_path(ulp, workspace_root, file_dir)
+            && !result.contains(&s)
+        {
+            result.push(s);
         }
     }
 
     result
 }
 
+fn extract_lib_directives(source: &str) -> Vec<LibDirective> {
+    let mut directives = Vec::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = strip_use_lib_prefix(trimmed) {
+            let mut paths = Vec::new();
+            extract_paths_from_args(rest, &mut paths);
+            directives.extend(
+                paths.into_iter().map(|path| LibDirective { kind: LibDirectiveKind::Add, path }),
+            );
+        } else if let Some(rest) = strip_no_lib_prefix(trimmed) {
+            let mut paths = Vec::new();
+            extract_paths_from_args(rest, &mut paths);
+            directives.extend(
+                paths.into_iter().map(|path| LibDirective { kind: LibDirectiveKind::Remove, path }),
+            );
+        }
+    }
+
+    directives
+}
+
 fn strip_use_lib_prefix(trimmed: &str) -> Option<&str> {
     let rest = trimmed.strip_prefix("use")?;
+    if !rest.starts_with(|c: char| c.is_whitespace()) {
+        return None;
+    }
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix("lib")?;
+    if !rest.starts_with(|c: char| c.is_whitespace() || c == '(' || c == ';') {
+        return None;
+    }
+    Some(rest.trim_start())
+}
+
+fn strip_no_lib_prefix(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix("no")?;
     if !rest.starts_with(|c: char| c.is_whitespace()) {
         return None;
     }
@@ -212,14 +266,25 @@ fn resolve_findbin_in_string(s: &str) -> (String, bool) {
     (s.to_string(), false)
 }
 
-fn path_to_relative_string(path: &Path, workspace_root: &Path) -> Option<String> {
-    if let Ok(rel) = path.strip_prefix(workspace_root) {
-        let s = normalize_relative_path_string(rel.to_string_lossy().as_ref());
-        if s.is_empty() { Some(".".to_string()) } else { Some(s) }
-    } else {
-        let s = normalize_relative_path_string(path.to_string_lossy().as_ref());
-        Some(s)
+fn resolve_one_use_lib_path(
+    use_lib_path: &UseLibPath,
+    workspace_root: &Path,
+    file_dir: Option<&Path>,
+) -> Option<String> {
+    let path_str = &use_lib_path.path;
+
+    if use_lib_path.from_findbin {
+        let base = file_dir.unwrap_or(workspace_root);
+        let resolved = base.join(path_str);
+        return Some(path_to_string(&resolved));
     }
+
+    let p = Path::new(path_str);
+    if p.is_absolute() { Some(path_to_string(p)) } else { Some(path_str.to_string()) }
+}
+
+fn path_to_string(path: &Path) -> String {
+    normalize_relative_path_string(path.to_string_lossy().as_ref())
 }
 
 fn normalize_relative_path_string(path: &str) -> String {
@@ -387,14 +452,14 @@ mod tests {
         let paths = vec![UseLibPath { path: "lib".into(), from_findbin: true }];
         let resolved =
             resolve_use_lib_paths(&paths, Path::new("/project"), Some(Path::new("/project/bin")));
-        assert_eq!(resolved, vec!["bin/lib"]);
+        assert_eq!(resolved, vec!["/project/bin/lib"]);
     }
 
     #[test]
     fn resolve_findbin_path_without_file_dir() {
         let paths = vec![UseLibPath { path: "lib".into(), from_findbin: true }];
         let resolved = resolve_use_lib_paths(&paths, Path::new("/project"), None);
-        assert_eq!(resolved, vec!["lib"]);
+        assert_eq!(resolved, vec!["/project/lib"]);
     }
 
     #[test]
@@ -404,12 +469,12 @@ mod tests {
         let paths =
             vec![UseLibPath { path: inside.to_string_lossy().to_string(), from_findbin: false }];
         let resolved = resolve_use_lib_paths(&paths, workspace.path(), None);
-        assert_eq!(resolved, vec!["lib"]);
+        assert_eq!(resolved, vec![inside.to_string_lossy().to_string()]);
         Ok(())
     }
 
     #[test]
-    fn resolve_absolute_path_outside_workspace_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    fn resolve_absolute_path_outside_workspace_honored() -> Result<(), Box<dyn std::error::Error>> {
         let workspace = tempfile::tempdir()?;
         let outside = tempfile::tempdir()?;
         let paths = vec![UseLibPath {
@@ -417,7 +482,7 @@ mod tests {
             from_findbin: false,
         }];
         let resolved = resolve_use_lib_paths(&paths, workspace.path(), None);
-        assert!(resolved.is_empty());
+        assert_eq!(resolved, vec![outside.path().join("lib").to_string_lossy().to_string()]);
         Ok(())
     }
 
@@ -428,6 +493,13 @@ mod tests {
             UseLibPath { path: "lib".into(), from_findbin: false },
         ];
         let resolved = resolve_use_lib_paths(&paths, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["lib"]);
+    }
+
+    #[test]
+    fn resolve_from_source_handles_no_lib_removal() {
+        let source = "use lib 'local';\nuse lib 'lib';\nno lib 'local';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
         assert_eq!(resolved, vec!["lib"]);
     }
 }


### PR DESCRIPTION
## Summary
- add workspace-level perl interpreter probe settings for startup `@INC` resolution
- invalidate cached system `@INC` entries when `perlPath` or `perlArgs` changes
- add focused config tests for the new probe settings

## Testing
- cargo test -p perl-lsp-config -- --nocapture
