### PR TITLE
feat(code-actions): add quick fixes for 8 common diagnostic violations (#3469)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -173,6 +173,37 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::TwoArgOpen.as_str() => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
+                    // PL200: Missing package declaration
+                    c if c == DiagnosticCode::MissingPackageDeclaration.as_str() => {
+                        actions.extend(quick_fixes::fix_missing_package_declaration(&self.source));
+                    }
+                    // PL105: Variable redeclaration (duplicate my)
+                    c if c == DiagnosticCode::VariableRedeclaration.as_str() => {
+                        actions.extend(quick_fixes::fix_variable_redeclaration(
+                            &self.source,
+                            &qf_diag,
+                        ));
+                    }
+                    // PL110: Uninitialized variable
+                    c if c == DiagnosticCode::UninitializedVariable.as_str() => {
+                        actions.extend(quick_fixes::fix_uninitialized_variable(&qf_diag));
+                    }
+                    // PL111: Misspelled pragma
+                    c if c == DiagnosticCode::MisspelledPragma.as_str() => {
+                        actions.extend(quick_fixes::fix_misspelled_pragma(&self.source, &qf_diag));
+                    }
+                    // PL406: Unreachable code
+                    c if c == DiagnosticCode::UnreachableCode.as_str() => {
+                        actions.extend(quick_fixes::fix_unreachable_code(&self.source, &qf_diag));
+                    }
+                    // PL300: Duplicate subroutine
+                    c if c == DiagnosticCode::DuplicateSubroutine.as_str() => {
+                        actions.extend(quick_fixes::fix_duplicate_subroutine(&qf_diag));
+                    }
+                    // PL301: Missing return statement
+                    c if c == DiagnosticCode::MissingReturn.as_str() => {
+                        actions.extend(quick_fixes::fix_missing_return(&self.source, &qf_diag));
+                    }
                     _ => {}
                 }
             }

--- a/crates/perl-lsp-code-actions/src/quick_fixes.rs
+++ b/crates/perl-lsp-code-actions/src/quick_fixes.rs
@@ -621,6 +621,221 @@ pub fn fix_bareword_filehandle(diagnostic: &QuickFixDiagnostic) -> Vec<CodeActio
     }]
 }
 
+/// Fix missing package declaration by inserting `package main;` at the top
+///
+/// When a Perl file has no `package` declaration (PL200), the default package
+/// is `main`. This fix makes that intent explicit by inserting `package main;`
+/// at the top of the file.
+pub fn fix_missing_package_declaration(source: &str) -> Vec<CodeAction> {
+    // Insert after shebang if present, otherwise at top
+    let insert_pos =
+        if source.starts_with("#!") { source.find('\n').map(|p| p + 1).unwrap_or(0) } else { 0 };
+
+    vec![CodeAction {
+        title: "Add 'package main;' declaration".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::MissingPackageDeclaration.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: "package main;\n".to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Fix variable redeclaration by removing the duplicate `my` keyword
+///
+/// When a variable is declared twice in the same scope (PL105), the fix
+/// is to remove the `my` keyword from the second declaration, turning it
+/// into a plain assignment.
+pub fn fix_variable_redeclaration(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    // Look for `my ` at or near the start of the diagnostic range
+    let search_start = diagnostic.range.0;
+    let search_end = diagnostic.range.1.min(source.len());
+
+    if search_start >= source.len() {
+        return actions;
+    }
+
+    let snippet = &source[search_start..search_end];
+    if let Some(my_pos) = snippet.find("my ") {
+        let abs_my_start = search_start + my_pos;
+        let abs_my_end = abs_my_start + 3; // "my ".len()
+
+        actions.push(CodeAction {
+            title: "Remove duplicate 'my' declaration".to_string(),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::VariableRedeclaration.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: abs_my_start, end: abs_my_end },
+                    new_text: String::new(),
+                }],
+            },
+            is_preferred: true,
+        });
+    }
+
+    actions
+}
+
+/// Fix uninitialized variable by inserting `= undef` or `= ""` initialization
+///
+/// When a variable is used before being initialized (PL110), offer to initialize
+/// it at the declaration site with `undef` (the safer default) or an empty string.
+pub fn fix_uninitialized_variable(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    if let Some(var_name) = diagnostic.message.split('\'').nth(1) {
+        // Initialize with undef — safe default
+        actions.push(CodeAction {
+            title: format!("Initialize '{}' with undef", var_name),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::UninitializedVariable.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: diagnostic.range.1, end: diagnostic.range.1 },
+                    new_text: " = undef".to_string(),
+                }],
+            },
+            is_preferred: true,
+        });
+
+        // Initialize with empty string — common for string variables
+        actions.push(CodeAction {
+            title: format!("Initialize '{}' with empty string", var_name),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::UninitializedVariable.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: diagnostic.range.1, end: diagnostic.range.1 },
+                    new_text: r#" = """#.to_string(),
+                }],
+            },
+            is_preferred: false,
+        });
+    }
+
+    actions
+}
+
+/// Fix misspelled pragma by replacing with the correctly spelled name
+///
+/// The MisspelledPragma diagnostic (PL111) message has the format:
+/// `"Did you mean 'use <correct>;'? '<typo>' is not a known pragma"`
+/// This fix extracts the correct name and replaces the entire `use <typo>` statement.
+pub fn fix_misspelled_pragma(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    // Parse correct pragma from message: "Did you mean 'use <correct>;'?"
+    let msg = &diagnostic.message;
+    if let Some(after_use) = msg.strip_prefix("Did you mean 'use ")
+        && let Some(correct_name) = after_use.split(';').next()
+    {
+        let correct_pragma = correct_name.trim();
+        actions.push(CodeAction {
+            title: format!("Fix pragma spelling: 'use {};'", correct_pragma),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::MisspelledPragma.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                    new_text: format!("use {};", correct_pragma),
+                }],
+            },
+            is_preferred: true,
+        });
+    }
+
+    // Unused parameter suppression: source is used indirectly through the
+    // diagnostic message which was produced from the same source text.
+    let _ = source;
+
+    actions
+}
+
+/// Fix unreachable code by removing the unreachable statement
+///
+/// PL406 fires when a statement follows an unconditional exit (return, die, exit).
+/// The fix removes the entire line containing the unreachable statement.
+pub fn fix_unreachable_code(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    // Find the full line containing the unreachable statement
+    let line_start = source[..diagnostic.range.0].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_end = source[diagnostic.range.1..]
+        .find('\n')
+        .map(|p| diagnostic.range.1 + p + 1)
+        .unwrap_or(source.len());
+
+    vec![CodeAction {
+        title: "Remove unreachable code".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::UnreachableCode.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: line_start, end: line_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Fix duplicate subroutine by suggesting rename of the second definition
+///
+/// PL300 fires when a subroutine is defined more than once. The fix renames the
+/// second definition to avoid the conflict, preserving both implementations.
+pub fn fix_duplicate_subroutine(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    // Extract sub name from message: "Subroutine 'foo' is defined more than once..."
+    let sub_name = diagnostic.message.split('\'').nth(1).unwrap_or("sub");
+
+    actions.push(CodeAction {
+        title: format!("Rename duplicate subroutine '{}' to '{}_2'", sub_name, sub_name),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::DuplicateSubroutine.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: format!("{}_2", sub_name),
+            }],
+        },
+        is_preferred: true,
+    });
+
+    actions
+}
+
+/// Fix missing return statement by adding an explicit `return` before the closing brace
+///
+/// PL301 fires when a subroutine has no explicit return statement. The diagnostic
+/// range covers the subroutine body. This inserts `return;` at the end of the range.
+pub fn fix_missing_return(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    // Find indentation to match surrounding code style
+    let insert_pos = diagnostic.range.1.min(source.len());
+    let indent = get_indent_at(source, insert_pos.saturating_sub(1));
+
+    vec![CodeAction {
+        title: "Add explicit 'return' statement".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::MissingReturn.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: format!("{}return;\n", indent),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 /// Suggest upgrading two-argument open() to three-argument form
 ///
 /// Two-argument `open($fh, $filename)` is unsafe because `$filename` can

--- a/crates/perl-lsp-code-actions/tests/quick_fixes_new_diagnostics_test.rs
+++ b/crates/perl-lsp-code-actions/tests/quick_fixes_new_diagnostics_test.rs
@@ -1,0 +1,459 @@
+//! Tests for quick fixes added in issue #3469
+//!
+//! Covers the 7 new diagnostic quick fixes:
+//! - PL200: MissingPackageDeclaration — add `package main;`
+//! - PL105: VariableRedeclaration     — remove duplicate `my`
+//! - PL110: UninitializedVariable     — add `= undef` or `= ""`
+//! - PL111: MisspelledPragma          — fix pragma spelling
+//! - PL406: UnreachableCode           — remove unreachable statement
+//! - PL300: DuplicateSubroutine       — rename second definition
+//! - PL301: MissingReturn             — add explicit return
+
+use perl_lsp_code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn make_diag(start: usize, end: usize, code: &str, msg: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: msg.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn parse_and_get_actions(source: &str, diagnostics: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diagnostics)
+}
+
+fn has_action_with_title(actions: &[CodeAction], title_fragment: &str) -> bool {
+    actions.iter().any(|a| a.title.contains(title_fragment))
+}
+
+fn find_action<'a>(actions: &'a [CodeAction], title_fragment: &str) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| a.title.contains(title_fragment))
+}
+
+// ===========================================================================
+// PL200 — MissingPackageDeclaration
+// ===========================================================================
+
+#[test]
+fn missing_package_declaration_fix_inserts_package_main() {
+    let src = "sub greet { \"Hello\" }\n";
+    let diags = [make_diag(0, 1, "PL200", "Missing package declaration")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "package main"),
+        "Expected action to add package main, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn missing_package_declaration_fix_is_quick_fix_kind() {
+    let src = "my $x = 1;\n";
+    let diags = [make_diag(0, 1, "PL200", "Missing package declaration")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "package main");
+    assert!(action.is_some(), "Expected a 'package main' action");
+    assert_eq!(action.unwrap().kind, CodeActionKind::QuickFix);
+}
+
+#[test]
+fn missing_package_declaration_fix_inserts_after_shebang() {
+    let src = "#!/usr/bin/env perl\nmy $x = 1;\n";
+    let diags = [make_diag(0, 1, "PL200", "Missing package declaration")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "package main");
+    assert!(action.is_some(), "Expected a 'package main' action");
+
+    let edit = &action.unwrap().edit.changes[0];
+    assert!(
+        edit.location.start > 0,
+        "With shebang, insertion should be after the first line, not at position 0"
+    );
+    assert_eq!(edit.new_text, "package main;\n");
+}
+
+#[test]
+fn missing_package_declaration_fix_inserts_at_top_without_shebang() {
+    let src = "my $x = 1;\n";
+    let diags = [make_diag(0, 1, "PL200", "Missing package declaration")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "package main");
+    assert!(action.is_some(), "Expected a 'package main' action");
+
+    let edit = &action.unwrap().edit.changes[0];
+    assert_eq!(edit.location.start, 0, "Without shebang, insertion should be at position 0");
+    assert_eq!(edit.new_text, "package main;\n");
+}
+
+// ===========================================================================
+// PL105 — VariableRedeclaration
+// ===========================================================================
+
+#[test]
+fn variable_redeclaration_fix_removes_my_keyword() {
+    let src = "my $x = 1;\nmy $x = 2;\n";
+    let second_my_start = src.find("my $x = 2").unwrap_or(0);
+    let diags = [make_diag(
+        second_my_start,
+        second_my_start + 10,
+        "PL105",
+        "Variable '$x' is declared again in the same scope -- remove the duplicate 'my'",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "Remove duplicate"),
+        "Expected action to remove duplicate my, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn variable_redeclaration_fix_deletes_my_prefix() {
+    let src = "my $x = 1;\nmy $x = 2;\n";
+    // "my $x = 1;\n" is 11 chars, so second "my $x" starts at 11
+    let second_my_start = 11;
+    let diags = [make_diag(
+        second_my_start,
+        second_my_start + 10,
+        "PL105",
+        "Variable '$x' is declared again in the same scope -- remove the duplicate 'my'",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "Remove duplicate");
+    assert!(action.is_some(), "Expected remove duplicate action");
+
+    let edit = &action.unwrap().edit.changes[0];
+    assert_eq!(edit.new_text, "", "Edit should delete 'my '");
+    assert_eq!(
+        edit.location.end - edit.location.start,
+        3,
+        "Edit should span exactly 3 bytes ('my ')"
+    );
+}
+
+#[test]
+fn variable_redeclaration_fix_is_preferred() {
+    let src = "my $y = 1;\nmy $y = 2;\n";
+    let second_my_start = 11;
+    let diags = [make_diag(
+        second_my_start,
+        second_my_start + 10,
+        "PL105",
+        "Variable '$y' is declared again in the same scope",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "Remove duplicate");
+    assert!(action.is_some(), "Expected remove duplicate action");
+    assert!(action.unwrap().is_preferred, "Remove duplicate 'my' should be the preferred action");
+}
+
+// ===========================================================================
+// PL110 — UninitializedVariable
+// ===========================================================================
+
+#[test]
+fn uninitialized_variable_fix_offers_undef_initialization() {
+    let src = "my $x;\nprint $x;\n";
+    let diags = [make_diag(3, 5, "PL110", "Variable '$x' is used before being initialized")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "undef"),
+        "Expected action to initialize with undef, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn uninitialized_variable_fix_offers_empty_string_initialization() {
+    let src = "my $name;\nprint $name;\n";
+    let diags = [make_diag(3, 8, "PL110", "Variable '$name' is used before being initialized")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "empty string"),
+        "Expected action to initialize with empty string, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn uninitialized_variable_fix_undef_is_preferred() {
+    let src = "my $val;\nprint $val;\n";
+    let diags = [make_diag(3, 7, "PL110", "Variable '$val' is used before being initialized")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let undef_action = actions.iter().find(|a| a.title.contains("undef") && a.is_preferred);
+    assert!(undef_action.is_some(), "undef initialization should be the preferred action");
+}
+
+#[test]
+fn uninitialized_variable_fix_inserts_at_range_end() {
+    let src = "my $x;\nprint $x;\n";
+    // Range covers "$x" at position 3..5
+    let diags = [make_diag(3, 5, "PL110", "Variable '$x' is used before being initialized")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let undef_action = find_action(&actions, "undef");
+    assert!(undef_action.is_some(), "Expected undef action");
+
+    let edit = &undef_action.unwrap().edit.changes[0];
+    assert_eq!(edit.location.start, 5, "Should insert at end of diagnostic range");
+    assert_eq!(edit.location.start, edit.location.end, "Should be an insertion (start == end)");
+    assert!(edit.new_text.contains("undef"), "Inserted text should contain 'undef'");
+}
+
+// ===========================================================================
+// PL111 — MisspelledPragma
+// ===========================================================================
+
+#[test]
+fn misspelled_pragma_fix_suggests_correct_spelling() {
+    let src = "use warning;\nmy $x = 1;\n";
+    let diags = [make_diag(
+        0,
+        12,
+        "PL111",
+        "Did you mean 'use warnings;'? 'warning' is not a known pragma",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "warnings"),
+        "Expected action to fix to 'warnings', got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn misspelled_pragma_fix_replaces_full_range() {
+    let src = "use strict;\nuse warning;\n";
+    let use_warning_start = src.find("use warning;").unwrap_or(0);
+    let diags = [make_diag(
+        use_warning_start,
+        use_warning_start + 12,
+        "PL111",
+        "Did you mean 'use warnings;'? 'warning' is not a known pragma",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "warnings");
+    assert!(action.is_some(), "Expected a 'warnings' fix action");
+
+    let edit = &action.unwrap().edit.changes[0];
+    assert_eq!(edit.new_text, "use warnings;", "Should replace with 'use warnings;'");
+    assert_eq!(edit.location.start, use_warning_start, "Should start at diagnostic range start");
+}
+
+#[test]
+fn misspelled_pragma_fix_strict_typo() {
+    let src = "use structs;\nmy $x = 1;\n";
+    let diags =
+        [make_diag(0, 12, "PL111", "Did you mean 'use strict;'? 'structs' is not a known pragma")];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "strict"),
+        "Expected action to fix to 'strict', got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+
+    let action = find_action(&actions, "strict");
+    assert!(action.is_some());
+    let edit = &action.unwrap().edit.changes[0];
+    assert_eq!(edit.new_text, "use strict;");
+}
+
+#[test]
+fn misspelled_pragma_fix_is_preferred() {
+    let src = "use warning;\nmy $x = 1;\n";
+    let diags = [make_diag(
+        0,
+        12,
+        "PL111",
+        "Did you mean 'use warnings;'? 'warning' is not a known pragma",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "warnings");
+    assert!(action.is_some(), "Expected a 'warnings' fix action");
+    assert!(action.unwrap().is_preferred, "Pragma spelling fix should be preferred");
+}
+
+// ===========================================================================
+// PL406 — UnreachableCode
+// ===========================================================================
+
+#[test]
+fn unreachable_code_fix_removes_statement() {
+    let src = "sub foo {\n    return 1;\n    my $dead = 2;\n}\n";
+    let dead_start = src.find("my $dead").unwrap_or(0);
+    let dead_end = dead_start + "my $dead = 2;".len();
+    let diags = [make_diag(
+        dead_start,
+        dead_end,
+        "PL406",
+        "Unreachable code: this statement cannot be executed",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "unreachable"),
+        "Expected action to remove unreachable code, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn unreachable_code_fix_is_quick_fix_kind() {
+    let src = "sub foo {\n    return 1;\n    my $dead = 2;\n}\n";
+    let dead_start = src.find("my $dead").unwrap_or(0);
+    let dead_end = dead_start + "my $dead = 2;".len();
+    let diags = [make_diag(
+        dead_start,
+        dead_end,
+        "PL406",
+        "Unreachable code: this statement cannot be executed",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "unreachable");
+    assert!(action.is_some(), "Expected an unreachable code action");
+    assert_eq!(action.unwrap().kind, CodeActionKind::QuickFix);
+}
+
+#[test]
+fn unreachable_code_fix_deletes_entire_line() {
+    let src = "sub foo {\n    return 1;\n    my $dead = 2;\n}\n";
+    let dead_start = src.find("my $dead").unwrap_or(0);
+    let dead_end = dead_start + "my $dead = 2;".len();
+    let diags = [make_diag(
+        dead_start,
+        dead_end,
+        "PL406",
+        "Unreachable code: this statement cannot be executed",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "unreachable");
+    assert!(action.is_some(), "Expected an unreachable code action");
+
+    let edit = &action.unwrap().edit.changes[0];
+    assert_eq!(edit.new_text, "", "Should delete the line completely");
+    assert!(edit.location.end > edit.location.start, "Should span at least the statement");
+}
+
+// ===========================================================================
+// PL300 — DuplicateSubroutine
+// ===========================================================================
+
+#[test]
+fn duplicate_subroutine_fix_offers_rename() {
+    let src = "sub greet { 'hi' }\nsub greet { 'hello' }\n";
+    let second_greet = src.rfind("greet").unwrap_or(0);
+    let diags = [make_diag(
+        second_greet,
+        second_greet + 5,
+        "PL300",
+        "Subroutine 'greet' is defined more than once",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "greet"),
+        "Expected action mentioning the sub name, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn duplicate_subroutine_fix_is_quick_fix_kind() {
+    let src = "sub foo { 1 }\nsub foo { 2 }\n";
+    let second_foo = src.rfind("foo").unwrap_or(0);
+    let diags = [make_diag(
+        second_foo,
+        second_foo + 3,
+        "PL300",
+        "Subroutine 'foo' is defined more than once",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "foo");
+    assert!(action.is_some(), "Expected a duplicate subroutine action");
+    assert_eq!(action.unwrap().kind, CodeActionKind::QuickFix);
+}
+
+// ===========================================================================
+// PL301 — MissingReturn
+// ===========================================================================
+
+#[test]
+fn missing_return_fix_adds_return_statement() {
+    let src = "sub compute {\n    my $x = 1;\n}\n";
+    let close_brace = src.rfind('}').unwrap_or(0);
+    let diags = [make_diag(
+        close_brace,
+        close_brace + 1,
+        "PL301",
+        "Subroutine 'compute' has no explicit return statement",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    assert!(
+        has_action_with_title(&actions, "return"),
+        "Expected action to add return statement, got: {:?}",
+        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn missing_return_fix_is_quick_fix_kind() {
+    let src = "sub process {\n    my $y = 2;\n}\n";
+    let close_brace = src.rfind('}').unwrap_or(0);
+    let diags = [make_diag(
+        close_brace,
+        close_brace + 1,
+        "PL301",
+        "Subroutine 'process' has no explicit return statement",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "return");
+    assert!(action.is_some(), "Expected a missing return action");
+    assert_eq!(action.unwrap().kind, CodeActionKind::QuickFix);
+}
+
+#[test]
+fn missing_return_fix_is_preferred() {
+    let src = "sub calc {\n    my $z = 3;\n}\n";
+    let close_brace = src.rfind('}').unwrap_or(0);
+    let diags = [make_diag(
+        close_brace,
+        close_brace + 1,
+        "PL301",
+        "Subroutine 'calc' has no explicit return statement",
+    )];
+    let actions = parse_and_get_actions(src, &diags);
+
+    let action = find_action(&actions, "return");
+    assert!(action.is_some(), "Expected a missing return action");
+    assert!(action.unwrap().is_preferred, "Add return should be the preferred action");
+}

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -426,6 +426,13 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 | DiagnosticCode::AssignmentInCondition
                 | DiagnosticCode::NumericComparisonWithUndef
                 | DiagnosticCode::DeprecatedDefined
+                | DiagnosticCode::MissingPackageDeclaration
+                | DiagnosticCode::VariableRedeclaration
+                | DiagnosticCode::UninitializedVariable
+                | DiagnosticCode::MisspelledPragma
+                | DiagnosticCode::UnreachableCode
+                | DiagnosticCode::DuplicateSubroutine
+                | DiagnosticCode::MissingReturn
         )
     )
 }

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -502,9 +502,10 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_data_fixable_false_for_non_fixable() -> Result<(), Box<dyn std::error::Error>> {
-        // PL105 (VariableRedeclaration) has no quick-fix action; fixable must be false
-        // so clients do not show a lightning-bolt icon for it.
+    fn diagnostic_data_fixable_true_for_variable_redeclaration()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // PL105 (VariableRedeclaration) offers a quick-fix that removes the duplicate `my`,
+        // so the enriched diagnostic data must advertise it as fixable.
         let provider = PullDiagnosticsProvider::new();
         let uri: Uri = "file:///test.pl".parse()?;
         // Redeclare $x in the same scope to trigger PL105
@@ -516,7 +517,7 @@ mod tests {
         }) {
             let data = diag.data.as_ref().ok_or("data should be Some for PL105")?;
             assert_eq!(data["code"], "PL105");
-            assert_eq!(data["fixable"], false, "PL105 has no quick-fix; fixable must be false");
+            assert_eq!(data["fixable"], true, "PL105 now has a quick-fix; fixable must stay true");
         }
         // Also verify that every diagnostic with a code has a valid data object
         for d in &items {

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -943,6 +943,13 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 | DiagnosticCode::AssignmentInCondition
                 | DiagnosticCode::NumericComparisonWithUndef
                 | DiagnosticCode::DeprecatedDefined
+                | DiagnosticCode::MissingPackageDeclaration
+                | DiagnosticCode::VariableRedeclaration
+                | DiagnosticCode::UninitializedVariable
+                | DiagnosticCode::MisspelledPragma
+                | DiagnosticCode::UnreachableCode
+                | DiagnosticCode::DuplicateSubroutine
+                | DiagnosticCode::MissingReturn
         )
     )
 }

--- a/crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs
+++ b/crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs
@@ -114,11 +114,11 @@ fn test_pl100_data_fields_correct() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Test 3: non-fixable diagnostic has fixable: false
+// Test 3: PL105 fixable flag reflects quick-fix availability
 #[test]
-fn test_non_fixable_diagnostic_has_fixable_false() -> Result<(), Box<dyn std::error::Error>> {
-    let uri = "file:///test_non_fixable.pl";
-    // PL105 (VariableRedeclaration) has no quick-fix
+fn test_pl105_has_fixable_true_after_adding_quick_fix() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = "file:///test_pl105_fixable.pl";
+    // PL105 (VariableRedeclaration) now has a quick-fix: remove duplicate 'my' (#3469)
     let content = "use strict; use warnings; my $x = 1; my $x = 2;\n";
     let server = open_document(uri, content);
     let items = get_diagnostics(&server, uri)?;
@@ -132,15 +132,14 @@ fn test_non_fixable_diagnostic_has_fixable_false() -> Result<(), Box<dyn std::er
         }
     }
 
-    // PL105 (VariableRedeclaration) MUST fire and MUST have fixable: false.
-    // Using ok_or to enforce the requirement — a soft if-let would make this
-    // test vacuous (passes even if the serialization is broken).
+    // PL105 (VariableRedeclaration) MUST fire and now has fixable: true since the
+    // "remove duplicate my" quick-fix was added in issue #3469.
     let diag = items
         .iter()
         .find(|d| d["code"].as_str() == Some("PL105"))
         .ok_or("Expected PL105 (VariableRedeclaration) to fire for double-declare input")?;
     let data = &diag["data"];
-    assert_eq!(data["fixable"], false, "PL105 has no quick-fix; fixable must be false");
+    assert_eq!(data["fixable"], true, "PL105 now has a quick-fix (remove duplicate 'my')");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds quick-fix code actions for 7 previously-unhandled diagnostic violations from issue #3469:

- **PL200 MissingPackageDeclaration** — insert `package main;` at top of file (after shebang if present)
- **PL105 VariableRedeclaration** — remove the duplicate `my` keyword, converting redeclaration to plain assignment
- **PL110 UninitializedVariable** — offer to initialize with `= undef` (preferred) or `= ""` (alternate)
- **PL111 MisspelledPragma** — replace misspelled pragma with the correctly-spelled name parsed from diagnostic message (e.g., `use warning;` → `use warnings;`)
- **PL406 UnreachableCode** — remove the entire unreachable statement line
- **PL300 DuplicateSubroutine** — rename the second definition with a `_2` suffix
- **PL301 MissingReturn** — insert explicit `return;` before the closing brace

Note: PL404 (NumericComparisonWithUndef) was already handled before this PR; the 8th item in the issue spec was pre-existing.

Also updates `is_fixable_diagnostic` in `pull.rs` so LSP clients see `fixable: true` in diagnostic data for all newly-fixable codes, and updates the test that previously asserted PL105 had `fixable: false`.

## Files changed

- `crates/perl-lsp-code-actions/src/quick_fixes.rs` — 7 new functions
- `crates/perl-lsp-code-actions/src/code_actions.rs` — wire 7 new diagnostic codes to handlers
- `crates/perl-lsp-code-actions/tests/quick_fixes_new_diagnostics_test.rs` — 23 new tests
- `crates/perl-lsp/src/features/diagnostics/pull.rs` — update fixable list
- `crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs` — update PL105 fixable assertion

## Test plan

- [x] 23 new unit tests covering all 7 new fixes
- [x] All 219 `perl-lsp-code-actions` tests pass
- [x] `cargo clippy -p perl-lsp-code-actions` clean
- [x] `cargo clippy -p perl-lsp-rs` clean
- [x] `cargo fmt` applied

Fixes #3469