### PR TITLE
fix(analysis): resolve UNIVERSAL methods (#3383)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -679,6 +679,13 @@ fn lookup_workspace_definition(
 
     if let Some(def_location) = find_workspace_definition_location(workspace_index, pkg, name)
         .or_else(|| inherited_method_definition_location(workspace_index, pkg, name))
+        .or_else(|| {
+            if is_universal_method(name) {
+                find_workspace_definition_location(workspace_index, "UNIVERSAL", name)
+            } else {
+                None
+            }
+        })
     {
         if let Some(lsp_location) =
             crate::workspace_index::lsp_adapter::to_lsp_location(&def_location)
@@ -688,6 +695,12 @@ fn lookup_workspace_definition(
     }
 
     None
+}
+
+const UNIVERSAL_METHODS: [&str; 4] = ["can", "isa", "DOES", "VERSION"];
+
+fn is_universal_method(name: &str) -> bool {
+    UNIVERSAL_METHODS.contains(&name)
 }
 
 impl LspServer {
@@ -1081,6 +1094,15 @@ impl LspServer {
                                 ) {
                                     return Ok(Some(result));
                                 }
+                                if is_universal_method(method_name)
+                                    && let Some(result) = lookup_workspace_definition(
+                                        self.coordinator(),
+                                        "UNIVERSAL",
+                                        method_name,
+                                    )
+                                {
+                                    return Ok(Some(result));
+                                }
                                 // Partial/None: fall through to same-file resolution
                                 break;
                             }
@@ -1116,6 +1138,15 @@ impl LspServer {
                                             return Ok(Some(result));
                                         }
                                     }
+                                }
+                                if is_universal_method(method_name)
+                                    && let Some(result) = lookup_workspace_definition(
+                                        self.coordinator(),
+                                        "UNIVERSAL",
+                                        method_name,
+                                    )
+                                {
+                                    return Ok(Some(result));
                                 }
                                 // Fall through for non-self variables
                                 break;

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -720,6 +720,181 @@ $dog->fetch('stick');
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Test 4c: UNIVERSAL methods fall back when the class does not shadow them
+// ---------------------------------------------------------------------------
+
+#[test]
+fn go_to_definition_universal_methods_fall_back_to_universal() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/UNIVERSAL.pm",
+        r#"package UNIVERSAL;
+
+sub can { 1 }
+sub isa { 1 }
+sub DOES { 1 }
+sub VERSION { 1 }
+
+1;
+"#,
+    )?;
+
+    workspace.write(
+        "lib/Base.pm",
+        r#"package Base;
+use strict;
+use warnings;
+
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let universal_uri = workspace.uri("lib/UNIVERSAL.pm");
+    let universal_content = std::fs::read_to_string(workspace.dir.path().join("lib/UNIVERSAL.pm"))
+        .map_err(|e| format!("failed to read UNIVERSAL.pm: {e}"))?;
+    harness.open(&universal_uri, &universal_content)?;
+
+    let base_uri = workspace.uri("lib/Base.pm");
+    let base_content = std::fs::read_to_string(workspace.dir.path().join("lib/Base.pm"))
+        .map_err(|e| format!("failed to read Base.pm: {e}"))?;
+    harness.open(&base_uri, &base_content)?;
+
+    harness.open(
+        &workspace.uri("app.pl"),
+        r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use Base;
+
+Base->can();
+Base->isa();
+Base->DOES();
+Base->VERSION();
+"#,
+    )?;
+
+    harness.barrier();
+
+    for (line, method) in [(5, "can"), (6, "isa"), (7, "DOES"), (8, "VERSION")] {
+        let result = harness.request(
+            "textDocument/definition",
+            json!({
+                "textDocument": {"uri": workspace.uri("app.pl")},
+                "position": {"line": line, "character": 8}
+            }),
+        )?;
+
+        if let Some(locations) = result.as_array() {
+            if !locations.is_empty() {
+                let first = &locations[0];
+                assert_valid_location(first);
+
+                let uri = first["uri"].as_str().ok_or("Expected URI")?;
+                assert!(
+                    uri.contains("UNIVERSAL.pm"),
+                    "Definition of {method} should point to UNIVERSAL.pm, got: {uri}"
+                );
+            } else {
+                return Err(format!("expected definition location for {method}").into());
+            }
+        } else {
+            return Err(format!("expected definition result array for {method}").into());
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn go_to_definition_shadowed_universal_method_stays_on_class_method() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/UNIVERSAL.pm",
+        r#"package UNIVERSAL;
+
+sub can { 1 }
+
+1;
+"#,
+    )?;
+
+    workspace.write(
+        "lib/Base.pm",
+        r#"package Base;
+use strict;
+use warnings;
+
+sub can { 1 }
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let universal_uri = workspace.uri("lib/UNIVERSAL.pm");
+    let universal_content = std::fs::read_to_string(workspace.dir.path().join("lib/UNIVERSAL.pm"))
+        .map_err(|e| format!("failed to read UNIVERSAL.pm: {e}"))?;
+    harness.open(&universal_uri, &universal_content)?;
+
+    let base_uri = workspace.uri("lib/Base.pm");
+    let base_content = std::fs::read_to_string(workspace.dir.path().join("lib/Base.pm"))
+        .map_err(|e| format!("failed to read Base.pm: {e}"))?;
+    harness.open(&base_uri, &base_content)?;
+
+    harness.open(
+        &workspace.uri("app.pl"),
+        r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use Base;
+
+Base->can();
+"#,
+    )?;
+
+    harness.barrier();
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": 5, "character": 8}
+        }),
+    )?;
+
+    if let Some(locations) = result.as_array() {
+        if !locations.is_empty() {
+            let first = &locations[0];
+            assert_valid_location(first);
+
+            let uri = first["uri"].as_str().ok_or("Expected URI")?;
+            assert!(
+                uri.contains("Base.pm"),
+                "Definition should stay on Base.pm when Base shadows UNIVERSAL, got: {uri}"
+            );
+        } else {
+            return Err("expected at least one definition location for shadowed can".into());
+        }
+    } else {
+        return Err("expected definition result array for shadowed can".into());
+    }
+
+    Ok(())
+}
+
 #[test]
 fn go_to_definition_cross_file_constructor_assigned_bare_method_call_in_framework_workspace()
 -> TestResult {

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -4,6 +4,7 @@
 //! Supports LocationLink for enhanced client experience.
 
 use crate::ast::{Node, NodeKind};
+use crate::symbol::is_universal_method;
 use crate::workspace_index::{SymKind, SymbolKey};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
@@ -491,6 +492,17 @@ impl<'a> DeclarationProvider<'a> {
 
             if let Some(decl) =
                 declarations.iter().find(|d| self.find_current_package(d) == Some(pkg))
+            {
+                return Some(vec![self.create_location_link(
+                    node,
+                    decl,
+                    self.get_subroutine_name_range(decl),
+                )]);
+            }
+
+            if is_universal_method(method_name)
+                && let Some(decl) =
+                    declarations.iter().find(|d| self.find_current_package(d) == Some("UNIVERSAL"))
             {
                 return Some(vec![self.create_location_link(
                     node,

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -35,7 +35,7 @@ pub use tokens::{SemanticToken, SemanticTokenModifier, SemanticTokenType};
 use crate::SourceLocation;
 use crate::analysis::class_model::{ClassModel, ClassModelBuilder, MethodResolutionOrder};
 use crate::ast::Node;
-use crate::symbol::{Symbol, SymbolExtractor, SymbolTable};
+use crate::symbol::{Symbol, SymbolExtractor, SymbolTable, is_universal_method};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
@@ -298,6 +298,20 @@ impl SemanticAnalyzer {
             }
         }
 
+        if is_universal_method(method_name) {
+            return self
+                .symbol_table
+                .symbols
+                .get(method_name)
+                .and_then(|symbols| {
+                    symbols.iter().find(|symbol| {
+                        symbol.kind == crate::symbol::SymbolKind::Subroutine
+                            && symbol.qualified_name == format!("UNIVERSAL::{method_name}")
+                    })
+                })
+                .map(|symbol| symbol.location);
+        }
+
         None
     }
 
@@ -335,6 +349,14 @@ impl SemanticAnalyzer {
             {
                 return Some(hover);
             }
+        }
+
+        if is_universal_method(method_name) {
+            return Some(HoverInfo {
+                signature: format!("sub UNIVERSAL::{method_name}"),
+                documentation: None,
+                details: vec!["Defined in UNIVERSAL".to_string()],
+            });
         }
 
         None
@@ -388,6 +410,14 @@ impl SemanticAnalyzer {
                 signature: format!("sub {}::{}", package_name, method_name),
                 documentation: None,
                 details: vec![format!("Inherited from {}", package_name)],
+            });
+        }
+
+        if is_universal_method(method_name) {
+            return Some(HoverInfo {
+                signature: format!("sub UNIVERSAL::{method_name}"),
+                documentation: None,
+                details: vec!["Defined in UNIVERSAL".to_string()],
             });
         }
 
@@ -621,6 +651,38 @@ Foo::bar();
 
         let hover = analyzer.hover_at(def.location).ok_or("hover not found")?;
         assert!(hover.documentation.as_ref().ok_or("doc not found")?.contains("bar sub"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_universal_method_hover_fallback() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+package UNIVERSAL;
+sub can { 1 }
+sub isa { 1 }
+
+package Foo;
+sub new { bless {}, shift }
+"#;
+
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let hover = analyzer
+            .resolve_inherited_method_hover("Foo", "can")
+            .ok_or("expected UNIVERSAL hover fallback")?;
+
+        assert!(
+            hover.signature.contains("UNIVERSAL::can"),
+            "expected UNIVERSAL hover signature, got: {}",
+            hover.signature
+        );
+        assert!(
+            hover.details.iter().any(|detail| detail.contains("UNIVERSAL")),
+            "expected UNIVERSAL hover details, got: {:?}",
+            hover.details
+        );
         Ok(())
     }
 

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -30,6 +30,8 @@ use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 
+const UNIVERSAL_METHODS: [&str; 4] = ["can", "isa", "DOES", "VERSION"];
+
 // Re-export the unified symbol types from perl-symbol-types
 /// Symbol kind enums used during Index/Analyze workflows.
 pub use perl_symbol_types::{SymbolKind, VarKind};
@@ -202,6 +204,11 @@ pub struct SymbolTable {
     next_scope_id: ScopeId,
     /// Current package context for symbol qualification
     current_package: String,
+}
+
+/// Return `true` if the method is one of Perl's always-available `UNIVERSAL` methods.
+pub fn is_universal_method(method_name: &str) -> bool {
+    UNIVERSAL_METHODS.contains(&method_name)
 }
 
 impl SymbolTable {


### PR DESCRIPTION
Adds UNIVERSAL fallback for can/isa/DOES/VERSION in cross-file go-to-definition and semantic hover, while preserving class-local overrides.\n\nTests:\n- cargo fmt --all --check\n- cargo test -p perl-semantic-analyzer test_universal_method_hover_fallback\n- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_universal_methods_fall_back_to_universal\n- cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_shadowed_universal_method_stays_on_class_method