### PR TITLE
feat(attributes): document locked subroutine attribute (#3387)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/builtins.rs
@@ -960,6 +960,10 @@ pub fn get_attribute_documentation(attr: &str) -> Option<BuiltinDoc> {
             signature: ":weak_ref",
             description: "Marks a Moose/Moo attribute as a weak reference. The stored reference will not prevent the referent from being garbage-collected.",
         }),
+        "locked" => Some(BuiltinDoc {
+            signature: ":locked",
+            description: "Marks a subroutine so concurrent callers are serialized. Useful for thread-safe methods that must not run at the same time.",
+        }),
         "overload" => Some(BuiltinDoc {
             signature: ":overload(OP)",
             description: "Declares that a subroutine implements an operator overload for OP.",

--- a/crates/perl-semantic-analyzer/tests/attribute_introspection_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/attribute_introspection_tests.rs
@@ -84,6 +84,19 @@ fn attribute_doc_shared_has_description() {
 }
 
 #[test]
+fn attribute_doc_locked_has_description() {
+    let doc = get_attribute_documentation("locked");
+    assert!(doc.is_some(), "locked should have documentation");
+    let doc = must_some(doc);
+    assert!(
+        doc.description.to_lowercase().contains("serialize")
+            || doc.description.to_lowercase().contains("thread"),
+        "locked description should mention serialization or threading, got: {}",
+        doc.description
+    );
+}
+
+#[test]
 fn attribute_doc_unknown_returns_none() {
     let doc = get_attribute_documentation("nonexistent_attribute_xyz");
     assert!(doc.is_none(), "unknown attribute should return None");
@@ -98,7 +111,7 @@ fn attribute_doc_colon_stripped_lvalue() {
 
 #[test]
 fn attribute_doc_covers_all_known_builtins() {
-    let known_attrs = ["lvalue", "method", "prototype", "const", "shared"];
+    let known_attrs = ["lvalue", "method", "prototype", "const", "shared", "locked"];
     for attr in &known_attrs {
         let doc = get_attribute_documentation(attr);
         assert!(doc.is_some(), "Expected documentation for attribute '{}' but got None", attr);


### PR DESCRIPTION
## Summary
- add built-in documentation for the `:locked` subroutine attribute
- extend attribute introspection coverage so the known built-in set includes `locked`
- keep the change scoped to the built-in attribute documentation path

## Tests
- cargo test -p perl-semantic-analyzer --test attribute_introspection_tests -- --nocapture
- cargo fmt --all --check
- git diff --check
