### PR TITLE
fix(parser): support proto-then-attribute ordering (#3381)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -206,10 +206,12 @@ impl<'a> Parser<'a> {
             (None, None)
         };
 
-        // Parse optional attributes first (they come before signature in modern Perl)
-        let attributes = self.parse_declaration_attributes()?;
+        // Parse optional attributes before the prototype/signature.
+        // Perl allows both `sub foo :lvalue ($)` and `sub foo ($) :lvalue`,
+        // so we collect attributes on both sides and merge them.
+        let mut attributes = self.parse_declaration_attributes()?;
 
-        // Parse optional prototype or signature after attributes
+        // Parse optional prototype or signature after leading attributes.
         let (prototype, signature) = if self.peek_kind() == Some(TokenKind::LeftParen) {
             // Look ahead to determine if this is a prototype or signature
             if self.is_likely_prototype()? {
@@ -232,6 +234,11 @@ impl<'a> Parser<'a> {
         } else {
             (None, None)
         };
+
+        // Parse optional trailing attributes after the prototype/signature.
+        if self.peek_kind() == Some(TokenKind::Colon) {
+            attributes.extend(self.parse_declaration_attributes()?);
+        }
 
         // Check for forward declaration: sub foo; or sub foo(@); or sub foo :method;
         // Forward declarations have no block body — they end with a semicolon

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
@@ -16,6 +16,7 @@
 
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
+use perl_parser_core::NodeKind;
 
 // ---------------------------------------------------------------------------
 // Core `+` prototype patterns
@@ -98,16 +99,20 @@ fn test_named_sub_attr_then_plus_proto() {
     assert_clean_parse("sub foo : lvalue (+) { 1 }");
 }
 
-/// Correct Perl ordering: prototype THEN attribute.
-/// `sub foo (+) : lvalue { ... }` is valid Perl (perlsub spec).
-/// NOTE: This is a KNOWN pre-existing parser limitation (tracked in fix_expected_colon):
-/// the parser does not yet support attributes after prototypes. The `+` prototype itself
-/// is parsed correctly; only the `: lvalue` suffix fails. This `#[ignore]` documents the
-/// gap without blocking the fix for the `+` prototype character.
 #[test]
-#[ignore = "pre-existing: parser does not support proto-then-attribute ordering (fix_expected_colon)"]
 fn test_proto_then_attr_correct_order() {
-    assert_clean_parse("sub foo (+) : lvalue { $_[0] }");
+    let ast = parse("sub foo (+) : lvalue { $_[0] }");
+    let NodeKind::Program { statements } = &ast.kind else {
+        panic!("expected program node, got: {:?}", ast.kind);
+    };
+    let Some(first) = statements.first() else {
+        panic!("expected a subroutine statement");
+    };
+    let NodeKind::Subroutine { prototype, attributes, .. } = &first.kind else {
+        panic!("expected subroutine node, got: {:?}", first.kind);
+    };
+    assert!(prototype.is_some(), "expected prototype for sub foo (+)");
+    assert_eq!(attributes, &vec!["lvalue".to_string()]);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow declaration attributes on either side of a subroutine prototype or signature
- preserve the prototype and merged attribute list for valid Perl `sub foo (+) : lvalue { ... }` forms
- add a regression that asserts the prototype and trailing attributes survive parsing

## Tests
- cargo test -p perl-parser-core --test fix_unexpected_rbrace_proto_plus_2835 -- --nocapture
- cargo test -p perl-parser-core --test parser_tests parse_subroutine_declaration -- --nocapture
- cargo fmt --all --check
- git diff --check

## Scope
This fixes the parser ordering bug from #3381 only. The broader `fix_expected_colon` suite still has unrelated failures and is intentionally left out of this slice.
