### PR TITLE
fix(config): detect perlbrew/plenv interpreters for @INC probing (#3552)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
 name = "perl-lsp-config"
 version = "0.12.3"
 dependencies = [
+ "perl-dap-platform",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/perl-lsp-config/Cargo.toml
+++ b/crates/perl-lsp-config/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["perl", "lsp", "config", "language-server", "settings"]
 categories = ["development-tools", "text-editors"]
 
 [dependencies]
+perl-dap-platform = { workspace = true }
 serde_json.workspace = true
 serde = { workspace = true }
 toml = "1.1.2"

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -4,6 +4,8 @@
 //! This microcrate isolates configuration parsing and defaults from the main
 //! server crate so they can evolve independently and be reused by tooling.
 
+#[cfg(not(target_arch = "wasm32"))]
+use perl_dap_platform::resolve_perl_path_with_toolchain;
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
@@ -410,7 +412,13 @@ impl WorkspaceConfig {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn fetch_perl_inc(perl_path: Option<&str>, perl_args: &[String]) -> Vec<PathBuf> {
-        let perl_path = perl_path.unwrap_or("perl");
+        let perl_path = match perl_path.filter(|path| !path.is_empty()) {
+            Some(path) => PathBuf::from(path),
+            None => match resolve_perl_path_with_toolchain() {
+                Ok(path) => path,
+                Err(_) => return Vec::new(),
+            },
+        };
         let mut command = Command::new(perl_path);
         command.args(perl_args);
         let output = command.args(["-e", "print join(\"\\n\", @INC)"]).output();

--- a/crates/perl-lsp-config/tests/behavioral.rs
+++ b/crates/perl-lsp-config/tests/behavioral.rs
@@ -219,7 +219,7 @@ mod perl_interpreter_detection_tests {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -246,11 +246,10 @@ mod perl_interpreter_detection_tests {
         EnvSnapshot(keys.iter().map(|key| (*key, std::env::var_os(key))).collect())
     }
 
-    fn env_lock() -> TestResult {
+    fn env_lock() -> Result<MutexGuard<'static, ()>, Box<dyn std::error::Error>> {
         ENV_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
-            .map(|_| ())
             .map_err(|_| std::io::Error::other("environment lock poisoned").into())
     }
 
@@ -277,7 +276,7 @@ mod perl_interpreter_detection_tests {
 
     #[test]
     fn workspace_config_get_system_inc_prefers_perlbrew_over_path() -> TestResult {
-        env_lock()?;
+        let _env_guard = env_lock()?;
         let _snapshot = snapshot_env(&[
             "PATH",
             "PERLBREW_ROOT",
@@ -314,7 +313,7 @@ mod perl_interpreter_detection_tests {
 
     #[test]
     fn workspace_config_get_system_inc_falls_back_to_plenv_when_perlbrew_unset() -> TestResult {
-        env_lock()?;
+        let _env_guard = env_lock()?;
         let _snapshot = snapshot_env(&[
             "PATH",
             "PERLBREW_ROOT",
@@ -351,7 +350,7 @@ mod perl_interpreter_detection_tests {
 
     #[test]
     fn workspace_config_explicit_perl_path_wins_over_toolchain_detection() -> TestResult {
-        env_lock()?;
+        let _env_guard = env_lock()?;
         let _snapshot = snapshot_env(&[
             "PATH",
             "PERLBREW_ROOT",

--- a/crates/perl-lsp-config/tests/behavioral.rs
+++ b/crates/perl-lsp-config/tests/behavioral.rs
@@ -12,6 +12,9 @@
 //! - WorkspaceConfig: cache cleared on use_system_inc → false transition
 
 use perl_lsp_config::{ServerConfig, WorkspaceConfig};
+use std::io::Write as _;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 // ---------------------------------------------------------------------------
 // ServerConfig defaults
@@ -207,6 +210,184 @@ fn workspace_config_get_system_inc_returns_empty_when_disabled() {
     // Should return empty immediately without querying the system
     let paths = cfg.get_system_inc();
     assert!(paths.is_empty(), "should return empty slice when use_system_inc is false");
+}
+
+#[cfg(unix)]
+mod perl_interpreter_detection_tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvSnapshot(Vec<(&'static str, Option<OsString>)>);
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in self.0.iter().rev() {
+                match value {
+                    Some(value) => {
+                        // Serialized by ENV_LOCK so these process-wide mutations stay bounded.
+                        unsafe { std::env::set_var(key, value) };
+                    }
+                    None => {
+                        // Serialized by ENV_LOCK so these process-wide mutations stay bounded.
+                        unsafe { std::env::remove_var(key) };
+                    }
+                }
+            }
+        }
+    }
+
+    fn snapshot_env(keys: &[&'static str]) -> EnvSnapshot {
+        EnvSnapshot(keys.iter().map(|key| (*key, std::env::var_os(key))).collect())
+    }
+
+    fn env_lock() -> TestResult {
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .map(|_| ())
+            .map_err(|_| std::io::Error::other("environment lock poisoned").into())
+    }
+
+    fn write_fake_perl(path: &Path, inc_paths: &[&str]) -> TestResult {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut file = fs::File::create(path)?;
+        writeln!(file, "#!/bin/sh")?;
+        let args = inc_paths.iter().map(|line| format!("{line:?}")).collect::<Vec<_>>().join(" ");
+        writeln!(file, "printf '%s\\n' {args}")?;
+
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+        Ok(())
+    }
+
+    fn set_env_var(key: &'static str, value: impl AsRef<std::ffi::OsStr>) {
+        // Serialized by ENV_LOCK so these process-wide mutations stay bounded.
+        unsafe { std::env::set_var(key, value) };
+    }
+
+    #[test]
+    fn workspace_config_get_system_inc_prefers_perlbrew_over_path() -> TestResult {
+        env_lock()?;
+        let _snapshot = snapshot_env(&[
+            "PATH",
+            "PERLBREW_ROOT",
+            "PERLBREW_PERL",
+            "PLENV_ROOT",
+            "PLENV_VERSION",
+        ]);
+
+        let temp = tempfile::tempdir()?;
+        let path_bin = temp.path().join("path-bin").join("perl");
+        let brew_root = temp.path().join("perlbrew");
+        let brew_bin = brew_root.join("perls").join("perl-5.38.0").join("bin").join("perl");
+        write_fake_perl(&path_bin, &["/path/lib"])?;
+        write_fake_perl(&brew_bin, &["/perlbrew/lib", "."])?;
+
+        set_env_var(
+            "PATH",
+            path_bin.parent().ok_or_else(|| std::io::Error::other("missing PATH bin"))?,
+        );
+        set_env_var("PERLBREW_ROOT", &brew_root);
+        set_env_var("PERLBREW_PERL", "perl-5.38.0");
+        unsafe {
+            std::env::remove_var("PLENV_ROOT");
+            std::env::remove_var("PLENV_VERSION");
+        }
+
+        let mut cfg = WorkspaceConfig::default();
+        cfg.use_system_inc = true;
+
+        let inc = cfg.get_system_inc();
+        assert_eq!(inc, &[PathBuf::from("/perlbrew/lib")]);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_config_get_system_inc_falls_back_to_plenv_when_perlbrew_unset() -> TestResult {
+        env_lock()?;
+        let _snapshot = snapshot_env(&[
+            "PATH",
+            "PERLBREW_ROOT",
+            "PERLBREW_PERL",
+            "PLENV_ROOT",
+            "PLENV_VERSION",
+        ]);
+
+        let temp = tempfile::tempdir()?;
+        let path_bin = temp.path().join("path-bin").join("perl");
+        let plenv_root = temp.path().join(".plenv");
+        let plenv_bin = plenv_root.join("versions").join("5.38.0").join("bin").join("perl");
+        write_fake_perl(&path_bin, &["/path/lib"])?;
+        write_fake_perl(&plenv_bin, &["/plenv/lib", "."])?;
+
+        set_env_var(
+            "PATH",
+            path_bin.parent().ok_or_else(|| std::io::Error::other("missing PATH bin"))?,
+        );
+        unsafe {
+            std::env::remove_var("PERLBREW_ROOT");
+            std::env::remove_var("PERLBREW_PERL");
+        }
+        set_env_var("PLENV_ROOT", &plenv_root);
+        set_env_var("PLENV_VERSION", "5.38.0");
+
+        let mut cfg = WorkspaceConfig::default();
+        cfg.use_system_inc = true;
+
+        let inc = cfg.get_system_inc();
+        assert_eq!(inc, &[PathBuf::from("/plenv/lib")]);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_config_explicit_perl_path_wins_over_toolchain_detection() -> TestResult {
+        env_lock()?;
+        let _snapshot = snapshot_env(&[
+            "PATH",
+            "PERLBREW_ROOT",
+            "PERLBREW_PERL",
+            "PLENV_ROOT",
+            "PLENV_VERSION",
+        ]);
+
+        let temp = tempfile::tempdir()?;
+        let explicit_bin = temp.path().join("explicit").join("perl");
+        let path_bin = temp.path().join("path-bin").join("perl");
+        let brew_root = temp.path().join("perlbrew");
+        let brew_bin = brew_root.join("perls").join("perl-5.40.0").join("bin").join("perl");
+        write_fake_perl(&explicit_bin, &["/explicit/lib"])?;
+        write_fake_perl(&path_bin, &["/path/lib"])?;
+        write_fake_perl(&brew_bin, &["/perlbrew/lib"])?;
+
+        set_env_var(
+            "PATH",
+            path_bin.parent().ok_or_else(|| std::io::Error::other("missing PATH bin"))?,
+        );
+        set_env_var("PERLBREW_ROOT", &brew_root);
+        set_env_var("PERLBREW_PERL", "perl-5.40.0");
+        unsafe {
+            std::env::remove_var("PLENV_ROOT");
+            std::env::remove_var("PLENV_VERSION");
+        }
+
+        let mut cfg = WorkspaceConfig::default();
+        cfg.use_system_inc = true;
+        cfg.perl_path = Some(explicit_bin.to_string_lossy().to_string());
+
+        let inc = cfg.get_system_inc();
+        assert_eq!(inc, &[PathBuf::from("/explicit/lib")]);
+        Ok(())
+    }
 }
 
 #[test]

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -234,6 +234,8 @@ impl LspServer {
 
         let system_paths = if use_system_inc {
             let mut config = self.workspace_config.lock();
+            // `WorkspaceConfig` now resolves the active interpreter with
+            // perlbrew/plenv-aware fallback before probing startup `@INC`.
             config.get_system_inc().to_vec()
         } else {
             Vec::new()

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -182,7 +182,30 @@ the workspace root. Absolute entries are honored as provided only when they
 still stay inside the workspace boundary. These paths are searched by
 `perl-lsp` and are not appended to Perl's runtime `@INC`.
 
-Use `useSystemInc` to opt in to system `@INC` lookup.
+When `perlPath` is unset, the server will try perlbrew/plenv-managed
+interpreters before falling back to `perl` on `PATH` for the system `@INC`
+probe. Use `useSystemInc` to opt in to that system `@INC` lookup.
+
+#### `perl.workspace.perlPath`
+
+| Property | Value |
+|---|---|
+| Type | `string` |
+| Default | auto-detected |
+| Key | `perlPath` |
+
+Path to the Perl interpreter used for system `@INC` probing. When set, this
+value overrides auto-detection and `PATH` lookup.
+
+#### `perl.workspace.perlArgs`
+
+| Property | Value |
+|---|---|
+| Type | `string[]` |
+| Default | `[]` |
+| Key | `perlArgs` |
+
+Extra arguments passed to the Perl interpreter when probing startup `@INC`.
 
 ```json
 {


### PR DESCRIPTION
Follow-up fix for #3552.\n\n- Return the env mutex guard from the helper so each test holds the lock for its full body\n- Keep process-wide env mutations serialized during the perlbrew/plenv detection behavioral tests\n- Verified with the perl-lsp-config behavioral test target