### PR TITLE
fix(parser): suppress spurious ':isa' warning for native class declarations (#3540)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -64,6 +64,13 @@ impl<'a> Parser<'a> {
     /// CPAN code (e.g. Moose `:ro`, Catalyst `:Private`).
     const BUILTIN_SUB_ATTRIBUTES: &'static [&'static str] = &["lvalue", "method", "prototype", "const"];
 
+    /// Built-in class-level attributes defined by Perl 5.38+ `use feature 'class'`.
+    ///
+    /// These are valid on `class` declarations (not subroutines) and must not be
+    /// warned about when parsing class headers.  `:isa(Parent)` declares inheritance;
+    /// `:does(Role)` is reserved for future Perl versions.
+    const BUILTIN_CLASS_ATTRIBUTES: &'static [&'static str] = &["isa", "does"];
+
     /// Return `true` if `name` is a known built-in subroutine attribute.
     fn is_builtin_sub_attribute(name: &str) -> bool {
         Self::BUILTIN_SUB_ATTRIBUTES.contains(&name)
@@ -71,10 +78,17 @@ impl<'a> Parser<'a> {
 
     /// Parse declaration attributes like `:lvalue` or `:prototype($)`.
     ///
+    /// `extra_known` lists additional attribute names that should not trigger the
+    /// "unknown subroutine attribute" warning — used by `parse_class` to whitelist
+    /// class-level attributes such as `:isa(Parent)`.
+    ///
     /// Unknown attributes produce a soft warning pushed to `self.errors` but
     /// parsing continues — custom attributes are legal in Perl via the
     /// `attributes` module or framework hooks.
-    fn parse_declaration_attributes(&mut self) -> ParseResult<Vec<String>> {
+    fn parse_declaration_attributes_with_extras(
+        &mut self,
+        extra_known: &[&str],
+    ) -> ParseResult<Vec<String>> {
         let mut attributes = Vec::new();
 
         while self.peek_kind() == Some(TokenKind::Colon) {
@@ -122,10 +136,13 @@ impl<'a> Parser<'a> {
                     }
                 }
 
-                // Warn (but do not error) if the attribute is not a known built-in.
+                // Warn (but do not error) if the attribute is not a known built-in
+                // and not an extra-known context-specific attribute.
                 // Custom attributes are valid when `attributes` or a framework hook is
                 // in scope, so a warning is the correct diagnostic level.
-                if !Self::is_builtin_sub_attribute(&base_name) {
+                let is_known = Self::is_builtin_sub_attribute(&base_name)
+                    || extra_known.contains(&base_name.as_str());
+                if !is_known {
                     self.errors.push(ParseError::syntax(
                         format!(
                             "unknown subroutine attribute ':{base_name}'; \
@@ -145,6 +162,13 @@ impl<'a> Parser<'a> {
         }
 
         Ok(attributes)
+    }
+
+    /// Parse declaration attributes like `:lvalue` or `:prototype($)`.
+    ///
+    /// Convenience wrapper for the common subroutine/method case (no extra-known attributes).
+    fn parse_declaration_attributes(&mut self) -> ParseResult<Vec<String>> {
+        self.parse_declaration_attributes_with_extras(&[])
     }
 
     /// Parse subroutine definition
@@ -246,8 +270,11 @@ impl<'a> Parser<'a> {
 
         let (name, _) = self.parse_qualified_name(false)?;
 
-        // Parse class-level attributes (e.g. `:isa(Parent)`)
-        let attributes = self.parse_declaration_attributes()?;
+        // Parse class-level attributes (e.g. `:isa(Parent)`).
+        // Pass BUILTIN_CLASS_ATTRIBUTES so `:isa` and `:does` don't produce
+        // "unknown subroutine attribute" warnings.
+        let attributes =
+            self.parse_declaration_attributes_with_extras(Self::BUILTIN_CLASS_ATTRIBUTES)?;
 
         // Extract parent class names from `:isa(Parent)` attributes.
         // `parse_declaration_attributes` stores `:isa(Parent)` as "isa(Parent)".

--- a/crates/perl-parser-core/tests/native_class_isa_tests.rs
+++ b/crates/perl-parser-core/tests/native_class_isa_tests.rs
@@ -101,3 +101,61 @@ fn class_with_qualified_isa_has_qualified_parent() {
     let parents = class_parents(r#"class MyApp::Point3D :isa(MyApp::Point) { }"#);
     assert_eq!(parents, vec!["MyApp::Point"], "expected qualified parent, got {:?}", parents);
 }
+
+// ── Regression: :isa must not produce spurious "unknown attribute" errors ─────
+//
+// Before the fix, `parse_declaration_attributes` used a single BUILTIN_SUB_ATTRIBUTES
+// list that didn't include "isa".  Every class with :isa(...) pushed a spurious
+// "unknown subroutine attribute ':isa'" error to parser.errors(), which surfaced
+// as a false diagnostic in the editor.
+
+#[test]
+fn class_with_isa_produces_no_parser_errors() {
+    let src = r#"class Point3D :isa(Point) { }"#;
+    let mut parser = Parser::new(src);
+    let _ast = must(parser.parse());
+    assert!(
+        parser.errors().is_empty(),
+        "class :isa(Point) must not produce any parser errors, got: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
+fn class_with_multiple_isa_produces_no_parser_errors() {
+    let src = r#"class Shape3D :isa(Shape) :isa(Printable) { }"#;
+    let mut parser = Parser::new(src);
+    let _ast = must(parser.parse());
+    assert!(
+        parser.errors().is_empty(),
+        "class with multiple :isa must not produce parser errors, got: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
+fn class_with_qualified_isa_produces_no_parser_errors() {
+    let src = r#"class MyApp::Point3D :isa(MyApp::Point) { }"#;
+    let mut parser = Parser::new(src);
+    let _ast = must(parser.parse());
+    assert!(
+        parser.errors().is_empty(),
+        "class :isa(MyApp::Point) must not produce parser errors, got: {:?}",
+        parser.errors()
+    );
+}
+
+// ── Guard: unknown sub attributes still warn when used on `sub`, not `class` ──
+
+#[test]
+fn sub_with_isa_attr_still_warns() {
+    // :isa is not a valid subroutine attribute — it should still produce a warning
+    // when used on `sub` (not `class`).
+    let src = r#"sub foo :isa { }"#;
+    let mut parser = Parser::new(src);
+    let _ast = must(parser.parse());
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "sub :isa should warn (not valid for subs), but errors was empty");
+    let mentions_isa = errors.iter().any(|e| format!("{e}").contains("isa"));
+    assert!(mentions_isa, "warning should mention 'isa', got: {:?}", errors);
+}

--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -2102,4 +2102,26 @@ class MyApp::Point3D :isa(MyApp::Point) {
             model.parents
         );
     }
+
+    #[test]
+    fn second_class_without_isa_does_not_inherit_first_class_parents() {
+        // Regression guard: parents from the first class must not bleed into the second.
+        // flush_current_package() uses mem::take so current_parents is reset between classes.
+        let models = build_models(
+            r#"
+class Point3D :isa(Point) {
+    field $z :param = 0;
+}
+class Standalone {
+    field $x :param = 0;
+}
+"#,
+        );
+        let standalone = models.iter().find(|m| m.name == "Standalone").expect("Standalone model");
+        assert!(
+            standalone.parents.is_empty(),
+            "Standalone class must have no parents, but got {:?}",
+            standalone.parents
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `parse_declaration_attributes` used a shared `BUILTIN_SUB_ATTRIBUTES` list that did not include `isa`. Every `class Foo :isa(Bar)` declaration pushed a spurious "unknown subroutine attribute ':isa'" error to `parser.errors()`, which surfaced as a false diagnostic in the editor for any Perl 5.38 native class with inheritance.
- Add `BUILTIN_CLASS_ATTRIBUTES = ["isa", "does"]` and a new `parse_declaration_attributes_with_extras(extra_known: &[&str])` function. `parse_class` passes the class-attribute list; sub/method parsing continues to use the original wrapper with an empty extras list — preserving the existing warning behavior for subroutines.
- Add 4 regression tests in `native_class_isa_tests.rs` verifying `parser.errors().is_empty()` for `:isa`-using classes, and 1 guard test confirming `:isa` still warns when used on `sub`.
- Add 1 semantic regression test verifying that `current_parents` does not bleed from one class into the next (guards the `mem::take` in `flush_current_package`).

## Root cause

PR #3705 added `:isa` parsing via the existing `parse_declaration_attributes` function which treats every unrecognized attribute name as a "subroutine attribute" warning. The tests added in #3705 only checked for AST `Error`/`Missing*` nodes (`assert_clean_parse`) and did not call `parser.errors()`, so the spurious soft error was not caught.

## Test plan

- [x] `cargo test -p perl-parser-core --test native_class_isa_tests` — 12 passed (was 8)
- [x] `cargo test -p perl-parser-core --test fix_attribute_validation_3357` — 11 passed (no regression to sub attribute warnings)
- [x] `cargo test -p perl-semantic-analyzer --lib native_class` — 6 passed
- [x] `cargo test -p perl-semantic-analyzer --lib second_class` — 1 passed
- [x] `cargo clippy -p perl-parser-core -p perl-semantic-analyzer --tests` — 0 errors
- [x] `just pr-fast` — passed