### PR TITLE
fix(semantic): track lexical builtin imports (#3349)

### DIFF
--- a/crates/perl-parser/benches/scope_benchmark.rs
+++ b/crates/perl-parser/benches/scope_benchmark.rs
@@ -78,7 +78,9 @@ fn benchmark_strict_barewords(c: &mut Criterion) {
             strict_vars: true,
             strict_refs: true,
             warnings: true,
+            disabled_warning_categories: Vec::new(),
             features: Vec::new(),
+            builtin_imports: Vec::new(),
         },
     )];
 

--- a/crates/perl-parser/tests/scope_analysis_test.rs
+++ b/crates/perl-parser/tests/scope_analysis_test.rs
@@ -29,7 +29,9 @@ fn analyze_strict(code: &str) -> Vec<ScopeIssue> {
             strict_subs: true,
             strict_vars: true,
             warnings: true,
+            disabled_warning_categories: Vec::new(),
             features: Vec::new(),
+            builtin_imports: Vec::new(),
         },
     )];
 

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -47,6 +47,8 @@ pub struct PragmaState {
     /// table. `use feature` declarations are **not** tracked here — only
     /// version-bundle implications.
     pub features: Vec<&'static str>,
+    /// Lexically imported builtin short names from `use builtin`.
+    pub builtin_imports: Vec<String>,
 }
 
 impl PragmaState {
@@ -59,6 +61,7 @@ impl PragmaState {
             warnings: false,
             disabled_warning_categories: Vec::new(),
             features: Vec::new(),
+            builtin_imports: Vec::new(),
         }
     }
 
@@ -83,6 +86,12 @@ impl PragmaState {
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {
         self.features.contains(&feature)
+    }
+
+    /// Returns `true` when a builtin short name was lexically imported in scope.
+    #[must_use]
+    pub fn has_builtin_import(&self, name: &str) -> bool {
+        self.builtin_imports.iter().any(|import| import == name)
     }
 }
 
@@ -195,6 +204,31 @@ fn enable_effective_version_semantics(state: &mut PragmaState, version: PerlVers
     state.features = features_enabled_by_version(version);
 }
 
+fn builtin_import_names(arg: &str) -> Vec<String> {
+    let trimmed = arg.trim();
+
+    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+        return inner
+            .split_whitespace()
+            .filter(|name| !name.is_empty())
+            .map(|name| name.trim_matches('\'').trim_matches('"').to_string())
+            .collect();
+    }
+
+    let name = trimmed.trim_matches('\'').trim_matches('"');
+    if name.is_empty() { Vec::new() } else { vec![name.to_string()] }
+}
+
+fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
+    for arg in args {
+        for name in builtin_import_names(arg) {
+            if !state.builtin_imports.iter().any(|import| import == &name) {
+                state.builtin_imports.push(name);
+            }
+        }
+    }
+}
+
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
@@ -300,6 +334,11 @@ impl PragmaTracker {
                                 current_state.clone(),
                             ));
                         }
+                    }
+                    "builtin" => {
+                        apply_builtin_imports(current_state, args);
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
                     }
                     _ => {
                         if let Some(version) = parse_perl_version(module) {

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -942,6 +942,26 @@ fn use_v5_40_state_has_builtin() -> Result<(), Box<dyn std::error::Error>> {
     let map = PragmaTracker::build(&ast);
     let state = &map[0].1;
     assert!(state.has_feature("builtin"), "v5.40 state must have 'builtin'");
+    assert!(!state.has_builtin_import("floor"), "v5.40 should not imply lexical builtin imports");
+    assert!(state.builtin_imports.is_empty(), "v5.40 should not populate lexical builtin imports");
+    Ok(())
+}
+
+#[test]
+fn use_builtin_tracks_lexical_imports_only() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("builtin", &["'true'", "'floor'"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.has_builtin_import("true"));
+    assert!(state.has_builtin_import("floor"));
+    assert!(
+        !state.has_builtin_import("is_bool"),
+        "only the names actually imported should be tracked"
+    );
+    assert!(
+        !state.has_feature("builtin"),
+        "lexical builtin imports should stay separate from version-implied features"
+    );
     Ok(())
 }
 

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -959,6 +959,7 @@ impl ScopeAnalyzer {
                 if strict_subs_mode
                     && !self.is_in_hash_key_context(node, ancestors, 1)
                     && !is_known_function(name)
+                    && !pragma_state.has_builtin_import(name)
                     && !self.is_in_hash_key_context(node, ancestors, 10)
                 {
                     issues.push(ScopeIssue {

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1700,6 +1700,66 @@ print FOO;
 }
 
 #[test]
+fn version_pragma_does_not_import_builtin_short_names() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use v5.40;
+print floor;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "floor"
+        }),
+        "use v5.40 should not lexically import builtin short names"
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_pragma_imports_are_lexical_only() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use builtin 'true';
+print floor;
+print true;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "floor"
+        }),
+        "importing `true` must not suppress unrelated builtin names"
+    );
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "true"
+        }),
+        "lexically imported builtin short name `true` should be allowed"
+    );
+    Ok(())
+}
+
+#[test]
+fn builtin_pragma_imports_allow_the_imported_name() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use builtin 'floor';
+print floor;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnquotedBareword) && i.variable_name == "floor"
+        }),
+        "lexically imported builtin short name `floor` should not be flagged"
+    );
+    Ok(())
+}
+
+#[test]
 fn v5_36_auto_strict_flags_undeclared_variable_in_signature_sub()
 -> Result<(), Box<dyn std::error::Error>> {
     // use v5.36 enables strict automatically via feature bundle.


### PR DESCRIPTION
## Summary
- add lexical builtin-import tracking to pragma state
- keep `use v5.40` feature availability separate from imported short names
- suppress strict-subs barewords only for names actually imported via `use builtin`
- add regressions for `use v5.40; print floor;`, `use builtin 'true'; print floor;`, and `use builtin 'floor'; print floor;`

## Testing
- cargo fmt --all
- cargo test -p perl-pragma --test comprehensive_unit_tests -- --nocapture
- cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests -- --nocapture
- cargo test -p perl-parser --test scope_analysis_test -- --nocapture
