### PR TITLE
feat(perlcritic): complete wiring and severity semantics (#3470)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -50,9 +50,11 @@ pub struct ServerConfig {
     /// be installed on the system; silently skipped if not available.
     pub perlcritic_enabled: bool,
 
-    /// Minimum severity level to report (1-5, where 1 = most severe).
+    /// Minimum severity level to report (1-5, where 1 = least severe).
     ///
-    /// Violations below this threshold are suppressed. Default is 3 (Harsh).
+    /// Perl::Critic treats this as a minimum threshold:
+    /// `1` reports everything, while `5` reports only the most severe findings.
+    /// Default is 3 (Harsh).
     /// Equivalent to `perlcritic --severity`.
     pub perlcritic_severity: u8,
 
@@ -511,7 +513,8 @@ pub struct ProjectPerlConfig {
 pub struct ProjectDiagnosticsConfig {
     /// Whether perlcritic is enabled. Maps to `ServerConfig.perlcritic_enabled`.
     pub perlcritic: Option<bool>,
-    /// Minimum perlcritic severity (1-5). Maps to `ServerConfig.perlcritic_severity`.
+    /// Minimum perlcritic severity (1-5). `1` reports everything; `5` is strictest.
+    /// Maps to `ServerConfig.perlcritic_severity`.
     pub perlcritic_severity: Option<u8>,
 }
 

--- a/crates/perl-lsp-tooling/src/perl_critic/types.rs
+++ b/crates/perl-lsp-tooling/src/perl_critic/types.rs
@@ -7,15 +7,15 @@ use lsp_types;
 /// Severity levels for Perl::Critic violations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Severity {
-    /// Cosmetic issues (severity 5)
+    /// Most severe category (severity 5 / "gentle")
     Gentle = 5,
-    /// Minor issues (severity 4)
+    /// High severity (severity 4 / "stern")
     Stern = 4,
-    /// Important issues (severity 3)
+    /// Medium severity (severity 3 / "harsh")
     Harsh = 3,
-    /// Serious issues (severity 2)
+    /// Low severity (severity 2 / "cruel")
     Cruel = 2,
-    /// Critical issues (severity 1)
+    /// Least severe category (severity 1 / "brutal")
     Brutal = 1,
 }
 
@@ -38,9 +38,10 @@ impl Severity {
     #[cfg(feature = "lsp-compat")]
     pub fn to_diagnostic_severity(self) -> lsp_types::DiagnosticSeverity {
         match self {
-            Self::Brutal | Self::Cruel => lsp_types::DiagnosticSeverity::ERROR,
-            Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
-            Self::Stern | Self::Gentle => lsp_types::DiagnosticSeverity::INFORMATION,
+            Self::Gentle => lsp_types::DiagnosticSeverity::ERROR,
+            Self::Stern | Self::Harsh => lsp_types::DiagnosticSeverity::WARNING,
+            Self::Cruel => lsp_types::DiagnosticSeverity::INFORMATION,
+            Self::Brutal => lsp_types::DiagnosticSeverity::HINT,
         }
     }
 

--- a/crates/perl-lsp-tooling/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lsp-tooling/tests/comprehensive_unit_tests.rs
@@ -364,11 +364,11 @@ fn severity_from_number_out_of_range_defaults_to_harsh() {
 fn severity_to_diagnostic_severity() {
     use lsp_types::DiagnosticSeverity;
 
-    assert_eq!(Severity::Brutal.to_diagnostic_severity(), DiagnosticSeverity::ERROR);
-    assert_eq!(Severity::Cruel.to_diagnostic_severity(), DiagnosticSeverity::ERROR);
+    assert_eq!(Severity::Gentle.to_diagnostic_severity(), DiagnosticSeverity::ERROR);
+    assert_eq!(Severity::Stern.to_diagnostic_severity(), DiagnosticSeverity::WARNING);
     assert_eq!(Severity::Harsh.to_diagnostic_severity(), DiagnosticSeverity::WARNING);
-    assert_eq!(Severity::Stern.to_diagnostic_severity(), DiagnosticSeverity::INFORMATION);
-    assert_eq!(Severity::Gentle.to_diagnostic_severity(), DiagnosticSeverity::INFORMATION);
+    assert_eq!(Severity::Cruel.to_diagnostic_severity(), DiagnosticSeverity::INFORMATION);
+    assert_eq!(Severity::Brutal.to_diagnostic_severity(), DiagnosticSeverity::HINT);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/crates/perl-lsp/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp/src/features/code_actions_provider/fixes.rs
@@ -264,3 +264,40 @@ pub(super) fn fix_unquoted_bareword(
 
     actions
 }
+
+pub(super) fn fix_perlcritic_policy(
+    provider: &CodeActionsProvider,
+    diagnostic: &Diagnostic,
+    policy: &str,
+) -> Vec<CodeAction> {
+    match policy {
+        "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict" => {
+            if provider.source().contains("use strict;") {
+                return Vec::new();
+            }
+            let insert_pos = source_utils::find_declaration_position(provider, diagnostic.range.0);
+            vec![diagnostic_action(
+                diagnostic,
+                "Add `use strict;` (Perl::Critic)",
+                CodeActionKind::QuickFix,
+                TextEdit { range: (insert_pos, insert_pos), new_text: "use strict;\n".to_string() },
+            )]
+        }
+        "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings" => {
+            if provider.source().contains("use warnings;") {
+                return Vec::new();
+            }
+            let insert_pos = source_utils::find_declaration_position(provider, diagnostic.range.0);
+            vec![diagnostic_action(
+                diagnostic,
+                "Add `use warnings;` (Perl::Critic)",
+                CodeActionKind::QuickFix,
+                TextEdit {
+                    range: (insert_pos, insert_pos),
+                    new_text: "use warnings;\n".to_string(),
+                },
+            )]
+        }
+        _ => Vec::new(),
+    }
+}

--- a/crates/perl-lsp/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp/src/features/code_actions_provider/mod.rs
@@ -143,6 +143,9 @@ impl CodeActionsProvider {
             {
                 fixes::fix_parse_error(self, diagnostic, "parse-error-missingsemicolon")
             }
+            Some(code) if code.starts_with("Perl::Critic::Policy::") => {
+                fixes::fix_perlcritic_policy(self, diagnostic, code)
+            }
             _ => Vec::new(),
         }
     }
@@ -251,6 +254,38 @@ mod tests {
 
         let actions = provider.get_actions_for_diagnostic(&diagnostic);
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn test_perlcritic_require_use_strict_fix() {
+        let source = "print 'hello';\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+        let diagnostic = make_diagnostic(
+            (0, 5),
+            DiagnosticSeverity::Warning,
+            "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict",
+            "Code does not use strict",
+        );
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add `use strict;` (Perl::Critic)");
+        assert_eq!(actions[0].edit.new_text, "use strict;\n");
+    }
+
+    #[test]
+    fn test_perlcritic_require_use_warnings_fix() {
+        let source = "use strict;\nprint 'hello';\n".to_string();
+        let provider = CodeActionsProvider::new(source);
+        let diagnostic = make_diagnostic(
+            (12, 17),
+            DiagnosticSeverity::Warning,
+            "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings",
+            "Code does not use warnings",
+        );
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add `use warnings;` (Perl::Critic)");
+        assert_eq!(actions[0].edit.new_text, "use warnings;\n");
     }
 
     // ── Quick-fix: unused variable ──────────────────────────────────────

--- a/crates/perl-lsp/src/runtime/constructors.rs
+++ b/crates/perl-lsp/src/runtime/constructors.rs
@@ -63,6 +63,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            critic_warning_once: Mutex::new(HashSet::new()),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -166,6 +168,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            critic_warning_once: Mutex::new(HashSet::new()),
             ai_inline_backend: Mutex::new(None),
         }
     }
@@ -232,6 +236,8 @@ impl LspServer {
             critic_runtime_override: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
             skip_perlcritic_command_check: AtomicBool::new(false),
+            #[cfg(not(target_arch = "wasm32"))]
+            critic_warning_once: Mutex::new(HashSet::new()),
             ai_inline_backend: Mutex::new(None),
         }
     }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -344,6 +344,12 @@ impl LspServer {
                                 None => d.message.clone(),
                             };
 
+                            let source = match d.code.as_deref() {
+                                Some(code) if code.starts_with("Perl::Critic::Policy::") => {
+                                    "perlcritic"
+                                }
+                                _ => "perl-lsp",
+                            };
                             let mut diag = json!({
                                 "range": {
                                     "start": {
@@ -362,7 +368,7 @@ impl LspServer {
                                     InternalDiagnosticSeverity::Hint => 4,
                                 },
                                 "code": d.code.clone(),
-                                "source": "perl-lsp",
+                                "source": source,
                                 "message": message,
                             });
 
@@ -579,6 +585,12 @@ impl LspServer {
                                     None => d.message.clone(),
                                 };
 
+                                let source = match d.code.as_deref() {
+                                    Some(code) if code.starts_with("Perl::Critic::Policy::") => {
+                                        "perlcritic"
+                                    }
+                                    _ => "perl-lsp",
+                                };
                                 let mut diag = json!({
                                     "range": {
                                         "start": {
@@ -597,7 +609,7 @@ impl LspServer {
                                         InternalDiagnosticSeverity::Hint => 4,
                                     },
                                     "code": d.code.clone(),
-                                    "source": "perl-lsp",
+                                    "source": source,
                                     "message": message,
                                 });
                                 if !d.tags.is_empty() {
@@ -670,6 +682,12 @@ impl LspServer {
                                 None => d.message.clone(),
                             };
 
+                            let source = match d.code.as_deref() {
+                                Some(code) if code.starts_with("Perl::Critic::Policy::") => {
+                                    "perlcritic"
+                                }
+                                _ => "perl-lsp",
+                            };
                             let mut diag = json!({
                                 "range": {
                                     "start": {
@@ -688,7 +706,7 @@ impl LspServer {
                                     InternalDiagnosticSeverity::Hint => 4,
                                 },
                                 "code": d.code.clone(),
-                                "source": "perl-lsp",
+                                "source": source,
                                 "message": message,
                             });
                             if !d.tags.is_empty() {
@@ -797,7 +815,7 @@ impl LspServer {
             }
         };
 
-        // Silently skip if perlcritic is not installed.
+        // Warn once if perlcritic is enabled but the binary is not installed.
         // The `skip_perlcritic_command_check` flag is always `false` in production
         // and is only set to `true` through the test helper
         // `LspServer::test_bypass_perlcritic_command_check`, enabling mock-runtime
@@ -805,6 +823,15 @@ impl LspServer {
         let skip_check =
             self.skip_perlcritic_command_check.load(std::sync::atomic::Ordering::Relaxed);
         if !skip_check && !crate::execute_command::command_exists("perlcritic") {
+            let warning_key = "missing-binary".to_string();
+            let mut warned = self.critic_warning_once.lock();
+            if !warned.contains(&warning_key) {
+                warned.insert(warning_key);
+                let _ = self.show_message(
+                    crate::runtime::window::MessageType::Warning,
+                    "Perl::Critic diagnostics are enabled, but `perlcritic` was not found on PATH. Install Perl::Critic or disable perl.perlcritic.enabled.",
+                );
+            }
             return;
         }
 
@@ -822,7 +849,7 @@ impl LspServer {
                 // workspace root looking for `.perlcriticrc`.  Ensures that a
                 // repo-root config is found even when the file lives in a
                 // sub-directory.  Only runs when the analyzer needs (re-)init.
-                let resolved_profile = profile.or_else(|| {
+                let resolved_profile = profile.clone().or_else(|| {
                     let workspace_root = self.root_path.lock().clone();
                     let mut dir = file_path.parent().map(|p| p.to_path_buf());
                     while let Some(current) = dir {
@@ -840,6 +867,25 @@ impl LspServer {
                     }
                     None
                 });
+                if let Some(configured_profile) = profile {
+                    let configured_path = std::path::Path::new(&configured_profile);
+                    if !configured_path.exists() {
+                        let warning_key = format!("missing-profile:{configured_profile}");
+                        let mut warned = self.critic_warning_once.lock();
+                        if !warned.contains(&warning_key) {
+                            warned.insert(warning_key);
+                            let _ = self.show_message(
+                                crate::runtime::window::MessageType::Warning,
+                                &format!(
+                                    "Perl::Critic profile not found: {}. Fix perl.perlcritic.profile or remove it.",
+                                    configured_profile
+                                ),
+                            );
+                        }
+                        return;
+                    }
+                }
+
                 let critic_config = crate::perl_critic::CriticConfig {
                     severity,
                     profile: resolved_profile,
@@ -872,17 +918,16 @@ impl LspServer {
         match result {
             Some(Ok(violations)) => {
                 for v in violations {
-                    // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
-                    // Brutal(1)/Cruel(2) -> Error, Harsh(3) -> Warning,
-                    // Stern(4)/Gentle(5) -> Information
                     let internal_severity = match v.severity {
-                        crate::perl_critic::Severity::Brutal
-                        | crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Error,
-                        crate::perl_critic::Severity::Harsh => InternalDiagnosticSeverity::Warning,
+                        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
                         crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Gentle => {
+                        | crate::perl_critic::Severity::Harsh => {
+                            InternalDiagnosticSeverity::Warning
+                        }
+                        crate::perl_critic::Severity::Cruel => {
                             InternalDiagnosticSeverity::Information
                         }
+                        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
                     };
 
                     // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
@@ -896,7 +941,7 @@ impl LspServer {
                     diagnostics.push(InternalDiagnostic {
                         range: (start_byte, end_byte),
                         severity: internal_severity,
-                        code: Some(format!("PC:{}", v.policy)),
+                        code: Some(v.policy),
                         message: v.description,
                         related_information: Vec::new(),
                         tags: Vec::new(),
@@ -906,6 +951,15 @@ impl LspServer {
             }
             Some(Err(e)) => {
                 tracing::warn!(uri, error = %e, "perlcritic failed");
+                let warning_key = format!("execution-error:{e}");
+                let mut warned = self.critic_warning_once.lock();
+                if !warned.contains(&warning_key) {
+                    warned.insert(warning_key);
+                    let _ = self.show_message(
+                        crate::runtime::window::MessageType::Warning,
+                        &format!("Perl::Critic failed to run: {e}"),
+                    );
+                }
             }
             None => {}
         }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -273,6 +273,13 @@ pub struct LspServer {
     /// Initialized to `false`; only the test helper methods flip this.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) skip_perlcritic_command_check: AtomicBool,
+    /// De-duplication set for workspace-level Perl::Critic environment warnings.
+    ///
+    /// Keys represent warning classes (for example "missing-binary" or
+    /// "missing-profile:/path/.perlcriticrc") so the user sees one actionable
+    /// message per condition instead of repeated popups on every diagnostics pass.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) critic_warning_once: Mutex<HashSet<String>>,
     /// Optional AI inline-completion backend.
     ///
     /// When `Some`, the `handle_inline_completion` handler will attempt

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -546,6 +546,7 @@ impl LspServer {
                     #[cfg(not(target_arch = "wasm32"))]
                     if critic_config_changed {
                         *self.critic_analyzer.lock() = None;
+                        self.critic_warning_once.lock().clear();
                     }
 
                     // Update workspace config (include paths, @INC)

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -53,8 +53,7 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
 
     // Install a mock runtime returning one severity-3 violation for the file.
     let runtime = Arc::new(MockSubprocessRuntime::new());
-    let mock_line =
-        b"test.pl:5:1:3:TestingAndDebugging::RequireUseStrict:Code does not use strict\n";
+    let mock_line = b"test.pl:5:1:3:Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict:Code does not use strict\n";
     runtime.add_response(MockResponse::success(mock_line.to_vec()));
     server.test_install_mock_critic_runtime(runtime);
     server.test_bypass_perlcritic_command_check();
@@ -68,23 +67,57 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
     let result = pull_diagnostics(&server, uri, "print 'hello';\n");
 
     // There must be at least one diagnostic with code
-    // "PC:TestingAndDebugging::RequireUseStrict" and severity 2 (Warning).
+    // "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict" and
+    // severity 2 (Warning).
     //
     // The pull-diagnostics response has the shape:
     //   { "kind": "full", "items": [ { "code": "...", "severity": N, ... } ], "resultId": "..." }
     let diags = result["items"].as_array().cloned().unwrap_or_default();
 
     let found = diags.iter().any(|d| {
-        d["code"].as_str() == Some("PC:TestingAndDebugging::RequireUseStrict")
+        d["code"].as_str() == Some("Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict")
             && d["severity"].as_u64() == Some(2)
     });
 
     assert!(
         found,
         "Expected a Warning diagnostic with code \
-         PC:TestingAndDebugging::RequireUseStrict in the pull response; \
+         Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict in the pull response; \
          got: {result}"
     );
+}
+
+#[test]
+fn test_a2_perlcritic_severity_extremes_map_to_error_and_hint() {
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 1, None);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    let output = b"test.pl:1:1:5:Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict:strict missing\n\
+test.pl:2:1:1:Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings:warnings missing\n";
+    runtime.add_response(MockResponse::success(output.to_vec()));
+    server.test_install_mock_critic_runtime(runtime);
+    server.test_bypass_perlcritic_command_check();
+
+    #[cfg(windows)]
+    let uri = "file:///C:/tmp/test_extremes.pl";
+    #[cfg(not(windows))]
+    let uri = "file:///tmp/test_extremes.pl";
+
+    let result = pull_diagnostics(&server, uri, "print 'hello';\nprint 'world';\n");
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+
+    let sev_5_is_error = diags.iter().any(|d| {
+        d["code"].as_str() == Some("Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict")
+            && d["severity"].as_u64() == Some(1)
+    });
+    let sev_1_is_hint = diags.iter().any(|d| {
+        d["code"].as_str() == Some("Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings")
+            && d["severity"].as_u64() == Some(4)
+    });
+
+    assert!(sev_5_is_error, "Expected severity 5 to map to LSP Error; got: {result}");
+    assert!(sev_1_is_hint, "Expected severity 1 to map to LSP Hint; got: {result}");
 }
 
 // ── Test B ────────────────────────────────────────────────────────────────────
@@ -117,8 +150,8 @@ fn test_b_no_subprocess_invocation_when_perlcritic_disabled() {
 
 // ── Test C ────────────────────────────────────────────────────────────────────
 
-/// When the `perlcritic` binary is absent from PATH, diagnostics are empty and
-/// no error is surfaced.
+/// When the `perlcritic` binary is absent from PATH, diagnostics stay empty and
+/// the analyzer subprocess is not invoked.
 ///
 /// This test is skipped when perlcritic *is* installed because there is no
 /// portable way to temporarily hide a binary from PATH in a single test.
@@ -147,7 +180,13 @@ fn test_c_graceful_skip_when_perlcritic_not_installed() {
     let diags = result["items"].as_array().cloned().unwrap_or_default();
     let perlcritic_diags: Vec<_> = diags
         .iter()
-        .filter(|d| d["code"].as_str().map(|c| c.starts_with("PC:")).unwrap_or(false))
+        .filter(|d| {
+            d["source"].as_str() == Some("perlcritic")
+                || d["code"]
+                    .as_str()
+                    .map(|c| c.starts_with("Perl::Critic::Policy::"))
+                    .unwrap_or(false)
+        })
         .collect();
 
     assert_eq!(

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -88,7 +88,7 @@ your-project/
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `perlcritic` | `boolean` | (unset) | Enable perlcritic diagnostics. When unset, the server default (`false`) applies. Requires `perlcritic` installed on the system. |
-| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. 1 = most severe (gentle), 5 = everything (brutal). Must be in the range 1–5; values outside this range are a parse error. |
+| `perlcritic_severity` | `integer` (1–5) | (unset) | Minimum severity to report. `1` reports everything (least severe threshold), while `5` reports only the most severe violations. Must be in the range 1–5; values outside this range are a parse error. |
 
 #### `[features]` — LSP Feature Toggles
 
@@ -392,8 +392,8 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream. If `perlcritic` is unavailable
+or misconfigured, the server surfaces a workspace warning.
 
 #### `perl.perlcritic.severity`
 
@@ -402,8 +402,9 @@ is not installed on the system.
 | Type | `integer` (1–5) |
 | Default | `3` |
 
-Minimum severity level to report. `1` = most severe (Brutal), `5` = everything
-(Gentle). Values are clamped to the valid range. Equivalent to
+Minimum severity level to report. `1` reports everything (least severe),
+while `5` reports only the most severe violations. Values are clamped to
+the valid range. Equivalent to
 `perlcritic --severity N`.
 
 #### `perl.perlcritic.profile`

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -302,6 +302,32 @@
             "description": "Path to your .perltidyrc configuration file. If omitted, perl-lsp searches the workspace and home directory.",
             "markdownDescription": "Path to your `.perltidyrc` configuration file. If omitted, perl-lsp searches the workspace and home directory."
           },
+          "perl.perlcritic.enabled": {
+            "type": "boolean",
+            "default": false,
+            "scope": "resource",
+            "order": 35,
+            "description": "Enable Perl::Critic diagnostics in the language server (requires perlcritic on PATH).",
+            "markdownDescription": "Enable Perl::Critic diagnostics in the language server (requires `perlcritic` on PATH)."
+          },
+          "perl.perlcritic.severity": {
+            "type": "integer",
+            "default": 3,
+            "minimum": 1,
+            "maximum": 5,
+            "scope": "resource",
+            "order": 36,
+            "description": "Minimum Perl::Critic severity threshold (1 reports everything, 5 reports only the most severe violations).",
+            "markdownDescription": "Minimum Perl::Critic severity threshold (`1` reports everything, `5` reports only the most severe violations)."
+          },
+          "perl.perlcritic.profile": {
+            "type": "string",
+            "default": "",
+            "scope": "resource",
+            "order": 37,
+            "description": "Path to a .perlcriticrc profile file. Leave empty for Perl::Critic auto-discovery.",
+            "markdownDescription": "Path to a `.perlcriticrc` profile file. Leave empty for Perl::Critic auto-discovery."
+          },
           "perl-lsp.enableRefactoring": {
             "type": "boolean",
             "default": true,

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -205,6 +205,37 @@ export class OnboardingManager {
   }
 
   /**
+   * Check whether `perlcritic` is on PATH.
+   *
+   * Perl::Critic absence is a warning: core LSP still works, but critic
+   * diagnostics cannot run when enabled.
+   */
+  async checkPerlcriticInstalled(): Promise<HealthCheckResult> {
+    const label = 'perlcritic';
+    try {
+      const { stdout } = await this._execCheck('perlcritic', ['--version']);
+      const version = stdout.trim() || '(unknown)';
+      this.outputChannel.appendLine(`[onboarding] perlcritic: ${version}`);
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `perlcritic found (${version})`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(`[onboarding] perlcritic not found: ${msg}`);
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Warning,
+        detail:
+          'perlcritic not found — Perl::Critic diagnostics will be unavailable. Install via: cpanm Perl::Critic',
+      };
+    }
+  }
+
+  /**
    * Check whether the LSP binary has been downloaded / located.
    *
    * @param serverPath  Path returned by `getServerPath`, or `null` if not found.
@@ -249,9 +280,10 @@ export class OnboardingManager {
   ): Promise<HealthCheckResult[]> {
     this.outputChannel.appendLine('[onboarding] Running setup health check...');
 
-    const [perlResult, perltidyResult] = await Promise.all([
+    const [perlResult, perltidyResult, perlcriticResult] = await Promise.all([
       this.checkPerlInstalled(),
       this.checkPerltidyInstalled(),
+      this.checkPerlcriticInstalled(),
     ]);
 
     const binaryResult = this.checkBinaryDownloaded(serverPath);
@@ -259,6 +291,7 @@ export class OnboardingManager {
     const results: HealthCheckResult[] = [
       perlResult,
       perltidyResult,
+      perlcriticResult,
       binaryResult,
     ];
 

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -259,6 +259,9 @@ describe('package.json contributes', () => {
       const keys = Object.keys(editorSection.properties);
       expect(keys).toContain('perl-lsp.enableFormatting');
       expect(keys).toContain('perl-lsp.formatOnSave');
+      expect(keys).toContain('perl.perlcritic.enabled');
+      expect(keys).toContain('perl.perlcritic.severity');
+      expect(keys).toContain('perl.perlcritic.profile');
       expect(keys).toContain('perl-lsp.enableRefactoring');
       expect(keys).toContain('perl-lsp.enableTestIntegration');
     });
@@ -437,6 +440,7 @@ describe('package.json contributes', () => {
       // Per-file/workspace settings should be resource-scoped so they can be
       // overridden in workspace and folder settings.
       const resourceScoped = ['perl-lsp.includePaths', 'perl-lsp.enableDiagnostics', 'perl-lsp.enableSemanticTokens', 'perl-lsp.enableFormatting', 'perl-lsp.formatOnSave', 'perl-lsp.perltidyConfig', 'perl-lsp.enableRefactoring', 'perl-lsp.enableTestIntegration', 'perl-lsp.autoPopulateNewFiles'];
+      resourceScoped.push('perl.perlcritic.enabled', 'perl.perlcritic.severity', 'perl.perlcritic.profile');
       for (const key of resourceScoped) {
         expect(properties[key]?.scope).toBe('resource');
       }


### PR DESCRIPTION
### Motivation
- Correct inverted Perl::Critic severity semantics and finish wiring the partially‑implemented critic integration so diagnostics and UI behave per upstream expectations.
- Surface workspace/tooling failures (missing binary, bad profile, execution errors) instead of silently skipping, and provide a small set of deterministic quick fixes to improve UX.

### Description
- Corrected server-side comments and public docs to reflect that `1` reports everything and `5` reports only the most severe findings in `perlcritic` (`crates/perl-lsp-config/src/lib.rs`, `docs/reference/CONFIG.md`).
- Reworked Critic→LSP severity mapping to the requested scale and updated the `Severity` conversion tests (`crates/perl-lsp-tooling/src/perl_critic/types.rs`, tests adjusted in `crates/perl-lsp-tooling/tests/*`).
- Emit policy names as diagnostic `code` (no `PC:` prefix) and mark Critic diagnostics `source` as `perlcritic` in the pull/workspace diagnostic payloads (`crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add workspace-level warning surfacing (deduplicated) and handling for: missing `perlcritic` binary, configured profile path not found, and execution failures; introduced `critic_warning_once` state to avoid notification spam (`crates/perl-lsp/src/runtime/{mod.rs,constructors.rs,workspace.rs,diagnostics.rs}`).
- Add small, deterministic quick fixes keyed by policy name for two low-risk policies (`RequireUseStrict`, `RequireUseWarnings`) via the existing code-action plumbing (no new crate): `crates/perl-lsp/src/features/code_actions_provider/{mod.rs,fixes.rs}` with unit tests.
- Exposed the existing server settings in the VS Code extension manifest as `perl.perlcritic.enabled`, `perl.perlcritic.severity`, and `perl.perlcritic.profile` and added `perlcritic` to the onboarding health checks (`vscode-extension/package.json`, `vscode-extension/src/onboarding.ts`, extension config tests updated).
- Updated and added integration/unit tests to lock the semantics and mapping changes (`crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs`, plus associated plumbing adjustments).

### Testing
- Ran formatting: `cargo fmt --all` — succeeded.
- Ran severity conversion unit test: `cargo test -p perl-lsp-tooling severity_to_diagnostic_severity` — succeeded.
- Ran Critic diagnostics integration test: `cargo test -p perl-lsp-rs --test lsp_perlcritic_diagnostics_tests --features expose_lsp_test_api test_a2_perlcritic_severity_extremes_map_to_error_and_hint` — succeeded.
- Ran code-action/unit tests for quick fixes: `cargo test -p perl-lsp-rs --lib perlcritic_require_use_` — succeeded.
- Ran server config tests: `cargo test -p perl-lsp-config server_config_perlcritic` — succeeded.
- Verified VS Code manifest JSON parses with `node -e "JSON.parse(require('fs').readFileSync('vscode-extension/package.json','utf8')); console.log('ok')"` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9260034288333b147f16b3fe3e80d)