### PR TITLE
docs(assets): canonicalize demo asset plan (#3302)

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -6,6 +6,7 @@ Static assets used in project documentation and marketing surfaces.
 |-----------|---------|
 | [`gifs/`](gifs/) | Animated GIFs for README.md — recording guide and inventory |
 | [`recordings/`](recordings/) | Raw screen-capture files (gitignored, not committed) |
+| [`demo-asset-plan.toml`](demo-asset-plan.toml) | Canonical P0 walkthrough asset plan and filenames |
 
 ## Adding Assets
 
@@ -14,3 +15,5 @@ Static assets used in project documentation and marketing surfaces.
   `.gitignore`).
 - Other static images (diagrams, screenshots) can go in subdirectories here.
   Follow the naming convention of the nearest existing asset.
+- Use `python scripts/marketing/check-demo-assets.py --check` to validate the
+  canonical P0 walkthrough plan before recording.

--- a/docs/assets/demo-asset-plan.toml
+++ b/docs/assets/demo-asset-plan.toml
@@ -1,0 +1,38 @@
+[[asset]]
+name = "install-health"
+priority = "P0"
+kind = "gif"
+target = "vscode-extension/media/walkthrough/install-health.gif"
+storyboard = "vscode-extension/media/walkthrough/install-health.svg"
+recording = "docs/assets/recordings/install-health.mp4"
+source_files = [
+  "demo_workspace/main.pl",
+  "demo_workspace/lib/Utils.pm",
+  "demo_workspace/lib/Database.pm",
+]
+notes = "Fresh install -> auto-download -> health check"
+
+[[asset]]
+name = "find-references"
+priority = "P0"
+kind = "gif"
+target = "vscode-extension/media/walkthrough/find-references.gif"
+storyboard = "vscode-extension/media/walkthrough/find-references.svg"
+recording = "docs/assets/recordings/find-references.mp4"
+source_files = [
+  "demo_workspace/main.pl",
+  "demo_workspace/lib/Utils.pm",
+]
+notes = "Go to definition + find references over the demo workspace"
+
+[[asset]]
+name = "extract-variable"
+priority = "P0"
+kind = "gif"
+target = "vscode-extension/media/walkthrough/extract-variable.gif"
+storyboard = "vscode-extension/media/walkthrough/extract-variable.svg"
+recording = "docs/assets/recordings/extract-variable.mp4"
+source_files = [
+  "demo_workspace/main.pl",
+]
+notes = "Select an expression and extract it into a named variable"

--- a/docs/assets/gifs/README.md
+++ b/docs/assets/gifs/README.md
@@ -9,12 +9,15 @@ surfaces. Each GIF is produced from a manual screen-recording session using the
 | Filename | Feature | Max Size | Duration |
 |----------|---------|---------|---------|
 | `install-health.gif` | VS Code install, extension auto-download, `perllsp --health` output | 3 MB | 15 s |
-| `goto-definition.gif` | Ctrl+Click go to definition, Find All References panel | 3 MB | 15 s |
+| `find-references.gif` | Ctrl+Click go to definition, Find All References panel | 3 MB | 15 s |
 | `extract-variable.gif` | Select expression, light-bulb, Extract Variable code action | 3 MB | 12 s |
 
 None of these files can be created by an automated agent because each requires a
 live editor session with a running LSP server. See the [recording guide](#recording-guide)
 below for instructions.
+
+The canonical P0 tracker lives in [`../demo-asset-plan.toml`](../demo-asset-plan.toml)
+and the reporting helper is [`../../../scripts/marketing/check-demo-assets.py`](../../../scripts/marketing/check-demo-assets.py).
 
 ## Storyboard Reference
 
@@ -25,7 +28,7 @@ Use them to rehearse the flow before recording.
 | GIF | Storyboard |
 |-----|-----------|
 | `install-health.gif` | [`install-health.svg`](../../../vscode-extension/media/walkthrough/install-health.svg) |
-| `goto-definition.gif` | [`find-references.svg`](../../../vscode-extension/media/walkthrough/find-references.svg) |
+| `find-references.gif` | [`find-references.svg`](../../../vscode-extension/media/walkthrough/find-references.svg) |
 | `extract-variable.gif` | [`extract-variable.svg`](../../../vscode-extension/media/walkthrough/extract-variable.svg) |
 
 ## Demo Workspace
@@ -95,7 +98,7 @@ Steps to record:
 
 Keep the terminal text large enough to read in the final GIF.
 
-### GIF #2 — Go to Definition and Find References (`goto-definition.gif`)
+### GIF #2 — Go to Definition and Find References (`find-references.gif`)
 
 Goal: show instant cross-file navigation.
 
@@ -140,8 +143,8 @@ Trim dead time at the start or end with `--start` and `--duration`:
 
 ```bash
 python scripts/marketing/render-walkthrough-gif.py \
-  --input recordings/goto-definition.mp4 \
-  --output docs/assets/gifs/goto-definition.gif \
+  --input recordings/find-references.mp4 \
+  --output docs/assets/gifs/find-references.gif \
   --start 00:00:01.5 \
   --duration 00:00:14.0 \
   --fps 12 \
@@ -169,18 +172,18 @@ between the "Why Teams Pick It" and "Quick Start" sections:
 
 | Install and Health Check | Go to Definition | Extract Variable |
 |:---:|:---:|:---:|
-| ![Install](docs/assets/gifs/install-health.gif) | ![Go to Def](docs/assets/gifs/goto-definition.gif) | ![Extract](docs/assets/gifs/extract-variable.gif) |
+| ![Install](docs/assets/gifs/install-health.gif) | ![Go to Def](docs/assets/gifs/find-references.gif) | ![Extract](docs/assets/gifs/extract-variable.gif) |
 ```
 
 GitHub renders GIFs inline in Markdown so no special hosting is required.
 
 ## File Naming and Versioning
 
-- Name GIF files after the feature, not the version: `goto-definition.gif` not
-  `goto-def-v1.gif`.
+- Name GIF files after the feature, not the version: `find-references.gif` not
+  `find-references-v1.gif`.
 - When a workflow changes enough to require a re-record, replace the file in
   place and commit with a message like:
-  `docs: re-record goto-definition gif for v0.13 navigation changes`
+  `docs: re-record find-references gif for v0.13 navigation changes`
 - Raw recordings are large and should not be committed. Add them to
   `docs/assets/recordings/` which is gitignored.
 

--- a/docs/assets/recordings/README.md
+++ b/docs/assets/recordings/README.md
@@ -12,7 +12,7 @@ Expected files:
 | File | Produces |
 |------|---------|
 | `install-health.mp4` | `docs/assets/gifs/install-health.gif` |
-| `goto-definition.mp4` | `docs/assets/gifs/goto-definition.gif` |
+| `find-references.mp4` | `docs/assets/gifs/find-references.gif` |
 | `extract-variable.mp4` | `docs/assets/gifs/extract-variable.gif` |
 
 See [`../gifs/README.md`](../gifs/README.md) for the full recording guide.

--- a/scripts/marketing/check-demo-assets.py
+++ b/scripts/marketing/check-demo-assets.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Report the planned demo assets and validate the capture plan."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(frozen=True)
+class Asset:
+    name: str
+    priority: str
+    kind: str
+    target: Path
+    storyboard: Path
+    recording: Path
+    source_files: list[Path]
+    notes: str
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_assets(manifest: Path) -> list[Asset]:
+    with manifest.open("rb") as handle:
+        payload = tomllib.load(handle)
+
+    assets: list[Asset] = []
+    for entry in payload.get("asset", []):
+        assets.append(
+            Asset(
+                name=entry["name"],
+                priority=entry["priority"],
+                kind=entry["kind"],
+                target=Path(entry["target"]),
+                storyboard=Path(entry["storyboard"]),
+                recording=Path(entry["recording"]),
+                source_files=[Path(path) for path in entry.get("source_files", [])],
+                notes=entry.get("notes", ""),
+            )
+        )
+    return assets
+
+
+def format_status(asset: Asset, root: Path) -> str:
+    target = root / asset.target
+    storyboard = root / asset.storyboard
+    recording = root / asset.recording
+
+    target_state = "present" if target.exists() else "missing"
+    recording_state = "present" if recording.exists() else "missing"
+    storyboard_state = "present" if storyboard.exists() else "missing"
+
+    return (
+        f"{asset.priority} {asset.name}: target={target_state}, "
+        f"recording={recording_state}, storyboard={storyboard_state}"
+    )
+
+
+def validate_assets(assets: list[Asset], root: Path) -> list[str]:
+    errors: list[str] = []
+    expected = {"install-health", "find-references", "extract-variable"}
+
+    names = {asset.name for asset in assets}
+    if names != expected:
+        errors.append(
+            "manifest should contain exactly the three P0 walkthrough assets "
+            f"{sorted(expected)}, found {sorted(names)}"
+        )
+
+    for asset in assets:
+        if asset.kind != "gif":
+            errors.append(f"{asset.name}: expected kind=gif, got {asset.kind!r}")
+        if not (root / asset.storyboard).exists():
+            errors.append(f"{asset.name}: missing storyboard {asset.storyboard}")
+        for source in asset.source_files:
+            if not (root / source).exists():
+                errors.append(f"{asset.name}: missing source file {source}")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Report the current demo-asset plan and validate the P0 walkthrough tracker.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="docs/assets/demo-asset-plan.toml",
+        help="Path to the asset-plan manifest (default: docs/assets/demo-asset-plan.toml).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate the manifest and referenced source/storyboard files.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    root = repo_root()
+    manifest = root / args.manifest
+
+    if not manifest.exists():
+        print(f"error: manifest not found: {manifest}", file=sys.stderr)
+        return 2
+
+    assets = load_assets(manifest)
+
+    for asset in assets:
+        print(format_status(asset, root))
+        print(f"  target:     {asset.target}")
+        print(f"  storyboard: {asset.storyboard}")
+        print(f"  recording:  {asset.recording}")
+        if asset.notes:
+            print(f"  notes:      {asset.notes}")
+
+    if args.check:
+        errors = validate_assets(assets, root)
+        if errors:
+            print("\nvalidation errors:", file=sys.stderr)
+            for error in errors:
+                print(f"- {error}", file=sys.stderr)
+            return 1
+        print("\nmanifest check passed")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vscode-extension/media/walkthrough/README.md
+++ b/vscode-extension/media/walkthrough/README.md
@@ -1,6 +1,6 @@
 # Walkthrough Assets
 
-This directory is the current home for the launch-demo visuals called out in issue #2336.
+This directory is the current home for the launch-demo visuals called out in issue #3302.
 
 Status:
 - The SVG files in this folder are storyboard previews, not recorded GIFs.
@@ -14,6 +14,9 @@ Status:
 | `install-health.gif` | [`install-health.svg`](install-health.svg) | Fresh install, extension auto-download, and `perllsp --health` |
 | `find-references.gif` | [`find-references.svg`](find-references.svg) | Go to definition and find references over `demo_workspace/main.pl` and `demo_workspace/lib/Utils.pm` |
 | `extract-variable.gif` | [`extract-variable.svg`](extract-variable.svg) | Code action refactor flow in `demo_workspace/main.pl` |
+
+For the canonical capture checklist and asset names, see
+[`../../../docs/assets/demo-asset-plan.toml`](../../../docs/assets/demo-asset-plan.toml).
 
 ## Manual Capture Notes
 


### PR DESCRIPTION
This narrows UX issue #3302 without touching unrelated Rust crates or `vscode-extension/package.json`.

What changed:
- Added a canonical P0 demo asset manifest at `docs/assets/demo-asset-plan.toml`.
- Added `scripts/marketing/check-demo-assets.py` to report/check the asset punch list.
- Fixed stale naming drift in the assets docs by standardizing on `find-references.gif`.
- Linked the walkthrough/media docs back to the canonical asset plan.

Validation:
- `python3 scripts/marketing/check-demo-assets.py --check`
- `git diff --check`

Notes:
- The actual demo GIFs/recordings are still missing; this PR makes the punch list canonical and machine-checkable so the remaining work is easier to finish.