### PR TITLE
feat(object-pad): model ADJUST blocks (#3603)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -292,7 +292,10 @@ impl<'a> Parser<'a> {
             .filter(|s| !s.is_empty())
             .collect();
 
-        let body = self.parse_block()?;
+        self.in_class_body += 1;
+        let body = self.parse_block();
+        self.in_class_body -= 1;
+        let body = body?;
 
         let end = self.previous_position();
         Ok(Node::new(
@@ -327,6 +330,25 @@ impl<'a> Parser<'a> {
         let end = self.previous_position();
         Ok(Node::new(
             NodeKind::Method { name, signature, attributes, body: Box::new(body) },
+            SourceLocation { start, end },
+        ))
+    }
+
+    /// Parse an Object::Pad `ADJUST` block as a method-like class body node.
+    fn parse_adjust_block(&mut self) -> ParseResult<Node> {
+        let start = self.current_position();
+        self.tokens.next()?; // consume 'ADJUST'
+
+        let body = self.parse_block()?;
+
+        let end = self.previous_position();
+        Ok(Node::new(
+            NodeKind::Method {
+                name: "ADJUST".to_string(),
+                signature: None,
+                attributes: Vec::new(),
+                body: Box::new(body),
+            },
             SourceLocation { start, end },
         ))
     }

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -93,6 +93,8 @@ pub struct Parser<'a> {
     last_end_position: usize,
     /// Context flag for disambiguating for-loop initialization syntax
     in_for_loop_init: bool,
+    /// Depth of nested class bodies for context-sensitive class-body constructs
+    in_class_body: usize,
     /// Statement boundary tracking for indirect object syntax detection
     at_stmt_start: bool,
     /// FIFO queue of pending heredoc declarations awaiting content collection
@@ -144,6 +146,7 @@ impl<'a> Parser<'a> {
             recursion_depth: 0,
             last_end_position: 0,
             in_for_loop_init: false,
+            in_class_body: 0,
             at_stmt_start: true,
             pending_heredocs: VecDeque::new(),
             src_bytes: input.as_bytes(),
@@ -227,6 +230,7 @@ impl<'a> Parser<'a> {
             recursion_depth: 0,
             last_end_position: 0,
             in_for_loop_init: false,
+            in_class_body: 0,
             at_stmt_start: true,
             pending_heredocs: VecDeque::new(),
             src_bytes: source.as_bytes(),

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -93,6 +93,17 @@ impl<'a> Parser<'a> {
                 .is_some_and(|t| t.kind == TokenKind::Sub)
     }
 
+    fn is_adjust_block_start(&mut self) -> bool {
+        self.in_class_body > 0
+            && self.peek_kind() == Some(TokenKind::Identifier)
+            && self.tokens.peek().ok().is_some_and(|t| t.text.as_ref() == "ADJUST")
+            && self
+                .tokens
+                .peek_second()
+                .ok()
+                .is_some_and(|t| t.kind == TokenKind::LeftBrace)
+    }
+
     fn finish_subroutine_statement(&mut self, sub_node: Node) -> ParseResult<Node> {
         Ok(if let NodeKind::Subroutine { name, .. } = &sub_node.kind {
             if name.is_none() {
@@ -173,6 +184,10 @@ impl<'a> Parser<'a> {
 
             if keyword_text.as_ref() == "elsif" && next_kind == Some(TokenKind::LeftParen) {
                 return self.parse_orphaned_elsif();
+            }
+
+            if self.is_adjust_block_start() {
+                return self.parse_adjust_block();
             }
         }
 

--- a/crates/perl-parser-core/tests/object_pad_adjust_tests.rs
+++ b/crates/perl-parser-core/tests/object_pad_adjust_tests.rs
@@ -1,0 +1,51 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::*;
+use perl_parser_core::NodeKind;
+use perl_tdd_support::must_some;
+
+#[test]
+fn object_pad_adjust_block_parses_cleanly() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use Object::Pad;
+
+class Config {
+    ADJUST {
+        my $tmp = 1;
+    }
+}
+"#;
+
+    assert_clean_parse(source);
+
+    let ast = parse(source);
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got {}", ast.kind.kind_name());
+    };
+
+    let class_stmt = statements
+        .iter()
+        .find(|statement| matches!(statement.kind, NodeKind::Class { .. }))
+        .expect("expected Object::Pad class statement");
+
+    let NodeKind::Class { body, .. } = &class_stmt.kind else {
+        panic!("expected class node, got {}", class_stmt.kind.kind_name());
+    };
+
+    let NodeKind::Block { statements } = &body.kind else {
+        panic!("expected class body block, got {}", body.kind.kind_name());
+    };
+
+    let adjust_stmt = must_some(statements.first());
+    let NodeKind::Method { name, signature, attributes, .. } = &adjust_stmt.kind else {
+        panic!(
+            "expected ADJUST block to parse as a method-like node, got {}",
+            adjust_stmt.kind.kind_name()
+        );
+    };
+
+    assert_eq!(name, "ADJUST");
+    assert!(signature.is_none(), "ADJUST blocks should not carry method signatures");
+    assert!(attributes.is_empty(), "ADJUST blocks should not synthesize attributes");
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -943,43 +943,23 @@ impl ClassModelBuilder {
 
         match &statement.kind {
             NodeKind::Method { name, body, .. } if name == "ADJUST" => {
-                self.current_adjusts.push(MethodInfo::synthetic(
-                    "ADJUST".to_string(),
-                    statement.location,
-                    None,
-                ));
+                self.record_object_pad_adjust(statement.location);
                 self.visit_node(body);
                 return Some(1);
             }
             NodeKind::Subroutine { name, body, .. } if name.as_deref() == Some("ADJUST") => {
-                self.current_adjusts.push(MethodInfo::synthetic(
-                    "ADJUST".to_string(),
-                    statement.location,
-                    None,
-                ));
+                self.record_object_pad_adjust(statement.location);
                 self.visit_node(body);
                 return Some(1);
-            }
-            NodeKind::ExpressionStatement { expression } => {
-                if matches!(&expression.kind, NodeKind::Identifier { name } if name == "ADJUST") {
-                    self.current_adjusts.push(MethodInfo::synthetic(
-                        "ADJUST".to_string(),
-                        statement.location,
-                        None,
-                    ));
-                    if idx + 1 < statements.len()
-                        && matches!(&statements[idx + 1].kind, NodeKind::Block { .. })
-                    {
-                        self.visit_node(&statements[idx + 1]);
-                        return Some(2);
-                    }
-                    return Some(1);
-                }
             }
             _ => {}
         }
 
         None
+    }
+
+    fn record_object_pad_adjust(&mut self, location: SourceLocation) {
+        self.current_adjusts.push(MethodInfo::synthetic("ADJUST".to_string(), location, None));
     }
 
     fn object_pad_field_from_statement(statement: &Node) -> Option<FieldInfo> {
@@ -1801,6 +1781,27 @@ class Point {
 
         let param_names: Vec<_> = model.object_pad_param_field_names().collect();
         assert_eq!(param_names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn object_pad_adjust_blocks_are_tracked() {
+        let models = build_models(
+            r#"
+use Object::Pad;
+
+class Config {
+    ADJUST {
+        my $tmp = 1;
+    }
+}
+"#,
+        );
+
+        let model = find_model(&models, "Config").expect("Config model");
+        assert_eq!(model.framework, Framework::ObjectPad);
+        assert_eq!(model.adjusts.len(), 1, "expected one ADJUST block");
+        assert_eq!(model.adjusts[0].name, "ADJUST");
+        assert!(model.adjusts[0].synthetic, "ADJUST should be modeled as synthetic");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse Object::Pad `ADJUST { ... }` blocks as minimal method-like class-body nodes
- record Object::Pad ADJUST blocks in the semantic class model as stable adjust entries
- add focused parser and semantic regression coverage for ADJUST handling

## Testing
- cargo test -p perl-parser-core --test object_pad_adjust_tests -- --nocapture
- cargo test -p perl-semantic-analyzer object_pad_adjust_blocks_are_tracked -- --nocapture
- cargo fmt --all --check
- git diff --check