### PR TITLE
feat(semantic): add Catalyst action metadata (#3577)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -380,6 +380,8 @@ pub struct FrameworkFlags {
     pub web_framework: Option<WebFrameworkKind>,
     /// Async framework variant, if any (IO::Async).
     pub async_framework: Option<AsyncFrameworkKind>,
+    /// Catalyst controller/package marker used for action synthesis.
+    pub catalyst_controller: bool,
 }
 
 /// Extract symbols from an AST for Parse/Index workflows.
@@ -522,6 +524,37 @@ impl SymbolExtractor {
 
                 if name.is_some() {
                     let documentation = self.extract_leading_comment(node.location.start);
+                    let mut symbol_attributes = attributes.clone();
+                    let documentation = if self.current_package_is_catalyst_controller()
+                        && let Some((action_kind, action_details)) =
+                            Self::catalyst_action_metadata(attributes)
+                    {
+                        symbol_attributes.push("framework=Catalyst".to_string());
+                        symbol_attributes.push("catalyst_controller=true".to_string());
+                        symbol_attributes.push("catalyst_action=true".to_string());
+                        symbol_attributes.push(format!("catalyst_action_kind={action_kind}"));
+                        if !action_details.is_empty() {
+                            symbol_attributes.push(format!(
+                                "catalyst_action_attributes={}",
+                                action_details.join(", ")
+                            ));
+                        }
+
+                        let action_doc = if action_details.is_empty() {
+                            format!("Catalyst action ({action_kind})")
+                        } else {
+                            format!(
+                                "Catalyst action ({action_kind}; {})",
+                                action_details.join(", ")
+                            )
+                        };
+                        match documentation {
+                            Some(doc) => Some(format!("{doc}\n{action_doc}")),
+                            None => Some(action_doc),
+                        }
+                    } else {
+                        documentation
+                    };
                     let symbol = Symbol {
                         name: sub_name.clone(),
                         qualified_name: format!("{}::{}", self.table.current_package, sub_name),
@@ -530,7 +563,7 @@ impl SymbolExtractor {
                         scope_id: self.table.current_scope(),
                         declaration: None,
                         documentation,
-                        attributes: attributes.clone(),
+                        attributes: symbol_attributes,
                     };
 
                     self.table.add_symbol(symbol);
@@ -552,6 +585,9 @@ impl SymbolExtractor {
             NodeKind::Package { name, block, name_span: _ } => {
                 let old_package = self.table.current_package.clone();
                 self.table.current_package = name.clone();
+                if Self::is_catalyst_controller_package_name(name) {
+                    self.mark_catalyst_controller_package(name);
+                }
 
                 let documentation = self.extract_package_documentation(name, node.location);
                 let symbol = Symbol {
@@ -801,8 +837,13 @@ impl SymbolExtractor {
                 self.visit_node(body);
             }
 
-            NodeKind::Class { name, body, .. } => {
+            NodeKind::Class { name, parents, body } => {
                 let documentation = self.extract_leading_comment(node.location.start);
+                if Self::is_catalyst_controller_package_name(name)
+                    || parents.iter().any(|parent| parent == "Catalyst::Controller")
+                {
+                    self.mark_catalyst_controller_package(name);
+                }
                 let symbol = Symbol {
                     name: name.clone(),
                     qualified_name: name.clone(),
@@ -1222,6 +1263,10 @@ impl SymbolExtractor {
             let keyword = name.as_str();
             let names: Vec<String> = args.iter().flat_map(Self::collect_symbol_names).collect();
             if !names.is_empty() {
+                if names.iter().any(|name| name == "Catalyst::Controller") {
+                    let package = self.table.current_package.clone();
+                    self.mark_catalyst_controller_package(&package);
+                }
                 let ref_kind =
                     if keyword == "extends" { SymbolKind::Class } else { SymbolKind::Role };
                 for ref_name in names {
@@ -1262,6 +1307,11 @@ impl SymbolExtractor {
         let names = Self::collect_symbol_names(expression);
         if names.is_empty() {
             return None;
+        }
+
+        if names.iter().any(|name| name == "Catalyst::Controller") {
+            let package = self.table.current_package.clone();
+            self.mark_catalyst_controller_package(&package);
         }
 
         let ref_location = SourceLocation { start: first.location.start, end: second.location.end };
@@ -1994,14 +2044,14 @@ impl SymbolExtractor {
         };
 
         if let Some(kind) = framework_kind {
-            let flags = self.framework_flags.entry(pkg).or_default();
+            let flags = self.framework_flags.entry(pkg.clone()).or_default();
             flags.moo = true;
             flags.kind = Some(kind);
             return;
         }
 
         if module == "Class::Accessor" {
-            self.framework_flags.entry(pkg).or_default().class_accessor = true;
+            self.framework_flags.entry(pkg.clone()).or_default().class_accessor = true;
             return;
         }
 
@@ -2012,66 +2062,66 @@ impl SymbolExtractor {
             _ => None,
         };
         if let Some(kind) = web_kind {
-            self.framework_flags.entry(pkg).or_default().web_framework = Some(kind);
+            self.framework_flags.entry(pkg.clone()).or_default().web_framework = Some(kind);
             return;
         }
 
         if module == "IO::Async" || module.starts_with("IO::Async::") {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::IOAsync);
             return;
         }
 
         if module == "AnyEvent" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::AnyEvent);
             return;
         }
 
         if module == "EV" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::EV);
             return;
         }
 
         if module == "Future" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::Future);
             return;
         }
 
         if module == "Future::XS" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::FutureXS);
             return;
         }
 
         if module == "Promise" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::Promise);
             return;
         }
 
         if module == "Promise::XS" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::PromiseXS);
             return;
         }
 
         if module == "POE" || module.starts_with("POE::") {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::POE);
             return;
         }
 
         if module == "Mojo::Redis" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::MojoRedis);
             return;
         }
 
         if module == "Mojo::Pg" {
-            self.framework_flags.entry(pkg).or_default().async_framework =
+            self.framework_flags.entry(pkg.clone()).or_default().async_framework =
                 Some(AsyncFrameworkKind::MojoPg);
             return;
         }
@@ -2082,9 +2132,82 @@ impl SymbolExtractor {
                 .filter_map(|arg| Self::normalize_symbol_name(arg))
                 .any(|arg| arg == "Class::Accessor");
             if has_class_accessor_parent {
-                self.framework_flags.entry(pkg).or_default().class_accessor = true;
+                self.framework_flags.entry(pkg.clone()).or_default().class_accessor = true;
+            }
+            let has_catalyst_controller_parent = args
+                .iter()
+                .filter_map(|arg| Self::normalize_symbol_name(arg))
+                .any(|arg| arg == "Catalyst::Controller");
+            if has_catalyst_controller_parent {
+                self.mark_catalyst_controller_package(&pkg);
             }
         }
+    }
+
+    fn mark_catalyst_controller_package(&mut self, package: &str) {
+        self.framework_flags.entry(package.to_string()).or_default().catalyst_controller = true;
+    }
+
+    fn current_package_is_catalyst_controller(&self) -> bool {
+        self.framework_flags
+            .get(&self.table.current_package)
+            .is_some_and(|flags| flags.catalyst_controller)
+            || Self::is_catalyst_controller_package_name(&self.table.current_package)
+    }
+
+    fn is_catalyst_controller_package_name(package: &str) -> bool {
+        package.contains("::Controller::") || package.ends_with("::Controller")
+    }
+
+    fn catalyst_action_metadata(attributes: &[String]) -> Option<(String, Vec<String>)> {
+        let mut kind = None;
+        let mut details = Vec::new();
+        let mut seen = HashSet::new();
+
+        for attr in attributes {
+            let attr_name = Self::attribute_base_name(attr);
+            if !Self::is_catalyst_action_attribute(&attr_name) {
+                continue;
+            }
+
+            if kind.is_none()
+                || matches!(kind.as_deref(), Some("Args" | "CaptureArgs" | "PathPart"))
+            {
+                if matches!(attr_name.as_str(), "Path" | "Local" | "Global" | "Regex" | "Chained") {
+                    kind = Some(attr_name.clone());
+                } else if kind.is_none() {
+                    kind = Some(attr_name.clone());
+                }
+            }
+
+            if seen.insert(attr.clone()) {
+                details.push(attr.clone());
+            }
+        }
+
+        if kind
+            .as_deref()
+            .is_some_and(|kind| matches!(kind, "Path" | "Local" | "Global" | "Regex" | "Chained"))
+        {
+            details.retain(|attr| Self::attribute_base_name(attr) != kind.as_deref().unwrap());
+        }
+
+        kind.map(|kind| (kind, details))
+    }
+
+    fn is_catalyst_action_attribute(attr_name: &str) -> bool {
+        matches!(
+            attr_name,
+            "Path" | "Local" | "Global" | "Regex" | "Chained" | "PathPart" | "Args" | "CaptureArgs"
+        )
+    }
+
+    fn attribute_base_name(attr: &str) -> String {
+        attr.trim_start_matches(':')
+            .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == ':'))
+            .next()
+            .unwrap_or("")
+            .to_string()
     }
 
     /// Parse attribute metadata from Moo/Moose option hashes.

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -2185,11 +2185,10 @@ impl SymbolExtractor {
             }
         }
 
-        if kind
-            .as_deref()
-            .is_some_and(|kind| matches!(kind, "Path" | "Local" | "Global" | "Regex" | "Chained"))
+        if let Some(action_kind) = kind.as_deref()
+            && matches!(action_kind, "Path" | "Local" | "Global" | "Regex" | "Chained")
         {
-            details.retain(|attr| Self::attribute_base_name(attr) != kind.as_deref().unwrap());
+            details.retain(|attr| Self::attribute_base_name(attr) != action_kind);
         }
 
         kind.map(|kind| (kind, details))

--- a/crates/perl-semantic-analyzer/tests/frameworks_catalyst.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_catalyst.rs
@@ -1,0 +1,121 @@
+//! Catalyst controller/action semantic extraction tests.
+
+use perl_semantic_analyzer::{
+    Parser,
+    symbol::{Symbol, SymbolExtractor, SymbolKind, SymbolTable},
+};
+use perl_tdd_support::{must, must_some};
+
+fn extract_symbols(code: &str) -> SymbolTable {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    SymbolExtractor::new_with_source(code).extract(&ast)
+}
+
+fn symbol<'a>(table: &'a SymbolTable, name: &str, kind: SymbolKind) -> Option<&'a Symbol> {
+    table.symbols.get(name).and_then(|symbols| symbols.iter().find(|symbol| symbol.kind == kind))
+}
+
+#[test]
+fn catalyst_controller_package_marks_action_metadata() {
+    let code = r#"
+package MyApp::Controller::Root;
+
+sub index :Path :Args(0) { }
+sub ping :Local { }
+"#;
+
+    let table = extract_symbols(code);
+
+    let index = must_some(symbol(&table, "index", SymbolKind::Subroutine));
+    assert!(
+        index.attributes.iter().any(|attr| attr == "framework=Catalyst"),
+        "expected Catalyst framework metadata on `index`"
+    );
+    assert!(
+        index.attributes.iter().any(|attr| attr == "catalyst_controller=true"),
+        "expected controller marker on `index`"
+    );
+    assert!(
+        index.attributes.iter().any(|attr| attr == "catalyst_action=true"),
+        "expected action marker on `index`"
+    );
+    assert!(
+        index.attributes.iter().any(|attr| attr == "catalyst_action_kind=Path"),
+        "expected `Path` action kind on `index`"
+    );
+    assert!(
+        index.attributes.iter().any(|attr| attr.starts_with("catalyst_action_attributes=")),
+        "expected synthesized action attribute summary on `index`"
+    );
+    let index_doc = must_some(index.documentation.as_deref());
+    assert!(
+        index_doc.contains("Catalyst action") && index_doc.contains("Args(0)"),
+        "expected Catalyst action documentation on `index`, got: {index_doc}"
+    );
+
+    let ping = must_some(symbol(&table, "ping", SymbolKind::Subroutine));
+    assert!(
+        ping.attributes.iter().any(|attr| attr == "catalyst_action_kind=Local"),
+        "expected `Local` action kind on `ping`"
+    );
+    let ping_doc = must_some(ping.documentation.as_deref());
+    assert!(
+        ping_doc.contains("Catalyst action") && ping_doc.contains("Local"),
+        "expected Catalyst action documentation on `ping`, got: {ping_doc}"
+    );
+}
+
+#[test]
+fn catalyst_controller_via_parent_marks_global_action() {
+    let code = r#"
+package MyApp::Admin;
+use parent 'Catalyst::Controller';
+
+sub dashboard :Global { }
+"#;
+
+    let table = extract_symbols(code);
+    let dashboard = must_some(symbol(&table, "dashboard", SymbolKind::Subroutine));
+    assert!(
+        dashboard.attributes.iter().any(|attr| attr == "framework=Catalyst"),
+        "expected Catalyst framework metadata on `dashboard`"
+    );
+    assert!(
+        dashboard.attributes.iter().any(|attr| attr == "catalyst_controller=true"),
+        "expected controller marker on `dashboard`"
+    );
+    assert!(
+        dashboard.attributes.iter().any(|attr| attr == "catalyst_action_kind=Global"),
+        "expected `Global` action kind on `dashboard`"
+    );
+    let dashboard_doc = must_some(dashboard.documentation.as_deref());
+    assert!(
+        dashboard_doc.contains("Catalyst action") && dashboard_doc.contains("Global"),
+        "expected Catalyst action documentation on `dashboard`, got: {dashboard_doc}"
+    );
+}
+
+#[test]
+fn non_controller_package_is_not_tagged_as_catalyst_action() {
+    let code = r#"
+package MyApp::Utility;
+
+sub helper :Path :Args(0) { }
+"#;
+
+    let table = extract_symbols(code);
+    let helper = must_some(symbol(&table, "helper", SymbolKind::Subroutine));
+    assert!(
+        !helper.attributes.iter().any(|attr| attr == "framework=Catalyst"),
+        "did not expect Catalyst metadata in a non-controller package"
+    );
+    assert!(
+        !helper.attributes.iter().any(|attr| attr == "catalyst_action=true"),
+        "did not expect Catalyst action marker in a non-controller package"
+    );
+    assert!(
+        helper.documentation.as_deref().map_or(true, |doc| !doc.contains("Catalyst action")),
+        "did not expect Catalyst action documentation in a non-controller package"
+    );
+}


### PR DESCRIPTION
## Summary
- detect Catalyst controller packages with narrow package/parent heuristics
- tag action subs with Catalyst metadata derived from existing subroutine attributes
- add focused semantic-analyzer coverage for Catalyst controller/action extraction

## Testing
- cargo test -p perl-semantic-analyzer --test frameworks_catalyst -- --nocapture
- cargo test -p perl-semantic-analyzer --test frameworks_web -- --nocapture
- cargo fmt --all --check

## Notes
- `cargo test -p perl-semantic-analyzer --test comprehensive_unit_tests symbol_extraction_method_preserves_attributes -- --nocapture` still fails on clean `master`; this branch does not introduce that failure.
