### PR TITLE
perf(code-actions): bound AST traversal to requested range (#3471)

### DIFF
--- a/crates/perl-lsp-code-actions/src/enhanced/mod.rs
+++ b/crates/perl-lsp-code-actions/src/enhanced/mod.rs
@@ -82,6 +82,15 @@ impl EnhancedCodeActionsProvider {
     /// control-flow construct (`If`, `While`, `For`, `Foreach`, `Subroutine`).
     /// In that case the node is not offered as "Extract to subroutine" — only
     /// standalone bare blocks are extractable.
+    ///
+    /// # Range bounding
+    ///
+    /// This function returns immediately when the node's span does not overlap the
+    /// requested range.  Because AST children are always contained within their
+    /// parent's span, a non-overlapping parent implies none of its descendants can
+    /// overlap either — so the entire subtree is pruned in one check.  This keeps
+    /// code-action collection O(nodes in range) rather than O(total AST nodes),
+    /// which is critical for responsiveness on large files (>5000 lines).
     fn collect_actions_for_range(
         &self,
         node: &Node,
@@ -90,53 +99,58 @@ impl EnhancedCodeActionsProvider {
         actions: &mut Vec<CodeAction>,
         extract_var_seen: &mut HashSet<(usize, String)>,
     ) {
-        // Check if this node overlaps the range
-        if node.location.start <= range.1 && node.location.end >= range.0 {
-            let helpers = Helpers::new(&self.source, &self.lines);
+        // Prune entire subtree when the node is completely outside the range.
+        // Children are always within the parent span, so if the parent doesn't
+        // overlap the range neither can any child.
+        if node.location.end < range.0 || node.location.start > range.1 {
+            return;
+        }
 
-            // Extract variable — only emit when the node's end reaches or exceeds the
-            // selection's end. This prevents duplicate actions for nested expressions:
-            // when both a Binary(8..25) and its inner FunctionCall(8..20) overlap a
-            // selection (8..25), the FunctionCall's end (20) is before the selection's
-            // end (25) and is skipped; only the outermost matching node emits an action.
-            // Partial-left overlap (cursor inside expression) is still supported.
-            let node_reaches_selection_end = node.location.end >= range.1;
-            if node_reaches_selection_end && self.is_extractable_expression(node) {
-                let action =
-                    extract_variable::create_extract_variable_action(node, &self.source, &helpers);
-                if let Some(decl) = action.edit.changes.first() {
-                    let key = (decl.location.start, decl.new_text.clone());
-                    if extract_var_seen.insert(key) {
-                        actions.push(action);
-                    }
-                } else {
+        // The node overlaps the range — collect applicable actions.
+        let helpers = Helpers::new(&self.source, &self.lines);
+
+        // Extract variable — only emit when the node's end reaches or exceeds the
+        // selection's end. This prevents duplicate actions for nested expressions:
+        // when both a Binary(8..25) and its inner FunctionCall(8..20) overlap a
+        // selection (8..25), the FunctionCall's end (20) is before the selection's
+        // end (25) and is skipped; only the outermost matching node emits an action.
+        // Partial-left overlap (cursor inside expression) is still supported.
+        let node_reaches_selection_end = node.location.end >= range.1;
+        if node_reaches_selection_end && self.is_extractable_expression(node) {
+            let action =
+                extract_variable::create_extract_variable_action(node, &self.source, &helpers);
+            if let Some(decl) = action.edit.changes.first() {
+                let key = (decl.location.start, decl.new_text.clone());
+                if extract_var_seen.insert(key) {
                     actions.push(action);
                 }
-            }
-
-            // Convert old-style loops
-            if let Some(action) = loop_conversion::convert_loop_style(node, &self.source) {
+            } else {
                 actions.push(action);
             }
+        }
 
-            // Add error checking
-            if let Some(action) = error_checking::add_error_checking(node, &self.source) {
-                actions.push(action);
-            }
+        // Convert old-style loops
+        if let Some(action) = loop_conversion::convert_loop_style(node, &self.source) {
+            actions.push(action);
+        }
 
-            // Convert to postfix
-            if let Some(action) = postfix::convert_to_postfix(node, &self.source) {
-                actions.push(action);
-            }
+        // Add error checking
+        if let Some(action) = error_checking::add_error_checking(node, &self.source) {
+            actions.push(action);
+        }
 
-            // Extract subroutine — only for standalone blocks, not control-flow bodies
-            if !is_control_body && self.is_extractable_block(node) {
-                actions.push(extract_subroutine::create_extract_subroutine_action(
-                    node,
-                    &self.source,
-                    &helpers,
-                ));
-            }
+        // Convert to postfix
+        if let Some(action) = postfix::convert_to_postfix(node, &self.source) {
+            actions.push(action);
+        }
+
+        // Extract subroutine — only for standalone blocks, not control-flow bodies
+        if !is_control_body && self.is_extractable_block(node) {
+            actions.push(extract_subroutine::create_extract_subroutine_action(
+                node,
+                &self.source,
+                &helpers,
+            ));
         }
 
         // Recursively check children, flagging control-flow body blocks

--- a/crates/perl-lsp-code-actions/tests/extract_refactoring_test.rs
+++ b/crates/perl-lsp-code-actions/tests/extract_refactoring_test.rs
@@ -386,3 +386,110 @@ fn extract_subroutine_spec_example_inner_block() {
         call_edit.new_text
     );
 }
+
+// Issue #3471: Range-bounded traversal — actions from outside the requested range must
+// not appear in the result set.
+#[test]
+fn range_bounded_traversal_excludes_out_of_range_nodes() {
+    // Two separate if-blocks. The range covers only the first one.
+    // The second block contains a convertible if-statement, but it is outside the range.
+    // After the fix, no actions from the second block should appear.
+    let source = "if ($debug) { print \"yes\"; }\nif ($trace) { open my $fh, '<', 'file.txt'; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+
+    // Range covers only the first if-block (bytes 0..28)
+    let first_block_end = source.find('\n').unwrap_or(28);
+    let provider = EnhancedCodeActionsProvider::new(source.to_string());
+    let actions = provider.get_enhanced_refactoring_actions(&ast, (0, first_block_end));
+
+    // Actions from the second block (open with or-die, postfix conversion of second if)
+    // must not appear. Verify no action has an edit location starting after first_block_end.
+    for action in &actions {
+        for edit in &action.edit.changes {
+            assert!(
+                edit.location.start <= first_block_end,
+                "Action '{}' produced an edit at byte {} which is outside the requested range 0..{}",
+                action.title,
+                edit.location.start,
+                first_block_end
+            );
+        }
+    }
+}
+
+// Issue #3471: Large-file responsiveness — actions on a narrow range in a large file
+// must only return actions for the selected region, not for the entire file.
+#[test]
+fn large_file_narrow_range_returns_only_in_range_actions() {
+    // Build a file with 50 subroutines. The target range covers only sub_000.
+    let mut source = String::from("use strict;\nuse warnings;\n\n");
+    // sub_000 is inserted first; record where it starts and ends
+    let sub_target_start = source.len();
+    source.push_str("if ($debug) { print \"target\\n\"; }\n");
+    let sub_target_end = source.len() - 1; // up to the closing newline
+
+    // Add 49 more if-blocks that each contain an open() call (triggering error_checking)
+    for i in 1..50 {
+        source.push_str(&format!("if ($cond_{i}) {{ open my $fh, '<', 'file_{i}.txt'; }}\n"));
+    }
+
+    let mut parser = Parser::new(&source);
+    let ast = must(parser.parse());
+
+    let provider = EnhancedCodeActionsProvider::new(source.clone());
+    let actions =
+        provider.get_enhanced_refactoring_actions(&ast, (sub_target_start, sub_target_end));
+
+    // All returned edits must fall within or at the boundary of the target range
+    for action in &actions {
+        for edit in &action.edit.changes {
+            assert!(
+                edit.location.start <= sub_target_end,
+                "Action '{}' produced edit at byte {} — outside target range {}..{}",
+                action.title,
+                edit.location.start,
+                sub_target_start,
+                sub_target_end
+            );
+        }
+    }
+
+    // The postfix action for the targeted if-block must be present
+    assert!(
+        actions.iter().any(|a| a.title.contains("postfix")),
+        "Expected a postfix action for the targeted if-block"
+    );
+}
+
+// Issue #3471: Verify that the traversal does not visit children of nodes that are
+// entirely before the requested range. This is a structural correctness check:
+// a node whose end <= range.start cannot contribute any action.
+#[test]
+fn traversal_skips_nodes_entirely_before_range() {
+    // Three sequential expression statements. The range covers only the third one.
+    let source = "my $a = foo();\nmy $b = bar();\nmy $c = baz();\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+
+    // Find offset of the third statement
+    let third_start = source.rfind("my $c").unwrap_or(0);
+    let provider = EnhancedCodeActionsProvider::new(source.to_string());
+    let actions = provider.get_enhanced_refactoring_actions(&ast, (third_start, source.len()));
+
+    // Any extract-variable action must reference the third expression, not $a or $b
+    for action in
+        actions.iter().filter(|a| a.title.contains("Extract") && a.title.contains("variable"))
+    {
+        for edit in &action.edit.changes {
+            assert!(
+                edit.location.start >= third_start || edit.location.end >= third_start,
+                "Extract action '{}' has edit at {}..{} which is entirely before the range start {}",
+                action.title,
+                edit.location.start,
+                edit.location.end,
+                third_start
+            );
+        }
+    }
+}


### PR DESCRIPTION
Clean replacement for #3742.\n\nScope:\n- early subtree pruning in `collect_actions_for_range` when a node cannot overlap the requested range\n- focused regression coverage for out-of-range exclusion and large-file narrow-range traversal\n\nValidation:\n- `cargo test -p perl-lsp-code-actions --test extract_refactoring_test -- --nocapture`\n\nFixes #3471