### PR TITLE
feat(workspace): discover .xs files (#3568)

### DIFF
--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -57,6 +57,21 @@ pub fn discover_perl_files(root: &Path) -> DiscoveryResult {
     }
 }
 
+/// Returns `true` if `path` should be considered discoverable by workspace
+/// indexing.
+///
+/// This intentionally includes XS implementation files so editor discovery can
+/// surface them even though they are not classified as Perl source files by
+/// the shared source-file helper.
+#[must_use]
+pub fn is_perl_discovery_path(path: &Path) -> bool {
+    is_perl_source_path(path)
+        || path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("xs"))
+}
+
 fn try_git_discovery(root: &Path, start: Instant) -> Result<DiscoveryResult, std::io::Error> {
     let output = std::process::Command::new("git")
         .args(GIT_LS_FILES_ARGS)
@@ -98,7 +113,7 @@ fn parse_git_ls_files_output(root: &Path, stdout: &[u8]) -> (Vec<PathBuf>, usize
         }
 
         let path = root.join(relative_path);
-        if is_perl_source_path(&path) {
+        if is_perl_discovery_path(&path) {
             files.push(path);
         } else {
             excluded_count += 1;
@@ -126,7 +141,7 @@ fn walk_discovery(root: &Path, start: Instant) -> DiscoveryResult {
             continue;
         }
 
-        if is_perl_source_path(entry.path()) {
+        if is_perl_discovery_path(entry.path()) {
             files.push(entry.path().to_path_buf());
         } else {
             excluded_count += 1;
@@ -296,14 +311,15 @@ mod tests {
     #[test]
     fn parse_git_output_recognizes_all_perl_extensions() {
         let root = Path::new("/tmp/workspace");
-        let payload = b"lib/Foo.pm\0scripts/run.pl\0t/basic.t\0app/main.psgi\0";
+        let payload = b"lib/Foo.pm\0scripts/run.pl\0t/basic.t\0app/main.psgi\0ext/native.xs\0";
         let (files, excluded_count) = parse_git_ls_files_output(root, payload);
 
-        assert_eq!(files.len(), 4);
+        assert_eq!(files.len(), 5);
         assert!(files.iter().any(|p| p.ends_with("Foo.pm")));
         assert!(files.iter().any(|p| p.ends_with("run.pl")));
         assert!(files.iter().any(|p| p.ends_with("basic.t")));
         assert!(files.iter().any(|p| p.ends_with("main.psgi")));
+        assert!(files.iter().any(|p| p.ends_with("native.xs")));
         assert_eq!(excluded_count, 0);
     }
 
@@ -418,9 +434,10 @@ mod tests {
         create_file(root, "bin/run.pl")?;
         create_file(root, "t/basic.t")?;
         create_file(root, "app/main.psgi")?;
+        create_file(root, "xs/native.xs")?;
 
         let result = walk_discovery(root, Instant::now());
-        assert_eq!(result.files.len(), 4);
+        assert_eq!(result.files.len(), 5);
 
         Ok(())
     }

--- a/crates/perl-workspace-discovery/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-discovery/tests/comprehensive_unit_tests.rs
@@ -101,7 +101,7 @@ fn discover_perl_files_all_returned_paths_are_perl_sources() -> TestResult {
     create_file(root, "Cargo.toml")?;
 
     let result = discover_perl_files(root);
-    let valid_extensions: HashSet<&str> = ["pl", "pm", "t", "psgi"].iter().copied().collect();
+    let valid_extensions: HashSet<&str> = ["pl", "pm", "t", "psgi", "xs"].iter().copied().collect();
 
     for path in &result.files {
         let ext = path
@@ -464,10 +464,10 @@ fn discover_perl_files_handles_spaces_in_paths() -> TestResult {
     Ok(())
 }
 
-// --- All four Perl extensions in one workspace ---
+// --- All five Perl extensions in one workspace ---
 
 #[test]
-fn discover_perl_files_finds_all_four_perl_extensions() -> TestResult {
+fn discover_perl_files_finds_all_five_perl_extensions() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
@@ -475,9 +475,10 @@ fn discover_perl_files_finds_all_four_perl_extensions() -> TestResult {
     create_file(root, "Module.pm")?;
     create_file(root, "test.t")?;
     create_file(root, "app.psgi")?;
+    create_file(root, "native.xs")?;
 
     let result = discover_perl_files(root);
-    assert_eq!(result.files.len(), 4);
+    assert_eq!(result.files.len(), 5);
 
     let extensions: HashSet<String> = result
         .files
@@ -489,5 +490,6 @@ fn discover_perl_files_finds_all_four_perl_extensions() -> TestResult {
     assert!(extensions.contains("pm"));
     assert!(extensions.contains("t"));
     assert!(extensions.contains("psgi"));
+    assert!(extensions.contains("xs"));
     Ok(())
 }

--- a/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
@@ -315,11 +315,11 @@ fn gitignore_negation_pattern_re_includes_file_level() -> TestResult {
 }
 
 // ============================================================
-// Perl file extension filtering (.pl, .pm, .t, .psgi)
+// Perl file extension filtering (.pl, .pm, .t, .psgi, .xs)
 // ============================================================
 
 #[test]
-fn extension_filtering_accepts_all_four_perl_extensions() -> TestResult {
+fn extension_filtering_accepts_all_five_perl_extensions() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
@@ -327,6 +327,7 @@ fn extension_filtering_accepts_all_four_perl_extensions() -> TestResult {
     create_file(root, "Module.pm")?;
     create_file(root, "test.t")?;
     create_file(root, "app.psgi")?;
+    create_file(root, "native.xs")?;
 
     let result = discover_perl_files(root);
 
@@ -336,11 +337,12 @@ fn extension_filtering_accepts_all_four_perl_extensions() -> TestResult {
         .filter_map(|p| p.extension().and_then(|e| e.to_str()).map(String::from))
         .collect();
 
-    assert_eq!(extensions.len(), 4);
+    assert_eq!(extensions.len(), 5);
     assert!(extensions.contains("pl"));
     assert!(extensions.contains("pm"));
     assert!(extensions.contains("t"));
     assert!(extensions.contains("psgi"));
+    assert!(extensions.contains("xs"));
 
     Ok(())
 }

--- a/crates/perl-workspace-discovery/tests/discovery_fuzz_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_fuzz_tests.rs
@@ -1,7 +1,6 @@
 //! Fuzz-style randomized stress tests for workspace discovery.
 
-use perl_source_file::is_perl_source_path;
-use perl_workspace_discovery::discover_perl_files;
+use perl_workspace_discovery::{discover_perl_files, is_perl_discovery_path};
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
@@ -60,7 +59,7 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
         ".cache/precompiled",
         ".git/hooks",
     ];
-    let extensions = ["pl", "pm", "t", "psgi", "txt", "md", "json", "rs"];
+    let extensions = ["pl", "pm", "t", "psgi", "xs", "txt", "md", "json", "rs"];
 
     let mut rng = XorShift64::new(0xA11C_E55D_1234_5678);
 
@@ -82,7 +81,7 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
 
         for path in &result.files {
             assert!(path.starts_with(root));
-            assert!(is_perl_source_path(path));
+            assert!(is_perl_discovery_path(path));
             assert!(seen.insert(path.clone()));
         }
     }

--- a/crates/perl-workspace-discovery/tests/discovery_property_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_property_tests.rs
@@ -1,7 +1,6 @@
 //! Property tests for workspace discovery invariants.
 
-use perl_source_file::is_perl_source_path;
-use perl_workspace_discovery::discover_perl_files;
+use perl_workspace_discovery::{discover_perl_files, is_perl_discovery_path};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;
@@ -12,6 +11,7 @@ fn extension_strategy() -> impl Strategy<Value = String> {
         Just("pm".to_string()),
         Just("t".to_string()),
         Just("psgi".to_string()),
+        Just("xs".to_string()),
         Just("md".to_string()),
         Just("txt".to_string()),
         Just("json".to_string()),
@@ -46,7 +46,7 @@ proptest! {
             prop_assert!(fs::create_dir_all(parent).is_ok());
             prop_assert!(fs::write(&path, "# generated\n").is_ok());
 
-            if matches!(ext.as_str(), "pl" | "pm" | "t" | "psgi") {
+            if matches!(ext.as_str(), "pl" | "pm" | "t" | "psgi" | "xs") {
                 expected.insert(path);
             }
         }
@@ -59,7 +59,7 @@ proptest! {
 
         for path in &discovered {
             prop_assert!(path.starts_with(root));
-            prop_assert!(is_perl_source_path(path));
+            prop_assert!(is_perl_discovery_path(path));
         }
 
         prop_assert_eq!(discovered, expected);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -72,7 +72,8 @@
           ".t",
           ".psgi",
           ".mason",
-          ".mas"
+          ".mas",
+          ".xs"
         ],
         "firstLine": "^#!.*\\bperl\\b",
         "configuration": "./language-configuration.json"

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -127,6 +127,7 @@ describe('package.json contributes', () => {
       expect(exts).toContain('.mason');
       expect(exts).toContain('.mas');
       expect(exts).not.toContain('.m');
+      expect(exts).toContain('.xs');
     });
 
     test('perl language has shebang first-line detection', () => {


### PR DESCRIPTION
Narrow MVP for issue #3568.\n\nScope:\n- add .xs to the VS Code Perl language association\n- teach workspace discovery to surface .xs files without changing the shared Perl-source classification\n- update discovery coverage/tests for the new file type\n\nOut of scope:\n- full XS grammar\n- syntax highlighting engine work\n- C/C++ injection\n\nVerification:\n- cargo test -p perl-workspace-discovery --test comprehensive_unit_tests -- --nocapture\n- cargo test -p perl-workspace-discovery --test discovery_coverage_tests -- --nocapture extension_filtering_accepts_all_five_perl_extensions\n- cargo test -p perl-workspace-discovery --test discovery_property_tests -- --nocapture\n- cargo test -p perl-workspace-discovery --test discovery_fuzz_tests -- --nocapture\n- cargo test -p perl-workspace-discovery --lib -- --nocapture reproduced pre-existing failure in tests::skipped_component_allows_safe_directories (expected blib to be allowed)\n- node assertion against vscode-extension/package.json confirming .xs is registered