### PR TITLE
Treat container-sigil derefs as uses of scalar-declared refs (fix #3445)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -222,6 +222,8 @@ impl Scope {
 
     fn use_variable_parts(&self, sigil: &str, name: &str) -> (bool, bool) {
         let idx = sigil_to_index(sigil);
+        let fallback_idx =
+            if sigil == "@" || sigil == "%" { Some(sigil_to_index("$")) } else { None };
         let mut current_scope = self;
 
         loop {
@@ -232,6 +234,17 @@ impl Scope {
                         *var.is_used.borrow_mut() = true;
                         return (true, *var.is_initialized.borrow());
                     }
+                }
+
+                // Perl dereference syntax can present a scalar-declared reference with
+                // a container sigil (e.g. `@$ref`, `%$ref`). If no lexical declaration
+                // exists for the container sigil, fall back to the scalar declaration.
+                if let Some(fallback_idx) = fallback_idx
+                    && let Some(map) = &vars[fallback_idx]
+                    && let Some(var) = map.get(name)
+                {
+                    *var.is_used.borrow_mut() = true;
+                    return (true, *var.is_initialized.borrow());
                 }
             }
 

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -1348,6 +1348,38 @@ push @$arrayref, 'second';
     Ok(())
 }
 
+/// Regression test for issue #3445: scalar-declared array references used through
+/// both explicit `@$ref` and arrow access must count as uses of the same lexical.
+#[test]
+fn issue_3445_arrayref_deref_and_arrow_access_not_unused() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict;
+use warnings;
+
+my $arrayref = [];
+push @$arrayref, 'item';
+print $arrayref->[0];
+"#;
+
+    let issues = scope_issues_strict(code);
+    let relevant_issues: Vec<_> =
+        issues.iter().filter(|issue| issue.variable_name.contains("arrayref")).collect();
+
+    assert!(
+        relevant_issues.iter().all(|issue| issue.kind != IssueKind::UnusedVariable),
+        "issue #3445: $arrayref used via push @$arrayref / ->[] should not be unused; issues: {:?}",
+        relevant_issues.iter().map(|issue| (&issue.kind, &issue.variable_name)).collect::<Vec<_>>()
+    );
+    assert!(
+        relevant_issues.iter().all(|issue| issue.kind != IssueKind::UndeclaredVariable),
+        "issue #3445: declared $arrayref should not be undeclared; issues: {:?}",
+        relevant_issues.iter().map(|issue| (&issue.kind, &issue.variable_name)).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
 /// Regression test for issue #3338: all three primary dereference sigil forms
 /// (`@$ref`, `%$ref`, `$$ref`) should mark the underlying scalar declaration used.
 #[test]


### PR DESCRIPTION
### Motivation
- Scalar references accessed with a container sigil (e.g. `@$ref`, `%$ref`) or via arrow syntax were not always being recognized as uses of the underlying scalar lexical, causing spurious `UnusedVariable`/`UndeclaredVariable` issues.

### Description
- Add a fallback lookup in `Scope::use_variable_parts` so that when the sigil is `@` or `%` the analyzer will fall back to the scalar sigil index (`$`) if no container declaration is found, and mark that variable as used and return its initialization state.
- Implement the fallback check using `fallback_idx` and a conditional lookup against the scalar map when the initial container-sigil map does not contain the name.
- Add a regression test `issue_3445_arrayref_deref_and_arrow_access_not_unused` in `tests/scope_and_symbol_tests.rs` that verifies `my $arrayref` used via `push @$arrayref` and `$arrayref->[0]` is not reported as unused or undeclared.

### Testing
- Ran the crate unit tests with `cargo test -p perl-semantic-analyzer` and the test suite including the new regression test passed.
- Existing dereference coverage (e.g. the `issue_3338` tests) also passed unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ca3bf88333beb0b66c2d27808b)