### PR TITLE
test(lsp): expand pull diagnostics snapshot coverage (#2104)

### DIFF
--- a/crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs
+++ b/crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs
@@ -1,0 +1,126 @@
+//! Snapshot coverage for pull diagnostics (LSP 3.17).
+//!
+//! These tests complement assertion-based diagnostics tests by snapshotting the
+//! response payload shape and key fields. This makes protocol-visible changes
+//! obvious during review.
+
+use insta::assert_yaml_snapshot;
+use serde_json::{Value, json};
+
+mod support;
+use support::lsp_harness::LspHarness;
+
+fn scrub_result_ids(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("resultId") {
+                map.insert("resultId".to_string(), Value::String("<stable-result-id>".into()));
+            }
+            for nested in map.values_mut() {
+                scrub_result_ids(nested);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                scrub_result_ids(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn snapshot_document_diagnostic_full_report() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = "file:///snapshot-full.pl";
+    let content = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+
+my $x = 1;
+print $y;  # Undefined variable
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({})))?;
+    harness.open_document(uri, content)?;
+
+    let mut report = harness.request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+    )?;
+
+    scrub_result_ids(&mut report);
+    assert_yaml_snapshot!("document_diagnostic_full_report", report);
+    Ok(())
+}
+
+#[test]
+fn snapshot_document_diagnostic_unchanged_report() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = "file:///snapshot-unchanged.pl";
+    let content = r#"#!/usr/bin/perl
+print "Hello, World!\\n";
+"#;
+
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({})))?;
+    harness.open_document(uri, content)?;
+
+    let first = harness.request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+    )?;
+
+    let previous_result_id = first
+        .get("resultId")
+        .and_then(Value::as_str)
+        .ok_or("missing resultId in first document diagnostic")?;
+
+    let mut unchanged = harness.request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": uri },
+            "previousResultId": previous_result_id
+        }),
+    )?;
+
+    scrub_result_ids(&mut unchanged);
+    assert_yaml_snapshot!("document_diagnostic_unchanged_report", unchanged);
+    Ok(())
+}
+
+#[test]
+fn snapshot_workspace_diagnostic_reports() -> Result<(), Box<dyn std::error::Error>> {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({})))?;
+
+    harness.open_document(
+        "file:///workspace-diagnostic-a.pl",
+        r#"use strict;
+my $x = 1;
+print $y;  # Error
+"#,
+    )?;
+
+    harness.open_document(
+        "file:///workspace-diagnostic-b.pl",
+        r#"#!/usr/bin/perl
+print "OK\\n";
+"#,
+    )?;
+
+    let mut workspace_result = harness.request("workspace/diagnostic", json!({}))?;
+
+    if let Some(items) = workspace_result.get_mut("items").and_then(Value::as_array_mut) {
+        items.sort_by(|left, right| {
+            left.get("uri").and_then(Value::as_str).cmp(&right.get("uri").and_then(Value::as_str))
+        });
+    }
+
+    scrub_result_ids(&mut workspace_result);
+    assert_yaml_snapshot!("workspace_diagnostic_reports", workspace_result);
+    Ok(())
+}

--- a/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__document_diagnostic_full_report.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__document_diagnostic_full_report.snap
@@ -1,0 +1,74 @@
+---
+source: crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs
+expression: report
+---
+items:
+  - code: PL102
+    data:
+      category: StrictWarnings
+      code: PL102
+      fixable: true
+      tags:
+        - Unnecessary
+    message: "Variable '$x' is declared but never used -- prefix with '_' or remove it\nSuggestion: Prefix as '_x'"
+    range:
+      end:
+        character: 5
+        line: 4
+      start:
+        character: 3
+        line: 4
+    relatedInformation:
+      - location:
+          range:
+            end:
+              character: 5
+              line: 4
+            start:
+              character: 3
+              line: 4
+          uri: "file:///snapshot-full.pl"
+        message: "💡 Remove the unused variable or prefix with '_' to indicate it's intentionally unused"
+    severity: 2
+    source: perl-lsp
+    tags:
+      - 1
+  - code: PL103
+    data:
+      category: StrictWarnings
+      code: PL103
+      fixable: true
+      tags: []
+    message: "Variable '$y' is used but not declared -- add 'my $y' to declare it in this scope\nSuggestion: Add 'my $y;' before this line"
+    range:
+      end:
+        character: 8
+        line: 5
+      start:
+        character: 6
+        line: 5
+    relatedInformation:
+      - location:
+          range:
+            end:
+              character: 8
+              line: 5
+            start:
+              character: 6
+              line: 5
+          uri: "file:///snapshot-full.pl"
+        message: "💡 Declare the variable with 'my', 'our', 'local', or 'state'"
+      - location:
+          range:
+            end:
+              character: 8
+              line: 5
+            start:
+              character: 6
+              line: 5
+          uri: "file:///snapshot-full.pl"
+        message: "ℹ️ Under 'use strict', all variables must be declared before use. Use 'my' for lexical scope or 'our' for package variables."
+    severity: 1
+    source: perl-lsp
+kind: full
+resultId: "<stable-result-id>"

--- a/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__document_diagnostic_unchanged_report.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__document_diagnostic_unchanged_report.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs
+expression: unchanged
+---
+kind: unchanged
+resultId: "<stable-result-id>"

--- a/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__workspace_diagnostic_reports.snap
+++ b/crates/perl-lsp/tests/snapshots/lsp_pull_diagnostics_snapshot_test__workspace_diagnostic_reports.snap
@@ -1,0 +1,193 @@
+---
+source: crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs
+expression: workspace_result
+---
+items:
+  - items:
+      - code: PL101
+        data:
+          category: StrictWarnings
+          code: PL101
+          fixable: true
+          tags: []
+        message: "Consider adding 'use warnings;' for better error detection\nSuggestion: Add 'use warnings;' at the top of the file"
+        range:
+          end:
+            character: 0
+            line: 0
+          start:
+            character: 0
+            line: 0
+        relatedInformation:
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-a.pl"
+            message: "💡 Add 'use warnings;' at the beginning of your script"
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-a.pl"
+            message: "ℹ️ The 'use warnings' pragma enables helpful warning messages about questionable constructs, uninitialized values, and deprecated features."
+        severity: 3
+        source: perl-lsp
+      - code: PL102
+        data:
+          category: StrictWarnings
+          code: PL102
+          fixable: true
+          tags:
+            - Unnecessary
+        message: "Variable '$x' is declared but never used -- prefix with '_' or remove it\nSuggestion: Prefix as '_x'"
+        range:
+          end:
+            character: 5
+            line: 1
+          start:
+            character: 3
+            line: 1
+        relatedInformation:
+          - location:
+              range:
+                end:
+                  character: 5
+                  line: 1
+                start:
+                  character: 3
+                  line: 1
+              uri: "file:///workspace-diagnostic-a.pl"
+            message: "💡 Remove the unused variable or prefix with '_' to indicate it's intentionally unused"
+        severity: 2
+        source: perl-lsp
+        tags:
+          - 1
+      - code: PL103
+        data:
+          category: StrictWarnings
+          code: PL103
+          fixable: true
+          tags: []
+        message: "Variable '$y' is used but not declared -- add 'my $y' to declare it in this scope\nSuggestion: Add 'my $y;' before this line"
+        range:
+          end:
+            character: 8
+            line: 2
+          start:
+            character: 6
+            line: 2
+        relatedInformation:
+          - location:
+              range:
+                end:
+                  character: 8
+                  line: 2
+                start:
+                  character: 6
+                  line: 2
+              uri: "file:///workspace-diagnostic-a.pl"
+            message: "💡 Declare the variable with 'my', 'our', 'local', or 'state'"
+          - location:
+              range:
+                end:
+                  character: 8
+                  line: 2
+                start:
+                  character: 6
+                  line: 2
+              uri: "file:///workspace-diagnostic-a.pl"
+            message: "ℹ️ Under 'use strict', all variables must be declared before use. Use 'my' for lexical scope or 'our' for package variables."
+        severity: 1
+        source: perl-lsp
+    kind: full
+    resultId: "<stable-result-id>"
+    uri: "file:///workspace-diagnostic-a.pl"
+    version: 1
+  - items:
+      - code: PL100
+        data:
+          category: StrictWarnings
+          code: PL100
+          fixable: true
+          tags: []
+        message: "Consider adding 'use strict;' for better error checking\nSuggestion: Add 'use strict;' at the top of the file"
+        range:
+          end:
+            character: 0
+            line: 0
+          start:
+            character: 0
+            line: 0
+        relatedInformation:
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-b.pl"
+            message: "💡 Add 'use strict;' at the beginning of your script"
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-b.pl"
+            message: "ℹ️ The 'use strict' pragma enforces good coding practices by requiring variable declarations, disabling barewords, and preventing symbolic references."
+        severity: 3
+        source: perl-lsp
+      - code: PL101
+        data:
+          category: StrictWarnings
+          code: PL101
+          fixable: true
+          tags: []
+        message: "Consider adding 'use warnings;' for better error detection\nSuggestion: Add 'use warnings;' at the top of the file"
+        range:
+          end:
+            character: 0
+            line: 0
+          start:
+            character: 0
+            line: 0
+        relatedInformation:
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-b.pl"
+            message: "💡 Add 'use warnings;' at the beginning of your script"
+          - location:
+              range:
+                end:
+                  character: 0
+                  line: 0
+                start:
+                  character: 0
+                  line: 0
+              uri: "file:///workspace-diagnostic-b.pl"
+            message: "ℹ️ The 'use warnings' pragma enables helpful warning messages about questionable constructs, uninitialized values, and deprecated features."
+        severity: 3
+        source: perl-lsp
+    kind: full
+    resultId: "<stable-result-id>"
+    uri: "file:///workspace-diagnostic-b.pl"
+    version: 1


### PR DESCRIPTION
### Motivation
- Add deterministic snapshot coverage for LSP 3.17 pull diagnostics so changes to protocol-visible diagnostic payloads are reviewable rather than noisy. 

### Description
- Add a new integration test suite `crates/perl-lsp/tests/lsp_pull_diagnostics_snapshot_test.rs` that snapshots document `full`, document `unchanged`, and `workspace/diagnostic` responses. 
- Normalize volatile identifiers by scrubbing every `resultId` to `<stable-result-id>` so snapshots focus on payload shape and content. 
- Stabilize workspace snapshots by sorting report items by `uri` before asserting to avoid nondeterministic ordering. 
- Add committed insta snapshots under `crates/perl-lsp/tests/snapshots/` for the three new tests.

### Testing
- Ran snapshot generation with `INSTA_UPDATE=unseen cargo test -p perl-lsp-rs --test lsp_pull_diagnostics_snapshot_test` and accepted new snapshots, which completed with all tests passing. 
- Ran formatting with `cargo fmt --all` successfully. 
- Re-ran `cargo test -p perl-lsp-rs --test lsp_pull_diagnostics_snapshot_test` and observed `3 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bbeb9b88333996898a0cc7c9780)