### PR TITLE
fix(navigation): resolve imported function goto-definition (#3466)

### DIFF
--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -199,6 +199,73 @@ Demo::Worker::run();
 }
 
 // ---------------------------------------------------------------------------
+// Test 2b: imported functions via `use Module qw(func)` navigate to the exporter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn go_to_definition_on_imported_function_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/My/Utils.pm",
+        r#"package My::Utils;
+use strict;
+use warnings;
+
+sub calculate_sum {
+    my (@nums) = @_;
+    my $total = 0;
+    $total += $_ for @nums;
+    return $total;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/My/Utils.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/My/Utils.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use My::Utils qw(calculate_sum);
+
+my $result = calculate_sum(1, 2, 3);
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "calculate_sum(1, 2, 3)")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected definition result for imported function");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("My/Utils.pm") || uri.contains("My%2FUtils.pm"),
+        "Definition should point to My/Utils.pm, got: {}",
+        uri
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Test 3: XS bootstrap calls navigate to native `.xs` entry points
 // ---------------------------------------------------------------------------
 

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1233,6 +1233,40 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
+    fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
+        fn find(node: &Node, name: &str) -> Option<String> {
+            match &node.kind {
+                NodeKind::Use { module, args, .. } => {
+                    for arg in args {
+                        if arg == name {
+                            return Some(module.clone());
+                        }
+                        if arg.starts_with("qw") {
+                            let content = arg
+                                .trim_start_matches("qw")
+                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                            if content.split_whitespace().any(|w| w == name) {
+                                return Some(module.clone());
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            for child in get_node_children(node) {
+                if let Some(module) = find(child, name) {
+                    return Some(module);
+                }
+            }
+
+            None
+        }
+
+        find(ast, symbol_name)
+    }
+
     fn plack_builder_middleware_symbol(path: &[&Node], offset: usize) -> Option<SymbolKey> {
         let has_builder = path.iter().any(|ancestor| {
             matches!(ancestor.kind, NodeKind::FunctionCall { ref name, .. } if name == "builder")
@@ -1398,9 +1432,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         }
         NodeKind::FunctionCall { name, .. } => {
             let (pkg, bare) = if let Some(idx) = name.rfind("::") {
-                (&name[..idx], &name[idx + 2..])
+                (name[..idx].to_string(), name[idx + 2..].to_string())
             } else {
-                (current_pkg, name.as_str())
+                (
+                    find_import_source(ast, name).unwrap_or_else(|| current_pkg.to_string()),
+                    name.clone(),
+                )
             };
             Some(SymbolKey { pkg: pkg.into(), name: bare.into(), sigil: None, kind: SymKind::Sub })
         }

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1235,24 +1235,21 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
 
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
         fn find(node: &Node, name: &str) -> Option<String> {
-            match &node.kind {
-                NodeKind::Use { module, args, .. } => {
-                    for arg in args {
-                        if arg == name {
+            if let NodeKind::Use { module, args, .. } = &node.kind {
+                for arg in args {
+                    if arg == name {
+                        return Some(module.clone());
+                    }
+                    if arg.starts_with("qw") {
+                        let content = arg
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        if content.split_whitespace().any(|w| w == name) {
                             return Some(module.clone());
-                        }
-                        if arg.starts_with("qw") {
-                            let content = arg
-                                .trim_start_matches("qw")
-                                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                                .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                            if content.split_whitespace().any(|w| w == name) {
-                                return Some(module.clone());
-                            }
                         }
                     }
                 }
-                _ => {}
             }
 
             for child in get_node_children(node) {


### PR DESCRIPTION
Summary:
- teach bare function symbol lookup to prefer a module imported via `use Foo qw(bar);` when resolving goto-definition
- keep qualified calls and existing `use Module` navigation behavior unchanged
- add a cross-file regression proving imported function calls jump to the exporting module

Tests:
- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_on_imported_function_navigates_to_source_module
- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_on_use_module_navigates_to_module