### PR TITLE
feat(module-resolution): resolve common :tag imports for goto-def (#3474)

### DIFF
--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -265,6 +265,68 @@ my $result = calculate_sum(1, 2, 3);
     Ok(())
 }
 
+#[test]
+fn go_to_definition_on_tag_imported_symbol_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/POSIX.pm",
+        r#"package POSIX;
+use strict;
+use warnings;
+
+sub WIFEXITED {
+    return 1;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/POSIX.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/POSIX.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use POSIX qw(:sys_wait_h);
+
+if (WIFEXITED(0)) {
+    print "ok\n";
+}
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "WIFEXITED(0)")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected definition result for tag-imported symbol");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("POSIX.pm") || uri.contains("POSIX%2Epm"),
+        "Definition should point to POSIX.pm, got: {}",
+        uri
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Test 3: XS bootstrap calls navigate to native `.xs` entry points
 // ---------------------------------------------------------------------------

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1309,6 +1309,42 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
+    fn export_tag_members(module: &str, tag: &str) -> &'static [&'static str] {
+        match (module, tag) {
+            // POSIX tag sets commonly used in system scripts.
+            ("POSIX", ":sys_wait_h") => {
+                &["WEXITSTATUS", "WIFEXITED", "WIFSIGNALED", "WIFSTOPPED", "WTERMSIG"]
+            }
+            ("POSIX", ":fcntl_h") => &["F_GETFD", "F_SETFD", "F_GETFL", "F_SETFL", "FD_CLOEXEC"],
+            ("POSIX", ":termios_h") => {
+                &["B9600", "B19200", "B38400", "TCSANOW", "TCSADRAIN", "TCSAFLUSH"]
+            }
+            // File::Find exports.
+            ("File::Find", ":find") => &["find", "finddepth"],
+            // Fcntl exports.
+            ("Fcntl", ":seek") => &["SEEK_SET", "SEEK_CUR", "SEEK_END"],
+            ("Fcntl", ":lock") => &["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"],
+            // Encode exports.
+            ("Encode", ":fallback") => &[
+                "FB_DEFAULT",
+                "FB_CROAK",
+                "FB_QUIET",
+                "FB_WARN",
+                "FB_PERLQQ",
+                "FB_HTMLCREF",
+                "FB_XMLCREF",
+            ],
+            _ => &[],
+        }
+    }
+
+    fn tag_imports_symbol(module: &str, import_token: &str, symbol_name: &str) -> bool {
+        if !import_token.starts_with(':') {
+            return false;
+        }
+        export_tag_members(module, import_token).contains(&symbol_name)
+    }
+
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
         fn find(node: &Node, name: &str) -> Option<String> {
             if let NodeKind::Use { module, args, .. } = &node.kind {
@@ -1316,13 +1352,20 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
                     if arg == name {
                         return Some(module.clone());
                     }
+                    if tag_imports_symbol(module, arg, name) {
+                        return Some(module.clone());
+                    }
                     if arg.starts_with("qw") {
                         let content = arg
                             .trim_start_matches("qw")
                             .trim_start_matches(|c: char| "([{/<|!".contains(c))
                             .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                        if content.split_whitespace().any(|w| w == name) {
-                            return Some(module.clone());
+                        for import_token in content.split_whitespace() {
+                            if import_token == name
+                                || tag_imports_symbol(module, import_token, name)
+                            {
+                                return Some(module.clone());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- Improve symbol resolution for POSIX-style tag imports (e.g. `use POSIX qw(:sys_wait_h);`) so editor features like go-to-definition can map tag-imported symbols back to their defining module.
- Provide a practical phase-2 hard-coded resolution path for common CPAN tag sets until dynamic `%EXPORT_TAGS` extraction is implemented.

### Description
- Add `export_tag_members` and helper `tag_imports_symbol` to `symbol_at_cursor` logic in `crates/perl-semantic-analyzer/src/analysis/declaration.rs` to recognize tag tokens (leading `:`) and map them to concrete symbol names for a small set of modules (`POSIX`, `File::Find`, `Fcntl`, `Encode`).
- Extend `find_import_source` to check tag tokens both as direct arguments and inside `qw(...)` import lists, supporting mixed tags and explicit symbol names.
- Add an end-to-end test `go_to_definition_on_tag_imported_symbol_navigates_to_source_module` in `crates/perl-lsp/tests/cross_file_goto_definition_tests.rs` to verify `use POSIX qw(:sys_wait_h);` allows navigating from `WIFEXITED(...)` to `POSIX.pm`.
- Run `cargo fmt --all` to apply formatting.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_on_tag_imported_symbol_navigates_to_source_module` and the new test passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ee0b9483339b4e26e8e471b943)