### PR TITLE
fix(module-resolution): restore repeated use lib precedence (#3720)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -512,6 +512,32 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_module_path_use_lib_reorders_existing_include_path() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let preferred = workspace.join("a").join("Prefer").join("Me.pm");
+        let fallback = workspace.join("b").join("Prefer").join("Me.pm");
+        fs::create_dir_all(preferred.parent().ok_or("no parent")?)?;
+        fs::create_dir_all(fallback.parent().ok_or("no parent")?)?;
+        fs::write(&preferred, "package Prefer::Me; 'a';")?;
+        fs::write(&fallback, "package Prefer::Me; 'b';")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace);
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec!["b".to_string(), "a".to_string()];
+        }
+
+        let doc_text = "use lib 'a';\n";
+        let resolved = server
+            .resolve_module_path("Prefer::Me", Some(doc_text))
+            .ok_or("expected candidate path")?;
+        assert_eq!(resolved, preferred, "use lib should move existing include path to front");
+        Ok(())
+    }
+
+    #[test]
     fn test_resolve_module_path_no_doc_text_unchanged() -> TestResult {
         let temp = tempfile::tempdir()?;
         let workspace = temp.path().join("workspace");

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -31,9 +31,8 @@ fn prepend_use_lib_paths(
 ) {
     let dynamic = resolve_use_lib_paths_from_source(doc_text, workspace_root, file_dir);
     for p in dynamic.into_iter().rev() {
-        if !include_paths.contains(&p) {
-            include_paths.insert(0, p);
-        }
+        include_paths.retain(|existing| existing != &p);
+        include_paths.insert(0, p);
     }
 }
 
@@ -483,6 +482,32 @@ mod tests {
             resolved, module_file,
             "no lib should remove prior use lib path from lexical overlay"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_module_path_repeated_use_lib_reinserts_to_front() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let first_file = workspace.join("a").join("Reorder").join("Case.pm");
+        let second_file = workspace.join("b").join("Reorder").join("Case.pm");
+        fs::create_dir_all(first_file.parent().ok_or("no parent")?)?;
+        fs::create_dir_all(second_file.parent().ok_or("no parent")?)?;
+        fs::write(&first_file, "package Reorder::Case; 'a';")?;
+        fs::write(&second_file, "package Reorder::Case; 'b';")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace);
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec![];
+        }
+
+        let doc_text = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = server
+            .resolve_module_path("Reorder::Case", Some(doc_text))
+            .ok_or("expected candidate path")?;
+        assert_eq!(resolved, first_file, "re-added path should return to highest precedence");
         Ok(())
     }
 

--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -153,10 +153,10 @@ pub fn resolve_use_lib_paths_from_source(
     for op in extract_use_lib_operations(source) {
         match op {
             UseLibAction::Add(paths) => {
-                for path in resolve_use_lib_paths(&paths, workspace_root, file_dir) {
-                    if !resolved.contains(&path) {
-                        resolved.push(path);
-                    }
+                let statement_paths = resolve_use_lib_paths(&paths, workspace_root, file_dir);
+                for path in statement_paths.into_iter().rev() {
+                    resolved.retain(|existing| existing != &path);
+                    resolved.insert(0, path);
                 }
             }
             UseLibAction::Remove(paths) => {
@@ -522,5 +522,12 @@ mod tests {
         let source = "use lib 'lib';\nuse lib 't/lib';\nno lib 'lib';\n";
         let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
         assert_eq!(resolved, vec!["t/lib"]);
+    }
+
+    #[test]
+    fn repeated_use_lib_reinserts_to_front() {
+        let source = "use lib 'a';\nuse lib 'b';\nuse lib 'a';\n";
+        let resolved = resolve_use_lib_paths_from_source(source, Path::new("/project"), None);
+        assert_eq!(resolved, vec!["a", "b"]);
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where repeated `use lib` additions did not move an already-active path back to highest precedence, causing resolution order to diverge from Perl semantics.
- Ensure the LSP’s per-document lexical overlay reflects the same reinsertion semantics so navigation and diagnostics observe consistent include ordering.

### Description
- Change lexical application in `resolve_use_lib_paths_from_source` to reinsert re-added paths at the front of the effective stack by removing any existing entry and `insert(0, path)` in statement order.
- Update `prepend_use_lib_paths` in the LSP resolver to remove any existing include before inserting it at the front so document-scoped overlays mirror core behavior.
- Add a unit regression test `repeated_use_lib_reinserts_to_front` in `crates/perl-module-resolution` validating `use lib 'a'; use lib 'b'; use lib 'a';` yields `['a','b']`.
- Add an LSP-level integration test `test_resolve_module_path_repeated_use_lib_reinserts_to_front` proving the overlayed include ordering makes resolution pick the reinserted path.

### Testing
- Ran `cargo fmt --all` to format changes and it completed successfully.
- Ran `cargo test -p perl-module-resolution repeated_use_lib_reinserts_to_front` and the new core `use_lib` unit test passed.
- Ran `cargo check -p perl-lsp-rs --lib` to validate the LSP crate builds cleanly and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d903b3529c8333b2f28259031ae4b6)