### PR TITLE
feat(vscode): add perlcritic settings and commands (#3429)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -63,6 +63,8 @@
     "onCommand:perl-lsp.checkForUpdate",
     "onCommand:perl-lsp.organizeImports",
     "onCommand:perl-lsp.runTests",
+    "onCommand:perl-lsp.runPerlCritic",
+    "onCommand:perl-lsp.setPerlCriticSeverity",
     "onCommand:perl-lsp.extractVariable",
     "onCommand:perl-lsp.extractMethod",
     "onCommand:perl-lsp.showRefactoringOptions",
@@ -302,11 +304,57 @@
             "description": "Path to your .perltidyrc configuration file. If omitted, perl-lsp searches the workspace and home directory.",
             "markdownDescription": "Path to your `.perltidyrc` configuration file. If omitted, perl-lsp searches the workspace and home directory."
           },
+          "perl-lsp.perlcritic.enabled": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "order": 40,
+            "description": "Enable Perl::Critic integration from the VS Code extension. This setting is synchronized to the server when you run PerlCritic or change the setting.",
+            "markdownDescription": "Enable `Perl::Critic` integration from the VS Code extension. This setting is synchronized to the server when you run PerlCritic or change the setting."
+          },
+          "perl-lsp.perlcritic.severity": {
+            "type": "number",
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "enumDescriptions": [
+              "Severity 1 - very permissive",
+              "Severity 2 - permissive",
+              "Severity 3 - balanced default",
+              "Severity 4 - strict",
+              "Severity 5 - very strict"
+            ],
+            "default": 3,
+            "scope": "resource",
+            "order": 41,
+            "description": "Perl::Critic severity threshold. Lower numbers are more permissive; higher numbers are stricter.",
+            "markdownDescription": "Perl::Critic severity threshold. Lower numbers are more permissive; higher numbers are stricter."
+          },
+          "perl-lsp.perlcritic.profile": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "order": 42,
+            "description": "Path to a .perlcriticrc profile file used by the extension when synchronizing critic settings.",
+            "markdownDescription": "Path to a `.perlcriticrc` profile file used by the extension when synchronizing critic settings."
+          },
+          "perl-lsp.perlcritic.theme": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "order": 43,
+            "description": "Optional display theme label for PerlCritic settings. Reserved for editor-facing UI organization.",
+            "markdownDescription": "Optional display theme label for PerlCritic settings. Reserved for editor-facing UI organization."
+          },
           "perl-lsp.enableRefactoring": {
             "type": "boolean",
             "default": true,
             "scope": "resource",
-            "order": 40,
+            "order": 50,
             "description": "Enable refactoring-related code actions (extract variable, extract method) when supported by the connected perllsp server.",
             "markdownDescription": "Enable refactoring-related code actions (extract variable, extract method) when supported by the connected `perllsp` server."
           },
@@ -314,7 +362,7 @@
             "type": "boolean",
             "default": true,
             "scope": "resource",
-            "order": 50,
+            "order": 60,
             "description": "Enable Test::More and Test2 integration for the VS Code Test Explorer panel.",
             "markdownDescription": "Enable `Test::More` and `Test2` integration for the VS Code Test Explorer panel."
           },
@@ -322,7 +370,7 @@
             "type": "boolean",
             "default": true,
             "scope": "resource",
-            "order": 60,
+            "order": 70,
             "description": "Auto-populate new .pm files with a package declaration and new .t files with Test::More boilerplate.",
             "markdownDescription": "Auto-populate new `.pm` files with a `package` declaration and new `.t` files with `Test::More` boilerplate."
           }
@@ -534,6 +582,18 @@
         "icon": "$(beaker)"
       },
       {
+        "command": "perl-lsp.runPerlCritic",
+        "title": "Run PerlCritic",
+        "category": "Perl",
+        "icon": "$(checklist)"
+      },
+      {
+        "command": "perl-lsp.setPerlCriticSeverity",
+        "title": "Set PerlCritic Severity",
+        "category": "Perl",
+        "icon": "$(symbol-numeric)"
+      },
+      {
         "command": "perl-lsp.extractVariable",
         "title": "Extract Variable",
         "category": "Perl",
@@ -657,6 +717,14 @@
           "when": "editorLangId == perl && resourceExtname =~ /\\.(t|pl)$/"
         },
         {
+          "command": "perl-lsp.runPerlCritic",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.setPerlCriticSeverity",
+          "when": "editorLangId == perl"
+        },
+        {
           "command": "perl-lsp.checkSyntax",
           "when": "editorLangId == perl"
         },
@@ -721,6 +789,11 @@
           "group": "navigation"
         },
         {
+          "command": "perl-lsp.runPerlCritic",
+          "when": "editorLangId == perl",
+          "group": "navigation"
+        },
+        {
           "command": "perl-lsp.previewPod",
           "when": "editorLangId == perl",
           "group": "navigation"
@@ -729,6 +802,11 @@
       "editor/context": [
         {
           "command": "perl-lsp.runTests",
+          "when": "editorLangId == perl",
+          "group": "navigation"
+        },
+        {
+          "command": "perl-lsp.runPerlCritic",
           "when": "editorLangId == perl",
           "group": "navigation"
         }
@@ -847,7 +925,7 @@
           {
             "id": "configure-settings",
             "title": "Configure Settings",
-            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** (personal, not committed) — open `Settings` and search for `perl-lsp`. Set `perl-lsp.includePaths` if you see _Can't locate Foo/Bar.pm_ errors. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** (team-wide, committed to your repo) — place this file in your project root, next to `.git/`. Key settings:\n- `[perl] include_paths = [\"lib\", \"local/lib/perl5\"]` — module search paths\n- `[diagnostics] perlcritic = true` — enable Perl::Critic linting (requires `perlcritic` on PATH)\n- `[features] inlay_hints = true` — toggle inlay hints\n\nCopy `.perl-lsp.toml.example` from the repo root to get started. Editor settings always override `.perl-lsp.toml`.",
+            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** (personal, not committed) — open `Settings` and search for `perl-lsp`. Set `perl-lsp.includePaths` if you see _Can't locate Foo/Bar.pm_ errors. Use `perl-lsp.perlcritic.enabled` and `perl-lsp.perlcritic.severity` for quick local Perl::Critic tuning, or run the `Perl: Run PerlCritic` / `Perl: Set PerlCritic Severity` commands from the palette. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** (team-wide, committed to your repo) — place this file in your project root, next to `.git/`. Key settings:\n- `[perl] include_paths = [\"lib\", \"local/lib/perl5\"]` — module search paths\n- `[diagnostics] perlcritic = true` — enable Perl::Critic linting (requires `perlcritic` on PATH)\n- `[features] inlay_hints = true` — toggle inlay hints\n\nCopy `.perl-lsp.toml.example` from the repo root to get started. Editor settings always override `.perl-lsp.toml`.",
             "media": {
               "image": "media/walkthrough/configure-settings.svg",
               "altText": "Configure Settings"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -53,6 +53,240 @@ function serverNotRunningMessage(): string {
         'Perl Language Server is not running. Run the Health Check (Command Palette: "Perl: Run Health Check") to diagnose the issue.';
 }
 
+type PerlCriticSettings = {
+    enabled: boolean;
+    severity: number;
+    profile: string;
+    theme: string;
+};
+
+function getPerlCriticSettings(documentUri?: vscode.Uri): PerlCriticSettings {
+    const config = vscode.workspace.getConfiguration('perl-lsp', documentUri);
+    return {
+        enabled: config.get<boolean>('perlcritic.enabled', false),
+        severity: config.get<number>('perlcritic.severity', 3),
+        profile: config.get<string>('perlcritic.profile', ''),
+        theme: config.get<string>('perlcritic.theme', ''),
+    };
+}
+
+type PerlCriticSyncSettings = {
+    enabled?: boolean;
+    severity?: number;
+    profile?: string;
+};
+
+function inspectPerlCriticOverride(
+    config: vscode.WorkspaceConfiguration,
+    key: string
+): { globalValue?: unknown; workspaceValue?: unknown; workspaceFolderValue?: unknown } | undefined {
+    return config.inspect(key) as {
+        globalValue?: unknown;
+        workspaceValue?: unknown;
+        workspaceFolderValue?: unknown;
+    } | undefined;
+}
+
+function getPerlCriticSyncSettings(
+    documentUri?: vscode.Uri,
+    severityOverride?: number
+): PerlCriticSyncSettings {
+    const config = vscode.workspace.getConfiguration('perl-lsp', documentUri);
+    const settings: PerlCriticSyncSettings = {};
+
+    const enabled = inspectPerlCriticOverride(config, 'perlcritic.enabled');
+    if (enabled?.globalValue !== undefined ||
+        enabled?.workspaceValue !== undefined ||
+        enabled?.workspaceFolderValue !== undefined) {
+        settings.enabled = config.get<boolean>('perlcritic.enabled', false);
+    }
+
+    const severity = inspectPerlCriticOverride(config, 'perlcritic.severity');
+    if (severityOverride !== undefined) {
+        settings.severity = severityOverride;
+    } else if (severity?.globalValue !== undefined ||
+        severity?.workspaceValue !== undefined ||
+        severity?.workspaceFolderValue !== undefined) {
+        settings.severity = config.get<number>('perlcritic.severity', 3);
+    }
+
+    const profile = inspectPerlCriticOverride(config, 'perlcritic.profile');
+    if (profile?.globalValue !== undefined ||
+        profile?.workspaceValue !== undefined ||
+        profile?.workspaceFolderValue !== undefined) {
+        settings.profile = config.get<string>('perlcritic.profile', '');
+    }
+
+    return settings;
+}
+
+function buildPerlCriticConfiguration(settings: PerlCriticSyncSettings): Record<string, unknown> | undefined {
+    if (
+        settings.enabled === undefined &&
+        settings.severity === undefined &&
+        settings.profile === undefined
+    ) {
+        return undefined;
+    }
+
+    return {
+        settings: {
+            perl: {
+                perlcritic: settings,
+            },
+        },
+    };
+}
+
+function hasExplicitPerlCriticOverrides(documentUri?: vscode.Uri): boolean {
+    const config = vscode.workspace.getConfiguration('perl-lsp', documentUri);
+    return ['perlcritic.enabled', 'perlcritic.severity', 'perlcritic.profile'].some(key => {
+        const value = config.inspect(key) as {
+            globalValue?: unknown;
+            workspaceValue?: unknown;
+            workspaceFolderValue?: unknown;
+        } | undefined;
+        return Boolean(
+            value &&
+            (value.globalValue !== undefined ||
+                value.workspaceValue !== undefined ||
+                value.workspaceFolderValue !== undefined)
+        );
+    });
+}
+
+export async function syncPerlCriticConfiguration(
+    activeClient: Pick<LanguageClient, 'sendNotification'> | undefined = client,
+    documentUri?: vscode.Uri
+): Promise<void> {
+    if (!activeClient) {
+        return;
+    }
+
+    const payload = buildPerlCriticConfiguration(getPerlCriticSyncSettings(documentUri));
+    if (payload) {
+        activeClient.sendNotification('workspace/didChangeConfiguration', payload);
+    }
+}
+
+export async function runPerlCriticOnActiveFile(
+    activeClient: Pick<LanguageClient, 'sendRequest' | 'sendNotification'> | undefined = client
+): Promise<void> {
+    const channel = outputChannel ?? vscode.window.createOutputChannel('Perl Language Server');
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'perl') {
+        vscode.window.showErrorMessage('No active Perl file to run PerlCritic on');
+        return;
+    }
+
+    if (editor.document.isDirty) {
+        await editor.document.save();
+    }
+
+    if (!activeClient) {
+        vscode.window.showWarningMessage(serverNotRunningMessage());
+        return;
+    }
+
+    if (hasExplicitPerlCriticOverrides(editor.document.uri)) {
+        await syncPerlCriticConfiguration(activeClient, editor.document.uri);
+    }
+
+    let result: unknown;
+    try {
+        result = await activeClient.sendRequest('workspace/executeCommand', {
+            command: 'perl.runCritic',
+            arguments: [editor.document.uri.toString()],
+        });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Failed to run PerlCritic: ${message}`);
+        return;
+    }
+
+    const response = (result && typeof result === 'object') ? result as Record<string, unknown> : {};
+    const status = typeof response.status === 'string' ? response.status : 'unknown';
+    const violationCount = typeof response.violationCount === 'number'
+        ? response.violationCount
+        : Array.isArray(response.violations)
+            ? response.violations.length
+            : 0;
+    const analyzerUsed = typeof response.analyzerUsed === 'string' ? response.analyzerUsed : 'unknown';
+    const fileName = path.basename(editor.document.uri.fsPath);
+
+    channel.appendLine(
+        `[perlcritic] ${fileName}: status=${status} violations=${violationCount} analyzer=${analyzerUsed}`
+    );
+
+    if (status === 'error' || typeof response.error === 'string') {
+        const message = typeof response.error === 'string'
+            ? response.error
+            : 'PerlCritic returned an error';
+        vscode.window.showErrorMessage(message, 'Show Output').then(selection => {
+            if (selection === 'Show Output') {
+                channel.show();
+            }
+        });
+        return;
+    }
+
+    if (violationCount > 0) {
+        vscode.window.showWarningMessage(
+            `PerlCritic found ${violationCount} issue${violationCount === 1 ? '' : 's'} in ${fileName}.`,
+            'Show Output'
+        ).then(selection => {
+            if (selection === 'Show Output') {
+                channel.show();
+            }
+        });
+        return;
+    }
+
+    vscode.window.showInformationMessage(
+        `PerlCritic passed for ${fileName} using ${analyzerUsed}.`,
+        'Show Output'
+    ).then(selection => {
+        if (selection === 'Show Output') {
+            channel.show();
+        }
+    });
+}
+
+export async function setPerlCriticSeverity(
+    activeClient: Pick<LanguageClient, 'sendNotification'> | undefined = client
+): Promise<void> {
+    const resourceUri = vscode.window.activeTextEditor?.document.uri;
+    const selection = await vscode.window.showQuickPick(
+        [
+            { label: '1', description: 'Very permissive' },
+            { label: '2', description: 'Permissive' },
+            { label: '3', description: 'Balanced default' },
+            { label: '4', description: 'Strict' },
+            { label: '5', description: 'Very strict' },
+        ],
+        {
+            placeHolder: 'Choose a PerlCritic severity level',
+        }
+    );
+
+    if (!selection) {
+        return;
+    }
+
+    const severity = Number(selection.label);
+    const config = vscode.workspace.getConfiguration('perl-lsp', resourceUri);
+    const target = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+    await config.update('perlcritic.severity', severity, target);
+    const payload = buildPerlCriticConfiguration(getPerlCriticSyncSettings(resourceUri, severity));
+    if (activeClient && payload) {
+        activeClient.sendNotification('workspace/didChangeConfiguration', payload);
+    }
+
+    vscode.window.showInformationMessage(`PerlCritic severity set to ${severity}.`);
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel('Perl Language Server');
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
@@ -116,6 +350,14 @@ export async function activate(context: vscode.ExtensionContext) {
         } else {
             vscode.window.showWarningMessage('Test adapter is not available. It might still be initializing.');
         }
+    });
+
+    const runPerlCriticCommand = vscode.commands.registerCommand('perl-lsp.runPerlCritic', async () => {
+        await runPerlCriticOnActiveFile();
+    });
+
+    const setPerlCriticSeverityCommand = vscode.commands.registerCommand('perl-lsp.setPerlCriticSeverity', async () => {
+        await setPerlCriticSeverity();
     });
     
     const showVersionCommand = vscode.commands.registerCommand('perl-lsp.showVersion', async () => {
@@ -184,6 +426,18 @@ export async function activate(context: vscode.ExtensionContext) {
                 detail: isTestFile ? 'Run tests for the active file' : 'Run tests for the active file (Only available for .t/.pl files)',
                 command: 'perl-lsp.runTests',
                 disabled: !isTestFile
+            },
+            {
+                label: '$(checklist) Run PerlCritic',
+                detail: isPerl ? 'Run PerlCritic on the active file' : 'Run PerlCritic on the active file (Only available for Perl files)',
+                command: 'perl-lsp.runPerlCritic',
+                disabled: !isPerl
+            },
+            {
+                label: '$(symbol-numeric) Set PerlCritic Severity',
+                detail: isPerl ? 'Choose a PerlCritic severity level' : 'Choose a PerlCritic severity level (Only available for Perl files)',
+                command: 'perl-lsp.setPerlCriticSeverity',
+                disabled: !isPerl
             },
             {
                 label: '$(list-flat) Format Document',
@@ -519,6 +773,14 @@ export async function activate(context: vscode.ExtensionContext) {
             await validateIncludePaths(context);
         }
 
+        if (
+            event.affectsConfiguration('perl-lsp.perlcritic.enabled') ||
+            event.affectsConfiguration('perl-lsp.perlcritic.severity') ||
+            event.affectsConfiguration('perl-lsp.perlcritic.profile')
+        ) {
+            await syncPerlCriticConfiguration(client);
+        }
+
         if (requiresClientRefresh(event)) {
             await promptForClientRefresh(context);
         }
@@ -564,6 +826,8 @@ export async function activate(context: vscode.ExtensionContext) {
         restartCommand,
         organizeImportsCommand,
         runTestsCommand,
+        runPerlCriticCommand,
+        setPerlCriticSeverityCommand,
         checkSyntaxCommand,
         runCurrentTestCommand,
         runAllTestsCommand,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -4,6 +4,8 @@
  *   - perl-lsp.runCurrentTest
  *   - perl-lsp.runAllTests
  *   - perl-lsp.formatDocument
+ *   - perl-lsp.runPerlCritic
+ *   - perl-lsp.setPerlCriticSeverity
  *   - perl-lsp.showIncPaths
  *   - perl-lsp.openModule
  *   - perl-lsp.showParserAst
@@ -37,6 +39,8 @@ const NEW_COMMAND_IDS = [
   'perl-lsp.runCurrentTest',
   'perl-lsp.runAllTests',
   'perl-lsp.formatDocument',
+  'perl-lsp.runPerlCritic',
+  'perl-lsp.setPerlCriticSeverity',
   'perl-lsp.showIncPaths',
   'perl-lsp.openModule',
   'perl-lsp.showParserAst',
@@ -94,6 +98,16 @@ describe('perl-lsp command palette commands (issue #2058)', () => {
 
     test('formatDocument is guarded by editorLangId == perl', () => {
       const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.formatDocument');
+      expect(entry?.when).toContain('editorLangId == perl');
+    });
+
+    test('runPerlCritic is guarded by editorLangId == perl', () => {
+      const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.runPerlCritic');
+      expect(entry?.when).toContain('editorLangId == perl');
+    });
+
+    test('setPerlCriticSeverity is guarded by editorLangId == perl', () => {
+      const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.setPerlCriticSeverity');
       expect(entry?.when).toContain('editorLangId == perl');
     });
 

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -261,6 +261,10 @@ describe('package.json contributes', () => {
       expect(keys).toContain('perl-lsp.formatOnSave');
       expect(keys).toContain('perl-lsp.enableRefactoring');
       expect(keys).toContain('perl-lsp.enableTestIntegration');
+      expect(keys).toContain('perl-lsp.perlcritic.enabled');
+      expect(keys).toContain('perl-lsp.perlcritic.severity');
+      expect(keys).toContain('perl-lsp.perlcritic.profile');
+      expect(keys).toContain('perl-lsp.perlcritic.theme');
     });
 
     test('Advanced group contains featureProfile, trace.server, channel, downloadBaseUrl', () => {
@@ -382,6 +386,36 @@ describe('package.json contributes', () => {
       expect(includePaths.default).toContain('local/lib/perl5');
     });
 
+    test('defines perlcritic.enabled with default false', () => {
+      const setting = properties['perl-lsp.perlcritic.enabled'];
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('boolean');
+      expect(setting.default).toBe(false);
+    });
+
+    test('defines perlcritic.severity as a 1-5 picker with default 3', () => {
+      const setting = properties['perl-lsp.perlcritic.severity'];
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('number');
+      expect(setting.enum).toEqual([1, 2, 3, 4, 5]);
+      expect(setting.enumDescriptions).toHaveLength(5);
+      expect(setting.default).toBe(3);
+    });
+
+    test('defines perlcritic.profile as a string setting', () => {
+      const setting = properties['perl-lsp.perlcritic.profile'];
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('string');
+      expect(setting.default).toBe('');
+    });
+
+    test('defines perlcritic.theme as a string setting', () => {
+      const setting = properties['perl-lsp.perlcritic.theme'];
+      expect(setting).toBeDefined();
+      expect(setting.type).toBe('string');
+      expect(setting.default).toBe('');
+    });
+
     test('includePaths markdownDescription mentions module-not-found guidance', () => {
       const desc: string = properties['perl-lsp.includePaths'].markdownDescription;
       // Must mention the "Can't locate" symptom so users know what to search for
@@ -436,7 +470,7 @@ describe('package.json contributes', () => {
     test('resource-scoped settings use scope resource', () => {
       // Per-file/workspace settings should be resource-scoped so they can be
       // overridden in workspace and folder settings.
-      const resourceScoped = ['perl-lsp.includePaths', 'perl-lsp.enableDiagnostics', 'perl-lsp.enableSemanticTokens', 'perl-lsp.enableFormatting', 'perl-lsp.formatOnSave', 'perl-lsp.perltidyConfig', 'perl-lsp.enableRefactoring', 'perl-lsp.enableTestIntegration', 'perl-lsp.autoPopulateNewFiles'];
+      const resourceScoped = ['perl-lsp.includePaths', 'perl-lsp.enableDiagnostics', 'perl-lsp.enableSemanticTokens', 'perl-lsp.enableFormatting', 'perl-lsp.formatOnSave', 'perl-lsp.perltidyConfig', 'perl-lsp.perlcritic.enabled', 'perl-lsp.perlcritic.severity', 'perl-lsp.perlcritic.profile', 'perl-lsp.perlcritic.theme', 'perl-lsp.enableRefactoring', 'perl-lsp.enableTestIntegration', 'perl-lsp.autoPopulateNewFiles'];
       for (const key of resourceScoped) {
         expect(properties[key]?.scope).toBe('resource');
       }

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -19,6 +19,9 @@ jest.mock('vscode-languageclient/node', () => ({
 }));
 import {
   validateIncludePaths,
+  runPerlCriticOnActiveFile,
+  setPerlCriticSeverity,
+  syncPerlCriticConfiguration,
   warnAboutPerlExtensionConflicts,
 } from '../extension';
 
@@ -153,5 +156,134 @@ describe('extension UX warnings', () => {
     showWarningMessage.mockClear();
     await warnAboutPerlExtensionConflicts(context);
     expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  test('syncs perlcritic settings to the server', async () => {
+    const sendNotification = jest.fn();
+    const getConfiguration = vscode.workspace.getConfiguration as jest.Mock;
+    getConfiguration.mockImplementation(() => ({
+      get: jest.fn((key: string, defaultValue?: any) => {
+        switch (key) {
+          case 'perlcritic.enabled':
+            return true;
+          case 'perlcritic.severity':
+            return 5;
+          case 'perlcritic.profile':
+            return '/tmp/.perlcriticrc';
+          case 'perlcritic.theme':
+            return 'classic';
+          default:
+            return defaultValue;
+        }
+      }),
+      has: jest.fn(() => false),
+      inspect: jest.fn((key: string) => {
+        switch (key) {
+          case 'perlcritic.enabled':
+            return { workspaceValue: true };
+          case 'perlcritic.severity':
+            return { workspaceValue: 5 };
+          case 'perlcritic.profile':
+            return { workspaceValue: '/tmp/.perlcriticrc' };
+          default:
+            return undefined;
+        }
+      }),
+      update: jest.fn(),
+    }));
+
+    await syncPerlCriticConfiguration({ sendNotification } as any, vscode.Uri.file('/tmp/example.pl'));
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      'workspace/didChangeConfiguration',
+      expect.objectContaining({
+        settings: expect.objectContaining({
+          perl: expect.objectContaining({
+            perlcritic: expect.objectContaining({
+              enabled: true,
+              severity: 5,
+              profile: '/tmp/.perlcriticrc',
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('does not sync perlcritic defaults when nothing is explicitly configured', async () => {
+    const sendNotification = jest.fn();
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn((key: string, defaultValue?: any) => defaultValue),
+      has: jest.fn(() => false),
+      inspect: jest.fn(() => undefined),
+      update: jest.fn(),
+    }));
+
+    await syncPerlCriticConfiguration({ sendNotification } as any, vscode.Uri.file('/tmp/example.pl'));
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  test('runs perlcritic on the active Perl file', async () => {
+    const sendRequest = jest.fn(async () => ({
+      status: 'success',
+      violationCount: 2,
+      analyzerUsed: 'external',
+      violations: [{}, {}],
+    }));
+    const activeTextEditor = {
+      document: {
+        languageId: 'perl',
+        isDirty: false,
+        uri: vscode.Uri.file('/workspace/lib/Foo.pm'),
+        save: jest.fn(async () => undefined),
+      },
+    };
+    (vscode.window as any).activeTextEditor = activeTextEditor;
+
+    await runPerlCriticOnActiveFile({ sendRequest, sendNotification: jest.fn() } as any);
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      expect.objectContaining({
+        command: 'perl.runCritic',
+        arguments: ['file:///workspace/lib/Foo.pm'],
+      })
+    );
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('PerlCritic found 2 issues in Foo.pm.'),
+      'Show Output'
+    );
+  });
+
+  test('sets perlcritic severity and syncs it to the server', async () => {
+    const sendNotification = jest.fn();
+    const sendRequest = jest.fn();
+    const showQuickPick = vscode.window.showQuickPick as jest.Mock;
+    showQuickPick.mockResolvedValue({ label: '4', description: 'Strict' });
+
+    const update = jest.fn(async () => undefined);
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn((key: string, defaultValue?: any) => defaultValue),
+      has: jest.fn(() => false),
+      inspect: jest.fn(),
+      update,
+    }));
+
+    await setPerlCriticSeverity({ sendNotification, sendRequest } as any);
+
+    expect(update).toHaveBeenCalledWith('perlcritic.severity', 4, vscode.ConfigurationTarget.Global);
+    expect(sendNotification).toHaveBeenCalledWith(
+      'workspace/didChangeConfiguration',
+      expect.objectContaining({
+        settings: expect.objectContaining({
+          perl: expect.objectContaining({
+            perlcritic: expect.objectContaining({
+              severity: 4,
+            }),
+          }),
+        }),
+      })
+    );
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('PerlCritic severity set to 4.');
   });
 });


### PR DESCRIPTION
## Summary
- Add VS Code settings for perlcritic enablement, severity, profile, and theme.
- Add command palette and status menu integration for running PerlCritic on the active file and changing severity.
- Sync explicit VS Code perlcritic overrides to the server without clobbering server-side defaults.
- Add manifest and helper tests covering the new settings and command contracts.

## Scope note
This intentionally keeps the backend unchanged and only syncs explicit VS Code overrides for `enabled`, `severity`, and `profile`. `theme` is surfaced in the VS Code settings UI for now; full editor-setup docs and any broader critic UX polish remain follow-up work.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('vscode-extension/package.json','utf8'))"`
- `npm test` could not be run here because `jest` is not installed in this checkout.