### PR TITLE
fix(module-resolution): restore lexical use lib precedence (#3720)

### DIFF
--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -153,10 +153,10 @@ pub fn resolve_use_lib_paths_from_source(
     for op in extract_use_lib_operations(source) {
         match op {
             UseLibAction::Add(paths) => {
-                for path in resolve_use_lib_paths(&paths, workspace_root, file_dir) {
-                    if !resolved.contains(&path) {
-                        resolved.push(path);
-                    }
+                let add_paths = resolve_use_lib_paths(&paths, workspace_root, file_dir);
+                for path in add_paths.into_iter().rev() {
+                    resolved.retain(|existing| existing != &path);
+                    resolved.insert(0, path);
                 }
             }
             UseLibAction::Remove(paths) => {
@@ -522,5 +522,26 @@ mod tests {
         let source = "use lib 'lib';\nuse lib 't/lib';\nno lib 'lib';\n";
         let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
         assert_eq!(resolved, vec!["t/lib"]);
+    }
+
+    #[test]
+    fn resolves_use_lib_later_statements_first() {
+        let source = "use lib 'a';\nuse lib 'b';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn resolves_readding_path_moves_to_front() {
+        let source = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn resolves_no_lib_then_readd_restores_precedence() {
+        let source = "use lib 'a';\nuse lib 'b';\nno lib 'a';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
     }
 }


### PR DESCRIPTION
### Motivation

- Correct a correctness bug where repeated `use lib` reinsertion did not move an already-active path back to highest precedence, causing resolution order to diverge from Perl semantics.
- Ensure lexical `use lib` / `no lib` overlays behave deterministically so module resolution, diagnostics, and navigation can rely on a stable include-stack ordering.

### Description

- Change `resolve_use_lib_paths_from_source` in `crates/perl-module-resolution/src/use_lib.rs` to apply add operations as front-of-stack inserts while deduplicating existing entries, restoring Perl-like precedence semantics.
- Preserve `no lib` semantics by removing matching entries while allowing subsequent `use lib` to reintroduce the path at the front.
- Add regression tests in `crates/perl-module-resolution/src/use_lib.rs` covering later `use lib` precedence, reinsertion moving a path to the front, and `no lib` followed by `use lib` reintroducing the path.

### Testing

- Ran `cargo fmt --all` to format code successfully.
- Ran `cargo test -p perl-module-resolution use_lib::tests::` and all relevant unit tests passed (31 passed, 0 failed).
- Built and ran tests for the `perllsp` package as part of the workspace exercise which completed without failures (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d903b3529c8333b2f28259031ae4b6)