### PR TITLE
feat(navigation): add Mojolicious route target definitions (#3576)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -27,6 +27,12 @@ static PACKAGE_ARROW_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock
 static VAR_METHOD_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 
 #[cfg(feature = "workspace")]
+static MOJO_STRING_ROUTE_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+#[cfg(feature = "workspace")]
+static MOJO_KV_ROUTE_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+#[cfg(feature = "workspace")]
 fn get_fqn_regex() -> Result<&'static regex::Regex, JsonRpcError> {
     FQN_RE
         .get_or_init(|| regex::Regex::new(r"([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)"))
@@ -167,6 +173,137 @@ fn workspace_document_text(
         crate::workspace_index::uri_to_fs_path(uri)
             .and_then(|path| std::fs::read_to_string(path).ok())
     })
+}
+
+#[cfg(feature = "workspace")]
+fn get_mojo_string_route_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    MOJO_STRING_ROUTE_RE
+        .get_or_init(|| {
+            regex::Regex::new(r"->\s*to\s*\(\s*'(?P<controller>[^'#]+)#(?P<action>[^']+)'\s*\)")
+        })
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize Mojolicious route regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn get_mojo_kv_route_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    MOJO_KV_ROUTE_RE
+        .get_or_init(|| {
+            regex::Regex::new(
+                r"->\s*to\s*\(\s*controller\s*=>\s*'(?P<controller>[^']+)'\s*,\s*action\s*=>\s*'(?P<action>[^']+)'\s*\)",
+            )
+        })
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize Mojolicious route regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn mojolicious_app_root(current_package: &str) -> Option<String> {
+    let package = current_package.trim();
+    if package.is_empty() {
+        return None;
+    }
+
+    Some(package.strip_suffix("::App").unwrap_or(package).to_string())
+}
+
+#[cfg(feature = "workspace")]
+fn normalize_mojolicious_controller_name(raw: &str) -> Option<String> {
+    let normalized = raw.trim().trim_matches('\'').trim_matches('"').trim();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let mut segments = Vec::new();
+    for segment in normalized.split("::").flat_map(|part| part.split('/')) {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        let mut chars = segment.chars();
+        let first = chars.next()?;
+        let mut normalized_segment = first.to_uppercase().collect::<String>();
+        normalized_segment.push_str(chars.as_str());
+        segments.push(normalized_segment);
+    }
+
+    if segments.is_empty() { None } else { Some(segments.join("::")) }
+}
+
+#[cfg(feature = "workspace")]
+fn resolve_mojolicious_route_definition(
+    workspace_index: &crate::workspace_index::WorkspaceIndex,
+    current_package: &str,
+    text_around: &str,
+    cursor_in_text: usize,
+) -> Option<crate::workspace_index::Location> {
+    let app_root = mojolicious_app_root(current_package)?;
+
+    let try_route = |controller: &str, action: &str| {
+        let controller_name = normalize_mojolicious_controller_name(controller)?;
+        let package_name = format!("{app_root}::Controller::{controller_name}");
+        find_workspace_definition_location(workspace_index, &package_name, action)
+    };
+
+    let string_re = get_mojo_string_route_regex().ok()?;
+    for cap in string_re.captures_iter(text_around) {
+        let Some(full_match) = cap.get(0) else {
+            continue;
+        };
+        if cursor_in_text < full_match.start() || cursor_in_text >= full_match.end() {
+            continue;
+        }
+
+        let Some(controller_match) = cap.name("controller") else {
+            continue;
+        };
+        let Some(action_match) = cap.name("action") else {
+            continue;
+        };
+
+        if (cursor_in_text >= controller_match.start() && cursor_in_text < controller_match.end())
+            || (cursor_in_text >= action_match.start() && cursor_in_text < action_match.end())
+        {
+            if let Some(location) = try_route(controller_match.as_str(), action_match.as_str()) {
+                return Some(location);
+            }
+        }
+    }
+
+    let kv_re = get_mojo_kv_route_regex().ok()?;
+    for cap in kv_re.captures_iter(text_around) {
+        let Some(full_match) = cap.get(0) else {
+            continue;
+        };
+        if cursor_in_text < full_match.start() || cursor_in_text >= full_match.end() {
+            continue;
+        }
+
+        let Some(controller_match) = cap.name("controller") else {
+            continue;
+        };
+        let Some(action_match) = cap.name("action") else {
+            continue;
+        };
+
+        if (cursor_in_text >= controller_match.start() && cursor_in_text < controller_match.end())
+            || (cursor_in_text >= action_match.start() && cursor_in_text < action_match.end())
+        {
+            if let Some(location) = try_route(controller_match.as_str(), action_match.as_str()) {
+                return Some(location);
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(feature = "workspace")]
@@ -535,6 +672,28 @@ impl LspServer {
 
                 #[cfg(feature = "workspace")]
                 {
+                    if let Some(ref ast) = doc.ast {
+                        if let Some(coordinator) = self.coordinator() {
+                            let workspace_index = coordinator.index();
+                            let current_package =
+                                crate::declaration::current_package_at(ast, offset);
+                            if let Some(def_location) = resolve_mojolicious_route_definition(
+                                workspace_index,
+                                current_package,
+                                &text_around,
+                                cursor_in_text,
+                            ) {
+                                if let Some(lsp_location) =
+                                    crate::workspace_index::lsp_adapter::to_lsp_location(
+                                        &def_location,
+                                    )
+                                {
+                                    return Ok(Some(json!([lsp_location])));
+                                }
+                            }
+                        }
+                    }
+
                     // Attempt to resolve fully-qualified symbols like Package::sub
                     let fqn_regex = get_fqn_regex()?;
                     for cap in fqn_regex.captures_iter(&text_around) {

--- a/crates/perl-lsp/tests/mojolicious_navigation_tests.rs
+++ b/crates/perl-lsp/tests/mojolicious_navigation_tests.rs
@@ -1,0 +1,181 @@
+//! Focused go-to-definition tests for Mojolicious route targets.
+
+mod support;
+
+use serde_json::json;
+use support::lsp_harness::{LspHarness, TempWorkspace};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn assert_valid_location(location: &serde_json::Value) {
+    assert!(location.get("uri").is_some(), "Location must have 'uri' field, got: {:?}", location);
+    let range = location.get("range");
+    assert!(range.is_some(), "Location must have 'range' field, got: {:?}", location);
+    let range = range.unwrap_or(&json!(null));
+    assert!(range.get("start").is_some(), "Range must have 'start' position");
+    assert!(range.get("end").is_some(), "Range must have 'end' position");
+}
+
+fn first_location(result: &serde_json::Value) -> Option<&serde_json::Value> {
+    if let Some(locations) = result.as_array() {
+        locations.first()
+    } else if result.is_object() {
+        Some(result)
+    } else {
+        None
+    }
+}
+
+fn position_of(text: &str, needle: &str) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    for (line_idx, line) in text.lines().enumerate() {
+        if let Some(char_idx) = line.find(needle) {
+            return Ok((line_idx, char_idx));
+        }
+    }
+
+    Err(format!("needle `{needle}` not found in test text").into())
+}
+
+#[test]
+fn mojolicious_string_route_target_definitions_to_controller_method() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    workspace.write(
+        "lib/MyApp/Controller/User.pm",
+        r#"package MyApp::Controller::User;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub list {
+    my $self = shift;
+    return "ok";
+}
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "lib/MyApp/App.pm",
+        r#"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/')->to('user#list');
+}
+
+1;
+"#,
+    )?;
+
+    let app_text = r#"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/')->to('user#list');
+}
+
+1;
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(
+        &workspace.uri("lib/MyApp/Controller/User.pm"),
+        &std::fs::read_to_string(workspace.dir.path().join("lib/MyApp/Controller/User.pm"))?,
+    )?;
+    harness.open(&workspace.uri("lib/MyApp/App.pm"), app_text)?;
+    harness.barrier();
+
+    let (line, character) = position_of(app_text, "user#list")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/MyApp/App.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let location = first_location(&result).ok_or("expected a definition location")?;
+    assert_valid_location(location);
+    let uri = location["uri"].as_str().ok_or("expected definition URI")?;
+    assert!(
+        uri.contains("MyApp/Controller/User.pm"),
+        "definition should point to controller file, got: {uri}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mojolicious_kv_route_target_definitions_to_controller_method() -> TestResult {
+    let workspace = TempWorkspace::new()?;
+    workspace.write(
+        "lib/MyApp/Controller/Admin.pm",
+        r#"package MyApp::Controller::Admin;
+use Mojo::Base 'Mojolicious::Controller';
+
+sub dashboard {
+    my $self = shift;
+    return "ok";
+}
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "lib/MyApp/App.pm",
+        r#"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/admin')->to(controller => 'admin', action => 'dashboard');
+}
+
+1;
+"#,
+    )?;
+
+    let app_text = r#"package MyApp::App;
+use Mojo::Base 'Mojolicious';
+
+sub startup {
+    my $self = shift;
+    my $r = $self->routes;
+    $r->get('/admin')->to(controller => 'admin', action => 'dashboard');
+}
+
+1;
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(
+        &workspace.uri("lib/MyApp/Controller/Admin.pm"),
+        &std::fs::read_to_string(workspace.dir.path().join("lib/MyApp/Controller/Admin.pm"))?,
+    )?;
+    harness.open(&workspace.uri("lib/MyApp/App.pm"), app_text)?;
+    harness.barrier();
+
+    let (line, character) = position_of(app_text, "dashboard")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/MyApp/App.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let location = first_location(&result).ok_or("expected a definition location")?;
+    assert_valid_location(location);
+    let uri = location["uri"].as_str().ok_or("expected definition URI")?;
+    assert!(
+        uri.contains("MyApp/Controller/Admin.pm"),
+        "definition should point to controller file, got: {uri}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add focused goto-definition support for Mojolicious route targets in app startup code
- support `->to('controller#action')` and `->to(controller => '...', action => '...')`
- add focused LSP tests covering both route-target forms

## Testing
- cargo test -p perl-lsp-rs --test mojolicious_navigation_tests -- --nocapture
- cargo test -p perl-lsp-rs --test lsp_definition_tests test_go_to_sub_definition -- --nocapture
- cargo fmt --all --check
