### PR TITLE
test(coverage): add smoke coverage for perllsp and parser bench (#3213)

### DIFF
--- a/crates/perl-parser-bench/tests/smoke.rs
+++ b/crates/perl-parser-bench/tests/smoke.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn write_temp_perl_file() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut path = std::env::temp_dir();
+    let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    path.push(format!("perl-parser-bench-smoke-{}-{unique}.pl", std::process::id()));
+    fs::write(&path, "use strict;\nprint \"hello\\n\";\n")?;
+    Ok(path)
+}
+
+#[test]
+fn file_smoke_reports_success() -> Result<(), Box<dyn std::error::Error>> {
+    let file = write_temp_perl_file()?;
+    let output = Command::new(env!("CARGO_BIN_EXE_perl-parser-bench")).arg(&file).output()?;
+
+    let _ = fs::remove_file(&file);
+
+    assert!(output.status.success(), "benchmark binary should succeed on a valid file");
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("status=success"), "expected the success status line");
+    assert!(stdout.contains("error=false"), "expected a non-error parse result");
+    Ok(())
+}

--- a/crates/perllsp/tests/cli_smoke.rs
+++ b/crates/perllsp/tests/cli_smoke.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn run_perllsp(args: &[&str]) -> Result<std::process::Output, Box<dyn std::error::Error>> {
+    let output = Command::new(env!("CARGO_BIN_EXE_perllsp")).args(args).output()?;
+    Ok(output)
+}
+
+#[test]
+fn help_mentions_perllsp() -> Result<(), Box<dyn std::error::Error>> {
+    let output = run_perllsp(&["--help"])?;
+    assert!(output.status.success(), "help should succeed");
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Usage: perllsp"), "help should mention the facade name");
+    Ok(())
+}
+
+#[test]
+fn version_mentions_facade_name_and_git_tag() -> Result<(), Box<dyn std::error::Error>> {
+    let output = run_perllsp(&["--version"])?;
+    assert!(output.status.success(), "version should succeed");
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("perllsp "), "version should print the facade name");
+    assert!(stdout.contains("Git tag:"), "version should include the git tag line");
+    Ok(())
+}


### PR DESCRIPTION
Adds the smallest high-signal smoke coverage for the two zero-test crates called out in #3213.

Validation:
- `cargo fmt --all`
- `cargo test -p perllsp --test cli_smoke`
- `cargo test -p perl-parser-bench --test smoke`

Files changed:
- `crates/perllsp/tests/cli_smoke.rs`
- `crates/perl-parser-bench/tests/smoke.rs`