### PR TITLE
fix(perlcritic): map gentle severities to hint and warn on missing tool (#3470)

### DIFF
--- a/crates/perl-lsp-tooling/src/perl_critic/types.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic/types.rs
@@ -40,7 +40,7 @@ impl Severity {
         match self {
             Self::Brutal | Self::Cruel => lsp_types::DiagnosticSeverity::ERROR,
             Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
-            Self::Stern | Self::Gentle => lsp_types::DiagnosticSeverity::INFORMATION,
+            Self::Stern | Self::Gentle => lsp_types::DiagnosticSeverity::HINT,
         }
     }
 

--- a/crates/perl-lsp-tooling/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-tooling/tests/comprehensive_unit_tests.rs
@@ -367,8 +367,8 @@ fn severity_to_diagnostic_severity() {
     assert_eq!(Severity::Brutal.to_diagnostic_severity(), DiagnosticSeverity::ERROR);
     assert_eq!(Severity::Cruel.to_diagnostic_severity(), DiagnosticSeverity::ERROR);
     assert_eq!(Severity::Harsh.to_diagnostic_severity(), DiagnosticSeverity::WARNING);
-    assert_eq!(Severity::Stern.to_diagnostic_severity(), DiagnosticSeverity::INFORMATION);
-    assert_eq!(Severity::Gentle.to_diagnostic_severity(), DiagnosticSeverity::INFORMATION);
+    assert_eq!(Severity::Stern.to_diagnostic_severity(), DiagnosticSeverity::HINT);
+    assert_eq!(Severity::Gentle.to_diagnostic_severity(), DiagnosticSeverity::HINT);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -2057,7 +2057,7 @@ fn critic_analyzer_to_diagnostics_multiple_severities() {
     assert_eq!(diagnostics.len(), 3);
     assert_eq!(diagnostics[0].severity, Some(lsp_types::DiagnosticSeverity::ERROR));
     assert_eq!(diagnostics[1].severity, Some(lsp_types::DiagnosticSeverity::WARNING));
-    assert_eq!(diagnostics[2].severity, Some(lsp_types::DiagnosticSeverity::INFORMATION));
+    assert_eq!(diagnostics[2].severity, Some(lsp_types::DiagnosticSeverity::HINT));
 }
 
 #[cfg(feature = "lsp-compat")]

--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -63,6 +63,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_warning_shown: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -166,6 +168,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_warning_shown: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -232,6 +236,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_warning_shown: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -755,7 +755,7 @@ impl LspServer {
     /// installed on the system. If both conditions are met, runs perlcritic on
     /// the file and appends violations with severity mapped from Perl::Critic's
     /// 1-5 scale to LSP severity levels (Brutal/Cruel -> Error, Harsh ->
-    /// Warning, Stern/Gentle -> Information).
+    /// Warning, Stern/Gentle -> Hint).
     ///
     /// The `CriticAnalyzer` is reused across calls via `self.critic_analyzer`
     /// so that the per-file violation cache survives between `didChange` events.
@@ -763,9 +763,26 @@ impl LspServer {
     /// analyzer is reset to `None` from `didChangeConfiguration` whenever any
     /// critic-related setting changes.
     ///
-    /// Silently skips if perlcritic is not installed or the URI is not a file.
+    /// Warns once if perlcritic is not installed or the URI is not a file.
     /// The `doc_text` parameter is used to convert perlcritic's line/column
     /// positions into byte offsets for the internal diagnostic range.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn warn_perlcritic_missing_once(&self) {
+        if !self.should_emit_perlcritic_missing_warning() {
+            return;
+        }
+
+        let message = perlcritic_missing_warning_message();
+        if let Err(e) = self.show_message(crate::runtime::window::MessageType::Warning, &message) {
+            tracing::warn!(error = %e, "Failed to send perlcritic missing warning");
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn should_emit_perlcritic_missing_warning(&self) -> bool {
+        !self.perlcritic_missing_warning_shown.swap(true, std::sync::atomic::Ordering::Relaxed)
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn collect_external_perlcritic_diagnostics(
         &self,
@@ -797,7 +814,7 @@ impl LspServer {
             }
         };
 
-        // Silently skip if perlcritic is not installed.
+        // Warn the user once if perlcritic is not installed.
         // The `skip_perlcritic_command_check` flag is always `false` in production
         // and is only set to `true` through the test helper
         // `LspServer::test_bypass_perlcritic_command_check`, enabling mock-runtime
@@ -805,6 +822,7 @@ impl LspServer {
         let skip_check =
             self.skip_perlcritic_command_check.load(std::sync::atomic::Ordering::Relaxed);
         if !skip_check && !crate::execute_command::command_exists("perlcritic") {
+            self.warn_perlcritic_missing_once();
             return;
         }
 
@@ -874,15 +892,13 @@ impl LspServer {
                 for v in violations {
                     // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
                     // Brutal(1)/Cruel(2) -> Error, Harsh(3) -> Warning,
-                    // Stern(4)/Gentle(5) -> Information
+                    // Stern(4)/Gentle(5) -> Hint
                     let internal_severity = match v.severity {
                         crate::perl_critic::Severity::Brutal
                         | crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Error,
                         crate::perl_critic::Severity::Harsh => InternalDiagnosticSeverity::Warning,
                         crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Gentle => {
-                            InternalDiagnosticSeverity::Information
-                        }
+                        | crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Hint,
                     };
 
                     // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
@@ -973,5 +989,51 @@ fn builtin_violation_to_diagnostic(
         related_information: Vec::new(),
         tags: Vec::new(),
         suggestion: None,
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn perlcritic_missing_warning_message() -> String {
+    "Perl::Critic is not installed, so perlcritic diagnostics are disabled. Install it with `cpan Perl::Critic` or your system package manager, then reload the file."
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn perlcritic_missing_warning_message_mentions_install_step() {
+        let message = perlcritic_missing_warning_message();
+        assert!(message.contains("Perl::Critic is not installed"));
+        assert!(message.contains("cpan Perl::Critic"));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn perlcritic_missing_warning_is_emitted_once() {
+        let server = LspServer::new();
+        assert!(server.should_emit_perlcritic_missing_warning());
+        assert!(!server.should_emit_perlcritic_missing_warning());
+    }
+
+    #[test]
+    fn builtin_violation_maps_gentle_to_hint() {
+        let violation = crate::perl_critic::Violation {
+            policy: "GentlePolicy".to_string(),
+            description: "gentle".to_string(),
+            explanation: String::new(),
+            severity: crate::perl_critic::Severity::Gentle,
+            range: perl_parser::position::Range {
+                start: perl_parser::position::Position { byte: 0, line: 0, column: 0 },
+                end: perl_parser::position::Position { byte: 0, line: 0, column: 1 },
+            },
+            file: "test.pl".to_string(),
+        };
+
+        let diagnostic = builtin_violation_to_diagnostic(&violation);
+        assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Hint);
+        assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
     }
 }

--- a/crates/perl-lsp/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp/src/runtime/language/code_actions.rs
@@ -110,7 +110,8 @@ impl LspServer {
                                 crate::perl_critic::Severity::Brutal |
                                 crate::perl_critic::Severity::Cruel => 1, // Error
                                 crate::perl_critic::Severity::Harsh => 2, // Warning
-                                _ => 3, // Information
+                                crate::perl_critic::Severity::Stern
+                                | crate::perl_critic::Severity::Gentle => 4, // Hint
                             },
                             "code": violation.policy.clone(),
                             "source": "Perl::Critic",

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -273,6 +273,9 @@ pub struct LspServer {
     /// Initialized to `false`; only the test helper methods flip this.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) skip_perlcritic_command_check: AtomicBool,
+    /// Ensures the missing perlcritic warning is only surfaced once.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_missing_warning_shown: AtomicBool,
     /// Optional AI inline-completion backend.
     ///
     /// When `Some`, the `handle_inline_completion` handler will attempt


### PR DESCRIPTION
Summary:
- Map Perl::Critic severities 4/5 to LSP Hint instead of Information.
- Surface a one-time warning when perlcritic is enabled but the perlcritic binary is missing.

Tests:
- cargo fmt --all
- cargo test -p perl-lsp-tooling severity_to_diagnostic_severity
- cargo test -p perl-lsp-rs perlcritic_missing_warning
- cargo test -p perl-lsp-rs builtin_violation_maps_gentle_to_hint

Deferred:
- Perlcritic settings UI/schema expansion.
- New code actions beyond the existing quick-fix plumbing.
- Profile/severity configuration UX changes in VS Code settings.