### PR TITLE
feat(vscode): add XS directive highlighting (#3568)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -161,6 +161,7 @@ For environments without internet access, set `perl-lsp.downloadBaseUrl` to an i
 - Smart match operator (`~~`)
 - Indirect object syntax
 - Built-in function signatures with parameter documentation
+- XS interface files (`.xs` and `.i`) are associated with Perl for bundled syntax highlighting
 
 ## Commands
 

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -131,6 +131,13 @@ describe('package.json contributes', () => {
       expect(exts).toContain('.ep');
       expect(exts).not.toContain('.m');
       expect(exts).toContain('.xs');
+      expect(exts).toContain('.i');
+    });
+
+    test('perl language keeps XS interface files associated with perl', () => {
+      const perl = pkg.contributes.languages.find((l: any) => l.id === 'perl');
+      const exts: string[] = perl.extensions;
+      expect(exts.filter((ext: string) => ext === '.xs' || ext === '.i')).toHaveLength(2);
     });
 
     test('perl language has shebang first-line detection', () => {
@@ -603,6 +610,22 @@ describe('package.json contributes', () => {
       const perl = grammars.find((g: any) => g.language === 'perl');
       const grammarPath = path.join(EXT_ROOT, perl.path);
       expect(fs.existsSync(grammarPath)).toBe(true);
+    });
+
+    test('grammar includes common XS directives', () => {
+      const grammar = readJson('syntaxes/perl.tmLanguage.json');
+      const keywordPattern = grammar.repository.keywords.patterns
+        .map((entry: any) => entry.match)
+        .find((match: string) =>
+          typeof match === 'string' &&
+          match.includes('MODULE') &&
+          match.includes('PACKAGE') &&
+          match.includes('PPCODE') &&
+          match.includes('INPUT') &&
+          match.includes('OUTPUT')
+        );
+
+      expect(keywordPattern).toBeDefined();
     });
   });
 });

--- a/vscode-extension/syntaxes/perl.tmLanguage.json
+++ b/vscode-extension/syntaxes/perl.tmLanguage.json
@@ -171,7 +171,7 @@
                 },
                 {
                     "name": "keyword.other.perl",
-                    "match": "\\b(my|our|local|state|sub|package|use|no|require|BEGIN|END|INIT|CHECK|UNITCHECK)\\b"
+                    "match": "\\b(my|our|local|state|sub|package|use|no|require|BEGIN|END|INIT|CHECK|UNITCHECK|MODULE|PACKAGE|BOOT|PPCODE|INPUT|OUTPUT|PREINIT|CLEANUP|PROTOTYPES)\\b"
                 },
                 {
                     "name": "keyword.operator.logical.perl",


### PR DESCRIPTION
## Summary
- keep `.xs` / `.i` files associated with Perl in the VS Code extension manifest
- extend the bundled TextMate grammar with common XS directives like `MODULE`, `PACKAGE`, `BOOT`, `PPCODE`, `INPUT`, and `OUTPUT`
- add contract tests so the file association and grammar coverage do not drift
- document XS interface support in the extension README

## Validation
- `npm run compile`
- `npx jest --runInBand -t "XS interface files|grammar includes common XS directives|expected file extensions" src/test/configuration.test.ts`
- `git diff --check`

## Note
The broader `src/test/configuration.test.ts` suite still has unrelated activation-event expectations that fail on the current manifest, so I ran only the XS-focused assertions for this slice.
