### PR TITLE
feat(module-import): distinguish empty import lists (#3473)

### DIFF
--- a/crates/perl-module-import/src/lib.rs
+++ b/crates/perl-module-import/src/lib.rs
@@ -248,20 +248,14 @@ fn classify_use_import_list(rest: &str) -> ImportListForm {
         return ImportListForm::Default;
     }
 
-    if let Some(after_open) = trimmed.strip_prefix('(') {
-        if let Some(close_idx) = after_open.find(')') {
-            if after_open[..close_idx].trim().is_empty() {
-                let after_close = after_open[close_idx + 1..].trim_start();
-                if after_close.is_empty()
-                    || after_close.starts_with(';')
-                    || after_close.starts_with('#')
-                {
-                    return ImportListForm::Empty;
-                }
-            }
+    if let Some(after_open) = trimmed.strip_prefix('(')
+        && let Some(close_idx) = after_open.find(')')
+        && after_open[..close_idx].trim().is_empty()
+    {
+        let after_close = after_open[close_idx + 1..].trim_start();
+        if after_close.is_empty() || after_close.starts_with(';') || after_close.starts_with('#') {
+            return ImportListForm::Empty;
         }
-
-        return ImportListForm::Explicit;
     }
 
     ImportListForm::Explicit

--- a/crates/perl-module-import/src/lib.rs
+++ b/crates/perl-module-import/src/lib.rs
@@ -53,6 +53,20 @@ impl DispatchSemantics {
     }
 }
 
+/// How a `use` statement spells its import list.
+///
+/// This is syntactic only: it distinguishes the default import form from an
+/// explicitly empty list and from an explicit parenthesized import list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportListForm {
+    /// `use Module;`
+    Default,
+    /// `use Module ();`
+    Empty,
+    /// `use Module (...)`
+    Explicit,
+}
+
 /// Distinguishes the two syntactic forms of `require`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequireForm {
@@ -108,6 +122,8 @@ pub struct ModuleImportHead<'a> {
     /// For `require`, whether the argument was a quoted file path or a bare module name.
     /// Always `None` for `use` forms.
     require_form: Option<RequireForm>,
+    /// For `use` statements, how the import list is spelled.
+    pub import_list: Option<ImportListForm>,
 }
 
 impl<'a> ModuleImportHead<'a> {
@@ -147,7 +163,21 @@ pub fn parse_module_import_head(line: &str) -> Option<ModuleImportHead<'_>> {
             "base" => ModuleImportKind::UseBase,
             _ => ModuleImportKind::Use,
         };
-        return Some(ModuleImportHead { kind, token, token_start, token_end, require_form: None });
+
+        let import_list = match kind {
+            ModuleImportKind::Use => Some(classify_use_import_list(&line[token_end..])),
+            ModuleImportKind::UseParent | ModuleImportKind::UseBase => None,
+            ModuleImportKind::Require => None,
+        };
+
+        return Some(ModuleImportHead {
+            kind,
+            token,
+            token_start,
+            token_end,
+            require_form: None,
+            import_list,
+        });
     }
 
     if let Some(result) = parse_require_head(line) {
@@ -192,6 +222,7 @@ fn parse_require_head(line: &str) -> Option<ModuleImportHead<'_>> {
             token_start,
             token_end,
             require_form: Some(RequireForm::FilePath),
+            import_list: None,
         });
     }
 
@@ -206,7 +237,34 @@ fn parse_require_head(line: &str) -> Option<ModuleImportHead<'_>> {
         token_start,
         token_end,
         require_form: Some(RequireForm::ModuleName),
+        import_list: None,
     })
+}
+
+fn classify_use_import_list(rest: &str) -> ImportListForm {
+    let trimmed = rest.trim_start();
+
+    if trimmed.is_empty() || trimmed.starts_with(';') {
+        return ImportListForm::Default;
+    }
+
+    if let Some(after_open) = trimmed.strip_prefix('(') {
+        if let Some(close_idx) = after_open.find(')') {
+            if after_open[..close_idx].trim().is_empty() {
+                let after_close = after_open[close_idx + 1..].trim_start();
+                if after_close.is_empty()
+                    || after_close.starts_with(';')
+                    || after_close.starts_with('#')
+                {
+                    return ImportListForm::Empty;
+                }
+            }
+        }
+
+        return ImportListForm::Explicit;
+    }
+
+    ImportListForm::Explicit
 }
 
 fn parse_statement_head<'a>(line: &'a str, keyword: &str) -> Option<(&'a str, usize, usize)> {

--- a/crates/perl-module-import/tests/dispatch_semantics.rs
+++ b/crates/perl-module-import/tests/dispatch_semantics.rs
@@ -4,7 +4,8 @@
 //! including import call behaviour, load timing, and file-path `require` syntax.
 
 use perl_module_import::{
-    ImportBehavior, LoadTiming, ModuleImportKind, RequireForm, parse_module_import_head,
+    ImportBehavior, ImportListForm, LoadTiming, ModuleImportKind, RequireForm,
+    parse_module_import_head,
 };
 
 // ===========================================================================
@@ -171,6 +172,36 @@ fn test_use_has_no_require_form() -> Result<(), String> {
         parse_module_import_head("use Foo::Bar;").ok_or("expected Some for use statement")?;
     if head.require_form().is_some() {
         return Err(format!("expected None require_form for use, got {:?}", head.require_form()));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_default_import_list_form_is_recorded() -> Result<(), String> {
+    let head =
+        parse_module_import_head("use Foo::Bar;").ok_or("expected Some for use statement")?;
+    if head.import_list != Some(ImportListForm::Default) {
+        return Err(format!("expected Default import list, got {:?}", head.import_list));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_empty_import_list_form_is_recorded() -> Result<(), String> {
+    let head = parse_module_import_head("use Foo::Bar ();")
+        .ok_or("expected Some for empty import form")?;
+    if head.import_list != Some(ImportListForm::Empty) {
+        return Err(format!("expected Empty import list, got {:?}", head.import_list));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_use_explicit_import_list_form_is_recorded() -> Result<(), String> {
+    let head = parse_module_import_head("use Foo::Bar qw(baz);")
+        .ok_or("expected Some for explicit import form")?;
+    if head.import_list != Some(ImportListForm::Explicit) {
+        return Err(format!("expected Explicit import list, got {:?}", head.import_list));
     }
     Ok(())
 }


### PR DESCRIPTION
Distinguish  from  in  by carrying an explicit import-list form on . This keeps the empty-list syntax separate from the default-import form without widening consumers yet.\n\nValidation: 
running 5 tests
test tests::parses_require_statement_head ... ok
test tests::classifies_parent_and_base_specializations ... ok
test tests::parses_use_statement_head ... ok
test tests::rejects_non_keyword_boundaries ... ok
test tests::rejects_missing_tokens ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 80 tests
test batch_invalid_lines_all_reject ... ok
test head_clone_produces_equal_value ... ok
test batch_valid_lines_all_parse ... ok
test close_paren_terminates_token ... ok
test head_debug_includes_all_fields ... ok
test kind_clone_produces_equal_value ... ok
test kind_debug_displays_variant_name ... ok
test kind_partial_eq_distinguishes_all_variants ... ok
test open_paren_terminates_token ... ok
test rejects_arbitrary_text ... ok
test rejects_comment_line ... ok
test rejects_empty_string ... ok
test rejects_function_call_use_module ... ok
test rejects_method_call_with_use ... ok
test rejects_no_module ... ok
test rejects_require_alone ... ok
test rejects_package_statement ... ok
test rejects_require_followed_by_semicolon ... ok
test rejects_require_with_only_whitespace ... ok
test rejects_require_without_whitespace_before_token ... ok
test rejects_required_not_require ... ok
test rejects_requires_not_require ... ok
test rejects_requiring_not_require ... ok
test rejects_use_alone ... ok
test rejects_use_followed_by_only_semicolons ... ok
test rejects_use_followed_by_parens_only ... ok
test rejects_use_with_only_paren ... ok
test rejects_use_with_only_semicolon ... ok
test rejects_use_without_whitespace_before_token ... ok
test rejects_useful_not_use ... ok
test rejects_user_not_use ... ok
test rejects_uses_not_use ... ok
test rejects_using_not_use ... ok
test rejects_whitespace_only ... ok
test require_carp ... ok
test require_module_no_semicolon ... ok
test require_module_token_at_end_of_line ... ok
test require_qualified_module ... ok
test require_simple_module ... ok
test require_single_char_module ... ok
test require_with_mixed_whitespace ... ok
test require_with_tab_after_keyword ... ok
test require_with_two_space_indent ... ok
test semicolon_terminates_token ... ok
test space_terminates_token ... ok
test token_end_within_line_bounds ... ok
test token_slice_equals_token_field ... ok
test token_start_less_than_token_end_for_all_valid_parses ... ok
test use_base_exporter ... ok
test use_base_with_quoted_string ... ok
test use_base_with_qw ... ok
test use_carp_qw_croak ... ok
test use_deeply_qualified_module ... ok
test use_file_basename ... ok
test use_module_no_semicolon ... ok
test use_module_token_at_end_of_line ... ok
test use_module_with_numbers ... ok
test use_moo ... ok
test use_moose ... ok
test use_parent_multiple_bases ... ok
test use_parent_with_indent ... ok
test use_parent_with_qw ... ok
test use_parent_with_single_quote ... ok
test use_qualified_module ... ok
test use_scalar_util ... ok
test use_simple_module ... ok
test use_single_char_module ... ok
test use_strict ... ok
test use_test_more ... ok
test use_underscore_module ... ok
test use_warnings ... ok
test use_with_four_space_indent ... ok
test use_with_import_list ... ok
test use_with_multiple_spaces_between_keyword_and_token ... ok
test use_with_multiple_tabs_after_keyword ... ok
test use_with_single_space_indent ... ok
test use_with_space_before_parens ... ok
test use_with_tab_between_keyword_and_token ... ok
test use_with_tab_indent ... ok
test use_with_version_number_first ... ok

test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 24 tests
test test_dispatch_semantics_debug_contains_load_timing ... ok
test test_dispatch_semantics_equality ... ok
test test_dispatch_semantics_inequality_across_kinds ... ok
test test_require_bare_module_is_module_name_form ... ok
test test_require_does_not_call_import ... ok
test test_require_file_path_double_quote_parses ... ok
test test_require_file_path_single_quote_parses ... ok
test test_require_file_path_is_file_form ... ok
test test_require_file_path_single_quote_token_strips_quotes ... ok
test test_require_file_path_token_strips_quotes ... ok
test test_require_has_runtime_load_timing ... ok
test test_require_hover_description_mentions_no_import ... ok
test test_require_hover_description_mentions_runtime ... ok
test test_use_base_calls_import ... ok
test test_use_base_has_compile_time_load_timing ... ok
test test_use_calls_import ... ok
test test_use_default_import_list_form_is_recorded ... ok
test test_use_empty_import_list_form_is_recorded ... ok
test test_use_explicit_import_list_form_is_recorded ... ok
test test_use_has_compile_time_load_timing ... ok
test test_use_has_no_require_form ... ok
test test_use_hover_description_mentions_compile_time ... ok
test test_use_parent_calls_import ... ok
test test_use_parent_has_compile_time_load_timing ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test given_non_import_line_when_parsed_then_none_is_returned ... ok
test given_require_statement_when_parsed_then_require_kind_and_module_token_are_returned ... ok
test given_use_parent_statement_when_parsed_then_use_parent_kind_is_returned ... ok
test given_use_base_statement_when_parsed_then_use_base_kind_is_returned ... ok
test given_use_statement_when_parsed_then_use_kind_and_module_token_are_returned ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test fuzz_import_head_parser_preserves_range_and_token_invariants ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test parses_require_head_and_drives_token_rewrite_for_path_derived_module_names ... ok
test parses_use_parent_head_and_allows_parent_module_token_detection ... ok
test parses_use_head_and_drives_token_rewrite_for_path_derived_module_names ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test prop_keyword_requires_word_boundary ... ok
test prop_use_head_extracts_first_module_token_with_correct_range ... ok
test prop_require_head_extracts_first_module_token_with_correct_range ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test crates/perl-module-import/src/lib.rs - parse_module_import_head (line 147) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

all doctests ran in 0.31s; merged doctests compilation took 0.31s and .