### PR TITLE
feat(tree-sitter): add Inline::CPP heredoc injection (#3567)

### DIFF
--- a/crates/perl-corpus/src/cases.rs
+++ b/crates/perl-corpus/src/cases.rs
@@ -24,7 +24,7 @@ pub struct ComplexDataStructureCase {
     pub source: &'static str,
 }
 
-static EDGE_CASES: [EdgeCase; 101] = [
+static EDGE_CASES: [EdgeCase; 102] = [
     EdgeCase {
         id: "heredoc.basic",
         description: "Basic quoted heredoc with multiple lines.",
@@ -942,6 +942,24 @@ int add(int x, int y) {
 END_C
 
 my $sum = add(1, 2);
+"#,
+    },
+    EdgeCase {
+        id: "inline.cpp",
+        description: "Inline::CPP heredoc embedding C++ source.",
+        tags: &["inline", "xs", "ffi", "edge-case"],
+        source: r#"use Inline CPP => <<'END_CPP';
+#include <string>
+
+class Greet {
+public:
+    std::string hello(const char* name) {
+        return std::string("Hello, ") + name;
+    }
+};
+END_CPP
+
+my $g = Greet->new();
 "#,
     },
     EdgeCase {

--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -158,6 +158,19 @@ pub fn get_scanner_config() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+    const INJECTIONS_QUERY: &str = include_str!("../../../tree-sitter-perl/queries/injections.scm");
+
+    fn capture_text<'a>(
+        query: &'a Query,
+        code: &'a str,
+        capture: tree_sitter::QueryCapture<'a>,
+    ) -> Option<(&'a str, &'a str)> {
+        let name = query.capture_names().get(capture.index as usize)?;
+        let text = capture.node.utf8_text(code.as_bytes()).ok()?;
+        Some((*name, text))
+    }
 
     #[test]
     fn test_language_loading() {
@@ -180,6 +193,45 @@ mod tests {
     fn test_parser_creation() {
         let parser = create_parser();
         assert!(parser.language().is_some());
+    }
+
+    #[test]
+    fn test_inline_cpp_injection_query_matches_heredoc_body()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let code = "use Inline CPP => <<'END_CPP';\n#include <string>\nclass Greet {};\nEND_CPP\n";
+        let tree = parse_perl_code(code)?;
+        let query = Query::new(&language(), INJECTIONS_QUERY)?;
+        let mut cursor = QueryCursor::new();
+
+        let mut matched = false;
+        let mut matches = cursor.matches(&query, tree.root_node(), code.as_bytes());
+        while let Some(m) = matches.next() {
+            let mut saw_inline_package = false;
+            let mut saw_inline_language = false;
+            let mut saw_injection_content = false;
+
+            for capture in m.captures {
+                if let Some((name, text)) = capture_text(&query, code, *capture) {
+                    match name {
+                        "inline.package" => saw_inline_package = text == "Inline",
+                        "inline.language" => saw_inline_language = text == "CPP",
+                        "injection.content" => {
+                            saw_injection_content = capture.node.kind() == "heredoc_content"
+                                && text.contains("#include <string>");
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if saw_inline_package && saw_inline_language && saw_injection_content {
+                matched = true;
+                break;
+            }
+        }
+
+        assert!(matched, "expected Inline::CPP heredoc to match the injection query");
+        Ok(())
     }
 }
 

--- a/tree-sitter-perl/queries/injections.scm
+++ b/tree-sitter-perl/queries/injections.scm
@@ -12,3 +12,29 @@
   (#match? @_modifiers "e")
   (#not-match? @_modifiers "e.*e")
   (#set! injection.language "perl"))
+
+; Inline::C / Inline::CPP heredocs embed C or C++ source in a Perl file.
+;
+; Keep the detection explicit and narrow: only the existing Inline package
+; form with a bareword language argument and heredoc body is recognized here.
+((source_file
+  (use_statement
+    (package) @inline.package
+    (list_expression
+      (autoquoted_bareword) @inline.language
+      (heredoc_token)))
+  (heredoc_content) @injection.content)
+ (#eq? @inline.package "Inline")
+ (#eq? @inline.language "C")
+ (#set! injection.language "c"))
+
+((source_file
+  (use_statement
+    (package) @inline.package
+    (list_expression
+      (autoquoted_bareword) @inline.language
+      (heredoc_token)))
+  (heredoc_content) @injection.content)
+ (#eq? @inline.package "Inline")
+ (#eq? @inline.language "CPP")
+ (#set! injection.language "cpp"))


### PR DESCRIPTION
Smallest coherent slice for #3567:\n\n- extend the existing tree-sitter injections query to recognize Inline::C and Inline::CPP heredoc blocks\n- add a focused query-level regression for Inline::CPP in the C binding\n- add a matching corpus fixture for Inline::CPP\n\nThis is query-based language injection only; I did not build a broader Inline subsystem.