### PR TITLE
fix(config): preserve perl5lib_precedence on unknown LSP value; add missing tests (#3555)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -388,10 +388,13 @@ impl WorkspaceConfig {
                 self.use_perl5lib = use_p5l;
             }
             if let Some(prec) = workspace.get("perl5libPrecedence").and_then(|v| v.as_str()) {
-                self.perl5lib_precedence = match prec {
-                    "append" => Perl5LibPrecedence::Append,
-                    _ => Perl5LibPrecedence::Prepend,
-                };
+                // Only update on recognised values; leave the current setting unchanged for
+                // unknown strings so a typo does not silently reset an explicitly-set Append.
+                match prec {
+                    "append" => self.perl5lib_precedence = Perl5LibPrecedence::Append,
+                    "prepend" => self.perl5lib_precedence = Perl5LibPrecedence::Prepend,
+                    _ => {} // unknown value — leave current setting intact
+                }
             }
         }
     }

--- a/crates/perl-lsp-config/tests/project_config.rs
+++ b/crates/perl-lsp-config/tests/project_config.rs
@@ -402,3 +402,101 @@ fn project_config_applies_use_perl5lib_false_to_workspace_config() -> TestResult
     assert!(!config.use_perl5lib, "apply_to_workspace_config must propagate use_perl5lib=false");
     Ok(())
 }
+
+// ── WorkspaceConfig::update_from_value — PERL5LIB fields ─────────────────────
+
+#[test]
+fn workspace_config_update_from_value_sets_use_perl5lib_false() {
+    let mut config = WorkspaceConfig::default();
+    assert!(config.use_perl5lib, "use_perl5lib is true by default");
+    config.update_from_value(&serde_json::json!({
+        "workspace": { "usePerl5lib": false }
+    }));
+    assert!(!config.use_perl5lib, "update_from_value must set use_perl5lib=false");
+}
+
+#[test]
+fn workspace_config_update_from_value_sets_use_perl5lib_true() {
+    let mut config = WorkspaceConfig::default();
+    config.use_perl5lib = false;
+    config.update_from_value(&serde_json::json!({
+        "workspace": { "usePerl5lib": true }
+    }));
+    assert!(config.use_perl5lib, "update_from_value must set use_perl5lib=true");
+}
+
+#[test]
+fn workspace_config_update_from_value_sets_perl5lib_precedence_append() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    assert_eq!(config.perl5lib_precedence, Perl5LibPrecedence::Prepend);
+    config.update_from_value(&serde_json::json!({
+        "workspace": { "perl5libPrecedence": "append" }
+    }));
+    assert_eq!(
+        config.perl5lib_precedence,
+        Perl5LibPrecedence::Append,
+        "update_from_value must set perl5lib_precedence to Append"
+    );
+}
+
+#[test]
+fn workspace_config_update_from_value_sets_perl5lib_precedence_prepend() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    config.perl5lib_precedence = Perl5LibPrecedence::Append;
+    config.update_from_value(&serde_json::json!({
+        "workspace": { "perl5libPrecedence": "prepend" }
+    }));
+    assert_eq!(
+        config.perl5lib_precedence,
+        Perl5LibPrecedence::Prepend,
+        "update_from_value must set perl5lib_precedence to Prepend"
+    );
+}
+
+#[test]
+fn workspace_config_update_from_value_unknown_precedence_leaves_current_value() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    // Set to Append first, then send an unknown value — must leave Append intact.
+    config.perl5lib_precedence = Perl5LibPrecedence::Append;
+    config.update_from_value(&serde_json::json!({
+        "workspace": { "perl5libPrecedence": "replace" }
+    }));
+    assert_eq!(
+        config.perl5lib_precedence,
+        Perl5LibPrecedence::Append,
+        "unknown perl5libPrecedence value must NOT reset to Prepend"
+    );
+}
+
+#[test]
+fn effective_include_paths_prepend_preserves_full_order() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    config.perl5lib_precedence = Perl5LibPrecedence::Prepend;
+    config.include_paths = vec!["lib".to_string(), "local/lib/perl5".to_string()];
+    let p5l = vec!["/ext/a".to_string(), "/ext/b".to_string()];
+    let result = config.effective_include_paths(&p5l);
+    assert_eq!(
+        result,
+        vec!["/ext/a", "/ext/b", "lib", "local/lib/perl5"],
+        "Prepend: PERL5LIB paths first (in order), then include_paths (in order)"
+    );
+}
+
+#[test]
+fn effective_include_paths_append_preserves_full_order() {
+    use perl_lsp_config::Perl5LibPrecedence;
+    let mut config = WorkspaceConfig::default();
+    config.perl5lib_precedence = Perl5LibPrecedence::Append;
+    config.include_paths = vec!["lib".to_string(), "local/lib/perl5".to_string()];
+    let p5l = vec!["/ext/a".to_string(), "/ext/b".to_string()];
+    let result = config.effective_include_paths(&p5l);
+    assert_eq!(
+        result,
+        vec!["lib", "local/lib/perl5", "/ext/a", "/ext/b"],
+        "Append: include_paths first (in order), then PERL5LIB paths (in order)"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #3717 (merged). Two correctness issues found during deep review.

**Bug fixed**: `update_from_value` for `WorkspaceConfig` silently reset `perl5lib_precedence` to `Prepend` whenever the LSP client sent an unrecognised string (the `_` match arm). If a user had configured `Append` via TOML and then the LSP client sent a `perl5libPrecedence` key with an unexpected casing or variant (e.g. `"replace"`), the setting was silently overwritten to `Prepend`. Only `"append"` and `"prepend"` are now matched; any other string leaves the current setting intact.

**Tests added**: The LSP `update_from_value` code path for the two new PERL5LIB fields (`usePerl5lib`, `perl5libPrecedence`) had zero test coverage. Five tests added. Two additional tests assert full path-list order for `effective_include_paths` rather than only spot-checking `.first()`/`.last()`.

## Changes

- `crates/perl-lsp-config/src/lib.rs`: fix `_` match arm for `perl5libPrecedence` in `update_from_value`
- `crates/perl-lsp-config/tests/project_config.rs`: 7 new tests

## Test plan

- [x] All 33 project_config integration tests pass
- [x] `cargo clippy -p perl-lsp-config --tests` clean
- [x] `cargo fmt -p perl-lsp-config` produces no changes
- [x] `workspace_config_update_from_value_unknown_precedence_leaves_current_value` would have **failed** before the fix (would have seen `Prepend` instead of `Append`)

## Related

- Follow-up issue #3741: absolute PERL5LIB paths are silently rejected by `validate_workspace_path` — a structural issue requiring changes to `perl-module-resolution-path` and `perl-module-resolution-uri`, filed separately.