### PR TITLE
fix(code-actions): align PL105 spans and roll back unsafe PL110 quick fix (#3754)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -184,10 +184,6 @@ impl CodeActionsProvider {
                             &qf_diag,
                         ));
                     }
-                    // PL110: Uninitialized variable
-                    c if c == DiagnosticCode::UninitializedVariable.as_str() => {
-                        actions.extend(quick_fixes::fix_uninitialized_variable(&qf_diag));
-                    }
                     // PL111: Misspelled pragma
                     c if c == DiagnosticCode::MisspelledPragma.as_str() => {
                         actions.extend(quick_fixes::fix_misspelled_pragma(&self.source, &qf_diag));

--- a/crates/perl-lsp-code-actions/src/quick_fixes.rs
+++ b/crates/perl-lsp-code-actions/src/quick_fixes.rs
@@ -656,18 +656,8 @@ pub fn fix_variable_redeclaration(
 ) -> Vec<CodeAction> {
     let mut actions = Vec::new();
 
-    // Look for `my ` at or near the start of the diagnostic range
-    let search_start = diagnostic.range.0;
-    let search_end = diagnostic.range.1.min(source.len());
-
-    if search_start >= source.len() {
-        return actions;
-    }
-
-    let snippet = &source[search_start..search_end];
-    if let Some(my_pos) = snippet.find("my ") {
-        let abs_my_start = search_start + my_pos;
-        let abs_my_end = abs_my_start + 3; // "my ".len()
+    if let Some((abs_my_start, abs_my_end)) = find_duplicate_my_span(source, diagnostic) {
+        // Remove only the duplicate declarator and keep the assignment/value intact.
 
         actions.push(CodeAction {
             title: "Remove duplicate 'my' declaration".to_string(),
@@ -686,44 +676,18 @@ pub fn fix_variable_redeclaration(
     actions
 }
 
-/// Fix uninitialized variable by inserting `= undef` or `= ""` initialization
-///
-/// When a variable is used before being initialized (PL110), offer to initialize
-/// it at the declaration site with `undef` (the safer default) or an empty string.
-pub fn fix_uninitialized_variable(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
-    let mut actions = Vec::new();
+fn find_duplicate_my_span(source: &str, diagnostic: &QuickFixDiagnostic) -> Option<(usize, usize)> {
+    let variable_start = diagnostic.range.0.min(source.len());
+    let line_start = source[..variable_start].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+    let before_var = &source[line_start..variable_start];
+    let my_offset = before_var.rfind("my ")?;
 
-    if let Some(var_name) = diagnostic.message.split('\'').nth(1) {
-        // Initialize with undef — safe default
-        actions.push(CodeAction {
-            title: format!("Initialize '{}' with undef", var_name),
-            kind: CodeActionKind::QuickFix,
-            diagnostics: vec![DiagnosticCode::UninitializedVariable.as_str().to_string()],
-            edit: CodeActionEdit {
-                changes: vec![TextEdit {
-                    location: SourceLocation { start: diagnostic.range.1, end: diagnostic.range.1 },
-                    new_text: " = undef".to_string(),
-                }],
-            },
-            is_preferred: true,
-        });
-
-        // Initialize with empty string — common for string variables
-        actions.push(CodeAction {
-            title: format!("Initialize '{}' with empty string", var_name),
-            kind: CodeActionKind::QuickFix,
-            diagnostics: vec![DiagnosticCode::UninitializedVariable.as_str().to_string()],
-            edit: CodeActionEdit {
-                changes: vec![TextEdit {
-                    location: SourceLocation { start: diagnostic.range.1, end: diagnostic.range.1 },
-                    new_text: r#" = """#.to_string(),
-                }],
-            },
-            is_preferred: false,
-        });
+    if before_var[my_offset + 3..].chars().all(char::is_whitespace) {
+        let start = line_start + my_offset;
+        return Some((start, start + 3));
     }
 
-    actions
+    None
 }
 
 /// Fix misspelled pragma by replacing with the correctly spelled name

--- a/crates/perl-lsp-code-actions/tests/quick_fixes_new_diagnostics_test.rs
+++ b/crates/perl-lsp-code-actions/tests/quick_fixes_new_diagnostics_test.rs
@@ -1,9 +1,8 @@
 //! Tests for quick fixes added in issue #3469
 //!
-//! Covers the 7 new diagnostic quick fixes:
+//! Covers the 6 new diagnostic quick fixes:
 //! - PL200: MissingPackageDeclaration — add `package main;`
 //! - PL105: VariableRedeclaration     — remove duplicate `my`
-//! - PL110: UninitializedVariable     — add `= undef` or `= ""`
 //! - PL111: MisspelledPragma          — fix pragma spelling
 //! - PL406: UnreachableCode           — remove unreachable statement
 //! - PL300: DuplicateSubroutine       — rename second definition
@@ -107,10 +106,10 @@ fn missing_package_declaration_fix_inserts_at_top_without_shebang() {
 #[test]
 fn variable_redeclaration_fix_removes_my_keyword() {
     let src = "my $x = 1;\nmy $x = 2;\n";
-    let second_my_start = src.find("my $x = 2").unwrap_or(0);
+    let second_var_start = src.rfind("$x").unwrap_or(0);
     let diags = [make_diag(
-        second_my_start,
-        second_my_start + 10,
+        second_var_start,
+        second_var_start + 2,
         "PL105",
         "Variable '$x' is declared again in the same scope -- remove the duplicate 'my'",
     )];
@@ -126,11 +125,11 @@ fn variable_redeclaration_fix_removes_my_keyword() {
 #[test]
 fn variable_redeclaration_fix_deletes_my_prefix() {
     let src = "my $x = 1;\nmy $x = 2;\n";
-    // "my $x = 1;\n" is 11 chars, so second "my $x" starts at 11
-    let second_my_start = 11;
+    let second_my_start = src.find("my $x = 2").unwrap_or(0);
+    let second_var_start = second_my_start + 3;
     let diags = [make_diag(
-        second_my_start,
-        second_my_start + 10,
+        second_var_start,
+        second_var_start + 2,
         "PL105",
         "Variable '$x' is declared again in the same scope -- remove the duplicate 'my'",
     )];
@@ -141,6 +140,7 @@ fn variable_redeclaration_fix_deletes_my_prefix() {
 
     let edit = &action.unwrap().edit.changes[0];
     assert_eq!(edit.new_text, "", "Edit should delete 'my '");
+    assert_eq!(edit.location.start, second_my_start, "Edit should start at the duplicate 'my'");
     assert_eq!(
         edit.location.end - edit.location.start,
         3,
@@ -151,10 +151,10 @@ fn variable_redeclaration_fix_deletes_my_prefix() {
 #[test]
 fn variable_redeclaration_fix_is_preferred() {
     let src = "my $y = 1;\nmy $y = 2;\n";
-    let second_my_start = 11;
+    let second_var_start = src.rfind("$y").unwrap_or(0);
     let diags = [make_diag(
-        second_my_start,
-        second_my_start + 10,
+        second_var_start,
+        second_var_start + 2,
         "PL105",
         "Variable '$y' is declared again in the same scope",
     )];
@@ -163,62 +163,6 @@ fn variable_redeclaration_fix_is_preferred() {
     let action = find_action(&actions, "Remove duplicate");
     assert!(action.is_some(), "Expected remove duplicate action");
     assert!(action.unwrap().is_preferred, "Remove duplicate 'my' should be the preferred action");
-}
-
-// ===========================================================================
-// PL110 — UninitializedVariable
-// ===========================================================================
-
-#[test]
-fn uninitialized_variable_fix_offers_undef_initialization() {
-    let src = "my $x;\nprint $x;\n";
-    let diags = [make_diag(3, 5, "PL110", "Variable '$x' is used before being initialized")];
-    let actions = parse_and_get_actions(src, &diags);
-
-    assert!(
-        has_action_with_title(&actions, "undef"),
-        "Expected action to initialize with undef, got: {:?}",
-        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn uninitialized_variable_fix_offers_empty_string_initialization() {
-    let src = "my $name;\nprint $name;\n";
-    let diags = [make_diag(3, 8, "PL110", "Variable '$name' is used before being initialized")];
-    let actions = parse_and_get_actions(src, &diags);
-
-    assert!(
-        has_action_with_title(&actions, "empty string"),
-        "Expected action to initialize with empty string, got: {:?}",
-        actions.iter().map(|a| &a.title).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn uninitialized_variable_fix_undef_is_preferred() {
-    let src = "my $val;\nprint $val;\n";
-    let diags = [make_diag(3, 7, "PL110", "Variable '$val' is used before being initialized")];
-    let actions = parse_and_get_actions(src, &diags);
-
-    let undef_action = actions.iter().find(|a| a.title.contains("undef") && a.is_preferred);
-    assert!(undef_action.is_some(), "undef initialization should be the preferred action");
-}
-
-#[test]
-fn uninitialized_variable_fix_inserts_at_range_end() {
-    let src = "my $x;\nprint $x;\n";
-    // Range covers "$x" at position 3..5
-    let diags = [make_diag(3, 5, "PL110", "Variable '$x' is used before being initialized")];
-    let actions = parse_and_get_actions(src, &diags);
-
-    let undef_action = find_action(&actions, "undef");
-    assert!(undef_action.is_some(), "Expected undef action");
-
-    let edit = &undef_action.unwrap().edit.changes[0];
-    assert_eq!(edit.location.start, 5, "Should insert at end of diagnostic range");
-    assert_eq!(edit.location.start, edit.location.end, "Should be an insertion (start == end)");
-    assert!(edit.new_text.contains("undef"), "Inserted text should contain 'undef'");
 }
 
 // ===========================================================================

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -428,7 +428,6 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 | DiagnosticCode::DeprecatedDefined
                 | DiagnosticCode::MissingPackageDeclaration
                 | DiagnosticCode::VariableRedeclaration
-                | DiagnosticCode::UninitializedVariable
                 | DiagnosticCode::MisspelledPragma
                 | DiagnosticCode::UnreachableCode
                 | DiagnosticCode::DuplicateSubroutine

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -945,7 +945,6 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 | DiagnosticCode::DeprecatedDefined
                 | DiagnosticCode::MissingPackageDeclaration
                 | DiagnosticCode::VariableRedeclaration
-                | DiagnosticCode::UninitializedVariable
                 | DiagnosticCode::MisspelledPragma
                 | DiagnosticCode::UnreachableCode
                 | DiagnosticCode::DuplicateSubroutine


### PR DESCRIPTION
## Summary

- fixes PL105 quick-fix span handling so live variable-redeclaration diagnostics can actually surface the duplicate `my` removal
- removes the unsafe PL110 quick-fix/edit advertising until declaration-site tracking exists
- keeps both diagnostics metadata paths (`pull.rs` and `runtime/diagnostics.rs`) in sync

## Validation

- `cargo test -p perl-lsp-code-actions --test quick_fixes_new_diagnostics_test -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_diagnostic_enrichment_test -- --nocapture`

## Notes

This is a narrow follow-up to #3469 after #3747 merged with two remaining correctness gaps.
