### PR TITLE
feat(module-resolution): establish EffectiveInc root model and unify URI resolver (#3337)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -4,7 +4,8 @@
 
 use super::super::*;
 use perl_module_resolution::{
-    ModuleUriResolution, resolve_module_path as resolve_workspace_module_path, resolve_module_uri,
+    IncRoot, IncRootKind, ModuleUriResolution,
+    resolve_module_path as resolve_workspace_module_path, resolve_module_uri_with_effective_inc,
     use_lib::resolve_use_lib_paths_from_source,
 };
 use std::path::PathBuf;
@@ -64,6 +65,59 @@ fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -
         .first()
         .and_then(|u| url::Url::parse(u).ok())
         .and_then(|u| u.to_file_path().ok())
+}
+
+fn build_effective_inc_roots(
+    include_paths: &[String],
+    lexical_paths: &[String],
+    system_paths: &[PathBuf],
+) -> Vec<IncRoot> {
+    let mut roots = Vec::new();
+    let mut precedence = 0usize;
+
+    for path in lexical_paths {
+        let path_buf = PathBuf::from(path);
+        let kind = if path_buf.is_absolute() {
+            IncRootKind::ExternalAbsolute
+        } else {
+            IncRootKind::FileLocalLexical
+        };
+        roots.push(IncRoot {
+            kind,
+            path: path_buf,
+            precedence,
+            source: "use-lib-lexical".to_string(),
+        });
+        precedence += 1;
+    }
+
+    for path in include_paths {
+        let path_buf = PathBuf::from(path);
+        let kind = if path_buf.is_absolute() {
+            IncRootKind::ExternalAbsolute
+        } else {
+            IncRootKind::WorkspaceRelative
+        };
+        roots.push(IncRoot {
+            kind,
+            path: path_buf,
+            precedence,
+            source: "workspace-include-paths".to_string(),
+        });
+        precedence += 1;
+    }
+
+    for path in system_paths {
+        roots.push(IncRoot {
+            kind: IncRootKind::InterpreterStartup,
+            path: path.clone(),
+            precedence,
+            source: "interpreter-startup-inc".to_string(),
+        });
+        precedence += 1;
+    }
+
+    roots
 }
 
 impl LspServer {
@@ -230,7 +284,7 @@ impl LspServer {
         doc_text: Option<&str>,
         doc_uri: Option<&str>,
     ) -> Option<String> {
-        let (mut include_paths, timeout_ms, use_system_inc) = {
+        let (include_paths, timeout_ms, use_system_inc) = {
             let config = self.workspace_config.lock();
             let perl5lib_paths = std::env::var("PERL5LIB")
                 .map(|v| perl_lsp_config::WorkspaceConfig::parse_perl5lib(&v))
@@ -246,6 +300,7 @@ impl LspServer {
         let workspace_folders = self.workspace_folders.lock().clone();
 
         // Wire use lib paths scoped to this call
+        let mut lexical_paths = Vec::new();
         if let Some(text) = doc_text {
             let root_opt = workspace_root_for_doc(&workspace_folders, doc_uri);
             if root_opt.is_none() && !workspace_folders.is_empty() {
@@ -262,7 +317,7 @@ impl LspServer {
                 if file_dir.is_none() && doc_uri.is_some() {
                     tracing::trace!("Module URI resolution failed for doc_uri: {:?}", doc_uri);
                 }
-                prepend_use_lib_paths(&mut include_paths, text, &root, file_dir.as_deref());
+                lexical_paths = resolve_use_lib_paths_from_source(text, &root, file_dir.as_deref());
             }
         }
 
@@ -280,13 +335,14 @@ impl LspServer {
             Vec::new()
         };
 
-        match resolve_module_uri(
+        let effective_inc =
+            build_effective_inc_roots(&include_paths, &lexical_paths, &system_paths);
+
+        match resolve_module_uri_with_effective_inc(
             module_name,
             &open_document_uris,
             &workspace_folders,
-            &include_paths,
-            use_system_inc,
-            &system_paths,
+            &effective_inc,
             timeout,
         ) {
             ModuleUriResolution::Resolved(uri) => Some(uri),

--- a/crates/perl-module-resolution-uri/src/lib.rs
+++ b/crates/perl-module-resolution-uri/src/lib.rs
@@ -15,6 +15,34 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use url::Url;
 
+/// Source/category of an effective include root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncRootKind {
+    /// File-local lexical include roots (for example `use lib` overlays).
+    FileLocalLexical,
+    /// Workspace-relative include roots, resolved against each owning workspace.
+    WorkspaceRelative,
+    /// External absolute include roots.
+    ExternalAbsolute,
+    /// Startup `@INC` entries from the selected Perl interpreter.
+    InterpreterStartup,
+    /// Runtime-derived include roots (reserved for future trusted runtime mode).
+    RuntimeDerived,
+}
+
+/// A single ordered include root entry used to resolve modules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IncRoot {
+    /// Root kind/category.
+    pub kind: IncRootKind,
+    /// Path value for this root.
+    pub path: PathBuf,
+    /// Search precedence: lower values are searched first.
+    pub precedence: usize,
+    /// Human-readable source label (`"workspace.includePaths"`, `"use lib"`, etc).
+    pub source: String,
+}
+
 /// Outcome of a module name to URI resolution attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModuleUriResolution {
@@ -45,6 +73,49 @@ pub fn resolve_module_uri(
     system_inc: &[PathBuf],
     timeout: Duration,
 ) -> ModuleUriResolution {
+    let mut effective_inc_roots = Vec::new();
+    for (idx, include_path) in include_paths.iter().enumerate() {
+        let path = PathBuf::from(include_path);
+        let kind = if path.is_absolute() {
+            IncRootKind::ExternalAbsolute
+        } else {
+            IncRootKind::WorkspaceRelative
+        };
+        effective_inc_roots.push(IncRoot {
+            kind,
+            path,
+            precedence: idx,
+            source: "includePaths".to_string(),
+        });
+    }
+    if use_system_inc {
+        for (offset, path) in system_inc.iter().enumerate() {
+            effective_inc_roots.push(IncRoot {
+                kind: IncRootKind::InterpreterStartup,
+                path: path.clone(),
+                precedence: include_paths.len() + offset,
+                source: "interpreter-startup-inc".to_string(),
+            });
+        }
+    }
+    resolve_module_uri_with_effective_inc(
+        module_name,
+        open_document_uris,
+        workspace_folders,
+        &effective_inc_roots,
+        timeout,
+    )
+}
+
+/// Resolve a module name to a `file://` URI using an ordered effective `@INC` model.
+#[must_use]
+pub fn resolve_module_uri_with_effective_inc(
+    module_name: &str,
+    open_document_uris: &[String],
+    workspace_folders: &[String],
+    effective_inc_roots: &[IncRoot],
+    timeout: Duration,
+) -> ModuleUriResolution {
     let start_time = Instant::now();
     let relative_path = module_name_to_path(module_name);
 
@@ -54,6 +125,9 @@ pub fn resolve_module_uri(
         }
     }
 
+    let mut ordered_roots = effective_inc_roots.to_vec();
+    ordered_roots.sort_by_key(|r| r.precedence);
+
     for workspace_folder in workspace_folders {
         if start_time.elapsed() > timeout {
             return ModuleUriResolution::TimedOut;
@@ -61,28 +135,17 @@ pub fn resolve_module_uri(
 
         let workspace_path = workspace_folder_to_path(workspace_folder);
 
-        for include_path in include_paths {
+        for inc_root in &ordered_roots {
+            if !matches!(inc_root.kind, IncRootKind::FileLocalLexical | IncRootKind::WorkspaceRelative)
+            {
+                continue;
+            }
             if start_time.elapsed() > timeout {
                 return ModuleUriResolution::TimedOut;
             }
 
-            let include_base = Path::new(include_path);
-            let full_path = if include_base.is_absolute() {
-                include_base.join(&relative_path)
-            } else if include_path == "." {
-                workspace_path.join(&relative_path)
-            } else {
-                workspace_path.join(include_path).join(&relative_path)
-            };
-
-            let full_path = if include_base.is_absolute() {
-                full_path
-            } else {
-                match validate_workspace_path(&full_path, &workspace_path) {
-                    Ok(path) => path,
-                    Err(_) => continue,
-                }
-            };
+            let full_path = full_path_for_root(inc_root, &workspace_path, &relative_path);
+            let Some(full_path) = full_path else { continue };
 
             if full_path.is_file()
                 && let Ok(url) = Url::from_file_path(&full_path)
@@ -92,20 +155,47 @@ pub fn resolve_module_uri(
         }
     }
 
-    if use_system_inc {
-        for inc_path in system_inc {
-            if start_time.elapsed() > timeout {
-                return ModuleUriResolution::TimedOut;
-            }
+    for inc_root in &ordered_roots {
+        if !matches!(
+            inc_root.kind,
+            IncRootKind::ExternalAbsolute | IncRootKind::InterpreterStartup | IncRootKind::RuntimeDerived
+        ) {
+            continue;
+        }
+        if start_time.elapsed() > timeout {
+            return ModuleUriResolution::TimedOut;
+        }
 
-            let full_path = inc_path.join(&relative_path);
-            if full_path.is_file()
-                && let Ok(url) = Url::from_file_path(&full_path)
-            {
-                return ModuleUriResolution::Resolved(url.to_string());
-            }
+        let full_path = inc_root.path.join(&relative_path);
+        if full_path.is_file()
+            && let Ok(url) = Url::from_file_path(&full_path)
+        {
+            return ModuleUriResolution::Resolved(url.to_string());
         }
     }
 
     ModuleUriResolution::NotFound
+}
+
+fn full_path_for_root(
+    inc_root: &IncRoot,
+    workspace_path: &Path,
+    relative_path: &str,
+) -> Option<PathBuf> {
+    match inc_root.kind {
+        IncRootKind::FileLocalLexical | IncRootKind::WorkspaceRelative => {
+            if inc_root.path == Path::new(".") {
+                let full_path = workspace_path.join(relative_path);
+                validate_workspace_path(&full_path, workspace_path).ok()
+            } else if inc_root.path.is_absolute() {
+                Some(inc_root.path.join(relative_path))
+            } else {
+                let full_path = workspace_path.join(&inc_root.path).join(relative_path);
+                validate_workspace_path(&full_path, workspace_path).ok()
+            }
+        }
+        IncRootKind::ExternalAbsolute
+        | IncRootKind::InterpreterStartup
+        | IncRootKind::RuntimeDerived => Some(inc_root.path.join(relative_path)),
+    }
 }

--- a/crates/perl-module-resolution-uri/src/lib.rs
+++ b/crates/perl-module-resolution-uri/src/lib.rs
@@ -136,8 +136,10 @@ pub fn resolve_module_uri_with_effective_inc(
         let workspace_path = workspace_folder_to_path(workspace_folder);
 
         for inc_root in &ordered_roots {
-            if !matches!(inc_root.kind, IncRootKind::FileLocalLexical | IncRootKind::WorkspaceRelative)
-            {
+            if !matches!(
+                inc_root.kind,
+                IncRootKind::FileLocalLexical | IncRootKind::WorkspaceRelative
+            ) {
                 continue;
             }
             if start_time.elapsed() > timeout {
@@ -158,7 +160,9 @@ pub fn resolve_module_uri_with_effective_inc(
     for inc_root in &ordered_roots {
         if !matches!(
             inc_root.kind,
-            IncRootKind::ExternalAbsolute | IncRootKind::InterpreterStartup | IncRootKind::RuntimeDerived
+            IncRootKind::ExternalAbsolute
+                | IncRootKind::InterpreterStartup
+                | IncRootKind::RuntimeDerived
         ) {
             continue;
         }

--- a/crates/perl-module-resolution/src/lib.rs
+++ b/crates/perl-module-resolution/src/lib.rs
@@ -10,4 +10,7 @@
 pub mod use_lib;
 
 pub use perl_module_resolution_path::resolve_module_path;
-pub use perl_module_resolution_uri::{ModuleUriResolution, resolve_module_uri};
+pub use perl_module_resolution_uri::{
+    IncRoot, IncRootKind, ModuleUriResolution, resolve_module_uri,
+    resolve_module_uri_with_effective_inc,
+};


### PR DESCRIPTION
### Motivation
- Provide a single ordered representation of effective include roots (`@INC`) so all resolvers agree on search precedence and avoid ad-hoc ordering scattered across consumers.
- Make interpreter startup `@INC` first-class and keep open-document/editor overlays as a separate UX overlay rather than mixing them into core `@INC` logic.
- Enable a clear layering for resolution (lexical `use lib` → workspace include paths → external / interpreter `@INC`) as the foundation for future AST-aware and runtime modes.

### Description
- Introduce `IncRootKind` and `IncRoot` and add `resolve_module_uri_with_effective_inc(...)` to `crates/perl-module-resolution-uri/src/lib.rs` to model ordered include roots and perform URI resolution from that ordered model.
- Keep `resolve_module_uri(...)` backward-compatible by translating the legacy `include_paths`/`system_inc` inputs into an ordered `IncRoot` list and delegating to the new resolver.
- Add `full_path_for_root` helper and split workspace-root vs external/interpreter traversal so workspace-relative and lexical roots are checked per-workspace and external/interpreter roots are checked as a separate phase.
- Re-export the new types and function from `crates/perl-module-resolution/src/lib.rs` and update `crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs` to build an `effective_inc` list (lexical `use lib` entries, workspace `include_paths`, interpreter startup `@INC`) and pass it to the shared resolver while preserving open-document precedence.
- Small tidy: removed an unnecessary `mut` on `include_paths` extraction and added `build_effective_inc_roots` to compose the effective roots.

### Testing
- Ran `cargo fmt --all` to apply formatting, which completed successfully.
- Ran `cargo test -p perl-module-resolution-uri`, which executed the module-resolution URI tests and completed successfully (all tests passed).
- Ran the targeted workspace test `cargo test -p perllsp --lib module_resolution::tests::resolve_module_to_path_finds_workspace_module`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d913a03f5c833394c9fde669a48ad6)