### PR TITLE
test(scope): add regression for arrayref deref unused-variable false positive (#3445)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1380,6 +1380,33 @@ my $val   = $$sref;
     Ok(())
 }
 
+/// Regression test for issue #3445: scalar ref declarations used through arrayref
+/// dereference syntax (e.g. `push @$arrayref`) must not emit UnusedVariable.
+#[test]
+fn issue_3445_arrayref_deref_marks_scalar_declaration_used()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+
+my $arrayref = [];
+push @$arrayref, 'item';
+print $arrayref->[0];
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UnusedVariable | IssueKind::UndeclaredVariable)
+                && i.variable_name.contains("arrayref")
+        }),
+        "issue #3445: $arrayref used via @$arrayref and $arrayref->[0] should not be flagged: {:?}",
+        issues
+    );
+
+    Ok(())
+}
+
 #[test]
 fn unused_variable_used_via_coderef_and_glob_dereference_forms()
 -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
### Motivation
- Add a targeted regression test to prevent a false-positive PL103 `UnusedVariable`/`UndeclaredVariable` when a scalar reference (e.g. `my $arrayref`) is used via array-dereference syntax (`@$arrayref`) as reported in #3445.

### Description
- Added `issue_3445_arrayref_deref_marks_scalar_declaration_used` in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` which asserts that `my $arrayref = []; push @$arrayref, 'item'; print $arrayref->[0];` does not produce `UnusedVariable` or `UndeclaredVariable` diagnostics.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-semantic-analyzer issue_3445_arrayref_deref_marks_scalar_declaration_used -- --nocapture` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ca3bf88333beb0b66c2d27808b)