### PR TITLE
test(tree-sitter-perl-rs): build out snapshot coverage (#3845)

### DIFF
--- a/crates/tree-sitter-perl-rs/tests/snapshots.rs
+++ b/crates/tree-sitter-perl-rs/tests/snapshots.rs
@@ -73,3 +73,30 @@ fn snapshot_complex_regex() {
     let sexp = tree.root_node().to_sexp();
     insta::assert_snapshot!("complex_regex", sexp);
 }
+
+#[test]
+fn snapshot_control_flow_with_postfix_condition() {
+    let mut parser = Parser::new();
+    let src = "my $x = 3;\nprint \"odd\\n\" if $x % 2;\n";
+    let tree = must_some(parser.parse(src));
+    let sexp = tree.root_node().to_sexp();
+    insta::assert_snapshot!("control_flow_with_postfix_condition", sexp);
+}
+
+#[test]
+fn snapshot_data_structure_dereference() {
+    let mut parser = Parser::new();
+    let src = "my $name = $user->{profile}->{name} // 'unknown';";
+    let tree = must_some(parser.parse(src));
+    let sexp = tree.root_node().to_sexp();
+    insta::assert_snapshot!("data_structure_dereference", sexp);
+}
+
+#[test]
+fn snapshot_for_loop_with_lexical_iterator() {
+    let mut parser = Parser::new();
+    let src = "for my $item (@items) { print $item, \"\\n\"; }";
+    let tree = must_some(parser.parse(src));
+    let sexp = tree.root_node().to_sexp();
+    insta::assert_snapshot!("for_loop_with_lexical_iterator", sexp);
+}

--- a/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__control_flow_with_postfix_condition.snap
+++ b/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__control_flow_with_postfix_condition.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-rs/tests/snapshots.rs
+expression: sexp
+---
+(source_file (my_declaration (variable $ x)(number 3)) (statement_modifier_if (expression_statement (call print ((string_interpolated "\"odd\\n\"")))) (binary_% (variable $ x) (number 2))))

--- a/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__data_structure_dereference.snap
+++ b/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__data_structure_dereference.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-rs/tests/snapshots.rs
+expression: sexp
+---
+(source_file (my_declaration (variable $ name)(binary_// (arrow_hash_deref (arrow_hash_deref (variable $ user) (identifier profile)) (identifier name)) (string "'unknown'"))))

--- a/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__for_loop_with_lexical_iterator.snap
+++ b/crates/tree-sitter-perl-rs/tests/snapshots/snapshots__for_loop_with_lexical_iterator.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-rs/tests/snapshots.rs
+expression: sexp
+---
+(source_file (foreach (my_declaration (variable $ item)) (variable @ items) (block (expression_statement (call print ((variable $ item) (string_interpolated "\"\\n\"")))))))


### PR DESCRIPTION
### Motivation
- Expand tree-sitter S-expression snapshot coverage to lock down parsing shape for additional Perl constructs and prevent silent regressions.

### Description
- Add three new tests to `crates/tree-sitter-perl-rs/tests/snapshots.rs` for postfix conditionals, nested hash dereference with `//`, and `for my $item (@items)` lexical iterator loops.
- Record corresponding Insta snapshot files under `crates/tree-sitter-perl-rs/tests/snapshots/` for each new test.
- Commit the updated test file and the three new snapshot files to the repository.

### Testing
- Ran `INSTA_UPDATE=always cargo test -p tree-sitter-perl-rs --test snapshots` which updated snapshots and completed successfully.
- Ran `cargo fmt --all` which completed without changes required.
- Ran `cargo test -p tree-sitter-perl-rs --test snapshots` which passed all tests (`11 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bbeb9b88333996898a0cc7c9780)