### PR TITLE
fix(module-resolution): honor lexical use lib reinsertion precedence (#3720)

### DIFF
--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -149,14 +149,18 @@ pub fn resolve_use_lib_paths_from_source(
     workspace_root: &Path,
     file_dir: Option<&Path>,
 ) -> Vec<String> {
+    // Highest-precedence path first, matching lexical `use lib` behavior.
     let mut resolved = Vec::new();
     for op in extract_use_lib_operations(source) {
         match op {
             UseLibAction::Add(paths) => {
-                for path in resolve_use_lib_paths(&paths, workspace_root, file_dir) {
-                    if !resolved.contains(&path) {
-                        resolved.push(path);
-                    }
+                // `use lib` unshifts list entries in order, so process from back-to-front.
+                // Re-adding an existing path must move it back to the front.
+                for path in
+                    resolve_use_lib_paths(&paths, workspace_root, file_dir).into_iter().rev()
+                {
+                    resolved.retain(|existing| existing != &path);
+                    resolved.insert(0, path);
                 }
             }
             UseLibAction::Remove(paths) => {
@@ -522,5 +526,26 @@ mod tests {
         let source = "use lib 'lib';\nuse lib 't/lib';\nno lib 'lib';\n";
         let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
         assert_eq!(resolved, vec!["t/lib"]);
+    }
+
+    #[test]
+    fn latest_use_lib_takes_precedence() {
+        let source = "use lib 'a';\nuse lib 'b';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn repeated_use_lib_reinserts_at_front() {
+        let source = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn no_lib_then_use_lib_reintroduces_at_front() {
+        let source = "use lib 'a';\nuse lib 'b';\nno lib 'a';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
     }
 }


### PR DESCRIPTION
### Motivation

- Fix a correctness bug where repeated `use lib` of an already-active path was ignored instead of moving that path back to highest precedence. 
- Bring lexical `use lib` behavior in the include-stack implementation in line with Perl semantics so module resolution and navigation are deterministic.

### Description

- Update `resolve_use_lib_paths_from_source` in `crates/perl-module-resolution/src/use_lib.rs` to treat `use lib` as a highest-precedence-first stack by reinserting re-used paths at the front. 
- Preserve `no lib` semantics by removing matching paths from the active stack when encountered. 
- Iterate `use lib` items back-to-front to model unshift semantics and explicitly remove any existing occurrence before inserting at index 0. 
- Add focused regression tests (`latest_use_lib_takes_precedence`, `repeated_use_lib_reinserts_at_front`, `no_lib_then_use_lib_reintroduces_at_front`) to validate precedence and reinsertion behavior.

### Testing

- Ran `cargo fmt --all` to format the workspace and it completed successfully. 
- Ran `cargo test -p perl-module-resolution` and all unit and integration tests in that crate passed. 
- Ran `cargo test -p perllsp module_resolution -- --nocapture` (workspace module-resolution suites) and the module-resolution test suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d903b3529c8333b2f28259031ae4b6)