### PR TITLE
feat(semantic): add Promise async chain symbols (#3612)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -1898,11 +1898,12 @@ impl SymbolExtractor {
         true
     }
 
-    /// Synthesize a narrow Future/Future::XS promise-chain surface for common entrypoints.
+    /// Synthesize a narrow async framework API surface for common entrypoints.
     ///
     /// This intentionally avoids type inference. It only exposes the canonical
     /// constructor / class methods and the common chain methods that are most
-    /// useful for navigation and references when a file opts into Future.
+    /// useful for navigation and references when a file opts into an async
+    /// framework such as Future or Promise.
     fn synthesize_future_api_symbols(
         &mut self,
         object: &Node,
@@ -1913,14 +1914,34 @@ impl SymbolExtractor {
             return false;
         };
 
-        let (framework_name, root_name) = match flags.async_framework {
-            Some(AsyncFrameworkKind::Future) => ("Future", "Future"),
-            Some(AsyncFrameworkKind::FutureXS) => ("Future::XS", "Future::XS"),
-            _ => return false,
-        };
-
-        let chain_methods = ["then", "catch", "finally", "get", "is_done", "is_ready"];
-        let class_entrypoints = ["new", "done", "fail", "wait_all", "needs_all", "needs_any"];
+        let (framework_name, root_name, chain_methods, class_entrypoints) =
+            match flags.async_framework {
+                Some(AsyncFrameworkKind::Future) => (
+                    "Future",
+                    "Future",
+                    vec!["then", "catch", "finally", "get", "is_done", "is_ready"],
+                    vec!["new", "done", "fail", "wait_all", "needs_all", "needs_any"],
+                ),
+                Some(AsyncFrameworkKind::FutureXS) => (
+                    "Future::XS",
+                    "Future::XS",
+                    vec!["then", "catch", "finally", "get", "is_done", "is_ready"],
+                    vec!["new", "done", "fail", "wait_all", "needs_all", "needs_any"],
+                ),
+                Some(AsyncFrameworkKind::Promise) => (
+                    "Promise",
+                    "Promise",
+                    vec!["then", "catch", "finally", "resolve", "reject"],
+                    vec!["new", "all", "race", "any"],
+                ),
+                Some(AsyncFrameworkKind::PromiseXS) => (
+                    "Promise::XS",
+                    "Promise::XS",
+                    vec!["then", "catch", "finally", "resolve", "reject"],
+                    vec!["new", "all", "race", "any"],
+                ),
+                _ => return false,
+            };
 
         let object_name = Self::single_symbol_name(object);
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_async.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_async.rs
@@ -478,6 +478,41 @@ my $promise = Promise->new(sub { return 1 });
 }
 
 #[test]
+fn promise_use_synthesizes_common_chain_methods() {
+    let code = r#"
+use Promise;
+
+my $promise = Promise->new(sub { return 1 });
+my $next = $promise->then(sub { return Promise->resolve(1) });
+$promise->catch(sub { return Promise->reject("boom") });
+$promise->finally(sub { });
+$promise->resolve(1);
+$promise->reject("boom");
+Promise->all($promise);
+Promise->race($promise);
+Promise->any($promise);
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in ["new", "then", "catch", "finally", "resolve", "reject", "all", "race", "any"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Subroutine),
+            "expected synthetic Promise API symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Subroutine);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=Promise"),
+            "expected `framework=Promise` on `{name}`, got {attrs:?}"
+        );
+        assert!(
+            attrs.iter().any(|attr| attr == &format!("future_api={name}")),
+            "expected `future_api={name}` on `{name}`, got {attrs:?}"
+        );
+    }
+}
+
+#[test]
 fn promise_xs_use_synthesizes_class_symbol_for_method_calls() {
     let code = r#"
 use Promise::XS;
@@ -496,6 +531,41 @@ my $promise = Promise::XS->new(sub { return 1 });
         attrs.iter().any(|attr| attr == "framework=Promise::XS"),
         "expected `framework=Promise::XS` on Promise::XS, got {attrs:?}"
     );
+}
+
+#[test]
+fn promise_xs_use_synthesizes_common_chain_methods() {
+    let code = r#"
+use Promise::XS;
+
+my $promise = Promise::XS->new(sub { return 1 });
+my $next = $promise->then(sub { return Promise::XS->resolve(1) });
+$promise->catch(sub { return Promise::XS->reject("boom") });
+$promise->finally(sub { });
+$promise->resolve(1);
+$promise->reject("boom");
+Promise::XS->all($promise);
+Promise::XS->race($promise);
+Promise::XS->any($promise);
+"#;
+
+    let table = extract_symbols(code);
+
+    for name in ["new", "then", "catch", "finally", "resolve", "reject", "all", "race", "any"] {
+        assert!(
+            has_symbol(&table, name, SymbolKind::Subroutine),
+            "expected synthetic Promise::XS API symbol `{name}`"
+        );
+        let attrs = symbol_attrs(&table, name, SymbolKind::Subroutine);
+        assert!(
+            attrs.iter().any(|attr| attr == "framework=Promise::XS"),
+            "expected `framework=Promise::XS` on `{name}`, got {attrs:?}"
+        );
+        assert!(
+            attrs.iter().any(|attr| attr == &format!("future_api={name}")),
+            "expected `future_api={name}` on `{name}`, got {attrs:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Adds Promise / Promise::XS async semantic coverage to match the existing EV and Future family.

- synthesizes Promise chain and class helper symbols
- covers Promise::XS as well
- adds focused regression tests in frameworks_async

Tests:
- cargo test -p perl-semantic-analyzer --test frameworks_async -- --nocapture