### PR TITLE
test(fuzz): expand fuzz target coverage (#3846)

### DIFF
--- a/docs/project/PARSER_EVOLUTION.md
+++ b/docs/project/PARSER_EVOLUTION.md
@@ -420,9 +420,10 @@ The parser is validated against a comprehensive test corpus:
 
 ### Fuzz Testing
 
-Seven fuzz targets exercise the most fragile parsing paths:
+Eight fuzz targets exercise the most fragile parsing paths:
 
 - `parser_integration` -- parser, trivia, and symbol-extraction integration
+- `quote_operators` -- regex, substitution, and transliteration delimiter handling
 - `heredoc_parsing` -- heredoc edge cases
 - `substitution_parsing` -- s/// variants
 - `builtin_functions` -- list operator argument parsing

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,8 @@ libfuzzer-sys = "0.4"
 path = "../crates/perl-parser"
 [dependencies.perl-lsp-cancellation]
 path = "../crates/perl-lsp-cancellation"
+[dependencies.perl-quote]
+path = "../crates/perl-quote"
 
 [dependencies.serde_json]
 version = "1.0.149"
@@ -63,6 +65,14 @@ bench = false
 [[bin]]
 name = "parser_integration"
 path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+bench = false
+
+
+[[bin]]
+name = "quote_operators"
+path = "fuzz_targets/quote_operators.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/quote_operators.rs
+++ b/fuzz/fuzz_targets/quote_operators.rs
@@ -1,0 +1,46 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use perl_quote::{extract_regex_parts, extract_substitution_parts, extract_transliteration_parts};
+
+const MAX_INPUT_BYTES: usize = 1024;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES {
+        data
+    } else {
+        &data[..MAX_INPUT_BYTES]
+    };
+
+    String::from_utf8_lossy(capped)
+}
+
+fuzz_target!(|data: &[u8]| {
+    let input = bounded_utf8_lossy(data);
+
+    // Raw input against each extractor.
+    let _ = extract_regex_parts(&input);
+    let _ = extract_substitution_parts(&input);
+    let _ = extract_transliteration_parts(&input);
+
+    // Template inputs to drive parser branches for quoted/pair-delimited operators.
+    let templates = [
+        format!("/{}/", input),
+        format!("m{{{}}}", input),
+        format!("qr<{0}>ix", input),
+        format!("s/{0}/{0}/g", input),
+        format!("s{{{0}}}({0})e", input),
+        format!("tr[{0}]<{0}>cd", input),
+        format!("y|{0}|{0}|r", input),
+    ];
+
+    for candidate in &templates {
+        let _ = extract_regex_parts(candidate);
+        let _ = extract_substitution_parts(candidate);
+        let _ = extract_transliteration_parts(candidate);
+    }
+});

--- a/justfile
+++ b/justfile
@@ -304,6 +304,7 @@ fuzz-bounded:
     @cargo +nightly fuzz run lsp_cancellation_registry -- -max_total_time=60 || echo "  LSP cancellation registry fuzzing complete"
     @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
     @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
+    @cargo +nightly fuzz run quote_operators -- -max_total_time=60 || echo "  Quote operators fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
     @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
     @echo "✅ Fuzz testing complete"
@@ -1788,6 +1789,7 @@ fuzz-regression duration='30':
     @just fuzz heredoc_parsing {{duration}} || true
     @just fuzz lsp_cancellation_registry {{duration}} || true
     @just fuzz parser_integration {{duration}} || true
+    @just fuzz quote_operators {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true


### PR DESCRIPTION
### Motivation

- Improve fuzzing coverage around quote operator parsing and increase branch hit-rate for regex/substitution/transliteration extraction paths.

### Description

- Add a new cargo-fuzz target `fuzz/fuzz_targets/quote_operators.rs` that exercises `extract_regex_parts`, `extract_substitution_parts`, and `extract_transliteration_parts` with both raw fuzz input and templated operator forms.
- Wire the new target into `fuzz/Cargo.toml` and add `perl-quote` as a fuzz dependency so the target can call the quote extraction APIs directly.
- Include `quote_operators` in CI-facing fuzz recipes by updating the `justfile` entries for `fuzz-bounded` and `fuzz-regression`.
- Update `docs/project/PARSER_EVOLUTION.md` to reflect eight fuzz targets and document the new `quote_operators` target.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo check --manifest-path fuzz/Cargo.toml` which completed successfully (dev profile finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bc2fe60833382bad2e018240e0c)