### PR TITLE
feat(completion): infer object methods from constructor assignment (#3461)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -118,6 +118,7 @@ use perl_parser_core::ast::NodeKind;
 use perl_semantic_analyzer::class_model::{ClassModel, ClassModelBuilder, Framework};
 use perl_semantic_analyzer::semantic::{BuiltinDoc, get_moose_type_documentation};
 use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
+use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_workspace_index::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -165,6 +166,7 @@ const MOOSE_TYPE_CANDIDATES: &[&str] = &[
 pub struct CompletionProvider {
     symbol_table: SymbolTable,
     class_models: Vec<ClassModel>,
+    type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
 }
@@ -248,9 +250,14 @@ impl CompletionProvider {
     ) -> Self {
         let symbol_table = SymbolExtractor::new_with_source(source).extract(ast);
         let class_models = ClassModelBuilder::new().build(ast);
+        let type_engine = workspace_index.as_ref().map(|_| {
+            let mut type_engine = TypeInferenceEngine::new();
+            let _ = type_engine.infer(ast);
+            type_engine
+        });
         let import_map = Self::extract_import_map(ast);
 
-        CompletionProvider { symbol_table, class_models, workspace_index, import_map }
+        CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
     }
 
     /// Walk the top-level AST and build an `ImportMap` from `use` statements.
@@ -590,6 +597,7 @@ impl CompletionProvider {
                 &mut completions,
                 &context,
                 source,
+                self.type_engine.as_ref(),
                 &self.workspace_index,
             );
         } else if context.prefix.starts_with('$') && context.prefix.contains("::") {

--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -9,6 +9,7 @@ use super::{
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
+use perl_semantic_analyzer::type_inference::{PerlType, TypeInferenceEngine};
 use perl_workspace_index::workspace_index::{SymbolKind as WsSymbolKind, VarKind, WorkspaceIndex};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -389,6 +390,24 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
     None
 }
 
+fn infer_receiver_package_from_type_engine(
+    context: &CompletionContext,
+    type_engine: Option<&TypeInferenceEngine>,
+) -> Option<String> {
+    let arrow_prefix = context.prefix.trim_end_matches("->");
+    let var_name = arrow_prefix.strip_prefix('$')?;
+    let ty = type_engine?.get_type_at(var_name)?;
+
+    match ty {
+        PerlType::Object(class) => Some(class),
+        PerlType::Reference(inner) => match inner.as_ref() {
+            PerlType::Object(class) => Some(class.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Add method completions from the workspace index for `->` expressions.
 ///
 /// When the user types `$obj->` or `Package->`, queries the workspace index for
@@ -399,6 +418,7 @@ pub fn add_workspace_method_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     source: &str,
+    type_engine: Option<&TypeInferenceEngine>,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
 ) {
     let Some(index) = workspace_index else {
@@ -409,7 +429,10 @@ pub fn add_workspace_method_completions(
         return;
     }
 
-    let Some(package_name) = infer_receiver_package(context, source) else {
+    let package_name = infer_receiver_package_from_type_engine(context, type_engine)
+        .or_else(|| infer_receiver_package(context, source));
+
+    let Some(package_name) = package_name else {
         return;
     };
 

--- a/crates/perl-lsp-completion/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-completion/tests/extended_unit_tests.rs
@@ -1238,6 +1238,31 @@ fn arrow_completion_from_variable_assignment() {
 }
 
 #[test]
+fn arrow_completion_from_multiline_object_assignment() {
+    let index = Arc::new(WorkspaceIndex::new());
+
+    let uri = must(Url::parse("file:///workspace/lib/Cache.pm"));
+    must(index.index_file(
+        uri,
+        "package Cache;\nsub new { }\nsub get { }\nsub set { }\n1;\n".to_string(),
+    ));
+
+    let code = "my $cache =\n    Cache->new();\n$cache->";
+    let provider = parse_provider_with_index(code, index);
+    let items = provider.get_completions(code, code.len());
+
+    assert!(
+        has_label(&items, "get"),
+        "should suggest `get` from Cache via multiline object assignment inference, got: {:?}",
+        items.iter().map(|i| &i.label).collect::<Vec<_>>()
+    );
+    assert!(
+        has_label(&items, "set"),
+        "should suggest `set` from Cache via multiline object assignment inference"
+    );
+}
+
+#[test]
 fn arrow_completion_does_not_duplicate_local_methods() {
     let index = Arc::new(WorkspaceIndex::new());
 


### PR DESCRIPTION
Summary:
- use inferred object types from constructor assignments to resolve `$obj->` method completions
- keep the existing line-scan fallback for older receiver inference cases
- add a regression for multiline `my $obj = Package->new();` assignments

Tests:
- cargo test -p perl-lsp-completion --test extended_unit_tests arrow_completion_from_
- cargo test -p perl-lsp-completion --test auto_import_tests workspace_method_auto_import_when_not_imported