### PR TITLE
feat(parser): add contextual async/await syntax (#3608)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
@@ -19,10 +19,61 @@ fn is_typeglob_punct_terminator(kind: Option<TokenKind>) -> bool {
 }
 
 impl<'a> Parser<'a> {
+    fn is_contextual_await_start(&mut self) -> bool {
+        if self.peek_kind() != Some(TokenKind::Identifier)
+            || !self.tokens.peek().is_ok_and(|token| token.text.as_ref() == "await")
+        {
+            return false;
+        }
+
+        let second_kind = self.tokens.peek_second().ok().map(|token| token.kind);
+        if matches!(
+            second_kind,
+            Some(TokenKind::FatArrow | TokenKind::Arrow | TokenKind::DoubleColon)
+        ) {
+            return false;
+        }
+
+        if second_kind == Some(TokenKind::Colon)
+            && self.tokens.peek_third().is_ok_and(|token| token.kind == TokenKind::Colon)
+        {
+            return false;
+        }
+
+        true
+    }
+
     /// Parse unary expression
     fn parse_unary(&mut self) -> ParseResult<Node> {
         if self.peek_kind() == Some(TokenKind::Slash) {
             self.tokens.relex_as_term();
+        }
+
+        if self.is_contextual_await_start() {
+            let op_token = self.tokens.next()?;
+            let start = op_token.start;
+
+            if self.tokens.is_eof() || self.is_at_statement_end() {
+                let end = op_token.end;
+                return Ok(Node::new(
+                    NodeKind::Unary {
+                        op: op_token.text.to_string(),
+                        operand: Box::new(Node::new(
+                            NodeKind::Undef,
+                            SourceLocation { start: end, end },
+                        )),
+                    },
+                    SourceLocation { start, end },
+                ));
+            }
+
+            let operand = self.parse_unary()?;
+            let end = operand.location.end;
+
+            return Ok(Node::new(
+                NodeKind::Unary { op: op_token.text.to_string(), operand: Box::new(operand) },
+                SourceLocation { start, end },
+            ));
         }
 
         if let Some(kind) = self.peek_kind() {

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -83,6 +83,41 @@ impl<'a> Parser<'a> {
             .unwrap_or(false)
     }
 
+    fn is_async_sub_start(&mut self) -> bool {
+        self.peek_kind() == Some(TokenKind::Identifier)
+            && self.tokens.peek().ok().is_some_and(|t| t.text.as_ref() == "async")
+            && self
+                .tokens
+                .peek_second()
+                .ok()
+                .is_some_and(|t| t.kind == TokenKind::Sub)
+    }
+
+    fn finish_subroutine_statement(&mut self, sub_node: Node) -> ParseResult<Node> {
+        Ok(if let NodeKind::Subroutine { name, .. } = &sub_node.kind {
+            if name.is_none() {
+                // Anonymous sub may be followed by arrow: sub { 42 }->()
+                let expr = if self.peek_kind() == Some(TokenKind::Arrow) {
+                    self.parse_postfix_chain(sub_node)?
+                } else {
+                    sub_node
+                };
+                // Wrap anonymous subroutines in expression statements
+                let location = expr.location;
+                Node::new(
+                    NodeKind::ExpressionStatement { expression: Box::new(expr) },
+                    location,
+                )
+            } else {
+                // Named subroutines are statements by themselves
+                sub_node
+            }
+        } else {
+            // Shouldn't happen, but return as-is
+            sub_node
+        })
+    }
+
     fn parse_statement_inner(&mut self) -> ParseResult<Node> {
         // Every new statement begins here
         self.at_stmt_start = true;
@@ -141,7 +176,18 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let mut stmt = match kind {
+        let mut stmt = if self.is_async_sub_start() {
+            let async_token = self.consume_token()?;
+            let mut sub_node = self.parse_subroutine()?;
+            sub_node.location.start = async_token.start;
+            if let NodeKind::Subroutine { attributes, .. } = &mut sub_node.kind
+                && !attributes.iter().any(|attr| attr == "async")
+            {
+                attributes.insert(0, "async".to_string());
+            }
+            self.finish_subroutine_statement(sub_node)
+        } else {
+            match kind {
             // Empty statement (lone semicolon) - just consume and return a no-op
             TokenKind::Semicolon => {
                 let pos = self.current_position();
@@ -234,29 +280,7 @@ impl<'a> Parser<'a> {
             // Subroutines and modern OOP
             TokenKind::Sub => {
                 let sub_node = self.parse_subroutine()?;
-                // Check if this is an anonymous subroutine
-                Ok(if let NodeKind::Subroutine { name, .. } = &sub_node.kind {
-                    if name.is_none() {
-                        // Anonymous sub may be followed by arrow: sub { 42 }->()
-                        let expr = if self.peek_kind() == Some(TokenKind::Arrow) {
-                            self.parse_postfix_chain(sub_node)?
-                        } else {
-                            sub_node
-                        };
-                        // Wrap anonymous subroutines in expression statements
-                        let location = expr.location;
-                        Node::new(
-                            NodeKind::ExpressionStatement { expression: Box::new(expr) },
-                            location,
-                        )
-                    } else {
-                        // Named subroutines are statements by themselves
-                        sub_node
-                    }
-                } else {
-                    // Shouldn't happen, but return as-is
-                    sub_node
-                })
+                self.finish_subroutine_statement(sub_node)
             }
             TokenKind::Class => self.parse_class(),
             // `method NAME SIGNATURE BLOCK` is a Perl 5.38+ declaration.
@@ -357,6 +381,7 @@ impl<'a> Parser<'a> {
                 } else {
                     self.parse_expression_statement()
                 }
+            }
             }
         }?;
 

--- a/crates/perl-parser-core/tests/fix_async_await_3608.rs
+++ b/crates/perl-parser-core/tests/fix_async_await_3608.rs
@@ -1,0 +1,120 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::*;
+use perl_parser_core::{Node, NodeKind};
+
+fn find_unary_op<'a>(node: &'a Node, op: &str) -> Option<&'a Node> {
+    if matches!(&node.kind, NodeKind::Unary { op: unary_op, .. } if unary_op == op) {
+        return Some(node);
+    }
+
+    node.children().into_iter().find_map(|child| find_unary_op(child, op))
+}
+
+#[test]
+fn async_named_subroutine_carries_async_attribute() {
+    let ast = parse("use Future::AsyncAwait; async sub fetch { return await lookup(); }");
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got {}", ast.kind.kind_name());
+    };
+
+    let sub = statements
+        .iter()
+        .find(|statement| matches!(statement.kind, NodeKind::Subroutine { .. }))
+        .expect("expected named subroutine statement");
+
+    let NodeKind::Subroutine { name, attributes, body, .. } = &sub.kind else {
+        panic!("expected subroutine node, got {}", sub.kind.kind_name());
+    };
+
+    assert_eq!(name.as_deref(), Some("fetch"));
+    assert!(
+        attributes.iter().any(|attr| attr == "async"),
+        "expected `async` attribute on async subroutine, got {attributes:?}"
+    );
+    assert!(
+        find_unary_op(body, "await").is_some(),
+        "expected unary `await` inside async subroutine body, got {}",
+        body.to_sexp()
+    );
+}
+
+#[test]
+fn await_parses_as_unary_operator() {
+    let ast = parse("my $result = await fetch();");
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got {}", ast.kind.kind_name());
+    };
+
+    let decl = statements.first().expect("expected one statement");
+    let NodeKind::VariableDeclaration { initializer: Some(initializer), .. } = &decl.kind else {
+        panic!("expected variable declaration with initializer, got {}", decl.kind.kind_name());
+    };
+
+    let NodeKind::Unary { op, .. } = &initializer.kind else {
+        panic!("expected unary initializer, got {}", initializer.kind.kind_name());
+    };
+
+    assert_eq!(op, "await");
+}
+
+#[test]
+fn async_bareword_hash_key_stays_parseable() {
+    assert_clean_parse("async => 1;");
+}
+
+#[test]
+fn async_block_stays_parseable_as_a_call() {
+    let ast = parse("async { 1 };");
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got {}", ast.kind.kind_name());
+    };
+
+    let stmt = statements.first().expect("expected one statement");
+    let NodeKind::ExpressionStatement { expression } = &stmt.kind else {
+        panic!(
+            "expected expression statement for `async {{ ... }}`, got {}",
+            stmt.kind.kind_name()
+        );
+    };
+
+    let NodeKind::FunctionCall { name, .. } = &expression.kind else {
+        panic!(
+            "expected `async {{ ... }}` to stay a function call, got {}",
+            expression.kind.kind_name()
+        );
+    };
+
+    assert_eq!(name, "async");
+}
+
+#[test]
+fn package_qualified_await_stays_a_function_call() {
+    let ast = parse("await::helper();");
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got {}", ast.kind.kind_name());
+    };
+
+    let stmt = statements.first().expect("expected one statement");
+    let NodeKind::ExpressionStatement { expression } = &stmt.kind else {
+        panic!(
+            "expected expression statement for `await::helper()`, got {}",
+            stmt.kind.kind_name()
+        );
+    };
+
+    assert!(
+        find_unary_op(expression, "await").is_none(),
+        "expected package-qualified `await::helper()` to avoid unary await parsing, got {}",
+        expression.to_sexp()
+    );
+
+    let NodeKind::FunctionCall { name, .. } = &expression.kind else {
+        panic!(
+            "expected `await::helper()` to stay a function call, got {}",
+            expression.kind.kind_name()
+        );
+    };
+
+    assert_eq!(name, "await::helper");
+}

--- a/crates/perl-semantic-analyzer/tests/async_sub_attributes.rs
+++ b/crates/perl-semantic-analyzer/tests/async_sub_attributes.rs
@@ -1,0 +1,39 @@
+use perl_semantic_analyzer::{
+    Parser,
+    symbol::{SymbolExtractor, SymbolKind, SymbolTable},
+};
+use perl_tdd_support::must;
+
+fn extract_symbols(code: &str) -> SymbolTable {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    SymbolExtractor::new_with_source(code).extract(&ast)
+}
+
+fn symbol_attrs(table: &SymbolTable, name: &str, kind: SymbolKind) -> Vec<String> {
+    table
+        .symbols
+        .get(name)
+        .and_then(|symbols| symbols.iter().find(|symbol| symbol.kind == kind))
+        .map(|symbol| symbol.attributes.clone())
+        .unwrap_or_default()
+}
+
+#[test]
+fn named_async_subroutines_propagate_the_async_attribute() {
+    let code = r#"
+use Future::AsyncAwait;
+
+async sub fetch {
+    return await lookup();
+}
+"#;
+
+    let table = extract_symbols(code);
+    let attrs = symbol_attrs(&table, "fetch", SymbolKind::Subroutine);
+
+    assert!(
+        attrs.iter().any(|attr| attr == "async"),
+        "expected `async` attribute on named async subroutine, got {attrs:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add contextual async sub parsing and tag subroutines with the async attribute
- parse unary await without turning ordinary async/await barewords into global keywords
- add parser and semantic regression tests for async/await forms and package-qualified await::... calls

## Testing
- cargo test -p perl-parser-core --test fix_async_await_3608 -- --nocapture
- cargo test -p perl-semantic-analyzer --test async_sub_attributes -- --nocapture
- cargo fmt --all --check
- git diff --check