### PR TITLE
test(quality): add missing perl-tdd-support dev-deps (#3261)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ dependencies = [
 name = "perl-dead-code"
 version = "0.12.3"
 dependencies = [
+ "perl-tdd-support",
  "perl-workspace-index",
  "serde",
  "serde_json",
@@ -1992,6 +1993,7 @@ dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
  "perl-lsp-feature-profile",
+ "perl-tdd-support",
 ]
 
 [[package]]

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -27,6 +27,7 @@ perl-workspace-index = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+perl-tdd-support = { workspace = true }
 serde_json = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -20,6 +20,9 @@ perl-lsp-feature-contracts = { workspace = true }
 perl-lsp-feature-profile = { workspace = true }
 perl-lsp-feature-flags = { workspace = true }
 
+[dev-dependencies]
+perl-tdd-support = { workspace = true }
+
 [features]
 lsp-ga-lock = [
     "perl-lsp-feature-contracts/lsp-ga-lock",


### PR DESCRIPTION
Adds the missing `perl-tdd-support = { workspace = true }` dev-dependency to the two crates that were still missing it: `perl-dead-code` and `perl-lsp-feature-policy`.\n\nValidation: `cargo check -p perl-dead-code -p perl-lsp-feature-policy --tests`