### PR TITLE
chore(features): sync vendored fallback catalogs (#3222)

### DIFF
--- a/crates/perl-dap/features_sot.toml
+++ b/crates/perl-dap/features_sot.toml
@@ -3,9 +3,9 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 65  # Auto-calculated in future
+compliance_percent = 100  # 102 total features (87 LSP + 10 DAP + 5 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -15,7 +15,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Code completion with 150+ built-in functions"
 
 [[feature]]
@@ -24,7 +24,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_hover_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_hover_tests.rs"]
 description = "Hover information with documentation"
 
 [[feature]]
@@ -33,7 +33,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_signature_help_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_signature_help_tests.rs"]
 description = "Signature help with parameter hints"
 
 [[feature]]
@@ -42,7 +42,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to definition"
 
 [[feature]]
@@ -51,7 +51,7 @@ spec = "LSP 3.14"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to declaration"
 
 [[feature]]
@@ -60,7 +60,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_references_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_references_tests.rs"]
 description = "Find references across workspace"
 
 [[feature]]
@@ -69,7 +69,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_symbols_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_symbols_tests.rs"]
 description = "Document symbols with hierarchy"
 
 [[feature]]
@@ -78,7 +78,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Code actions and quick fixes"
 
 [[feature]]
@@ -87,7 +87,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Code lens with reference counts"
 
 [[feature]]
@@ -96,7 +96,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Document formatting with Perl::Tidy"
 
 [[feature]]
@@ -105,7 +105,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Range formatting (single range)"
 
 [[feature]]
@@ -114,7 +114,7 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_e2e.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_e2e.rs"]
 description = "Multi-range formatting (textDocument/rangesFormatting) (@proposed)"
 
 [[feature]]
@@ -123,7 +123,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_on_type_formatting.rs"]
+tests = ["crates/perl-lsp/tests/lsp_on_type_formatting.rs"]
 description = "On-type formatting with auto-indent"
 
 [[feature]]
@@ -132,7 +132,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Rename symbol across files"
 
 [[feature]]
@@ -141,7 +141,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_links_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_links_test.rs"]
 description = "Document links to modules and docs"
 
 [[feature]]
@@ -150,7 +150,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_folding_ranges_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_folding_ranges_test.rs"]
 description = "Folding ranges with fallback"
 
 [[feature]]
@@ -159,7 +159,7 @@ spec = "LSP 3.15"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_selection_range_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_selection_range_tests.rs"]
 description = "Smart selection expansion"
 
 [[feature]]
@@ -168,7 +168,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_semantic_tokens.rs"]
+tests = ["crates/perl-lsp/tests/lsp_semantic_tokens.rs"]
 description = "Enhanced syntax highlighting"
 
 [[feature]]
@@ -177,7 +177,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hints.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hints.rs"]
 description = "Parameter names and type hints"
 
 [[feature]]
@@ -186,7 +186,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_hierarchy_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_hierarchy_test.rs"]
 description = "Type hierarchy for classes/roles"
 
 [[feature]]
@@ -195,7 +195,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_call_hierarchy_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs"]
 description = "Call hierarchy navigation"
 
 [[feature]]
@@ -204,8 +204,44 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
+
+[[feature]]
+id = "lsp.diagnostic.missing_strict"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.missing_warnings"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.unreachable_code"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
+
+[[feature]]
+id = "lsp.diagnostic.unused_variable"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
+description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
 
 [[feature]]
 id = "lsp.inline_completion"
@@ -213,8 +249,17 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inline_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inline_completion_tests.rs"]
 description = "Inline AI-powered completions (@proposed)"
+
+[[feature]]
+id = "experimental.perlInlineCompletionStream"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_streaming_completion_tests.rs"]
+description = "Streaming inline AI completions via textDocument/perlInlineCompletionStream — delivers incremental completions via $/progress with session and sequence tracking"
 
 [[feature]]
 id = "lsp.type_definition"
@@ -222,7 +267,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_definition_tests.rs"]
 description = "Go to type definition"
 
 [[feature]]
@@ -231,7 +276,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_implementation_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_implementation_tests.rs"]
 description = "Go to implementation"
 
 [[feature]]
@@ -240,7 +285,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color decorators"
 
 [[feature]]
@@ -249,7 +294,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_linked_editing_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_linked_editing_tests.rs"]
 description = "Linked editing of related tokens"
 
 # Workspace Features
@@ -260,7 +305,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Search symbols across workspace"
 
 [[feature]]
@@ -269,7 +314,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Workspace-wide pull diagnostics"
 
 [[feature]]
@@ -278,7 +323,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_execute_command_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_execute_command_tests.rs"]
 description = "Execute commands (Perl::Critic, etc)"
 
 [[feature]]
@@ -287,7 +332,7 @@ spec = "LSP 3.6"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "Multi-root workspace support"
 
 [[feature]]
@@ -296,7 +341,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "File rename/create/delete tracking"
 
 [[feature]]
@@ -305,7 +350,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "Apply workspace-wide edits"
 
 [[feature]]
@@ -314,7 +359,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Cross-project symbol identity"
 
 # Window Features
@@ -325,7 +370,7 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_progress_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_progress_tests.rs"]
 description = "Progress reporting"
 
 [[feature]]
@@ -335,7 +380,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Show messages to user"
 
 [[feature]]
@@ -345,7 +390,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs", "crates/perl-lsp/tests/lsp_window_progress_test.rs"]
 description = "Log messages"
 
 [[feature]]
@@ -354,7 +399,7 @@ spec = "LSP 3.15"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Detailed work progress"
 
 # Notebook Features
@@ -366,7 +411,7 @@ area = "notebook"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook document synchronization (didOpen/didChange/didSave/didClose handlers)"
 
 [[feature]]
@@ -376,7 +421,7 @@ area = "notebook"
 maturity = "ga"
 advertised = false
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook cell execution summary tracking (LSP does not execute cells; this tracks executionSummary metadata)"
 
 # Debug Features (DAP)
@@ -490,7 +535,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialize handshake"
 
 [[feature]]
@@ -500,7 +545,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialized notification"
 
 [[feature]]
@@ -510,7 +555,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Graceful shutdown request"
 
 [[feature]]
@@ -520,7 +565,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Exit notification with proper exit codes"
 
 [[feature]]
@@ -530,7 +575,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Request cancellation ($/cancelRequest)"
 
 [[feature]]
@@ -540,7 +585,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability registration (server->client)"
 
 [[feature]]
@@ -550,7 +595,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability unregistration (server->client)"
 
 [[feature]]
@@ -560,7 +605,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Client sets server trace level ($/setTrace)"
 
 [[feature]]
@@ -570,7 +615,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Server trace logging ($/logTrace)"
 
 # Text Document Synchronization
@@ -582,7 +627,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didOpen/didChange/didClose text synchronization"
 
 [[feature]]
@@ -592,7 +637,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didSave notifications"
 
 [[feature]]
@@ -602,7 +647,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSave notifications"
 
 [[feature]]
@@ -612,7 +657,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSaveWaitUntil request with format-on-save"
 
 # Additional Language Features
@@ -623,7 +668,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_highlight_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_highlight_tests.rs"]
 description = "Document highlights (local references)"
 
 [[feature]]
@@ -632,7 +677,7 @@ spec = "LSP 3.12"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Validate rename and compute placeholder/range"
 
 [[feature]]
@@ -641,7 +686,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Inline values during debugging (LSP inlineValue)"
 
 [[feature]]
@@ -650,7 +695,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color presentation request (pairs with documentColor)"
 
 # Resolve Routes
@@ -661,7 +706,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Resolve additional completion item details"
 
 [[feature]]
@@ -670,7 +715,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Resolve additional code action details"
 
 [[feature]]
@@ -679,7 +724,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Resolve code lens command"
 
 [[feature]]
@@ -688,7 +733,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_link_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs"]
 description = "Resolve document link target"
 
 [[feature]]
@@ -697,7 +742,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hint_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs"]
 description = "Resolve inlay hint label locations"
 
 [[feature]]
@@ -706,7 +751,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Resolve additional workspace symbol info"
 
 # Refresh Routes (Server -> Client)
@@ -718,7 +763,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh code lenses"
 
 [[feature]]
@@ -728,7 +773,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh semantic tokens"
 
 [[feature]]
@@ -738,7 +783,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inlay hints"
 
 [[feature]]
@@ -748,7 +793,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inline values"
 
 [[feature]]
@@ -758,7 +803,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh pulled diagnostics"
 
 [[feature]]
@@ -768,7 +813,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh folding ranges (workspace/foldingRange/refresh, @proposed)"
 
 # Workspace Plumbing
@@ -780,7 +825,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/configuration request (server->client)"
 
 [[feature]]
@@ -790,7 +835,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeConfiguration notification"
 
 [[feature]]
@@ -800,7 +845,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeWatchedFiles notification"
 
 [[feature]]
@@ -810,7 +855,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/applyEdit request (server->client)"
 
 [[feature]]
@@ -820,7 +865,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Push diagnostics via textDocument/publishDiagnostics"
 
 # Window / Telemetry
@@ -832,7 +877,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Prompt user with choices (showMessageRequest)"
 
 [[feature]]
@@ -842,7 +887,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Ask client to open/display a URI (showDocument)"
 
 [[feature]]
@@ -852,7 +897,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Create server-initiated work done progress"
 
 [[feature]]
@@ -862,7 +907,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Client cancels server-initiated work done progress"
 
 [[feature]]
@@ -872,7 +917,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
@@ -883,7 +928,7 @@ spec = "LSP 3.18"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent request (@proposed)"
 
 [[feature]]
@@ -893,7 +938,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent/refresh request (@proposed)"
 
 # File Operations (method-level breakdown)
@@ -904,7 +949,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willCreateFiles request"
 
 [[feature]]
@@ -913,7 +958,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didCreateFiles notification"
 
 [[feature]]
@@ -922,7 +967,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/willRenameFiles request"
 
 [[feature]]
@@ -931,7 +976,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/didRenameFiles notification"
 
 [[feature]]
@@ -940,7 +985,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willDeleteFiles request"
 
 [[feature]]
@@ -949,5 +994,5 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didDeleteFiles notification"

--- a/crates/perl-feature-catalog/src/lib.rs
+++ b/crates/perl-feature-catalog/src/lib.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_DAP_FEATURES: &[&str] =
     &["dap.breakpoints.basic", "dap.core", "dap.inline_values"];
 
 /// Source metadata for the catalog file.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Meta {
     /// Canonical release or feature-set version.
     pub version: String,
@@ -66,7 +66,7 @@ impl Maturity {
 }
 
 /// Per-feature catalog entry.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Feature {
     /// Canonical feature identifier (for example: `lsp.completion`).
     pub id: String,
@@ -97,7 +97,7 @@ const fn default_counts_in_coverage() -> bool {
 }
 
 /// Full catalog loaded from `features.toml`.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct Catalog {
     /// Shared metadata section.
     pub meta: Meta,

--- a/crates/perl-feature-catalog/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-feature-catalog/tests/comprehensive_unit_tests.rs
@@ -756,6 +756,36 @@ advertised = true
     Ok(())
 }
 
+#[test]
+fn vendored_feature_catalogs_match_workspace_root_catalog() -> Result<(), Box<dyn std::error::Error>>
+{
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or("perl-feature-catalog should live under crates/")?;
+    let workspace_catalog = perl_feature_catalog::read_catalog(&repo_root.join("features.toml"))?;
+
+    let vendored_paths = [
+        repo_root.join("crates/perl-lsp/features_sot.toml"),
+        repo_root.join("crates/perl-dap/features_sot.toml"),
+        repo_root.join("crates/perl-parser/features_sot.toml"),
+        repo_root.join("crates/perl-lsp-feature-contracts/features_sot.toml"),
+    ];
+
+    for vendored_path in vendored_paths {
+        let vendored_catalog = perl_feature_catalog::read_catalog(&vendored_path)?;
+        assert_eq!(
+            vendored_catalog,
+            workspace_catalog,
+            "vendored catalog should stay in lockstep with workspace features.toml: {}",
+            vendored_path.display()
+        );
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // render_lsp_feature_catalog_module
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp-feature-contracts/features_sot.toml
+++ b/crates/perl-lsp-feature-contracts/features_sot.toml
@@ -3,9 +3,9 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 65  # Auto-calculated in future
+compliance_percent = 100  # 102 total features (87 LSP + 10 DAP + 5 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -15,7 +15,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Code completion with 150+ built-in functions"
 
 [[feature]]
@@ -24,7 +24,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_hover_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_hover_tests.rs"]
 description = "Hover information with documentation"
 
 [[feature]]
@@ -33,7 +33,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_signature_help_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_signature_help_tests.rs"]
 description = "Signature help with parameter hints"
 
 [[feature]]
@@ -42,7 +42,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to definition"
 
 [[feature]]
@@ -51,7 +51,7 @@ spec = "LSP 3.14"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to declaration"
 
 [[feature]]
@@ -60,7 +60,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_references_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_references_tests.rs"]
 description = "Find references across workspace"
 
 [[feature]]
@@ -69,7 +69,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_symbols_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_symbols_tests.rs"]
 description = "Document symbols with hierarchy"
 
 [[feature]]
@@ -78,7 +78,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Code actions and quick fixes"
 
 [[feature]]
@@ -87,7 +87,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Code lens with reference counts"
 
 [[feature]]
@@ -96,7 +96,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Document formatting with Perl::Tidy"
 
 [[feature]]
@@ -105,7 +105,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Range formatting (single range)"
 
 [[feature]]
@@ -114,7 +114,7 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_e2e.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_e2e.rs"]
 description = "Multi-range formatting (textDocument/rangesFormatting) (@proposed)"
 
 [[feature]]
@@ -123,7 +123,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_on_type_formatting.rs"]
+tests = ["crates/perl-lsp/tests/lsp_on_type_formatting.rs"]
 description = "On-type formatting with auto-indent"
 
 [[feature]]
@@ -132,7 +132,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Rename symbol across files"
 
 [[feature]]
@@ -141,7 +141,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_links_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_links_test.rs"]
 description = "Document links to modules and docs"
 
 [[feature]]
@@ -150,7 +150,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_folding_ranges_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_folding_ranges_test.rs"]
 description = "Folding ranges with fallback"
 
 [[feature]]
@@ -159,7 +159,7 @@ spec = "LSP 3.15"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_selection_range_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_selection_range_tests.rs"]
 description = "Smart selection expansion"
 
 [[feature]]
@@ -168,7 +168,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_semantic_tokens.rs"]
+tests = ["crates/perl-lsp/tests/lsp_semantic_tokens.rs"]
 description = "Enhanced syntax highlighting"
 
 [[feature]]
@@ -177,7 +177,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hints.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hints.rs"]
 description = "Parameter names and type hints"
 
 [[feature]]
@@ -186,7 +186,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_hierarchy_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_hierarchy_test.rs"]
 description = "Type hierarchy for classes/roles"
 
 [[feature]]
@@ -195,7 +195,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_call_hierarchy_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs"]
 description = "Call hierarchy navigation"
 
 [[feature]]
@@ -204,8 +204,44 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
+
+[[feature]]
+id = "lsp.diagnostic.missing_strict"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.missing_warnings"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.unreachable_code"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
+
+[[feature]]
+id = "lsp.diagnostic.unused_variable"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
+description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
 
 [[feature]]
 id = "lsp.inline_completion"
@@ -213,8 +249,17 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inline_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inline_completion_tests.rs"]
 description = "Inline AI-powered completions (@proposed)"
+
+[[feature]]
+id = "experimental.perlInlineCompletionStream"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_streaming_completion_tests.rs"]
+description = "Streaming inline AI completions via textDocument/perlInlineCompletionStream — delivers incremental completions via $/progress with session and sequence tracking"
 
 [[feature]]
 id = "lsp.type_definition"
@@ -222,7 +267,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_definition_tests.rs"]
 description = "Go to type definition"
 
 [[feature]]
@@ -231,7 +276,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_implementation_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_implementation_tests.rs"]
 description = "Go to implementation"
 
 [[feature]]
@@ -240,7 +285,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color decorators"
 
 [[feature]]
@@ -249,7 +294,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_linked_editing_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_linked_editing_tests.rs"]
 description = "Linked editing of related tokens"
 
 # Workspace Features
@@ -260,7 +305,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Search symbols across workspace"
 
 [[feature]]
@@ -269,7 +314,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Workspace-wide pull diagnostics"
 
 [[feature]]
@@ -278,7 +323,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_execute_command_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_execute_command_tests.rs"]
 description = "Execute commands (Perl::Critic, etc)"
 
 [[feature]]
@@ -287,7 +332,7 @@ spec = "LSP 3.6"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "Multi-root workspace support"
 
 [[feature]]
@@ -296,7 +341,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "File rename/create/delete tracking"
 
 [[feature]]
@@ -305,7 +350,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "Apply workspace-wide edits"
 
 [[feature]]
@@ -314,7 +359,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Cross-project symbol identity"
 
 # Window Features
@@ -325,7 +370,7 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_progress_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_progress_tests.rs"]
 description = "Progress reporting"
 
 [[feature]]
@@ -335,7 +380,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Show messages to user"
 
 [[feature]]
@@ -345,7 +390,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs", "crates/perl-lsp/tests/lsp_window_progress_test.rs"]
 description = "Log messages"
 
 [[feature]]
@@ -354,7 +399,7 @@ spec = "LSP 3.15"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Detailed work progress"
 
 # Notebook Features
@@ -366,7 +411,7 @@ area = "notebook"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook document synchronization (didOpen/didChange/didSave/didClose handlers)"
 
 [[feature]]
@@ -376,7 +421,7 @@ area = "notebook"
 maturity = "ga"
 advertised = false
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook cell execution summary tracking (LSP does not execute cells; this tracks executionSummary metadata)"
 
 # Debug Features (DAP)
@@ -490,7 +535,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialize handshake"
 
 [[feature]]
@@ -500,7 +545,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialized notification"
 
 [[feature]]
@@ -510,7 +555,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Graceful shutdown request"
 
 [[feature]]
@@ -520,7 +565,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Exit notification with proper exit codes"
 
 [[feature]]
@@ -530,7 +575,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Request cancellation ($/cancelRequest)"
 
 [[feature]]
@@ -540,7 +585,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability registration (server->client)"
 
 [[feature]]
@@ -550,7 +595,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability unregistration (server->client)"
 
 [[feature]]
@@ -560,7 +605,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Client sets server trace level ($/setTrace)"
 
 [[feature]]
@@ -570,7 +615,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Server trace logging ($/logTrace)"
 
 # Text Document Synchronization
@@ -582,7 +627,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didOpen/didChange/didClose text synchronization"
 
 [[feature]]
@@ -592,7 +637,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didSave notifications"
 
 [[feature]]
@@ -602,7 +647,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSave notifications"
 
 [[feature]]
@@ -612,7 +657,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSaveWaitUntil request with format-on-save"
 
 # Additional Language Features
@@ -623,7 +668,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_highlight_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_highlight_tests.rs"]
 description = "Document highlights (local references)"
 
 [[feature]]
@@ -632,7 +677,7 @@ spec = "LSP 3.12"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Validate rename and compute placeholder/range"
 
 [[feature]]
@@ -641,7 +686,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Inline values during debugging (LSP inlineValue)"
 
 [[feature]]
@@ -650,7 +695,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color presentation request (pairs with documentColor)"
 
 # Resolve Routes
@@ -661,7 +706,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Resolve additional completion item details"
 
 [[feature]]
@@ -670,7 +715,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Resolve additional code action details"
 
 [[feature]]
@@ -679,7 +724,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Resolve code lens command"
 
 [[feature]]
@@ -688,7 +733,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_link_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs"]
 description = "Resolve document link target"
 
 [[feature]]
@@ -697,7 +742,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hint_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs"]
 description = "Resolve inlay hint label locations"
 
 [[feature]]
@@ -706,7 +751,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Resolve additional workspace symbol info"
 
 # Refresh Routes (Server -> Client)
@@ -718,7 +763,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh code lenses"
 
 [[feature]]
@@ -728,7 +773,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh semantic tokens"
 
 [[feature]]
@@ -738,7 +783,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inlay hints"
 
 [[feature]]
@@ -748,7 +793,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inline values"
 
 [[feature]]
@@ -758,7 +803,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh pulled diagnostics"
 
 [[feature]]
@@ -768,7 +813,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh folding ranges (workspace/foldingRange/refresh, @proposed)"
 
 # Workspace Plumbing
@@ -780,7 +825,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/configuration request (server->client)"
 
 [[feature]]
@@ -790,7 +835,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeConfiguration notification"
 
 [[feature]]
@@ -800,7 +845,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeWatchedFiles notification"
 
 [[feature]]
@@ -810,7 +855,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/applyEdit request (server->client)"
 
 [[feature]]
@@ -820,7 +865,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Push diagnostics via textDocument/publishDiagnostics"
 
 # Window / Telemetry
@@ -832,7 +877,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Prompt user with choices (showMessageRequest)"
 
 [[feature]]
@@ -842,7 +887,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Ask client to open/display a URI (showDocument)"
 
 [[feature]]
@@ -852,7 +897,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Create server-initiated work done progress"
 
 [[feature]]
@@ -862,7 +907,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Client cancels server-initiated work done progress"
 
 [[feature]]
@@ -872,7 +917,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
@@ -883,7 +928,7 @@ spec = "LSP 3.18"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent request (@proposed)"
 
 [[feature]]
@@ -893,7 +938,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent/refresh request (@proposed)"
 
 # File Operations (method-level breakdown)
@@ -904,7 +949,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willCreateFiles request"
 
 [[feature]]
@@ -913,7 +958,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didCreateFiles notification"
 
 [[feature]]
@@ -922,7 +967,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/willRenameFiles request"
 
 [[feature]]
@@ -931,7 +976,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/didRenameFiles notification"
 
 [[feature]]
@@ -940,7 +985,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willDeleteFiles request"
 
 [[feature]]
@@ -949,5 +994,5 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didDeleteFiles notification"

--- a/crates/perl-lsp/features_sot.toml
+++ b/crates/perl-lsp/features_sot.toml
@@ -3,9 +3,9 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.10.0"
+version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 65  # Auto-calculated in future
+compliance_percent = 100  # 102 total features (87 LSP + 10 DAP + 5 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -15,7 +15,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Code completion with 150+ built-in functions"
 
 [[feature]]
@@ -24,7 +24,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_hover_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_hover_tests.rs"]
 description = "Hover information with documentation"
 
 [[feature]]
@@ -33,7 +33,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_signature_help_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_signature_help_tests.rs"]
 description = "Signature help with parameter hints"
 
 [[feature]]
@@ -42,7 +42,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to definition"
 
 [[feature]]
@@ -51,7 +51,7 @@ spec = "LSP 3.14"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to declaration"
 
 [[feature]]
@@ -60,7 +60,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_references_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_references_tests.rs"]
 description = "Find references across workspace"
 
 [[feature]]
@@ -69,7 +69,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_symbols_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_symbols_tests.rs"]
 description = "Document symbols with hierarchy"
 
 [[feature]]
@@ -78,7 +78,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Code actions and quick fixes"
 
 [[feature]]
@@ -87,7 +87,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Code lens with reference counts"
 
 [[feature]]
@@ -96,7 +96,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Document formatting with Perl::Tidy"
 
 [[feature]]
@@ -105,7 +105,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Range formatting (single range)"
 
 [[feature]]
@@ -114,7 +114,7 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_e2e.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_e2e.rs"]
 description = "Multi-range formatting (textDocument/rangesFormatting) (@proposed)"
 
 [[feature]]
@@ -123,7 +123,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_on_type_formatting.rs"]
+tests = ["crates/perl-lsp/tests/lsp_on_type_formatting.rs"]
 description = "On-type formatting with auto-indent"
 
 [[feature]]
@@ -132,7 +132,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Rename symbol across files"
 
 [[feature]]
@@ -141,7 +141,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_links_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_links_test.rs"]
 description = "Document links to modules and docs"
 
 [[feature]]
@@ -150,7 +150,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_folding_ranges_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_folding_ranges_test.rs"]
 description = "Folding ranges with fallback"
 
 [[feature]]
@@ -159,7 +159,7 @@ spec = "LSP 3.15"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_selection_range_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_selection_range_tests.rs"]
 description = "Smart selection expansion"
 
 [[feature]]
@@ -168,7 +168,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_semantic_tokens.rs"]
+tests = ["crates/perl-lsp/tests/lsp_semantic_tokens.rs"]
 description = "Enhanced syntax highlighting"
 
 [[feature]]
@@ -177,7 +177,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hints.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hints.rs"]
 description = "Parameter names and type hints"
 
 [[feature]]
@@ -186,7 +186,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_hierarchy_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_hierarchy_test.rs"]
 description = "Type hierarchy for classes/roles"
 
 [[feature]]
@@ -195,7 +195,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_call_hierarchy_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs"]
 description = "Call hierarchy navigation"
 
 [[feature]]
@@ -204,8 +204,44 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
+
+[[feature]]
+id = "lsp.diagnostic.missing_strict"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.missing_warnings"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.unreachable_code"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
+
+[[feature]]
+id = "lsp.diagnostic.unused_variable"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
+description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
 
 [[feature]]
 id = "lsp.inline_completion"
@@ -213,8 +249,17 @@ spec = "LSP 3.18"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inline_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inline_completion_tests.rs"]
 description = "Inline AI-powered completions (@proposed)"
+
+[[feature]]
+id = "experimental.perlInlineCompletionStream"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_streaming_completion_tests.rs"]
+description = "Streaming inline AI completions via textDocument/perlInlineCompletionStream — delivers incremental completions via $/progress with session and sequence tracking"
 
 [[feature]]
 id = "lsp.type_definition"
@@ -222,7 +267,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_definition_tests.rs"]
 description = "Go to type definition"
 
 [[feature]]
@@ -231,7 +276,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_implementation_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_implementation_tests.rs"]
 description = "Go to implementation"
 
 [[feature]]
@@ -240,7 +285,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color decorators"
 
 [[feature]]
@@ -249,7 +294,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_linked_editing_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_linked_editing_tests.rs"]
 description = "Linked editing of related tokens"
 
 # Workspace Features
@@ -260,7 +305,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Search symbols across workspace"
 
 [[feature]]
@@ -269,7 +314,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Workspace-wide pull diagnostics"
 
 [[feature]]
@@ -278,7 +323,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_execute_command_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_execute_command_tests.rs"]
 description = "Execute commands (Perl::Critic, etc)"
 
 [[feature]]
@@ -287,7 +332,7 @@ spec = "LSP 3.6"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "Multi-root workspace support"
 
 [[feature]]
@@ -296,7 +341,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "File rename/create/delete tracking"
 
 [[feature]]
@@ -305,7 +350,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "Apply workspace-wide edits"
 
 [[feature]]
@@ -314,7 +359,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Cross-project symbol identity"
 
 # Window Features
@@ -325,7 +370,7 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_progress_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_progress_tests.rs"]
 description = "Progress reporting"
 
 [[feature]]
@@ -335,7 +380,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Show messages to user"
 
 [[feature]]
@@ -345,7 +390,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = []
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs", "crates/perl-lsp/tests/lsp_window_progress_test.rs"]
 description = "Log messages"
 
 [[feature]]
@@ -354,7 +399,7 @@ spec = "LSP 3.15"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Detailed work progress"
 
 # Notebook Features
@@ -366,7 +411,7 @@ area = "notebook"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook document synchronization (didOpen/didChange/didSave/didClose handlers)"
 
 [[feature]]
@@ -376,7 +421,7 @@ area = "notebook"
 maturity = "ga"
 advertised = false
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
 description = "Notebook cell execution summary tracking (LSP does not execute cells; this tracks executionSummary metadata)"
 
 # Debug Features (DAP)
@@ -490,7 +535,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialize handshake"
 
 [[feature]]
@@ -500,7 +545,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Initialized notification"
 
 [[feature]]
@@ -510,7 +555,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Graceful shutdown request"
 
 [[feature]]
@@ -520,7 +565,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
 description = "Exit notification with proper exit codes"
 
 [[feature]]
@@ -530,7 +575,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Request cancellation ($/cancelRequest)"
 
 [[feature]]
@@ -540,7 +585,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability registration (server->client)"
 
 [[feature]]
@@ -550,7 +595,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_registration_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
 description = "Dynamic capability unregistration (server->client)"
 
 [[feature]]
@@ -560,7 +605,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Client sets server trace level ($/setTrace)"
 
 [[feature]]
@@ -570,7 +615,7 @@ area = "protocol"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_trace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
 description = "Server trace logging ($/logTrace)"
 
 # Text Document Synchronization
@@ -582,7 +627,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didOpen/didChange/didClose text synchronization"
 
 [[feature]]
@@ -592,7 +637,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "didSave notifications"
 
 [[feature]]
@@ -602,7 +647,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSave notifications"
 
 [[feature]]
@@ -612,7 +657,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_text_sync_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
 description = "willSaveWaitUntil request with format-on-save"
 
 # Additional Language Features
@@ -623,7 +668,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_highlight_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_highlight_tests.rs"]
 description = "Document highlights (local references)"
 
 [[feature]]
@@ -632,7 +677,7 @@ spec = "LSP 3.12"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Validate rename and compute placeholder/range"
 
 [[feature]]
@@ -641,7 +686,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_comprehensive_3_17_test.rs"]
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Inline values during debugging (LSP inlineValue)"
 
 [[feature]]
@@ -650,7 +695,7 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_color_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color presentation request (pairs with documentColor)"
 
 # Resolve Routes
@@ -661,7 +706,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Resolve additional completion item details"
 
 [[feature]]
@@ -670,7 +715,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Resolve additional code action details"
 
 [[feature]]
@@ -679,7 +724,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_lens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
 description = "Resolve code lens command"
 
 [[feature]]
@@ -688,7 +733,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_link_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs"]
 description = "Resolve document link target"
 
 [[feature]]
@@ -697,7 +742,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hint_resolve_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs"]
 description = "Resolve inlay hint label locations"
 
 [[feature]]
@@ -706,7 +751,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Resolve additional workspace symbol info"
 
 # Refresh Routes (Server -> Client)
@@ -718,7 +763,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh code lenses"
 
 [[feature]]
@@ -728,7 +773,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh semantic tokens"
 
 [[feature]]
@@ -738,7 +783,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inlay hints"
 
 [[feature]]
@@ -748,7 +793,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh inline values"
 
 [[feature]]
@@ -758,7 +803,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh pulled diagnostics"
 
 [[feature]]
@@ -768,7 +813,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_refresh_methods_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
 description = "Request client to refresh folding ranges (workspace/foldingRange/refresh, @proposed)"
 
 # Workspace Plumbing
@@ -780,7 +825,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/configuration request (server->client)"
 
 [[feature]]
@@ -790,7 +835,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeConfiguration notification"
 
 [[feature]]
@@ -800,7 +845,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/didChangeWatchedFiles notification"
 
 [[feature]]
@@ -810,7 +855,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "workspace/applyEdit request (server->client)"
 
 [[feature]]
@@ -820,7 +865,7 @@ area = "text_document"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Push diagnostics via textDocument/publishDiagnostics"
 
 # Window / Telemetry
@@ -832,7 +877,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Prompt user with choices (showMessageRequest)"
 
 [[feature]]
@@ -842,7 +887,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Ask client to open/display a URI (showDocument)"
 
 [[feature]]
@@ -852,7 +897,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Create server-initiated work done progress"
 
 [[feature]]
@@ -862,7 +907,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Client cancels server-initiated work done progress"
 
 [[feature]]
@@ -872,7 +917,7 @@ area = "window"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_window_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
@@ -883,7 +928,7 @@ spec = "LSP 3.18"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent request (@proposed)"
 
 [[feature]]
@@ -893,7 +938,7 @@ area = "workspace"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["tests/lsp_virtual_content_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
 description = "workspace/textDocumentContent/refresh request (@proposed)"
 
 # File Operations (method-level breakdown)
@@ -904,7 +949,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willCreateFiles request"
 
 [[feature]]
@@ -913,7 +958,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didCreateFiles notification"
 
 [[feature]]
@@ -922,7 +967,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/willRenameFiles request"
 
 [[feature]]
@@ -931,7 +976,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "workspace/didRenameFiles notification"
 
 [[feature]]
@@ -940,7 +985,7 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/willDeleteFiles request"
 
 [[feature]]
@@ -949,5 +994,5 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_file_ops_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "workspace/didDeleteFiles notification"

--- a/crates/perl-parser/features_sot.toml
+++ b/crates/perl-parser/features_sot.toml
@@ -1,11 +1,11 @@
-# LSP Feature Catalog (vendored fallback)
-# This file is a vendored copy of the workspace root features.toml.
-# Used only when building the crate outside the workspace.
+# LSP Feature Catalog - Single Source of Truth
+# This file defines all LSP features and their maturity status
+# Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.8.5"
+version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 93  # Added prepareRename, codeAction resolve, inlineValues, moniker, documentColor
+compliance_percent = 100  # 102 total features (87 LSP + 10 DAP + 5 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -15,7 +15,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_completion_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
 description = "Code completion with 150+ built-in functions"
 
 [[feature]]
@@ -24,7 +24,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_hover_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_hover_tests.rs"]
 description = "Hover information with documentation"
 
 [[feature]]
@@ -33,7 +33,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_signature_help_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_signature_help_tests.rs"]
 description = "Signature help with parameter hints"
 
 [[feature]]
@@ -42,7 +42,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to definition"
 
 [[feature]]
@@ -51,7 +51,7 @@ spec = "LSP 3.14"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_definition_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_definition_tests.rs"]
 description = "Go to declaration"
 
 [[feature]]
@@ -60,7 +60,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_references_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_references_tests.rs"]
 description = "Find references across workspace"
 
 [[feature]]
@@ -69,7 +69,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_symbols_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_symbols_tests.rs"]
 description = "Document symbols with hierarchy"
 
 [[feature]]
@@ -78,7 +78,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_code_actions_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
 description = "Code actions and quick fixes"
 
 [[feature]]
@@ -87,8 +87,8 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_codelens_tests.rs"]
-description = "Code lens with reference counts for subroutines and packages"
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
+description = "Code lens with reference counts"
 
 [[feature]]
 id = "lsp.formatting"
@@ -96,7 +96,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
 description = "Document formatting with Perl::Tidy"
 
 [[feature]]
@@ -105,8 +105,17 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_formatting_tests.rs"]
-description = "Range formatting"
+tests = ["crates/perl-lsp/tests/lsp_formatting_tests.rs"]
+description = "Range formatting (single range)"
+
+[[feature]]
+id = "lsp.ranges_formatting"
+spec = "LSP 3.18"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_formatting_e2e.rs"]
+description = "Multi-range formatting (textDocument/rangesFormatting) (@proposed)"
 
 [[feature]]
 id = "lsp.on_type_formatting"
@@ -114,7 +123,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_on_type_formatting_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_on_type_formatting.rs"]
 description = "On-type formatting with auto-indent"
 
 [[feature]]
@@ -123,7 +132,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_rename_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
 description = "Rename symbol across files"
 
 [[feature]]
@@ -132,7 +141,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_document_link_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_document_links_test.rs"]
 description = "Document links to modules and docs"
 
 [[feature]]
@@ -141,7 +150,7 @@ spec = "LSP 3.0"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_folding_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_folding_ranges_test.rs"]
 description = "Folding ranges with fallback"
 
 [[feature]]
@@ -150,7 +159,7 @@ spec = "LSP 3.15"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_selection_range_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_selection_range_tests.rs"]
 description = "Smart selection expansion"
 
 [[feature]]
@@ -159,7 +168,7 @@ spec = "LSP 3.16"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_semantic_tokens_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_semantic_tokens.rs"]
 description = "Enhanced syntax highlighting"
 
 [[feature]]
@@ -168,7 +177,7 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inlay_hints_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_inlay_hints.rs"]
 description = "Parameter names and type hints"
 
 [[feature]]
@@ -177,26 +186,17 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_hierarchy_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_type_hierarchy_test.rs"]
 description = "Type hierarchy for classes/roles"
 
 [[feature]]
 id = "lsp.call_hierarchy"
 spec = "LSP 3.16"
 area = "text_document"
-maturity = "preview"
-advertised = true
-tests = ["tests/lsp_call_hierarchy_tests.rs"]
-description = "Call hierarchy navigation"
-
-[[feature]]
-id = "lsp.linked_editing_range"
-spec = "LSP 3.16"
-area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_linked_editing_tests.rs"]
-description = "Linked editing for paired delimiters ((), [], {}, <>, quotes)"
+tests = ["crates/perl-lsp/tests/lsp_call_hierarchy_tests.rs"]
+description = "Call hierarchy navigation"
 
 [[feature]]
 id = "lsp.pull_diagnostics"
@@ -204,17 +204,62 @@ spec = "LSP 3.17"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Pull model diagnostics"
+
+[[feature]]
+id = "lsp.diagnostic.missing_strict"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use strict' pragma diagnostic (PL100) — warns when .pm/.pl files lack strict enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.missing_warnings"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
+description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
+
+[[feature]]
+id = "lsp.diagnostic.unreachable_code"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp-diagnostics/tests/unreachable_code_tests.rs"]
+description = "Unreachable code highlighting (PL406) with DiagnosticTag::Unnecessary — detects code after return/die/exit/croak statements"
+
+[[feature]]
+id = "lsp.diagnostic.unused_variable"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
+description = "Unused variable diagnostics (PL102) via scope analyzer — warns on declared-but-never-used variables, suppressed by underscore prefix"
 
 [[feature]]
 id = "lsp.inline_completion"
 spec = "LSP 3.18"
 area = "text_document"
-maturity = "preview"
+maturity = "ga"
 advertised = true
-tests = ["tests/lsp_inline_completion_tests.rs"]
-description = "Deterministic inline completions (non-AI, via experimental)"
+tests = ["crates/perl-lsp/tests/lsp_inline_completion_tests.rs"]
+description = "Inline AI-powered completions (@proposed)"
+
+[[feature]]
+id = "experimental.perlInlineCompletionStream"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_streaming_completion_tests.rs"]
+description = "Streaming inline AI completions via textDocument/perlInlineCompletionStream — delivers incremental completions via $/progress with session and sequence tracking"
 
 [[feature]]
 id = "lsp.type_definition"
@@ -222,8 +267,8 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_type_definition_tests.rs"]
-description = "Go to type definition (with multi-file support)"
+tests = ["crates/perl-lsp/tests/lsp_type_definition_tests.rs"]
+description = "Go to type definition"
 
 [[feature]]
 id = "lsp.implementation"
@@ -231,18 +276,26 @@ spec = "LSP 3.6"
 area = "text_document"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_implementation_tests.rs"]
-description = "Go to implementation (with workspace index)"
+tests = ["crates/perl-lsp/tests/lsp_implementation_tests.rs"]
+description = "Go to implementation"
 
 [[feature]]
 id = "lsp.document_color"
 spec = "LSP 3.6"
 area = "text_document"
-maturity = "planned"
-advertised = false
-tests = []
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
 description = "Color decorators"
 
+[[feature]]
+id = "lsp.linked_editing_range"
+spec = "LSP 3.16"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_linked_editing_tests.rs"]
+description = "Linked editing of related tokens"
 
 # Workspace Features
 
@@ -252,7 +305,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_symbol_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
 description = "Search symbols across workspace"
 
 [[feature]]
@@ -261,7 +314,7 @@ spec = "LSP 3.17"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_pull_diagnostics_tests.rs"]
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
 description = "Workspace-wide pull diagnostics"
 
 [[feature]]
@@ -270,7 +323,7 @@ spec = "LSP 3.0"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_execute_command_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_execute_command_tests.rs"]
 description = "Execute commands (Perl::Critic, etc)"
 
 [[feature]]
@@ -279,7 +332,7 @@ spec = "LSP 3.6"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_workspace_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
 description = "Multi-root workspace support"
 
 [[feature]]
@@ -288,25 +341,25 @@ spec = "LSP 3.16"
 area = "workspace"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_file_operations_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
 description = "File rename/create/delete tracking"
 
 [[feature]]
 id = "lsp.workspace_edit"
 spec = "LSP 3.0"
 area = "workspace"
-maturity = "experimental"
-advertised = false
-tests = []
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
 description = "Apply workspace-wide edits"
 
 [[feature]]
 id = "lsp.moniker"
 spec = "LSP 3.16"
 area = "workspace"
-maturity = "planned"
-advertised = false
-tests = []
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
 description = "Cross-project symbol identity"
 
 # Window Features
@@ -317,7 +370,7 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = ["tests/lsp_progress_tests.rs"]
+tests = ["crates/perl-lsp/tests/lsp_progress_tests.rs"]
 description = "Progress reporting"
 
 [[feature]]
@@ -326,7 +379,8 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = []
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Show messages to user"
 
 [[feature]]
@@ -335,16 +389,17 @@ spec = "LSP 3.0"
 area = "window"
 maturity = "ga"
 advertised = true
-tests = []
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs", "crates/perl-lsp/tests/lsp_window_progress_test.rs"]
 description = "Log messages"
 
 [[feature]]
 id = "lsp.work_done_progress"
 spec = "LSP 3.15"
 area = "window"
-maturity = "experimental"
-advertised = false
-tests = []
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
 description = "Detailed work progress"
 
 # Notebook Features
@@ -353,36 +408,591 @@ description = "Detailed work progress"
 id = "lsp.notebook_document_sync"
 spec = "LSP 3.17"
 area = "notebook"
-maturity = "planned"
-advertised = false
-tests = []
-description = "Notebook document synchronization"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
+description = "Notebook document synchronization (didOpen/didChange/didSave/didClose handlers)"
 
 [[feature]]
 id = "lsp.notebook_cell_execution"
 spec = "LSP 3.17"
 area = "notebook"
-maturity = "planned"
+maturity = "ga"
 advertised = false
-tests = []
-description = "Execute notebook cells"
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_notebook_tests.rs"]
+description = "Notebook cell execution summary tracking (LSP does not execute cells; this tracks executionSummary metadata)"
 
 # Debug Features (DAP)
+
+[[feature]]
+id = "dap.core"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_smoke_e2e.rs", "crates/perl-dap/tests/session_lifecycle_tests.rs"]
+description = "Core VS Code debug loop: initialize/launch/configurationDone, break/step, stack/scopes/variables, evaluate/setVariable, disconnect/terminate"
+
+[[feature]]
+id = "dap.breakpoints.basic"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_smoke_e2e.rs", "crates/perl-dap/tests/dap_breakpoint_matrix_tests.rs"]
+description = "Verified/unverified source breakpoints with replace semantics and deterministic stopped(reason=breakpoint) behavior"
+
+[[feature]]
+id = "dap.breakpoints.hit_condition"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_breakpoint_matrix_tests.rs", "crates/perl-dap/tests/dap_preview_e2e_receipts.rs"]
+description = "Hit-count breakpoints (e.g., >= N, == N, %N) with runtime counter gating"
+
+[[feature]]
+id = "dap.breakpoints.logpoints"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_breakpoint_matrix_tests.rs", "crates/perl-dap/tests/dap_preview_e2e_receipts.rs"]
+description = "Logpoint breakpoints (`logMessage`) emit output events and continue execution"
+
+[[feature]]
+id = "dap.exceptions.die"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_comprehensive_test.rs", "crates/perl-dap/tests/dap_preview_e2e_receipts.rs"]
+description = "Exception breakpoint handling for `die`/uncaught exception categories with exceptionInfo support"
 
 [[feature]]
 id = "dap.inline_values"
 spec = "DAP 1.0"
 area = "debug"
-maturity = "planned"
-advertised = false
-tests = []
-description = "Inline variable values while debugging"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_comprehensive_test.rs"]
+description = "Inline variable values while debugging (native adapter)"
 
 [[feature]]
-id = "dap.breakpoints"
+id = "dap.completions"
 spec = "DAP 1.0"
 area = "debug"
-maturity = "planned"
-advertised = false
-tests = []
-description = "Breakpoint support"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_completions_tests.rs"]
+description = "Debug console autocomplete with Perl keywords"
+
+[[feature]]
+id = "dap.modules"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_modules_tests.rs"]
+description = "Loaded modules view via %INC inspection"
+
+[[feature]]
+id = "dap.watchpoints"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_watchpoints_tests.rs"]
+description = "Data breakpoints (watchpoints) via Perl debugger w/W commands"
+
+[[feature]]
+id = "dap.exceptions.warn"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_warn_exception_tests.rs"]
+description = "Exception breakpoint handling for warn/carp/cluck warnings"
+
+# Protocol / Lifecycle Features
+
+[[feature]]
+id = "lsp.initialize"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
+description = "Initialize handshake"
+
+[[feature]]
+id = "lsp.initialized"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
+description = "Initialized notification"
+
+[[feature]]
+id = "lsp.shutdown"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
+description = "Graceful shutdown request"
+
+[[feature]]
+id = "lsp.exit"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_lifecycle_tests.rs"]
+description = "Exit notification with proper exit codes"
+
+[[feature]]
+id = "lsp.cancel_request"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_3_17_window_tests.rs"]
+description = "Request cancellation ($/cancelRequest)"
+
+[[feature]]
+id = "lsp.client_register_capability"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
+description = "Dynamic capability registration (server->client)"
+
+[[feature]]
+id = "lsp.client_unregister_capability"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_registration_tests.rs"]
+description = "Dynamic capability unregistration (server->client)"
+
+[[feature]]
+id = "lsp.set_trace"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
+description = "Client sets server trace level ($/setTrace)"
+
+[[feature]]
+id = "lsp.log_trace"
+spec = "LSP 3.0"
+area = "protocol"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_trace_tests.rs"]
+description = "Server trace logging ($/logTrace)"
+
+# Text Document Synchronization
+
+[[feature]]
+id = "lsp.text_document_sync"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
+description = "didOpen/didChange/didClose text synchronization"
+
+[[feature]]
+id = "lsp.did_save"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
+description = "didSave notifications"
+
+[[feature]]
+id = "lsp.will_save"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
+description = "willSave notifications"
+
+[[feature]]
+id = "lsp.will_save_wait_until"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_text_sync_tests.rs"]
+description = "willSaveWaitUntil request with format-on-save"
+
+# Additional Language Features
+
+[[feature]]
+id = "lsp.document_highlight"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_document_highlight_tests.rs"]
+description = "Document highlights (local references)"
+
+[[feature]]
+id = "lsp.prepare_rename"
+spec = "LSP 3.12"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_rename_tests.rs"]
+description = "Validate rename and compute placeholder/range"
+
+[[feature]]
+id = "lsp.inline_value"
+spec = "LSP 3.17"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_3_17_compliance_tests.rs"]
+description = "Inline values during debugging (LSP inlineValue)"
+
+[[feature]]
+id = "lsp.color_presentation"
+spec = "LSP 3.6"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_color_tests.rs"]
+description = "Color presentation request (pairs with documentColor)"
+
+# Resolve Routes
+
+[[feature]]
+id = "lsp.completion_item_resolve"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_completion_tests.rs"]
+description = "Resolve additional completion item details"
+
+[[feature]]
+id = "lsp.code_action_resolve"
+spec = "LSP 3.16"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_code_actions_tests.rs"]
+description = "Resolve additional code action details"
+
+[[feature]]
+id = "lsp.code_lens_resolve"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_code_lens_tests.rs"]
+description = "Resolve code lens command"
+
+[[feature]]
+id = "lsp.document_link_resolve"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_document_link_resolve_tests.rs"]
+description = "Resolve document link target"
+
+[[feature]]
+id = "lsp.inlay_hint_resolve"
+spec = "LSP 3.17"
+area = "text_document"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_inlay_hint_resolve_tests.rs"]
+description = "Resolve inlay hint label locations"
+
+[[feature]]
+id = "lsp.workspace_symbol_resolve"
+spec = "LSP 3.17"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_symbol_tests.rs"]
+description = "Resolve additional workspace symbol info"
+
+# Refresh Routes (Server -> Client)
+
+[[feature]]
+id = "lsp.code_lens_refresh"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh code lenses"
+
+[[feature]]
+id = "lsp.semantic_tokens_refresh"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh semantic tokens"
+
+[[feature]]
+id = "lsp.inlay_hint_refresh"
+spec = "LSP 3.17"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh inlay hints"
+
+[[feature]]
+id = "lsp.inline_value_refresh"
+spec = "LSP 3.17"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh inline values"
+
+[[feature]]
+id = "lsp.diagnostic_refresh"
+spec = "LSP 3.17"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh pulled diagnostics"
+
+[[feature]]
+id = "lsp.folding_range_refresh"
+spec = "LSP 3.18"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_refresh_methods_tests.rs"]
+description = "Request client to refresh folding ranges (workspace/foldingRange/refresh, @proposed)"
+
+# Workspace Plumbing
+
+[[feature]]
+id = "lsp.configuration"
+spec = "LSP 3.6"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
+description = "workspace/configuration request (server->client)"
+
+[[feature]]
+id = "lsp.did_change_configuration"
+spec = "LSP 3.0"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
+description = "workspace/didChangeConfiguration notification"
+
+[[feature]]
+id = "lsp.did_change_watched_files"
+spec = "LSP 3.0"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
+description = "workspace/didChangeWatchedFiles notification"
+
+[[feature]]
+id = "lsp.apply_edit"
+spec = "LSP 3.0"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_workspace_tests.rs"]
+description = "workspace/applyEdit request (server->client)"
+
+[[feature]]
+id = "lsp.publish_diagnostics"
+spec = "LSP 3.0"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/pull_diagnostics_tests.rs"]
+description = "Push diagnostics via textDocument/publishDiagnostics"
+
+# Window / Telemetry
+
+[[feature]]
+id = "lsp.show_message_request"
+spec = "LSP 3.0"
+area = "window"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
+description = "Prompt user with choices (showMessageRequest)"
+
+[[feature]]
+id = "lsp.show_document"
+spec = "LSP 3.16"
+area = "window"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
+description = "Ask client to open/display a URI (showDocument)"
+
+[[feature]]
+id = "lsp.work_done_progress_create"
+spec = "LSP 3.15"
+area = "window"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
+description = "Create server-initiated work done progress"
+
+[[feature]]
+id = "lsp.work_done_progress_cancel"
+spec = "LSP 3.15"
+area = "window"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
+description = "Client cancels server-initiated work done progress"
+
+[[feature]]
+id = "lsp.telemetry_event"
+spec = "LSP 3.0"
+area = "window"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
+description = "Server telemetry events (telemetry/event)"
+
+# LSP 3.18 Additions
+
+[[feature]]
+id = "lsp.text_document_content"
+spec = "LSP 3.18"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
+description = "workspace/textDocumentContent request (@proposed)"
+
+[[feature]]
+id = "lsp.text_document_content_refresh"
+spec = "LSP 3.18"
+area = "workspace"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_virtual_content_tests.rs"]
+description = "workspace/textDocumentContent/refresh request (@proposed)"
+
+# File Operations (method-level breakdown)
+
+[[feature]]
+id = "lsp.will_create_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
+description = "workspace/willCreateFiles request"
+
+[[feature]]
+id = "lsp.did_create_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
+description = "workspace/didCreateFiles notification"
+
+[[feature]]
+id = "lsp.will_rename_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
+description = "workspace/willRenameFiles request"
+
+[[feature]]
+id = "lsp.did_rename_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_file_operations_tests.rs"]
+description = "workspace/didRenameFiles notification"
+
+[[feature]]
+id = "lsp.will_delete_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
+description = "workspace/willDeleteFiles request"
+
+[[feature]]
+id = "lsp.did_delete_files"
+spec = "LSP 3.16"
+area = "workspace"
+maturity = "ga"
+advertised = true
+tests = ["crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs"]
+description = "workspace/didDeleteFiles notification"


### PR DESCRIPTION
## Summary
- refresh the vendored `features_sot.toml` fallbacks so they match the workspace root catalog again
- derive `PartialEq`/`Eq` for feature-catalog structs to support lockstep assertions
- add a regression test proving all vendored fallbacks match the root `features.toml` catalog

## Testing
- cargo test -p perl-feature-catalog --test comprehensive_unit_tests vendored_feature_catalogs_match_workspace_root_catalog
- cargo xtask features invariants