### PR TITLE
test(scope): add AUTOLOAD regression coverage (#3462)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -3193,6 +3193,37 @@ CHECK {
     Ok(())
 }
 
+// ===========================================================================
+// AUTOLOAD special variable coverage (#3462)
+// ===========================================================================
+
+#[test]
+fn autoload_special_variable_is_not_undeclared_under_strict()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict;
+use warnings;
+
+package MyClass;
+
+sub AUTOLOAD {
+    our $AUTOLOAD;
+    my $method = $AUTOLOAD;
+    return $method;
+}
+
+package main;
+MyClass->some_method();
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !has_issue(&issues, IssueKind::UndeclaredVariable, "$AUTOLOAD"),
+        "$AUTOLOAD in AUTOLOAD context must not be flagged as undeclared; issues: {:?}",
+        issues.iter().map(|i| (&i.kind, &i.variable_name)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
 // ---- Issue #3503: variables in print comma-separated args must be marked used ----
 
 #[test]


### PR DESCRIPTION
Adds one focused regression for `sub AUTOLOAD` under strict/warnings in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs`.

`#3460` is already covered by the existing sort-block regressions in the same test file, so this branch keeps the scope test-only and targets the remaining missing coverage from `#3462`.

Fixes #3462.

Validation:
- `cargo fmt --all`
- `cargo test -p perl-semantic-analyzer autoload_special_variable_is_not_undeclared_under_strict -- --nocapture`
- `cargo test -p perl-semantic-analyzer sort_a_b_no_diagnostic_in_sort_block -- --nocapture`