### PR TITLE
fix(module-resolution): restore use lib reinsertion precedence (#3720)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -31,9 +31,8 @@ fn prepend_use_lib_paths(
 ) {
     let dynamic = resolve_use_lib_paths_from_source(doc_text, workspace_root, file_dir);
     for p in dynamic.into_iter().rev() {
-        if !include_paths.contains(&p) {
-            include_paths.insert(0, p);
-        }
+        include_paths.retain(|existing| existing != &p);
+        include_paths.insert(0, p);
     }
 }
 
@@ -483,6 +482,34 @@ mod tests {
             resolved, module_file,
             "no lib should remove prior use lib path from lexical overlay"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_module_path_repeated_use_lib_reorders_precedence() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+
+        let a_mod = workspace.join("a").join("Dup").join("Winner.pm");
+        let b_mod = workspace.join("b").join("Dup").join("Winner.pm");
+        fs::create_dir_all(a_mod.parent().ok_or("no parent")?)?;
+        fs::create_dir_all(b_mod.parent().ok_or("no parent")?)?;
+        fs::write(&a_mod, "package Dup::Winner; 1;")?;
+        fs::write(&b_mod, "package Dup::Winner; 1;")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace.clone());
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec![];
+        }
+
+        let doc_text = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = server
+            .resolve_module_path("Dup::Winner", Some(doc_text))
+            .ok_or("expected resolve_module_path to find Dup::Winner via repeated use lib")?;
+
+        assert_eq!(resolved, a_mod, "re-adding a path should move it to front");
         Ok(())
     }
 

--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -149,14 +149,17 @@ pub fn resolve_use_lib_paths_from_source(
     workspace_root: &Path,
     file_dir: Option<&Path>,
 ) -> Vec<String> {
+    // Front of this vector is highest-precedence (searched first), matching Perl's
+    // `use lib` behavior where later statements prepend to `@INC`.
     let mut resolved = Vec::new();
     for op in extract_use_lib_operations(source) {
         match op {
             UseLibAction::Add(paths) => {
-                for path in resolve_use_lib_paths(&paths, workspace_root, file_dir) {
-                    if !resolved.contains(&path) {
-                        resolved.push(path);
-                    }
+                let added = resolve_use_lib_paths(&paths, workspace_root, file_dir);
+                for path in added.into_iter().rev() {
+                    // Re-adding an existing path must move it back to highest precedence.
+                    resolved.retain(|existing| existing != &path);
+                    resolved.insert(0, path);
                 }
             }
             UseLibAction::Remove(paths) => {
@@ -522,5 +525,19 @@ mod tests {
         let source = "use lib 'lib';\nuse lib 't/lib';\nno lib 'lib';\n";
         let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
         assert_eq!(resolved, vec!["t/lib"]);
+    }
+
+    #[test]
+    fn repeated_use_lib_reinserts_with_highest_precedence() {
+        let source = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn multiple_use_lib_statements_last_statement_wins() {
+        let source = "use lib 'a';\nuse lib 'b';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["b", "a"]);
     }
 }


### PR DESCRIPTION
### Motivation
- Lexical `use lib` handling incorrectly skipped reinsertion of already-active paths, changing search order (e.g. `use lib 'a'; use lib 'b'; use lib 'a';` produced the wrong precedence).
- LSP runtime overlay logic also skipped inserting document-scoped `use lib` entries when they already existed in configured include paths, causing runtime resolution to diverge from lexical semantics.

### Description
- Change `resolve_use_lib_paths_from_source` to treat the front of the returned vector as highest-precedence and to reinsert an existing path at the front when re-added (moves an existing entry to index 0 instead of ignoring it).
- Update `prepend_use_lib_paths` in the LSP runtime to always reinsert dynamic lexical paths at the front by removing any existing occurrence and inserting at index 0 so document-scoped overlays reflect lexical precedence.
- Add unit tests in `crates/perl-module-resolution` covering repeated reinsertion (`repeated_use_lib_reinserts_with_highest_precedence`) and multi-statement precedence (`multiple_use_lib_statements_last_statement_wins`).
- Add an integration-style lifecycle test in `crates/perl-lsp` (`test_resolve_module_path_repeated_use_lib_reorders_precedence`) that verifies repeated lexical reinsertion causes the resolver to pick the front-most module file.

### Testing
- Ran formatter with `cargo fmt --all` which completed successfully.
- Ran unit tests for the module-resolution crate with `cargo test -p perl-module-resolution use_lib` and the `use_lib` test group passed (all added tests passed).
- Attempted to run a focused `perl-lsp` crate test for the new lifecycle test, but a workspace-wide relink/test fan-out made the run expensive in this environment; the focused `perl-module-resolution` coverage was validated while the full `perl-lsp` run was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d903b3529c8333b2f28259031ae4b6)