### PR TITLE
fix(parser): support Attribute::Handlers custom attrs (#3388)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -76,6 +76,23 @@ impl<'a> Parser<'a> {
         Self::BUILTIN_SUB_ATTRIBUTES.contains(&name)
     }
 
+    /// Return `true` if `Attribute::Handlers` has been enabled in this file.
+    fn has_attribute_handlers_support(&self) -> bool {
+        self.attribute_handlers_enabled
+    }
+
+    /// Register a custom attribute handler for later `:MyAttr` uses.
+    fn register_custom_attribute_handler(&mut self, handler: &str) {
+        if self.has_attribute_handlers_support() {
+            self.custom_attribute_handlers.insert(handler.to_string());
+        }
+    }
+
+    /// Return `true` if `name` was registered as a custom Attribute::Handlers attribute.
+    fn is_custom_attribute_handler(&self, name: &str) -> bool {
+        self.has_attribute_handlers_support() && self.custom_attribute_handlers.contains(name)
+    }
+
     /// Parse declaration attributes like `:lvalue` or `:prototype($)`.
     ///
     /// `extra_known` lists additional attribute names that should not trigger the
@@ -141,7 +158,9 @@ impl<'a> Parser<'a> {
                 // Custom attributes are valid when `attributes` or a framework hook is
                 // in scope, so a warning is the correct diagnostic level.
                 let is_known = Self::is_builtin_sub_attribute(&base_name)
-                    || extra_known.contains(&base_name.as_str());
+                    || extra_known.contains(&base_name.as_str())
+                    || self.is_custom_attribute_handler(&base_name)
+                    || (self.has_attribute_handlers_support() && base_name == "ATTR");
                 if !is_known {
                     self.errors.push(ParseError::syntax(
                         format!(
@@ -210,6 +229,12 @@ impl<'a> Parser<'a> {
         // Perl allows both `sub foo :lvalue ($)` and `sub foo ($) :lvalue`,
         // so we collect attributes on both sides and merge them.
         let mut attributes = self.parse_declaration_attributes()?;
+
+        if let Some(handler_name) = name.as_deref() {
+            if attributes.iter().any(|attr| attr.starts_with("ATTR(") || attr == "ATTR") {
+                self.register_custom_attribute_handler(handler_name);
+            }
+        }
 
         // Parse optional prototype or signature after leading attributes.
         let (prototype, signature) = if self.peek_kind() == Some(TokenKind::LeftParen) {
@@ -541,6 +566,10 @@ impl<'a> Parser<'a> {
         if self.peek_kind() == Some(TokenKind::Number) {
             module.push(' ');
             module.push_str(&self.consume_token()?.text);
+        }
+
+        if module.split_whitespace().next() == Some("Attribute::Handlers") {
+            self.attribute_handlers_enabled = true;
         }
 
         // `use if CONDITION, MODULE [, ARGS]` and `use unless ...` are special:

--- a/crates/perl-parser-core/src/engine/parser/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/mod.rs
@@ -61,7 +61,7 @@ use crate::{
     quote_parser,
     token_stream::{Token, TokenKind, TokenStream},
 };
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
@@ -99,6 +99,10 @@ pub struct Parser<'a> {
     at_stmt_start: bool,
     /// FIFO queue of pending heredoc declarations awaiting content collection
     pending_heredocs: VecDeque<PendingHeredoc>,
+    /// Custom attributes registered by Attribute::Handlers declarations in this file.
+    custom_attribute_handlers: HashSet<String>,
+    /// Whether `use Attribute::Handlers;` has been seen in this file.
+    attribute_handlers_enabled: bool,
     /// Source bytes for heredoc content collection (shared with token stream)
     src_bytes: &'a [u8],
     /// Byte cursor tracking position for heredoc content collection
@@ -149,6 +153,8 @@ impl<'a> Parser<'a> {
             in_class_body: 0,
             at_stmt_start: true,
             pending_heredocs: VecDeque::new(),
+            custom_attribute_handlers: HashSet::new(),
+            attribute_handlers_enabled: false,
             src_bytes: input.as_bytes(),
             byte_cursor: 0,
             heredoc_start_time: None,
@@ -233,6 +239,8 @@ impl<'a> Parser<'a> {
             in_class_body: 0,
             at_stmt_start: true,
             pending_heredocs: VecDeque::new(),
+            custom_attribute_handlers: HashSet::new(),
+            attribute_handlers_enabled: false,
             src_bytes: source.as_bytes(),
             byte_cursor: 0,
             heredoc_start_time: None,

--- a/crates/perl-parser-core/tests/fix_attribute_validation_3357.rs
+++ b/crates/perl-parser-core/tests/fix_attribute_validation_3357.rs
@@ -128,6 +128,24 @@ fn unknown_foobar_attr_warns() {
 }
 
 #[test]
+fn attribute_handlers_custom_attribute_is_recognized() {
+    let src = r#"
+use Attribute::Handlers;
+sub MyAttr :ATTR(CODE) { }
+sub foo :MyAttr(foo) { }
+"#;
+    assert_clean_parse(src);
+
+    let mut parser = Parser::new(src);
+    let _ast = must(parser.parse());
+    assert!(
+        parser.errors().is_empty(),
+        "Expected Attribute::Handlers custom attribute support to avoid warnings, got: {:?}",
+        parser.errors()
+    );
+}
+
+#[test]
 fn unknown_attr_does_not_produce_error_ast_node() {
     // Parsing should succeed — unknown attributes produce warnings, not hard errors
     let src = "sub unknown :foobar { }";


### PR DESCRIPTION
## Summary
- track `use Attribute::Handlers;` in the parser and register `sub Name :ATTR(...)` handlers for later attribute validation
- treat later `:MyAttr(...)` uses as known when that handler was declared in the file
- add a regression covering the narrow `Attribute::Handlers` happy path

## Tests
- cargo fmt --all --check
- cargo test -p perl-parser-core --test fix_attribute_validation_3357 -- --nocapture
- git diff --check

## Scope
This is the parser slice only for #3388. It does not add broader semantic processing for custom attribute handlers beyond suppressing the false warning path.
