### PR TITLE
feat(diagnostics): add FFI::CheckLib hints (#3574)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
  "perl-semantic-analyzer",
  "perl-tdd-support",
  "perl-workspace-index",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/perl-lsp-diagnostics/Cargo.toml
+++ b/crates/perl-lsp-diagnostics/Cargo.toml
@@ -28,6 +28,7 @@ perl-heredoc-anti-patterns = { workspace = true }
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
 perl-parser = { workspace = true }
+tempfile = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -15,6 +15,7 @@ use crate::lints::common_mistakes::check_common_mistakes;
 use crate::lints::deprecated::check_deprecated_syntax;
 use crate::lints::duplicate_hash_keys::check_duplicate_hash_keys;
 use crate::lints::eval_error_flow::check_eval_error_flow;
+use crate::lints::ffi_checklib::check_ffi_checklib;
 use crate::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -148,6 +149,7 @@ impl DiagnosticsProvider {
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);
+        check_ffi_checklib(ast, &mut diagnostics);
         check_eval_error_flow(ast, &mut diagnostics);
 
         // Unused import detection

--- a/crates/perl-lsp-diagnostics/src/lints/ffi_checklib.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/ffi_checklib.rs
@@ -1,0 +1,384 @@
+//! FFI::CheckLib native-library validation hints
+//!
+//! This is a small, conservative diagnostics pass for the most common
+//! `FFI::CheckLib` call shapes:
+//!
+//! - `find_lib(...)`
+//! - `check_lib_or_exit(...)`
+//! - fully-qualified `FFI::CheckLib::find_lib(...)`
+//!
+//! It recognizes literal `lib` / `libpath` arguments and checks for matching
+//! library filenames in the explicit search paths plus a small set of common
+//! fallback directories.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity};
+use perl_parser_core::ast::{Node, NodeKind};
+
+use super::super::walker::walk_node;
+
+const CHECKLIB_SUPPORT_MODULES: &[&str] = &["FFI::CheckLib", "FFI::Platypus::Bundle"];
+
+pub fn check_ffi_checklib(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
+    let has_support_module = has_checklib_support_module(node);
+
+    walk_node(node, &mut |n| {
+        if let NodeKind::FunctionCall { name, args } = &n.kind
+            && is_checklib_call(name, has_support_module)
+        {
+            check_call(n, args, diagnostics);
+        }
+    });
+}
+
+fn has_checklib_support_module(node: &Node) -> bool {
+    let mut found = false;
+    walk_node(node, &mut |n| {
+        if let NodeKind::Use { module, .. } = &n.kind
+            && CHECKLIB_SUPPORT_MODULES.contains(&module.as_str())
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+fn is_checklib_call(name: &str, has_support_module: bool) -> bool {
+    if name.ends_with("::find_lib") || name.ends_with("::check_lib_or_exit") {
+        return true;
+    }
+
+    has_support_module && matches!(name, "find_lib" | "check_lib_or_exit")
+}
+
+fn check_call(node: &Node, args: &[Node], diagnostics: &mut Vec<Diagnostic>) {
+    let (libs, libpaths) = collect_checklib_arguments(args);
+    if libs.is_empty() {
+        return;
+    }
+
+    let mut search_paths = collect_search_paths(&libpaths);
+    if search_paths.is_empty() {
+        search_paths = default_search_paths();
+    }
+
+    for lib in libs {
+        if !library_exists(&lib, &search_paths) {
+            diagnostics.push(Diagnostic {
+                range: (node.location.start, node.location.end),
+                severity: DiagnosticSeverity::Warning,
+                code: None,
+                message: format!(
+                    "FFI::CheckLib could not find native library `{lib}` in the configured search paths"
+                ),
+                related_information: vec![],
+                tags: vec![],
+                suggestion: Some(
+                    "Add a matching `libpath` entry or install the library development package"
+                        .to_string(),
+                ),
+            });
+        }
+    }
+}
+
+fn collect_checklib_arguments(args: &[Node]) -> (Vec<String>, Vec<String>) {
+    let mut libs = Vec::new();
+    let mut libpaths = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let key = match literal_text(&args[index]) {
+            Some(key) => key,
+            None => {
+                index += 1;
+                continue;
+            }
+        };
+
+        match key.as_str() {
+            "lib" | "libpath" => {
+                if index + 1 < args.len() {
+                    match key.as_str() {
+                        "lib" => libs.extend(extract_literal_strings(&args[index + 1])),
+                        "libpath" => libpaths.extend(extract_literal_strings(&args[index + 1])),
+                        _ => unreachable!(),
+                    }
+                    index += 2;
+                    continue;
+                }
+            }
+            _ => {}
+        }
+
+        index += 1;
+    }
+
+    dedup_strings(&mut libs);
+    dedup_strings(&mut libpaths);
+    (libs, libpaths)
+}
+
+fn extract_literal_strings(node: &Node) -> Vec<String> {
+    match &node.kind {
+        NodeKind::String { value, .. } => literal_text_from_raw(value).into_iter().collect(),
+        NodeKind::Identifier { name } => vec![name.clone()],
+        NodeKind::ArrayLiteral { elements } => {
+            elements.iter().flat_map(extract_literal_strings).collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn literal_text(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::String { value, .. } => literal_text_from_raw(value),
+        NodeKind::Identifier { name } => Some(name.clone()),
+        _ => None,
+    }
+}
+
+fn literal_text_from_raw(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed.len() >= 2 {
+        let bytes = trimmed.as_bytes();
+        let first = bytes[0];
+        let last = bytes[trimmed.len() - 1];
+        if (first == b'\'' && last == b'\'') || (first == b'"' && last == b'"') {
+            return Some(trimmed[1..trimmed.len() - 1].to_string());
+        }
+    }
+
+    Some(trimmed.to_string())
+}
+
+fn collect_search_paths(libpaths: &[String]) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = libpaths.iter().map(PathBuf::from).collect();
+
+    for env_name in ["LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "LIBRARY_PATH"] {
+        if let Some(value) = std::env::var_os(env_name) {
+            paths.extend(std::env::split_paths(&value));
+        }
+    }
+
+    dedup_paths(&mut paths);
+    paths
+}
+
+fn default_search_paths() -> Vec<PathBuf> {
+    let mut paths = collect_search_paths(&[]);
+
+    #[cfg(target_os = "windows")]
+    {
+        paths.extend(
+            ["C:\\Windows\\System32", "C:\\Windows\\SysWOW64", "C:\\Windows"]
+                .iter()
+                .map(PathBuf::from),
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        paths.extend(
+            ["/usr/lib", "/usr/local/lib", "/opt/homebrew/lib", "/opt/local/lib"]
+                .iter()
+                .map(PathBuf::from),
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        paths.extend(
+            ["/lib", "/usr/lib", "/usr/local/lib", "/opt/local/lib"].iter().map(PathBuf::from),
+        );
+    }
+
+    dedup_paths(&mut paths);
+    paths
+}
+
+fn library_exists(lib: &str, search_paths: &[PathBuf]) -> bool {
+    let candidates = candidate_library_names(lib);
+    candidates.iter().any(|candidate| library_exists_anywhere(candidate, search_paths))
+}
+
+fn library_exists_anywhere(candidate: &str, search_paths: &[PathBuf]) -> bool {
+    let exact = Path::new(candidate);
+    if exact.exists() {
+        return true;
+    }
+
+    search_paths.iter().any(|dir| library_exists_in_dir(dir, candidate))
+}
+
+fn library_exists_in_dir(dir: &Path, candidate: &str) -> bool {
+    if dir.join(candidate).exists() {
+        return true;
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+
+    entries.flatten().any(|entry| {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        candidate_matches(&name, candidate)
+    })
+}
+
+fn candidate_matches(file_name: &str, candidate: &str) -> bool {
+    if file_name == candidate {
+        return true;
+    }
+
+    (candidate.ends_with(".so") || candidate.ends_with(".dylib"))
+        && file_name.starts_with(candidate)
+}
+
+fn candidate_library_names(lib: &str) -> Vec<String> {
+    let trimmed = lib.trim().trim_matches(|c| c == '\'' || c == '"');
+    let mut candidates = vec![trimmed.to_string()];
+    let stem = trimmed.strip_prefix("lib").unwrap_or(trimmed);
+
+    #[cfg(target_os = "windows")]
+    {
+        candidates.push(format!("{stem}.dll"));
+        candidates.push(format!("lib{stem}.dll"));
+        candidates.push(format!("{stem}.lib"));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        candidates.push(format!("lib{stem}.dylib"));
+        candidates.push(format!("lib{stem}.so"));
+        candidates.push(format!("lib{stem}.a"));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        candidates.push(format!("lib{stem}.so"));
+        candidates.push(format!("lib{stem}.so.1"));
+        candidates.push(format!("lib{stem}.a"));
+    }
+
+    dedup_strings(&mut candidates);
+    candidates
+}
+
+fn dedup_strings(values: &mut Vec<String>) {
+    values.sort();
+    values.dedup();
+}
+
+fn dedup_paths(values: &mut Vec<PathBuf>) {
+    values.sort();
+    values.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+    use tempfile::tempdir;
+
+    fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diagnostics = Vec::new();
+        check_ffi_checklib(&ast, &mut diagnostics);
+        diagnostics
+    }
+
+    fn write_library(dir: &Path, lib: &str) {
+        for candidate in candidate_library_names(lib) {
+            let path = dir.join(candidate);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, b"").unwrap();
+        }
+    }
+
+    #[test]
+    fn missing_library_emits_diagnostic() {
+        let diags =
+            diagnostics_for("use FFI::CheckLib;\nfind_lib(lib => 'ffi_checklib_missing_3574');\n");
+        assert!(
+            diags.iter().any(|d| d.message.contains("ffi_checklib_missing_3574")),
+            "expected a missing-library diagnostic, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_libpath_suppresses_missing_library() {
+        let tempdir = tempdir().unwrap();
+        write_library(tempdir.path(), "ffi_checklib_present_3574");
+
+        let source = format!(
+            "use FFI::CheckLib;\nfind_lib(lib => 'ffi_checklib_present_3574', libpath => '{}');\n",
+            tempdir.path().display()
+        );
+
+        let diags = diagnostics_for(&source);
+        assert!(diags.is_empty(), "expected no diagnostics for a present library, got: {diags:?}");
+    }
+
+    #[test]
+    fn array_library_list_reports_only_missing_entries() {
+        let tempdir = tempdir().unwrap();
+        write_library(tempdir.path(), "ffi_checklib_present_3574");
+
+        let source = format!(
+            "use FFI::CheckLib;\ncheck_lib_or_exit(lib => ['ffi_checklib_present_3574', 'ffi_checklib_missing_3574'], libpath => '{}');\n",
+            tempdir.path().display()
+        );
+
+        let diags = diagnostics_for(&source);
+        assert_eq!(diags.len(), 1, "expected one missing library diagnostic, got: {diags:?}");
+        assert!(
+            diags[0].message.contains("ffi_checklib_missing_3574"),
+            "expected the missing library to be named in the diagnostic"
+        );
+    }
+
+    #[test]
+    fn qualified_call_is_detected_without_import() {
+        let tempdir = tempdir().unwrap();
+        write_library(tempdir.path(), "ffi_checklib_present_3574");
+
+        let source = format!(
+            "FFI::CheckLib::find_lib(lib => 'ffi_checklib_present_3574', libpath => '{}');\n",
+            tempdir.path().display()
+        );
+
+        let diags = diagnostics_for(&source);
+        assert!(diags.is_empty(), "qualified FFI::CheckLib call should be handled, got: {diags:?}");
+    }
+
+    #[test]
+    fn platypus_bundle_import_is_treated_as_supporting_context() {
+        let tempdir = tempdir().unwrap();
+        write_library(tempdir.path(), "ffi_checklib_present_3574");
+
+        let source = format!(
+            "use FFI::Platypus::Bundle;\nfind_lib(lib => 'ffi_checklib_present_3574', libpath => '{}');\n",
+            tempdir.path().display()
+        );
+
+        let diags = diagnostics_for(&source);
+        assert!(
+            diags.is_empty(),
+            "FFI::Platypus::Bundle should participate in the same CheckLib hinting, got: {diags:?}"
+        );
+    }
+}

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -129,6 +129,8 @@ pub mod deprecated;
 pub mod duplicate_hash_keys;
 /// Conservative `$@` / `$EVAL_ERROR` flow checks after `eval` / `try`
 pub mod eval_error_flow;
+/// FFI::CheckLib native-library validation hints
+pub mod ffi_checklib;
 /// Missing module detection (PL701)
 pub mod missing_module;
 /// Package and subroutine diagnostics (PL200, PL201, PL300, PL303)

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticTag, DiagnosticsProvider};
 use perl_parser::Parser;
+use tempfile::tempdir;
 
 fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
     let output = Parser::new(source).parse_with_recovery();
@@ -381,4 +382,24 @@ fn lint_pipeline_dedup_removes_exact_duplicates() {
             );
         }
     }
+}
+
+// =========================================================================
+// 16. FFI::CheckLib hints surface through the full pipeline
+// =========================================================================
+
+#[test]
+fn lint_pipeline_ffi_checklib_missing_library_emits_hint() {
+    let tempdir = tempdir().unwrap();
+    let source = format!(
+        "use FFI::CheckLib;\nfind_lib(lib => 'ffi_checklib_pipeline_missing_3574', libpath => '{}');\n",
+        tempdir.path().display()
+    );
+    let diags = diagnostics_for(&source);
+
+    assert!(
+        diags.iter().any(|d| d.message.contains("ffi_checklib_pipeline_missing_3574")),
+        "Expected an FFI::CheckLib missing-library diagnostic, got: {:?}",
+        diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>()
+    );
 }


### PR DESCRIPTION
Adds a small, user-facing FFI::CheckLib diagnostics slice: detects literal  /  calls (including qualified calls), extracts static  /  arguments, and warns when the requested libraries are not present in the verified search roots.\n\nThis intentionally stops short of a full native-library resolution subsystem; the first shipped slice is conservative, testable, and wired through .\n\nValidation: , 
running 5 tests
test lints::ffi_checklib::tests::missing_library_emits_diagnostic ... ok
test lints::ffi_checklib::tests::platypus_bundle_import_is_treated_as_supporting_context ... ok
test lints::ffi_checklib::tests::qualified_call_is_detected_without_import ... ok
test lints::ffi_checklib::tests::explicit_libpath_suppresses_missing_library ... ok
test lints::ffi_checklib::tests::array_library_list_reports_only_missing_entries ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 53 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 41 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 1 test
test lint_pipeline_ffi_checklib_missing_library_emits_hint ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 16 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 87 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 49 filtered out; finished in 0.00s, 
running 58 tests
test lints::missing_module::tests::broken_file_with_valid_use_still_emits_pl701 ... ok
test lints::missing_module::tests::core_modules_not_flagged ... ok
test lints::missing_module::tests::diagnostic_range_covers_use_statement ... ok
test lints::missing_module::tests::empty_module_string_is_silently_skipped ... ok
test lints::missing_module::tests::found_module_no_diagnostic ... ok
test lints::missing_module::tests::list_more_utils_is_not_core_and_fires_pl701 ... ok
test lints::missing_module::tests::missing_module_emits_pl701 ... ok
test lints::missing_module::tests::mixed_present_and_missing_only_flags_missing ... ok
test lints::missing_module::tests::multiple_missing_modules_emits_multiple_diagnostics ... ok
test lints::ffi_checklib::tests::missing_library_emits_diagnostic ... ok
test lints::missing_module::tests::resolver_always_finds_no_diagnostic ... ok
test lints::ffi_checklib::tests::platypus_bundle_import_is_treated_as_supporting_context ... ok
test lints::ffi_checklib::tests::qualified_call_is_detected_without_import ... ok
test lints::missing_module::tests::resolver_called_multiple_times_is_stable ... ok
test lints::ffi_checklib::tests::explicit_libpath_suppresses_missing_library ... ok
test lints::missing_module::tests::suggestion_contains_module_name ... ok
test lints::missing_module::tests::severity_is_warning ... ok
test lints::missing_module::tests::use_if_conditional_not_flagged ... ok
test lints::missing_module::tests::version_only_use_not_flagged ... ok
test lints::missing_module::tests::versioned_module_strips_version_before_lookup ... ok
test lints::printf_format::tests::count_basic_specifiers ... ok
test lints::printf_format::tests::double_percent_not_counted ... ok
test lints::printf_format::tests::flags_and_width_handled ... ok
test lints::printf_format::tests::unquote_double_quotes ... ok
test lints::printf_format::tests::unquote_no_quotes_unchanged ... ok
test lints::printf_format::tests::unquote_single_quotes ... ok
test lints::ffi_checklib::tests::array_library_list_reports_only_missing_entries ... ok
test lints::security::tests::exec_call_is_flagged ... ok
test lints::security::tests::exec_call_list_form_is_flagged ... ok
test lints::security::tests::global_sig_die_handler_is_flagged ... ok
test lints::security::tests::lexical_sig_shadow_is_not_flagged ... ok
test lints::security::tests::global_sig_warn_handler_is_flagged ... ok
test lints::security::tests::main_qualified_sig_warn_handler_is_flagged ... ok
test lints::security::tests::normal_three_arg_open_is_not_pipe_flagged ... ok
test lints::security::tests::local_sig_handlers_are_not_flagged ... ok
test lints::security::tests::pipe_read_open_is_flagged ... ok
test lints::security::tests::pipe_write_open_is_flagged ... ok
test lints::security::tests::quoted_global_sig_warn_handler_is_flagged ... ok
test lints::security::tests::readpipe_call_is_flagged ... ok
test lints::security::tests::system_call_list_form_is_flagged ... ok
test lints::strict_warnings::tests::comment_only_no_strict_warnings_diagnostic ... ok
test lints::security::tests::two_arg_pipe_open_is_flagged_as_pipe_open ... ok
test lints::security::tests::system_call_is_flagged ... ok
test lints::strict_warnings::tests::developer_version_pragma_suppresses_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::crlf_only_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::file_with_strict_and_warnings_no_diagnostic ... ok
test lints::strict_warnings::tests::misspelled_pragma_in_non_empty_file_still_detected ... ok
test lints::strict_warnings::tests::numeric_version_pragma_suppresses_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::empty_file_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::shebang_plus_comment_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::pod_only_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::v5_12_suppresses_strict_but_not_missing_warnings ... ok
test lints::strict_warnings::tests::non_empty_file_without_strict_still_gets_diagnostic ... ok
test lints::strict_warnings::tests::v5_36_suppresses_both_strict_and_warnings_diagnostics ... ok
test lints::strict_warnings::tests::version_pragma_suppresses_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::shebang_only_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::whitespace_only_no_strict_warnings_diagnostic ... ok
test lints::strict_warnings::tests::v5_36_numeric_form_suppresses_both_strict_and_warnings ... ok

test result: ok. 58 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 12 tests
test bareword_under_strict_is_flagged ... ok
test hash_key_bareword_is_not_flagged ... ok
test bareword_diagnostic_has_correct_code ... ok
test bareword_without_strict_is_not_flagged ... ok
test bareword_diagnostic_has_auto_quote_suggestion ... ok
test bareword_diagnostic_has_related_info ... ok
test bareword_diagnostic_message_explains_strict ... ok
test multiple_barewords_each_get_diagnostic ... ok
test bareword_suggestion_mentions_quoting ... ok
test bareword_diagnostic_message_names_the_bareword ... ok
test bareword_suggestion_includes_bareword_name ... ok
test bareword_under_strict_severity_is_error ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 14 tests
test non_parse_error_diagnostics_not_suppressed ... ok
test single_parse_error_is_preserved ... ok
test adjacent_cascade_errors_suppressed_to_one ... ok
test two_distant_parse_errors_both_preserved ... ok
test two_independent_syntax_errors_both_reported ... ok
test cascade_suppression_reduces_adjacent_errors_to_one_at_error_level ... ok
test single_missing_semicolon_produces_at_most_two_parse_errors ... ok
test unclosed_paren_does_not_produce_error_explosion ... ok
test empty_error_list_produces_empty_parse_diagnostics ... ok
test errors_at_threshold_plus_one_start_new_cluster ... ok
test errors_at_exactly_threshold_boundary_suppressed ... ok
test two_separate_clusters_one_primary_each ... ok
test exact_duplicate_cascades_all_removed ... ok
test valid_perl_produces_no_parse_error_markers ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test test_dead_code_only_in_current_document ... ok
test test_dead_code_detection ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 41 tests
test test_clearing_on_fix_lint_diagnostics_also_clear ... ok
test test_deprecated_tag_for_deprecated_syntax ... ok
test test_range_accuracy_line_col_conversion_known_position ... ok
test test_severity_ordering_is_consistent ... ok
test empty_file_produces_no_strict_warnings_diagnostics ... ok
test test_parse_error_mapping_unexpected_token ... ok
test test_parse_error_mapping_missing_semicolon ... ok
test test_full_pipeline_empty_source ... ok
test test_parse_error_mapping_valid_perl_no_parse_errors ... ok
test comment_only_file_produces_no_strict_warnings_diagnostics ... ok
test test_multiple_diagnostics_each_has_distinct_range ... ok
test test_range_accuracy_eof_offset ... ok
test test_range_accuracy_parse_error_near_correct_position ... ok
test test_diagnostic_codes_are_well_formed ... ok
test test_parse_error_mapping_unclosed_brace ... ok
test test_severity_parse_errors_are_error_level ... ok
test test_edge_case_single_character_source ... ok
test test_multiple_diagnostics_multiple_parse_errors ... ok
test test_range_accuracy_multiline_source ... ok
test test_clearing_on_fix_broken_then_fixed ... ok
test test_range_accuracy_offset_within_source ... ok
test test_multiple_diagnostics_mixed_categories ... ok
test test_severity_unused_variable_is_warning ... ok
test test_clearing_on_fix_unclosed_brace_then_closed ... ok
test test_full_pipeline_complex_perl_file ... ok
test test_clearing_on_fix_synthetic_error_then_none ... ok
test test_suggestion_present_for_eof_error ... ok
test test_diagnostic_code_field_always_present_for_parse_errors ... ok
test test_edge_case_only_whitespace ... ok
test test_severity_missing_strict_is_information ... ok
test test_suggestion_present_for_unclosed_delimiter ... ok
test test_full_pipeline_clean_perl_minimal_diagnostics ... ok
test test_unknown_subroutine_attribute_is_warning ... ok
test test_v5_36_suppresses_missing_strict_warnings ... ok
test whitespace_only_file_produces_no_strict_warnings_diagnostics ... ok
test test_version_pragma_suppresses_missing_strict_warnings ... ok
test test_try_catch_variable_diagnostic_range_targets_parameter ... ok
test test_edge_case_unicode_source ... ok
test test_try_catch_variable_does_not_escape_into_outer_scope ... ok
test test_edge_case_very_long_line ... ok
test test_try_catch_variable_is_declared_inside_catch ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 13 tests
test snapshot_two_arg_open_fires ... ok
test snapshot_unused_variable_fires ... ok
test snapshot_oop_pattern ... ok
test snapshot_missing_strict_fires ... ok
test snapshot_basic_strict_warnings ... ok
test snapshot_all_codes_are_stable ... ok
test snapshot_file_io ... ok
test snapshot_string_eval_fires ... ok
test snapshot_regex_pattern ... ok
test snapshot_hash_array_operations ... ok
test snapshot_error_handling ... ok
test snapshot_module_usage_carp ... ok
test snapshot_modern_perl_v536 ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 11 tests
test empty_hash_no_pl407 ... ok
test hash_variable_multiple_duplicates_fires_pl407_multiple_times ... ok
test hash_with_mixed_static_variable_no_false_positive ... ok
test hash_variable_string_key_duplicate_fires_pl407 ... ok
test hash_all_unique_keys_no_pl407 ... ok
test hash_ref_fat_arrow_duplicate_key_fires_pl407 ... ok
test single_pair_hash_no_pl407 ... ok
test hash_with_variable_keys_no_pl407 ... ok
test hash_ref_all_unique_no_pl407 ... ok
test hash_variable_fat_arrow_duplicate_key_fires_pl407 ... ok
test hash_triply_duplicated_key_fires_pl407_twice ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test immediate_check_after_eval_is_allowed ... ok
test immediate_check_after_try_is_allowed_for_eval_error ... ok
test localizing_error_variable_is_not_treated_as_a_read ... ok
test intervening_statement_before_check_warns ... ok
test statement_modifier_reads_are_visible ... ok
test reading_error_without_prior_eval_or_try_warns ... ok
test assignment_targets_do_not_count_as_reads ... ok
test stale_read_inside_handler_body_is_reported ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test clean_heredoc_produces_no_diagnostics ... ok
test format_heredoc_detected ... ok
test eval_string_heredoc_produces_warning ... ok
test source_filter_heredoc_detected ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 17 tests
test lint_pipeline_warnings_inside_end_suppresses_pl101 ... ok
test lint_pipeline_missing_strict_emits_pl100 ... ok
test lint_pipeline_strict_and_warnings_present_no_pl100_pl101 ... ok
test lint_pipeline_strict_inside_init_suppresses_pl100 ... ok
test lint_pipeline_missing_warnings_emits_pl101 ... ok
test lint_pipeline_moose_suppresses_pl100_pl101 ... ok
test lint_pipeline_strict_inside_begin_suppresses_pl100 ... ok
test lint_pipeline_dedup_removes_exact_duplicates ... ok
test lint_pipeline_assignment_in_if_emits_pl403 ... ok
test lint_pipeline_deprecated_defined_array_emits_pl500 ... ok
test lint_pipeline_unused_import_emits_pl700 ... ok
test lint_pipeline_used_import_no_pl700 ... ok
test lint_pipeline_eval_error_flow_emits_pl407 ... ok
test lint_pipeline_ffi_checklib_missing_library_emits_hint ... ok
test lint_pipeline_global_sig_handler_emits_pl602 ... ok
test lint_pipeline_string_eval_emits_pl600 ... ok
test lint_pipeline_lexical_sig_shadow_does_not_emit_pl602 ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 11 tests
test pl300_absent_for_anonymous_subs ... ok
test pl200_suppressed_when_package_present ... ok
test pl201_absent_when_packages_are_different ... ok
test pl300_absent_when_sub_names_are_different ... ok
test pl300_fires_inside_package_block_form ... ok
test pl200_fires_when_no_package_declaration ... ok
test pl300_absent_for_same_sub_name_in_different_packages ... ok
test pl200_suppressed_for_block_form_package ... ok
test pl201_fires_twice_on_triple_duplicate_package ... ok
test pl201_fires_on_duplicate_package ... ok
test pl300_fires_on_duplicate_named_sub ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test variable_format_string_no_pl405 ... ok
test printf_with_filehandle_mismatch_fires_pl405 ... ok
test printf_too_few_args_fires_pl405 ... ok
test printf_double_percent_not_counted ... ok
test sprintf_too_many_args_fires_pl405 ... ok
test sprintf_no_specifiers_no_args_no_pl405 ... ok
test printf_with_filehandle_exact_match_no_pl405 ... ok
test sprintf_exact_match_no_pl405 ... ok
test sprintf_too_few_args_fires_pl405 ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 7 tests
test role_consuming_roles_does_not_trigger_pl303 ... ok
test distinct_role_methods_do_not_conflict ... ok
test multiple_with_calls_accumulate_and_conflict ... ok
test requires_does_not_count_as_a_provided_method ... ok
test class_defining_the_method_suppresses_pl303 ... ok
test three_conflicting_roles_emit_single_pl303 ... ok
test same_file_role_conflict_emits_pl303_at_with_reference ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 13 tests
test parse_error_variable_suggestion ... ok
test no_related_info_when_no_suggestion ... ok
test unexpected_closing_brace_enhanced_message ... ok
test missing_semicolon_enhanced_message ... ok
test suggestion_surfaces_as_related_information ... ok
test semicolon_suggestion_text ... ok
test variable_suggestion ... ok
test closing_bracket_suggestion ... ok
test unexpected_closing_bracket_enhanced_message ... ok
test expected_variable_enhanced_message ... ok
test default_message_fallback ... ok
test all_parse_errors_have_code ... ok
test unexpected_closing_paren_enhanced_message ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 87 tests
test common_mistakes_assignment_in_if_condition ... ok
test common_mistakes_assignment_in_while_condition ... ok
test common_mistakes_comparison_in_condition_ok ... ok
test common_mistakes_ne_undef_comparison ... ok
test common_mistakes_no_warning_for_string_comparison ... ok
test common_mistakes_related_info_for_assignment ... ok
test common_mistakes_undef_comparison ... ok
test dead_code_tests::dead_code_empty_workspace ... ok
test dead_code_tests::dead_code_all_used ... ok
test dead_code_tests::dead_code_filters_by_document_uri ... ok
test dead_code_tests::dead_code_severity_and_tags ... ok
test dead_code_tests::dead_code_unused_sub_flagged ... ok
test deprecated_array_base_variable ... ok
test deprecated_defined_array ... ok
test deprecated_defined_hash ... ok
test deprecated_defined_scalar_no_warning ... ok
test deprecated_no_false_positive_other_variable ... ok
test deprecated_related_info_has_suggestion ... ok
test diagnostic_clone_eq ... ok
test diagnostic_clone_preserves_suggestion ... ok
test diagnostic_equality_considers_suggestion ... ok
test diagnostic_struct_construction ... ok
test diagnostic_tag_variants ... ok
test diagnostic_with_related_info ... ok
test misspelled_pragma_feaure_suggests_feature ... ok
test misspelled_pragma_no_false_positive_for_valid_module ... ok
test misspelled_pragma_structs_suggests_strict ... ok
test misspelled_pragma_warning_suggests_warnings ... ok
test related_information_debug ... ok
test security_backtick_string_warns ... ok
test security_eval_block_no_warning ... ok
test security_eval_with_concatenation_warns ... ok
test security_eval_with_variable_warns ... ok
test security_non_interpolated_backtick_no_warning ... ok
test security_normal_string_no_backtick_warning ... ok
test security_one_arg_open_no_warning ... ok
test security_other_function_no_open_warning ... ok
test security_related_info_quality ... ok
test security_string_eval_warns ... ok
test security_three_arg_open_no_warning ... ok
test security_two_arg_open_warns ... ok
test severity_clone_copy_eq ... ok
test severity_ordering ... ok
test strict_warnings_both_missing ... ok
test strict_warnings_both_present ... ok
test strict_warnings_related_info ... ok
test strict_warnings_strict_present ... ok
test strict_warnings_suppressed_for_modern_perl ... ok
test strict_warnings_suppressed_for_mojo_base ... ok
test strict_warnings_suppressed_for_moo ... ok
test strict_warnings_suppressed_for_moose ... ok
test provider_error_range_is_clamped_to_source_bounds ... ok
test provider_lexer_error ... ok
test provider_unknown_subroutine_attribute_stays_warning ... ok
test provider_clamps_out_of_bounds_ranges ... ok
test suggestion_field_is_none_when_not_applicable ... ok
test lexer_error_with_unterminated_string_has_suggestion ... ok
test provider_scope_analysis_runs ... ok
test strict_warnings_warnings_present ... ok
test full_pipeline_fallback_parse_error ... ok
test provider_no_errors_no_scope_issues ... ok
test found_semicolon_when_expecting_expression_has_suggestion ... ok
test full_pipeline_uninitialized_variable_emits_warning ... ok
test suggestion_field_is_populated_for_scope_diagnostics ... ok
test missing_semicolon_parse_error_has_suggestion ... ok
test provider_multiple_errors ... ok
test provider_syntax_error ... ok
test full_pipeline_empty_source ... ok
test full_pipeline_initialized_variable_no_warning ... ok
test provider_unexpected_eof_error ... ok
test syntax_error_with_heredoc_hint_has_suggestion ... ok
test invalid_regex_error_has_suggestion ... ok
test provider_invalid_prototype_maps_to_pl302_warning ... ok
test provider_unexpected_token_formats_end_of_input ... ok
test nesting_too_deep_error_has_suggestion ... ok
test recursion_limit_error_has_suggestion ... ok
test invalid_number_error_has_suggestion ... ok
test unclosed_delimiter_error_has_suggestion ... ok
test provider_unexpected_token_error ... ok
test undeclared_variable_diagnostic_has_suggestion_and_enhanced_message ... ok
test undeclared_variable_related_info_explains_strict ... ok
test unexpected_closing_brace_has_helpful_suggestion ... ok
test unexpected_eof_has_suggestion ... ok
test unused_parameter_has_warning_severity_and_unnecessary_tag ... ok
test unused_variable_has_warning_severity_and_unnecessary_tag ... ok
test unused_variable_through_provider_has_correct_severity ... ok
test invalid_string_error_has_suggestion ... ok

test result: ok. 87 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 17 tests
test n1_conditional_return_via_statement_modifier ... ok
test n5_return_at_end_of_block ... ok
test n6_die_inside_or_not_unconditional ... ok
test n4_nested_sub_return_no_false_positive ... ok
test n2_return_in_one_branch_only ... ok
test n3_eval_block_containing_die ... ok
test n7_goto_label_not_yet_detected ... ok
test t10_confess_qualified_followed_by_statement ... ok
test t1_return_followed_by_statement ... ok
test t2_die_followed_by_statement ... ok
test t3_exit_at_top_level ... ok
test t4_croak_qualified_followed_by_statement ... ok
test t5_multiple_unreachable_statements ... ok
test t6_last_inside_loop_body ... ok
test t7_unqualified_croak_followed_by_statement ... ok
test t8_next_inside_loop_body ... ok
test t9_redo_inside_loop_body ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 14 tests
test diagnostic_has_hint_severity_and_unnecessary_tag ... ok
test empty_program_no_diagnostics ... ok
test method_call_target_not_flagged ... ok
test mixed_used_and_unused ... ok
test module_with_import_args_not_flagged ... ok
test moose_not_flagged ... ok
test multiple_unused_all_flagged ... ok
test pragma_strict_not_flagged ... ok
test pragma_warnings_not_flagged ... ok
test substring_match_does_not_count ... ok
test test_more_not_flagged ... ok
test unused_module_is_flagged ... ok
test used_module_is_not_flagged ... ok
test version_import_not_flagged ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 49 tests
test test_builtin_imports_have_distinct_minimum_versions ... ok
test test_builtin_qualified_call_ok_on_v5_40 ... ok
test test_builtin_qualified_call_floor_ok_on_v5_36 ... ok
test test_builtin_qualified_calls_have_distinct_minimum_versions ... ok
test test_builtin_qw_imports_have_distinct_minimum_versions ... ok
test test_class_inside_default_is_reached_by_walker ... ok
test test_class_ok_on_v5_38 ... ok
test test_class_ok_on_v5_38_dev_release ... ok
test test_class_ok_on_v5_40 ... ok
test test_class_ok_with_use_feature_class ... ok
test test_default_errors_on_v5_42 ... ok
test test_class_warns_on_v5_36 ... ok
test test_default_ok_on_v5_10 ... ok
test test_default_warns_on_v5_38 ... ok
test test_default_warns_on_v5_8 ... ok
test test_defer_helper_call_is_not_version_feature ... ok
test test_defer_ok_on_v5_36 ... ok
test test_defer_ok_with_use_feature_defer ... ok
test test_defer_warns_on_v5_34 ... ok
test test_given_errors_on_v5_42 ... ok
test test_explicit_use_feature_suppresses_warning ... ok
test test_given_ok_on_v5_10 ... ok
test test_given_ok_with_use_feature_switch ... ok
test test_given_ok_on_v5_36 ... ok
test test_given_warns_on_v5_38 ... ok
test test_given_warns_on_v5_8 ... ok
test test_given_when_errors_on_v5_42 ... ok
test test_given_when_warns_on_v5_38 ... ok
test test_isa_ok_on_v5_36 ... ok
test test_isa_ok_with_use_feature_isa ... ok
test test_isa_warns_on_v5_30 ... ok
test test_no_version_no_warnings ... ok
test test_numeric_version_5_036 ... ok
test test_say_in_return_value_detected ... ok
test test_say_in_ternary_branch_detected ... ok
test test_say_inside_given_when_is_reached_by_walker ... ok
test test_say_nested_in_method_call_object_detected ... ok
test test_say_ok_on_v5_10 ... ok
test test_say_warns_on_v5_8 ... ok
test test_signatures_ok_on_v5_36 ... ok
test test_signatures_warns_on_v5_20 ... ok
test test_try_ok_on_v5_34 ... ok
test test_try_warns_on_v5_32 ... ok
test test_use_builtin_bundle_warns_on_v5_36 ... ok
test test_use_builtin_floor_ok_on_v5_36 ... ok
test test_use_builtin_suppresses_qualified_call_warning ... ok
test test_when_ok_on_v5_10 ... ok
test test_when_warns_on_v5_38 ... ok
test test_when_warns_on_v5_8 ... ok

test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s.