### PR TITLE
feat(semantic): add Future framework symbols (#3611)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -343,6 +343,10 @@ pub enum WebFrameworkKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Async framework variant detected via `use` statements during Parse/Analyze workflows.
 pub enum AsyncFrameworkKind {
+    /// `use Future;`
+    Future,
+    /// `use Future::XS;`
+    FutureXS,
     /// `use IO::Async;`
     IOAsync,
     /// `use Mojo::Redis;`
@@ -1605,16 +1609,22 @@ impl SymbolExtractor {
             return false;
         };
 
-        let (module_prefix, framework_name) = match flags.async_framework {
-            Some(AsyncFrameworkKind::IOAsync) => ("IO::Async::", "IO::Async"),
-            Some(AsyncFrameworkKind::MojoRedis) => ("Mojo::Redis", "Mojo::Redis"),
+        let (module_name, framework_name, exact_match) = match flags.async_framework {
+            Some(AsyncFrameworkKind::Future) => ("Future", "Future", true),
+            Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
+            Some(AsyncFrameworkKind::IOAsync) => ("IO::Async", "IO::Async", false),
+            Some(AsyncFrameworkKind::MojoRedis) => ("Mojo::Redis", "Mojo::Redis", true),
             None => return false,
         };
 
         let Some(name) = Self::single_symbol_name(object) else {
             return false;
         };
-        if !name.starts_with(module_prefix) {
+        if exact_match {
+            if name != module_name {
+                return false;
+            }
+        } else if !name.starts_with(&format!("{module_name}::")) {
             return false;
         }
 
@@ -1681,6 +1691,18 @@ impl SymbolExtractor {
         if module == "IO::Async" || module.starts_with("IO::Async::") {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::IOAsync);
+            return;
+        }
+
+        if module == "Future" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::Future);
+            return;
+        }
+
+        if module == "Future::XS" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::FutureXS);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -114,3 +114,73 @@ my $redis = Mojo::Redis->new;
         "did not expect Mojo::Redis class synthesis without `use Mojo::Redis`"
     );
 }
+
+#[test]
+fn future_use_synthesizes_class_symbol_for_method_calls() {
+    let code = r#"
+use Future;
+
+my $future = Future->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Future", SymbolKind::Class),
+        "expected Future class symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "Future", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=Future"),
+        "expected `framework=Future` on Future, got {attrs:?}"
+    );
+}
+
+#[test]
+fn future_xs_use_synthesizes_class_symbol_for_method_calls() {
+    let code = r#"
+use Future::XS;
+
+my $future = Future::XS->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Future::XS", SymbolKind::Class),
+        "expected Future::XS class symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "Future::XS", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=Future::XS"),
+        "expected `framework=Future::XS` on Future::XS, got {attrs:?}"
+    );
+}
+
+#[test]
+fn future_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $future = Future->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "Future", SymbolKind::Class),
+        "did not expect Future class synthesis without `use Future`"
+    );
+}
+
+#[test]
+fn future_xs_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $future = Future::XS->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "Future::XS", SymbolKind::Class),
+        "did not expect Future::XS class synthesis without `use Future::XS`"
+    );
+}


### PR DESCRIPTION
## Summary
- add narrow semantic surface for `Future` and `Future::XS`
- synthesize framework class symbols when used in method-call form
- add focused positive and negative regression tests

## Testing
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
