### PR TITLE
test(scope): add regression coverage for inline builtin declarations (#3446)

### DIFF
--- a/crates/perl-parser/tests/scope_analyzer_tests.rs
+++ b/crates/perl-parser/tests/scope_analyzer_tests.rs
@@ -735,3 +735,42 @@ print($a[0]); # Should resolve to @a
         issues
     );
 }
+
+#[test]
+fn test_open_my_declaration_is_tracked() {
+    let code = r#"
+use strict;
+use warnings;
+open my $fh, '<', 'file.txt' or die $!;
+print <$fh>;
+close $fh;
+"#;
+    let issues = analyze_code(code);
+    assert!(
+        !issues
+            .iter()
+            .any(|i| matches!(i.kind, IssueKind::UndeclaredVariable) && i.variable_name == "$fh"),
+        "Unexpected undeclared variable error for $fh declared via open my: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn test_pipe_my_declarations_are_tracked() {
+    let code = r#"
+use strict;
+use warnings;
+pipe my $read_fh, my $write_fh or die $!;
+close $read_fh;
+close $write_fh;
+"#;
+    let issues = analyze_code(code);
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(i.kind, IssueKind::UndeclaredVariable)
+                && (i.variable_name == "$read_fh" || i.variable_name == "$write_fh")
+        }),
+        "Unexpected undeclared variable error for pipe my declarations: {:?}",
+        issues
+    );
+}


### PR DESCRIPTION
### Motivation
- Prevent regressions for builtin argument inline declarations (e.g., `open my $fh`, `pipe my $r, my $w`) that previously produced false `PL102` / `IssueKind::UndeclaredVariable` diagnostics by exercising and documenting the expected behavior.

### Description
- Add two regression tests to `crates/perl-parser/tests/scope_analyzer_tests.rs` that assert `open my $fh, ...` and `pipe my $read_fh, my $write_fh` produce no `UndeclaredVariable` issues for the introduced lexicals.

### Testing
- Ran `cargo test -p perl-parser test_open_my_declaration_is_tracked -- --nocapture` which passed; ran `cargo test -p perl-parser test_pipe_my_declarations_are_tracked -- --nocapture` which also passed, and ran `cargo fmt --all` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928d82b408333a9aa14b7f4df2e34)