### PR TITLE
feat(moose): support override and augment modifiers (#3408)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -143,6 +143,33 @@ impl LspServer {
     ) -> HoverExtracted {
         let analyzer = self.get_or_build_analyzer(uri, text, ast);
 
+        if let Some(symbol_info) =
+            analyzer.symbol_at(crate::SourceLocation { start: offset, end: offset })
+            && let Some(modifier_kind) =
+                symbol_info.attributes.iter().find_map(|a| a.strip_prefix("modifier="))
+        {
+            let method_name = &symbol_info.name;
+            let kind_label = match modifier_kind {
+                "before" => "runs **before** the method — use for preconditions and logging",
+                "after" => "runs **after** the method — use for postconditions and cleanup",
+                "around" => {
+                    "wraps the method — receives `$orig` as first arg, must call `$orig->($self, @_)`"
+                }
+                "override" => "overrides the parent method — use to replace inherited behavior",
+                "augment" => "extends the parent method — call `inner()` to invoke the next layer",
+                _ => "modifies the method",
+            };
+            let doc = symbol_info.documentation.as_deref().unwrap_or("");
+            return HoverExtracted::Complete(json!({
+                "contents": {
+                    "kind": "markdown",
+                    "value": format!(
+                        "**Method Modifier (`{modifier_kind}`)**\n\n`{method_name}` — {kind_label}\n\n{doc}"
+                    ),
+                },
+            }));
+        }
+
         if let Some(symbol_info) = analyzer.find_definition(offset) {
             // Detect Moo/Moose attribute accessors (declaration == "has") early and
             // render a dedicated card that shows the attribute metadata clearly,
@@ -158,7 +185,7 @@ impl LspServer {
                 }));
             }
 
-            // Detect method modifier symbols (before/after/around) early and render
+            // Detect method modifier symbols (before/after/around/override/augment) early and render
             // a dedicated card instead of the generic "Subroutine" label.
             if let Some(modifier_kind) =
                 symbol_info.attributes.iter().find_map(|a| a.strip_prefix("modifier="))
@@ -169,6 +196,10 @@ impl LspServer {
                     "after" => "runs **after** the method — use for postconditions and cleanup",
                     "around" => {
                         "wraps the method — receives `$orig` as first arg, must call `$orig->($self, @_)`"
+                    }
+                    "override" => "overrides the parent method — use to replace inherited behavior",
+                    "augment" => {
+                        "extends the parent method — call `inner()` to invoke the next layer"
                     }
                     _ => "modifies the method",
                 };

--- a/crates/perl-lsp/tests/method_modifier_definition_tests.rs
+++ b/crates/perl-lsp/tests/method_modifier_definition_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for method modifier go-to-definition navigation.
 //!
 //! Covers issue #3599: go-to-definition on the method name string inside
-//! `before`/`after`/`around` modifiers should navigate to the `sub` being modified.
+//! `before`/`after`/`around`/`override`/`augment` modifiers should navigate to
+//! the `sub` being modified.
 
 mod common;
 
@@ -96,6 +97,49 @@ mod method_modifier_definition_tests {
         assert_eq!(
             def_line, 2,
             "Definition should point to line 2 (sub validate), got line {def_line}"
+        );
+        Ok(())
+    }
+
+    /// Go-to-definition on `'render'` in `override 'render' => sub { }` must jump
+    /// to the `sub render { }` definition.
+    #[test]
+    fn test_override_modifier_goto_def_jumps_to_sub() -> TestResult {
+        let code =
+            "package MyApp::User;\nuse Moose;\nsub render { }\noverride 'render' => sub { };\n";
+        let uri = "file:///myapp_user_override.pl";
+
+        let resp = goto_def(code, uri, "render", 3)?;
+
+        let (def_uri, def_line, _) = semantic::first_location(&resp).ok_or(
+            "Expected goto-definition on 'render' in override modifier to find sub render",
+        )?;
+
+        assert_eq!(def_uri, uri, "Definition should be in the same file");
+        assert_eq!(
+            def_line, 2,
+            "Definition should point to line 2 (sub render), got line {def_line}"
+        );
+        Ok(())
+    }
+
+    /// Go-to-definition on `'render'` in `augment 'render' => sub { }` must jump
+    /// to the `sub render { }` definition.
+    #[test]
+    fn test_augment_modifier_goto_def_jumps_to_sub() -> TestResult {
+        let code =
+            "package MyApp::User;\nuse Moose;\nsub render { }\naugment 'render' => sub { };\n";
+        let uri = "file:///myapp_user_augment.pl";
+
+        let resp = goto_def(code, uri, "render", 3)?;
+
+        let (def_uri, def_line, _) = semantic::first_location(&resp)
+            .ok_or("Expected goto-definition on 'render' in augment modifier to find sub render")?;
+
+        assert_eq!(def_uri, uri, "Definition should be in the same file");
+        assert_eq!(
+            def_line, 2,
+            "Definition should point to line 2 (sub render), got line {def_line}"
         );
         Ok(())
     }

--- a/crates/perl-lsp/tests/semantic_hover.rs
+++ b/crates/perl-lsp/tests/semantic_hover.rs
@@ -659,6 +659,62 @@ mod method_modifier_hover_tests {
         Ok(())
     }
 
+    /// Hovering over the method name inside `override 'render' => sub { ... }`
+    /// should identify the override modifier and avoid the generic Subroutine label.
+    #[test]
+    fn hover_on_override_modifier_mentions_override() -> Result<(), Box<dyn std::error::Error>> {
+        let code =
+            "package MyApp::User;\nuse Moose;\nsub render { }\noverride 'render' => sub { };\n";
+        let uri = "file:///moo_modifiers_override.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        let (line, col) = find_pos(code, "render", 3)?;
+        let response = server.get_hover(uri, line, col);
+
+        let content =
+            hover_content(&response).ok_or("expected hover content on override modifier")?;
+
+        assert!(
+            content.contains("override") || content.contains("modifier"),
+            "override modifier hover should name the modifier, got: {content}"
+        );
+        assert!(
+            !content.contains("**Subroutine**"),
+            "hover should not show generic Subroutine label for an override modifier, got: {content}"
+        );
+        Ok(())
+    }
+
+    /// Hovering over the method name inside `augment 'render' => sub { ... }`
+    /// should identify the augment modifier and avoid the generic Subroutine label.
+    #[test]
+    fn hover_on_augment_modifier_mentions_augment() -> Result<(), Box<dyn std::error::Error>> {
+        let code =
+            "package MyApp::User;\nuse Moose;\nsub render { }\naugment 'render' => sub { };\n";
+        let uri = "file:///moo_modifiers_augment.pl";
+
+        let server = TestServerBuilder::new().build();
+        server.open_document(uri, code);
+
+        let (line, col) = find_pos(code, "render", 3)?;
+        let response = server.get_hover(uri, line, col);
+
+        let content =
+            hover_content(&response).ok_or("expected hover content on augment modifier")?;
+
+        assert!(
+            content.contains("augment") || content.contains("modifier"),
+            "augment modifier hover should name the modifier, got: {content}"
+        );
+        assert!(
+            !content.contains("**Subroutine**"),
+            "hover should not show generic Subroutine label for an augment modifier, got: {content}"
+        );
+        Ok(())
+    }
+
     /// `use Mouse;` packages should get modifier symbols just like `use Moo;`.
     /// This verifies that Mouse is recognized in symbol.rs framework detection.
     /// Without the fix, Mouse is not in `update_framework_context`, so `is_moo`

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -212,7 +212,7 @@ impl SemanticAnalyzer {
 
     /// Redirect method modifier definitions to the underlying method they modify.
     ///
-    /// Method modifiers (`before`, `after`, `around`) are modeled as synthetic
+    /// Method modifiers (`before`, `after`, `around`, `override`, `augment`) are modeled as synthetic
     /// subroutine symbols so hover/navigation can describe them, but go-to-definition
     /// should land on the real method declaration when it exists.
     fn resolve_definition_target<'a>(&'a self, symbol: &'a Symbol) -> &'a Symbol {
@@ -221,7 +221,10 @@ impl SemanticAnalyzer {
 
     /// If `symbol` is a method modifier target, find the underlying method symbol.
     fn resolve_method_modifier_target<'a>(&'a self, symbol: &'a Symbol) -> Option<&'a Symbol> {
-        if !matches!(symbol.declaration.as_deref(), Some("before" | "after" | "around")) {
+        if !matches!(
+            symbol.declaration.as_deref(),
+            Some("before" | "after" | "around" | "override" | "augment")
+        ) {
             return None;
         }
 
@@ -232,7 +235,7 @@ impl SemanticAnalyzer {
                 candidate.location != symbol.location
                     && !matches!(
                         candidate.declaration.as_deref(),
-                        Some("before" | "after" | "around")
+                        Some("before" | "after" | "around" | "override" | "augment")
                     )
             })
     }

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -1152,10 +1152,10 @@ impl SymbolExtractor {
         None
     }
 
-    /// Detect Moo/Moose method modifiers (`around`, `before`, `after`).
+    /// Detect Moo/Moose method modifiers (`before`, `after`, `around`, `override`, `augment`).
     ///
     /// Pattern (two statements):
-    /// 1. `ExpressionStatement(Identifier("around"))` (or `before`/`after`)
+    /// 1. `ExpressionStatement(Identifier("around"))` (or `before`/`after`/`override`/`augment`)
     /// 2. `ExpressionStatement(HashLiteral([ (method_name, Subroutine{...}) ]))`
     ///
     /// Also handles FunctionCall form: `around 'name' => sub { }` (post parser fix).
@@ -1165,7 +1165,7 @@ impl SymbolExtractor {
         // FunctionCall form: `around 'name' => sub { }` parsed as a bare call.
         if let NodeKind::ExpressionStatement { expression } = &first.kind
             && let NodeKind::FunctionCall { name, args } = &expression.kind
-            && matches!(name.as_str(), "around" | "before" | "after")
+            && Self::is_moose_method_modifier(name)
         {
             let modifier_name = name.as_str();
             let method_names: Vec<String> =
@@ -1197,12 +1197,10 @@ impl SymbolExtractor {
 
         let second = &statements[idx + 1];
 
-        // Check: first is ExpressionStatement(Identifier("around"|"before"|"after"))
+        // Check: first is ExpressionStatement(Identifier("before"|"after"|"around"|"override"|"augment"))
         let modifier_name = match &first.kind {
             NodeKind::ExpressionStatement { expression } => match &expression.kind {
-                NodeKind::Identifier { name }
-                    if matches!(name.as_str(), "around" | "before" | "after") =>
-                {
+                NodeKind::Identifier { name } if Self::is_moose_method_modifier(name) => {
                     name.as_str()
                 }
                 _ => return None,
@@ -1245,6 +1243,10 @@ impl SymbolExtractor {
         self.visit_node(second);
 
         Some(2)
+    }
+
+    fn is_moose_method_modifier(name: &str) -> bool {
+        matches!(name, "before" | "after" | "around" | "override" | "augment")
     }
 
     /// Detect Moo/Moose `extends 'Parent'` and `with 'Role'` declarations.

--- a/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_moo.rs
@@ -327,6 +327,34 @@ after 'cleanup' => sub { };
 }
 
 #[test]
+fn moose_override_modifier_emits_subroutine_symbol() {
+    let code = r#"
+package MyApp::User;
+use Moose;
+override 'render' => sub { };
+"#;
+
+    let table = extract_symbols(code);
+
+    let sym = find_symbol_with_declaration(&table, "render", SymbolKind::Subroutine, "override");
+    assert!(sym.is_some(), "expected Subroutine symbol with declaration='override' for `render`");
+}
+
+#[test]
+fn moose_augment_modifier_emits_subroutine_symbol() {
+    let code = r#"
+package MyApp::User;
+use Moose;
+augment 'render' => sub { };
+"#;
+
+    let table = extract_symbols(code);
+
+    let sym = find_symbol_with_declaration(&table, "render", SymbolKind::Subroutine, "augment");
+    assert!(sym.is_some(), "expected Subroutine symbol with declaration='augment' for `render`");
+}
+
+#[test]
 fn moo_modifier_not_emitted_without_framework() {
     let code = r#"
 package Plain;


### PR DESCRIPTION
## Summary
- recognize Moose `override` and `augment` as method modifiers alongside the existing before/after/around support
- route definition lookup for those modifier targets back to the underlying method symbol
- extend hover and regression coverage so modifier names render as dedicated method-modifier UI instead of generic subroutines

## Tests
- cargo test -p perl-semantic-analyzer --test frameworks_moo -- --nocapture
- cargo test -p perl-lsp-rs --test method_modifier_definition_tests -- --nocapture
- cargo test -p perl-lsp-rs --test semantic_hover -- --nocapture
- cargo fmt --all --check
- git diff --check
