### PR TITLE
fix(perl-pragma): track utf8, encoding, locale, and unicode_strings (#3367)

### DIFF
--- a/crates/perl-parser/benches/scope_benchmark.rs
+++ b/crates/perl-parser/benches/scope_benchmark.rs
@@ -78,9 +78,7 @@ fn benchmark_strict_barewords(c: &mut Criterion) {
             strict_vars: true,
             strict_refs: true,
             warnings: true,
-            disabled_warning_categories: Vec::new(),
-            features: Vec::new(),
-            builtin_imports: Vec::new(),
+            ..PragmaState::default()
         },
     )];
 

--- a/crates/perl-parser/tests/scope_analysis_test.rs
+++ b/crates/perl-parser/tests/scope_analysis_test.rs
@@ -29,9 +29,7 @@ fn analyze_strict(code: &str) -> Vec<ScopeIssue> {
             strict_subs: true,
             strict_vars: true,
             warnings: true,
-            disabled_warning_categories: Vec::new(),
-            features: Vec::new(),
-            builtin_imports: Vec::new(),
+            ..PragmaState::default()
         },
     )];
 

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -33,6 +33,16 @@ pub struct PragmaState {
     pub strict_refs: bool,
     /// Whether warnings are enabled (globally)
     pub warnings: bool,
+    /// Whether `use utf8` is enabled.
+    pub utf8: bool,
+    /// Active source encoding from `use encoding`.
+    pub encoding: Option<String>,
+    /// Whether `use feature 'unicode_strings'` or a matching feature bundle is enabled.
+    pub unicode_strings: bool,
+    /// Whether locale-sensitive behavior is enabled.
+    pub locale: bool,
+    /// Locale scope from `use locale`, if any.
+    pub locale_scope: Option<String>,
     /// Warning categories explicitly disabled via `no warnings 'CATEGORY'`.
     ///
     /// When `no warnings` is used with specific category arguments (e.g.
@@ -59,6 +69,11 @@ impl PragmaState {
             strict_subs: true,
             strict_refs: true,
             warnings: false,
+            utf8: false,
+            encoding: None,
+            unicode_strings: false,
+            locale: false,
+            locale_scope: None,
             disabled_warning_categories: Vec::new(),
             features: Vec::new(),
             builtin_imports: Vec::new(),
@@ -229,6 +244,16 @@ fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
     }
 }
 
+fn pragma_arg_items(arg: &str) -> Vec<String> {
+    let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
+
+    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+        return inner.split_whitespace().map(|item| item.to_string()).collect();
+    }
+
+    vec![trimmed.to_string()]
+}
+
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
@@ -306,29 +331,59 @@ impl PragmaTracker {
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }
+                    "utf8" => {
+                        current_state.utf8 = true;
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "encoding" => {
+                        current_state.encoding = args
+                            .first()
+                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "locale" => {
+                        current_state.locale = true;
+                        current_state.locale_scope = args
+                            .first()
+                            .map(|arg| arg.trim().trim_matches('\'').trim_matches('"').to_string());
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
                     "feature" => {
-                        // `use feature 'signatures'` implicitly enables strict
-                        // (same effective behavior as `use v5.36` for strictness).
-                        // Accept quoted and unquoted args, and qw(...) bundles.
-                        let enables_signatures = args.iter().any(|arg| {
-                            let normalized = arg.trim_matches('\'').trim_matches('"');
-                            if normalized == "signatures" {
-                                return true;
+                        // Track the small set of feature pragma effects that this
+                        // crate currently needs for semantic consumers.
+                        let mut changed = false;
+                        for arg in args {
+                            for item in pragma_arg_items(arg) {
+                                match item.as_str() {
+                                    "signatures" => {
+                                        current_state.strict_vars = true;
+                                        current_state.strict_subs = true;
+                                        current_state.strict_refs = true;
+                                        changed = true;
+                                    }
+                                    "unicode_strings" => {
+                                        current_state.unicode_strings = true;
+                                        changed = true;
+                                    }
+                                    item if item.starts_with(':') => {
+                                        if let Some(version) =
+                                            parse_perl_version(item.trim_start_matches(':'))
+                                        {
+                                            if version >= PerlVersion::new(5, 12) {
+                                                current_state.unicode_strings = true;
+                                                changed = true;
+                                            }
+                                        }
+                                    }
+                                    _ => {}
+                                }
                             }
+                        }
 
-                            if let Some(inner) =
-                                normalized.strip_prefix("qw(").and_then(|s| s.strip_suffix(')'))
-                            {
-                                return inner.split_whitespace().any(|item| item == "signatures");
-                            }
-
-                            false
-                        });
-
-                        if enables_signatures {
-                            current_state.strict_vars = true;
-                            current_state.strict_subs = true;
-                            current_state.strict_refs = true;
+                        if changed {
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -406,6 +461,22 @@ impl PragmaTracker {
                                 }
                             }
                         }
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "utf8" => {
+                        current_state.utf8 = false;
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "encoding" => {
+                        current_state.encoding = None;
+                        ranges
+                            .push((node.location.start..node.location.end, current_state.clone()));
+                    }
+                    "locale" => {
+                        current_state.locale = false;
+                        current_state.locale_scope = None;
                         ranges
                             .push((node.location.start..node.location.end, current_state.clone()));
                     }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -61,6 +61,11 @@ fn default_state_is_all_false() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!state.strict_subs);
     assert!(!state.strict_refs);
     assert!(!state.warnings);
+    assert!(!state.utf8);
+    assert!(state.encoding.is_none());
+    assert!(!state.unicode_strings);
+    assert!(!state.locale);
+    assert!(state.locale_scope.is_none());
     Ok(())
 }
 
@@ -71,6 +76,11 @@ fn all_strict_enables_strict_but_not_warnings() -> Result<(), Box<dyn std::error
     assert!(state.strict_subs);
     assert!(state.strict_refs);
     assert!(!state.warnings, "all_strict should not enable warnings");
+    assert!(!state.utf8);
+    assert!(state.encoding.is_none());
+    assert!(!state.unicode_strings);
+    assert!(!state.locale);
+    assert!(state.locale_scope.is_none());
     Ok(())
 }
 
@@ -313,6 +323,60 @@ fn no_warnings_disables_warnings() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("warnings", &[], 0, 15), no_node("warnings", &[], 16, 30)]);
     let map = PragmaTracker::build(&ast);
     assert!(!map[1].1.warnings);
+    Ok(())
+}
+
+#[test]
+fn use_utf8_and_no_utf8_toggle_state() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("utf8", &[], 0, 9), no_node("utf8", &[], 10, 19)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2);
+    assert!(map[0].1.utf8);
+    assert!(!map[1].1.utf8);
+    Ok(())
+}
+
+#[test]
+fn use_encoding_tracks_active_source_encoding() -> Result<(), Box<dyn std::error::Error>> {
+    let ast =
+        program(vec![use_node("encoding", &["'utf8'"], 0, 18), no_node("encoding", &[], 19, 31)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2);
+    assert_eq!(map[0].1.encoding.as_deref(), Some("utf8"));
+    assert!(map[1].1.encoding.is_none());
+    Ok(())
+}
+
+#[test]
+fn use_locale_tracks_scope_and_clears_on_no_locale() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("locale", &["':not_characters'"], 0, 28),
+        no_node("locale", &[], 29, 39),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 2);
+    assert!(map[0].1.locale);
+    assert_eq!(map[0].1.locale_scope.as_deref(), Some(":not_characters"));
+    assert!(!map[1].1.locale);
+    assert!(map[1].1.locale_scope.is_none());
+    Ok(())
+}
+
+#[test]
+fn use_feature_unicode_strings_sets_state() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["'unicode_strings'"], 0, 30)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert!(map[0].1.unicode_strings);
+    Ok(())
+}
+
+#[test]
+fn use_feature_bundle_5_12_sets_unicode_strings() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["':5.12'"], 0, 22)]);
+    let map = PragmaTracker::build(&ast);
+    assert_eq!(map.len(), 1);
+    assert!(map[0].1.unicode_strings);
     Ok(())
 }
 


### PR DESCRIPTION
Implements a focused pragma-state expansion in `perl-pragma`.

Handled in this slice:
- #3367 `use utf8` / `no utf8`
- #3368 `use encoding` / `no encoding`
- #3369 `use feature 'unicode_strings'` plus `:5.12` feature-bundle detection
- #3370 `use locale` / `no locale`

Notes:
- Scope stayed inside `crates/perl-pragma` plus the two dependent test/bench literals that needed the new `PragmaState` fields.
- `PragmaState` now tracks `utf8`, `encoding`, `unicode_strings`, `locale`, and `locale_scope`.

Validation:
- `cargo test -p perl-pragma --test comprehensive_unit_tests`
- `cargo test -p perl-parser --test scope_analysis_test`
- `cargo test -p perl-parser --benches --no-run`