### PR TITLE
feat(dap): pre-launch syntax check with perl -c (#3477)

### DIFF
--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -181,6 +181,11 @@ name = "dap_step_through_tests"
 path = "tests/dap_step_through_tests.rs"
 # AC:3535 Comprehensive step-through debugging tests: stepIn, stepOut, stepOver, continue, pause, gotoTargets, cancel
 
+[[test]]
+name = "dap_syntax_check_tests"
+path = "tests/dap_syntax_check_tests.rs"
+# AC:3477 Pre-launch syntax check using perl -c, clear error messages before debug start
+
 [[bench]]
 name = "dap_benchmarks"
 path = "benches/dap_benchmarks.rs"

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -256,6 +256,12 @@ impl DebugAdapter {
             })?;
         }
 
+        // Pre-launch syntax check: run `perl -c <script>` before spawning the
+        // debugger.  This catches syntax errors early and surfaces a clear,
+        // actionable message to the user instead of a generic "Cannot start
+        // Perl debugger" failure after `perl -d` exits immediately.
+        Self::check_syntax(program)?;
+
         let mut cmd = Command::new("perl");
         cmd.arg("-d");
 
@@ -315,6 +321,66 @@ impl DebugAdapter {
             }
             Err(e) => Err(e.to_string()),
         }
+    }
+
+    /// Run `perl -c <script>` and return `Ok(())` if the syntax is valid,
+    /// or `Err(message)` with a user-friendly error describing the problem.
+    ///
+    /// `perl -c` exits with status 0 when the script compiles successfully
+    /// (printing "syntax OK" to stderr).  Any non-zero exit is a syntax
+    /// failure; the error detail is on stderr.
+    ///
+    /// If `perl` cannot be found or spawned, the check is silently skipped
+    /// and `Ok(())` is returned so that the subsequent `perl -d` launch
+    /// produces the correct "perl not on PATH" error to the user.
+    pub(super) fn check_syntax(program: &str) -> Result<(), String> {
+        let output = match Command::new("perl")
+            .arg("-c")
+            .arg("--")
+            .arg(program)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+        {
+            Ok(out) => out,
+            Err(e) => {
+                // `perl` not found or could not be spawned — skip the check
+                // and let the real launch produce the "perl not on PATH" error.
+                tracing::warn!("perl -c could not be run (will try perl -d anyway): {}", e);
+                return Ok(());
+            }
+        };
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        // Combine stdout + stderr (perl writes errors to stderr; stdout is
+        // normally empty for -c, but merge both for robustness).
+        let raw_stderr = String::from_utf8_lossy(&output.stderr);
+        let raw_stdout = String::from_utf8_lossy(&output.stdout);
+        let combined = if raw_stderr.is_empty() { raw_stdout } else { raw_stderr };
+
+        // Strip the "syntax OK" confirmation line that sometimes appears even
+        // on partial failures, and drop blank lines.
+        let error_lines: Vec<&str> = combined
+            .lines()
+            .filter(|l| {
+                let trimmed = l.trim();
+                !trimmed.eq_ignore_ascii_case("syntax ok") && !trimmed.is_empty()
+            })
+            .collect();
+
+        let detail = if error_lines.is_empty() {
+            combined.trim().to_string()
+        } else {
+            error_lines.join("\n")
+        };
+
+        Err(format!(
+            "Syntax error in '{}' — fix the error below before debugging:\n{}",
+            program, detail
+        ))
     }
 
     /// Start thread to read debugger output with enhanced error recovery

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -260,7 +260,7 @@ impl DebugAdapter {
         // debugger.  This catches syntax errors early and surfaces a clear,
         // actionable message to the user instead of a generic "Cannot start
         // Perl debugger" failure after `perl -d` exits immediately.
-        Self::check_syntax(program)?;
+        Self::check_syntax(program, &env_overrides)?;
 
         let mut cmd = Command::new("perl");
         cmd.arg("-d");
@@ -333,11 +333,15 @@ impl DebugAdapter {
     /// If `perl` cannot be found or spawned, the check is silently skipped
     /// and `Ok(())` is returned so that the subsequent `perl -d` launch
     /// produces the correct "perl not on PATH" error to the user.
-    pub(super) fn check_syntax(program: &str) -> Result<(), String> {
+    pub(super) fn check_syntax(
+        program: &str,
+        env_overrides: &HashMap<String, String>,
+    ) -> Result<(), String> {
         let output = match Command::new("perl")
             .arg("-c")
             .arg("--")
             .arg(program)
+            .envs(env_overrides)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()

--- a/crates/perl-dap/tests/dap_syntax_check_tests.rs
+++ b/crates/perl-dap/tests/dap_syntax_check_tests.rs
@@ -1,0 +1,189 @@
+/// Tests for pre-launch syntax checking (issue #3477)
+///
+/// The DAP server should run `perl -c` on the target script before launching
+/// `perl -d`, and report syntax errors clearly instead of failing mid-execution.
+use perl_dap::DapMessage;
+use perl_dap::DebugAdapter;
+use perl_tdd_support::must_some;
+use serde_json::json;
+use std::fs;
+
+/// Helper: create a Perl script in a temp dir.
+fn write_script(dir: &tempfile::TempDir, filename: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.path().join(filename);
+    fs::write(&path, content).expect("write test script");
+    path
+}
+
+// ── syntax error cases ──────────────────────────────────────────────────────
+
+#[test]
+fn test_launch_rejects_missing_semicolon() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+
+    // Missing semicolon between statements — perl -c catches this
+    let script = write_script(&tmp, "missing_semicolon.pl", "my $x = 1\nprint $x;\n");
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd":     must_some(tmp.path().to_str()),
+        "args":    []
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(!success, "Launch should fail: script has a missing semicolon");
+            let msg = must_some(message);
+            assert!(
+                msg.to_lowercase().contains("syntax") || msg.contains("line"),
+                "Error message should mention 'syntax' or a line number, got: {msg}"
+            );
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_launch_rejects_unclosed_brace() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+
+    // Unclosed block brace
+    let script = write_script(
+        &tmp,
+        "unclosed_brace.pl",
+        "sub foo {\n    my $x = 1;\n# missing closing brace\n",
+    );
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd":     must_some(tmp.path().to_str()),
+        "args":    []
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(!success, "Launch should fail: script has an unclosed brace");
+            let msg = must_some(message);
+            assert!(
+                msg.to_lowercase().contains("syntax") || msg.contains("line"),
+                "Error message should mention 'syntax' or a line number, got: {msg}"
+            );
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}
+
+#[test]
+fn test_launch_rejects_simple_syntax_error() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+
+    // `use strict` + bareword: perl -c exits non-zero with a clear error.
+    // Without strict, barewords are valid Perl, so we must use strict here.
+    let script = write_script(
+        &tmp,
+        "simple_syntax_error.pl",
+        "use strict;\nmy $x = BAREWORD_NOT_DEFINED;\n",
+    );
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd":     must_some(tmp.path().to_str()),
+        "args":    []
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(!success, "Launch should fail: script has a syntax error under strict");
+            let msg = must_some(message);
+            assert!(
+                msg.to_lowercase().contains("syntax") || msg.contains("line"),
+                "Error message should mention 'syntax' or a line number, got: {msg}"
+            );
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}
+
+// ── valid script passes through ─────────────────────────────────────────────
+
+#[test]
+fn test_launch_allows_syntactically_valid_script() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+
+    // Valid Perl — no syntax error.  If perl is not on PATH the launch will
+    // fail for a different reason, which is fine; the test asserts that the
+    // failure is NOT attributed to a syntax error.
+    let script = write_script(
+        &tmp,
+        "valid.pl",
+        "use strict;\nuse warnings;\nmy $x = 42;\nprint \"$x\\n\";\n",
+    );
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd":     must_some(tmp.path().to_str()),
+        "args":    []
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            if !success {
+                let msg = message.unwrap_or_default();
+                assert!(
+                    !msg.to_lowercase().contains("syntax error in"),
+                    "Valid script was incorrectly rejected for syntax: {msg}"
+                );
+            }
+            // success is fine too — perl was found and the session launched
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}
+
+// ── message quality: line number ────────────────────────────────────────────
+
+#[test]
+fn test_syntax_error_message_contains_line_number() -> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+
+    // Assignment with no right-hand side on line 2
+    let script = write_script(&tmp, "line_number_test.pl", "my $a = 1;\nmy $b = ;\nmy $c = 3;\n");
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd":     must_some(tmp.path().to_str()),
+        "args":    []
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(!success, "Launch should fail: assignment with no right-hand side");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("line") || msg.contains("Line"),
+                "Syntax error message should include a line reference, got: {msg}"
+            );
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}

--- a/crates/perl-dap/tests/dap_syntax_check_tests.rs
+++ b/crates/perl-dap/tests/dap_syntax_check_tests.rs
@@ -187,3 +187,49 @@ fn test_syntax_error_message_contains_line_number() -> Result<(), Box<dyn std::e
     }
     Ok(())
 }
+
+#[test]
+fn test_launch_syntax_check_honors_perl5lib_env_override() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut adapter = DebugAdapter::new();
+    let tmp = tempfile::tempdir()?;
+    let lib_dir = tmp.path().join("lib");
+    fs::create_dir_all(lib_dir.join("Local"))?;
+
+    fs::write(
+        lib_dir.join("Local").join("Helper.pm"),
+        "package Local::Helper;\nsub ok { 1 }\n1;\n",
+    )?;
+
+    let script = write_script(
+        &tmp,
+        "needs_perl5lib.pl",
+        "use strict;\nuse warnings;\nuse Local::Helper;\nprint Local::Helper::ok();\n",
+    );
+
+    let args = json!({
+        "program": must_some(script.to_str()),
+        "cwd": must_some(tmp.path().to_str()),
+        "args": [],
+        "env": {
+            "PERL5LIB": must_some(lib_dir.to_str())
+        }
+    });
+
+    let response = adapter.handle_request(1, "launch", Some(args));
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            if !success {
+                let msg = message.unwrap_or_default();
+                assert!(
+                    !msg.contains("Local/Helper.pm")
+                        && !msg.contains("Can't locate Local/Helper.pm"),
+                    "Launch should honor PERL5LIB during syntax check, got: {msg}"
+                );
+            }
+        }
+        _ => return Err("Expected a Response message".into()),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Runs `perl -c <script>` before launching `perl -d` to detect syntax errors early
- Returns a user-friendly error message with file path, line number, and perl's diagnostic instead of the generic "Cannot start Perl debugger" failure
- If `perl` is not on PATH, the check is silently skipped and the existing "perl not found" error is shown

## Changes

- `crates/perl-dap/src/debug_adapter/process.rs`: Added `check_syntax()` method called in `launch_debugger()` before spawning `perl -d`
- `crates/perl-dap/tests/dap_syntax_check_tests.rs`: 5 tests covering missing semicolon, unclosed brace, strict bareword error, valid script pass-through, and line number presence
- `crates/perl-dap/Cargo.toml`: Added `dap_syntax_check_tests` test target

## Test plan

- [ ] `cargo test -p perl-dap --test dap_syntax_check_tests` — all 5 tests pass
- [ ] `cargo clippy -p perl-dap` — clean (no warnings)
- [ ] `cargo fmt -p perl-dap` — no changes needed
- [ ] Manually: script with syntax error gives "Syntax error in '...' — fix the error below before debugging: ..."
- [ ] Manually: valid script launches normally

## Notes

The 3 CI failures in `perl-module-resolution` and `perl-workspace-discovery` are pre-existing Windows path separator issues (`/` vs `\`) unrelated to this change — no diff to those crates on this branch.

Closes #3477