### PR TITLE
ci(clippy): derive MethodResolutionOrder default (#3780)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -45,18 +45,13 @@ pub enum AccessorType {
 }
 
 /// Method-resolution order for inherited method lookup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MethodResolutionOrder {
     /// Default Perl depth-first resolution order.
+    #[default]
     Dfs,
     /// C3 linearization enabled via `use mro 'c3';`.
     C3,
-}
-
-impl Default for MethodResolutionOrder {
-    fn default() -> Self {
-        Self::Dfs
-    }
 }
 
 /// A Moose/Moo attribute declared via `has`.


### PR DESCRIPTION
Small CI-unblocker for the Clippy `derivable_impls` regression on `MethodResolutionOrder`.

Validation: `cargo fmt --all`, `cargo test -p perl-semantic-analyzer class_model -- --nocapture`, `cargo clippy -p perl-semantic-analyzer --locked -- -D warnings -A missing_docs`.
