### PR TITLE
fix(vscode-extension): add UX bundle for activation, conflicts, debug help, and include paths (#3452)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -46,10 +46,22 @@ A fast, native Perl 5 language server extension. Written in Rust for speed and r
 - **Variable Inspection** -- View variables, watch expressions, and call stack
 - **Attach to Process** -- Debug running Perl processes by PID or TCP
 
+Debugging is optional and uses `perl-dap` as a separate adapter. See the
+[debugging guide](../docs/tutorials/DAP_USER_GUIDE.md) for setup steps and
+the required launch configuration.
+
 ### Test Explorer
 - **Test Discovery** -- Automatic discovery of `.t` test files
 - **Run Tests** -- Run individual tests or entire files from the Testing panel (`Shift+Alt+T`)
 - **TAP Support** -- Native Test Anything Protocol result parsing
+
+### Extension Coexistence
+
+If VS Code warns that other Perl extensions are installed, keep one provider
+for navigation, diagnostics, and formatting where possible. Perl Navigator,
+Perl::Critic, and PerlTidy can overlap with perl-lsp features. If you see
+duplicate hover, completion, or formatting results, disable the competing
+feature in one extension and keep the other as the source of truth.
 
 ### Walkthrough Previews
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -54,7 +54,31 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
-    "onWalkthrough:perl-lsp.gettingStarted"
+    "onWalkthrough:perl-lsp.gettingStarted",
+    "onCommand:perl-lsp.restart",
+    "onCommand:perl-lsp.showVersion",
+    "onCommand:perl-lsp.showOutput",
+    "onCommand:perl-lsp.showStatusMenu",
+    "onCommand:perl-lsp.reinstall",
+    "onCommand:perl-lsp.checkForUpdate",
+    "onCommand:perl-lsp.organizeImports",
+    "onCommand:perl-lsp.runTests",
+    "onCommand:perl-lsp.extractVariable",
+    "onCommand:perl-lsp.extractMethod",
+    "onCommand:perl-lsp.showRefactoringOptions",
+    "onCommand:perl-lsp.showWhatsNew",
+    "onCommand:perl-lsp.createDebugConfig",
+    "onCommand:perl-lsp.runHealthCheck",
+    "onCommand:perl-lsp.checkSyntax",
+    "onCommand:perl-lsp.runCurrentTest",
+    "onCommand:perl-lsp.runAllTests",
+    "onCommand:perl-lsp.formatDocument",
+    "onCommand:perl-lsp.showIncPaths",
+    "onCommand:perl-lsp.openModule",
+    "onCommand:perl-lsp.showParserAst",
+    "onCommand:perl-lsp.openConfigurationGuide",
+    "onCommand:perl-lsp.reportIssue",
+    "onCommand:perl-lsp.previewPod"
   ],
   "contributes": {
     "languages": [
@@ -831,8 +855,8 @@
           },
           {
             "id": "debug-first-script",
-            "title": "Debug Your First Script",
-            "description": "Create a debug configuration with the Create Debug Configuration command.",
+            "title": "Debug Your First Script (Optional)",
+            "description": "Create a debug configuration with the Create Debug Configuration command. Debugging requires `perl-dap`; see the [debugging guide](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/tutorials/DAP_USER_GUIDE.md) for setup steps.",
             "media": {
               "image": "media/walkthrough/debug-first-script.svg",
               "altText": "Debug Script"

--- a/vscode-extension/src/debugAdapter.ts
+++ b/vscode-extension/src/debugAdapter.ts
@@ -5,6 +5,8 @@ import { BinaryDownloader } from './downloader';
 
 const SERVER_DEBUG_TEST_COMMAND = 'perl.debugTest';
 export const VSCODE_DEBUG_TEST_COMMAND = 'perl-lsp.debugTest';
+const DEBUGGING_GUIDE_URL =
+    'https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/tutorials/DAP_USER_GUIDE.md';
 
 export interface DebugTestLaunchTarget {
     label: string;
@@ -364,13 +366,16 @@ export class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
         if (!dapPath) {
             vscode.window.showErrorMessage(
-                'Perl Debug Adapter (perl-dap) not found. ' +
+                'Perl Debug Adapter (perl-dap) not found. Debugging requires perl-dap. ' +
                 'Use "Perl LSP: Reinstall" from the Command Palette to re-download it, ' +
-                'or install it manually with: cargo install perl-dap',
-                'Reinstall'
+                'or install it manually with: cargo install perl-dap.',
+                'Reinstall',
+                'Open Debugging Guide'
             ).then(sel => {
                 if (sel === 'Reinstall') {
                     void vscode.commands.executeCommand('perl-lsp.reinstall');
+                } else if (sel === 'Open Debugging Guide') {
+                    void vscode.env.openExternal(vscode.Uri.parse(DEBUGGING_GUIDE_URL));
                 }
             });
             return undefined;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -29,6 +29,8 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let healthWidget: HealthWidget | undefined;
 let streamingController: StreamingCompletionController | undefined;
 let stateChangeDisposable: vscode.Disposable | undefined;
+const COEXISTENCE_GUIDE_URL =
+    'https://github.com/EffortlessMetrics/perl-lsp/blob/master/vscode-extension/README.md#extension-coexistence';
 /**
  * Cached diagnostic message from the last startup failure.
  * Set by `initializeLanguageClient` when the LSP fails to start; read by
@@ -513,6 +515,10 @@ export async function activate(context: vscode.ExtensionContext) {
             refreshStreamingController(client);
         }
 
+        if (event.affectsConfiguration('perl-lsp.includePaths')) {
+            await validateIncludePaths(context);
+        }
+
         if (requiresClientRefresh(event)) {
             await promptForClientRefresh(context);
         }
@@ -586,6 +592,8 @@ export async function activate(context: vscode.ExtensionContext) {
     // Initialize debug adapter
     activateDebugger(context);
     await initializeLanguageClient(context);
+    await validateIncludePaths(context);
+    await warnAboutPerlExtensionConflicts(context);
 
     // Background update check — fire-and-forget after startup completes.
     // Runs at most once per updateCheckInterval hours; no-ops when serverPath
@@ -1170,6 +1178,146 @@ async function runCheckSyntax(): Promise<void> {
             }
         });
     });
+}
+
+/**
+ * Validate configured include paths for each workspace folder and warn once
+ * per workspace when a path does not exist.
+ */
+export async function validateIncludePaths(context: vscode.ExtensionContext): Promise<void> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return;
+    }
+
+    for (const folder of workspaceFolders) {
+        const cacheKey = `perl-lsp.includePathsWarning.${encodeURIComponent(folder.uri.toString())}`;
+        if (context.globalState.get<boolean>(cacheKey, false)) {
+            continue;
+        }
+
+        const config = vscode.workspace.getConfiguration('perl-lsp', folder.uri);
+        const includePaths: string[] = config.get('includePaths', ['lib', 'local/lib/perl5']);
+        const missingPaths = includePaths.filter(includePath => {
+            const resolved = path.resolve(folder.uri.fsPath, includePath);
+            return !fs.existsSync(resolved);
+        });
+
+        if (missingPaths.length === 0) {
+            continue;
+        }
+
+        const firstMissing = missingPaths[0];
+        const relativeNote = path.isAbsolute(firstMissing)
+            ? 'absolute path'
+            : 'relative to the workspace';
+        const suffix =
+            missingPaths.length > 1
+                ? ` ${missingPaths.length} include paths are missing.`
+                : '';
+
+        const choice = await vscode.window.showWarningMessage(
+            `Perl LSP: include path "${firstMissing}" (${relativeNote}) does not exist.${suffix}`,
+            'Open Settings'
+        );
+
+        if (choice === 'Open Settings') {
+            void vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                '@ext:EffortlessMetrics.perl-lsp-rs perl-lsp.includePaths'
+            );
+        }
+
+        await context.globalState.update(cacheKey, true);
+    }
+}
+
+type ExtensionPackage = {
+    publisher?: string;
+    name?: string;
+    version?: string;
+    displayName?: string;
+    description?: string;
+    keywords?: string[];
+    contributes?: {
+        languages?: Array<{ id?: string }>;
+    };
+};
+
+type InstalledExtension = {
+    id?: string;
+    packageJSON?: ExtensionPackage;
+};
+
+function isPerlLanguageExtension(extension: InstalledExtension): boolean {
+    const packageJSON = extension.packageJSON;
+    if (!packageJSON) {
+        return false;
+    }
+
+    if ((packageJSON.contributes?.languages ?? []).some(language => language.id === 'perl')) {
+        return true;
+    }
+
+    const haystack = [
+        extension.id,
+        packageJSON.publisher && packageJSON.name
+            ? `${packageJSON.publisher}.${packageJSON.name}`
+            : undefined,
+        packageJSON.displayName,
+        packageJSON.name,
+        packageJSON.description,
+        ...(packageJSON.keywords ?? []),
+    ]
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .join(' ')
+        .toLowerCase();
+
+    return /\bperl(?:\b|[-:]|navigator|critic|tidy|lsp)/i.test(haystack);
+}
+
+/**
+ * Warn once per major version when conflicting Perl extensions are installed.
+ */
+export async function warnAboutPerlExtensionConflicts(
+    context: vscode.ExtensionContext
+): Promise<void> {
+    const packageJSON = context.extension.packageJSON as ExtensionPackage;
+    const currentMajor = String(packageJSON.version ?? '0').split('.')[0] ?? '0';
+    const warnedMajor = context.globalState.get<string>('perl-lsp.conflictWarningMajorVersion');
+    if (warnedMajor === currentMajor) {
+        return;
+    }
+
+    const selfId = `${packageJSON.publisher ?? 'EffortlessMetrics'}.${packageJSON.name ?? 'perl-lsp-rs'}`;
+    const conflicts = (vscode.extensions.all as unknown as InstalledExtension[]).filter(extension => {
+        if (!extension || extension.id === selfId) {
+            return false;
+        }
+        return isPerlLanguageExtension(extension);
+    });
+
+    if (conflicts.length === 0) {
+        return;
+    }
+
+    const names = conflicts
+        .map(extension => extension.packageJSON?.displayName ?? extension.id ?? 'unknown extension')
+        .slice(0, 3);
+    const label = names.length === 1
+        ? names[0]
+        : `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+    const extra = conflicts.length > names.length ? ` (+${conflicts.length - names.length} more)` : '';
+    const choice = await vscode.window.showWarningMessage(
+        `Perl LSP detected ${conflicts.length} other Perl extension${conflicts.length === 1 ? '' : 's'}: ${label}${extra}. These can conflict with completion, hover, diagnostics, or formatting. See the coexistence guide for details.`,
+        'Open Coexistence Guide'
+    );
+
+    if (choice === 'Open Coexistence Guide') {
+        await vscode.env.openExternal(vscode.Uri.parse(COEXISTENCE_GUIDE_URL));
+    }
+
+    await context.globalState.update('perl-lsp.conflictWarningMajorVersion', currentMajor);
 }
 
 async function runProveTask(name: string, args: string[], cwd?: string): Promise<void> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1192,10 +1192,6 @@ export async function validateIncludePaths(context: vscode.ExtensionContext): Pr
 
     for (const folder of workspaceFolders) {
         const cacheKey = `perl-lsp.includePathsWarning.${encodeURIComponent(folder.uri.toString())}`;
-        if (context.globalState.get<boolean>(cacheKey, false)) {
-            continue;
-        }
-
         const config = vscode.workspace.getConfiguration('perl-lsp', folder.uri);
         const includePaths: string[] = config.get('includePaths', ['lib', 'local/lib/perl5']);
         const missingPaths = includePaths.filter(includePath => {
@@ -1204,6 +1200,13 @@ export async function validateIncludePaths(context: vscode.ExtensionContext): Pr
         });
 
         if (missingPaths.length === 0) {
+            await context.globalState.update(cacheKey, undefined);
+            continue;
+        }
+
+        const missingSignature = missingPaths.join('\n');
+        const warnedSignature = context.globalState.get<string | undefined>(cacheKey);
+        if (warnedSignature === missingSignature) {
             continue;
         }
 
@@ -1228,7 +1231,7 @@ export async function validateIncludePaths(context: vscode.ExtensionContext): Pr
             );
         }
 
-        await context.globalState.update(cacheKey, true);
+        await context.globalState.update(cacheKey, missingSignature);
     }
 }
 

--- a/vscode-extension/src/test/__mocks__/vscode.ts
+++ b/vscode-extension/src/test/__mocks__/vscode.ts
@@ -174,6 +174,7 @@ export const env = {
 };
 
 export const extensions = {
+  all: [] as any[],
   getExtension: jest.fn(() => undefined),
 };
 

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -114,6 +114,12 @@ describe('perl-lsp command palette commands (issue #2058)', () => {
   });
 
   describe('activation events', () => {
+    test('every contributed command has an activation event', () => {
+      for (const command of pkg.contributes.commands) {
+        expect(pkg.activationEvents).toContain(`onCommand:${command.command}`);
+      }
+    });
+
     for (const id of NEW_COMMAND_IDS) {
       test(`activates on ${id} command`, () => {
         expect(pkg.activationEvents).toContain(`onCommand:${id}`);

--- a/vscode-extension/src/test/debugAdapter.test.ts
+++ b/vscode-extension/src/test/debugAdapter.test.ts
@@ -165,9 +165,10 @@ describe('PerlDebugAdapterDescriptorFactory', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('returns undefined when perl-dap is not found anywhere', () => {
+  test('returns undefined and shows an actionable warning when perl-dap is not found anywhere', () => {
     const ctx = makeContext(tmpDir);
     const factory = new PerlDebugAdapterDescriptorFactory(ctx);
+    const vscode = require('vscode');
 
     const origPath = process.env.PATH;
     const origHome = process.env.HOME;
@@ -179,6 +180,11 @@ describe('PerlDebugAdapterDescriptorFactory', () => {
     try {
       const result = factory.createDebugAdapterDescriptor({} as any, undefined);
       expect(result).toBeUndefined();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining('perl-dap'),
+        'Reinstall',
+        'Open Debugging Guide'
+      );
     } finally {
       process.env.PATH = origPath;
       process.env.HOME = origHome;

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -59,11 +59,12 @@ describe('extension UX warnings', () => {
     fs.mkdirSync(path.join(workspaceDir, 'lib'), { recursive: true });
 
     const context = makeContext();
-    let warned = false;
+    let warnedSignature: string | undefined;
+    let includePaths = ['lib', 'src/libx'];
     const globalState = {
-      get: jest.fn(() => warned),
-      update: jest.fn(async (_key: string, value: boolean) => {
-        warned = value;
+      get: jest.fn(() => warnedSignature),
+      update: jest.fn(async (_key: string, value: string | undefined) => {
+        warnedSignature = value;
       }),
     };
     context.globalState = globalState;
@@ -73,7 +74,7 @@ describe('extension UX warnings', () => {
 
     const getConfiguration = vscode.workspace.getConfiguration as jest.Mock;
     getConfiguration.mockImplementation(() => ({
-      get: jest.fn(() => ['lib', 'src/libx']),
+      get: jest.fn(() => includePaths),
     }));
 
     (vscode.workspace as any).workspaceFolders = [
@@ -94,12 +95,19 @@ describe('extension UX warnings', () => {
     );
     expect(globalState.update).toHaveBeenCalledWith(
       expect.stringContaining('perl-lsp.includePathsWarning.'),
-      true
+      'src/libx'
     );
 
     showWarningMessage.mockClear();
     await validateIncludePaths(context);
     expect(showWarningMessage).not.toHaveBeenCalled();
+
+    includePaths = ['lib', 'vendorx'];
+    await validateIncludePaths(context);
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('vendorx'),
+      'Open Settings'
+    );
   });
 
   test('warns once per major version when conflicting Perl extensions are installed', async () => {

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Focused UX contract tests for extension startup warnings.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+jest.mock('vscode-languageclient/node', () => ({
+  LanguageClient: class {},
+  Trace: {
+    Off: 'off',
+    Messages: 'messages',
+    Verbose: 'verbose',
+  },
+  TransportKind: {
+    stdio: 0,
+  },
+}));
+import {
+  validateIncludePaths,
+  warnAboutPerlExtensionConflicts,
+} from '../extension';
+
+function makeContext(version = '0.12.3'): any {
+  return {
+    extension: {
+      packageJSON: {
+        publisher: 'EffortlessMetrics',
+        name: 'perl-lsp-rs',
+        version,
+      },
+    },
+    globalState: {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+    },
+  };
+}
+
+describe('extension UX warnings', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    (vscode.workspace as any).workspaceFolders = undefined;
+    (vscode.extensions as any).all = [];
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(
+      (section?: string) => ({
+        get: jest.fn((key: string, defaultValue?: any) => defaultValue),
+        has: jest.fn(() => false),
+        inspect: jest.fn(),
+        update: jest.fn(),
+      })
+    );
+    (vscode.window.showWarningMessage as jest.Mock).mockImplementation(async () => undefined);
+  });
+
+  test('warns once for missing include paths and offers settings', async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-ux-'));
+    fs.mkdirSync(path.join(workspaceDir, 'lib'), { recursive: true });
+
+    const context = makeContext();
+    let warned = false;
+    const globalState = {
+      get: jest.fn(() => warned),
+      update: jest.fn(async (_key: string, value: boolean) => {
+        warned = value;
+      }),
+    };
+    context.globalState = globalState;
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue(undefined);
+
+    const getConfiguration = vscode.workspace.getConfiguration as jest.Mock;
+    getConfiguration.mockImplementation(() => ({
+      get: jest.fn(() => ['lib', 'src/libx']),
+    }));
+
+    (vscode.workspace as any).workspaceFolders = [
+      {
+        name: 'workspace',
+        uri: {
+          fsPath: workspaceDir,
+          toString: () => `file://${workspaceDir}`,
+        },
+      },
+    ];
+
+    await validateIncludePaths(context);
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('src/libx'),
+      'Open Settings'
+    );
+    expect(globalState.update).toHaveBeenCalledWith(
+      expect.stringContaining('perl-lsp.includePathsWarning.'),
+      true
+    );
+
+    showWarningMessage.mockClear();
+    await validateIncludePaths(context);
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  test('warns once per major version when conflicting Perl extensions are installed', async () => {
+    const context = makeContext('0.12.3');
+    let warnedMajor: string | undefined;
+    context.globalState = {
+      get: jest.fn(() => warnedMajor),
+      update: jest.fn(async (_key: string, value: string) => {
+        warnedMajor = value;
+      }),
+    };
+
+    const showWarningMessage = vscode.window.showWarningMessage as jest.Mock;
+    showWarningMessage.mockResolvedValue(undefined);
+
+    (vscode.extensions as any).all = [
+      {
+        id: 'EffortlessMetrics.perl-lsp-rs',
+        packageJSON: {
+          publisher: 'EffortlessMetrics',
+          name: 'perl-lsp-rs',
+          version: '0.12.3',
+        },
+      },
+      {
+        id: 'example.perl-navigator',
+        packageJSON: {
+          displayName: 'Perl Navigator',
+          version: '1.0.0',
+          contributes: {
+            languages: [{ id: 'perl' }],
+          },
+        },
+      },
+    ];
+
+    await warnAboutPerlExtensionConflicts(context);
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Perl Navigator'),
+      'Open Coexistence Guide'
+    );
+
+    showWarningMessage.mockClear();
+    await warnAboutPerlExtensionConflicts(context);
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+});

--- a/vscode-extension/src/test/walkthrough.test.ts
+++ b/vscode-extension/src/test/walkthrough.test.ts
@@ -88,6 +88,14 @@ describe('package.json walkthrough contribution', () => {
     }
   });
 
+  test('debug step clearly marks debugging as optional and mentions perl-dap', () => {
+    const wt = pkg.contributes.walkthroughs[0];
+    const debugStep = wt.steps.find((step: any) => step.id === 'debug-first-script');
+    expect(debugStep).toBeDefined();
+    expect(debugStep.title).toMatch(/optional/i);
+    expect(debugStep.description).toMatch(/perl-dap/i);
+  });
+
   test('walkthrough activationEvents includes onWalkthrough', () => {
     // VSCode requires walkthroughs to be listed in activationEvents
     // with onWalkthrough:<id> so that the extension activates when


### PR DESCRIPTION
Closes #3452
Closes #3453
Closes #3454
Closes #3455

Summary:
- add onCommand activation events for every contributed command
- warn once per workspace when includePaths point at missing directories
- warn once per major version when conflicting Perl extensions are installed
- clarify walkthrough debugging requirements and make the missing perl-dap error actionable
- add focused UX contract tests for the new startup warnings

Validation:
- npm test -- --runInBand src/test/commands.test.ts src/test/walkthrough.test.ts src/test/debugAdapter.test.ts src/test/extensionUx.test.ts
- npm run compile