### PR TITLE
test(diagnostics): build out insta snapshot coverage (#3845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ version = "0.12.3"
 name = "perl-lsp-diagnostics"
 version = "0.12.3"
 dependencies = [
+ "insta",
  "perl-diagnostics-codes",
  "perl-heredoc-anti-patterns",
  "perl-lsp-diagnostic-types",

--- a/crates/perl-lsp-diagnostics/Cargo.toml
+++ b/crates/perl-lsp-diagnostics/Cargo.toml
@@ -29,6 +29,7 @@ perl-heredoc-anti-patterns = { workspace = true }
 perl-tdd-support = { workspace = true }
 perl-parser = { workspace = true }
 tempfile = { workspace = true }
+insta = { version = "1.47.2", features = ["yaml"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
@@ -1,0 +1,87 @@
+//! Insta snapshots for full diagnostic payload coverage.
+//!
+//! These tests complement code-level assertions by snapshotting normalized
+//! diagnostics (code, severity, range, message, suggestion) for representative
+//! snippets. This catches regressions in message text and location metadata, not
+//! just code presence.
+
+use std::sync::Arc;
+
+use insta::assert_snapshot;
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticSeverity, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn severity_name(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Error => "Error",
+        DiagnosticSeverity::Warning => "Warning",
+        DiagnosticSeverity::Information => "Information",
+        DiagnosticSeverity::Hint => "Hint",
+    }
+}
+
+fn normalize(diags: Vec<Diagnostic>) -> String {
+    let mut normalized: Vec<_> = diags
+        .into_iter()
+        .map(|diag| {
+            let code = diag.code.unwrap_or_else(|| "<none>".to_string());
+            let suggestion = diag.suggestion.unwrap_or_else(|| "<none>".to_string());
+            format!(
+                "{code} | {} | {:?} | {} | {suggestion}",
+                severity_name(diag.severity),
+                diag.range,
+                diag.message
+            )
+        })
+        .collect();
+
+    normalized.sort_unstable();
+    normalized.join("\n")
+}
+
+#[test]
+fn snapshot_script_happy_path() {
+    let source = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("script_happy_path", snapshot);
+}
+
+#[test]
+fn snapshot_package_module_happy_path() {
+    let source = concat!(
+        "package Foo;\n",
+        "use strict;\n",
+        "use warnings;\n",
+        "sub value { return 42 }\n",
+        "1;\n",
+    );
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("package_module_happy_path", snapshot);
+}
+
+#[test]
+fn snapshot_missing_pragmas_and_unused_variable() {
+    let source = "my $unused = 1;\n";
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("missing_pragmas_and_unused_variable", snapshot);
+}
+
+#[test]
+fn snapshot_security_string_eval() {
+    let source = concat!(
+        "package Foo;\n",
+        "use strict;\n",
+        "use warnings;\n",
+        "eval(\"system('rm -rf /')\");\n",
+        "1;\n",
+    );
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("security_string_eval", snapshot);
+}

--- a/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__missing_pragmas_and_unused_variable.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__missing_pragmas_and_unused_variable.snap
@@ -1,0 +1,8 @@
+---
+source: crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
+expression: snapshot
+---
+PL100 | Information | (0, 0) | Consider adding 'use strict;' for better error checking | Add 'use strict;' at the top of the file
+PL101 | Information | (0, 0) | Consider adding 'use warnings;' for better error detection | Add 'use warnings;' at the top of the file
+PL102 | Warning | (3, 10) | Variable '$unused' is declared but never used -- prefix with '_' or remove it | Prefix as '_unused'
+PL200 | Warning | (0, 0) | This file has no package declaration. Add 'package MyModule;' to declare the package namespace. | Add 'package MyModule;' at the top of the file

--- a/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__package_module_happy_path.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__package_module_happy_path.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
+expression: snapshot
+---
+

--- a/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__script_happy_path.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__script_happy_path.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
+expression: snapshot
+---
+PL200 | Warning | (0, 0) | This file has no package declaration. Add 'package MyModule;' to declare the package namespace. | Add 'package MyModule;' at the top of the file

--- a/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__security_string_eval.snap
+++ b/crates/perl-lsp-diagnostics/tests/snapshots/diagnostic_insta_snapshot_tests__security_string_eval.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs
+expression: snapshot
+---
+PL600 | Warning | (39, 64) | String eval is a security risk. Consider eval { } for exception handling. | Use eval { } for exception handling, or consider safer alternatives like Try::Tiny


### PR DESCRIPTION
### Motivation

- Increase automated snapshot coverage for the diagnostics pipeline to catch regressions in diagnostic messages, codes, severity, and location metadata.
- Provide committed golden snapshots that make message or range changes visible and require explicit review when diagnostics change.
- Make it easy for developers to run and accept snapshots locally with the `insta` tool.

### Description

- Add `insta = { version = "1.47.2", features = ["yaml"] }` as a dev-dependency to `crates/perl-lsp-diagnostics/Cargo.toml` and update `Cargo.lock` accordingly.
- Add a new integration test `crates/perl-lsp-diagnostics/tests/diagnostic_insta_snapshot_tests.rs` that normalizes full diagnostic payloads and asserts against committed snapshots.
- Commit four new snapshots under `crates/perl-lsp-diagnostics/tests/snapshots/` covering script/module happy paths, missing-pragmas + unused variable, and string-eval security cases.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `INSTA_UPDATE=always cargo test -p perl-lsp-diagnostics --test diagnostic_insta_snapshot_tests` to generate/accept snapshots and it completed with updated snapshots.
- Ran `cargo test -p perl-lsp-diagnostics --test diagnostic_insta_snapshot_tests` and `cargo test -p perl-lsp-diagnostics --test diagnostic_snapshot_tests` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bbeb9b88333996898a0cc7c9780)