### PR TITLE
docs(index): improve docs front-door routing (#3877)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,18 @@ just status-update
 just status-check
 ```
 
+If your change introduces or modifies public APIs, also run the documentation
+coverage workflow so CI catches missing rustdoc before review:
+
+```bash
+just docs-check
+just docs-report
+```
+
+See [docs/reference/MISSING_DOCUMENTATION_GUIDE.md](docs/reference/MISSING_DOCUMENTATION_GUIDE.md)
+for remediation workflow and [docs/reference/API_DOCUMENTATION_STANDARDS.md](docs/reference/API_DOCUMENTATION_STANDARDS.md)
+for required rustdoc structure.
+
 ### 7. Open a Pull Request
 
 1. Push your branch and open a PR

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,6 +19,7 @@ Choose the path that matches what you are trying to do:
 | Understand the server architecture | [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) |
 | Work on LSP features as a contributor | [LSP Development Guide](tutorials/LSP_DEVELOPMENT_GUIDE.md) |
 | Run builds, tests, and CI commands | [Commands Reference](reference/COMMANDS_REFERENCE.md) |
+| Add or audit public API documentation | [Missing Documentation Guide](reference/MISSING_DOCUMENTATION_GUIDE.md) |
 | Understand stability and compatibility | [Stability Policy](reference/STABILITY.md) |
 | Read the historical analyses and launch material | [Articles and Research Notes](articles/README.md) |
 
@@ -54,6 +55,8 @@ Authoritative descriptions of configuration, architecture, commands, and feature
 - [Configuration Reference](reference/CONFIG.md)
 - [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md)
 - [LSP Features](reference/LSP_FEATURES.md)
+- [Missing Documentation Guide](reference/MISSING_DOCUMENTATION_GUIDE.md)
+- [API Documentation Standards](reference/API_DOCUMENTATION_STANDARDS.md)
 - [FAQ](reference/FAQ.md)
 - [Parser Feature Matrix](reference/PARSER_FEATURE_MATRIX.md)
 - [Known Limitations](reference/KNOWN_LIMITATIONS.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,12 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | set up `perllsp` in GitHub Actions | [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md) |
 | configure an editor | [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md) |
 | troubleshoot a broken setup | [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md) |
+| enforce public API docs coverage in CI | [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md) |
+| learn API docs writing standards | [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md) |
+| tune performance or threading | [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md) |
+| work with DAP workflows | [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md) |
+| understand project architecture | [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md) |
+| check known limitations and parser support | [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md) |
 | see what is true now | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) |
 | see the current release plan | [project/ROADMAP.md](project/ROADMAP.md) |
 | work on the codebase | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
@@ -34,10 +40,10 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 
 ## Docs by Type
 
-- Tutorial: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md)
-- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md)
-- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md)
-- Explanation and project docs: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md)
+- Tutorials: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md), [tutorials/LSP_DEVELOPMENT_GUIDE.md](tutorials/LSP_DEVELOPMENT_GUIDE.md), [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md), [tutorials/COMPREHENSIVE_TESTING_GUIDE.md](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
+- How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md), [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md), [how-to/SECURITY_DEVELOPMENT_GUIDE.md](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
+- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/FAQ.md](reference/FAQ.md)
+- Project, specs, and explanations: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md), [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md)
 
 ## Maintenance
 


### PR DESCRIPTION
### Motivation
- Improve discoverability of the public-API documentation coverage workflow so contributors can find and run the docs checks before review. 
- Make it explicit in contributor guidance which commands to run when changes introduce or modify public APIs.

### Description
- Added direct links to the missing-documentation workflow and API documentation standards in `docs/README.md` to surface the docs-coverage guidance. 
- Added “Add or audit public API documentation” and included the missing-docs and API-doc standards to the Reference section in `docs/INDEX.md` for easier navigation. 
- Updated `CONTRIBUTING.md` to recommend running `just docs-check` and `just docs-report` when public APIs are added or changed and linked the remediation and standards documents.

### Testing
- Attempted to run `just docs-check` in this environment but the command failed with `just: command not found`, so the docs-check could not be executed here. 
- No additional automated test runs were performed in this environment; CI will run format, clippy, and the configured docs checks on the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92fb28b748333b2efd433fe28860e)