### PR TITLE
fix(symbols): extract all hash-ref use constant names (#3391)

### DIFF
--- a/crates/perl-symbol-surface/src/decl.rs
+++ b/crates/perl-symbol-surface/src/decl.rs
@@ -226,23 +226,17 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
 
         // ── use constant NAME => value ─────────────────────────────────────
         NodeKind::Use { module, args, .. } if module == "constant" => {
-            // `args` layout: [NAME, value, ...] or [NAME1, val1, NAME2, val2, ...]
-            // The first arg is the constant name (or a hash-ref style with
-            // multiple names — for MVP we take just the first string arg).
-            if let Some(const_name) = args.first() {
-                // Skip if it looks like a reference marker or is empty.
-                if !const_name.is_empty() && !const_name.starts_with('{') {
-                    let container = ctx.current_package.clone();
-                    out.push(SymbolDecl {
-                        kind: SymbolKind::Constant,
-                        name: const_name.clone(),
-                        qualified_name: ctx.qualify(const_name),
-                        full_span: (node.location.start, node.location.end),
-                        anchor_span: None, // No precise span available from Use node
-                        container,
-                        declarator: None,
-                    });
-                }
+            for const_name in constant_names_from_use_args(args) {
+                let container = ctx.current_package.clone();
+                out.push(SymbolDecl {
+                    kind: SymbolKind::Constant,
+                    name: const_name.clone(),
+                    qualified_name: ctx.qualify(&const_name),
+                    full_span: (node.location.start, node.location.end),
+                    anchor_span: None, // No precise span available from Use node
+                    container,
+                    declarator: None,
+                });
             }
         }
 
@@ -257,6 +251,84 @@ fn walk(node: &Node, ctx: &mut WalkCtx, out: &mut Vec<SymbolDecl>) {
 
         // All other nodes: no declaration to project.
         _ => {}
+    }
+}
+
+fn constant_names_from_use_args(args: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut brace_depth = 0usize;
+    let mut fallback_name: Option<String> = None;
+
+    for (idx, arg) in args.iter().enumerate() {
+        match arg.as_str() {
+            "{" => {
+                brace_depth += 1;
+                continue;
+            }
+            "}" => {
+                brace_depth = brace_depth.saturating_sub(1);
+                continue;
+            }
+            "+" | "," => continue,
+            _ => {}
+        }
+
+        if let Some(qw_names) = qw_names(arg) {
+            for name in qw_names {
+                push_unique(&mut names, name);
+            }
+            continue;
+        }
+
+        if is_constant_name_candidate(arg) {
+            if brace_depth == 1 && args.get(idx + 1).is_some_and(|next| next == "=>") {
+                push_unique(&mut names, arg.clone());
+                continue;
+            }
+
+            if brace_depth == 0 && fallback_name.is_none() {
+                fallback_name = Some(arg.clone());
+            }
+        }
+    }
+
+    if names.is_empty() {
+        if let Some(name) = fallback_name {
+            names.push(name);
+        }
+    }
+
+    names
+}
+
+fn qw_names(arg: &str) -> Option<Vec<String>> {
+    let content = arg.strip_prefix("qw").and_then(|rest| {
+        rest.strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .or_else(|| rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')))
+            .or_else(|| rest.strip_prefix('{').and_then(|s| s.strip_suffix('}')))
+            .or_else(|| rest.strip_prefix('<').and_then(|s| s.strip_suffix('>')))
+    });
+
+    content.map(|text| {
+        text.split_whitespace().filter(|name| !name.is_empty()).map(str::to_owned).collect()
+    })
+}
+
+fn is_constant_name_candidate(arg: &str) -> bool {
+    !arg.is_empty()
+        && arg != "=>"
+        && !arg.starts_with('{')
+        && !arg.starts_with('}')
+        && !arg.starts_with('-')
+        && !arg.starts_with('$')
+        && !arg.starts_with('@')
+        && !arg.starts_with('%')
+}
+
+fn push_unique(names: &mut Vec<String>, name: String) {
+    if !names.iter().any(|existing| existing == &name) {
+        names.push(name);
     }
 }
 

--- a/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
+++ b/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
@@ -193,6 +193,40 @@ fn test_use_constant_produces_symbol_decl() {
     assert!(d.anchor_span.is_none());
 }
 
+#[test]
+fn test_use_constant_hash_ref_style_produces_all_symbol_decls() {
+    // use constant { FOO => 1, BAR => 2, BAZ => 3 };
+    let use_node = Node::new(
+        NodeKind::Use {
+            module: "constant".to_string(),
+            args: vec![
+                "{".to_string(),
+                "FOO".to_string(),
+                "=>".to_string(),
+                "1".to_string(),
+                "BAR".to_string(),
+                "=>".to_string(),
+                "2".to_string(),
+                "BAZ".to_string(),
+                "=>".to_string(),
+                "3".to_string(),
+                "}".to_string(),
+            ],
+            has_filter_risk: false,
+        },
+        loc(0, 39),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![use_node] }, loc(0, 39));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 3);
+    assert_eq!(decls[0].kind, SymbolKind::Constant);
+    assert_eq!(decls[0].name, "FOO");
+    assert_eq!(decls[1].name, "BAR");
+    assert_eq!(decls[2].name, "BAZ");
+}
+
 // ── Class (Perl 5.38+) ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- collect all constant names from hash-ref style `use constant` declarations
- keep the existing simple single-name form working while avoiding duplicate symbol entries
- add a regression that asserts `FOO`, `BAR`, and `BAZ` are all surfaced as constant declarations

## Tests
- cargo test -p perl-symbol-surface --test symbol_decl_tests -- --nocapture
- cargo fmt --all --check
- git diff --check

## Scope
This fixes the symbol-surface extraction gap for `use constant { ... }` from #3391. It does not expand the broader semantic-analyzer constant indexing path.
