### PR TITLE
test(scope): add regression coverage for open-my readline handle (#3446)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -177,6 +177,36 @@ print $client;
 }
 
 #[test]
+fn open_my_handle_used_in_readline_is_tracked() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression: `open my $fh, ...` declares `$fh` and later `<$fh>` must not
+    // trigger undeclared/uninitialized/unused diagnostics.
+    let code = r#"
+use strict;
+use warnings;
+
+open my $fh, '<', 'file.txt' or die $!;
+print <$fh>;
+close $fh;
+"#;
+
+    let issues = scope_issues_strict(code);
+    assert!(
+        !issues.iter().any(|i| {
+            matches!(
+                i.kind,
+                IssueKind::UndeclaredVariable
+                    | IssueKind::UninitializedVariable
+                    | IssueKind::UnusedVariable
+            ) && i.variable_name == "$fh"
+        }),
+        "open-my handle should remain declared/initialized/used across <$fh>: {:?}",
+        issues
+    );
+
+    Ok(())
+}
+
+#[test]
 fn scope_phase_blocks_keep_lexicals_inside_their_block() -> Result<(), Box<dyn std::error::Error>> {
     for phase in ["BEGIN", "CHECK", "INIT", "UNITCHECK", "END"] {
         let code = format!(


### PR DESCRIPTION
### Motivation
- Add a regression test to ensure `open my $fh, ...` followed by a diamond/readline (`<$fh>`) is treated as a lexical declaration so the analyzer does not emit PL102/undeclared/uninitialized/unused diagnostics.

### Description
- Add `open_my_handle_used_in_readline_is_tracked` test in `crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs` which asserts `$fh` is not reported as `UndeclaredVariable`, `UninitializedVariable`, or `UnusedVariable` when declared inline by `open my $fh` and later read with `<$fh>`.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran the new test with `cargo test -p perl-semantic-analyzer open_my_handle_used_in_readline_is_tracked -- --nocapture` and it passed (1 test ran, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d928d82b408333a9aa14b7f4df2e34)