### PR TITLE
feat(semantic): add Mojo::Pg framework symbols (#3615)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -351,6 +351,8 @@ pub enum AsyncFrameworkKind {
     IOAsync,
     /// `use Mojo::Redis;`
     MojoRedis,
+    /// `use Mojo::Pg;`
+    MojoPg,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1614,6 +1616,7 @@ impl SymbolExtractor {
             Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
             Some(AsyncFrameworkKind::IOAsync) => ("IO::Async", "IO::Async", false),
             Some(AsyncFrameworkKind::MojoRedis) => ("Mojo::Redis", "Mojo::Redis", true),
+            Some(AsyncFrameworkKind::MojoPg) => ("Mojo::Pg", "Mojo::Pg", true),
             None => return false,
         };
 
@@ -1709,6 +1712,12 @@ impl SymbolExtractor {
         if module == "Mojo::Redis" {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::MojoRedis);
+            return;
+        }
+
+        if module == "Mojo::Pg" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::MojoPg);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -116,6 +116,42 @@ my $redis = Mojo::Redis->new;
 }
 
 #[test]
+fn mojo_pg_use_synthesizes_framework_class_symbol() {
+    let code = r#"
+use Mojo::Pg;
+
+my $pg = Mojo::Pg->new;
+my $mode = Mojo::Pg->strict_mode;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Mojo::Pg", SymbolKind::Class),
+        "expected Mojo::Pg class symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "Mojo::Pg", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=Mojo::Pg"),
+        "expected `framework=Mojo::Pg` on Mojo::Pg, got {attrs:?}"
+    );
+}
+
+#[test]
+fn mojo_pg_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $pg = Mojo::Pg->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "Mojo::Pg", SymbolKind::Class),
+        "did not expect Mojo::Pg class synthesis without `use Mojo::Pg`"
+    );
+}
+
+#[test]
 fn future_use_synthesizes_class_symbol_for_method_calls() {
     let code = r#"
 use Future;


### PR DESCRIPTION
## Summary
- add narrow semantic support for `Mojo::Pg`
- synthesize the core class symbol only when `Mojo::Pg` is actually used in method-call form
- add focused positive and negative regression tests

## Testing
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
