### PR TITLE
feat(perlcritic): fix severity semantics, map to LSP, surface failures, add VS Code settings, and small quick-fixes (#3470)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -50,9 +50,10 @@ pub struct ServerConfig {
     /// be installed on the system; silently skipped if not available.
     pub perlcritic_enabled: bool,
 
-    /// Minimum severity level to report (1-5, where 1 = most severe).
+    /// Minimum Perl::Critic severity threshold to report (1-5).
     ///
-    /// Violations below this threshold are suppressed. Default is 3 (Harsh).
+    /// Perl::Critic semantics: `5` reports only the most severe violations, while
+    /// `1` reports all severities (least restrictive). Default is `3` (Harsh).
     /// Equivalent to `perlcritic --severity`.
     pub perlcritic_severity: u8,
 
@@ -511,7 +512,9 @@ pub struct ProjectPerlConfig {
 pub struct ProjectDiagnosticsConfig {
     /// Whether perlcritic is enabled. Maps to `ServerConfig.perlcritic_enabled`.
     pub perlcritic: Option<bool>,
-    /// Minimum perlcritic severity (1-5). Maps to `ServerConfig.perlcritic_severity`.
+    /// Minimum Perl::Critic severity threshold (1-5). Maps to `ServerConfig.perlcritic_severity`.
+    ///
+    /// Perl::Critic semantics: `5` is strictest (only most severe), `1` reports all.
     pub perlcritic_severity: Option<u8>,
 }
 

--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -63,6 +63,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_failure_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -166,6 +172,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_failure_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -232,6 +244,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_failure_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -11,6 +11,14 @@ use crate::features::diagnostics::{
 use perl_diagnostics_codes::DiagnosticCode;
 
 impl LspServer {
+    fn source_for_internal_diagnostic(diagnostic: &InternalDiagnostic) -> &'static str {
+        if diagnostic.code.as_deref().is_some_and(|code| code.contains("::")) {
+            "perlcritic"
+        } else {
+            "perl-lsp"
+        }
+    }
+
     /// Convert internal diagnostic tags to LSP tag values
     ///
     /// Maps internal `DiagnosticTag` variants to their LSP numeric equivalents:
@@ -161,7 +169,7 @@ impl LspServer {
                             InternalDiagnosticSeverity::Hint => 4,
                         },
                         "code": d.code,
-                        "source": "perl-parser",
+                        "source": Self::source_for_internal_diagnostic(&d),
                         "message": d.message,
                     });
                     if !d.tags.is_empty() {
@@ -362,7 +370,7 @@ impl LspServer {
                                     InternalDiagnosticSeverity::Hint => 4,
                                 },
                                 "code": d.code.clone(),
-                                "source": "perl-lsp",
+                                "source": Self::source_for_internal_diagnostic(&d),
                                 "message": message,
                             });
 
@@ -597,7 +605,7 @@ impl LspServer {
                                         InternalDiagnosticSeverity::Hint => 4,
                                     },
                                     "code": d.code.clone(),
-                                    "source": "perl-lsp",
+                                    "source": Self::source_for_internal_diagnostic(&d),
                                     "message": message,
                                 });
                                 if !d.tags.is_empty() {
@@ -754,8 +762,8 @@ impl LspServer {
     /// Checks the `perlcritic_enabled` config flag and whether `perlcritic` is
     /// installed on the system. If both conditions are met, runs perlcritic on
     /// the file and appends violations with severity mapped from Perl::Critic's
-    /// 1-5 scale to LSP severity levels (Brutal/Cruel -> Error, Harsh ->
-    /// Warning, Stern/Gentle -> Information).
+    /// 1-5 scale to LSP severity levels (5->Error, 4/3->Warning,
+    /// 2->Information, 1->Hint).
     ///
     /// The `CriticAnalyzer` is reused across calls via `self.critic_analyzer`
     /// so that the per-file violation cache survives between `didChange` events.
@@ -763,9 +771,22 @@ impl LspServer {
     /// analyzer is reset to `None` from `didChangeConfiguration` whenever any
     /// critic-related setting changes.
     ///
-    /// Silently skips if perlcritic is not installed or the URI is not a file.
+    /// Skips non-file URIs; emits workspace-scoped warnings for missing tooling/config.
     /// The `doc_text` parameter is used to convert perlcritic's line/column
     /// positions into byte offsets for the internal diagnostic range.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn warn_perlcritic_once(&self, guard: &std::sync::atomic::AtomicBool, message: String) {
+        if !guard.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            let _ = self.show_message(super::window::MessageType::Warning, &message);
+            let _ = self.log_message(super::window::MessageType::Warning, &message);
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn note_perlcritic_health_issue(&self, message: &str) {
+        tracing::warn!("perlcritic health: {message}");
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn collect_external_perlcritic_diagnostics(
         &self,
@@ -805,6 +826,20 @@ impl LspServer {
         let skip_check =
             self.skip_perlcritic_command_check.load(std::sync::atomic::Ordering::Relaxed);
         if !skip_check && !crate::execute_command::command_exists("perlcritic") {
+            let message = "Perl::Critic is enabled but `perlcritic` was not found on PATH. Install it (for example: cpanm Perl::Critic) or disable `perl.perlcritic.enabled`.".to_string();
+            self.warn_perlcritic_once(&self.perlcritic_missing_tool_warned, message.clone());
+            self.note_perlcritic_health_issue(&message);
+            return;
+        }
+
+        if let Some(profile_path) = profile.as_deref()
+            && !std::path::Path::new(profile_path).exists()
+        {
+            let message = format!(
+                "Perl::Critic profile not found: {profile_path}. Update `perl.perlcritic.profile` or remove it to use auto-discovery."
+            );
+            self.warn_perlcritic_once(&self.perlcritic_missing_profile_warned, message.clone());
+            self.note_perlcritic_health_issue(&message);
             return;
         }
 
@@ -872,17 +907,18 @@ impl LspServer {
         match result {
             Some(Ok(violations)) => {
                 for v in violations {
-                    // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
-                    // Brutal(1)/Cruel(2) -> Error, Harsh(3) -> Warning,
-                    // Stern(4)/Gentle(5) -> Information
+                    // Map Perl::Critic severity to LSP DiagnosticSeverity:
+                    // 5 -> Error, 4/3 -> Warning, 2 -> Information, 1 -> Hint
                     let internal_severity = match v.severity {
-                        crate::perl_critic::Severity::Brutal
-                        | crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Error,
-                        crate::perl_critic::Severity::Harsh => InternalDiagnosticSeverity::Warning,
+                        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
                         crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Gentle => {
+                        | crate::perl_critic::Severity::Harsh => {
+                            InternalDiagnosticSeverity::Warning
+                        }
+                        crate::perl_critic::Severity::Cruel => {
                             InternalDiagnosticSeverity::Information
                         }
+                        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
                     };
 
                     // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
@@ -896,8 +932,8 @@ impl LspServer {
                     diagnostics.push(InternalDiagnostic {
                         range: (start_byte, end_byte),
                         severity: internal_severity,
-                        code: Some(format!("PC:{}", v.policy)),
-                        message: v.description,
+                        code: Some(v.policy.clone()),
+                        message: format!("[{}] {}", v.policy, v.description),
                         related_information: Vec::new(),
                         tags: Vec::new(),
                         suggestion: None,
@@ -906,6 +942,11 @@ impl LspServer {
             }
             Some(Err(e)) => {
                 tracing::warn!(uri, error = %e, "perlcritic failed");
+                let message = format!(
+                    "Perl::Critic execution failed for workspace diagnostics: {e}. Check perlcritic installation/profile settings."
+                );
+                self.warn_perlcritic_once(&self.perlcritic_runtime_failure_warned, message.clone());
+                self.note_perlcritic_health_issue(&message);
             }
             None => {}
         }

--- a/crates/perl-lsp/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp/src/runtime/language/code_actions.rs
@@ -37,6 +37,39 @@ fn retain_requested_code_action_kinds(code_actions: &mut Vec<Value>, requested_k
     });
 }
 
+fn critic_quick_fix_for_policy(code: &str, uri: &str) -> Option<Value> {
+    let (title, new_text) = match code {
+        "TestingAndDebugging::RequireUseStrict" => ("Add `use strict;`", "use strict;\n"),
+        "TestingAndDebugging::RequireUseWarnings" => ("Add `use warnings;`", "use warnings;\n"),
+        _ => return None,
+    };
+
+    let mut changes = serde_json::Map::new();
+    changes.insert(
+        uri.to_string(),
+        json!([{
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 0}
+            },
+            "newText": new_text
+        }]),
+    );
+
+    Some(json!({
+        "title": title,
+        "kind": "quickfix",
+        "diagnostics": [{
+            "code": code,
+            "source": "perlcritic",
+            "message": format!("Perl::Critic policy violation: {code}"),
+        }],
+        "edit": {
+            "changes": changes
+        }
+    }))
+}
+
 fn display_diagnostic_message(diagnostic: &crate::features::diagnostics::Diagnostic) -> String {
     match &diagnostic.suggestion {
         Some(suggestion) => format!("{}\nSuggestion: {}", diagnostic.message, suggestion),
@@ -76,6 +109,22 @@ impl LspServer {
 
             // Get code actions from both providers
             let mut code_actions: Vec<Value> = Vec::new();
+
+            // Add external Perl::Critic quick fixes keyed by diagnostic policy code.
+            if let Some(context_diags) =
+                params.get("context").and_then(|c| c.get("diagnostics")).and_then(Value::as_array)
+            {
+                for diagnostic in context_diags {
+                    if diagnostic.get("source").and_then(Value::as_str) != Some("perlcritic") {
+                        continue;
+                    }
+                    if let Some(code) = diagnostic.get("code").and_then(Value::as_str)
+                        && let Some(action) = critic_quick_fix_for_policy(code, uri)
+                    {
+                        code_actions.push(action);
+                    }
+                }
+            }
 
             // Add Perl::Critic quick fixes
             let builtin_analyzer = BuiltInAnalyzer::new();

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -273,6 +273,15 @@ pub struct LspServer {
     /// Initialized to `false`; only the test helper methods flip this.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) skip_perlcritic_command_check: AtomicBool,
+    /// Guard to emit missing-`perlcritic` warning only once per workspace/session.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_missing_tool_warned: AtomicBool,
+    /// Guard to emit missing-profile warning only once per workspace/session.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_missing_profile_warned: AtomicBool,
+    /// Guard to emit runtime execution failure warning only once per workspace/session.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_runtime_failure_warned: AtomicBool,
     /// Optional AI inline-completion backend.
     ///
     /// When `Some`, the `handle_inline_completion` handler will attempt

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -546,6 +546,12 @@ impl LspServer {
                     #[cfg(not(target_arch = "wasm32"))]
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
+                        self.perlcritic_missing_tool_warned
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
+                        self.perlcritic_missing_profile_warned
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
+                        self.perlcritic_runtime_failure_warned
+                            .store(false, std::sync::atomic::Ordering::Relaxed);
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -75,14 +75,14 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
     let diags = result["items"].as_array().cloned().unwrap_or_default();
 
     let found = diags.iter().any(|d| {
-        d["code"].as_str() == Some("PC:TestingAndDebugging::RequireUseStrict")
+        d["code"].as_str() == Some("TestingAndDebugging::RequireUseStrict")
             && d["severity"].as_u64() == Some(2)
     });
 
     assert!(
         found,
         "Expected a Warning diagnostic with code \
-         PC:TestingAndDebugging::RequireUseStrict in the pull response; \
+         TestingAndDebugging::RequireUseStrict in the pull response; \
          got: {result}"
     );
 }
@@ -145,10 +145,8 @@ fn test_c_graceful_skip_when_perlcritic_not_installed() {
     let result = pull_diagnostics(&server, uri, "use strict;\n");
 
     let diags = result["items"].as_array().cloned().unwrap_or_default();
-    let perlcritic_diags: Vec<_> = diags
-        .iter()
-        .filter(|d| d["code"].as_str().map(|c| c.starts_with("PC:")).unwrap_or(false))
-        .collect();
+    let perlcritic_diags: Vec<_> =
+        diags.iter().filter(|d| d["source"].as_str() == Some("perlcritic")).collect();
 
     assert_eq!(
         perlcritic_diags.len(),
@@ -218,4 +216,49 @@ fn test_d_perlcriticrc_walkup_finds_workspace_root_config() {
          .perlcriticrc; args: {:?}",
         invocations[0].args
     );
+}
+
+#[test]
+fn test_e_perlcritic_severity_five_maps_to_lsp_error() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 5, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(
+        b"test.pl:3:1:5:TestingAndDebugging::RequireUseStrict:Code does not use strict\n".to_vec(),
+    ));
+    server.test_install_mock_critic_runtime(runtime);
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_severity_5.pl";
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_severity_5.pl";
+
+    let result = pull_diagnostics(&server, uri, "print 'x';\n");
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+    assert!(diags.iter().any(|d| d["severity"].as_u64() == Some(1)));
+}
+
+#[test]
+fn test_f_perlcritic_severity_one_maps_to_lsp_hint() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 1, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(
+        b"test.pl:3:1:1:ValuesAndExpressions::ProhibitNoisyQuotes:Noisy quote-like operator\n"
+            .to_vec(),
+    ));
+    server.test_install_mock_critic_runtime(runtime);
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_severity_1.pl";
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_severity_1.pl";
+
+    let result = pull_diagnostics(&server, uri, "print q{hello};\n");
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+    assert!(diags.iter().any(|d| d["severity"].as_u64() == Some(4)));
 }

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -88,7 +88,7 @@ your-project/
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `perlcritic` | `boolean` | (unset) | Enable perlcritic diagnostics. When unset, the server default (`false`) applies. Requires `perlcritic` installed on the system. |
-| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. 1 = most severe (gentle), 5 = everything (brutal). Must be in the range 1–5; values outside this range are a parse error. |
+| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum Perl::Critic severity threshold to report. `5` = only most severe violations, `1` = all violations. Must be in the range 1–5; values outside this range are a parse error. |
 
 #### `[features]` — LSP Feature Toggles
 
@@ -392,8 +392,8 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream. When `perlcritic` is missing,
+the server emits a workspace warning and records the issue in health output.
 
 #### `perl.perlcritic.severity`
 
@@ -402,9 +402,9 @@ is not installed on the system.
 | Type | `integer` (1–5) |
 | Default | `3` |
 
-Minimum severity level to report. `1` = most severe (Brutal), `5` = everything
-(Gentle). Values are clamped to the valid range. Equivalent to
-`perlcritic --severity N`.
+Minimum Perl::Critic severity threshold. `5` = only most severe violations
+(`Gentle`), `1` = all violations (`Brutal` and above). Values are clamped to
+the valid range. Equivalent to `perlcritic --severity N`.
 
 #### `perl.perlcritic.profile`
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -318,6 +318,32 @@
             "description": "Enable Test::More and Test2 integration for the VS Code Test Explorer panel.",
             "markdownDescription": "Enable `Test::More` and `Test2` integration for the VS Code Test Explorer panel."
           },
+          "perl.perlcritic.enabled": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "order": 70,
+            "description": "Enable Perl::Critic diagnostics from the language server.",
+            "markdownDescription": "Enable Perl::Critic diagnostics from the language server (`perlcritic` must be installed)."
+          },
+          "perl.perlcritic.severity": {
+            "type": "integer",
+            "default": 3,
+            "minimum": 1,
+            "maximum": 5,
+            "scope": "resource",
+            "order": 80,
+            "description": "Perl::Critic severity threshold (5 = strictest, 1 = report all).",
+            "markdownDescription": "Perl::Critic severity threshold (`5` = only most severe, `1` = report all)."
+          },
+          "perl.perlcritic.profile": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "order": 90,
+            "description": "Path to a .perlcriticrc profile file.",
+            "markdownDescription": "Path to a `.perlcriticrc` profile file. Leave empty to use auto-discovery."
+          },
           "perl-lsp.autoPopulateNewFiles": {
             "type": "boolean",
             "default": true,
@@ -811,7 +837,7 @@
           {
             "id": "verify-perl",
             "title": "Verify Your Perl Installation",
-            "description": "Run the health check to confirm Perl and perltidy are available.",
+            "description": "Run the health check to confirm Perl, perltidy, and perlcritic are available.",
             "media": {
               "image": "media/walkthrough/verify-perl.svg",
               "altText": "Verify Perl"

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -3,7 +3,7 @@
  *
  * Responsibilities:
  * - Detect first run via `context.globalState` key `perl-lsp.welcomed`.
- * - Run a multi-step health check: Perl version, perltidy, LSP binary.
+ * - Run a multi-step health check: Perl version, perltidy, perlcritic, LSP binary.
  * - Expose individual check methods so tests can exercise them in isolation.
  */
 
@@ -204,6 +204,37 @@ export class OnboardingManager {
     }
   }
 
+
+  /**
+   * Check whether `perlcritic` is on PATH.
+   *
+   * Perl::Critic absence is a warning — core LSP features still work.
+   */
+  async checkPerlcriticInstalled(): Promise<HealthCheckResult> {
+    const label = 'perlcritic';
+    try {
+      const { stdout } = await this._execCheck('perlcritic', ['--version']);
+      const version = stdout.trim() || '(unknown)';
+      this.outputChannel.appendLine(`[onboarding] perlcritic: ${version}`);
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `perlcritic found (${version})`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(`[onboarding] perlcritic not found: ${msg}`);
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Warning,
+        detail:
+          'perlcritic not found — Perl::Critic diagnostics will be unavailable. Install via: cpanm Perl::Critic',
+      };
+    }
+  }
+
   /**
    * Check whether the LSP binary has been downloaded / located.
    *
@@ -249,9 +280,10 @@ export class OnboardingManager {
   ): Promise<HealthCheckResult[]> {
     this.outputChannel.appendLine('[onboarding] Running setup health check...');
 
-    const [perlResult, perltidyResult] = await Promise.all([
+    const [perlResult, perltidyResult, perlcriticResult] = await Promise.all([
       this.checkPerlInstalled(),
       this.checkPerltidyInstalled(),
+      this.checkPerlcriticInstalled(),
     ]);
 
     const binaryResult = this.checkBinaryDownloaded(serverPath);
@@ -259,6 +291,7 @@ export class OnboardingManager {
     const results: HealthCheckResult[] = [
       perlResult,
       perltidyResult,
+      perlcriticResult,
       binaryResult,
     ];
 


### PR DESCRIPTION
### Motivation
- Upstream Perl::Critic semantics were documented/handled incorrectly (severity inverted), making any UX built on the numeric value wrong. Fixing that is foundational.  
- Diagnostics should preserve policy identity and map Critic severities to meaningful LSP severities so editors and code actions can act on them.  
- Silent failures (missing binary, bad profile, execution errors) produce poor UX and need explicit workspace-level surfacing.  

### Description
- Corrected server-side comments/docs and public config docs to reflect real Perl::Critic semantics (`5` = strictest / report only most severe; `1` = report everything) and adjusted `ServerConfig`/project config docstrings.  
- Rewired external perlcritic→LSP mapping to: `5 -> Error`, `4/3 -> Warning`, `2 -> Information`, `1 -> Hint`, set `Diagnostic.code` to the Perl::Critic policy name, formatted messages to include policy context, and mark `source` as `perlcritic`.  
- Surface tool/config failures: emit workspace-scoped warnings (and log) when `perlcritic` is missing, when a configured profile path is absent, or when execution fails; use atomic once-per-session guards and reset guards on relevant config changes.  
- Exposed VS Code settings in `vscode-extension/package.json`: `perl.perlcritic.enabled`, `perl.perlcritic.severity`, and `perl.perlcritic.profile`, and extended onboarding/health checks to include `perlcritic` availability.  
- Added a compact critic quick-fix registry in the existing code-action path keyed by `Diagnostic.code` (policy name) with two deterministic quick fixes (`RequireUseStrict`, `RequireUseWarnings`) without creating a new crate.  
- Adjusted code paths and tests: updated diagnostic publishing to pick `source` dynamically, updated and added integration tests that assert severity semantics and diagnostic shape, and reset warning guards on config changes.  

### Testing
- Ran formatting: `cargo fmt --all` (success).  
- Ran unit tests for config crate: `cargo test -p perl-lsp-config --lib` (25 passed).  
- Ran targeted integration tests for perlcritic pipeline: `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests` (6 passed).  
- Attempted `npm run compile` in `vscode-extension` to validate TypeScript build, which failed in this environment due to unavailable Node dependency resolution for `vscode-jsonrpc` (failure unrelated to Rust changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9260034288333b147f16b3fe3e80d)