### PR TITLE
fix(scope): mark scalar deref bases as used (#3445)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1300,6 +1300,20 @@ impl ScopeAnalyzer {
             return None;
         };
 
+        // Explicit scalar-reference dereference forms should count as uses of the
+        // underlying scalar lexical (`$ref`) rather than a container lexical of the
+        // same bare name. This covers compact and braced syntaxes such as:
+        // - `@$ref`, `%$ref`, `$$ref`
+        // - `@{$ref}`, `%{$ref}`, `${$ref}`
+        if (sigil == "@" || sigil == "%" || sigil == "$")
+            && context
+                .code
+                .get(node.location.start..node.location.end)
+                .is_some_and(is_explicit_scalar_reference_deref)
+        {
+            return Some(("$", normalize_scalar_deref_base_name(name)));
+        }
+
         if (sigil == "@" || sigil == "%" || sigil == "$") && name.starts_with('$') && name.len() > 1
         {
             return Some(("$", &name[1..]));
@@ -1998,6 +2012,22 @@ fn is_topic_defaulting_builtin(name: &str) -> bool {
 /// Topic-defaulting builtins that also modify `$_` when called without args.
 fn is_topic_modifying_builtin(name: &str) -> bool {
     matches!(name, "chomp" | "chop")
+}
+
+fn is_explicit_scalar_reference_deref(source: &str) -> bool {
+    source.starts_with("@$")
+        || source.starts_with("%$")
+        || source.starts_with("$$")
+        || source.starts_with("@{$")
+        || source.starts_with("%{$")
+        || source.starts_with("${$")
+}
+
+fn normalize_scalar_deref_base_name(name: &str) -> &str {
+    let unwrapped =
+        name.strip_prefix('{').and_then(|inner| inner.strip_suffix('}')).unwrap_or(name);
+
+    unwrapped.strip_prefix('$').unwrap_or(unwrapped)
 }
 
 /// Check if an identifier is a known filehandle

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -267,6 +267,66 @@ CHECK {
 }
 
 #[test]
+fn scope_scalar_arrayref_deref_counts_as_use() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+my $arrayref = [];
+push @$arrayref, 'item';
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues
+            .iter()
+            .any(|issue| issue.kind == IssueKind::UnusedVariable
+                && issue.variable_name == "$arrayref"),
+        "scalar arrayref dereference should mark $arrayref as used: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_scalar_hashref_deref_counts_as_use() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+my $hashref = {};
+keys %$hashref;
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues
+            .iter()
+            .any(|issue| issue.kind == IssueKind::UnusedVariable
+                && issue.variable_name == "$hashref"),
+        "scalar hashref dereference should mark $hashref as used: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
+fn scope_scalar_scalarref_deref_counts_as_use() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+my $target = 1;
+my $ref = \$target;
+$$ref = 3;
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues
+            .iter()
+            .any(|issue| issue.kind == IssueKind::UnusedVariable && issue.variable_name == "$ref"),
+        "scalar dereference should mark $ref as used: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
 fn scope_try_catch_binds_catch_variable() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict;


### PR DESCRIPTION
### Motivation

- Prevent false-positive PL103 "declared but never used" when a scalar lexical (e.g. `my $ref`) is dereferenced with a different sigil (`@$ref`, `%$ref`, `$$ref`).
- The analyzer previously looked up uses by exact sigil bucket, so deref forms were recorded in the wrong bucket and the original declaration stayed unused.
- Implement a deref-aware mapping so dereference syntax counts as a use of the scalar base binding.

### Description

- Update `resolve_variable_use_target` to detect explicit scalar-reference dereference syntaxes in the source text and map those sites to the scalar base (`$` sigil) before lookup. (crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs)
- Add helper functions `is_explicit_scalar_reference_deref` and `normalize_scalar_deref_base_name` to recognize compact and braced forms and normalize the base variable name for lookup. (crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs)
- Add regression tests that exercise arrayref/hashref/scalarref dereference patterns under `use strict` to ensure the scalar base is marked used and no PL103 is emitted. (crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs)

### Testing

- Ran `cargo fmt --all` and formatting succeeded.
- Attempted a multi-test-name `cargo test` invocation with multiple explicit test filters which failed due to invalid argument usage (operator error), this was a CLI invocation issue, not a code failure.
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests scope_scalar_` which exercised the new tests and succeeded (new tests ran and passed).
- Ran the full `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests` and the suite passed (151 tests passed; 0 failed), including the added regressions for dereference patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ca3bf88333beb0b66c2d27808b)