### PR TITLE
feat(semantic): add Promise framework symbols (#3612)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -347,6 +347,10 @@ pub enum AsyncFrameworkKind {
     Future,
     /// `use Future::XS;`
     FutureXS,
+    /// `use Promise;`
+    Promise,
+    /// `use Promise::XS;`
+    PromiseXS,
     /// `use IO::Async;`
     IOAsync,
     /// `use Mojo::Redis;`
@@ -1614,6 +1618,8 @@ impl SymbolExtractor {
         let (module_name, framework_name, exact_match) = match flags.async_framework {
             Some(AsyncFrameworkKind::Future) => ("Future", "Future", true),
             Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
+            Some(AsyncFrameworkKind::Promise) => ("Promise", "Promise", true),
+            Some(AsyncFrameworkKind::PromiseXS) => ("Promise::XS", "Promise::XS", true),
             Some(AsyncFrameworkKind::IOAsync) => ("IO::Async", "IO::Async", false),
             Some(AsyncFrameworkKind::MojoRedis) => ("Mojo::Redis", "Mojo::Redis", true),
             Some(AsyncFrameworkKind::MojoPg) => ("Mojo::Pg", "Mojo::Pg", true),
@@ -1706,6 +1712,18 @@ impl SymbolExtractor {
         if module == "Future::XS" {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::FutureXS);
+            return;
+        }
+
+        if module == "Promise" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::Promise);
+            return;
+        }
+
+        if module == "Promise::XS" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::PromiseXS);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -220,3 +220,59 @@ my $future = Future::XS->new;
         "did not expect Future::XS class synthesis without `use Future::XS`"
     );
 }
+
+#[test]
+fn promise_use_synthesizes_class_symbol_for_method_calls() {
+    let code = r#"
+use Promise;
+
+my $promise = Promise->new(sub { return 1 });
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Promise", SymbolKind::Class),
+        "expected Promise class symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "Promise", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=Promise"),
+        "expected `framework=Promise` on Promise, got {attrs:?}"
+    );
+}
+
+#[test]
+fn promise_xs_use_synthesizes_class_symbol_for_method_calls() {
+    let code = r#"
+use Promise::XS;
+
+my $promise = Promise::XS->new(sub { return 1 });
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Promise::XS", SymbolKind::Class),
+        "expected Promise::XS class symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "Promise::XS", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=Promise::XS"),
+        "expected `framework=Promise::XS` on Promise::XS, got {attrs:?}"
+    );
+}
+
+#[test]
+fn promise_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $promise = Promise->new(sub { return 1 });
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "Promise", SymbolKind::Class),
+        "did not expect Promise class synthesis without `use Promise`"
+    );
+}


### PR DESCRIPTION
## Summary
- add Promise and Promise::XS async-framework detection
- synthesize Promise class symbols only when used in method-call form
- add focused positive and negative regression tests

## Testing
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
