### PR TITLE
feat(workspace): discover .ep templates (#3579)

### DIFF
--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -60,16 +60,16 @@ pub fn discover_perl_files(root: &Path) -> DiscoveryResult {
 /// Returns `true` if `path` should be considered discoverable by workspace
 /// indexing.
 ///
-/// This intentionally includes XS implementation files so editor discovery can
-/// surface them even though they are not classified as Perl source files by
-/// the shared source-file helper.
+/// This intentionally includes XS implementation files and embedded Perl
+/// templates so editor discovery can surface them even though they are not
+/// classified as Perl source files by the shared source-file helper.
 #[must_use]
 pub fn is_perl_discovery_path(path: &Path) -> bool {
     is_perl_source_path(path)
         || path
             .extension()
             .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("xs"))
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("xs") || ext.eq_ignore_ascii_case("ep"))
 }
 
 fn try_git_discovery(root: &Path, start: Instant) -> Result<DiscoveryResult, std::io::Error> {
@@ -311,15 +311,17 @@ mod tests {
     #[test]
     fn parse_git_output_recognizes_all_perl_extensions() {
         let root = Path::new("/tmp/workspace");
-        let payload = b"lib/Foo.pm\0scripts/run.pl\0t/basic.t\0app/main.psgi\0ext/native.xs\0";
+        let payload =
+            b"lib/Foo.pm\0scripts/run.pl\0t/basic.t\0app/main.psgi\0ext/native.xs\0templates/page.html.ep\0";
         let (files, excluded_count) = parse_git_ls_files_output(root, payload);
 
-        assert_eq!(files.len(), 5);
+        assert_eq!(files.len(), 6);
         assert!(files.iter().any(|p| p.ends_with("Foo.pm")));
         assert!(files.iter().any(|p| p.ends_with("run.pl")));
         assert!(files.iter().any(|p| p.ends_with("basic.t")));
         assert!(files.iter().any(|p| p.ends_with("main.psgi")));
         assert!(files.iter().any(|p| p.ends_with("native.xs")));
+        assert!(files.iter().any(|p| p.ends_with("page.html.ep")));
         assert_eq!(excluded_count, 0);
     }
 
@@ -435,9 +437,11 @@ mod tests {
         create_file(root, "t/basic.t")?;
         create_file(root, "app/main.psgi")?;
         create_file(root, "xs/native.xs")?;
+        create_file(root, "templates/page.html.ep")?;
 
         let result = walk_discovery(root, Instant::now());
-        assert_eq!(result.files.len(), 5);
+        assert_eq!(result.files.len(), 6);
+        assert!(result.files.iter().any(|p| p.ends_with("page.html.ep")));
 
         Ok(())
     }

--- a/crates/perl-workspace-discovery/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-discovery/tests/comprehensive_unit_tests.rs
@@ -101,7 +101,8 @@ fn discover_perl_files_all_returned_paths_are_perl_sources() -> TestResult {
     create_file(root, "Cargo.toml")?;
 
     let result = discover_perl_files(root);
-    let valid_extensions: HashSet<&str> = ["pl", "pm", "t", "psgi", "xs"].iter().copied().collect();
+    let valid_extensions: HashSet<&str> =
+        ["pl", "pm", "t", "psgi", "xs", "ep"].iter().copied().collect();
 
     for path in &result.files {
         let ext = path
@@ -467,7 +468,7 @@ fn discover_perl_files_handles_spaces_in_paths() -> TestResult {
 // --- All five Perl extensions in one workspace ---
 
 #[test]
-fn discover_perl_files_finds_all_five_perl_extensions() -> TestResult {
+fn discover_perl_files_finds_all_six_perl_extensions() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
@@ -476,9 +477,10 @@ fn discover_perl_files_finds_all_five_perl_extensions() -> TestResult {
     create_file(root, "test.t")?;
     create_file(root, "app.psgi")?;
     create_file(root, "native.xs")?;
+    create_file(root, "templates/page.html.ep")?;
 
     let result = discover_perl_files(root);
-    assert_eq!(result.files.len(), 5);
+    assert_eq!(result.files.len(), 6);
 
     let extensions: HashSet<String> = result
         .files
@@ -491,5 +493,6 @@ fn discover_perl_files_finds_all_five_perl_extensions() -> TestResult {
     assert!(extensions.contains("t"));
     assert!(extensions.contains("psgi"));
     assert!(extensions.contains("xs"));
+    assert!(extensions.contains("ep"));
     Ok(())
 }

--- a/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
@@ -315,11 +315,11 @@ fn gitignore_negation_pattern_re_includes_file_level() -> TestResult {
 }
 
 // ============================================================
-// Perl file extension filtering (.pl, .pm, .t, .psgi, .xs)
+// Perl file extension filtering (.pl, .pm, .t, .psgi, .xs, .ep)
 // ============================================================
 
 #[test]
-fn extension_filtering_accepts_all_five_perl_extensions() -> TestResult {
+fn extension_filtering_accepts_all_six_perl_extensions() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
@@ -328,6 +328,7 @@ fn extension_filtering_accepts_all_five_perl_extensions() -> TestResult {
     create_file(root, "test.t")?;
     create_file(root, "app.psgi")?;
     create_file(root, "native.xs")?;
+    create_file(root, "templates/page.html.ep")?;
 
     let result = discover_perl_files(root);
 
@@ -337,12 +338,13 @@ fn extension_filtering_accepts_all_five_perl_extensions() -> TestResult {
         .filter_map(|p| p.extension().and_then(|e| e.to_str()).map(String::from))
         .collect();
 
-    assert_eq!(extensions.len(), 5);
+    assert_eq!(extensions.len(), 6);
     assert!(extensions.contains("pl"));
     assert!(extensions.contains("pm"));
     assert!(extensions.contains("t"));
     assert!(extensions.contains("psgi"));
     assert!(extensions.contains("xs"));
+    assert!(extensions.contains("ep"));
 
     Ok(())
 }

--- a/crates/perl-workspace-discovery/tests/discovery_property_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_property_tests.rs
@@ -12,6 +12,7 @@ fn extension_strategy() -> impl Strategy<Value = String> {
         Just("t".to_string()),
         Just("psgi".to_string()),
         Just("xs".to_string()),
+        Just("ep".to_string()),
         Just("md".to_string()),
         Just("txt".to_string()),
         Just("json".to_string()),
@@ -46,7 +47,7 @@ proptest! {
             prop_assert!(fs::create_dir_all(parent).is_ok());
             prop_assert!(fs::write(&path, "# generated\n").is_ok());
 
-            if matches!(ext.as_str(), "pl" | "pm" | "t" | "psgi" | "xs") {
+            if matches!(ext.as_str(), "pl" | "pm" | "t" | "psgi" | "xs" | "ep") {
                 expected.insert(path);
             }
         }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -73,6 +73,7 @@
           ".psgi",
           ".mason",
           ".mas",
+          ".ep",
           ".xs"
         ],
         "firstLine": "^#!.*\\bperl\\b",

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -126,6 +126,7 @@ describe('package.json contributes', () => {
       expect(exts).toContain('.psgi');
       expect(exts).toContain('.mason');
       expect(exts).toContain('.mas');
+      expect(exts).toContain('.ep');
       expect(exts).not.toContain('.m');
       expect(exts).toContain('.xs');
     });


### PR DESCRIPTION
Narrow MVP for issue #3579.

Scope: file recognition / discovery only.

- add .ep to VS Code language association so embedded templates like .html.ep are visible
- teach workspace discovery to recognize .ep via the final extension
- keep parser, navigation, and embedded Perl analysis unchanged