### PR TITLE
test(fuzz): expand quote-operator fuzz coverage (#3846)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -60,6 +60,14 @@ test = false
 doc = false
 bench = false
 
+
+[[bin]]
+name = "quote_operators"
+path = "fuzz_targets/quote_operators.rs"
+test = false
+doc = false
+bench = false
+
 [[bin]]
 name = "parser_integration"
 path = "fuzz_targets/fuzz_target_1.rs"

--- a/fuzz/fuzz_targets/quote_operators.rs
+++ b/fuzz/fuzz_targets/quote_operators.rs
@@ -1,0 +1,64 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT_BYTES: usize = 1000;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
+use perl_parser::quote_parser::{
+    extract_regex_parts, extract_substitution_parts, extract_substitution_parts_strict,
+    extract_transliteration_parts,
+};
+use perl_parser::Parser;
+
+fuzz_target!(|data: &[u8]| {
+    let input = bounded_utf8_lossy(data);
+
+    let quote_patterns = [
+        format!("m/{}/", input),
+        format!("m{{{}}}", input),
+        format!("qr/{}/", input),
+        format!("s/{0}/{0}/g", input),
+        format!("s{{{0}}}{{{0}}}gi", input),
+        format!("tr/{0}/{0}/", input),
+        format!("y{{{0}}}{{{0}}}", input),
+    ];
+
+    for pattern in &quote_patterns {
+        let _ = extract_regex_parts(pattern);
+        let _ = extract_substitution_parts(pattern);
+        let _ = extract_substitution_parts_strict(pattern);
+        let _ = extract_transliteration_parts(pattern);
+
+        let mut parser = Parser::new(pattern);
+        let _ = parser.parse();
+    }
+
+    let malformed_patterns = [
+        format!("m/{}", input),
+        format!("s/{}/", input),
+        format!("s/{}/{}/q", input, input),
+        format!("tr/{}/", input),
+        format!("y{{{}}}", input),
+    ];
+
+    for pattern in &malformed_patterns {
+        let _ = extract_substitution_parts_strict(pattern);
+
+        let mut parser = Parser::new(pattern);
+        let _ = parser.parse();
+    }
+});

--- a/justfile
+++ b/justfile
@@ -304,6 +304,7 @@ fuzz-bounded:
     @cargo +nightly fuzz run lsp_cancellation_registry -- -max_total_time=60 || echo "  LSP cancellation registry fuzzing complete"
     @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
     @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
+    @cargo +nightly fuzz run quote_operators -- -max_total_time=60 || echo "  Quote operators fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
     @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
     @echo "✅ Fuzz testing complete"
@@ -1788,6 +1789,7 @@ fuzz-regression duration='30':
     @just fuzz heredoc_parsing {{duration}} || true
     @just fuzz lsp_cancellation_registry {{duration}} || true
     @just fuzz parser_integration {{duration}} || true
+    @just fuzz quote_operators {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true


### PR DESCRIPTION
### Motivation
- Broaden corpus and harness coverage around quote-like operators (regex, substitution, transliteration) which are known fragile parsing surfaces. 
- Exercise both the `quote_parser` helper extractors and end-to-end parsing to catch extractor and integration regressions. 
- Ensure the new target is exercised by bounded/nightly and short regression fuzz lanes so CI captures regressions automatically.

### Description
- Add a new cargo-fuzz target at `fuzz/fuzz_targets/quote_operators.rs` that calls `extract_regex_parts`, `extract_substitution_parts`, `extract_substitution_parts_strict`, `extract_transliteration_parts`, and runs `Parser::new(...).parse()` on well-formed and malformed quote-like operator inputs. 
- Register the new binary in `fuzz/Cargo.toml` as `quote_operators` so the fuzz harness can discover and run it. 
- Wire the target into CI/dev recipes by updating the `justfile` to include `quote_operators` in `fuzz-bounded` and `fuzz-regression` sequences.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo check --manifest-path fuzz/Cargo.toml` which completed successfully and confirmed the new fuzz target compiles under the workspace. 
- Attempted to run `cd fuzz && cargo +nightly fuzz list` but the `cargo-fuzz` subcommand is not installed in this environment, so listing/executing fuzz runs was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bc2fe60833382bad2e018240e0c)