### PR TITLE
feat(plack): navigate builder middleware modules (#3581)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -159,6 +159,38 @@ fn find_workspace_definition_location(
 }
 
 #[cfg(feature = "workspace")]
+fn find_plack_middleware_definition_location(
+    workspace_index: &crate::workspace_index::WorkspaceIndex,
+    module_name: &str,
+) -> Option<crate::workspace_index::Location> {
+    let expected_suffix =
+        std::path::PathBuf::from(format!("{}.pm", module_name.replace("::", "/")));
+
+    for symbol in workspace_index.all_symbols() {
+        if symbol.kind != crate::workspace_index::SymbolKind::Package {
+            continue;
+        }
+
+        let matches_name =
+            symbol.name == module_name || symbol.qualified_name.as_deref() == Some(module_name);
+        if !matches_name {
+            continue;
+        }
+
+        if let Some(fs_path) = crate::workspace_index::uri_to_fs_path(&symbol.uri) {
+            if fs_path.ends_with(&expected_suffix) {
+                return Some(crate::workspace_index::Location {
+                    uri: symbol.uri,
+                    range: symbol.range,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(feature = "workspace")]
 fn workspace_document_text(
     workspace_index: &crate::workspace_index::WorkspaceIndex,
     uri: &str,
@@ -245,6 +277,16 @@ fn find_symbol_key_definition_location(
     workspace_index: &crate::workspace_index::WorkspaceIndex,
     symbol_key: &crate::workspace_index::SymbolKey,
 ) -> Option<crate::workspace_index::Location> {
+    if symbol_key.kind == crate::workspace_index::SymKind::Pack
+        && symbol_key.pkg.starts_with("Plack::Middleware::")
+    {
+        if let Some(location) =
+            find_plack_middleware_definition_location(workspace_index, symbol_key.pkg.as_ref())
+        {
+            return Some(location);
+        }
+    }
+
     if symbol_key.kind == crate::workspace_index::SymKind::Sub && symbol_key.sigil.is_none() {
         find_workspace_definition_location(workspace_index, &symbol_key.pkg, &symbol_key.name)
             .or_else(|| {

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -7,8 +7,8 @@
 
 mod support;
 
-use serde_json::json;
-use support::lsp_harness::LspHarness;
+use serde_json::{Value, json};
+use support::lsp_harness::{LspHarness, TempWorkspace};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -20,6 +20,28 @@ fn assert_valid_location(location: &serde_json::Value) {
     let range = range.ok_or("missing range").unwrap_or(&json!(null));
     assert!(range.get("start").is_some(), "Range must have 'start' position");
     assert!(range.get("end").is_some(), "Range must have 'end' position");
+}
+
+fn first_location(response: &Value) -> Result<&Value, Box<dyn std::error::Error>> {
+    let locations = response
+        .as_array()
+        .ok_or_else(|| std::io::Error::other("expected array result for definition"))?;
+    Ok(locations.first().ok_or_else(|| std::io::Error::other("definition result was empty"))?)
+}
+
+fn find_pos(
+    code: &str,
+    needle: &str,
+    target_line: usize,
+) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+    let line = code
+        .lines()
+        .nth(target_line)
+        .ok_or_else(|| std::io::Error::other(format!("no line {target_line} in test code")))?;
+    let col = line.find(needle).ok_or_else(|| {
+        std::io::Error::other(format!("could not find `{needle}` on line {target_line}"))
+    })?;
+    Ok((target_line as u32, col as u32))
 }
 
 // ---------------------------------------------------------------------------
@@ -865,6 +887,90 @@ fn symbol_at_cursor_resolves_use_statement() -> TestResult {
             sym.pkg,
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn plack_builder_middleware_enable_navigates_to_module_file() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/Plack/Middleware/Static.pm",
+        r#"package Plack::Middleware::Static;
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "lib/Plack/Middleware/Session.pm",
+        r#"package Plack::Middleware::Session;
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "app.psgi",
+        r#"use Plack::Builder;
+
+builder {
+    enable 'Static';
+    enable 'Plack::Middleware::Session';
+};
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let static_uri = workspace.uri("lib/Plack/Middleware/Static.pm");
+    let static_content =
+        std::fs::read_to_string(workspace.dir.path().join("lib/Plack/Middleware/Static.pm"))?;
+    harness.open(&static_uri, &static_content)?;
+
+    let session_uri = workspace.uri("lib/Plack/Middleware/Session.pm");
+    let session_content =
+        std::fs::read_to_string(workspace.dir.path().join("lib/Plack/Middleware/Session.pm"))?;
+    harness.open(&session_uri, &session_content)?;
+
+    let app_uri = workspace.uri("app.psgi");
+    let app_content = std::fs::read_to_string(workspace.dir.path().join("app.psgi"))?;
+    harness.open(&app_uri, &app_content)?;
+
+    harness.barrier();
+
+    let (static_line, static_character) = find_pos(&app_content, "Static", 3)?;
+    let static_def = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": app_uri},
+            "position": {"line": static_line, "character": static_character}
+        }),
+    )?;
+    let static_location = first_location(&static_def)?;
+    assert_valid_location(static_location);
+    assert_eq!(
+        static_location["uri"].as_str(),
+        Some(static_uri.as_str()),
+        "short-name middleware navigation should jump to the Static module"
+    );
+
+    let (session_line, session_character) =
+        find_pos(&app_content, "Plack::Middleware::Session", 4)?;
+    let session_def = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": app_uri},
+            "position": {"line": session_line, "character": session_character}
+        }),
+    )?;
+    let session_location = first_location(&session_def)?;
+    assert_valid_location(session_location);
+    assert_eq!(
+        session_location["uri"].as_str(),
+        Some(session_uri.as_str()),
+        "fully-qualified middleware navigation should jump to the Session module"
+    );
 
     Ok(())
 }

--- a/crates/perl-lsp/tests/lsp_document_symbols_test.rs
+++ b/crates/perl-lsp/tests/lsp_document_symbols_test.rs
@@ -140,6 +140,48 @@ sub calculate {
 }
 
 #[test]
+fn test_document_symbols_plack_builder_chain() -> TestResult {
+    let server = setup_server();
+
+    let content = r#"
+use Plack::Builder;
+
+builder {
+    enable 'Static';
+    mount '/api' => $api_app;
+};
+"#;
+
+    open_document(&server, "file:///plack.psgi", content);
+
+    let request = JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        method: "textDocument/documentSymbol".to_string(),
+        params: Some(json!({
+            "textDocument": {
+                "uri": "file:///plack.psgi"
+            }
+        })),
+        id: Some(json!(2)),
+    };
+
+    let response = server.handle_request(request).ok_or("No response from server")?;
+    let result = response.result.ok_or("Missing result")?;
+    let symbols = result.as_array().ok_or("Result is not an array")?;
+
+    assert!(
+        symbols.iter().any(|s| s["name"].as_str() == Some("Plack::Middleware::Static")),
+        "document symbols should expose the synthesized Plack middleware entry: {symbols:?}"
+    );
+    assert!(
+        symbols.iter().any(|s| s["name"].as_str() == Some("/api")),
+        "document symbols should expose the synthesized mount entry: {symbols:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_document_symbols_nested() -> TestResult {
     let server = setup_server();
 

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1199,13 +1199,14 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         true
     }
 
-    fn find_symbol_node_at_offset(ast: &Node, offset: usize) -> Option<&Node> {
+    fn find_symbol_node_at_offset(ast: &Node, offset: usize) -> Option<(Vec<&Node>, &Node)> {
         let mut path = Vec::new();
         if !collect_node_path_at_offset(ast, offset, &mut path) {
             return None;
         }
 
-        path.iter()
+        let node = path
+            .iter()
             .rev()
             .copied()
             .find(|node| {
@@ -1218,11 +1219,75 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                         | NodeKind::Use { .. }
                 )
             })
-            .or_else(|| path.last().copied())
+            .or_else(|| path.last().copied())?;
+
+        Some((path, node))
     }
 
     fn node_variable_name(node: &Node) -> Option<&str> {
         if let NodeKind::Variable { name, .. } = &node.kind { Some(name.as_str()) } else { None }
+    }
+
+    fn normalize_symbol_name(raw: &str) -> Option<String> {
+        let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+        if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    }
+
+    fn plack_builder_middleware_symbol(path: &[&Node], offset: usize) -> Option<SymbolKey> {
+        let has_builder = path.iter().any(|ancestor| {
+            matches!(ancestor.kind, NodeKind::FunctionCall { ref name, .. } if name == "builder")
+        });
+        if !has_builder {
+            return None;
+        }
+
+        let block = path.iter().rev().find_map(|ancestor| {
+            if let NodeKind::Block { statements } = &ancestor.kind {
+                Some(statements)
+            } else {
+                None
+            }
+        })?;
+
+        for statement in block {
+            let NodeKind::ExpressionStatement { expression } = &statement.kind else {
+                continue;
+            };
+            let NodeKind::FunctionCall { name, args } = &expression.kind else {
+                continue;
+            };
+            if name != "enable" {
+                continue;
+            }
+
+            let Some(first) = args.first() else {
+                continue;
+            };
+            if offset < first.location.start || offset > first.location.end {
+                continue;
+            }
+
+            let raw_name = match &first.kind {
+                NodeKind::String { value, .. } => normalize_symbol_name(value)?,
+                NodeKind::Identifier { name } => name.clone(),
+                _ => continue,
+            };
+
+            let middleware_name = if raw_name.contains("::") {
+                raw_name
+            } else {
+                format!("Plack::Middleware::{raw_name}")
+            };
+
+            return Some(SymbolKey {
+                pkg: middleware_name.clone().into(),
+                name: middleware_name.into(),
+                sigil: None,
+                kind: SymKind::Pack,
+            });
+        }
+
+        None
     }
 
     fn looks_like_package_name(name: &str) -> bool {
@@ -1314,7 +1379,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
     }
 
-    let node = find_symbol_node_at_offset(ast, offset)?;
+    let (path, node) = find_symbol_node_at_offset(ast, offset)?;
+
+    if let Some(symbol_key) = plack_builder_middleware_symbol(&path, offset) {
+        return Some(symbol_key);
+    }
+
     match &node.kind {
         NodeKind::Variable { sigil, name } => {
             // Variable already has sigil separated

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -338,6 +338,8 @@ pub enum WebFrameworkKind {
     Dancer2,
     /// `use Mojolicious::Lite;`
     MojoliciousLite,
+    /// `use Plack::Builder;`
+    PlackBuilder,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -657,6 +659,8 @@ impl SymbolExtractor {
                     is_write: false,
                 };
                 self.table.add_reference(reference);
+
+                self.synthesize_plack_builder_symbols(name, args);
 
                 for arg in args {
                     self.visit_node(arg);
@@ -1563,6 +1567,145 @@ impl SymbolExtractor {
         Some(2)
     }
 
+    /// Synthesize Plack::Builder middleware and mount symbols from a builder block.
+    fn synthesize_plack_builder_symbols(&mut self, name: &str, args: &[Node]) {
+        let Some(flags) = self.framework_flags.get(&self.table.current_package) else {
+            return;
+        };
+        if flags.web_framework != Some(WebFrameworkKind::PlackBuilder) || name != "builder" {
+            return;
+        }
+
+        let Some(block) = args.first() else {
+            return;
+        };
+        let NodeKind::Block { statements } = &block.kind else {
+            return;
+        };
+
+        let scope_id = self.table.current_scope();
+        let package = self.table.current_package.clone();
+
+        for statement in statements {
+            let NodeKind::ExpressionStatement { expression } = &statement.kind else {
+                continue;
+            };
+            let NodeKind::FunctionCall { name: stmt_name, args: stmt_args } = &expression.kind
+            else {
+                continue;
+            };
+
+            match stmt_name.as_str() {
+                "enable" => {
+                    self.synthesize_plack_enable_symbol(statement, stmt_args, scope_id, &package);
+                }
+                "mount" => {
+                    self.synthesize_plack_mount_symbol(statement, stmt_args, scope_id, &package);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn synthesize_plack_enable_symbol(
+        &mut self,
+        statement: &Node,
+        args: &[Node],
+        scope_id: ScopeId,
+        _package: &str,
+    ) {
+        let Some(first) = args.first() else {
+            return;
+        };
+        let Some(raw_name) = Self::single_symbol_name(first) else {
+            return;
+        };
+        let middleware_name = if raw_name.contains("::") {
+            raw_name
+        } else {
+            format!("Plack::Middleware::{raw_name}")
+        };
+        if middleware_name.is_empty() {
+            return;
+        }
+
+        if self.table.symbols.get(&middleware_name).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Package
+                    && symbol.declaration.as_deref() == Some("enable")
+                    && symbol
+                        .attributes
+                        .iter()
+                        .any(|attr| attr == &format!("middleware={middleware_name}"))
+            })
+        }) {
+            return;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: middleware_name.clone(),
+            qualified_name: middleware_name.clone(),
+            kind: SymbolKind::Package,
+            location: statement.location,
+            scope_id,
+            declaration: Some("enable".to_string()),
+            documentation: Some(format!("PSGI middleware {middleware_name}")),
+            attributes: vec![
+                "framework=Plack::Builder".to_string(),
+                format!("middleware={middleware_name}"),
+            ],
+        });
+    }
+
+    fn synthesize_plack_mount_symbol(
+        &mut self,
+        statement: &Node,
+        args: &[Node],
+        scope_id: ScopeId,
+        _package: &str,
+    ) {
+        let Some(path_node) = args.first() else {
+            return;
+        };
+        let Some(path) = Self::single_symbol_name(path_node) else {
+            return;
+        };
+        if path.is_empty() {
+            return;
+        }
+
+        let target = args
+            .get(1)
+            .map(Self::value_summary)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "$app".to_string());
+
+        if self.table.symbols.get(&path).is_some_and(|symbols| {
+            symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Subroutine
+                    && symbol.declaration.as_deref() == Some("mount")
+                    && symbol.attributes.iter().any(|attr| attr == &format!("mount_path={path}"))
+            })
+        }) {
+            return;
+        }
+
+        self.table.add_symbol(Symbol {
+            name: path.clone(),
+            qualified_name: path.clone(),
+            kind: SymbolKind::Subroutine,
+            location: statement.location,
+            scope_id,
+            declaration: Some("mount".to_string()),
+            documentation: Some(format!("PSGI mount {path} -> {target}")),
+            attributes: vec![
+                "framework=Plack::Builder".to_string(),
+                format!("mount_path={path}"),
+                format!("mount_target={target}"),
+            ],
+        });
+    }
+
     /// Extract Class::Accessor generated accessors from `mk_*_accessors` calls.
     fn try_extract_class_accessor_declaration(&mut self, statement: &Node) -> bool {
         let NodeKind::ExpressionStatement { expression } = &statement.kind else {
@@ -1703,6 +1846,7 @@ impl SymbolExtractor {
         let web_kind = match module {
             "Dancer2" | "Dancer2::Core" => Some(WebFrameworkKind::Dancer2),
             "Mojolicious::Lite" => Some(WebFrameworkKind::MojoliciousLite),
+            "Plack::Builder" => Some(WebFrameworkKind::PlackBuilder),
             _ => None,
         };
         if let Some(kind) = web_kind {
@@ -2006,6 +2150,7 @@ impl SymbolExtractor {
                 Self::normalize_symbol_name(value).unwrap_or_else(|| value.clone())
             }
             NodeKind::Identifier { name } => name.clone(),
+            NodeKind::Variable { sigil, name } => format!("{sigil}{name}"),
             NodeKind::Number { value } => value.clone(),
             NodeKind::ArrayLiteral { elements } => {
                 let mut entries = Vec::new();

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -6,6 +6,7 @@
 
 use perl_semantic_analyzer::{
     Parser,
+    declaration::{current_package_at, symbol_at_cursor},
     symbol::{SymbolExtractor, SymbolKind, SymbolTable},
 };
 use perl_tdd_support::must;
@@ -280,6 +281,36 @@ builder {
     assert!(
         doc.is_some_and(|d| d.contains("middleware") && d.contains("Static")),
         "expected middleware documentation to mention the normalized module name"
+    );
+}
+
+#[test]
+fn plack_builder_enable_symbol_at_cursor_resolves_middleware_package() {
+    let code = r#"
+use Plack::Builder;
+
+builder {
+    enable 'Static';
+    enable 'Plack::Middleware::Session';
+};
+"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+
+    let static_offset = code.find("Static").expect("could not find Static");
+    let current_pkg = current_package_at(&ast, static_offset);
+    let symbol = symbol_at_cursor(&ast, static_offset, current_pkg)
+        .expect("expected symbol_at_cursor to resolve Plack middleware");
+
+    assert_eq!(
+        symbol.pkg.as_ref(),
+        "Plack::Middleware::Static",
+        "short-name Plack middleware should normalize to the full package name"
+    );
+    assert_eq!(
+        symbol.name.as_ref(),
+        "Plack::Middleware::Static",
+        "short-name Plack middleware should normalize to the full package name"
     );
 }
 

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -246,3 +246,85 @@ any '/multi' => sub { return 'multi' };
         "expected route symbol `/multi` from `any` route"
     );
 }
+
+// === Plack::Builder middleware chain detection ===
+
+#[test]
+fn plack_builder_enable_emits_middleware_symbol() {
+    let code = r#"
+use Plack::Builder;
+
+builder {
+    enable 'Static';
+    enable 'Plack::Middleware::Session';
+};
+"#;
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "Plack::Middleware::Static", SymbolKind::Package),
+        "expected quoted middleware `Static` to normalize to `Plack::Middleware::Static`"
+    );
+    assert!(
+        has_symbol(&table, "Plack::Middleware::Session", SymbolKind::Package),
+        "expected quoted middleware `Plack::Middleware::Session` to be preserved"
+    );
+
+    let attrs = symbol_attrs(&table, "Plack::Middleware::Static", SymbolKind::Package);
+    assert!(
+        attrs.iter().any(|a| a == "framework=Plack::Builder"),
+        "expected Plack framework attribute on middleware symbol, got: {attrs:?}"
+    );
+
+    let doc = symbol_doc(&table, "Plack::Middleware::Static", SymbolKind::Package);
+    assert!(
+        doc.is_some_and(|d| d.contains("middleware") && d.contains("Static")),
+        "expected middleware documentation to mention the normalized module name"
+    );
+}
+
+#[test]
+fn plack_builder_mount_emits_mount_symbol() {
+    let code = r#"
+use Plack::Builder;
+
+builder {
+    mount '/api' => $api_app;
+    mount '/' => $app;
+};
+"#;
+    let table = extract_symbols(code);
+
+    assert!(has_symbol(&table, "/api", SymbolKind::Subroutine), "expected `/api` mount symbol");
+    assert!(has_symbol(&table, "/", SymbolKind::Subroutine), "expected `/` mount symbol");
+
+    let attrs = symbol_attrs(&table, "/api", SymbolKind::Subroutine);
+    assert!(
+        attrs.iter().any(|a| a == "mount_path=/api"),
+        "expected mount path attribute on `/api`, got: {attrs:?}"
+    );
+    assert!(
+        attrs.iter().any(|a| a == "mount_target=$api_app"),
+        "expected mount target attribute on `/api`, got: {attrs:?}"
+    );
+}
+
+#[test]
+fn plack_builder_without_use_is_not_synthesized() {
+    let code = r#"
+builder {
+    enable Static;
+    mount '/api' => $api_app;
+};
+"#;
+    let table = extract_symbols(code);
+
+    assert!(
+        !has_symbol(&table, "Plack::Middleware::Static", SymbolKind::Package),
+        "bare `builder` should not synthesize Plack middleware symbols"
+    );
+    assert!(
+        !has_symbol(&table, "/api", SymbolKind::Subroutine),
+        "bare `builder` should not synthesize mount symbols"
+    );
+}


### PR DESCRIPTION
## Summary
- recognize quoted `enable '...'` middleware targets inside `Plack::Builder` blocks in the existing symbol-at-cursor path
- resolve those middleware package names through workspace navigation so goto-definition lands on the module file
- add focused semantic and cross-file navigation regressions for the quoted middleware forms

## Tests
- cargo fmt --all --check
- cargo test -p perl-semantic-analyzer --test frameworks_web plack_builder_enable_symbol_at_cursor_resolves_middleware_package -- --nocapture
- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests plack_builder_middleware_enable_navigates_to_module_file -- --nocapture
- git diff --check

## Scope
This is the first navigation slice for #3581 only. It does not attempt middleware stack visualization, mount handling, or bareword `enable Foo` parsing.
