### PR TITLE
feat(navigation): add Dancer route target definitions (#3575)

### DIFF
--- a/crates/perl-lsp/tests/dancer_navigation_tests.rs
+++ b/crates/perl-lsp/tests/dancer_navigation_tests.rs
@@ -1,0 +1,53 @@
+//! Focused go-to-definition tests for Dancer and Dancer2 route targets.
+
+mod common;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[cfg(test)]
+mod dancer_navigation_tests {
+    use super::TestResult;
+    use crate::common::test_utils::{TestServerBuilder, semantic};
+
+    fn goto_def(
+        code: &str,
+        uri: &str,
+        needle: &str,
+        target_line: usize,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+        let (line, character) = semantic::find_pos(code, needle, target_line);
+        Ok(server.get_definition(uri, line, character))
+    }
+
+    #[test]
+    fn dancer_route_target_definitions_to_named_sub() -> TestResult {
+        let code =
+            "use Dancer;\nget '/about' => 'show_about';\nsub show_about { return 'About'; }\n";
+        let uri = "file:///dancer_route_target.pl";
+
+        let resp = goto_def(code, uri, "show_about", 1)?;
+        let (def_uri, def_line, _) = semantic::first_location(&resp)
+            .ok_or("Expected goto-definition to resolve the Dancer route target")?;
+
+        assert_eq!(def_uri, uri, "Definition should stay in the same file");
+        assert_eq!(def_line, 2, "Definition should point to the named sub handler");
+        Ok(())
+    }
+
+    #[test]
+    fn dancer2_route_target_definitions_to_named_sub() -> TestResult {
+        let code =
+            "use Dancer2;\nget '/status' => 'show_status';\nsub show_status { return 'ok'; }\n";
+        let uri = "file:///dancer2_route_target.pl";
+
+        let resp = goto_def(code, uri, "show_status", 1)?;
+        let (def_uri, def_line, _) = semantic::first_location(&resp)
+            .ok_or("Expected goto-definition to resolve the Dancer2 route target")?;
+
+        assert_eq!(def_uri, uri, "Definition should stay in the same file");
+        assert_eq!(def_line, 2, "Definition should point to the named sub handler");
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -334,6 +334,8 @@ pub enum FrameworkKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Web framework variant detected via `use` statements during Parse/Analyze workflows.
 pub enum WebFrameworkKind {
+    /// `use Dancer;`
+    Dancer,
     /// `use Dancer2;` or `use Dancer2::Core;`
     Dancer2,
     /// `use Mojolicious::Lite;`
@@ -376,7 +378,7 @@ pub struct FrameworkFlags {
     pub class_accessor: bool,
     /// Which specific Moo/Moose variant was detected.
     pub kind: Option<FrameworkKind>,
-    /// Web framework variant, if any (Dancer2, Mojolicious::Lite).
+    /// Web framework variant, if any (Dancer, Dancer2, Mojolicious::Lite).
     pub web_framework: Option<WebFrameworkKind>,
     /// Async framework variant, if any (IO::Async).
     pub async_framework: Option<AsyncFrameworkKind>,
@@ -1504,7 +1506,7 @@ impl SymbolExtractor {
         if require_embedded_marker { None } else { Some(attr_expr) }
     }
 
-    /// Detect Dancer2/Mojolicious::Lite route declarations and synthesize route symbols.
+    /// Detect Dancer/Dancer2/Mojolicious::Lite route declarations and synthesize route symbols.
     ///
     /// Pattern (two statements):
     /// 1. `ExpressionStatement(Identifier("get"|"post"|"put"|"del"|"patch"|"any"))`
@@ -1517,6 +1519,10 @@ impl SymbolExtractor {
         statements: &[Node],
         idx: usize,
     ) -> Option<usize> {
+        let web_framework = self
+            .framework_flags
+            .get(&self.table.current_package)
+            .and_then(|flags| flags.web_framework);
         let first = &statements[idx];
 
         // FunctionCall form: `get '/path' => sub { }` parsed as a bare call.
@@ -1549,6 +1555,25 @@ impl SymbolExtractor {
                             documentation: Some(format!("{http_method} {path}")),
                             attributes: vec![format!("http_method={http_method}")],
                         });
+
+                        if matches!(
+                            web_framework,
+                            Some(WebFrameworkKind::Dancer | WebFrameworkKind::Dancer2)
+                        ) && let Some(target_node) = args.get(1)
+                        {
+                            if let Some(target_name) =
+                                Self::collect_symbol_names(target_node).first().cloned()
+                            {
+                                self.table.add_reference(SymbolReference {
+                                    name: target_name,
+                                    kind: SymbolKind::Subroutine,
+                                    location: target_node.location,
+                                    scope_id: self.table.current_scope(),
+                                    is_write: false,
+                                });
+                            }
+                        }
+
                         self.visit_node(first);
                         return Some(1);
                     }
@@ -2056,6 +2081,7 @@ impl SymbolExtractor {
         }
 
         let web_kind = match module {
+            "Dancer" => Some(WebFrameworkKind::Dancer),
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
             "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -20,6 +20,13 @@ fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
     table.symbols.get(name).is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == kind))
 }
 
+fn has_reference(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
+    table
+        .references
+        .get(name)
+        .is_some_and(|references| references.iter().any(|reference| reference.kind == kind))
+}
+
 fn symbol_doc(table: &SymbolTable, name: &str, kind: SymbolKind) -> Option<String> {
     table
         .symbols
@@ -244,6 +251,42 @@ any '/multi' => sub { return 'multi' };
     assert!(
         has_symbol(&table, "/multi", SymbolKind::Subroutine),
         "expected route symbol `/multi` from `any` route"
+    );
+}
+
+#[test]
+fn dancer_route_target_string_adds_subroutine_reference() {
+    let code = r#"
+use Dancer;
+
+get '/about' => 'show_about';
+
+sub show_about {
+    return 'About';
+}
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_reference(&table, "show_about", SymbolKind::Subroutine),
+        "expected route target string `show_about` to be recorded as a Subroutine reference"
+    );
+}
+
+#[test]
+fn dancer2_route_target_string_adds_subroutine_reference() {
+    let code = r#"
+use Dancer2;
+
+get '/status' => 'show_status';
+
+sub show_status {
+    return 'ok';
+}
+"#;
+    let table = extract_symbols(code);
+    assert!(
+        has_reference(&table, "show_status", SymbolKind::Subroutine),
+        "expected route target string `show_status` to be recorded as a Subroutine reference"
     );
 }
 


### PR DESCRIPTION
## Summary
- detect `use Dancer` alongside existing Dancer2 web framework handling
- record Dancer/Dancer2 named route targets as subroutine references for existing goto-definition flows
- add semantic and LSP regression tests for named route handler navigation

## Testing
- cargo test -p perl-semantic-analyzer --test frameworks_web -- --nocapture
- cargo test -p perl-lsp-rs --test dancer_navigation_tests -- --nocapture
- cargo fmt --all --check
- git diff --check