### PR TITLE
fix(module-resolution): prefer most-specific workspace root for doc include context (#3478)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -41,14 +41,22 @@ fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -
         doc_uri.and_then(|u| url::Url::parse(u).ok()).and_then(|u| u.to_file_path().ok());
 
     if let Some(doc_path) = doc_path {
+        let mut best_match: Option<(PathBuf, usize)> = None;
         for folder in workspace_folders {
             let Some(candidate) = url::Url::parse(folder).ok().and_then(|u| u.to_file_path().ok())
             else {
                 continue;
             };
             if doc_path.starts_with(&candidate) {
-                return Some(candidate);
+                let depth = candidate.components().count();
+                match &best_match {
+                    Some((_, best_depth)) if *best_depth >= depth => {}
+                    _ => best_match = Some((candidate, depth)),
+                }
             }
+        }
+        if let Some((best, _)) = best_match {
+            return Some(best);
         }
     }
 
@@ -427,6 +435,47 @@ mod tests {
         assert!(resolved.starts_with("file://"));
         assert!(resolved.contains("Demo"));
         assert!(resolved.contains("Worker.pm"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_root_for_doc_prefers_most_specific_workspace_folder() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let repo = temp.path().join("repo");
+        let app = repo.join("app");
+        let script = app.join("script").join("run.pl");
+        fs::create_dir_all(script.parent().ok_or("missing script parent")?)?;
+        fs::write(&script, "use strict;\n")?;
+
+        let repo_uri = url::Url::from_file_path(&repo).map_err(|_| "failed repo URI")?;
+        let app_uri = url::Url::from_file_path(&app).map_err(|_| "failed app URI")?;
+        let doc_uri = url::Url::from_file_path(&script).map_err(|_| "failed doc URI")?;
+        let workspace_folders = vec![repo_uri.to_string(), app_uri.to_string()];
+
+        let matched = workspace_root_for_doc(&workspace_folders, Some(doc_uri.as_str()))
+            .ok_or("expected a matching workspace root")?;
+        assert_eq!(matched, app, "nested workspace root should prefer most specific folder");
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_root_for_doc_falls_back_to_first_workspace_folder() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let repo = temp.path().join("repo");
+        let app = repo.join("app");
+        fs::create_dir_all(&repo)?;
+        fs::create_dir_all(&app)?;
+
+        let repo_uri = url::Url::from_file_path(&repo).map_err(|_| "failed repo URI")?;
+        let app_uri = url::Url::from_file_path(&app).map_err(|_| "failed app URI")?;
+        let workspace_folders = vec![repo_uri.to_string(), app_uri.to_string()];
+
+        let matched = workspace_root_for_doc(&workspace_folders, None)
+            .ok_or("expected fallback workspace root")?;
+        assert_eq!(
+            matched, repo,
+            "fallback should keep first workspace folder when no document URI is provided"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Nested multi-root workspaces could bind a document to the wrong workspace root, causing `use lib` / `FindBin` resolution to use the parent root instead of the owning workspace.
- Document-scoped include resolution must be deterministic and prefer the most specific matching workspace folder to avoid cross-workspace leakage.

### Description
- Change `workspace_root_for_doc` to pick the most specific matching workspace folder (by path depth) when a document URI is provided rather than returning the first match. 
- Add regression tests validating nested-workspace matching prefers the inner folder and that the original fallback to the first workspace folder remains when no document URI is present. 
- Keep existing behavior unchanged when no document URI is available (fallback to the first workspace folder).

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- An initial test invocation `cargo test -p perl-lsp workspace_root_for_doc -- --nocapture` failed due to an incorrect package name (`perl-lsp` vs `perl-lsp-rs`).
- Ran `cargo test -p perl-lsp-rs workspace_root_for_doc --lib -- --nocapture` which executed the new regression tests and reported: 2 tests passed and 0 failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90f4c5f608333a299c6c6c633dc50)