### PR TITLE
feat(semantic): add AnyEvent framework symbols (#3610)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -343,6 +343,8 @@ pub enum WebFrameworkKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Async framework variant detected via `use` statements during Parse/Analyze workflows.
 pub enum AsyncFrameworkKind {
+    /// `use AnyEvent;`
+    AnyEvent,
     /// `use Future;`
     Future,
     /// `use Future::XS;`
@@ -1616,6 +1618,7 @@ impl SymbolExtractor {
         };
 
         let (module_name, framework_name, exact_match) = match flags.async_framework {
+            Some(AsyncFrameworkKind::AnyEvent) => ("AnyEvent", "AnyEvent", false),
             Some(AsyncFrameworkKind::Future) => ("Future", "Future", true),
             Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
             Some(AsyncFrameworkKind::Promise) => ("Promise", "Promise", true),
@@ -1629,7 +1632,14 @@ impl SymbolExtractor {
         let Some(name) = Self::single_symbol_name(object) else {
             return false;
         };
-        if exact_match {
+        if flags.async_framework == Some(AsyncFrameworkKind::AnyEvent) {
+            if !matches!(
+                name.as_str(),
+                "AnyEvent" | "AnyEvent::CondVar" | "AnyEvent::Timer" | "AnyEvent::IO"
+            ) {
+                return false;
+            }
+        } else if exact_match {
             if name != module_name {
                 return false;
             }
@@ -1700,6 +1710,12 @@ impl SymbolExtractor {
         if module == "IO::Async" || module.starts_with("IO::Async::") {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::IOAsync);
+            return;
+        }
+
+        if module == "AnyEvent" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::AnyEvent);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -81,6 +81,63 @@ my $loop = IO::Async::Loop->new;
 }
 
 #[test]
+fn anyevent_use_synthesizes_core_class_symbols_for_method_calls() {
+    let code = r#"
+use AnyEvent;
+
+my $cv = AnyEvent->condvar;
+my $timer = AnyEvent::Timer->new;
+my $io = AnyEvent::IO->new;
+my $other = AnyEvent::CondVar->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in ["AnyEvent", "AnyEvent::CondVar", "AnyEvent::Timer", "AnyEvent::IO"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Class),
+            "expected synthetic AnyEvent class symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Class);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=AnyEvent"),
+            "expected `framework=AnyEvent` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
+fn anyevent_core_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $cv = AnyEvent->condvar;
+my $timer = AnyEvent::Timer->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "AnyEvent", SymbolKind::Class),
+        "did not expect AnyEvent class synthesis without `use AnyEvent`"
+    );
+}
+
+#[test]
+fn anyevent_http_names_are_not_synthesized_as_core_support() {
+    let code = r#"
+use AnyEvent;
+
+my $http = AnyEvent::HTTP->new;
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "AnyEvent::HTTP", SymbolKind::Class),
+        "did not expect AnyEvent::HTTP synthesis in the core-only MVP"
+    );
+}
+
+#[test]
 fn mojo_redis_use_synthesizes_framework_class_symbol() {
     let code = r#"
 use Mojo::Redis;


### PR DESCRIPTION
## Summary
- add narrow AnyEvent framework symbol synthesis for direct class usage
- whitelist only core AnyEvent symbols used in method-call form
- keep scope limited to symbol extraction and focused regressions

## Testing
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture
