### PR TITLE
feat(config): detect native build hints at init (#3572)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -6,9 +6,13 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use perl_dap_platform::resolve_perl_path_with_toolchain;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
+
+mod native_build_hints;
+
+pub use native_build_hints::{NativeBuildHints, detect_native_build_hints};
 
 /// Server configuration
 ///
@@ -288,6 +292,12 @@ pub struct WorkspaceConfig {
     /// Extra arguments passed to the Perl interpreter for startup `@INC` probing.
     pub perl_args: Vec<String>,
 
+    /// Native build hints derived from workspace-root `Makefile.PL` / `Build.PL`.
+    ///
+    /// These are cached once at workspace initialization and kept separate from
+    /// Perl module search paths.
+    pub native_build_hints: NativeBuildHints,
+
     /// Resolution timeout in milliseconds
     /// Default: 50ms
     pub resolution_timeout_ms: u64,
@@ -309,6 +319,7 @@ impl Default for WorkspaceConfig {
             system_inc_cache: None,
             perl_path: None,
             perl_args: Vec::new(),
+            native_build_hints: NativeBuildHints::default(),
             resolution_timeout_ms: 50,
             use_perl5lib: true,
             perl5lib_precedence: Perl5LibPrecedence::Prepend,
@@ -351,6 +362,14 @@ impl WorkspaceConfig {
                 result
             }
         }
+    }
+
+    /// Refresh workspace-native build hints from the selected workspace root.
+    ///
+    /// This is a workspace-initialization cache step only; it does not mutate
+    /// module-resolution include paths.
+    pub fn refresh_native_build_hints(&mut self, workspace_root: &Path) {
+        self.native_build_hints = detect_native_build_hints(workspace_root);
     }
 
     /// Update workspace configuration from LSP settings.

--- a/crates/perl-lsp-config/src/native_build_hints.rs
+++ b/crates/perl-lsp-config/src/native_build_hints.rs
@@ -1,0 +1,231 @@
+//! Conservative native build hint extraction.
+//!
+//! This module looks for literal `Makefile.PL` / `Build.PL` hints at the
+//! workspace root and extracts only native include directories. It does not
+//! execute Perl or try to model full build metadata.
+
+use std::fs;
+use std::path::Path;
+
+/// Native build hints derived from workspace-root build scripts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NativeBuildHints {
+    /// Native include directories discovered from static build-script hints.
+    pub include_dirs: Vec<String>,
+}
+
+/// Detect literal native include directories from `Makefile.PL` / `Build.PL`.
+pub fn detect_native_build_hints(workspace_root: &Path) -> NativeBuildHints {
+    let mut include_dirs = Vec::new();
+
+    let makefile_path = workspace_root.join("Makefile.PL");
+    if let Ok(source) = fs::read_to_string(&makefile_path) {
+        collect_unique(&mut include_dirs, extract_makefile_include_dirs(&source).into_iter());
+    }
+
+    let build_pl_path = workspace_root.join("Build.PL");
+    if let Ok(source) = fs::read_to_string(&build_pl_path) {
+        collect_unique(&mut include_dirs, extract_build_include_dirs(&source).into_iter());
+    }
+
+    NativeBuildHints { include_dirs }
+}
+
+fn extract_makefile_include_dirs(source: &str) -> Vec<String> {
+    extract_literal_values_after_key(source, "INC")
+        .into_iter()
+        .flat_map(|flags| split_include_flags(&flags).into_iter())
+        .collect()
+}
+
+fn extract_build_include_dirs(source: &str) -> Vec<String> {
+    let mut include_dirs = extract_literal_values_after_key(source, "include_dirs");
+    let mut extra_flags = extract_literal_values_after_key(source, "extra_compiler_flags")
+        .into_iter()
+        .flat_map(|flags| split_include_flags(&flags).into_iter())
+        .collect::<Vec<_>>();
+    include_dirs.append(&mut extra_flags);
+    include_dirs
+}
+
+fn split_include_flags(flags: &str) -> Vec<String> {
+    flags
+        .split_whitespace()
+        .filter_map(|token| token.strip_prefix("-I"))
+        .filter(|path| !path.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn collect_unique<I>(into: &mut Vec<String>, values: I)
+where
+    I: Iterator<Item = String>,
+{
+    for value in values {
+        if !value.is_empty() && !into.contains(&value) {
+            into.push(value);
+        }
+    }
+}
+
+fn extract_literal_values_after_key(source: &str, key: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let bytes = source.as_bytes();
+    let mut search_from = 0;
+
+    while let Some((_, value_start)) = find_key_assignment(bytes, key, search_from) {
+        if let Some((mut parsed, consumed)) = parse_literal_value(source, value_start) {
+            values.append(&mut parsed);
+            search_from = value_start + consumed;
+        } else {
+            search_from = value_start + 1;
+        }
+    }
+
+    values
+}
+
+fn find_key_assignment(bytes: &[u8], key: &str, start: usize) -> Option<(usize, usize)> {
+    let key_bytes = key.as_bytes();
+    let mut search_from = start;
+
+    while search_from < bytes.len() {
+        let haystack = &bytes[search_from..];
+        let rel = haystack.windows(key_bytes.len()).position(|window| window == key_bytes)?;
+        let key_pos = search_from + rel;
+        if !is_key_boundary(bytes, key_pos, key_bytes.len()) {
+            search_from = key_pos + key_bytes.len();
+            continue;
+        }
+
+        let mut idx = key_pos + key_bytes.len();
+        skip_ws_and_comments(bytes, &mut idx);
+        if idx + 1 >= bytes.len()
+            || bytes.get(idx) != Some(&b'=')
+            || bytes.get(idx + 1) != Some(&b'>')
+        {
+            search_from = idx.saturating_add(1);
+            continue;
+        }
+
+        idx += 2;
+        skip_ws_and_comments(bytes, &mut idx);
+        return Some((key_pos, idx));
+    }
+
+    None
+}
+
+fn is_key_boundary(bytes: &[u8], key_pos: usize, key_len: usize) -> bool {
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+
+    let before_ok =
+        key_pos.checked_sub(1).and_then(|idx| bytes.get(idx)).is_none_or(|b| !is_ident(*b));
+    let after_ok = bytes.get(key_pos + key_len).is_none_or(|b| !is_ident(*b));
+
+    before_ok && after_ok
+}
+
+fn skip_ws_and_comments(bytes: &[u8], idx: &mut usize) {
+    loop {
+        while let Some(b) = bytes.get(*idx) {
+            match b {
+                b' ' | b'\t' | b'\r' | b'\n' => *idx += 1,
+                _ => break,
+            }
+        }
+
+        if bytes.get(*idx) == Some(&b'#') {
+            while *idx < bytes.len() && bytes[*idx] != b'\n' {
+                *idx += 1;
+            }
+            continue;
+        }
+
+        break;
+    }
+}
+
+fn parse_literal_value(source: &str, start: usize) -> Option<(Vec<String>, usize)> {
+    let bytes = source.as_bytes();
+    match bytes.get(start).copied()? {
+        b'\'' | b'"' => {
+            let (value, consumed) = parse_quoted_string(source, start)?;
+            Some((vec![value], consumed))
+        }
+        b'[' => parse_quoted_string_array(source, start),
+        _ => None,
+    }
+}
+
+fn parse_quoted_string(source: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = source.as_bytes();
+    let quote = *bytes.get(start)?;
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+
+    let mut value = String::new();
+    let mut idx = start + 1;
+    let mut escaped = false;
+
+    while idx < bytes.len() {
+        let ch = source[idx..].chars().next()?;
+        let ch_len = ch.len_utf8();
+        idx += ch_len;
+
+        if escaped {
+            value.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch as u8 == quote {
+            return Some((value, idx - start));
+        }
+
+        if ch == '\n' {
+            return None;
+        }
+
+        value.push(ch);
+    }
+
+    None
+}
+
+fn parse_quoted_string_array(source: &str, start: usize) -> Option<(Vec<String>, usize)> {
+    let bytes = source.as_bytes();
+    if bytes.get(start) != Some(&b'[') {
+        return None;
+    }
+
+    let mut idx = start + 1;
+    let mut values = Vec::new();
+
+    loop {
+        skip_ws_and_comments(bytes, &mut idx);
+        match bytes.get(idx).copied()? {
+            b']' => return Some((values, idx + 1 - start)),
+            b'\'' | b'"' => {
+                let (value, consumed) = parse_quoted_string(source, idx)?;
+                values.push(value);
+                idx += consumed;
+                skip_ws_and_comments(bytes, &mut idx);
+                match bytes.get(idx).copied()? {
+                    b',' => {
+                        idx += 1;
+                    }
+                    b']' => {}
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        }
+    }
+}

--- a/crates/perl-lsp-config/src/native_build_hints.rs
+++ b/crates/perl-lsp-config/src/native_build_hints.rs
@@ -87,30 +87,89 @@ fn extract_literal_values_after_key(source: &str, key: &str) -> Vec<String> {
 
 fn find_key_assignment(bytes: &[u8], key: &str, start: usize) -> Option<(usize, usize)> {
     let key_bytes = key.as_bytes();
-    let mut search_from = start;
+    let mut idx = start;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_comment = false;
 
-    while search_from < bytes.len() {
-        let haystack = &bytes[search_from..];
-        let rel = haystack.windows(key_bytes.len()).position(|window| window == key_bytes)?;
-        let key_pos = search_from + rel;
+    while idx < bytes.len() {
+        let byte = bytes[idx];
+
+        if in_comment {
+            idx += 1;
+            if byte == b'\n' {
+                in_comment = false;
+            }
+            continue;
+        }
+
+        if in_single_quote {
+            idx += 1;
+            if byte == b'\\' && idx < bytes.len() {
+                idx += 1;
+                continue;
+            }
+            if byte == b'\'' {
+                in_single_quote = false;
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            idx += 1;
+            if byte == b'\\' && idx < bytes.len() {
+                idx += 1;
+                continue;
+            }
+            if byte == b'"' {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        match byte {
+            b'#' => {
+                in_comment = true;
+                idx += 1;
+                continue;
+            }
+            b'\'' => {
+                in_single_quote = true;
+                idx += 1;
+                continue;
+            }
+            b'"' => {
+                in_double_quote = true;
+                idx += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        if !bytes[idx..].starts_with(key_bytes) {
+            idx += 1;
+            continue;
+        }
+
+        let key_pos = idx;
         if !is_key_boundary(bytes, key_pos, key_bytes.len()) {
-            search_from = key_pos + key_bytes.len();
+            idx = key_pos + key_bytes.len();
             continue;
         }
 
-        let mut idx = key_pos + key_bytes.len();
-        skip_ws_and_comments(bytes, &mut idx);
-        if idx + 1 >= bytes.len()
-            || bytes.get(idx) != Some(&b'=')
-            || bytes.get(idx + 1) != Some(&b'>')
+        let mut value_idx = key_pos + key_bytes.len();
+        skip_ws_and_comments(bytes, &mut value_idx);
+        if value_idx + 1 >= bytes.len()
+            || bytes.get(value_idx) != Some(&b'=')
+            || bytes.get(value_idx + 1) != Some(&b'>')
         {
-            search_from = idx.saturating_add(1);
+            idx = value_idx.saturating_add(1);
             continue;
         }
 
-        idx += 2;
-        skip_ws_and_comments(bytes, &mut idx);
-        return Some((key_pos, idx));
+        value_idx += 2;
+        skip_ws_and_comments(bytes, &mut value_idx);
+        return Some((key_pos, value_idx));
     }
 
     None

--- a/crates/perl-lsp-config/tests/behavioral.rs
+++ b/crates/perl-lsp-config/tests/behavioral.rs
@@ -173,6 +173,12 @@ fn workspace_config_resolution_timeout_defaults_to_50ms() {
     assert_eq!(cfg.resolution_timeout_ms, 50);
 }
 
+#[test]
+fn workspace_config_native_build_hints_default_empty() {
+    let cfg = WorkspaceConfig::default();
+    assert!(cfg.native_build_hints.include_dirs.is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // WorkspaceConfig: system_inc_cache invalidation
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp-config/tests/native_build_hints.rs
+++ b/crates/perl-lsp-config/tests/native_build_hints.rs
@@ -1,0 +1,70 @@
+use perl_lsp_config::{WorkspaceConfig, detect_native_build_hints};
+use std::fs;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn write_script(dir: &tempfile::TempDir, name: &str, content: &str) -> TestResult {
+    fs::write(dir.path().join(name), content)?;
+    Ok(())
+}
+
+#[test]
+fn makefile_pl_literal_inc_extracts_include_dirs() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    write_script(
+        &dir,
+        "Makefile.PL",
+        "WriteMakefile(\n    INC => '-Iinclude -I. -Ilocal/lib/perl5',\n);\n",
+    )?;
+
+    let hints = detect_native_build_hints(dir.path());
+    assert_eq!(hints.include_dirs, vec!["include", ".", "local/lib/perl5"]);
+    Ok(())
+}
+
+#[test]
+fn build_pl_literal_arrays_extract_include_dirs_and_compiler_flags() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    write_script(
+        &dir,
+        "Build.PL",
+        "Module::Build->new(\n    include_dirs => ['include', '.'],\n    extra_compiler_flags => ['-Ilocal/include -I.'],\n);\n",
+    )?;
+
+    let hints = detect_native_build_hints(dir.path());
+    assert_eq!(hints.include_dirs, vec!["include", ".", "local/include"]);
+    Ok(())
+}
+
+#[test]
+fn dynamic_native_build_hints_are_ignored() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    write_script(
+        &dir,
+        "Makefile.PL",
+        "my $extra = '-Iignored';\nWriteMakefile( INC => join(' ', '-Iinclude', $extra) );\n",
+    )?;
+    write_script(
+        &dir,
+        "Build.PL",
+        "Module::Build->new(\n    include_dirs => [map { $_ } qw(include .)],\n);\n",
+    )?;
+
+    let hints = detect_native_build_hints(dir.path());
+    assert!(hints.include_dirs.is_empty());
+    Ok(())
+}
+
+#[test]
+fn workspace_config_refresh_native_build_hints_leaves_include_paths_untouched() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    write_script(&dir, "Makefile.PL", "WriteMakefile( INC => '-Iinclude' );\n")?;
+
+    let mut cfg = WorkspaceConfig::default();
+    let include_paths_before = cfg.include_paths.clone();
+    cfg.refresh_native_build_hints(dir.path());
+
+    assert_eq!(cfg.include_paths, include_paths_before);
+    assert_eq!(cfg.native_build_hints.include_dirs, vec!["include"]);
+    Ok(())
+}

--- a/crates/perl-lsp-config/tests/native_build_hints.rs
+++ b/crates/perl-lsp-config/tests/native_build_hints.rs
@@ -56,6 +56,25 @@ fn dynamic_native_build_hints_are_ignored() -> TestResult {
 }
 
 #[test]
+fn commented_or_quoted_native_build_hints_are_ignored() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    write_script(
+        &dir,
+        "Makefile.PL",
+        "# INC => '-Iignored-comment'\nmy $doc = \"INC => '-Iignored-string'\";\nWriteMakefile( INC => '-Iinclude' );\n",
+    )?;
+    write_script(
+        &dir,
+        "Build.PL",
+        "my $doc = \"include_dirs => ['ignored-string']\";\n# include_dirs => ['ignored-comment']\nModule::Build->new( include_dirs => ['module-include'] );\n",
+    )?;
+
+    let hints = detect_native_build_hints(dir.path());
+    assert_eq!(hints.include_dirs, vec!["include", "module-include"]);
+    Ok(())
+}
+
+#[test]
 fn workspace_config_refresh_native_build_hints_leaves_include_paths_untouched() -> TestResult {
     let dir = tempfile::tempdir()?;
     write_script(&dir, "Makefile.PL", "WriteMakefile( INC => '-Iinclude' );\n")?;

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -67,5 +67,71 @@ impl LspServer {
                 }
             }
         }
+
+        {
+            let mut workspace_config = self.workspace_config.lock();
+            workspace_config.refresh_native_build_hints(&root);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LspServer;
+    use parking_lot::Mutex;
+    use std::fs;
+    use std::io::Write;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use url::Url;
+
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl CapturingWriter {
+        fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {
+            Self { buffer }
+        }
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buffer.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn load_and_apply_project_config_refreshes_native_build_hints_once() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("Makefile.PL"),
+            "WriteMakefile( INC => '-Iinclude -I. -Ilocal/lib/perl5' );\n",
+        )
+        .expect("write Makefile.PL");
+
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let writer = CapturingWriter::new(buffer);
+        let output: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(Box::new(writer)));
+        let server = LspServer::with_output(output);
+
+        let root_uri = Url::from_file_path(dir.path()).expect("file uri").to_string();
+        {
+            let mut folders = server.workspace_folders.lock();
+            folders.push(root_uri);
+        }
+
+        server.load_and_apply_project_config();
+
+        let workspace_config = server.workspace_config.lock();
+        assert_eq!(
+            workspace_config.native_build_hints.include_dirs,
+            vec!["include", ".", "local/lib/perl5"]
+        );
     }
 }


### PR DESCRIPTION
Summary:
- add conservative literal-only native build hint extraction from workspace-root Makefile.PL / Build.PL
- cache native build hints once during workspace config init
- keep native hints separate from Perl module search paths

Tests:
- cargo test -p perl-lsp-config --test native_build_hints
- cargo test -p perl-lsp-config --test behavioral workspace_config_native_build_hints_default_empty
- cargo test -p perl-lsp-rs load_and_apply_project_config_refreshes_native_build_hints_once