### PR TITLE
test(workspace-index): cover file deletion reference cleanup (#3494)

### DIFF
--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -171,6 +171,29 @@ fn test_remove_file_url() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn test_remove_file_clears_references() -> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = file_url("/refs.pl")?;
+    let code = "package Refs;\nsub keep_me { 1 }\nkeep_me();\nRefs::keep_me();\n";
+    index.index_file(uri.clone(), code.to_string())?;
+
+    assert!(!index.find_references("Refs::keep_me").is_empty());
+    assert!(!index.find_references("keep_me").is_empty());
+
+    index.remove_file(&uri.to_string());
+
+    assert!(
+        index.find_references("Refs::keep_me").is_empty(),
+        "qualified references should be removed after file deletion"
+    );
+    assert!(
+        index.find_references("keep_me").is_empty(),
+        "bare references should be removed after file deletion"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_clear_index() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
     let uri = file_url("/c.pl")?;


### PR DESCRIPTION
Summary:
- add a regression proving remove_file() clears stale reference index entries after file deletion
- keep the existing symbol-cache cleanup coverage and add an explicit find_references() assertion

Tests:
- cargo test -p perl-workspace-index -- --nocapture test_remove_file_clears_references test_remove_file_clears_symbol_cache_qualified_and_bare test_remove_file_bare_name_falls_back_to_surviving_file