### PR TITLE
fix(ux): surface missing Perl startup diagnostic (#3451)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,7 +14,11 @@ import { handleFormattingError } from './formattingErrors';
 import { HealthWidget, ClientState } from './healthWidget';
 import { registerPodPreview } from './podPreview';
 import { StreamingCompletionController } from './streamingCompletion';
-import { classifyStartupError, selectBestDiagnosis, StartupErrorKind } from './startupDiagnosis';
+import {
+    classifyStartupError,
+    formatStartupFailureDialog,
+    StartupErrorKind,
+} from './startupDiagnosis';
 import type { StartupErrorDiagnosis } from './startupDiagnosis';
 
 let client: LanguageClient | undefined;
@@ -737,10 +741,8 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
             const onboarding = new OnboardingManager(context, outputChannel);
             healthMsg = await onboarding.runStartupDiagnostics(currentServerPath ?? null);
         }
-        const diagnosis = selectBestDiagnosis(probeResult, healthMsg);
-        lastStartupDiagnostic = `${diagnosis.hint} Suggestion: ${diagnosis.remediation}`;
-        const dialogMessage =
-            `Perl Language Server failed to start.\n\n${diagnosis.hint}\n\nSuggestion: ${diagnosis.remediation}`;
+        const dialogMessage = formatStartupFailureDialog(probeResult, healthMsg);
+        lastStartupDiagnostic = dialogMessage;
 
         const choice = await vscode.window.showErrorMessage(
             dialogMessage,

--- a/vscode-extension/src/startupDiagnosis.ts
+++ b/vscode-extension/src/startupDiagnosis.ts
@@ -142,3 +142,24 @@ export function selectBestDiagnosis(
         remediation: probe.remediation,
     };
 }
+
+/**
+ * Format the startup failure dialog shown to the user.
+ *
+ * When the health-check fallback returns a specific onboarding message, we
+ * surface that verbatim so the user sees the actionable Perl-missing guidance
+ * immediately instead of a generic wrapper.
+ */
+export function formatStartupFailureDialog(
+    probe: StartupErrorDiagnosis,
+    healthMsg: string | undefined,
+): string {
+    if (probe.kind === StartupErrorKind.Unknown && healthMsg) {
+        return healthMsg;
+    }
+
+    return (
+        `Perl Language Server failed to start.\n\n${probe.hint}\n\n` +
+        `Suggestion: ${probe.remediation}`
+    );
+}

--- a/vscode-extension/src/test/startupError.test.ts
+++ b/vscode-extension/src/test/startupError.test.ts
@@ -15,7 +15,12 @@
  * "corrupted or incompatible") and a specific remediation step.
  */
 
-import { classifyStartupError, StartupErrorKind, selectBestDiagnosis } from '../startupDiagnosis';
+import {
+  classifyStartupError,
+  formatStartupFailureDialog,
+  StartupErrorKind,
+  selectBestDiagnosis,
+} from '../startupDiagnosis';
 
 // ---------------------------------------------------------------------------
 // classifyStartupError — pure classification of stderr/stdout text
@@ -240,5 +245,32 @@ describe('selectBestDiagnosis', () => {
     const probe = classifyStartupError('');  // Unknown
     const result = selectBestDiagnosis(probe, '');
     expect(result.kind).toBe(StartupErrorKind.Unknown);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatStartupFailureDialog — exact dialog text surfaced on startup failure
+// ---------------------------------------------------------------------------
+
+describe('formatStartupFailureDialog', () => {
+  test('surfaces onboarding guidance verbatim when probe is Unknown and health message exists', () => {
+    const probe = classifyStartupError('');
+    const healthMsg =
+      'Perl interpreter not found. Install Perl 5.10+ and reload the window. ' +
+      'Alternatively, set the `perl-lsp.perl.path` setting to an existing Perl executable.';
+
+    expect(formatStartupFailureDialog(probe, healthMsg)).toBe(healthMsg);
+  });
+
+  test('keeps the generic startup wrapper for classified probe failures', () => {
+    const probe = classifyStartupError(
+      '/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.35` not found',
+    );
+
+    const message = formatStartupFailureDialog(probe, 'Perl interpreter not found...');
+
+    expect(message).toContain('Perl Language Server failed to start.');
+    expect(message).toContain('glibc');
+    expect(message).not.toContain('Perl interpreter not found...');
   });
 });


### PR DESCRIPTION
Surface the onboarding Perl-missing diagnostic directly in the startup failure dialog when the binary probe is inconclusive. Adds a regression test for the exact dialog text.