### PR TITLE
fix(declaration): resolve signature parameter navigation (#3362)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -373,6 +373,14 @@ impl<'a> DeclarationProvider<'a> {
                 break;
             };
 
+            if matches!(parent.kind, NodeKind::Subroutine { .. } | NodeKind::Method { .. }) {
+                if let Some(links) =
+                    self.find_signature_parameter_declaration(parent, usage, var_name)
+                {
+                    return Some(links);
+                }
+            }
+
             // Check siblings before this node in the current scope
             for child in self.get_children(parent) {
                 // Stop when we reach or pass the usage node
@@ -418,6 +426,48 @@ impl<'a> DeclarationProvider<'a> {
             }
 
             current_ptr = parent_ptr;
+        }
+
+        None
+    }
+
+    fn find_signature_parameter_declaration(
+        &self,
+        declaration_site: &Node,
+        usage: &Node,
+        var_name: &str,
+    ) -> Option<Vec<LocationLink>> {
+        let signature = match &declaration_site.kind {
+            NodeKind::Subroutine { signature, .. } | NodeKind::Method { signature, .. } => {
+                signature.as_deref()?
+            }
+            _ => return None,
+        };
+
+        let NodeKind::Signature { parameters } = &signature.kind else {
+            return None;
+        };
+
+        for parameter in parameters {
+            let variable = match &parameter.kind {
+                NodeKind::MandatoryParameter { variable }
+                | NodeKind::OptionalParameter { variable, .. }
+                | NodeKind::SlurpyParameter { variable }
+                | NodeKind::NamedParameter { variable } => variable.as_ref(),
+                _ => continue,
+            };
+
+            let NodeKind::Variable { name, .. } = &variable.kind else {
+                continue;
+            };
+
+            if name == var_name {
+                return Some(vec![self.create_location_link(
+                    usage,
+                    parameter,
+                    (variable.location.start, variable.location.end),
+                )]);
+            }
         }
 
         None
@@ -1070,10 +1120,24 @@ impl<'a> DeclarationProvider<'a> {
             }
             NodeKind::Binary { left, right, .. } => vec![left.as_ref(), right.as_ref()],
             NodeKind::Unary { operand, .. } => vec![operand.as_ref()],
+            NodeKind::Return { value } => {
+                if let Some(value) = value {
+                    vec![value.as_ref()]
+                } else {
+                    vec![]
+                }
+            }
             NodeKind::VariableDeclaration { variable, initializer, .. } => {
                 let mut children = vec![variable.as_ref()];
                 if let Some(init) = initializer {
                     children.push(init.as_ref());
+                }
+                children
+            }
+            NodeKind::Method { signature, body, .. } => {
+                let mut children = vec![body.as_ref()];
+                if let Some(sig) = signature {
+                    children.push(sig.as_ref());
                 }
                 children
             }

--- a/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
@@ -60,6 +60,10 @@ fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
     table.symbols.get(name).is_some_and(|syms| syms.iter().any(|s| s.kind == kind))
 }
 
+fn byte_offset_to_line(code: &str, offset: usize) -> usize {
+    code[..offset].bytes().filter(|b| *b == b'\n').count()
+}
+
 // ===========================================================================
 // 1. Declaration provider utility functions
 // ===========================================================================
@@ -336,6 +340,56 @@ fn declaration_provider_matching_version_returns_result() -> Result<(), Box<dyn 
         result.is_some(),
         "matching-version provider must still return a result for a declared variable"
     );
+    Ok(())
+}
+
+#[test]
+fn declaration_provider_resolves_signature_parameters() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "sub add ($x, $y = 1, @rest) {\n    return $x + $y + scalar @rest;\n}\n\npackage Demo;\nmethod greet ($self, $name) {\n    return $name;\n}\n";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let ast_arc = Arc::new(ast);
+
+    let mut parent_map = ParentMap::default();
+    DeclarationProvider::build_parent_map(&ast_arc, &mut parent_map, None);
+
+    let provider =
+        DeclarationProvider::new(ast_arc, code.to_string(), "file:///test.pl".to_string())
+            .with_parent_map(&parent_map);
+
+    let x_usage = must_some(code.match_indices("$x").nth(1)).0 + 1;
+    let x_links = provider
+        .find_declaration(x_usage, 0)
+        .ok_or("expected declaration for signature parameter $x")?;
+    let x_link = x_links.first().ok_or("expected a declaration link for $x")?;
+    assert_eq!(
+        byte_offset_to_line(code, x_link.target_selection_range.0),
+        0,
+        "signature parameter $x should resolve to the subroutine signature"
+    );
+    assert_eq!(
+        &code[x_link.target_selection_range.0..x_link.target_selection_range.1],
+        "$x",
+        "signature parameter $x should resolve to its declaration span"
+    );
+
+    let name_usage = must_some(code.match_indices("$name").nth(1)).0 + 1;
+    let name_links = provider
+        .find_declaration(name_usage, 0)
+        .ok_or("expected declaration for method signature parameter $name")?;
+    let name_link =
+        name_links.first().ok_or("expected a declaration link for method parameter $name")?;
+    assert_eq!(
+        byte_offset_to_line(code, name_link.target_selection_range.0),
+        5,
+        "signature parameter $name should resolve to the method signature"
+    );
+    assert_eq!(
+        &code[name_link.target_selection_range.0..name_link.target_selection_range.1],
+        "$name",
+        "signature parameter $name should resolve to its declaration span"
+    );
+
     Ok(())
 }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -44,6 +44,25 @@ fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
     table.symbols.get(name).is_some_and(|syms| syms.iter().any(|s| s.kind == kind))
 }
 
+fn has_symbol_with_declaration(
+    table: &SymbolTable,
+    name: &str,
+    kind: SymbolKind,
+    declaration: &str,
+    source: &str,
+    expected_text: &str,
+) -> bool {
+    table.symbols.get(name).is_some_and(|symbols| {
+        symbols.iter().any(|symbol| {
+            symbol.kind == kind
+                && symbol.declaration.as_deref() == Some(declaration)
+                && source
+                    .get(symbol.location.start..symbol.location.end)
+                    .is_some_and(|text| text == expected_text)
+        })
+    })
+}
+
 fn has_issue(issues: &[ScopeIssue], kind: IssueKind, var_name: &str) -> bool {
     issues.iter().any(|i| i.kind == kind && i.variable_name.contains(var_name))
 }
@@ -1830,6 +1849,45 @@ sub foo ($x) { $z = 1; }
         !has_issue(&issues, IssueKind::UndeclaredVariable, "x"),
         "signature parameter $x should not be flagged as undeclared"
     );
+    Ok(())
+}
+
+#[test]
+fn signature_parameters_are_registered_as_symbols() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+sub add ($x, $y = 1, @rest) {
+    return $x + $y + scalar @rest;
+}
+
+package Demo;
+method greet ($self, $name) {
+    return $name;
+}
+"#;
+
+    let table = parse_and_extract(code);
+
+    assert!(
+        has_symbol_with_declaration(&table, "x", SymbolKind::scalar(), "my", code, "$x"),
+        "signature parameter $x should be recorded as a lexical symbol"
+    );
+    assert!(
+        has_symbol_with_declaration(&table, "y", SymbolKind::scalar(), "my", code, "$y"),
+        "optional signature parameter $y should be recorded as a lexical symbol"
+    );
+    assert!(
+        has_symbol_with_declaration(&table, "rest", SymbolKind::array(), "my", code, "@rest"),
+        "slurpy signature parameter @rest should be recorded as an array symbol"
+    );
+    assert!(
+        has_symbol_with_declaration(&table, "self", SymbolKind::scalar(), "my", code, "$self"),
+        "method signature parameter $self should be recorded as a lexical symbol"
+    );
+    assert!(
+        has_symbol_with_declaration(&table, "name", SymbolKind::scalar(), "my", code, "$name"),
+        "method signature parameter $name should be recorded as a lexical symbol"
+    );
+
     Ok(())
 }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1863,6 +1863,10 @@ package Demo;
 method greet ($self, $name) {
     return $name;
 }
+
+sub annotate (:$tag) {
+    return $tag;
+}
 "#;
 
     let table = parse_and_extract(code);
@@ -1886,6 +1890,10 @@ method greet ($self, $name) {
     assert!(
         has_symbol_with_declaration(&table, "name", SymbolKind::scalar(), "my", code, "$name"),
         "method signature parameter $name should be recorded as a lexical symbol"
+    );
+    assert!(
+        has_symbol_with_declaration(&table, "tag", SymbolKind::scalar(), "my", code, "$tag"),
+        "named signature parameter $tag should be recorded as a lexical symbol"
     );
 
     Ok(())


### PR DESCRIPTION
Signature parameters now resolve through declaration lookup in subroutines and methods, because the declaration provider now walks `Return` and `Method` nodes and inspects signature children directly.

The symbol-table side is pinned by regression coverage for signature parameters as symbols in both subroutines and methods. Related issue: #3361.

Tests:
- `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests signature_parameters_are_registered_as_symbols -- --nocapture`
- `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests v5_36_auto_strict_flags_undeclared_variable_in_signature_sub -- --nocapture`
- `cargo test -p perl-semantic-analyzer --test extended_unit_tests declaration_provider_resolves_signature_parameters -- --nocapture`
- `cargo test -p perl-semantic-analyzer --test extended_unit_tests declaration_provider -- --nocapture`
