### PR TITLE
feat(vscode): add SWIG interface highlighting (#3569)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -161,7 +161,7 @@ For environments without internet access, set `perl-lsp.downloadBaseUrl` to an i
 - Smart match operator (`~~`)
 - Indirect object syntax
 - Built-in function signatures with parameter documentation
-- XS interface files (`.xs` and `.i`) are associated with Perl for bundled syntax highlighting
+- XS interface files (`.xs`) and SWIG interface files (`.i`) are associated with Perl for bundled syntax highlighting, including common SWIG directives and embedded C/C++ blocks
 
 ## Commands
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -87,7 +87,11 @@
       {
         "language": "perl",
         "scopeName": "source.perl",
-        "path": "./syntaxes/perl.tmLanguage.json"
+        "path": "./syntaxes/perl.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.c.perl": "c",
+          "meta.embedded.block.perl.perl": "perl"
+        }
       }
     ],
     "breakpoints": [

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -630,14 +630,12 @@ describe('package.json contributes', () => {
 
     test('grammar includes common SWIG directives', () => {
       const grammar = readJson('syntaxes/perl.tmLanguage.json');
-      const swigPattern = grammar.repository.swig.patterns
-        .map((entry: any) => entry.match)
-        .find((match: string) =>
-          typeof match === 'string' &&
-          match.includes('module|include|inline|header|wrapper|init|perlcode|perl5')
-        );
+      const swigPattern = grammar.repository.swig.patterns.find(
+        (entry: any) => entry.name === 'keyword.other.perl.swig'
+      );
 
       expect(swigPattern).toBeDefined();
+      expect(swigPattern.match).toContain('module|include|inline|header|wrapper|init|perlcode|perl5');
     });
 
     test('grammar maps SWIG embedded blocks to C and Perl languages', () => {

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -627,6 +627,25 @@ describe('package.json contributes', () => {
 
       expect(keywordPattern).toBeDefined();
     });
+
+    test('grammar includes common SWIG directives', () => {
+      const grammar = readJson('syntaxes/perl.tmLanguage.json');
+      const swigPattern = grammar.repository.swig.patterns
+        .map((entry: any) => entry.match)
+        .find((match: string) =>
+          typeof match === 'string' &&
+          match.includes('module|include|inline|header|wrapper|init|perlcode|perl5')
+        );
+
+      expect(swigPattern).toBeDefined();
+    });
+
+    test('grammar maps SWIG embedded blocks to C and Perl languages', () => {
+      const pkg = readJson('package.json');
+      const grammar = pkg.contributes.grammars.find((g: any) => g.language === 'perl');
+      expect(grammar.embeddedLanguages['meta.embedded.block.c.perl']).toBe('c');
+      expect(grammar.embeddedLanguages['meta.embedded.block.perl.perl']).toBe('perl');
+    });
   });
 });
 

--- a/vscode-extension/syntaxes/perl.tmLanguage.json
+++ b/vscode-extension/syntaxes/perl.tmLanguage.json
@@ -2,12 +2,12 @@
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "Perl",
     "scopeName": "source.perl",
-    "patterns": [
-        {
-            "include": "#comments"
-        },
-        {
-            "include": "#pod"
+        "patterns": [
+            {
+                "include": "#comments"
+            },
+            {
+                "include": "#pod"
         },
         {
             "include": "#strings"
@@ -24,14 +24,17 @@
         {
             "include": "#operators"
         },
-        {
-            "include": "#functions"
-        },
-        {
-            "include": "#regex"
-        }
-    ],
-    "repository": {
+            {
+                "include": "#functions"
+            },
+            {
+                "include": "#regex"
+            },
+            {
+                "include": "#swig"
+            }
+        ],
+        "repository": {
         "comments": {
             "patterns": [
                 {
@@ -280,6 +283,26 @@
                             "match": "\\\\."
                         }
                     ]
+                }
+            ]
+        },
+        "swig": {
+            "patterns": [
+                {
+                    "name": "keyword.other.perl.swig",
+                    "match": "^\\s*%(module|include|inline|header|wrapper|init|perlcode|perl5)\\b"
+                },
+                {
+                    "name": "meta.embedded.block.c.perl",
+                    "begin": "^\\s*(?:%inline\\b\\s*)?%\\{\\s*$",
+                    "end": "^\\s*%\\}\\s*$",
+                    "contentName": "source.c"
+                },
+                {
+                    "name": "meta.embedded.block.perl.perl",
+                    "begin": "^\\s*%(?:perlcode|perl5)\\b\\s*%\\{\\s*$",
+                    "end": "^\\s*%\\}\\s*$",
+                    "contentName": "source.perl"
                 }
             ]
         }


### PR DESCRIPTION
Add SWIG-specific highlighting for Perl .i interface files in the VS Code extension.

Scope:
- highlight common SWIG directives
- treat embedded C and Perl SWIG blocks as embedded language regions
- document .i support in the extension README
- add contract tests for the grammar and embedded-language mapping

Validation:
- npm test -- --runInBand src/test/configuration.test.ts -t 'grammar includes common XS directives|grammar includes common SWIG directives|grammar maps SWIG embedded blocks to C and Perl languages|perl language keeps XS interface files associated with perl'
- git diff --check