### PR TITLE
feat(navigation): add XS bootstrap goto-definition (#3570)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -106,6 +106,213 @@ fn get_super_method_regex() -> Result<&'static regex::Regex, JsonRpcError> {
         })
 }
 
+#[derive(Debug, Clone)]
+enum EarlyDefinitionTarget {
+    Module(String),
+    XsBootstrap(String),
+}
+
+fn is_module_token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'\'')
+}
+
+fn normalize_bootstrap_module(token: &str, current_package: &str) -> Option<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed == "__PACKAGE__" {
+        return Some(current_package.to_string());
+    }
+
+    let normalized = normalize_package_separator(trimmed).into_owned();
+    let first = normalized.chars().next()?;
+    if normalized.contains("::") || first.is_ascii_uppercase() { Some(normalized) } else { None }
+}
+
+fn parse_bootstrap_argument(
+    text: &str,
+    mut start: usize,
+    current_package: &str,
+) -> Option<(usize, usize, String)> {
+    while let Some(byte) = text.as_bytes().get(start) {
+        if byte.is_ascii_whitespace() || *byte == b',' {
+            start += 1;
+        } else {
+            break;
+        }
+    }
+
+    let bytes = text.as_bytes();
+    let byte = *bytes.get(start)?;
+
+    if byte == b'\'' || byte == b'"' {
+        let quote = byte;
+        let token_start = start + 1;
+        let mut end = token_start;
+        while let Some(next) = bytes.get(end) {
+            if *next == quote {
+                break;
+            }
+            end += 1;
+        }
+        let token = text.get(token_start..end)?;
+        let module = normalize_bootstrap_module(token, current_package)?;
+        return Some((token_start, end, module));
+    }
+
+    let mut end = start;
+    while let Some(next) = bytes.get(end) {
+        if is_module_token_byte(*next) {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+
+    if end <= start {
+        return None;
+    }
+
+    let token = text.get(start..end)?;
+    let module = normalize_bootstrap_module(token, current_package)?;
+    Some((start, end, module))
+}
+
+fn extract_xs_loader_target(
+    text: &str,
+    cursor: usize,
+    current_package: &str,
+    marker: &str,
+) -> Option<String> {
+    let mut search_from = 0;
+    while let Some(found) = text.get(search_from..)?.find(marker) {
+        let marker_start = search_from + found;
+        let marker_end = marker_start + marker.len();
+        let mut arg_start = marker_end;
+
+        while let Some(byte) = text.as_bytes().get(arg_start) {
+            if byte.is_ascii_whitespace() {
+                arg_start += 1;
+            } else {
+                break;
+            }
+        }
+
+        if text.as_bytes().get(arg_start) == Some(&b'(') {
+            arg_start += 1;
+        }
+
+        if let Some((token_start, token_end, module_name)) =
+            parse_bootstrap_argument(text, arg_start, current_package)
+            && ((cursor >= marker_start && cursor <= marker_end)
+                || (cursor >= token_start && cursor <= token_end))
+        {
+            return Some(module_name);
+        }
+
+        search_from = marker_end;
+    }
+
+    None
+}
+
+fn extract_bare_bootstrap_target(
+    text: &str,
+    cursor: usize,
+    current_package: &str,
+) -> Option<String> {
+    let mut search_from = 0;
+    let needle = "bootstrap";
+    while let Some(found) = text.get(search_from..)?.find(needle) {
+        let start = search_from + found;
+        let end = start + needle.len();
+
+        let left_ok = start == 0 || !is_module_token_byte(text.as_bytes()[start - 1]);
+        let right_ok = end == text.len() || !is_module_token_byte(text.as_bytes()[end]);
+        let qualified = start >= 2 && &text[start - 2..start] == "::";
+        if !left_ok || !right_ok || qualified {
+            search_from = end;
+            continue;
+        }
+
+        if let Some((token_start, token_end, module_name)) =
+            parse_bootstrap_argument(text, end, current_package)
+            && ((cursor >= start && cursor <= end)
+                || (cursor >= token_start && cursor <= token_end))
+        {
+            return Some(module_name);
+        }
+
+        search_from = end;
+    }
+
+    None
+}
+
+fn extract_qualified_bootstrap_target(text: &str, cursor: usize) -> Option<String> {
+    let mut search_from = 0;
+    let needle = "::bootstrap";
+    while let Some(found) = text.get(search_from..)?.find(needle) {
+        let suffix_start = search_from + found;
+        let mut module_start = suffix_start;
+        while module_start > 0 && is_module_token_byte(text.as_bytes()[module_start - 1]) {
+            module_start -= 1;
+        }
+
+        if module_start == suffix_start {
+            search_from = suffix_start + needle.len();
+            continue;
+        }
+
+        let module = text.get(module_start..suffix_start)?;
+        let module_name = normalize_bootstrap_module(module, "main")?;
+        let full_end = suffix_start + needle.len();
+        if cursor >= module_start && cursor <= full_end {
+            return Some(module_name);
+        }
+
+        search_from = full_end;
+    }
+
+    None
+}
+
+fn extract_xs_bootstrap_target(text: &str, cursor: usize, current_package: &str) -> Option<String> {
+    extract_xs_loader_target(text, cursor, current_package, "XSLoader::load")
+        .or_else(|| {
+            extract_xs_loader_target(text, cursor, current_package, "DynaLoader::bootstrap")
+        })
+        .or_else(|| extract_bare_bootstrap_target(text, cursor, current_package))
+        .or_else(|| extract_qualified_bootstrap_target(text, cursor))
+}
+
+fn xs_boot_symbol_name(module_name: &str) -> String {
+    format!("boot_{}", normalize_package_separator(module_name).replace("::", "__"))
+}
+
+fn xs_bootstrap_location(path: &Path, module_name: &str) -> Value {
+    let uri = Url::from_file_path(path).map(|url| url.to_string()).unwrap_or_default();
+    let boot_symbol = xs_boot_symbol_name(module_name);
+
+    if let Ok(text) = std::fs::read_to_string(path)
+        && let Some(offset) = text.find(&boot_symbol)
+    {
+        let (start_line, start_char) = byte_to_line_col(&text, offset);
+        let (end_line, end_char) = byte_to_line_col(&text, offset + boot_symbol.len());
+        return json!({
+            "uri": uri,
+            "range": {
+                "start": {"line": start_line, "character": start_char},
+                "end": {"line": end_line, "character": end_char},
+            },
+        });
+    }
+
+    location_from_path(path)
+}
+
 /// Returns `true` if the module name is a known Perl core pragma or standard module
 /// that will never be found on disk in a user's workspace.
 ///
@@ -631,7 +838,7 @@ impl LspServer {
 
             // First, extract module reference info while holding the document lock briefly
             // We need to release the lock before calling resolve_module_to_path to avoid deadlock
-            let module_lookup_info: Option<(String, String)> = {
+            let module_lookup_info: Option<(EarlyDefinitionTarget, String)> = {
                 let documents = self.documents_guard();
                 if let Some(doc) = self.get_document(&documents, uri) {
                     let offset = self.pos16_to_offset(doc, line, character);
@@ -639,13 +846,19 @@ impl LspServer {
                     let text_start = offset.saturating_sub(radius);
                     let text_around = self.get_text_around_offset(&doc.text, offset, radius);
                     let cursor_in_text = offset - text_start;
+                    let current_package = doc.ast.as_ref().map_or_else(
+                        || "main".to_string(),
+                        |ast| crate::declaration::current_package_at(ast, offset).to_string(),
+                    );
 
-                    // Check for patterns like "use Module::Name", "require Module::Name",
-                    // and also "use parent 'Module::Name'", "use base qw(Module::Name)"
                     if let Some(module_name) =
+                        extract_xs_bootstrap_target(&text_around, cursor_in_text, &current_package)
+                    {
+                        Some((EarlyDefinitionTarget::XsBootstrap(module_name), doc.text.clone()))
+                    } else if let Some(module_name) =
                         self.extract_module_reference_extended(&text_around, cursor_in_text)
                     {
-                        Some((module_name, doc.text.clone()))
+                        Some((EarlyDefinitionTarget::Module(module_name), doc.text.clone()))
                     } else {
                         // Also check if we're on a package name followed by ->
                         let mut package_name_result = None;
@@ -656,7 +869,9 @@ impl LspServer {
                                 let match_end = package_match.end();
                                 if cursor_in_text >= match_start && cursor_in_text <= match_end {
                                     package_name_result = Some((
-                                        package_match.as_str().to_string(),
+                                        EarlyDefinitionTarget::Module(
+                                            package_match.as_str().to_string(),
+                                        ),
                                         doc.text.clone(),
                                     ));
                                     break;
@@ -672,40 +887,58 @@ impl LspServer {
             // Lock is released here
 
             // Now resolve module to path WITHOUT holding the document lock
-            if let Some((module_name, doc_text)) = module_lookup_info {
-                if let Some(module_path) =
-                    self.resolve_module_to_path_with_doc(&module_name, Some(&doc_text), Some(uri))
-                {
-                    return Ok(Some(json!([{
-                        "uri": module_path,
-                        "range": {
-                            "start": {
-                                "line": 0,
-                                "character": 0,
-                            },
-                            "end": {
-                                "line": 0,
-                                "character": 0,
-                            },
-                        },
-                    }])));
-                } else if is_core_perl_module(&module_name) {
-                    // Core pragma — not on disk in the user's workspace, so no file jump
-                    // is possible.  Log an info message to the LSP output channel
-                    // (visible in the VSCode Output panel) so users can discover that
-                    // hover (K) shows documentation for core modules.
-                    let _ = self.log_message(
-                        crate::runtime::window::MessageType::Info,
-                        &format!(
-                            "'{module_name}' is a Perl core module. \
-                             No source file is available for goto-definition. \
-                             Use hover (K) to view documentation."
-                        ),
-                    );
-                    tracing::debug!(
-                        module = %module_name,
-                        "core pragma requested via goto-def — no file target"
-                    );
+            if let Some((lookup_target, doc_text)) = module_lookup_info {
+                match lookup_target {
+                    EarlyDefinitionTarget::XsBootstrap(module_name) => {
+                        if let Some(xs_path) = self.resolve_xs_bootstrap_path_with_uri(
+                            &module_name,
+                            Some(&doc_text),
+                            Some(uri),
+                        ) {
+                            return Ok(Some(json!([xs_bootstrap_location(
+                                &xs_path,
+                                &module_name
+                            )])));
+                        }
+                    }
+                    EarlyDefinitionTarget::Module(module_name) => {
+                        if let Some(module_path) = self.resolve_module_to_path_with_doc(
+                            &module_name,
+                            Some(&doc_text),
+                            Some(uri),
+                        ) {
+                            return Ok(Some(json!([{
+                                "uri": module_path,
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0,
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "character": 0,
+                                    },
+                                },
+                            }])));
+                        } else if is_core_perl_module(&module_name) {
+                            // Core pragma — not on disk in the user's workspace, so no file jump
+                            // is possible.  Log an info message to the LSP output channel
+                            // (visible in the VSCode Output panel) so users can discover that
+                            // hover (K) shows documentation for core modules.
+                            let _ = self.log_message(
+                                crate::runtime::window::MessageType::Info,
+                                &format!(
+                                    "'{module_name}' is a Perl core module. \
+                                     No source file is available for goto-definition. \
+                                     Use hover (K) to view documentation."
+                                ),
+                            );
+                            tracing::debug!(
+                                module = %module_name,
+                                "core pragma requested via goto-def — no file target"
+                            );
+                        }
+                    }
                 }
             }
 

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -148,6 +148,38 @@ impl LspServer {
         resolve_workspace_module_path(&root, module, &include_paths)
     }
 
+    /// Resolve an XS bootstrap target to the most likely `.xs` source path.
+    ///
+    /// XS distributions commonly place native sources either next to the Perl
+    /// module file (`lib/Foo/Bar.xs`) or at the dist root as a leaf file
+    /// (`Bar.xs`). This helper covers those two high-signal layouts.
+    pub(crate) fn resolve_xs_bootstrap_path_with_uri(
+        &self,
+        module: &str,
+        doc_text: Option<&str>,
+        doc_uri: Option<&str>,
+    ) -> Option<PathBuf> {
+        let normalized = normalize_package_separator(module);
+        let leaf = normalized.rsplit("::").next()?;
+
+        if let Some(pm_path) = self.resolve_module_path_with_uri(module, doc_text, doc_uri)
+            && let Some(parent) = pm_path.parent()
+        {
+            let sibling = parent.join(format!("{leaf}.xs"));
+            if sibling.is_file() {
+                return Some(sibling);
+            }
+        }
+
+        let root = self.root_path.lock().clone()?;
+        let root_candidate = root.join(format!("{leaf}.xs"));
+        if root_candidate.is_file() {
+            return Some(root_candidate);
+        }
+
+        None
+    }
+
     /// Resolve a module name to a file path URI
     ///
     /// ## Resolution Precedence Order (deterministic)
@@ -396,6 +428,64 @@ mod tests {
         assert!(resolved.starts_with("file://"));
         assert!(resolved.contains("Demo"));
         assert!(resolved.contains("Worker.pm"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_xs_bootstrap_path_finds_sibling_xs_file() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let module_file = workspace.join("lib").join("My").join("Module.pm");
+        let xs_file = workspace.join("lib").join("My").join("Module.xs");
+
+        fs::create_dir_all(module_file.parent().ok_or("missing module parent")?)?;
+        fs::write(&module_file, "package My::Module; 1;")?;
+        fs::write(&xs_file, "EXTERN_C void boot_My__Module(pTHX_ CV* cv) {}")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace.clone());
+        let workspace_uri =
+            url::Url::from_file_path(&workspace).map_err(|_| "failed to create workspace URI")?;
+        *server.workspace_folders.lock() = vec![workspace_uri.to_string()];
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec!["lib".to_string()];
+            config.use_system_inc = false;
+        }
+
+        let resolved = server
+            .resolve_xs_bootstrap_path_with_uri("My::Module", None, None)
+            .ok_or("expected xs bootstrap path")?;
+        assert_eq!(resolved, xs_file);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_xs_bootstrap_path_finds_root_leaf_xs_file() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let module_file = workspace.join("lib").join("My").join("Module.pm");
+        let xs_file = workspace.join("Module.xs");
+
+        fs::create_dir_all(module_file.parent().ok_or("missing module parent")?)?;
+        fs::write(&module_file, "package My::Module; 1;")?;
+        fs::write(&xs_file, "EXTERN_C void boot_My__Module(pTHX_ CV* cv) {}")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace.clone());
+        let workspace_uri =
+            url::Url::from_file_path(&workspace).map_err(|_| "failed to create workspace URI")?;
+        *server.workspace_folders.lock() = vec![workspace_uri.to_string()];
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec!["lib".to_string()];
+            config.use_system_inc = false;
+        }
+
+        let resolved = server
+            .resolve_xs_bootstrap_path_with_uri("My::Module", None, None)
+            .ok_or("expected xs bootstrap path")?;
+        assert_eq!(resolved, xs_file);
         Ok(())
     }
 

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -199,6 +199,192 @@ Demo::Worker::run();
 }
 
 // ---------------------------------------------------------------------------
+// Test 3: XS bootstrap calls navigate to native `.xs` entry points
+// ---------------------------------------------------------------------------
+
+#[test]
+fn go_to_definition_on_xsloader_load_navigates_to_boot_symbol() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+    let server = perl_lsp::LspServer::new();
+
+    let module_pm = r#"package My::Module;
+use strict;
+use warnings;
+use XSLoader;
+our $VERSION = '0.01';
+XSLoader::load(__PACKAGE__, $VERSION);
+1;
+"#;
+    let module_xs = r#"#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+EXTERN_C void
+boot_My__Module(pTHX_ CV* cv)
+{
+}
+"#;
+
+    workspace.write("lib/My/Module.pm", module_pm)?;
+    workspace.write("Module.xs", module_xs)?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(&workspace.uri("lib/My/Module.pm"), module_pm)?;
+    harness.barrier();
+
+    let cursor = module_pm.find("load").ok_or("missing XSLoader::load")?;
+    let (line, character) = server.offset_to_position(module_pm, cursor);
+    let boot_offset = module_xs.find("boot_My__Module").ok_or("missing boot symbol")?;
+    let (boot_line, _) = server.offset_to_position(module_xs, boot_offset);
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/My/Module.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected XS bootstrap definition result");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("expected uri")?;
+    assert!(uri.contains("Module.xs"), "expected Module.xs target, got: {uri}");
+    assert_eq!(
+        first["range"]["start"]["line"].as_u64(),
+        Some(u64::from(boot_line)),
+        "expected goto-definition to land on boot_My__Module",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_bootstrap_keyword_navigates_to_boot_symbol() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+    let server = perl_lsp::LspServer::new();
+
+    let loader_pm = r#"package My::Module;
+use strict;
+use warnings;
+require DynaLoader;
+our @ISA = qw(DynaLoader);
+our $VERSION = '0.01';
+bootstrap My::Module $VERSION;
+1;
+"#;
+    let module_xs = r#"#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+EXTERN_C void
+boot_My__Module(pTHX_ CV* cv)
+{
+}
+"#;
+
+    workspace.write("lib/My/Module.pm", loader_pm)?;
+    workspace.write("Module.xs", module_xs)?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(&workspace.uri("lib/My/Module.pm"), loader_pm)?;
+    harness.barrier();
+
+    let cursor = loader_pm.find("bootstrap").ok_or("missing bootstrap keyword")?;
+    let (line, character) = server.offset_to_position(loader_pm, cursor);
+    let boot_offset = module_xs.find("boot_My__Module").ok_or("missing boot symbol")?;
+    let (boot_line, _) = server.offset_to_position(module_xs, boot_offset);
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/My/Module.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected XS bootstrap definition result");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("expected uri")?;
+    assert!(uri.contains("Module.xs"), "expected Module.xs target, got: {uri}");
+    assert_eq!(
+        first["range"]["start"]["line"].as_u64(),
+        Some(u64::from(boot_line)),
+        "expected goto-definition to land on boot_My__Module",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_on_dynaloader_bootstrap_navigates_to_boot_symbol() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+    let server = perl_lsp::LspServer::new();
+
+    let loader_pm = r#"package My::Module;
+use strict;
+use warnings;
+require DynaLoader;
+our @ISA = qw(DynaLoader);
+our $VERSION = '0.01';
+DynaLoader::bootstrap(__PACKAGE__, $VERSION);
+1;
+"#;
+    let module_xs = r#"#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+EXTERN_C void
+boot_My__Module(pTHX_ CV* cv)
+{
+}
+"#;
+
+    workspace.write("lib/My/Module.pm", loader_pm)?;
+    workspace.write("Module.xs", module_xs)?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+    harness.open(&workspace.uri("lib/My/Module.pm"), loader_pm)?;
+    harness.barrier();
+
+    let cursor = loader_pm.find("DynaLoader::bootstrap").ok_or("missing DynaLoader::bootstrap")?;
+    let (line, character) = server.offset_to_position(loader_pm, cursor);
+    let boot_offset = module_xs.find("boot_My__Module").ok_or("missing boot symbol")?;
+    let (boot_line, _) = server.offset_to_position(module_xs, boot_offset);
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("lib/My/Module.pm")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected XS bootstrap definition result");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("expected uri")?;
+    assert!(uri.contains("Module.xs"), "expected Module.xs target, got: {uri}");
+    assert_eq!(
+        first["range"]["start"]["line"].as_u64(),
+        Some(u64::from(boot_line)),
+        "expected goto-definition to land on boot_My__Module",
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3: $self->method() navigates to the method definition
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add early navigation handling for XS bootstrap call sites
- resolve likely .xs targets from module context and jump to the boot_* symbol when present
- cover XSLoader::load, bare bootstrap, and DynaLoader::bootstrap with resolver and cross-file tests

## Testing
- cargo fmt --all
- cargo test -p perl-lsp-rs go_to_definition_on_xsloader_load_navigates_to_boot_symbol -- --nocapture
- cargo test -p perl-lsp-rs go_to_definition_on_bootstrap_keyword_navigates_to_boot_symbol -- --nocapture
- cargo test -p perl-lsp-rs go_to_definition_on_dynaloader_bootstrap_navigates_to_boot_symbol -- --nocapture
- cargo test -p perl-lsp-rs resolve_xs_bootstrap_path -- --nocapture
