### PR TITLE
feat(analysis): add EV async symbols (#3607)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -347,6 +347,8 @@ pub enum WebFrameworkKind {
 pub enum AsyncFrameworkKind {
     /// `use AnyEvent;`
     AnyEvent,
+    /// `use EV;`
+    EV,
     /// `use Future;`
     Future,
     /// `use Future::XS;`
@@ -661,6 +663,7 @@ impl SymbolExtractor {
                 self.table.add_reference(reference);
 
                 self.synthesize_plack_builder_symbols(name, args);
+                self.synthesize_ev_symbols(name, node.location);
 
                 for arg in args {
                     self.visit_node(arg);
@@ -735,6 +738,9 @@ impl SymbolExtractor {
 
             NodeKind::Use { module, args, .. } => {
                 self.update_framework_context(module, args);
+                if module == "EV" {
+                    self.synthesize_ev_framework_symbol(node.location);
+                }
             }
 
             NodeKind::No { module: _, args: _, .. } => {
@@ -1764,6 +1770,7 @@ impl SymbolExtractor {
 
         let (module_name, framework_name, exact_match) = match flags.async_framework {
             Some(AsyncFrameworkKind::AnyEvent) => ("AnyEvent", "AnyEvent", false),
+            Some(AsyncFrameworkKind::EV) => ("EV", "EV", true),
             Some(AsyncFrameworkKind::Future) => ("Future", "Future", true),
             Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS", true),
             Some(AsyncFrameworkKind::Promise) => ("Promise", "Promise", true),
@@ -1819,6 +1826,77 @@ impl SymbolExtractor {
         true
     }
 
+    /// Synthesize the `EV` namespace symbol when the framework is imported.
+    fn synthesize_ev_framework_symbol(&mut self, location: SourceLocation) {
+        let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
+            return;
+        };
+        if flags.async_framework != Some(AsyncFrameworkKind::EV) {
+            return;
+        }
+
+        let name = "EV";
+        if self.table.symbols.get(name).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Class
+                    && symbol.declaration.as_deref() == Some("framework=EV")
+            })
+        }) {
+            return;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: name.to_string(),
+            qualified_name: name.to_string(),
+            kind: SymbolKind::Class,
+            location,
+            scope_id: self.table.current_scope(),
+            declaration: Some("framework=EV".to_string()),
+            documentation: Some("Synthetic EV namespace".to_string()),
+            attributes: vec!["framework=EV".to_string()],
+        });
+    }
+
+    /// Synthesize narrow EV watcher / loop API symbols used in function-call form.
+    fn synthesize_ev_symbols(&mut self, name: &str, location: SourceLocation) -> bool {
+        let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
+            return false;
+        };
+        if flags.async_framework != Some(AsyncFrameworkKind::EV) {
+            return false;
+        }
+
+        let Some(ev_suffix) = name.strip_prefix("EV::") else {
+            return false;
+        };
+        if !matches!(ev_suffix, "timer" | "io" | "signal" | "idle") {
+            return false;
+        }
+
+        let already_synthesized = self.table.symbols.get(name).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Subroutine
+                    && symbol.declaration.as_deref() == Some("framework=EV")
+            })
+        });
+        if already_synthesized {
+            return true;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: name.to_string(),
+            qualified_name: name.to_string(),
+            kind: SymbolKind::Subroutine,
+            location,
+            scope_id: self.table.current_scope(),
+            declaration: Some("framework=EV".to_string()),
+            documentation: Some(format!("Synthetic EV API `{ev_suffix}`")),
+            attributes: vec!["framework=EV".to_string(), format!("ev_api={ev_suffix}")],
+        });
+
+        true
+    }
+
     /// Update framework detection state from `use` statements.
     fn update_framework_context(&mut self, module: &str, args: &[String]) {
         let pkg = self.table.current_package.clone();
@@ -1863,6 +1941,12 @@ impl SymbolExtractor {
         if module == "AnyEvent" {
             self.framework_flags.entry(pkg).or_default().async_framework =
                 Some(AsyncFrameworkKind::AnyEvent);
+            return;
+        }
+
+        if module == "EV" {
+            self.framework_flags.entry(pkg).or_default().async_framework =
+                Some(AsyncFrameworkKind::EV);
             return;
         }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -138,6 +138,61 @@ my $http = AnyEvent::HTTP->new;
 }
 
 #[test]
+fn ev_use_synthesizes_root_and_common_api_symbols() {
+    let code = r#"
+use EV;
+
+EV::timer();
+EV::io();
+EV::signal();
+EV::idle();
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "EV", SymbolKind::Class),
+        "expected EV namespace symbol when framework is in use"
+    );
+    let attrs = symbol_attrs(&table, "EV", SymbolKind::Class);
+    assert!(
+        attrs.iter().any(|attr| attr == "framework=EV"),
+        "expected `framework=EV` on EV, got {attrs:?}"
+    );
+
+    for name in ["EV::timer", "EV::io", "EV::signal", "EV::idle"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Subroutine),
+            "expected synthetic EV API symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Subroutine);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=EV"),
+            "expected `framework=EV` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
+fn ev_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+EV::timer();
+EV::io();
+"#;
+
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "EV", SymbolKind::Class),
+        "did not expect EV namespace synthesis without `use EV`"
+    );
+    assert!(
+        !has_symbol(&table, "EV::timer", SymbolKind::Subroutine),
+        "did not expect EV::timer synthesis without `use EV`"
+    );
+}
+
+#[test]
 fn mojo_redis_use_synthesizes_framework_class_symbol() {
     let code = r#"
 use Mojo::Redis;


### PR DESCRIPTION
Adds a narrow EV async-framework MVP in the symbol extractor:

- detects `use EV`
- synthesizes a root EV namespace symbol
- synthesizes a small whitelist of EV API symbols (`EV::timer`, `EV::io`, `EV::signal`, `EV::idle`)

Focused coverage lives in `crates/perl-semantic-analyzer/tests/frameworks_async.rs`.

Validation:
- `cargo fmt --all`
- `cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture`