### PR TITLE
audit(msrv): normalize rust-version inheritance (#3207)

### DIFF
--- a/crates/perl-lsp-ai-provider/Cargo.toml
+++ b/crates/perl-lsp-ai-provider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-ai-provider"
 version.workspace = true
 edition = "2024"
-rust-version = "1.92"
+rust-version.workspace = true
 authors.workspace = true
 description = "AI completion providers (OpenAI-compatible streaming) for perl-lsp"
 license = "MIT OR Apache-2.0"

--- a/crates/perl-lsp-capability-map/Cargo.toml
+++ b/crates/perl-lsp-capability-map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-capability-map"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = "MIT OR Apache-2.0"
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-contracts/Cargo.toml
+++ b/crates/perl-lsp-feature-contracts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-contracts"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = "MIT OR Apache-2.0"
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-flags/Cargo.toml
+++ b/crates/perl-lsp-feature-flags/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-flags"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license.workspace = true
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-grid/Cargo.toml
+++ b/crates/perl-lsp-feature-grid/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-grid"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = "MIT OR Apache-2.0"
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-ids/Cargo.toml
+++ b/crates/perl-lsp-feature-ids/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-ids"
 version = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-policy"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = "MIT OR Apache-2.0"
 repository = { workspace = true }

--- a/crates/perl-lsp-feature-profile/Cargo.toml
+++ b/crates/perl-lsp-feature-profile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "perl-lsp-feature-profile"
 version.workspace = true
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version.workspace = true
 authors = { workspace = true }
 license = "MIT OR Apache-2.0"
 repository = { workspace = true }


### PR DESCRIPTION
Summary:\n- convert the remaining hardcoded / verbose per-crate rust-version declarations to rust-version.workspace = true\n- keep all crate MSRV declarations aligned with the workspace default\n\nValidation:\n- rg -n '^rust-version' crates/*/Cargo.toml xtask/Cargo.toml | rg -v 'rust-version\.workspace = true'\n- cargo metadata --no-deps --format-version 1