### PR TITLE
feat(plack): navigate builder middleware modules (#3581)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -180,6 +180,38 @@ fn find_workspace_definition_location(
 }
 
 #[cfg(feature = "workspace")]
+fn find_plack_middleware_definition_location(
+    workspace_index: &crate::workspace_index::WorkspaceIndex,
+    module_name: &str,
+) -> Option<crate::workspace_index::Location> {
+    let expected_suffix =
+        std::path::PathBuf::from(format!("{}.pm", module_name.replace("::", "/")));
+
+    for symbol in workspace_index.all_symbols() {
+        if symbol.kind != crate::workspace_index::SymbolKind::Package {
+            continue;
+        }
+
+        let matches_name =
+            symbol.name == module_name || symbol.qualified_name.as_deref() == Some(module_name);
+        if !matches_name {
+            continue;
+        }
+
+        if let Some(fs_path) = crate::workspace_index::uri_to_fs_path(&symbol.uri) {
+            if fs_path.ends_with(&expected_suffix) {
+                return Some(crate::workspace_index::Location {
+                    uri: symbol.uri,
+                    range: symbol.range,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(feature = "workspace")]
 fn workspace_document_text(
     workspace_index: &crate::workspace_index::WorkspaceIndex,
     uri: &str,
@@ -397,6 +429,16 @@ fn find_symbol_key_definition_location(
     workspace_index: &crate::workspace_index::WorkspaceIndex,
     symbol_key: &crate::workspace_index::SymbolKey,
 ) -> Option<crate::workspace_index::Location> {
+    if symbol_key.kind == crate::workspace_index::SymKind::Pack
+        && symbol_key.pkg.starts_with("Plack::Middleware::")
+    {
+        if let Some(location) =
+            find_plack_middleware_definition_location(workspace_index, symbol_key.pkg.as_ref())
+        {
+            return Some(location);
+        }
+    }
+
     if symbol_key.kind == crate::workspace_index::SymKind::Sub && symbol_key.sigil.is_none() {
         find_workspace_definition_location(workspace_index, &symbol_key.pkg, &symbol_key.name)
             .or_else(|| {

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -7,8 +7,8 @@
 
 mod support;
 
-use serde_json::json;
-use support::lsp_harness::LspHarness;
+use serde_json::{Value, json};
+use support::lsp_harness::{LspHarness, TempWorkspace};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -30,6 +30,28 @@ fn find_line_char(code: &str, needle: &str) -> Result<(u32, u32), Box<dyn std::e
     }
 
     Err(format!("could not find '{needle}' in test source").into())
+}
+
+fn first_location(response: &Value) -> Result<&Value, Box<dyn std::error::Error>> {
+    let locations = response
+        .as_array()
+        .ok_or_else(|| std::io::Error::other("expected array result for definition"))?;
+    Ok(locations.first().ok_or_else(|| std::io::Error::other("definition result was empty"))?)
+}
+
+fn find_pos(
+    code: &str,
+    needle: &str,
+    target_line: usize,
+) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+    let line = code
+        .lines()
+        .nth(target_line)
+        .ok_or_else(|| std::io::Error::other(format!("no line {target_line} in test code")))?;
+    let col = line.find(needle).ok_or_else(|| {
+        std::io::Error::other(format!("could not find `{needle}` on line {target_line}"))
+    })?;
+    Ok((target_line as u32, col as u32))
 }
 
 // ---------------------------------------------------------------------------
@@ -994,6 +1016,90 @@ fn symbol_at_cursor_resolves_use_statement() -> TestResult {
             sym.pkg,
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn plack_builder_middleware_enable_navigates_to_module_file() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/Plack/Middleware/Static.pm",
+        r#"package Plack::Middleware::Static;
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "lib/Plack/Middleware/Session.pm",
+        r#"package Plack::Middleware::Session;
+
+1;
+"#,
+    )?;
+    workspace.write(
+        "app.psgi",
+        r#"use Plack::Builder;
+
+builder {
+    enable 'Static';
+    enable 'Plack::Middleware::Session';
+};
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let static_uri = workspace.uri("lib/Plack/Middleware/Static.pm");
+    let static_content =
+        std::fs::read_to_string(workspace.dir.path().join("lib/Plack/Middleware/Static.pm"))?;
+    harness.open(&static_uri, &static_content)?;
+
+    let session_uri = workspace.uri("lib/Plack/Middleware/Session.pm");
+    let session_content =
+        std::fs::read_to_string(workspace.dir.path().join("lib/Plack/Middleware/Session.pm"))?;
+    harness.open(&session_uri, &session_content)?;
+
+    let app_uri = workspace.uri("app.psgi");
+    let app_content = std::fs::read_to_string(workspace.dir.path().join("app.psgi"))?;
+    harness.open(&app_uri, &app_content)?;
+
+    harness.barrier();
+
+    let (static_line, static_character) = find_pos(&app_content, "Static", 3)?;
+    let static_def = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": app_uri},
+            "position": {"line": static_line, "character": static_character}
+        }),
+    )?;
+    let static_location = first_location(&static_def)?;
+    assert_valid_location(static_location);
+    assert_eq!(
+        static_location["uri"].as_str(),
+        Some(static_uri.as_str()),
+        "short-name middleware navigation should jump to the Static module"
+    );
+
+    let (session_line, session_character) =
+        find_pos(&app_content, "Plack::Middleware::Session", 4)?;
+    let session_def = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": app_uri},
+            "position": {"line": session_line, "character": session_character}
+        }),
+    )?;
+    let session_location = first_location(&session_def)?;
+    assert_valid_location(session_location);
+    assert_eq!(
+        session_location["uri"].as_str(),
+        Some(session_uri.as_str()),
+        "fully-qualified middleware navigation should jump to the Session module"
+    );
 
     Ok(())
 }

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1199,13 +1199,14 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         true
     }
 
-    fn find_symbol_node_at_offset(ast: &Node, offset: usize) -> Option<&Node> {
+    fn find_symbol_node_at_offset(ast: &Node, offset: usize) -> Option<(Vec<&Node>, &Node)> {
         let mut path = Vec::new();
         if !collect_node_path_at_offset(ast, offset, &mut path) {
             return None;
         }
 
-        path.iter()
+        let node = path
+            .iter()
             .rev()
             .copied()
             .find(|node| {
@@ -1218,11 +1219,75 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                         | NodeKind::Use { .. }
                 )
             })
-            .or_else(|| path.last().copied())
+            .or_else(|| path.last().copied())?;
+
+        Some((path, node))
     }
 
     fn node_variable_name(node: &Node) -> Option<&str> {
         if let NodeKind::Variable { name, .. } = &node.kind { Some(name.as_str()) } else { None }
+    }
+
+    fn normalize_symbol_name(raw: &str) -> Option<String> {
+        let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+        if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+    }
+
+    fn plack_builder_middleware_symbol(path: &[&Node], offset: usize) -> Option<SymbolKey> {
+        let has_builder = path.iter().any(|ancestor| {
+            matches!(ancestor.kind, NodeKind::FunctionCall { ref name, .. } if name == "builder")
+        });
+        if !has_builder {
+            return None;
+        }
+
+        let block = path.iter().rev().find_map(|ancestor| {
+            if let NodeKind::Block { statements } = &ancestor.kind {
+                Some(statements)
+            } else {
+                None
+            }
+        })?;
+
+        for statement in block {
+            let NodeKind::ExpressionStatement { expression } = &statement.kind else {
+                continue;
+            };
+            let NodeKind::FunctionCall { name, args } = &expression.kind else {
+                continue;
+            };
+            if name != "enable" {
+                continue;
+            }
+
+            let Some(first) = args.first() else {
+                continue;
+            };
+            if offset < first.location.start || offset > first.location.end {
+                continue;
+            }
+
+            let raw_name = match &first.kind {
+                NodeKind::String { value, .. } => normalize_symbol_name(value)?,
+                NodeKind::Identifier { name } => name.clone(),
+                _ => continue,
+            };
+
+            let middleware_name = if raw_name.contains("::") {
+                raw_name
+            } else {
+                format!("Plack::Middleware::{raw_name}")
+            };
+
+            return Some(SymbolKey {
+                pkg: middleware_name.clone().into(),
+                name: middleware_name.into(),
+                sigil: None,
+                kind: SymKind::Pack,
+            });
+        }
+
+        None
     }
 
     fn looks_like_package_name(name: &str) -> bool {
@@ -1314,7 +1379,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
     }
 
-    let node = find_symbol_node_at_offset(ast, offset)?;
+    let (path, node) = find_symbol_node_at_offset(ast, offset)?;
+
+    if let Some(symbol_key) = plack_builder_middleware_symbol(&path, offset) {
+        return Some(symbol_key);
+    }
+
     match &node.kind {
         NodeKind::Variable { sigil, name } => {
             // Variable already has sigil separated

--- a/crates/perl-semantic-analyzer/tests/frameworks_web.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_web.rs
@@ -6,6 +6,7 @@
 
 use perl_semantic_analyzer::{
     Parser,
+    declaration::{current_package_at, symbol_at_cursor},
     symbol::{SymbolExtractor, SymbolKind, SymbolTable},
 };
 use perl_tdd_support::must;
@@ -323,6 +324,36 @@ builder {
     assert!(
         doc.is_some_and(|d| d.contains("middleware") && d.contains("Static")),
         "expected middleware documentation to mention the normalized module name"
+    );
+}
+
+#[test]
+fn plack_builder_enable_symbol_at_cursor_resolves_middleware_package() {
+    let code = r#"
+use Plack::Builder;
+
+builder {
+    enable 'Static';
+    enable 'Plack::Middleware::Session';
+};
+"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+
+    let static_offset = code.find("Static").expect("could not find Static");
+    let current_pkg = current_package_at(&ast, static_offset);
+    let symbol = symbol_at_cursor(&ast, static_offset, current_pkg)
+        .expect("expected symbol_at_cursor to resolve Plack middleware");
+
+    assert_eq!(
+        symbol.pkg.as_ref(),
+        "Plack::Middleware::Static",
+        "short-name Plack middleware should normalize to the full package name"
+    );
+    assert_eq!(
+        symbol.name.as_ref(),
+        "Plack::Middleware::Static",
+        "short-name Plack middleware should normalize to the full package name"
     );
 }
 


### PR DESCRIPTION
## Summary
- recognize quoted `enable '...'` middleware targets inside `Plack::Builder` blocks in the existing symbol-at-cursor path
- resolve those middleware package names through workspace navigation so goto-definition lands on the module file
- add focused semantic and cross-file navigation regressions for the quoted middleware forms

## Tests
- cargo fmt --all --check
- cargo test -p perl-semantic-analyzer --test frameworks_web plack_builder_enable_symbol_at_cursor_resolves_middleware_package -- --nocapture
- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests plack_builder_middleware_enable_navigates_to_module_file -- --nocapture
- git diff --check

## Scope
This is the first navigation slice for #3581 only. It does not attempt middleware stack visualization, mount handling, or bareword `enable Foo` parsing.
