### PR TITLE
test(position-tracking): expand utf16 conversion unit coverage (#3867)

### DIFF
--- a/crates/perl-position-tracking/src/convert.rs
+++ b/crates/perl-position-tracking/src/convert.rs
@@ -61,3 +61,48 @@ pub fn utf16_line_col_to_offset(text: &str, line: u32, col: u32) -> usize {
     }
     text.len()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{offset_to_utf16_line_col, utf16_line_col_to_offset};
+
+    #[test]
+    fn offset_to_utf16_handles_multibyte_and_surrogate_pairs() {
+        let text = "aé💖z";
+
+        assert_eq!(offset_to_utf16_line_col(text, 0), (0, 0));
+        assert_eq!(offset_to_utf16_line_col(text, 1), (0, 1));
+        assert_eq!(offset_to_utf16_line_col(text, 3), (0, 2));
+        assert_eq!(offset_to_utf16_line_col(text, 7), (0, 4));
+        assert_eq!(offset_to_utf16_line_col(text, text.len()), (0, 5));
+    }
+
+    #[test]
+    fn offset_to_utf16_clamps_out_of_bounds_to_last_position() {
+        let text = "alpha\nbeta";
+        assert_eq!(offset_to_utf16_line_col(text, text.len() + 25), (1, 4));
+    }
+
+    #[test]
+    fn offset_to_utf16_reports_new_empty_line_for_terminal_newline() {
+        let text = "one\ntwo\n";
+        assert_eq!(offset_to_utf16_line_col(text, text.len()), (2, 0));
+    }
+
+    #[test]
+    fn utf16_line_col_to_offset_handles_split_surrogate_column() {
+        let text = "x💖y";
+        assert_eq!(utf16_line_col_to_offset(text, 0, 0), 0);
+        assert_eq!(utf16_line_col_to_offset(text, 0, 1), 1);
+        assert_eq!(utf16_line_col_to_offset(text, 0, 2), 1);
+        assert_eq!(utf16_line_col_to_offset(text, 0, 3), 5);
+        assert_eq!(utf16_line_col_to_offset(text, 0, 4), 6);
+    }
+
+    #[test]
+    fn utf16_line_col_to_offset_clamps_when_column_or_line_is_too_large() {
+        let text = "abc\nw💡";
+        assert_eq!(utf16_line_col_to_offset(text, 1, 99), text.len());
+        assert_eq!(utf16_line_col_to_offset(text, 99, 0), text.len());
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for the UTF-8/UTF-16 conversion helpers to guard against multibyte, surrogate-pair, and boundary edge cases.

### Description

- Add a `#[cfg(test)]` test module to `crates/perl-position-tracking/src/convert.rs` with focused tests for `offset_to_utf16_line_col` and `utf16_line_col_to_offset` covering multibyte/supplementary characters, out-of-bounds clamping, terminal-newline behavior, and split-surrogate columns.
- Adjust the expected terminal-newline behavior in the test to match the implementation (updated the assertion from `(3, 0)` to `(2, 0)`).

### Testing

- Ran `cargo test -p perl-position-tracking`; the initial run showed one failing assertion related to the terminal-newline expectation, the test was updated, and the suite was re-run.
- After the fix all automated tests for the crate passed, including the library unit tests and the comprehensive/extended test suites (library: 22 tests, comprehensive: 210 tests, extended: 146 tests, plus property and doctests), with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bcdbcb88333879c4304abff32c2)