### PR TITLE
feat(discovery): recognize SWIG interface files (#3569)

### DIFF
--- a/crates/perl-source-file/tests/edge_cases_and_consistency.rs
+++ b/crates/perl-source-file/tests/edge_cases_and_consistency.rs
@@ -83,6 +83,11 @@ fn extension_rejects_xs() {
 }
 
 #[test]
+fn extension_rejects_i() {
+    assert!(!is_perl_source_extension("i"), "i is a SWIG interface file, not Perl source");
+}
+
+#[test]
 fn extension_rejects_al() {
     assert!(!is_perl_source_extension("al"), "al (autoloaded) is not a canonical extension");
 }

--- a/crates/perl-workspace-discovery/src/lib.rs
+++ b/crates/perl-workspace-discovery/src/lib.rs
@@ -60,14 +60,16 @@ pub fn discover_perl_files(root: &Path) -> DiscoveryResult {
 /// Returns `true` if `path` should be considered discoverable by workspace
 /// indexing.
 ///
-/// This intentionally includes XS implementation files and common Perl
-/// templating formats so editor discovery can surface them even though they are
-/// not classified as Perl source files by the shared source-file helper.
+/// This intentionally includes XS implementation files, SWIG interface files,
+/// and common Perl templating formats so editor discovery can surface them
+/// even though they are not classified as Perl source files by the shared
+/// source-file helper.
 #[must_use]
 pub fn is_perl_discovery_path(path: &Path) -> bool {
     is_perl_source_path(path)
         || path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| {
-            ext.eq_ignore_ascii_case("xs")
+            ext.eq_ignore_ascii_case("i")
+                || ext.eq_ignore_ascii_case("xs")
                 || ext.eq_ignore_ascii_case("ep")
                 || ext.eq_ignore_ascii_case("tt")
                 || ext.eq_ignore_ascii_case("tt2")

--- a/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
+++ b/crates/perl-workspace-discovery/tests/discovery_coverage_tests.rs
@@ -315,11 +315,11 @@ fn gitignore_negation_pattern_re_includes_file_level() -> TestResult {
 }
 
 // ============================================================
-// Perl file extension filtering (.pl, .pm, .t, .psgi, .xs, .ep, .tt, .tt2)
+// Perl file extension filtering (.pl, .pm, .t, .psgi, .xs, .i, .ep, .tt, .tt2)
 // ============================================================
 
 #[test]
-fn extension_filtering_accepts_all_eight_perl_extensions() -> TestResult {
+fn extension_filtering_accepts_all_nine_perl_extensions() -> TestResult {
     let tmp = TempDir::new()?;
     let root = tmp.path();
 
@@ -328,6 +328,7 @@ fn extension_filtering_accepts_all_eight_perl_extensions() -> TestResult {
     create_file(root, "test.t")?;
     create_file(root, "app.psgi")?;
     create_file(root, "native.xs")?;
+    create_file(root, "interface.i")?;
     create_file(root, "templates/page.html.ep")?;
     create_file(root, "templates/page.tt")?;
     create_file(root, "templates/layout.tt2")?;
@@ -340,12 +341,13 @@ fn extension_filtering_accepts_all_eight_perl_extensions() -> TestResult {
         .filter_map(|p| p.extension().and_then(|e| e.to_str()).map(String::from))
         .collect();
 
-    assert_eq!(extensions.len(), 8);
+    assert_eq!(extensions.len(), 9);
     assert!(extensions.contains("pl"));
     assert!(extensions.contains("pm"));
     assert!(extensions.contains("t"));
     assert!(extensions.contains("psgi"));
     assert!(extensions.contains("xs"));
+    assert!(extensions.contains("i"));
     assert!(extensions.contains("ep"));
     assert!(extensions.contains("tt"));
     assert!(extensions.contains("tt2"));

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -76,7 +76,8 @@
           ".tt",
           ".tt2",
           ".ep",
-          ".xs"
+          ".xs",
+          ".i"
         ],
         "firstLine": "^#!.*\\bperl\\b",
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
## Summary
- treat `.i` files as discoverable workspace inputs for indexing and editor workflows
- associate `.i` files with the VS Code Perl language surface
- keep canonical Perl source classification narrow by explicitly rejecting `.i` in `perl-source-file`

## Tests
- cargo test -p perl-source-file --test edge_cases_and_consistency -- --nocapture
- cargo test -p perl-workspace-discovery --test discovery_coverage_tests -- --nocapture
- cargo fmt --all --check
- git diff --check

## Scope
This is the narrow recognition MVP for #3569. It does not add SWIG directive parsing, `%perlcode` handling, or language injection for embedded C/C++ blocks.
