### PR TITLE
test(scope): add issue #3445 arrayref deref regression (#3445)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1348,6 +1348,38 @@ push @$arrayref, 'second';
     Ok(())
 }
 
+/// Regression test for issue #3445: scalar-declared array references used through
+/// both explicit `@$ref` and arrow access must count as uses of the same lexical.
+#[test]
+fn issue_3445_arrayref_deref_and_arrow_access_not_unused() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict;
+use warnings;
+
+my $arrayref = [];
+push @$arrayref, 'item';
+print $arrayref->[0];
+"#;
+
+    let issues = scope_issues_strict(code);
+    let relevant_issues: Vec<_> =
+        issues.iter().filter(|issue| issue.variable_name.contains("arrayref")).collect();
+
+    assert!(
+        relevant_issues.iter().all(|issue| issue.kind != IssueKind::UnusedVariable),
+        "issue #3445: $arrayref used via push @$arrayref / ->[] should not be unused; issues: {:?}",
+        relevant_issues.iter().map(|issue| (&issue.kind, &issue.variable_name)).collect::<Vec<_>>()
+    );
+    assert!(
+        relevant_issues.iter().all(|issue| issue.kind != IssueKind::UndeclaredVariable),
+        "issue #3445: declared $arrayref should not be undeclared; issues: {:?}",
+        relevant_issues.iter().map(|issue| (&issue.kind, &issue.variable_name)).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
 /// Regression test for issue #3338: all three primary dereference sigil forms
 /// (`@$ref`, `%$ref`, `$$ref`) should mark the underlying scalar declaration used.
 #[test]


### PR DESCRIPTION
### Motivation
- Add a focused regression test to prevent a false-positive UnusedVariable/UndeclaredVariable for scalar-declared arrayrefs used via mixed dereference forms (e.g. `push @$arrayref` + `$arrayref->[0]`).

### Description
- Add `issue_3445_arrayref_deref_and_arrow_access_not_unused` to `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` which reproduces the reported pattern and asserts no `UnusedVariable` or `UndeclaredVariable` is emitted, and run `cargo fmt --all` to format.

### Testing
- Ran `cargo fmt --all` and `cargo test -p perl-semantic-analyzer issue_3445_arrayref_deref_and_arrow_access_not_unused -- --nocapture` (passed) and also confirmed existing related regression `issue_3338_push_arrayref_deref_strict_mode` still passes with `cargo test -p perl-semantic-analyzer issue_3338_push_arrayref_deref_strict_mode -- --nocapture` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ca3bf88333beb0b66c2d27808b)