### PR TITLE
feat(navigation): resolve SUPER methods with mro support (#3384)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -27,6 +27,9 @@ static PACKAGE_ARROW_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock
 static VAR_METHOD_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 
 #[cfg(feature = "workspace")]
+static SUPER_METHOD_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+
+#[cfg(feature = "workspace")]
 static MOJO_STRING_ROUTE_RE: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 
 #[cfg(feature = "workspace")]
@@ -87,6 +90,18 @@ fn get_var_method_regex() -> Result<&'static regex::Regex, JsonRpcError> {
         .map_err(|err| {
             crate::protocol::internal_error(&format!(
                 "Failed to initialize variable method-call regex: {err}"
+            ))
+        })
+}
+
+#[cfg(feature = "workspace")]
+fn get_super_method_regex() -> Result<&'static regex::Regex, JsonRpcError> {
+    SUPER_METHOD_RE
+        .get_or_init(|| regex::Regex::new(r"\bSUPER::([A-Za-z_][A-Za-z0-9_]*)"))
+        .as_ref()
+        .map_err(|err| {
+            crate::protocol::internal_error(&format!(
+                "Failed to initialize SUPER method-call regex: {err}"
             ))
         })
 }
@@ -340,7 +355,7 @@ fn inherited_method_definition_location(
                         .class_models
                         .into_iter()
                         .find(|model| model.name == package_name)
-                        .map(|model| model.parents.into_iter().chain(model.roles).collect())
+                        .map(|model| model.parents)
                         .unwrap_or_default()
                 })
                 .clone();
@@ -687,6 +702,63 @@ impl LspServer {
                                     crate::workspace_index::lsp_adapter::to_lsp_location(
                                         &def_location,
                                     )
+                                {
+                                    return Ok(Some(json!([lsp_location])));
+                                }
+                            }
+                        }
+                    }
+
+                    // Attempt to resolve `SUPER::method` calls using the current package's
+                    // inheritance chain before falling back to generic fully-qualified lookup.
+                    let current_package = doc
+                        .ast
+                        .as_ref()
+                        .map(|ast| {
+                            let byte_offset = self.pos16_to_offset(doc, line, character);
+                            crate::declaration::current_package_at(ast, byte_offset)
+                        })
+                        .unwrap_or("main");
+
+                    let super_re = get_super_method_regex()?;
+                    for cap in super_re.captures_iter(&text_around) {
+                        if let Some(method_match) = cap.get(1)
+                            && cursor_in_text >= method_match.start()
+                            && cursor_in_text <= method_match.end()
+                        {
+                            if let Some(ref ast) = doc.ast {
+                                let analyzer =
+                                    crate::semantic::SemanticAnalyzer::analyze_with_source(
+                                        ast, &doc.text,
+                                    );
+                                if let Some(location) = analyzer.resolve_inherited_method_location(
+                                    &current_package,
+                                    method_match.as_str(),
+                                ) {
+                                    let lsp_start = self.offset_to_pos16(doc, location.start);
+                                    let lsp_end = self.offset_to_pos16(doc, location.end);
+                                    return Ok(Some(json!([{
+                                        "uri": uri,
+                                        "range": {
+                                            "start": {"line": lsp_start.0, "character": lsp_start.1},
+                                            "end": {"line": lsp_end.0, "character": lsp_end.1},
+                                        },
+                                    }])));
+                                }
+                            }
+
+                            #[cfg(feature = "workspace")]
+                            {
+                                if let Some(coordinator) = self.coordinator()
+                                    && let Some(def_location) = inherited_method_definition_location(
+                                        coordinator.index(),
+                                        &current_package,
+                                        method_match.as_str(),
+                                    )
+                                    && let Some(lsp_location) =
+                                        crate::workspace_index::lsp_adapter::to_lsp_location(
+                                            &def_location,
+                                        )
                                 {
                                     return Ok(Some(json!([lsp_location])));
                                 }

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -22,6 +22,16 @@ fn assert_valid_location(location: &serde_json::Value) {
     assert!(range.get("end").is_some(), "Range must have 'end' position");
 }
 
+fn find_line_char(code: &str, needle: &str) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+    for (line_idx, line) in code.lines().enumerate() {
+        if let Some(char_idx) = line.find(needle) {
+            return Ok((line_idx as u32, char_idx as u32));
+        }
+    }
+
+    Err(format!("could not find '{needle}' in test source").into())
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: Package::function() navigates to the function in Package.pm
 // ---------------------------------------------------------------------------
@@ -224,6 +234,125 @@ sub greet {
         let uri = first["uri"].as_str().ok_or("Expected URI")?;
         assert!(uri.contains("Animal.pm"), "Definition should point to Animal.pm, got: {}", uri);
     }
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_super_method_uses_parent_chain() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    harness.open(
+        "file:///lib/Animal.pm",
+        r#"package Base;
+sub greet { "base" }
+
+package Child;
+use parent 'Base';
+sub greet {
+    my $self = shift;
+    return $self->SUPER::greet();
+}
+
+1;
+"#,
+    )?;
+
+    harness.barrier();
+
+    let (line, character) = find_line_char(
+        r#"package Base;
+sub greet { "base" }
+
+package Child;
+use parent 'Base';
+sub greet {
+    my $self = shift;
+    return $self->SUPER::greet();
+}
+
+1;
+"#,
+        "SUPER::greet",
+    )?;
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": "file:///lib/Animal.pm"},
+            "position": {"line": line, "character": character + 8}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected array result for SUPER definition")?;
+    assert!(!locations.is_empty(), "SUPER::greet should resolve to parent implementation");
+    let first = &locations[0];
+    assert_valid_location(first);
+    assert!(
+        first["uri"].as_str().unwrap_or("").contains("Animal.pm"),
+        "SUPER::greet should resolve within the current file, got: {first:?}"
+    );
+    assert_eq!(
+        first["range"]["start"]["line"].as_u64(),
+        Some(1),
+        "SUPER::greet should navigate to Base::greet"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_super_method_respects_c3_mro() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    let code = r#"package Root;
+sub greet { "root" }
+
+package Left;
+use parent 'Root';
+
+package Right;
+use parent 'Root';
+sub greet { "right" }
+
+package Child;
+use mro 'c3';
+use parent 'Left', 'Right';
+sub greet {
+    my $self = shift;
+    return $self->SUPER::greet();
+}
+
+1;
+"#;
+
+    harness.open("file:///lib/Animal.pm", code)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(code, "SUPER::greet")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": "file:///lib/Animal.pm"},
+            "position": {"line": line, "character": character + 8}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected array result for SUPER definition")?;
+    assert!(!locations.is_empty(), "SUPER::greet should resolve under C3 mro");
+    let first = &locations[0];
+    assert_valid_location(first);
+    assert!(
+        first["uri"].as_str().unwrap_or("").contains("Animal.pm"),
+        "SUPER::greet should resolve within the current file, got: {first:?}"
+    );
+    assert_eq!(
+        first["range"]["start"]["line"].as_u64(),
+        Some(8),
+        "C3 mro should resolve to Right::greet, not the Root fallback"
+    );
 
     Ok(())
 }

--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -44,6 +44,21 @@ pub enum AccessorType {
     Bare,
 }
 
+/// Method-resolution order for inherited method lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodResolutionOrder {
+    /// Default Perl depth-first resolution order.
+    Dfs,
+    /// C3 linearization enabled via `use mro 'c3';`.
+    C3,
+}
+
+impl Default for MethodResolutionOrder {
+    fn default() -> Self {
+        Self::Dfs
+    }
+}
+
 /// A Moose/Moo attribute declared via `has`.
 #[derive(Debug, Clone)]
 pub struct Attribute {
@@ -179,6 +194,8 @@ pub struct ClassModel {
     pub adjusts: Vec<MethodInfo>,
     /// Parent classes from `extends 'Parent'`, `use parent`, `use base`, or `@ISA`
     pub parents: Vec<String>,
+    /// Method-resolution order for inherited method lookup.
+    pub mro: MethodResolutionOrder,
     /// Roles consumed via `with 'Role'`
     pub roles: Vec<String>,
     /// Method modifiers (before/after/around/override/augment)
@@ -211,6 +228,7 @@ pub struct ClassModelBuilder {
     current_methods: Vec<MethodInfo>,
     current_adjusts: Vec<MethodInfo>,
     current_parents: Vec<String>,
+    current_mro: MethodResolutionOrder,
     current_roles: Vec<String>,
     current_modifiers: Vec<MethodModifier>,
     current_exports: Vec<String>,
@@ -238,6 +256,7 @@ impl ClassModelBuilder {
             current_methods: Vec::new(),
             current_adjusts: Vec::new(),
             current_parents: Vec::new(),
+            current_mro: MethodResolutionOrder::Dfs,
             current_roles: Vec::new(),
             current_modifiers: Vec::new(),
             current_exports: Vec::new(),
@@ -274,6 +293,7 @@ impl ClassModelBuilder {
                 methods: std::mem::take(&mut self.current_methods),
                 adjusts: std::mem::take(&mut self.current_adjusts),
                 parents: std::mem::take(&mut self.current_parents),
+                mro: self.current_mro,
                 roles: std::mem::take(&mut self.current_roles),
                 modifiers: std::mem::take(&mut self.current_modifiers),
                 exports: std::mem::take(&mut self.current_exports),
@@ -288,6 +308,7 @@ impl ClassModelBuilder {
             self.current_methods.clear();
             self.current_adjusts.clear();
             self.current_parents.clear();
+            self.current_mro = MethodResolutionOrder::Dfs;
             self.current_roles.clear();
             self.current_modifiers.clear();
             self.current_exports.clear();
@@ -309,6 +330,7 @@ impl ClassModelBuilder {
                 self.current_package = name.clone();
                 self.current_framework =
                     self.framework_map.get(name).copied().unwrap_or(Framework::None);
+                self.current_mro = MethodResolutionOrder::Dfs;
 
                 if let Some(block) = block {
                     self.visit_node(block);
@@ -328,6 +350,10 @@ impl ClassModelBuilder {
 
             NodeKind::Use { module, args, .. } => {
                 self.detect_framework(module, args);
+            }
+
+            NodeKind::No { module, .. } if module == "mro" => {
+                self.current_mro = MethodResolutionOrder::Dfs;
             }
 
             // `our @ISA = qw(Parent1 Parent2);` / `our @EXPORT = qw(...);` / `our @EXPORT_OK = qw(...);`
@@ -406,6 +432,7 @@ impl ClassModelBuilder {
                 } else {
                     Framework::NativeClass
                 };
+                self.current_mro = MethodResolutionOrder::Dfs;
                 self.framework_map.insert(name.clone(), self.current_framework);
                 self.current_package_aliases.clear();
                 // Populate parent classes from `:isa(Parent)` attributes
@@ -455,6 +482,7 @@ impl ClassModelBuilder {
         while idx < statements.len() {
             // First, check for `use` declarations to detect frameworks
             if let NodeKind::Use { module, args, .. } = &statements[idx].kind {
+                self.detect_mro(module, args);
                 self.detect_framework(module, args);
                 idx += 1;
                 continue;
@@ -549,6 +577,33 @@ impl ClassModelBuilder {
 
         self.current_framework = framework;
         self.framework_map.insert(self.current_package.clone(), framework);
+    }
+
+    /// Detect `use mro 'c3'` / `use mro 'dfs'` for the current package.
+    fn detect_mro(&mut self, module: &str, args: &[String]) {
+        if module != "mro" {
+            return;
+        }
+
+        if args.is_empty() {
+            self.current_mro = MethodResolutionOrder::Dfs;
+            return;
+        }
+
+        for arg in args {
+            let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
+            match trimmed {
+                "c3" => {
+                    self.current_mro = MethodResolutionOrder::C3;
+                    return;
+                }
+                "dfs" => {
+                    self.current_mro = MethodResolutionOrder::Dfs;
+                    return;
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Extract Moo/Moose `has` declarations.
@@ -1329,6 +1384,30 @@ has 'level' => (is => 'ro');
         assert!(model.parents.contains(&"MyApp::User".to_string()));
         assert_eq!(model.roles, vec!["MyApp::Printable", "MyApp::Serializable"]);
         assert_eq!(model.attributes.len(), 1);
+    }
+
+    #[test]
+    fn mro_pragma_tracks_c3_and_reset() {
+        let models = build_models(
+            r#"
+package Example::Child;
+use parent 'Example::Base';
+use mro 'c3';
+sub greet { }
+
+package Example::Sibling;
+use parent 'Example::Base';
+no mro;
+sub greet { }
+"#,
+        );
+
+        let child = find_model(&models, "Example::Child").expect("expected ClassModel for Child");
+        assert_eq!(child.mro, MethodResolutionOrder::C3);
+
+        let sibling =
+            find_model(&models, "Example::Sibling").expect("expected ClassModel for Sibling");
+        assert_eq!(sibling.mro, MethodResolutionOrder::Dfs);
     }
 
     #[test]

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -33,10 +33,10 @@ pub use model::SemanticModel;
 pub use tokens::{SemanticToken, SemanticTokenModifier, SemanticTokenType};
 
 use crate::SourceLocation;
-use crate::analysis::class_model::{ClassModel, ClassModelBuilder};
+use crate::analysis::class_model::{ClassModel, ClassModelBuilder, MethodResolutionOrder};
 use crate::ast::Node;
 use crate::symbol::{Symbol, SymbolExtractor, SymbolTable};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
 /// Semantic analyzer providing comprehensive IDE features for Perl code.
@@ -266,64 +266,232 @@ impl SemanticAnalyzer {
         receiver_class: &str,
         method_name: &str,
     ) -> Option<HoverInfo> {
-        let mut visited: Vec<String> = Vec::new();
-        let mut queue: Vec<String> = vec![receiver_class.to_string()];
+        self.resolve_inherited_method_hover_ordered(receiver_class, method_name)
+    }
 
-        while !queue.is_empty() {
-            let current = queue.remove(0);
-            if visited.contains(&current) {
-                continue;
+    /// Resolve the source location of a method inherited from the current class.
+    ///
+    /// This skips the receiver class itself and searches its ancestors in the
+    /// package's configured method-resolution order.
+    pub fn resolve_inherited_method_location(
+        &self,
+        receiver_class: &str,
+        method_name: &str,
+    ) -> Option<SourceLocation> {
+        let models_by_name: HashMap<&str, &ClassModel> =
+            self.class_models.iter().map(|model| (model.name.as_str(), model)).collect();
+
+        let receiver_model = models_by_name.get(receiver_class).copied()?;
+        let ancestor_order = match receiver_model.mro {
+            MethodResolutionOrder::Dfs => self.dfs_ancestor_order(receiver_class, &models_by_name),
+            MethodResolutionOrder::C3 => self.c3_ancestor_order(receiver_class, &models_by_name),
+        };
+
+        for ancestor in ancestor_order {
+            if let Some(model) = models_by_name.get(ancestor.as_str()).copied()
+                && let Some(location) = self.method_location_in_model(model, method_name)
+            {
+                return Some(location);
             }
-            visited.push(current.clone());
+        }
 
-            // Check class model first (has method list + parent chain)
-            if let Some(model) = self.class_models.iter().find(|m| m.name == current) {
-                if model.methods.iter().any(|m| m.name == method_name) {
-                    let is_direct = current == receiver_class;
-                    let details = if is_direct {
-                        vec![format!("Defined in {}", current)]
-                    } else {
-                        vec![format!("Inherited from {}", current)]
-                    };
-                    return Some(HoverInfo {
-                        signature: format!("sub {}::{}", current, method_name),
-                        documentation: None,
-                        details,
-                    });
+        None
+    }
+
+    fn resolve_inherited_method_hover_ordered(
+        &self,
+        receiver_class: &str,
+        method_name: &str,
+    ) -> Option<HoverInfo> {
+        let models_by_name: HashMap<&str, &ClassModel> =
+            self.class_models.iter().map(|model| (model.name.as_str(), model)).collect();
+
+        let Some(receiver_model) = models_by_name.get(receiver_class).copied() else {
+            return self.resolve_plain_package_method_hover(receiver_class, method_name);
+        };
+
+        if let Some(hover) =
+            self.hover_for_model_method(receiver_model, receiver_class, method_name)
+        {
+            return Some(hover);
+        }
+
+        let ancestor_order = match receiver_model.mro {
+            MethodResolutionOrder::Dfs => self.dfs_ancestor_order(receiver_class, &models_by_name),
+            MethodResolutionOrder::C3 => self.c3_ancestor_order(receiver_class, &models_by_name),
+        };
+
+        for ancestor in ancestor_order {
+            if let Some(model) = models_by_name.get(ancestor.as_str()).copied() {
+                if let Some(hover) = self.hover_for_model_method(model, receiver_class, method_name)
+                {
+                    return Some(hover);
                 }
-                for parent in &model.parents {
-                    if !visited.contains(parent) {
-                        queue.push(parent.clone());
-                    }
-                }
+            } else if let Some(hover) =
+                self.resolve_plain_package_method_hover(&ancestor, method_name)
+            {
+                return Some(hover);
+            }
+        }
+
+        None
+    }
+
+    fn hover_for_model_method(
+        &self,
+        model: &ClassModel,
+        receiver_class: &str,
+        method_name: &str,
+    ) -> Option<HoverInfo> {
+        if model.methods.iter().any(|m| m.name == method_name) {
+            let is_direct = model.name == receiver_class;
+            let details = if is_direct {
+                vec![format!("Defined in {}", model.name)]
             } else {
-                // Plain package not in class_models — check the symbol table
-                // for a sub with qualified_name == "PackageName::method_name"
-                let qualified = format!("{}::{}", current, method_name);
-                let found_in_table =
-                    self.symbol_table.symbols.get(method_name).is_some_and(|syms| {
-                        syms.iter().any(|s| {
-                            matches!(s.kind, crate::symbol::SymbolKind::Subroutine)
-                                && s.qualified_name == qualified
-                        })
-                    }) || self.symbol_table.symbols.contains_key(&qualified);
+                vec![format!("Inherited from {}", model.name)]
+            };
+            return Some(HoverInfo {
+                signature: format!("sub {}::{}", model.name, method_name),
+                documentation: None,
+                details,
+            });
+        }
+        None
+    }
 
-                if found_in_table {
-                    let is_direct = current == receiver_class;
-                    let details = if is_direct {
-                        vec![format!("Defined in {}", current)]
-                    } else {
-                        vec![format!("Inherited from {}", current)]
-                    };
-                    return Some(HoverInfo {
-                        signature: format!("sub {}::{}", current, method_name),
-                        documentation: None,
-                        details,
-                    });
+    fn method_location_in_model(
+        &self,
+        model: &ClassModel,
+        method_name: &str,
+    ) -> Option<SourceLocation> {
+        model.methods.iter().find(|method| method.name == method_name).map(|method| method.location)
+    }
+
+    fn resolve_plain_package_method_hover(
+        &self,
+        package_name: &str,
+        method_name: &str,
+    ) -> Option<HoverInfo> {
+        let qualified = format!("{}::{}", package_name, method_name);
+        let found_in_table = self.symbol_table.symbols.get(method_name).is_some_and(|syms| {
+            syms.iter().any(|s| {
+                matches!(s.kind, crate::symbol::SymbolKind::Subroutine)
+                    && s.qualified_name == qualified
+            })
+        }) || self.symbol_table.symbols.contains_key(&qualified);
+
+        if found_in_table {
+            return Some(HoverInfo {
+                signature: format!("sub {}::{}", package_name, method_name),
+                documentation: None,
+                details: vec![format!("Inherited from {}", package_name)],
+            });
+        }
+
+        None
+    }
+
+    fn dfs_ancestor_order(
+        &self,
+        package: &str,
+        models_by_name: &HashMap<&str, &ClassModel>,
+    ) -> Vec<String> {
+        fn walk(
+            package: &str,
+            models_by_name: &HashMap<&str, &ClassModel>,
+            seen: &mut HashSet<String>,
+            out: &mut Vec<String>,
+        ) {
+            let Some(model) = models_by_name.get(package).copied() else {
+                return;
+            };
+
+            for parent in &model.parents {
+                if seen.insert(parent.clone()) {
+                    out.push(parent.clone());
+                    walk(parent, models_by_name, seen, out);
                 }
             }
         }
-        None
+
+        let mut seen = HashSet::from([package.to_string()]);
+        let mut out = Vec::new();
+        walk(package, models_by_name, &mut seen, &mut out);
+        out
+    }
+
+    fn c3_ancestor_order(
+        &self,
+        package: &str,
+        models_by_name: &HashMap<&str, &ClassModel>,
+    ) -> Vec<String> {
+        fn linearize(
+            package: &str,
+            models_by_name: &HashMap<&str, &ClassModel>,
+            visited: &mut HashSet<String>,
+        ) -> Vec<String> {
+            if !visited.insert(package.to_string()) {
+                return vec![];
+            }
+
+            let Some(model) = models_by_name.get(package).copied() else {
+                return vec![package.to_string()];
+            };
+
+            let parents = model.parents.clone();
+            if parents.is_empty() {
+                return vec![package.to_string()];
+            }
+
+            let mut parent_mros: Vec<Vec<String>> = parents
+                .iter()
+                .map(|parent| linearize(parent, models_by_name, &mut visited.clone()))
+                .collect();
+            parent_mros.push(parents.clone());
+
+            let mut result = vec![package.to_string()];
+            loop {
+                parent_mros.retain(|list| !list.is_empty());
+                if parent_mros.is_empty() {
+                    break;
+                }
+
+                let chosen = parent_mros.iter().find_map(|list| {
+                    let candidate = list.first()?;
+                    let in_tail = parent_mros
+                        .iter()
+                        .any(|other| other.iter().skip(1).any(|name| name == candidate));
+                    if in_tail { None } else { Some(candidate.clone()) }
+                });
+
+                match chosen {
+                    Some(name) => {
+                        if !result.contains(&name) {
+                            result.push(name.clone());
+                        }
+                        for list in &mut parent_mros {
+                            if list.first().is_some_and(|head| head == &name) {
+                                list.remove(0);
+                            }
+                        }
+                    }
+                    None => {
+                        for list in parent_mros {
+                            if let Some(head) = list.first()
+                                && !result.contains(head)
+                            {
+                                result.push(head.clone());
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            result
+        }
+
+        linearize(package, models_by_name, &mut HashSet::new()).into_iter().skip(1).collect()
     }
 }
 


### PR DESCRIPTION
## Summary
- track package-level `use mro` / `no mro` state in class models
- resolve inherited method lookup and `SUPER::method` navigation using DFS or C3 order as configured
- add targeted regression coverage for parent-chain and C3 `SUPER::greet` definition lookup

## Tests
- cargo test -p perl-semantic-analyzer mro_pragma_tracks_c3_and_reset -- --nocapture
- cargo test -p perl-lsp-rs go_to_definition_on_super_method -- --nocapture
- cargo fmt --all --check
- git diff --check

## Scope
This PR fixes #3384 and carries the minimal `mro` tracking needed for the inherited lookup path from #3385.
