### PR TITLE
test(scope): cover open my filehandle regression (#3446)

### DIFF
--- a/crates/perl-lsp-diagnostics/tests/diagnostic_snapshot_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/diagnostic_snapshot_tests.rs
@@ -227,6 +227,26 @@ fn snapshot_file_io() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn snapshot_open_my_readline_no_pl102() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for #3446: `open my $fh, ...` must declare `$fh` for later `<$fh>` and `close`.
+    let source = concat!(
+        "use strict;\n",
+        "use warnings;\n",
+        "open my $fh, '<', 'file.txt' or die $!;\n",
+        "print <$fh>;\n",
+        "close $fh;\n",
+    );
+    let diags = diagnostics_for(source);
+
+    assert_no_parse_errors(&diags, "open-my/readline regression");
+
+    let pl102: Vec<_> = diags.iter().filter(|d| d.code.as_deref() == Some("PL102")).collect();
+    assert!(pl102.is_empty(), "open my/readline must not trigger PL102: {pl102:?}");
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Snippet 4: Hash/array operations
 // ---------------------------------------------------------------------------

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -2782,6 +2782,34 @@ print $data;
 }
 
 #[test]
+fn open_my_filehandle_with_readline_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for #3446: `open my $fh, ...` declares `$fh` and later `<$fh>`
+    // reads must not be reported as undeclared/uninitialized.
+    let code = r#"
+use strict;
+use warnings;
+
+open my $fh, '<', 'file.txt' or die $!;
+print <$fh>;
+close $fh;
+"#;
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(
+                i.kind,
+                IssueKind::UndeclaredVariable
+                    | IssueKind::UninitializedVariable
+                    | IssueKind::UnusedVariable
+            ) && i.variable_name == "$fh"
+        }),
+        "open my $fh / <$fh> should not be flagged; issues: {:?}",
+        issues
+    );
+    Ok(())
+}
+
+#[test]
 fn read_position_zero_not_treated_as_declaration() -> Result<(), Box<dyn std::error::Error>> {
     // Position 0 in `read` is an existing filehandle, NOT a declaration target.
     // An undeclared handle at position 0 should still be flagged, while the


### PR DESCRIPTION
### Motivation
- Add regression coverage for #3446 where `open my $fh, ...` followed by `print <$fh>` / `close $fh` could be incorrectly reported as an undeclared/uninitialized/unused variable or emit PL102.

### Description
- Add `open_my_filehandle_with_readline_not_flagged` to `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` asserting `$fh` is not reported as `UndeclaredVariable`, `UninitializedVariable`, or `UnusedVariable`.
- Add `snapshot_open_my_readline_no_pl102` to `crates/perl-lsp-diagnostics/tests/diagnostic_snapshot_tests.rs` asserting the same snippet does not emit `PL102`.
- Run `cargo fmt --all` to apply formatting.

### Testing
- Ran `cargo test -p perl-semantic-analyzer --test scope_and_symbol_tests open_my_filehandle_with_readline_not_flagged -- --nocapture` and it passed.
- Ran `cargo test -p perl-lsp-diagnostics --test diagnostic_snapshot_tests snapshot_open_my_readline_no_pl102 -- --nocapture` and it passed.
- Ran `cargo fmt --all` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928d82b408333a9aa14b7f4df2e34)