### PR TITLE
test(lsp): extend BDD workflow coverage for folding & inlay hints (#3868)

### DIFF
--- a/crates/perl-lsp/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp/tests/lsp_bdd_workflows.rs
@@ -393,6 +393,18 @@ fn highlight_kinds(response: &Value) -> Vec<u64> {
         .unwrap_or_default()
 }
 
+fn inlay_labels(response: &Value) -> Vec<String> {
+    response
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("label").and_then(Value::as_str).map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn setup_workspace(files: &[(&str, &str)]) -> Result<(LspHarness, TempWorkspace), String> {
     let (mut harness, workspace) = LspHarness::with_workspace(files)?;
 
@@ -1653,6 +1665,78 @@ sub main_func {}
     assert!(find_symbol(symbols, "inner_func"), "Expected inner_func");
     assert!(find_symbol(symbols, "main"), "Expected main package");
     assert!(find_symbol(symbols, "main_func"), "Expected main_func");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn bdd_structural_navigation_supports_folding_and_inlay_hints()
+-> Result<(), Box<dyn std::error::Error>> {
+    let scenario = BddScenario::new("Structural navigation supports folding and inlay hints");
+
+    let code = r#"use strict;
+use warnings;
+
+sub render {
+    my ($name) = @_;
+    if ($name) {
+        return substr($name, 0, 3);
+    }
+    return "n/a";
+}
+"#;
+
+    scenario.given("a Perl document with nested blocks and a builtin call that takes arguments");
+    let (mut harness, workspace) = setup_workspace(&[("structure.pl", code)])?;
+    let uri = workspace.uri("structure.pl");
+    harness.open(&uri, code)?;
+    harness.barrier();
+
+    scenario.when("requesting folding ranges for the document");
+    let folding = harness.request(
+        "textDocument/foldingRange",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+    )?;
+
+    scenario.then("the server returns foldable structural ranges");
+    let folding_ranges = folding.as_array().ok_or("foldingRange should return an array payload")?;
+    assert!(!folding_ranges.is_empty(), "expected at least one folding range");
+    assert!(
+        folding_ranges
+            .iter()
+            .all(|range| range.get("startLine").is_some() && range.get("endLine").is_some()),
+        "all folding ranges should expose startLine and endLine"
+    );
+
+    scenario.when("requesting inlay hints for the same range");
+    let inlay = harness.request(
+        "textDocument/inlayHint",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": code.lines().count() as u32, "character": 0 }
+            }
+        }),
+    )?;
+
+    scenario.then("inlay hints return a valid payload shape for the requested range");
+    let hints = inlay.as_array().ok_or("inlayHint should return an array payload")?;
+    assert!(
+        hints.iter().all(|hint| hint.get("position").is_some() && hint.get("label").is_some()),
+        "every inlay hint should include position and label when present"
+    );
+
+    let labels = inlay_labels(&inlay);
+    if !labels.is_empty() {
+        assert!(
+            labels.iter().any(|label| matches!(label.as_str(), "expr:" | "offset:" | "length:")),
+            "expected substr-style parameter hints in {labels:?}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Increase end-to-end BDD coverage for structural editor features by exercising `textDocument/foldingRange` and `textDocument/inlayHint` in a single realistic workflow. 
- Make assertions resilient across environments where inlay hints may be absent while still validating payload shape when hints are produced.

### Description
- Added `inlay_labels` helper to extract inlay hint labels from JSON payloads. 
- Added new BDD test `bdd_structural_navigation_supports_folding_and_inlay_hints` in `crates/perl-lsp/tests/lsp_bdd_workflows.rs` that validates folding ranges and inlay hint payload shapes for a small Perl fixture. 
- The test asserts `foldingRange` returns an array with `startLine`/`endLine`, enforces `position`/`label` presence for any returned inlay hints, and conditionally checks for `substr`-style parameter labels when present. 
- Kept assertions permissive to avoid false negatives in environments that do not emit inlay hints.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Attempted `cargo test -p perl-lsp --test lsp_bdd_workflows bdd_structural_navigation_supports_folding_and_inlay_hints` which failed due to an incorrect package name. 
- Ran `cargo test -p perl-lsp-rs --test lsp_bdd_workflows bdd_structural_navigation_supports_folding_and_inlay_hints` which executed and the new test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bba97f08333bef3c5a54917bb7d)