### PR TITLE
fix(scope): isolate phase blocks in scope analysis (#3377)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1000,6 +1000,14 @@ impl ScopeAnalyzer {
                 self.collect_unused_variables(&block_scope, issues, context);
             }
 
+            NodeKind::PhaseBlock { block, .. } => {
+                let phase_scope = Rc::new(Scope::with_parent(scope.clone()));
+                ancestors.push(node);
+                self.analyze_node(block, &phase_scope, ancestors, issues, context);
+                ancestors.pop();
+                self.collect_unused_variables(&phase_scope, issues, context);
+            }
+
             NodeKind::For { init, condition, update, body, .. } => {
                 let loop_scope = Rc::new(Scope::with_parent(scope.clone()));
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -3083,6 +3083,50 @@ fn phase_block_symbol_in_global_scope() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
+#[test]
+fn phase_block_local_lexical_does_not_leak_outside() -> Result<(), Box<dyn std::error::Error>> {
+    for phase in ["BEGIN", "CHECK", "INIT", "UNITCHECK", "END"] {
+        let code = format!(
+            r#"
+use strict;
+{phase} {{
+    my $inner = 1;
+}}
+print $inner;
+"#
+        );
+        let issues = scope_issues_strict(&code);
+        assert!(
+            has_issue(&issues, IssueKind::UndeclaredVariable, "inner"),
+            "{} block lexical must not leak to outer scope; issues: {:?}",
+            phase,
+            issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn phase_block_local_lexical_does_not_leak_to_sibling_phase()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+BEGIN {
+    my $inner = 1;
+}
+CHECK {
+    print $inner;
+}
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        has_issue(&issues, IssueKind::UndeclaredVariable, "inner"),
+        "BEGIN lexical must not leak into sibling phaser; issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
 // ---- Issue #3503: variables in print comma-separated args must be marked used ----
 
 #[test]


### PR DESCRIPTION
## Summary
Add a dedicated scope boundary for `PhaseBlock` nodes so lexicals declared inside BEGIN/CHECK/INIT/END/UNITCHECK blocks do not leak into the outer scope or sibling phaser blocks.

## Validation
- `cargo fmt --all`
- `cargo test -p perl-semantic-analyzer socketpair_both_positions_declared -- --nocapture`
- `cargo test -p perl-semantic-analyzer socketpair_non_handle_positions_not_consumed -- --nocapture`
- `cargo test -p perl-semantic-analyzer package_stmt_does_not_break_my_variable_tracking -- --nocapture`
- `cargo test -p perl-semantic-analyzer package_stmt_our_no_false_redeclaration -- --nocapture`
- `cargo test -p perl-semantic-analyzer package_block_creates_scope_boundary -- --nocapture`
- `cargo test -p perl-semantic-analyzer package_block_inner_vars_not_visible_outside -- --nocapture`
- `cargo test -p perl-semantic-analyzer phase_block_local_lexical_does_not_leak_outside -- --nocapture`
- `cargo test -p perl-semantic-analyzer phase_block_local_lexical_does_not_leak_to_sibling_phase -- --nocapture`
- `cargo test -p perl-semantic-analyzer phase_block_symbol_in_global_scope -- --nocapture`
- `cargo test -p perl-semantic-analyzer phase_block_all_five_extracted -- --nocapture`

## Notes
`#3346` and `#3356` were already present in the current master history, so they were not part of this write set.
