### PR TITLE
test(scope): add issue #3445 arrayref deref regression coverage (#3445)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1380,6 +1380,35 @@ my $val   = $$sref;
     Ok(())
 }
 
+/// Regression test for issue #3445: scalar-declared reference used via `@$ref`
+/// must not trigger PL103/UnusedVariable.
+#[test]
+fn issue_3445_arrayref_deref_and_arrow_access_marks_scalar_used()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+
+my $arrayref = [];
+push @$arrayref, 'item';
+print $arrayref->[0];
+"#;
+
+    let issues = scope_issues_strict(code);
+    let unused = issues
+        .iter()
+        .filter(|i| i.kind == IssueKind::UnusedVariable && i.variable_name == "$arrayref")
+        .count();
+    assert_eq!(
+        unused,
+        0,
+        "issue #3445: $arrayref used by deref/arrow should not be reported unused; issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
 #[test]
 fn unused_variable_used_via_coderef_and_glob_dereference_forms()
 -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
### Motivation
- Prevent a PL103 false positive where a scalar-declared array reference (`my $arrayref`) used as `@$arrayref` / `$arrayref->[...]` is reported as unused by locking the expected behavior with a regression test.

### Description
- Add a focused regression test `issue_3445_arrayref_deref_and_arrow_access_marks_scalar_used` in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` that reproduces `my $arrayref = []; push @$arrayref, 'item'; print $arrayref->[0];` and asserts no `UnusedVariable` is emitted for `$arrayref`.

### Testing
- Ran formatter: `cargo fmt --all` (succeeded).
- Ran the new targeted test: `cargo test -p perl-semantic-analyzer issue_3445_arrayref_deref_and_arrow_access_marks_scalar_used -- --nocapture` (passed).
- Re-ran related regression test: `cargo test -p perl-semantic-analyzer issue_3338_all_deref_sigil_forms_mark_base_used -- --nocapture` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ca3bf88333beb0b66c2d27808b)