### PR TITLE
fix(scope): handle inline `open my` usage in readline contexts (#3446)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -826,6 +826,20 @@ impl ScopeAnalyzer {
                     );
                 }
             }
+            NodeKind::Readline { filehandle: Some(filehandle) } => {
+                let (sigil, var_name) = split_variable_name(filehandle);
+                if !sigil.is_empty() && !var_name.is_empty() && !var_name.contains("::") {
+                    self.record_variable_use(
+                        scope,
+                        strict_vars_mode,
+                        context,
+                        issues,
+                        node,
+                        sigil,
+                        var_name,
+                    );
+                }
+            }
             NodeKind::FunctionCall { name, args } => {
                 if let Some((sigil, var_name)) = self.extract_name_like_variable(name) {
                     self.record_variable_use(

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -196,6 +196,35 @@ print $client;
 }
 
 #[test]
+fn scope_open_my_filehandle_remains_declared_for_readline() -> Result<(), Box<dyn std::error::Error>>
+{
+    let code = r#"
+use strict;
+use warnings;
+
+open my $fh, '<', 'file.txt' or die $!;
+print <$fh>;
+close $fh;
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(
+                i.kind,
+                IssueKind::UndeclaredVariable
+                    | IssueKind::UninitializedVariable
+                    | IssueKind::UnusedVariable
+            ) && i.variable_name == "$fh"
+        }),
+        "open my $fh should keep $fh declared/initialized through readline + close: {:?}",
+        issues
+    );
+
+    Ok(())
+}
+
+#[test]
 fn scope_phase_blocks_keep_lexicals_inside_their_block() -> Result<(), Box<dyn std::error::Error>> {
     for phase in ["BEGIN", "CHECK", "INIT", "UNITCHECK", "END"] {
         let code = format!(


### PR DESCRIPTION
### Motivation
- Angle-bracket readline expressions like `print <$fh>` did not mark the filehandle as a variable use, causing `PL102` (Undefined variable) and related diagnostics for `open my $fh` patterns under `use strict`.
- The intent is to ensure builtin-initialized filehandles declared inline (e.g. `open my $fh, ...`) are recognized as declared/used when consumed by readline syntax so no false diagnostics are emitted.

### Description
- Add handling for `NodeKind::Readline { filehandle: Some(...) }` in `crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs` and route the filehandle through `split_variable_name` and `record_variable_use` so readline filehandles participate in strict-mode checks.
- Add a regression test `scope_open_my_filehandle_remains_declared_for_readline` in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` that asserts no `UndeclaredVariable`, `UninitializedVariable`, or `UnusedVariable` is reported for `$fh` in `open my $fh; print <$fh>; close $fh;`.
- Run `cargo fmt --all` to apply formatting to the modified files.

### Testing
- Ran `cargo fmt --all` (completed successfully).
- Ran `cargo test -p perl-semantic-analyzer scope_open_my_filehandle_remains_declared_for_readline -- --nocapture` and the test passed.
- Ran `cargo test -p perl-semantic-analyzer scope_declaration_capable_builtins_initialize_handle_bindings -- --nocapture` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928d82b408333a9aa14b7f4df2e34)