### PR TITLE
feat(semantic): add POE framework symbols (#3613)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -351,6 +351,8 @@ pub enum AsyncFrameworkKind {
     Promise,
     /// `use Promise::XS;`
     PromiseXS,
+    /// `use POE;`
+    POE,
     /// `use IO::Async;`
     IOAsync,
     /// `use Mojo::Redis;`
@@ -1620,6 +1622,7 @@ impl SymbolExtractor {
             Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
             Some(AsyncFrameworkKind::Promise) => ("Promise", "Promise", true),
             Some(AsyncFrameworkKind::PromiseXS) => ("Promise::XS", "Promise::XS", true),
+            Some(AsyncFrameworkKind::POE) => ("POE", "POE", false),
             Some(AsyncFrameworkKind::IOAsync) => ("IO::Async", "IO::Async", false),
             Some(AsyncFrameworkKind::MojoRedis) => ("Mojo::Redis", "Mojo::Redis", true),
             Some(AsyncFrameworkKind::MojoPg) => ("Mojo::Pg", "Mojo::Pg", true),
@@ -1724,6 +1727,12 @@ impl SymbolExtractor {
         if module == "Promise::XS" {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::PromiseXS);
+            return;
+        }
+
+        if module == "POE" || module.starts_with("POE::") {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::POE);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -276,3 +276,42 @@ my $promise = Promise->new(sub { return 1 });
         "did not expect Promise class synthesis without `use Promise`"
     );
 }
+
+#[test]
+fn poe_use_synthesizes_class_symbols_for_method_calls() {
+    let code = r#"
+use POE qw(Session Wheel::ReadWrite Component::Client::TCP);
+
+my $session = POE::Session->create;
+my $wheel = POE::Wheel::ReadWrite->new;
+my $component = POE::Component::Client::TCP->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in ["POE::Session", "POE::Wheel::ReadWrite", "POE::Component::Client::TCP"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Class),
+            "expected synthetic POE class symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Class);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=POE"),
+            "expected `framework=POE` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
+fn poe_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $session = POE::Session->create;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "POE::Session", SymbolKind::Class),
+        "did not expect POE class synthesis without `use POE`"
+    );
+}


### PR DESCRIPTION
## Summary
- add POE as an async framework variant in semantic extraction
- synthesize exact `POE::...` class symbols when POE packages are used in method-call form
- keep scope narrow: no session lifecycle, wheel/resource tracking, or cross-package inference

## Testing
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/perl-lsp-review-3613-target cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
