### PR TITLE
feat(mason): add .mason/.mas navigation MVP (#3583)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/mason.rs
+++ b/crates/perl-lsp/src/runtime/language/mason.rs
@@ -1,0 +1,203 @@
+//! Lightweight Mason navigation support.
+//!
+//! This helper intentionally keeps the Mason surface narrow:
+//! - `.mason` / `.mas` recognition
+//! - `<%method>` / `<%sub>` same-file goto-definition
+//! - `<& component &>` component-file goto-definition
+//!
+//! It does not attempt full Mason parsing, highlighting, args semantics,
+//! or embedded Perl diagnostics.
+
+use super::super::*;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use url::Url;
+
+use crate::position::{Position as EnginePosition, Range as EngineRange};
+use crate::workspace_index::Location;
+
+static MASON_DEF_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+static MASON_COMPONENT_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+fn get_mason_def_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    MASON_DEF_RE
+        .get_or_init(|| regex::Regex::new(r"(?s)<%(?:method|sub)\s+([A-Za-z_][A-Za-z0-9_]*)\b"))
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize Mason definition regex: {err}"
+            ))
+        })
+}
+
+fn get_mason_component_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    MASON_COMPONENT_RE.get_or_init(|| regex::Regex::new(r"(?s)<&(?P<body>.*?)&>")).as_ref().map_err(
+        |err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize Mason component regex: {err}"
+            ))
+        },
+    )
+}
+
+fn is_mason_template_path(path: &Path) -> bool {
+    path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| matches!(ext, "mason" | "mas"))
+}
+
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+    Url::parse(uri).ok()?.to_file_path().ok()
+}
+
+fn engine_position(text: &str, offset: usize) -> EnginePosition {
+    let (line, column) = byte_to_line_col(text, offset);
+
+    EnginePosition { byte: offset, line, column }
+}
+
+fn name_range_in_text(text: &str, start: usize, end: usize) -> EngineRange {
+    EngineRange { start: engine_position(text, start), end: engine_position(text, end) }
+}
+
+fn zero_range() -> EngineRange {
+    EngineRange {
+        start: EnginePosition { byte: 0, line: 0, column: 0 },
+        end: EnginePosition { byte: 0, line: 0, column: 0 },
+    }
+}
+
+fn component_token(body: &str) -> Option<(String, usize, usize)> {
+    let trimmed = body.trim_start();
+    let leading_ws = body.len().saturating_sub(trimmed.len());
+
+    if trimmed.is_empty() || trimmed.starts_with('|') {
+        return None;
+    }
+
+    let token_end = trimmed
+        .find(|ch: char| ch.is_whitespace() || ch == ',' || ch == '|')
+        .unwrap_or(trimmed.len());
+    if token_end == 0 {
+        return None;
+    }
+
+    let token = &trimmed[..token_end];
+    Some((token.to_string(), leading_ws, leading_ws + token_end))
+}
+
+fn same_file_mason_definitions(
+    text: &str,
+    def_re: &regex::Regex,
+) -> HashMap<String, (usize, usize)> {
+    let mut definitions = HashMap::new();
+
+    for cap in def_re.captures_iter(text) {
+        let Some(name) = cap.get(1) else {
+            continue;
+        };
+        definitions.entry(name.as_str().to_string()).or_insert((name.start(), name.end()));
+    }
+
+    definitions
+}
+
+fn resolve_mason_component_file(source_path: &Path, component_name: &str) -> Option<PathBuf> {
+    let raw = Path::new(component_name);
+    let candidates: Vec<PathBuf> = if raw.is_absolute()
+        || raw
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| matches!(ext, "mason" | "mas"))
+    {
+        vec![raw.to_path_buf()]
+    } else {
+        vec![raw.with_extension("mason"), raw.with_extension("mas")]
+    };
+
+    let mut search_roots = Vec::new();
+    let mut current = source_path.parent();
+    while let Some(dir) = current {
+        search_roots.push(dir.to_path_buf());
+        current = dir.parent();
+    }
+
+    for root in search_roots {
+        for candidate in &candidates {
+            let path = root.join(candidate);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+impl LspServer {
+    /// Resolve Mason-specific definitions in `.mason` / `.mas` files.
+    ///
+    /// The resolution is intentionally narrow:
+    /// - same-file `<%method>` / `<%sub>` names resolve to their own definition
+    /// - `<& component &>` resolves to a same-file Mason definition first, then
+    ///   to a sibling/ancestor component file with `.mason` or `.mas`
+    pub(crate) fn resolve_mason_definition(
+        &self,
+        uri: &str,
+        text: &str,
+        offset: usize,
+    ) -> Option<Location> {
+        let source_path = uri_to_path(uri)?;
+        if !is_mason_template_path(&source_path) {
+            return None;
+        }
+
+        let def_re = get_mason_def_regex().ok()?;
+        let component_re = get_mason_component_regex().ok()?;
+        let definitions = same_file_mason_definitions(text, def_re);
+
+        for cap in def_re.captures_iter(text) {
+            let Some(name) = cap.get(1) else {
+                continue;
+            };
+
+            if offset >= name.start() && offset < name.end() {
+                return Some(Location {
+                    uri: uri.to_string(),
+                    range: name_range_in_text(text, name.start(), name.end()),
+                });
+            }
+        }
+
+        for cap in component_re.captures_iter(text) {
+            let Some(body) = cap.name("body") else {
+                continue;
+            };
+            let Some((component_name, rel_start, rel_end)) = component_token(body.as_str()) else {
+                continue;
+            };
+
+            let name_start = body.start() + rel_start;
+            let name_end = body.start() + rel_end;
+            if offset < name_start || offset >= name_end {
+                continue;
+            }
+
+            if let Some((def_start, def_end)) = definitions.get(&component_name) {
+                return Some(Location {
+                    uri: uri.to_string(),
+                    range: name_range_in_text(text, *def_start, *def_end),
+                });
+            }
+
+            if let Some(component_path) =
+                resolve_mason_component_file(&source_path, &component_name)
+            {
+                if let Ok(component_uri) = Url::from_file_path(component_path) {
+                    return Some(Location { uri: component_uri.to_string(), range: zero_range() });
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/crates/perl-lsp/src/runtime/language/mod.rs
+++ b/crates/perl-lsp/src/runtime/language/mod.rs
@@ -21,6 +21,7 @@ mod completion;
 mod formatting;
 mod hierarchy;
 mod hover;
+mod mason;
 mod misc;
 mod navigation;
 mod references;

--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -524,6 +524,15 @@ impl LspServer {
                 let text_around = self.get_text_around_offset(&doc.text, offset, radius);
                 let cursor_in_text = offset - text_start;
 
+                if let Some(mason_location) = self.resolve_mason_definition(uri, &doc.text, offset)
+                {
+                    if let Some(lsp_location) =
+                        crate::workspace_index::lsp_adapter::to_lsp_location(&mason_location)
+                    {
+                        return Ok(Some(json!([lsp_location])));
+                    }
+                }
+
                 #[cfg(feature = "workspace")]
                 {
                     // Attempt to resolve fully-qualified symbols like Package::sub

--- a/crates/perl-lsp/tests/mason_navigation_tests.rs
+++ b/crates/perl-lsp/tests/mason_navigation_tests.rs
@@ -1,0 +1,133 @@
+//! Mason navigation MVP tests.
+//!
+//! Covers the intentionally narrow Mason surface:
+//! - `.mason` / `.mas` file recognition at the editor layer
+//! - same-file `<%method>` / `<%sub>` goto-definition
+//! - `<& component &>` component-file goto-definition
+//!
+//! This suite intentionally does not cover `.m`, `<%args>`, syntax highlighting,
+//! or embedded Perl diagnostics.
+
+mod support;
+
+use serde_json::{Value, json};
+use support::LspHarness;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn find_pos(code: &str, needle: &str, target_line: usize) -> Result<(u32, u32), String> {
+    let line =
+        code.lines().nth(target_line).ok_or_else(|| format!("missing line {target_line}"))?;
+    let character =
+        line.find(needle).ok_or_else(|| format!("missing `{needle}` on line {target_line}"))?;
+    Ok((target_line as u32, character as u32))
+}
+
+fn first_location(resp: &Value) -> Option<(String, u32, u32)> {
+    let result = resp.get("result").unwrap_or(resp);
+
+    let location = if let Some(arr) = result.as_array() {
+        arr.first()?
+    } else if result.is_object() {
+        result
+    } else {
+        return None;
+    };
+
+    let uri = location.get("uri").or_else(|| location.get("targetUri"))?.as_str()?.to_string();
+    let range = location.get("range").or_else(|| location.get("targetRange"))?;
+    let start = range.get("start")?;
+    let line = start.get("line")?.as_u64()? as u32;
+    let character = start.get("character")?.as_u64()? as u32;
+    Some((uri, line, character))
+}
+
+#[test]
+fn mason_language_extensions_and_navigation_smoke() -> TestResult {
+    const MAIN: &str = r#"<%method greet>
+  Hello from greet
+</%method>
+
+<%sub helper>
+  Hello from helper
+</%sub>
+
+<& greet &>
+<& helper &>
+
+<& components/menu &>
+<& components/header &>
+"#;
+
+    const MENU_COMPONENT: &str = r#"<p>Menu component</p>
+"#;
+
+    const HEADER_COMPONENT: &str = r#"<p>Header component</p>
+"#;
+
+    let (mut harness, workspace) = LspHarness::with_workspace(&[
+        ("main.mason", MAIN),
+        ("components/menu.mason", MENU_COMPONENT),
+        ("components/header.mas", HEADER_COMPONENT),
+    ])?;
+
+    let main_uri = workspace.uri("main.mason");
+    let menu_uri = workspace.uri("components/menu.mason");
+    let header_uri = workspace.uri("components/header.mas");
+
+    harness.open_document(&main_uri, MAIN)?;
+
+    let (greet_line, greet_character) = find_pos(MAIN, "greet", 8)?;
+    let greet = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": &main_uri },
+            "position": { "line": greet_line, "character": greet_character }
+        }),
+    )?;
+    let (greet_uri, greet_line, _) =
+        first_location(&greet).ok_or("expected Mason greet definition")?;
+    assert_eq!(greet_uri, main_uri);
+    assert_eq!(greet_line, 0);
+
+    let (helper_line, helper_character) = find_pos(MAIN, "helper", 9)?;
+    let helper = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": &main_uri },
+            "position": { "line": helper_line, "character": helper_character }
+        }),
+    )?;
+    let (helper_uri, helper_line, _) =
+        first_location(&helper).ok_or("expected Mason helper definition")?;
+    assert_eq!(helper_uri, main_uri);
+    assert_eq!(helper_line, 4);
+
+    let (menu_line, menu_character) = find_pos(MAIN, "components/menu", 11)?;
+    let menu = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": &main_uri },
+            "position": { "line": menu_line, "character": menu_character }
+        }),
+    )?;
+    let (menu_def_uri, menu_def_line, _) =
+        first_location(&menu).ok_or("expected Mason menu component definition")?;
+    assert_eq!(menu_def_uri, menu_uri);
+    assert_eq!(menu_def_line, 0);
+
+    let (header_line, header_character) = find_pos(MAIN, "components/header", 12)?;
+    let header = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": &main_uri },
+            "position": { "line": header_line, "character": header_character }
+        }),
+    )?;
+    let (header_def_uri, header_def_line, _) =
+        first_location(&header).ok_or("expected Mason header component definition")?;
+    assert_eq!(header_def_uri, header_uri);
+    assert_eq!(header_def_line, 0);
+
+    Ok(())
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -70,7 +70,9 @@
           ".pm",
           ".pod",
           ".t",
-          ".psgi"
+          ".psgi",
+          ".mason",
+          ".mas"
         ],
         "firstLine": "^#!.*\\bperl\\b",
         "configuration": "./language-configuration.json"

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -124,6 +124,9 @@ describe('package.json contributes', () => {
       expect(exts).toContain('.t');
       expect(exts).toContain('.pod');
       expect(exts).toContain('.psgi');
+      expect(exts).toContain('.mason');
+      expect(exts).toContain('.mas');
+      expect(exts).not.toContain('.m');
     });
 
     test('perl language has shebang first-line detection', () => {


### PR DESCRIPTION
## Summary\n- Add .mason and .mas recognition to the VS Code extension language metadata.\n- Add narrow Mason goto-definition support for same-file <%%method> / <%%sub> and component-file <& component &> lookups.\n\n## Explicitly out of scope\n- .m\n- full Mason syntax highlighting\n- <%%args> semantics\n- Mason 1 vs Mason 2 completeness\n- embedded Perl diagnostics