### PR TITLE
feat(module-resolution): resolve common import tags (#3474)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1245,22 +1245,79 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
+    fn exported_symbols_for_tag(module: &str, tag: &str) -> &'static [&'static str] {
+        match (module, tag) {
+            ("POSIX", "sys_wait_h") => &[
+                "WEXITSTATUS",
+                "WIFEXITED",
+                "WIFSIGNALED",
+                "WIFSTOPPED",
+                "WNOHANG",
+                "WSTOPSIG",
+                "WTERMSIG",
+            ],
+            ("POSIX", "fcntl_h") => {
+                &["F_DUPFD", "F_GETFD", "F_GETFL", "F_SETFD", "F_SETFL", "FD_CLOEXEC"]
+            }
+            ("POSIX", "termios_h") => &["B0", "B9600", "CS8", "ECHO", "ICANON", "ISIG", "TCSANOW"],
+            ("File::Find", "find") => &["find", "finddepth"],
+            ("Fcntl", "seek") => &["SEEK_SET", "SEEK_CUR", "SEEK_END"],
+            ("Fcntl", "lock") => &["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"],
+            ("Encode", "fallback") => &[
+                "FB_DEFAULT",
+                "FB_CROAK",
+                "FB_QUIET",
+                "FB_WARN",
+                "FB_PERLQQ",
+                "FB_HTMLCREF",
+                "FB_XMLCREF",
+            ],
+            _ => &[],
+        }
+    }
+
+    fn parse_qw_words(arg: &str) -> Option<Vec<&str>> {
+        if !arg.starts_with("qw") {
+            return None;
+        }
+
+        let content = arg
+            .trim_start_matches("qw")
+            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+
+        Some(content.split_whitespace().collect())
+    }
+
+    fn module_imports_symbol(module: &str, args: &[String], symbol_name: &str) -> bool {
+        for arg in args {
+            if arg == symbol_name {
+                return true;
+            }
+
+            if let Some(words) = parse_qw_words(arg) {
+                for word in words {
+                    if word == symbol_name {
+                        return true;
+                    }
+
+                    if let Some(tag) = word.strip_prefix(':')
+                        && exported_symbols_for_tag(module, tag).contains(&symbol_name)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
         fn find(node: &Node, name: &str) -> Option<String> {
             if let NodeKind::Use { module, args, .. } = &node.kind {
-                for arg in args {
-                    if arg == name {
-                        return Some(module.clone());
-                    }
-                    if arg.starts_with("qw") {
-                        let content = arg
-                            .trim_start_matches("qw")
-                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                        if content.split_whitespace().any(|w| w == name) {
-                            return Some(module.clone());
-                        }
-                    }
+                if module_imports_symbol(module, args, name) {
+                    return Some(module.clone());
                 }
             }
 

--- a/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
@@ -30,6 +30,7 @@ use perl_semantic_analyzer::analysis::type_inference::{
 use perl_semantic_analyzer::symbol::{
     ScopeKind, SymbolExtractor, SymbolKind, SymbolTable, VarKind,
 };
+use perl_semantic_analyzer::workspace_index::SymKind;
 use perl_tdd_support::{must, must_some};
 use std::sync::Arc;
 
@@ -152,6 +153,36 @@ fn symbol_at_cursor_on_function_call() -> Result<(), Box<dyn std::error::Error>>
     if let Some(key) = sym {
         assert_eq!(key.name.as_ref(), "print");
     }
+    Ok(())
+}
+
+#[test]
+fn symbol_at_cursor_resolves_posix_tag_import_symbol() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "use POSIX qw(:sys_wait_h);\nif (WIFEXITED()) { WEXITSTATUS(); }";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+
+    let wifexited_offset = code.find("WIFEXITED").ok_or("missing WIFEXITED in fixture")?;
+    let sym = symbol_at_cursor(&ast, wifexited_offset, "main").ok_or("no symbol resolved")?;
+
+    assert_eq!(sym.pkg.as_ref(), "POSIX");
+    assert_eq!(sym.name.as_ref(), "WIFEXITED");
+    assert_eq!(sym.kind, SymKind::Sub);
+    Ok(())
+}
+
+#[test]
+fn symbol_at_cursor_resolves_fcntl_tag_import_symbol() -> Result<(), Box<dyn std::error::Error>> {
+    let code = "use Fcntl qw(:seek);\nmy $x = SEEK_SET();";
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+
+    let seek_set_offset = code.find("SEEK_SET").ok_or("missing SEEK_SET in fixture")?;
+    let sym = symbol_at_cursor(&ast, seek_set_offset, "main").ok_or("no symbol resolved")?;
+
+    assert_eq!(sym.pkg.as_ref(), "Fcntl");
+    assert_eq!(sym.name.as_ref(), "SEEK_SET");
+    assert_eq!(sym.kind, SymKind::Sub);
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Resolve unqualified symbols imported via POSIX-style tag imports (e.g. `use POSIX qw(:sys_wait_h)`) so navigation and resolution (go-to-def/completion) work for tag-exported names.
- Many CPAN modules expose grouped symbols via `%EXPORT_TAGS`, which were previously ignored by import resolution and semantic analysis.

### Description
- Add a static tag-to-symbol catalog and tag-aware matching helpers in `crates/perl-semantic-analyzer/src/analysis/declaration.rs` (functions: `exported_symbols_for_tag`, `parse_qw_words`, `module_imports_symbol`) and wire them into `find_import_source` so `qw(:tag)` entries match the symbols they expand to.
- Preserve existing direct-symbol and `qw(...)` behavior while adding tag-based matches for common modules (`POSIX`, `File::Find`, `Fcntl`, `Encode`).
- Add regression tests in `crates/perl-semantic-analyzer/tests/extended_unit_tests.rs` verifying that `symbol_at_cursor` resolves `WIFEXITED` from `use POSIX qw(:sys_wait_h)` and `SEEK_SET` from `use Fcntl qw(:seek)`.

### Testing
- Ran formatter: `cargo fmt --all` (succeeded).
- Ran unit tests: `cargo test -p perl-semantic-analyzer --test extended_unit_tests` and the test suite passed (`106 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ee0b9483339b4e26e8e471b943)