### PR TITLE
feat(xs): add Perl C API hover/completion (#3573)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -104,12 +104,14 @@ mod sort;
 pub(crate) mod test_more;
 mod variables;
 mod workspace;
+mod xs_api;
 
 // Re-export public types
 pub use self::context::CompletionContext;
 pub use self::items::{CompletionItem, CompletionItemKind};
 pub use self::methods::get_dbi_method_documentation;
 pub use self::test_more::get_test_more_documentation;
+pub use self::xs_api::{get_xs_api_documentation, is_xs_source};
 
 use perl_parser_core::ast::Node;
 use perl_parser_core::ast::NodeKind;
@@ -720,6 +722,7 @@ impl CompletionProvider {
             }
 
             let builtins = builtins::create_builtins();
+            xs_api::add_xs_api_completions(&mut completions, &context, source, filepath);
             if context.prefix.is_empty() || self.could_be_function(&context.prefix, &builtins) {
                 builtins::add_builtin_completions(&mut completions, &context, &builtins);
                 if is_cancelled() {

--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -111,7 +111,7 @@ pub use self::context::CompletionContext;
 pub use self::items::{CompletionItem, CompletionItemKind};
 pub use self::methods::get_dbi_method_documentation;
 pub use self::test_more::get_test_more_documentation;
-pub use self::xs_api::{get_xs_api_documentation, is_xs_source};
+pub use self::xs_api::{add_xs_api_completions_for_prefix, get_xs_api_documentation, is_xs_source};
 
 use perl_parser_core::ast::Node;
 use perl_parser_core::ast::NodeKind;

--- a/crates/perl-lsp-completion/src/completion/xs_api.rs
+++ b/crates/perl-lsp-completion/src/completion/xs_api.rs
@@ -1,0 +1,204 @@
+//! XS / Perl C API completions and hover docs.
+//!
+//! This is intentionally small and source-gated so normal Perl files do not
+//! get C API noise.
+
+use super::{context::CompletionContext, items::CompletionItem, items::CompletionItemKind};
+
+struct XsApiEntry {
+    name: &'static str,
+    kind: CompletionItemKind,
+    insert_text: &'static str,
+    detail: &'static str,
+    signature: &'static str,
+    description: &'static str,
+}
+
+const XS_API_ENTRIES: &[XsApiEntry] = &[
+    XsApiEntry {
+        name: "dXSARGS",
+        kind: CompletionItemKind::Function,
+        insert_text: "dXSARGS",
+        detail: "Declare XS argument variables",
+        signature: "dXSARGS",
+        description: "Declare the standard XS argument variables, including `items`.",
+    },
+    XsApiEntry {
+        name: "ST",
+        kind: CompletionItemKind::Snippet,
+        insert_text: "ST(${1:index})",
+        detail: "Fetch an XS stack slot",
+        signature: "ST(n)",
+        description: "Return the stack entry at index `n`.",
+    },
+    XsApiEntry {
+        name: "SvIV",
+        kind: CompletionItemKind::Function,
+        insert_text: "SvIV(${1:sv})",
+        detail: "Convert SV to IV",
+        signature: "SvIV(sv)",
+        description: "Convert an SV to an IV value.",
+    },
+    XsApiEntry {
+        name: "newSVpv",
+        kind: CompletionItemKind::Snippet,
+        insert_text: "newSVpv(${1:pv}, ${2:len})",
+        detail: "Create a new PV SV",
+        signature: "newSVpv(pv, len)",
+        description: "Create a new scalar value from a byte buffer and length.",
+    },
+    XsApiEntry {
+        name: "PUSHs",
+        kind: CompletionItemKind::Snippet,
+        insert_text: "PUSHs(${1:sv})",
+        detail: "Push an SV onto the stack",
+        signature: "PUSHs(sv)",
+        description: "Push an SV onto Perl's return stack.",
+    },
+    XsApiEntry {
+        name: "XSRETURN_UNDEF",
+        kind: CompletionItemKind::Function,
+        insert_text: "XSRETURN_UNDEF",
+        detail: "Return undef from XS",
+        signature: "XSRETURN_UNDEF",
+        description: "Return `undef` from an XS function.",
+    },
+    XsApiEntry {
+        name: "XSRETURN_YES",
+        kind: CompletionItemKind::Function,
+        insert_text: "XSRETURN_YES",
+        detail: "Return true from XS",
+        signature: "XSRETURN_YES",
+        description: "Return a true value from an XS function.",
+    },
+    XsApiEntry {
+        name: "PL_sv_undef",
+        kind: CompletionItemKind::Constant,
+        insert_text: "PL_sv_undef",
+        detail: "Global undef SV",
+        signature: "PL_sv_undef",
+        description: "The global immortal `undef` scalar.",
+    },
+    XsApiEntry {
+        name: "PL_sv_yes",
+        kind: CompletionItemKind::Constant,
+        insert_text: "PL_sv_yes",
+        detail: "Global true SV",
+        signature: "PL_sv_yes",
+        description: "The global immortal true scalar.",
+    },
+    XsApiEntry {
+        name: "PL_sv_no",
+        kind: CompletionItemKind::Constant,
+        insert_text: "PL_sv_no",
+        detail: "Global false SV",
+        signature: "PL_sv_no",
+        description: "The global immortal false scalar.",
+    },
+    XsApiEntry {
+        name: "PL_na",
+        kind: CompletionItemKind::Constant,
+        insert_text: "PL_na",
+        detail: "No-length sentinel",
+        signature: "PL_na",
+        description: "Sentinel value for APIs that take a length argument.",
+    },
+];
+
+fn source_is_xs(source: &str, filepath: Option<&str>) -> bool {
+    if let Some(path) = filepath {
+        let lower = path.to_ascii_lowercase();
+        if lower.ends_with(".xs") || lower.ends_with(".xsi") {
+            return true;
+        }
+        if lower.ends_with(".c")
+            || lower.ends_with(".h")
+            || lower.ends_with(".cc")
+            || lower.ends_with(".cpp")
+        {
+            return source.contains("EXTERN.h")
+                || source.contains("perl.h")
+                || source.contains("XSUB.h")
+                || source.contains("MODULE =")
+                || source.contains("PACKAGE =")
+                || source.contains("PPCODE:")
+                || source.contains("CODE:")
+                || source.contains("BOOT:");
+        }
+    }
+
+    source.contains("EXTERN.h")
+        || source.contains("perl.h")
+        || source.contains("XSUB.h")
+        || source.contains("MODULE =")
+        || source.contains("PACKAGE =")
+        || source.contains("PPCODE:")
+        || source.contains("CODE:")
+        || source.contains("BOOT:")
+}
+
+/// Detect XS-like source files by extension or common XS markers.
+#[must_use]
+pub fn is_xs_source(source: &str, filepath: Option<&str>) -> bool {
+    source_is_xs(source, filepath)
+}
+
+/// Return hover documentation for XS / Perl C API names.
+pub fn get_xs_api_documentation(name: &str) -> Option<(&'static str, &'static str)> {
+    XS_API_ENTRIES
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| (entry.signature, entry.description))
+}
+
+/// Add XS / Perl C API completions in XS-like sources only.
+pub fn add_xs_api_completions(
+    completions: &mut Vec<CompletionItem>,
+    context: &CompletionContext,
+    source: &str,
+    filepath: Option<&str>,
+) {
+    if !source_is_xs(source, filepath) {
+        return;
+    }
+
+    for entry in XS_API_ENTRIES {
+        if context.prefix.is_empty() || entry.name.starts_with(&context.prefix) {
+            completions.push(CompletionItem {
+                label: entry.name.to_string(),
+                kind: entry.kind,
+                detail: Some(entry.detail.to_string()),
+                documentation: Some(entry.description.to_string()),
+                insert_text: Some(entry.insert_text.to_string()),
+                sort_text: Some(format!("2_xs_{}", entry.name)),
+                filter_text: Some(entry.name.to_string()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_xs_api_documentation, is_xs_source};
+
+    #[test]
+    fn detects_xs_source_by_extension() {
+        assert!(is_xs_source("", Some("example.xs")));
+        assert!(is_xs_source("", Some("example.xsi")));
+    }
+
+    #[test]
+    fn detects_xs_source_by_markers() {
+        let source = "#include \"EXTERN.h\"\n#include \"XSUB.h\"\nMODULE = Foo PACKAGE = Foo\n";
+        assert!(is_xs_source(source, Some("example.pl")));
+    }
+
+    #[test]
+    fn looks_up_xs_api_docs() {
+        let docs = get_xs_api_documentation("SvIV");
+        assert!(docs.is_some());
+    }
+}

--- a/crates/perl-lsp-completion/src/completion/xs_api.rs
+++ b/crates/perl-lsp-completion/src/completion/xs_api.rs
@@ -190,12 +190,31 @@ pub fn add_xs_api_completions(
     source: &str,
     filepath: Option<&str>,
 ) {
+    add_xs_api_completions_for_prefix(
+        completions,
+        &context.prefix,
+        context.prefix_start,
+        context.position,
+        source,
+        filepath,
+    );
+}
+
+/// Add XS / Perl C API completions using a raw textual prefix.
+pub fn add_xs_api_completions_for_prefix(
+    completions: &mut Vec<CompletionItem>,
+    prefix: &str,
+    prefix_start: usize,
+    position: usize,
+    source: &str,
+    filepath: Option<&str>,
+) {
     if !source_is_xs(source, filepath) {
         return;
     }
 
     for entry in XS_API_ENTRIES {
-        if context.prefix.is_empty() || entry.name.starts_with(&context.prefix) {
+        if prefix.is_empty() || entry.name.starts_with(prefix) {
             completions.push(CompletionItem {
                 label: entry.name.to_string(),
                 kind: entry.kind,
@@ -205,7 +224,7 @@ pub fn add_xs_api_completions(
                 sort_text: Some(format!("2_xs_{}", entry.name)),
                 filter_text: Some(entry.name.to_string()),
                 additional_edits: vec![],
-                text_edit_range: Some((context.prefix_start, context.position)),
+                text_edit_range: Some((prefix_start, position)),
                 commit_characters: None,
             });
         }

--- a/crates/perl-lsp-completion/src/completion/xs_api.rs
+++ b/crates/perl-lsp-completion/src/completion/xs_api.rs
@@ -24,6 +24,14 @@ const XS_API_ENTRIES: &[XsApiEntry] = &[
         description: "Declare the standard XS argument variables, including `items`.",
     },
     XsApiEntry {
+        name: "items",
+        kind: CompletionItemKind::Variable,
+        insert_text: "items",
+        detail: "XS argument count",
+        signature: "items",
+        description: "Number of XS arguments available in the current call.",
+    },
+    XsApiEntry {
         name: "ST",
         kind: CompletionItemKind::Snippet,
         insert_text: "ST(${1:index})",
@@ -40,6 +48,14 @@ const XS_API_ENTRIES: &[XsApiEntry] = &[
         description: "Convert an SV to an IV value.",
     },
     XsApiEntry {
+        name: "newSViv",
+        kind: CompletionItemKind::Snippet,
+        insert_text: "newSViv(${1:iv})",
+        detail: "Create a new IV SV",
+        signature: "newSViv(iv)",
+        description: "Create a new scalar value from an integer.",
+    },
+    XsApiEntry {
         name: "newSVpv",
         kind: CompletionItemKind::Snippet,
         insert_text: "newSVpv(${1:pv}, ${2:len})",
@@ -48,12 +64,28 @@ const XS_API_ENTRIES: &[XsApiEntry] = &[
         description: "Create a new scalar value from a byte buffer and length.",
     },
     XsApiEntry {
+        name: "sv_2mortal",
+        kind: CompletionItemKind::Function,
+        insert_text: "sv_2mortal(${1:sv})",
+        detail: "Mark SV mortal",
+        signature: "sv_2mortal(sv)",
+        description: "Mark an SV for destruction at the end of the statement.",
+    },
+    XsApiEntry {
         name: "PUSHs",
         kind: CompletionItemKind::Snippet,
         insert_text: "PUSHs(${1:sv})",
         detail: "Push an SV onto the stack",
         signature: "PUSHs(sv)",
         description: "Push an SV onto Perl's return stack.",
+    },
+    XsApiEntry {
+        name: "EXTEND",
+        kind: CompletionItemKind::Snippet,
+        insert_text: "EXTEND(${1:sp}, ${2:n})",
+        detail: "Grow the stack",
+        signature: "EXTEND(sp, n)",
+        description: "Ensure room on the Perl stack before pushing values.",
     },
     XsApiEntry {
         name: "XSRETURN_UNDEF",

--- a/crates/perl-lsp-completion/src/lib.rs
+++ b/crates/perl-lsp-completion/src/lib.rs
@@ -26,5 +26,6 @@ mod completion;
 
 pub use completion::{
     CompletionContext, CompletionItem, CompletionItemKind, CompletionProvider,
-    get_dbi_method_documentation, get_test_more_documentation,
+    get_dbi_method_documentation, get_test_more_documentation, get_xs_api_documentation,
+    is_xs_source,
 };

--- a/crates/perl-lsp-completion/src/lib.rs
+++ b/crates/perl-lsp-completion/src/lib.rs
@@ -26,6 +26,6 @@ mod completion;
 
 pub use completion::{
     CompletionContext, CompletionItem, CompletionItemKind, CompletionProvider,
-    get_dbi_method_documentation, get_test_more_documentation, get_xs_api_documentation,
-    is_xs_source,
+    add_xs_api_completions_for_prefix, get_dbi_method_documentation, get_test_more_documentation,
+    get_xs_api_documentation, is_xs_source,
 };

--- a/crates/perl-lsp-completion/tests/xs_api_tests.rs
+++ b/crates/perl-lsp-completion/tests/xs_api_tests.rs
@@ -1,0 +1,47 @@
+use perl_lsp_completion::{CompletionItem, CompletionItemKind, CompletionProvider};
+use perl_parser_core::Parser;
+use perl_tdd_support::must;
+
+fn parse_and_provider(code: &str) -> CompletionProvider {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    CompletionProvider::new_with_index_and_source(&ast, code, None)
+}
+
+fn completions_at_path(code: &str, pos: usize, path: &str) -> Vec<CompletionItem> {
+    let provider = parse_and_provider(code);
+    provider.get_completions_with_path(code, pos, Some(path))
+}
+
+fn labels(items: &[CompletionItem]) -> Vec<String> {
+    items.iter().map(|item| item.label.clone()).collect()
+}
+
+fn kind_for(items: &[CompletionItem], label: &str) -> Option<CompletionItemKind> {
+    items.iter().find(|item| item.label == label).map(|item| item.kind)
+}
+
+#[test]
+fn xs_api_completion_is_gated_to_xs_sources() {
+    let code = "package My::Module;\nnew";
+    let items = completions_at_path(code, code.len(), "example.pl");
+    let names = labels(&items);
+
+    assert!(!names.contains(&"dXSARGS".to_string()));
+    assert!(!names.contains(&"newSVpv".to_string()));
+    assert!(!names.contains(&"PL_sv_yes".to_string()));
+}
+
+#[test]
+fn xs_api_completion_is_available_in_xs_sources() {
+    let code = "package My::Module;\n";
+    let items = completions_at_path(code, code.len(), "example.xs");
+    let names = labels(&items);
+
+    assert!(names.contains(&"dXSARGS".to_string()));
+    assert!(names.contains(&"ST".to_string()));
+    assert!(names.contains(&"newSVpv".to_string()));
+    assert!(names.contains(&"PL_sv_yes".to_string()));
+    assert_eq!(kind_for(&items, "ST"), Some(CompletionItemKind::Snippet));
+    assert_eq!(kind_for(&items, "newSVpv"), Some(CompletionItemKind::Snippet));
+}

--- a/crates/perl-lsp-completion/tests/xs_api_tests.rs
+++ b/crates/perl-lsp-completion/tests/xs_api_tests.rs
@@ -39,9 +39,15 @@ fn xs_api_completion_is_available_in_xs_sources() {
     let names = labels(&items);
 
     assert!(names.contains(&"dXSARGS".to_string()));
+    assert!(names.contains(&"items".to_string()));
     assert!(names.contains(&"ST".to_string()));
+    assert!(names.contains(&"newSViv".to_string()));
     assert!(names.contains(&"newSVpv".to_string()));
+    assert!(names.contains(&"sv_2mortal".to_string()));
+    assert!(names.contains(&"EXTEND".to_string()));
     assert!(names.contains(&"PL_sv_yes".to_string()));
     assert_eq!(kind_for(&items, "ST"), Some(CompletionItemKind::Snippet));
     assert_eq!(kind_for(&items, "newSVpv"), Some(CompletionItemKind::Snippet));
+    assert_eq!(kind_for(&items, "newSViv"), Some(CompletionItemKind::Snippet));
+    assert_eq!(kind_for(&items, "EXTEND"), Some(CompletionItemKind::Snippet));
 }

--- a/crates/perl-lsp/src/runtime/language/completion.rs
+++ b/crates/perl-lsp/src/runtime/language/completion.rs
@@ -10,7 +10,9 @@
 use crate::cancellation::{
     GLOBAL_CANCELLATION_REGISTRY, PerlLspCancellationToken, RequestCleanupGuard,
 };
-use crate::completion::{CompletionItemKind, CompletionProvider};
+use crate::completion::{
+    CompletionItemKind, CompletionProvider, add_xs_api_completions_for_prefix,
+};
 use crate::{
     protocol::{JsonRpcError, REQUEST_CANCELLED, req_position, req_uri},
     runtime::routing::{IndexAccessMode, route_index_access},
@@ -377,7 +379,7 @@ impl LspServer {
                     base_completions
                 } else {
                     // Fallback: provide basic keyword completions when AST is unavailable
-                    self.lexical_complete(&doc.text, offset)
+                    self.lexical_complete(&doc.text, offset, Some(uri))
                 };
 
                 // Add workspace-wide completions using routing policy
@@ -587,7 +589,7 @@ impl LspServer {
                         &cancel_fn,
                     )
                 } else {
-                    self.lexical_complete(&doc.text, offset)
+                    self.lexical_complete(&doc.text, offset, Some(uri))
                 };
 
                 // Check for cancellation after provider call using relaxed read
@@ -687,6 +689,7 @@ impl LspServer {
         &self,
         content: &str,
         offset: usize,
+        filepath: Option<&str>,
     ) -> Vec<crate::completion::CompletionItem> {
         let mut completions = Vec::new();
 
@@ -700,6 +703,7 @@ impl LspServer {
             .chars()
             .rev()
             .collect::<String>();
+        let prefix_start = offset.saturating_sub(prefix.len());
 
         // Check if we're in a method call context (after ->)
         let is_method_call = text_before.ends_with("->")
@@ -820,6 +824,15 @@ impl LspServer {
                 }
             }
             _ => {
+                add_xs_api_completions_for_prefix(
+                    &mut completions,
+                    &prefix,
+                    prefix_start,
+                    offset,
+                    content,
+                    filepath,
+                );
+
                 // No sigil - suggest keywords
                 for kw in LSP_RUNTIME_COMPLETION_KEYWORDS {
                     if kw.starts_with(&prefix) {

--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -142,6 +142,10 @@ impl LspServer {
         text: &str,
         offset: usize,
     ) -> HoverExtracted {
+        if let Some(xs_hover) = Self::extract_xs_api_hover(uri, text, offset) {
+            return HoverExtracted::Complete(xs_hover);
+        }
+
         let analyzer = self.get_or_build_analyzer(uri, text, ast);
 
         if let Some(symbol_info) =
@@ -412,18 +416,8 @@ impl LspServer {
                 }));
             }
 
-            if crate::completion::is_xs_source(text, Some(uri))
-                && let Some((sig, desc)) = crate::completion::get_xs_api_documentation(bare)
-            {
-                return HoverExtracted::Complete(json!({
-                    "contents": {
-                        "kind": "markdown",
-                        "value": format!(
-                            "**XS / Perl C API**\n\n```c\n{}\n```\n\n{}",
-                            sig, desc
-                        ),
-                    },
-                }));
+            if let Some(xs_hover) = Self::extract_xs_api_hover(uri, text, offset) {
+                return HoverExtracted::Complete(xs_hover);
             }
 
             // Check Test::More/Test2 function hover when source imports a test framework
@@ -661,6 +655,29 @@ impl LspServer {
         }
 
         chars[start..end].iter().collect()
+    }
+
+    fn extract_xs_api_hover(uri: &str, text: &str, offset: usize) -> Option<Value> {
+        if !crate::completion::is_xs_source(text, Some(uri)) {
+            return None;
+        }
+
+        let token = Self::get_token_at_position_static(text, offset);
+        if token.is_empty() {
+            return None;
+        }
+
+        let bare = token.trim_start_matches(['$', '@', '%']);
+        let (sig, desc) = crate::completion::get_xs_api_documentation(bare)?;
+        Some(json!({
+            "contents": {
+                "kind": "markdown",
+                "value": format!(
+                    "**XS / Perl C API**\n\n```c\n{}\n```\n\n{}",
+                    sig, desc
+                ),
+            },
+        }))
     }
 
     /// Extract the receiver token immediately before `->` at `offset`.

--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -109,7 +109,8 @@ impl LspServer {
                             self.extract_symbol_hover(uri, ast, &doc.text, offset)
                         }
                     } else {
-                        HoverExtracted::None
+                        let offset = self.pos16_to_offset(doc, line, character);
+                        Self::extract_token_hover(uri, &doc.text, offset)
                     }
                 } else {
                     HoverExtracted::None
@@ -347,6 +348,11 @@ impl LspServer {
             }));
         }
 
+        Self::extract_token_hover(uri, text, offset)
+    }
+
+    /// Extract hover information from the token fallback path.
+    fn extract_token_hover(uri: &str, text: &str, offset: usize) -> HoverExtracted {
         // Check if the cursor is inside a regex literal and provide explanation.
         if let Some(regex_hover) = Self::extract_regex_hover(text, offset) {
             return HoverExtracted::Complete(regex_hover);
@@ -378,8 +384,13 @@ impl LspServer {
             }
         }
 
-        // Fall back to simple token display, with builtin docs
-        let hover_text = self.get_token_at_position(text, offset);
+        // Fall back to simple token display, with builtin docs.
+        let hover_text = {
+            // The normal tokenizer only captures `[$@%]` + alphanumeric/underscore,
+            // so it misses punctuation variables handled above.
+            let token = Self::get_token_at_position_static(text, offset);
+            token
+        };
 
         if !hover_text.is_empty() {
             // Check for special variable hover (handles $_, @_, @ISA, %ENV, etc.)
@@ -396,6 +407,20 @@ impl LspServer {
                             "**Built-in Function**\n\n```\n{}\n```\n\n{}",
                             builtin_doc.signature,
                             builtin_doc.description
+                        ),
+                    },
+                }));
+            }
+
+            if crate::completion::is_xs_source(text, Some(uri))
+                && let Some((sig, desc)) = crate::completion::get_xs_api_documentation(bare)
+            {
+                return HoverExtracted::Complete(json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": format!(
+                            "**XS / Perl C API**\n\n```c\n{}\n```\n\n{}",
+                            sig, desc
                         ),
                     },
                 }));
@@ -610,6 +635,32 @@ impl LspServer {
 
     fn is_truthy(value: &str) -> bool {
         matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+    }
+
+    /// Get a token using the same simple fallback as rename, without requiring `&self`.
+    fn get_token_at_position_static(content: &str, offset: usize) -> String {
+        let chars: Vec<char> = content.chars().collect();
+        if offset >= chars.len() {
+            return String::new();
+        }
+
+        let mut start = offset;
+        while start > 0
+            && (chars[start - 1].is_alphanumeric()
+                || chars[start - 1] == '_'
+                || chars[start - 1] == '$'
+                || chars[start - 1] == '@'
+                || chars[start - 1] == '%')
+        {
+            start -= 1;
+        }
+
+        let mut end = offset;
+        while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
+            end += 1;
+        }
+
+        chars[start..end].iter().collect()
     }
 
     /// Extract the receiver token immediately before `->` at `offset`.

--- a/crates/perl-lsp/tests/xs_api_hover_tests.rs
+++ b/crates/perl-lsp/tests/xs_api_hover_tests.rs
@@ -23,8 +23,7 @@ fn hover_shows_xs_api_docs_in_xs_sources() -> TestResult {
         "#include \"XSUB.h\"\n",
         "MODULE = My::Module PACKAGE = My::Module\n",
         "PPCODE:\n",
-        "    newSVpv\n",
-        "\0"
+        "    newSVpv\n"
     );
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
@@ -45,6 +44,49 @@ fn hover_shows_xs_api_docs_in_xs_sources() -> TestResult {
     assert!(
         val.contains("newSVpv(pv, len)"),
         "hover should include the XS API signature, got: {val}"
+    );
+    Ok(())
+}
+
+#[test]
+fn completion_offers_xs_api_docs_in_astless_xs_sources() -> TestResult {
+    let doc = concat!(
+        "#include \"EXTERN.h\"\n",
+        "#include \"perl.h\"\n",
+        "#include \"XSUB.h\"\n",
+        "MODULE = My::Module PACKAGE = My::Module\n",
+        "PPCODE:\n",
+        "    newS\n"
+    );
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///example.xs", doc)?;
+
+    let result = harness
+        .request(
+            "textDocument/completion",
+            json!({
+                "textDocument": {"uri": "file:///example.xs"},
+                "position": {"line": 5, "character": 8}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let labels: Vec<&str> = result
+        .get("items")
+        .and_then(|items| items.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("label").and_then(|label| label.as_str()))
+        .collect();
+
+    assert!(
+        labels.contains(&"newSVpv"),
+        "AST-less XS completion should offer newSVpv, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"newSViv"),
+        "AST-less XS completion should offer newSViv, got: {labels:?}"
     );
     Ok(())
 }

--- a/crates/perl-lsp/tests/xs_api_hover_tests.rs
+++ b/crates/perl-lsp/tests/xs_api_hover_tests.rs
@@ -1,0 +1,67 @@
+//! Tests for XS / Perl C API hover support.
+
+mod support;
+
+use serde_json::json;
+use support::lsp_harness::LspHarness;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn hover_value(result: &serde_json::Value) -> Option<String> {
+    result
+        .get("contents")
+        .and_then(|c| c.get("value"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+#[test]
+fn hover_shows_xs_api_docs_in_xs_sources() -> TestResult {
+    let doc = "package My::Module;\nnewSVpv\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///example.xs", doc)?;
+
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///example.xs"},
+                "position": {"line": 1, "character": 3}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover content for XS API symbol")?;
+    assert!(val.contains("XS / Perl C API"), "hover should identify the XS API docs, got: {val}");
+    assert!(
+        val.contains("newSVpv(pv, len)"),
+        "hover should include the XS API signature, got: {val}"
+    );
+    Ok(())
+}
+
+#[test]
+fn hover_does_not_show_xs_docs_in_normal_perl() -> TestResult {
+    let doc = "package My::Module;\nnewSVpv\n";
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open_document("file:///example.pl", doc)?;
+
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///example.pl"},
+                "position": {"line": 1, "character": 3}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    let val = hover_value(&result).ok_or("Expected hover content for fallback token")?;
+    assert!(
+        !val.contains("XS / Perl C API"),
+        "normal Perl hover should not surface XS docs, got: {val}"
+    );
+    Ok(())
+}

--- a/crates/perl-lsp/tests/xs_api_hover_tests.rs
+++ b/crates/perl-lsp/tests/xs_api_hover_tests.rs
@@ -17,7 +17,15 @@ fn hover_value(result: &serde_json::Value) -> Option<String> {
 
 #[test]
 fn hover_shows_xs_api_docs_in_xs_sources() -> TestResult {
-    let doc = "package My::Module;\nnewSVpv\n";
+    let doc = concat!(
+        "#include \"EXTERN.h\"\n",
+        "#include \"perl.h\"\n",
+        "#include \"XSUB.h\"\n",
+        "MODULE = My::Module PACKAGE = My::Module\n",
+        "PPCODE:\n",
+        "    newSVpv\n",
+        "\0"
+    );
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
     harness.open_document("file:///example.xs", doc)?;
@@ -27,7 +35,7 @@ fn hover_shows_xs_api_docs_in_xs_sources() -> TestResult {
             "textDocument/hover",
             json!({
                 "textDocument": {"uri": "file:///example.xs"},
-                "position": {"line": 1, "character": 3}
+                "position": {"line": 5, "character": 7}
             }),
         )
         .unwrap_or(json!(null));

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -68,6 +68,8 @@
         "extensions": [
           ".pl",
           ".pm",
+          ".xs",
+          ".xsi",
           ".pod",
           ".t",
           ".psgi",

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -121,6 +121,8 @@ describe('package.json contributes', () => {
       const exts: string[] = perl.extensions;
       expect(exts).toContain('.pl');
       expect(exts).toContain('.pm');
+      expect(exts).toContain('.xs');
+      expect(exts).toContain('.xsi');
       expect(exts).toContain('.t');
       expect(exts).toContain('.pod');
       expect(exts).toContain('.psgi');


### PR DESCRIPTION
## Summary
- add XS / Perl C API completion and hover docs gated to XS-like sources
- support AST-less XS completion fallback and prefer exact XS token docs in hover
- cover the new behavior with completion, hover, and VS Code configuration tests

## Testing
- cargo test -p perl-lsp-completion --test xs_api_tests
- cargo test -p perl-lsp-rs --test xs_api_hover_tests