### PR TITLE
Support tag-imported symbols in symbol resolution and goto-definition

### DIFF
--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -265,6 +265,68 @@ my $result = calculate_sum(1, 2, 3);
     Ok(())
 }
 
+#[test]
+fn go_to_definition_on_tag_imported_symbol_navigates_to_source_module() -> TestResult {
+    let mut harness = LspHarness::new();
+    let workspace = support::lsp_harness::TempWorkspace::new()?;
+
+    workspace.write(
+        "lib/POSIX.pm",
+        r#"package POSIX;
+use strict;
+use warnings;
+
+sub WIFEXITED {
+    return 1;
+}
+
+1;
+"#,
+    )?;
+
+    harness.initialize_with_root(&workspace.root_uri, None)?;
+
+    let module_uri = workspace.uri("lib/POSIX.pm");
+    let module_content = std::fs::read_to_string(workspace.dir.path().join("lib/POSIX.pm"))
+        .map_err(|e| format!("failed to read module: {e}"))?;
+    harness.open(&module_uri, &module_content)?;
+
+    let caller = r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use POSIX qw(:sys_wait_h);
+
+if (WIFEXITED(0)) {
+    print "ok\n";
+}
+"#;
+    harness.open(&workspace.uri("app.pl"), caller)?;
+    harness.barrier();
+
+    let (line, character) = find_line_char(caller, "WIFEXITED(0)")?;
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": workspace.uri("app.pl")},
+            "position": {"line": line, "character": character}
+        }),
+    )?;
+
+    let locations = result.as_array().ok_or("expected location array")?;
+    assert!(!locations.is_empty(), "expected definition result for tag-imported symbol");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+    let uri = first["uri"].as_str().ok_or("Expected URI")?;
+    assert!(
+        uri.contains("POSIX.pm") || uri.contains("POSIX%2Epm"),
+        "Definition should point to POSIX.pm, got: {}",
+        uri
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Test 3: XS bootstrap calls navigate to native `.xs` entry points
 // ---------------------------------------------------------------------------

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1245,20 +1245,102 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
         if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
     }
 
+    fn normalize_import_token(token: &str) -> &str {
+        token.trim().trim_matches('\'').trim_matches('"').trim()
+    }
+
+    fn export_tag_members(module: &str, tag: &str) -> &'static [&'static str] {
+        match (module, normalize_import_token(tag)) {
+            // POSIX tag sets commonly used in system scripts.
+            ("POSIX", ":sys_wait_h") => {
+                &["WEXITSTATUS", "WIFEXITED", "WIFSIGNALED", "WIFSTOPPED", "WTERMSIG"]
+            }
+            ("POSIX", ":fcntl_h") => &["F_GETFD", "F_SETFD", "F_GETFL", "F_SETFL", "FD_CLOEXEC"],
+            ("POSIX", ":termios_h") => {
+                &["B9600", "B19200", "B38400", "TCSANOW", "TCSADRAIN", "TCSAFLUSH"]
+            }
+            // File::Find exports.
+            ("File::Find", ":find") => &["find", "finddepth"],
+            // Fcntl exports.
+            ("Fcntl", ":seek") => &["SEEK_SET", "SEEK_CUR", "SEEK_END"],
+            ("Fcntl", ":lock") => &["LOCK_SH", "LOCK_EX", "LOCK_NB", "LOCK_UN"],
+            // Encode exports.
+            ("Encode", ":fallback") => &[
+                "FB_DEFAULT",
+                "FB_CROAK",
+                "FB_QUIET",
+                "FB_WARN",
+                "FB_PERLQQ",
+                "FB_HTMLCREF",
+                "FB_XMLCREF",
+            ],
+            _ => &[],
+        }
+    }
+
+    fn tag_imports_symbol(module: &str, import_token: &str, symbol_name: &str) -> bool {
+        let tag = normalize_import_token(import_token);
+        if !tag.starts_with(':') {
+            return false;
+        }
+        export_tag_members(module, tag).contains(&symbol_name)
+    }
+
+    fn qw_content(arg: &str) -> Option<&str> {
+        let bytes = arg.as_bytes();
+        if bytes.len() < 3 || bytes[0] != b'q' || bytes[1] != b'w' {
+            return None;
+        }
+
+        let mut idx = 2usize;
+        while idx < bytes.len() && (bytes[idx] as char).is_ascii_whitespace() {
+            idx += 1;
+        }
+        if idx >= bytes.len() {
+            return None;
+        }
+
+        let open = bytes[idx] as char;
+        if open.is_ascii_alphanumeric() || open == '_' {
+            return None;
+        }
+        let close = match open {
+            '(' => ')',
+            '[' => ']',
+            '{' => '}',
+            '<' => '>',
+            _ => open,
+        };
+
+        let start = idx + 1;
+        let mut end = start;
+        while end < bytes.len() && (bytes[end] as char) != close {
+            end += 1;
+        }
+        if end >= bytes.len() {
+            return None;
+        }
+
+        Some(&arg[start..end])
+    }
+
     fn find_import_source(ast: &Node, symbol_name: &str) -> Option<String> {
         fn find(node: &Node, name: &str) -> Option<String> {
             if let NodeKind::Use { module, args, .. } = &node.kind {
                 for arg in args {
-                    if arg == name {
+                    if normalize_import_token(arg) == name {
                         return Some(module.clone());
                     }
-                    if arg.starts_with("qw") {
-                        let content = arg
-                            .trim_start_matches("qw")
-                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
-                        if content.split_whitespace().any(|w| w == name) {
-                            return Some(module.clone());
+                    if tag_imports_symbol(module, arg, name) {
+                        return Some(module.clone());
+                    }
+                    if let Some(content) = qw_content(arg) {
+                        for import_token in content.split_whitespace() {
+                            if import_token == name
+                                || tag_imports_symbol(module, import_token, name)
+                            {
+                                return Some(module.clone());
+                            }
                         }
                     }
                 }

--- a/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/extended_unit_tests.rs
@@ -219,6 +219,59 @@ fn symbol_at_cursor_on_use_statement() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
+fn symbol_at_cursor_resolves_posix_tag_imported_symbol() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use POSIX qw(:sys_wait_h);
+my $status = 0;
+WIFEXITED($status);
+"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let offset = must_some(code.find("WIFEXITED"));
+
+    let sym = must_some(symbol_at_cursor(&ast, offset, "main"));
+    assert_eq!(sym.pkg.as_ref(), "POSIX");
+    assert_eq!(sym.name.as_ref(), "WIFEXITED");
+    Ok(())
+}
+
+#[test]
+fn symbol_at_cursor_resolves_quoted_posix_tag_imported_symbol()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use POSIX ':sys_wait_h';
+my $status = 0;
+WIFEXITED($status);
+"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let offset = must_some(code.find("WIFEXITED"));
+
+    let sym = must_some(symbol_at_cursor(&ast, offset, "main"));
+    assert_eq!(sym.pkg.as_ref(), "POSIX");
+    assert_eq!(sym.name.as_ref(), "WIFEXITED");
+    Ok(())
+}
+
+#[test]
+fn symbol_at_cursor_resolves_qw_angle_tag_imported_symbol() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use POSIX qw<:sys_wait_h>;
+my $status = 0;
+WIFEXITED($status);
+"#;
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    let offset = must_some(code.find("WIFEXITED"));
+
+    let sym = must_some(symbol_at_cursor(&ast, offset, "main"));
+    assert_eq!(sym.pkg.as_ref(), "POSIX");
+    assert_eq!(sym.name.as_ref(), "WIFEXITED");
+    Ok(())
+}
+
+#[test]
 fn symbol_at_cursor_returns_none_in_whitespace() -> Result<(), Box<dyn std::error::Error>> {
     let code = "    ";
     let mut parser = Parser::new(code);


### PR DESCRIPTION
### Motivation
- Improve symbol resolution for tag-based imports (e.g. `use POSIX qw(:sys_wait_h)`) so tag-members can be resolved back to their source module. 
- Ensure go-to-definition navigates from tag-imported symbols in scripts to the defining module file. 
- Expand unit and integration tests to cover quoted and `qw`-style tag imports and LSP navigation for tag imports.

### Description
- Added helper functions `normalize_import_token`, `export_tag_members`, `tag_imports_symbol`, and `qw_content` to `declaration.rs` to detect and map tag imports to exported members. 
- Enhanced `find_import_source` to recognize quoted tags, `qw` forms (including different delimiters), and tag-members when resolving an imported symbol to its module. 
- Added an LSP integration test `go_to_definition_on_tag_imported_symbol_navigates_to_source_module` to verify go-to-definition navigates to `POSIX.pm` for a `:sys_wait_h`-imported symbol. 
- Added unit tests `symbol_at_cursor_resolves_posix_tag_imported_symbol`, `symbol_at_cursor_resolves_quoted_posix_tag_imported_symbol`, and `symbol_at_cursor_resolves_qw_angle_tag_imported_symbol` to validate symbol resolution for various tag import syntaxes.

### Testing
- Ran the workspace test suite with `cargo test`; the new analyzer unit tests `symbol_at_cursor_resolves_*` and the LSP test `go_to_definition_on_tag_imported_symbol_navigates_to_source_module` were executed and passed. 
- Existing tests in `crates/perl-semantic-analyzer` and `crates/perl-lsp` were also executed as part of the run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928ee0b9483339b4e26e8e471b943)