### PR TITLE
feat(analysis): add Future promise-chain symbols (#3611)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -683,6 +683,7 @@ impl SymbolExtractor {
                 });
 
                 self.synthesize_async_framework_class_symbol(object);
+                self.synthesize_future_api_symbols(object, method, node.location);
                 self.visit_node(object);
                 for arg in args {
                     self.visit_node(arg);
@@ -1892,6 +1893,68 @@ impl SymbolExtractor {
             declaration: Some("framework=EV".to_string()),
             documentation: Some(format!("Synthetic EV API `{ev_suffix}`")),
             attributes: vec!["framework=EV".to_string(), format!("ev_api={ev_suffix}")],
+        });
+
+        true
+    }
+
+    /// Synthesize a narrow Future/Future::XS promise-chain surface for common entrypoints.
+    ///
+    /// This intentionally avoids type inference. It only exposes the canonical
+    /// constructor / class methods and the common chain methods that are most
+    /// useful for navigation and references when a file opts into Future.
+    fn synthesize_future_api_symbols(
+        &mut self,
+        object: &Node,
+        method: &str,
+        location: SourceLocation,
+    ) -> bool {
+        let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
+            return false;
+        };
+
+        let (framework_name, root_name) = match flags.async_framework {
+            Some(AsyncFrameworkKind::Future) => ("Future", "Future"),
+            Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS"),
+            _ => return false,
+        };
+
+        let chain_methods = ["then", "catch", "finally", "get", "is_done", "is_ready"];
+        let class_entrypoints = ["new", "done", "fail", "wait_all", "needs_all", "needs_any"];
+
+        let object_name = Self::single_symbol_name(object);
+
+        let should_synthesize = if chain_methods.contains(&method) {
+            true
+        } else if class_entrypoints.contains(&method) {
+            object_name.is_some_and(|name| name == root_name)
+        } else {
+            false
+        };
+        if !should_synthesize {
+            return false;
+        }
+
+        let already_synthesized = self.table.symbols.get(method).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Subroutine
+                    && symbol.declaration.as_deref() == Some(&format!("framework={framework_name}"))
+                    && symbol.attributes.iter().any(|attr| attr == &format!("future_api={method}"))
+            })
+        });
+        if already_synthesized {
+            return true;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: method.to_string(),
+            qualified_name: format!("{framework_name}::{method}"),
+            kind: SymbolKind::Subroutine,
+            location,
+            scope_id: self.table.current_scope(),
+            declaration: Some(format!("framework={framework_name}")),
+            documentation: Some(format!("Synthetic {framework_name} API `{method}`")),
+            attributes: vec![format!("framework={framework_name}"), format!("future_api={method}")],
         });
 
         true

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -285,6 +285,53 @@ my $future = Future->new;
 }
 
 #[test]
+fn future_use_synthesizes_common_chain_methods() {
+    let code = r#"
+use Future;
+
+my $future = Future->new;
+my $next = $future->then(sub { return Future->done(1) });
+$future->catch(sub { return Future->fail("boom") });
+$future->finally(sub { });
+$future->get;
+$future->is_done;
+$future->is_ready;
+Future->wait_all($future);
+Future->needs_all($future);
+Future->needs_any($future);
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in [
+        "new",
+        "then",
+        "catch",
+        "finally",
+        "get",
+        "is_done",
+        "is_ready",
+        "wait_all",
+        "needs_all",
+        "needs_any",
+    ] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Subroutine),
+            "expected synthetic Future API symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Subroutine);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=Future"),
+            "expected `framework=Future` on `{name}`, got {attrs:?}"
+        );
+        assert!(
+            attrs.iter().any(|attr| attr == &format!("future_api={name}")),
+            "expected `future_api={name}` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
 fn future_xs_use_synthesizes_class_symbol_for_method_calls() {
     let code = r#"
 use Future::XS;
@@ -306,6 +353,53 @@ my $future = Future::XS->new;
 }
 
 #[test]
+fn future_xs_use_synthesizes_common_chain_methods() {
+    let code = r#"
+use Future::XS;
+
+my $future = Future::XS->new;
+my $next = $future->then(sub { return Future::XS->done(1) });
+$future->catch(sub { return Future::XS->fail("boom") });
+$future->finally(sub { });
+$future->get;
+$future->is_done;
+$future->is_ready;
+Future::XS->wait_all($future);
+Future::XS->needs_all($future);
+Future::XS->needs_any($future);
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in [
+        "new",
+        "then",
+        "catch",
+        "finally",
+        "get",
+        "is_done",
+        "is_ready",
+        "wait_all",
+        "needs_all",
+        "needs_any",
+    ] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Subroutine),
+            "expected synthetic Future::XS API symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Subroutine);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=Future::XS"),
+            "expected `framework=Future::XS` on `{name}`, got {attrs:?}"
+        );
+        assert!(
+            attrs.iter().any(|attr| attr == &format!("future_api={name}")),
+            "expected `future_api={name}` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
 fn future_names_are_not_synthesized_without_framework_use() {
     let code = r#"
 my $future = Future->new;
@@ -317,6 +411,35 @@ my $future = Future->new;
         !has_symbol(&table, "Future", SymbolKind::Class),
         "did not expect Future class synthesis without `use Future`"
     );
+}
+
+#[test]
+fn future_api_names_are_not_synthesized_without_framework_use() {
+    let code = r#"
+my $future = Future->new;
+$future->then(sub { return Future->done(1) });
+Future->wait_all($future);
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in [
+        "new",
+        "then",
+        "catch",
+        "finally",
+        "get",
+        "is_done",
+        "is_ready",
+        "wait_all",
+        "needs_all",
+        "needs_any",
+    ] {
+        assert!(
+            !has_symbol(&table, name, SymbolKind::Subroutine),
+            "did not expect synthetic Future API symbol `{name}` without `use Future`"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Adds a narrow Future/Future::XS MVP in the semantic analyzer.

Scope:
- synthesize the Future/Future::XS class symbol when imported
- synthesize common class entrypoints for Future APIs
- synthesize common chain methods as framework-scoped callable symbols

Validation:
- cargo fmt --all
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture