### PR TITLE
feat(perlcritic): wire severity semantics, diagnostics, health, and vscode settings (#3470)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -50,9 +50,11 @@ pub struct ServerConfig {
     /// be installed on the system; silently skipped if not available.
     pub perlcritic_enabled: bool,
 
-    /// Minimum severity level to report (1-5, where 1 = most severe).
+    /// Minimum severity level to report (1-5, where 1 = least severe, 5 = most severe).
     ///
-    /// Violations below this threshold are suppressed. Default is 3 (Harsh).
+    /// Perl::Critic reports violations with severity >= this threshold.
+    /// A threshold of 1 reports all violations; 5 reports only the most severe.
+    /// Default is 3 (Harsh).
     /// Equivalent to `perlcritic --severity`.
     pub perlcritic_severity: u8,
 

--- a/crates/perl-lsp-tooling/src/perl_critic/types.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic/types.rs
@@ -7,15 +7,15 @@ use lsp_types;
 /// Severity levels for Perl::Critic violations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Severity {
-    /// Cosmetic issues (severity 5)
+    /// Most severe issues (severity 5)
     Gentle = 5,
-    /// Minor issues (severity 4)
+    /// High-severity issues (severity 4)
     Stern = 4,
     /// Important issues (severity 3)
     Harsh = 3,
-    /// Serious issues (severity 2)
+    /// Lower-severity issues (severity 2)
     Cruel = 2,
-    /// Critical issues (severity 1)
+    /// Least-severe issues (severity 1)
     Brutal = 1,
 }
 
@@ -38,9 +38,10 @@ impl Severity {
     #[cfg(feature = "lsp-compat")]
     pub fn to_diagnostic_severity(self) -> lsp_types::DiagnosticSeverity {
         match self {
-            Self::Brutal | Self::Cruel => lsp_types::DiagnosticSeverity::ERROR,
-            Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
-            Self::Stern | Self::Gentle => lsp_types::DiagnosticSeverity::INFORMATION,
+            Self::Gentle => lsp_types::DiagnosticSeverity::ERROR,
+            Self::Stern | Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
+            Self::Cruel => lsp_types::DiagnosticSeverity::INFORMATION,
+            Self::Brutal => lsp_types::DiagnosticSeverity::HINT,
         }
     }
 

--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -63,6 +63,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_error_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -166,6 +172,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_error_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -232,6 +244,12 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_tool_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_missing_profile_warned: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            perlcritic_runtime_error_warned: AtomicBool::new(false),
             ai_inline_backend: Mutex::new(None),
         }
     }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -754,8 +754,8 @@ impl LspServer {
     /// Checks the `perlcritic_enabled` config flag and whether `perlcritic` is
     /// installed on the system. If both conditions are met, runs perlcritic on
     /// the file and appends violations with severity mapped from Perl::Critic's
-    /// 1-5 scale to LSP severity levels (Brutal/Cruel -> Error, Harsh ->
-    /// Warning, Stern/Gentle -> Information).
+    /// 1-5 scale to LSP severity levels (5 -> Error, 4/3 -> Warning,
+    /// 2 -> Information, 1 -> Hint).
     ///
     /// The `CriticAnalyzer` is reused across calls via `self.critic_analyzer`
     /// so that the per-file violation cache survives between `didChange` events.
@@ -763,7 +763,9 @@ impl LspServer {
     /// analyzer is reset to `None` from `didChangeConfiguration` whenever any
     /// critic-related setting changes.
     ///
-    /// Silently skips if perlcritic is not installed or the URI is not a file.
+    /// Skips if URI is not a file. Emits one-time workspace warnings when
+    /// perlcritic is enabled but unavailable, configured profile is missing,
+    /// or external execution fails.
     /// The `doc_text` parameter is used to convert perlcritic's line/column
     /// positions into byte offsets for the internal diagnostic range.
     #[cfg(not(target_arch = "wasm32"))]
@@ -797,7 +799,7 @@ impl LspServer {
             }
         };
 
-        // Silently skip if perlcritic is not installed.
+        // Warn once and skip if perlcritic is not installed.
         // The `skip_perlcritic_command_check` flag is always `false` in production
         // and is only set to `true` through the test helper
         // `LspServer::test_bypass_perlcritic_command_check`, enabling mock-runtime
@@ -805,6 +807,13 @@ impl LspServer {
         let skip_check =
             self.skip_perlcritic_command_check.load(std::sync::atomic::Ordering::Relaxed);
         if !skip_check && !crate::execute_command::command_exists("perlcritic") {
+            if !self.perlcritic_missing_tool_warned.swap(true, std::sync::atomic::Ordering::Relaxed)
+            {
+                let _ = self.show_message(
+                    crate::runtime::MessageType::Warning,
+                    "Perl::Critic is enabled, but `perlcritic` was not found on PATH. Install Perl::Critic to enable external lint diagnostics.",
+                );
+            }
             return;
         }
 
@@ -822,7 +831,7 @@ impl LspServer {
                 // workspace root looking for `.perlcriticrc`.  Ensures that a
                 // repo-root config is found even when the file lives in a
                 // sub-directory.  Only runs when the analyzer needs (re-)init.
-                let resolved_profile = profile.or_else(|| {
+                let resolved_profile = profile.clone().or_else(|| {
                     let workspace_root = self.root_path.lock().clone();
                     let mut dir = file_path.parent().map(|p| p.to_path_buf());
                     while let Some(current) = dir {
@@ -840,6 +849,21 @@ impl LspServer {
                     }
                     None
                 });
+                if let Some(profile_path) = profile.as_deref() {
+                    let profile_exists = std::path::Path::new(profile_path).exists();
+                    if !profile_exists
+                        && !self
+                            .perlcritic_missing_profile_warned
+                            .swap(true, std::sync::atomic::Ordering::Relaxed)
+                    {
+                        let _ = self.show_message(
+                            crate::runtime::MessageType::Warning,
+                            &format!(
+                                "Perl::Critic profile not found: {profile_path}. Check perl.perlcritic.profile or workspace .perlcriticrc."
+                            ),
+                        );
+                    }
+                }
                 let critic_config = crate::perl_critic::CriticConfig {
                     severity,
                     profile: resolved_profile,
@@ -873,16 +897,17 @@ impl LspServer {
             Some(Ok(violations)) => {
                 for v in violations {
                     // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
-                    // Brutal(1)/Cruel(2) -> Error, Harsh(3) -> Warning,
-                    // Stern(4)/Gentle(5) -> Information
+                    // 5 -> Error, 4/3 -> Warning, 2 -> Information, 1 -> Hint.
                     let internal_severity = match v.severity {
-                        crate::perl_critic::Severity::Brutal
-                        | crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Error,
-                        crate::perl_critic::Severity::Harsh => InternalDiagnosticSeverity::Warning,
+                        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
                         crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Gentle => {
+                        | crate::perl_critic::Severity::Harsh => {
+                            InternalDiagnosticSeverity::Warning
+                        }
+                        crate::perl_critic::Severity::Cruel => {
                             InternalDiagnosticSeverity::Information
                         }
+                        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
                     };
 
                     // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
@@ -896,7 +921,7 @@ impl LspServer {
                     diagnostics.push(InternalDiagnostic {
                         range: (start_byte, end_byte),
                         severity: internal_severity,
-                        code: Some(format!("PC:{}", v.policy)),
+                        code: Some(v.policy),
                         message: v.description,
                         related_information: Vec::new(),
                         tags: Vec::new(),
@@ -906,6 +931,15 @@ impl LspServer {
             }
             Some(Err(e)) => {
                 tracing::warn!(uri, error = %e, "perlcritic failed");
+                if !self
+                    .perlcritic_runtime_error_warned
+                    .swap(true, std::sync::atomic::Ordering::Relaxed)
+                {
+                    let _ = self.show_message(
+                        crate::runtime::MessageType::Warning,
+                        &format!("Perl::Critic failed to run for workspace diagnostics: {e}"),
+                    );
+                }
             }
             None => {}
         }

--- a/crates/perl-lsp/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp/src/runtime/language/code_actions.rs
@@ -6,6 +6,81 @@
 use super::super::*;
 use crate::protocol::{req_range, req_uri};
 
+fn pragma_insert_byte(text: &str) -> usize {
+    if let Some(pos) = text.find("package ")
+        && let Some(newline) = text[pos..].find('\n')
+    {
+        return pos + newline + 1;
+    }
+    0
+}
+
+fn external_perlcritic_quick_fixes(params: &Value, uri: &str, doc_text: &str) -> Vec<Value> {
+    let mut actions = Vec::new();
+    let diagnostics = params
+        .get("context")
+        .and_then(|context| context.get("diagnostics"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if diagnostics.is_empty() {
+        return actions;
+    }
+
+    let insert_at = pragma_insert_byte(doc_text);
+    let (insert_line, insert_char) = {
+        let prefix = &doc_text[..insert_at.min(doc_text.len())];
+        let line = prefix.bytes().filter(|b| *b == b'\n').count() as u32;
+        (line, 0_u32)
+    };
+
+    let has_strict = doc_text.contains("use strict;");
+    let has_warnings = doc_text.contains("use warnings;");
+
+    for diag in diagnostics {
+        let Some(code) = diag.get("code").and_then(Value::as_str) else {
+            continue;
+        };
+        if code == "TestingAndDebugging::RequireUseStrict" && !has_strict {
+            actions.push(json!({
+                "title": "Add use strict; (Perl::Critic)",
+                "kind": "quickfix",
+                "diagnostics": [diag.clone()],
+                "edit": {
+                    "changes": {
+                        uri: [{
+                            "range": {
+                                "start": { "line": insert_line, "character": insert_char },
+                                "end": { "line": insert_line, "character": insert_char }
+                            },
+                            "newText": "use strict;\n"
+                        }]
+                    }
+                }
+            }));
+        } else if code == "TestingAndDebugging::RequireUseWarnings" && !has_warnings {
+            actions.push(json!({
+                "title": "Add use warnings; (Perl::Critic)",
+                "kind": "quickfix",
+                "diagnostics": [diag.clone()],
+                "edit": {
+                    "changes": {
+                        uri: [{
+                            "range": {
+                                "start": { "line": insert_line, "character": insert_char },
+                                "end": { "line": insert_line, "character": insert_char }
+                            },
+                            "newText": "use warnings;\n"
+                        }]
+                    }
+                }
+            }));
+        }
+    }
+
+    actions
+}
+
 fn requested_code_action_kinds(params: &Value) -> Vec<&str> {
     params
         .get("context")
@@ -76,6 +151,7 @@ impl LspServer {
 
             // Get code actions from both providers
             let mut code_actions: Vec<Value> = Vec::new();
+            code_actions.extend(external_perlcritic_quick_fixes(&params, uri, &doc.text));
 
             // Add Perl::Critic quick fixes
             let builtin_analyzer = BuiltInAnalyzer::new();
@@ -107,10 +183,11 @@ impl LspServer {
                                 "end": {"line": end_line, "character": end_char},
                             },
                             "severity": match violation.severity {
-                                crate::perl_critic::Severity::Brutal |
-                                crate::perl_critic::Severity::Cruel => 1, // Error
+                                crate::perl_critic::Severity::Gentle => 1, // Error
+                                crate::perl_critic::Severity::Stern |
                                 crate::perl_critic::Severity::Harsh => 2, // Warning
-                                _ => 3, // Information
+                                crate::perl_critic::Severity::Cruel => 3, // Information
+                                crate::perl_critic::Severity::Brutal => 4, // Hint
                             },
                             "code": violation.policy.clone(),
                             "source": "Perl::Critic",

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -273,6 +273,16 @@ pub struct LspServer {
     /// Initialized to `false`; only the test helper methods flip this.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) skip_perlcritic_command_check: AtomicBool,
+    /// Emits a one-time warning when external `perlcritic` is enabled but the
+    /// binary is unavailable on PATH.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_missing_tool_warned: AtomicBool,
+    /// Emits a one-time warning when a configured perlcritic profile path is invalid.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_missing_profile_warned: AtomicBool,
+    /// Emits a one-time warning when external perlcritic execution fails.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) perlcritic_runtime_error_warned: AtomicBool,
     /// Optional AI inline-completion backend.
     ///
     /// When `Some`, the `handle_inline_completion` handler will attempt

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -68,21 +68,21 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
     let result = pull_diagnostics(&server, uri, "print 'hello';\n");
 
     // There must be at least one diagnostic with code
-    // "PC:TestingAndDebugging::RequireUseStrict" and severity 2 (Warning).
+    // "TestingAndDebugging::RequireUseStrict" and severity 2 (Warning).
     //
     // The pull-diagnostics response has the shape:
     //   { "kind": "full", "items": [ { "code": "...", "severity": N, ... } ], "resultId": "..." }
     let diags = result["items"].as_array().cloned().unwrap_or_default();
 
     let found = diags.iter().any(|d| {
-        d["code"].as_str() == Some("PC:TestingAndDebugging::RequireUseStrict")
+        d["code"].as_str() == Some("TestingAndDebugging::RequireUseStrict")
             && d["severity"].as_u64() == Some(2)
     });
 
     assert!(
         found,
         "Expected a Warning diagnostic with code \
-         PC:TestingAndDebugging::RequireUseStrict in the pull response; \
+         TestingAndDebugging::RequireUseStrict in the pull response; \
          got: {result}"
     );
 }
@@ -118,7 +118,7 @@ fn test_b_no_subprocess_invocation_when_perlcritic_disabled() {
 // ── Test C ────────────────────────────────────────────────────────────────────
 
 /// When the `perlcritic` binary is absent from PATH, diagnostics are empty and
-/// no error is surfaced.
+/// no subprocess is attempted.
 ///
 /// This test is skipped when perlcritic *is* installed because there is no
 /// portable way to temporarily hide a binary from PATH in a single test.
@@ -145,10 +145,8 @@ fn test_c_graceful_skip_when_perlcritic_not_installed() {
     let result = pull_diagnostics(&server, uri, "use strict;\n");
 
     let diags = result["items"].as_array().cloned().unwrap_or_default();
-    let perlcritic_diags: Vec<_> = diags
-        .iter()
-        .filter(|d| d["code"].as_str().map(|c| c.starts_with("PC:")).unwrap_or(false))
-        .collect();
+    let perlcritic_diags: Vec<_> =
+        diags.iter().filter(|d| d["source"].as_str() == Some("perlcritic")).collect();
 
     assert_eq!(
         perlcritic_diags.len(),
@@ -161,6 +159,41 @@ fn test_c_graceful_skip_when_perlcritic_not_installed() {
         0,
         "Mock runtime must not be called when perlcritic binary is absent"
     );
+}
+
+/// Severity mapping must follow Perl::Critic semantics:
+/// 5 -> Error (1), 1 -> Hint (4).
+#[test]
+fn test_e_perlcritic_severity_maps_to_lsp_levels() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 1, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    let mock_lines = b"test.pl:5:1:5:ValuesAndExpressions::ProhibitMagicNumbers:magic number\n\
+test.pl:6:1:1:TestingAndDebugging::ProhibitNoWarnings:low severity\n";
+    runtime.add_response(MockResponse::success(mock_lines.to_vec()));
+    server.test_install_mock_critic_runtime(runtime);
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_severity_map.pl";
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_severity_map.pl";
+
+    let result = pull_diagnostics(&server, uri, "print 42;\n");
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+
+    let has_error = diags.iter().any(|d| {
+        d["code"].as_str() == Some("ValuesAndExpressions::ProhibitMagicNumbers")
+            && d["severity"].as_u64() == Some(1)
+    });
+    let has_hint = diags.iter().any(|d| {
+        d["code"].as_str() == Some("TestingAndDebugging::ProhibitNoWarnings")
+            && d["severity"].as_u64() == Some(4)
+    });
+
+    assert!(has_error, "expected severity-5 violation mapped to Error; got: {result}");
+    assert!(has_hint, "expected severity-1 violation mapped to Hint; got: {result}");
 }
 
 // ── Test D ────────────────────────────────────────────────────────────────────

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -88,7 +88,7 @@ your-project/
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `perlcritic` | `boolean` | (unset) | Enable perlcritic diagnostics. When unset, the server default (`false`) applies. Requires `perlcritic` installed on the system. |
-| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. 1 = most severe (gentle), 5 = everything (brutal). Must be in the range 1–5; values outside this range are a parse error. |
+| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. `1` reports everything (least severe threshold), `5` reports only the most severe violations. Must be in the range 1–5; values outside this range are a parse error. |
 
 #### `[features]` — LSP Feature Toggles
 
@@ -402,8 +402,9 @@ is not installed on the system.
 | Type | `integer` (1–5) |
 | Default | `3` |
 
-Minimum severity level to report. `1` = most severe (Brutal), `5` = everything
-(Gentle). Values are clamped to the valid range. Equivalent to
+Minimum severity level to report. `1` reports everything (least severe
+threshold), `5` reports only the most severe violations. Values are clamped to
+the valid range. Equivalent to
 `perlcritic --severity N`.
 
 #### `perl.perlcritic.profile`

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -272,6 +272,32 @@
             "order": 50,
             "description": "Enable semantic syntax highlighting. When disabled, the editor falls back to TextMate grammar coloring only.",
             "markdownDescription": "Enable semantic syntax highlighting. When disabled, the editor falls back to TextMate grammar coloring only."
+          },
+          "perl.perlcritic.enabled": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "order": 60,
+            "description": "Enable external Perl::Critic diagnostics (requires perlcritic installed).",
+            "markdownDescription": "Enable external `Perl::Critic` diagnostics (requires `perlcritic` on PATH)."
+          },
+          "perl.perlcritic.severity": {
+            "type": "number",
+            "default": 3,
+            "minimum": 1,
+            "maximum": 5,
+            "scope": "resource",
+            "order": 61,
+            "description": "Minimum Perl::Critic severity to report (1 reports everything, 5 reports only the most severe violations).",
+            "markdownDescription": "Minimum `Perl::Critic` severity to report (`1` reports everything, `5` reports only the most severe violations)."
+          },
+          "perl.perlcritic.profile": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "order": 62,
+            "description": "Path to a .perlcriticrc profile. Leave empty to use Perl::Critic auto-discovery.",
+            "markdownDescription": "Path to a `.perlcriticrc` profile. Leave empty to use `Perl::Critic` auto-discovery."
           }
         }
       },

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -205,6 +205,40 @@ export class OnboardingManager {
   }
 
   /**
+   * Check whether `perlcritic` is on PATH.
+   *
+   * Perl::Critic absence is a warning — core LSP still works, but optional
+   * external critic diagnostics are unavailable.
+   */
+  async checkPerlcriticInstalled(): Promise<HealthCheckResult> {
+    const label = 'perlcritic';
+    try {
+      const { stdout } = await this._execCheck('perlcritic', ['--version']);
+      const version = stdout.trim() || '(unknown)';
+      this.outputChannel.appendLine(`[onboarding] perlcritic: ${version}`);
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `perlcritic found (${version})`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(
+        `[onboarding] perlcritic not found: ${msg}`,
+      );
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Warning,
+        detail:
+          'perlcritic not found — external Perl::Critic diagnostics will be unavailable. ' +
+          'Install via: cpanm Perl::Critic',
+      };
+    }
+  }
+
+  /**
    * Check whether the LSP binary has been downloaded / located.
    *
    * @param serverPath  Path returned by `getServerPath`, or `null` if not found.
@@ -249,9 +283,10 @@ export class OnboardingManager {
   ): Promise<HealthCheckResult[]> {
     this.outputChannel.appendLine('[onboarding] Running setup health check...');
 
-    const [perlResult, perltidyResult] = await Promise.all([
+    const [perlResult, perltidyResult, perlcriticResult] = await Promise.all([
       this.checkPerlInstalled(),
       this.checkPerltidyInstalled(),
+      this.checkPerlcriticInstalled(),
     ]);
 
     const binaryResult = this.checkBinaryDownloaded(serverPath);
@@ -259,6 +294,7 @@ export class OnboardingManager {
     const results: HealthCheckResult[] = [
       perlResult,
       perltidyResult,
+      perlcriticResult,
       binaryResult,
     ];
 

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -262,10 +262,11 @@ describe('OnboardingManager.runSetupHealthCheck', () => {
     fs.writeFileSync(binPath, '#!/bin/sh\necho ok');
 
     const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
-    // Simulate both perl and perltidy available
+    // Simulate perl, perltidy, and perlcritic available
     mgr._execCheck = jest.fn((cmd: string, _args: string[]) => {
       if (cmd === 'perl') return Promise.resolve({ stdout: '5.036000', stderr: '' });
       if (cmd === 'perltidy') return Promise.resolve({ stdout: 'perltidy, v20230309', stderr: '' });
+      if (cmd === 'perlcritic') return Promise.resolve({ stdout: '1.156', stderr: '' });
       return Promise.reject(new Error('unknown'));
     });
     const results: HealthCheckResult[] = await mgr.runSetupHealthCheck(binPath);


### PR DESCRIPTION
### Motivation
- Correct upstream-incompatible severity semantics and finish wiring the partially-implemented Perl::Critic integration so diagnostics and UX behave predictably. 
- Surface workspace-level tool failures (missing binary, bad profile, runtime errors) instead of silently skipping analysis.
- Expose the already-existing server settings to the VS Code extension and add a small, safe set of quick fixes to demonstrate code-action integration.

### Description
- Fixed severity semantics and docs so `perlcritic` severity follows upstream semantics (`1` = least-severe threshold / reports everything, `5` = most severe only) in `crates/perl-lsp-config/src/lib.rs` and `docs/reference/CONFIG.md`.
- Remapped external Perl::Critic -> LSP severity mapping to `5 -> Error`, `4/3 -> Warning`, `2 -> Information`, `1 -> Hint`, set `Diagnostic.code` to the Perl::Critic policy name, and added one-time workspace warnings for missing binary, missing profile path, and runtime failures in `crates/perl-lsp/src/runtime/diagnostics.rs` and runtime state (`mod.rs`, `constructors.rs`).
- Added minimal, high-confidence external quick fixes keyed by policy name (add `use strict;` / `use warnings;`) and updated built-in critic quick-fix severity labels to match the new mapping in `crates/perl-lsp/src/runtime/language/code_actions.rs`.
- Harmonized severity conversions in shared tooling (`crates/perl-lsp-tooling/src/perl_critic/types.rs`).
- Exposed `perl.perlcritic.enabled`, `perl.perlcritic.severity`, and `perl.perlcritic.profile` in the VS Code extension manifest and added `perlcritic` to the extension onboarding health checks, updating corresponding tests (`vscode-extension/package.json`, `vscode-extension/src/onboarding.ts`, `vscode-extension/src/test/onboarding.test.ts`).
- Added/updated regression tests asserting severity semantics and diagnostic `code` usage in `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs`.

### Testing
- Ran formatting: `cargo fmt --all` (completed).
- Server config unit tests: `cargo test -p perl-lsp-config` — all tests passed.
- Perl::Critic diagnostic pipeline tests: `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests` — tests passed (covers severity mapping, missing-binary guard, profile walk-up).
- VS Code extension tests: `npm test -- --runInBand src/test/onboarding.test.ts` — onboarding tests passed; adding `perlcritic` check integrated successfully.
- Combined extension config tests: `npm test -- --runInBand src/test/onboarding.test.ts src/test/configuration.test.ts` — failed due to a pre-existing unrelated assertion in `configuration.test.ts` (duplicate `.xs` extension expectation); this failure is known and not caused by these changes.
- Full repo unit tests involving `perl-lsp` and related crates were exercised during `cargo test` runs; critical modified tests passed as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9260034288333b147f16b3fe3e80d)