### PR TITLE
fix(semantic-tokens): classify PL_sv_* as special variables (#3542)

### DIFF
--- a/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
+++ b/crates/perl-lsp-semantic-tokens/src/semantic_tokens.rs
@@ -379,6 +379,9 @@ fn is_special_variable(full_name: &str) -> bool {
             | "$INC"  // hash element access: $INC{'Foo.pm'}
             | "%SIG"
             | "$SIG" // hash element access: $SIG{INT}
+            | "$PL_sv_yes"
+            | "$PL_sv_no"
+            | "$PL_sv_undef"
     )
 }
 

--- a/crates/perl-lsp-semantic-tokens/tests/token_classification_tests.rs
+++ b/crates/perl-lsp-semantic-tokens/tests/token_classification_tests.rs
@@ -1159,9 +1159,35 @@ fn test_special_variable_at_underscore_has_default_library_modifier() {
     assert!(
         !special_tokens.is_empty(),
         "@_ should produce at least one variable token with defaultLibrary modifier, \
-         got variable tokens: {:?}",
+        got variable tokens: {:?}",
         tokens.iter().filter(|t| t[3] == var_idx).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn test_internal_pl_sv_variables_have_default_library_modifier() {
+    let code = "sub f { return $PL_sv_yes; return $PL_sv_no; return $PL_sv_undef; }";
+    let tokens = tokens_for(code);
+    let var_idx = type_idx("variable");
+    let positions = absolute_positions(&tokens);
+
+    for needle in ["$PL_sv_yes", "$PL_sv_no", "$PL_sv_undef"] {
+        let offset = code.find(needle).expect("needle should exist");
+        let expected_position = line_col_mapper(code)(offset);
+        let token = tokens
+            .iter()
+            .zip(positions.iter())
+            .find(|(tok, pos)| {
+                tok[3] == var_idx && has_default_library_modifier(tok) && **pos == expected_position
+            })
+            .map(|(tok, _)| *tok);
+
+        assert!(
+            token.is_some(),
+            "{needle} should produce a variable token with defaultLibrary modifier, got: {:?}",
+            tokens.iter().filter(|t| t[3] == var_idx).collect::<Vec<_>>()
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Recognize Perl internal `PL_sv_*` constants as built-in special variables in the semantic-token classifier so they get the `defaultLibrary` modifier. Hover handling for these names already exists; this PR aligns the token classification path with that behavior.

Validation:
- `cargo fmt --all`
- `cargo test -p perl-lsp-semantic-tokens test_internal_pl_sv_variables_have_default_library_modifier -- --nocapture`
- `cargo test -p perl-lsp-rs test_hover_internal_pl_sv_special_variables -- --nocapture` was started but left running too long for this slice, so it was stopped after confirming the semantic-tokens regression.
