### PR TITLE
test(diagnostics): add edge case tests for PL303 role conflict detection (#3605)

### DIFF
--- a/crates/perl-lsp-diagnostics/tests/role_conflicts_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/role_conflicts_tests.rs
@@ -127,3 +127,97 @@ requires 'shared';
 
     assert!(pl303_diags(source).is_empty(), "`requires` should not create a role-method conflict");
 }
+
+#[test]
+fn multiple_with_calls_accumulate_and_conflict() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::RoleA';
+with 'MyApp::RoleB';
+
+package MyApp::RoleA;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 1 }
+
+package MyApp::RoleB;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 2 }
+"#;
+    let diags = pl303_diags(source);
+    assert!(
+        !diags.is_empty(),
+        "multiple separate `with` calls should still detect method conflicts: {diags:?}"
+    );
+}
+
+#[test]
+fn three_conflicting_roles_emit_single_pl303() {
+    let source = r#"
+package MyApp::Consumer;
+use strict;
+use warnings;
+use Moo;
+with 'MyApp::RoleA', 'MyApp::RoleB', 'MyApp::RoleC';
+
+package MyApp::RoleA;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 1 }
+
+package MyApp::RoleB;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 2 }
+
+package MyApp::RoleC;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 3 }
+"#;
+    let diags = pl303_diags(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "three roles providing the same method is still one conflict: {diags:?}"
+    );
+    assert!(diags[0].message.contains("clash"), "message should mention the method name");
+}
+
+#[test]
+fn role_consuming_roles_does_not_trigger_pl303() {
+    // A role with its own `with` should not trigger PL303 since it is itself a role
+    let source = r#"
+package MyApp::RoleComposite;
+use strict;
+use warnings;
+use Moo::Role;
+with 'MyApp::RoleA', 'MyApp::RoleB';
+
+package MyApp::RoleA;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 1 }
+
+package MyApp::RoleB;
+use strict;
+use warnings;
+use Moo::Role;
+sub clash { 2 }
+"#;
+    assert!(
+        pl303_diags(source).is_empty(),
+        "a role composing conflicting roles should not itself trigger PL303: {:?}",
+        pl303_diags(source)
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #3719 (PL303 same-file role conflict detection).

The original PR had 4 tests covering the happy path and basic suppressions. Three edge cases were untested:

- **Multiple separate `with` calls**: `with 'RoleA'; with 'RoleB';` on separate lines — both roles accumulate in `class_model.roles` and should detect the conflict. Confirmed working.
- **Three-way role conflict**: when 3 roles all provide the same method, a single PL303 is emitted (not one per pair). Confirmed correct.
- **Role composing roles**: a composite role using `with` on other roles must not trigger PL303 itself (it is classified as `SymbolKind::Role`, so it's excluded from the class check). Confirmed correct.

All three new tests pass on master.

## Test plan
- [ ] `cargo test -p perl-lsp-diagnostics --test role_conflicts_tests` passes (7 tests)
- [ ] `cargo clippy -p perl-lsp-diagnostics` clean
- [ ] `cargo fmt -p perl-lsp-diagnostics -- --check` clean