### PR TITLE
test(parser): refresh semantic token legend snapshots (#3209)

### DIFF
--- a/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_index_mapping.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_index_mapping.snap
@@ -24,6 +24,8 @@ token_types:
   18: regexp
   19: operator
   20: sql_string
+  21: sql_heredoc_keyword
+  22: json_heredoc_key
 modifiers:
   0: declaration
   1: definition
@@ -35,3 +37,6 @@ modifiers:
   7: modification
   8: documentation
   9: defaultLibrary
+  10: scalarVariable
+  11: arrayVariable
+  12: hashVariable

--- a/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_modifiers.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_modifiers.snap
@@ -12,3 +12,6 @@ async
 modification
 documentation
 defaultLibrary
+scalarVariable
+arrayVariable
+hashVariable

--- a/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_types.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snapshot_tests__snapshot_semantic_token_legend_types.snap
@@ -23,3 +23,5 @@ number
 regexp
 operator
 sql_string
+sql_heredoc_keyword
+json_heredoc_key


### PR DESCRIPTION
## Summary
- refresh the semantic token legend snapshots for the newly added token types and variable modifiers
- update the index mapping snapshot to match the expanded legend
- keep scope limited to the stale legend snapshots rather than the broader recovery snapshot drift

## Tests
- cargo test -p perl-parser --test ast_snapshot_tests semantic_token_legend -- --nocapture
- cargo fmt --all --check
- git diff --check
