### PR TITLE
test(document-links): expand require mutation coverage (#3996)

### DIFF
--- a/crates/perl-lsp-document-links/src/lib.rs
+++ b/crates/perl-lsp-document-links/src/lib.rs
@@ -39,8 +39,13 @@ pub fn compute_links(uri: &str, text: &str, _roots: &[Url]) -> Vec<Value> {
                     }
                 }
                 ModuleImportKind::Require => {
-                    if !import.token.starts_with('"')
-                        && !import.token.starts_with('\'')
+                    let is_quoted_require = import.token_start > 0
+                        && matches!(
+                            line.as_bytes().get(import.token_start - 1),
+                            Some(b'\'' | b'"')
+                        );
+
+                    if !is_quoted_require
                         && import.token.contains("::")
                         && !is_pragma(import.token)
                         && let Some(link) = make_deferred_module_link(

--- a/crates/perl-lsp-document-links/tests/require_mutation_coverage.rs
+++ b/crates/perl-lsp-document-links/tests/require_mutation_coverage.rs
@@ -1,0 +1,49 @@
+//! Mutation-hardening tests for `require` parsing branches in document link extraction.
+//!
+//! These tests target boolean branch mutations in `compute_links` for:
+//! - module-form `require` filtering
+//! - quoted file `require` extraction
+//! - malformed quote handling
+
+use perl_lsp_document_links::compute_links;
+use serde_json::Value;
+
+const URI: &str = "file:///test.pl";
+
+fn data_type(link: &Value) -> Option<&str> {
+    link.pointer("/data/type").and_then(Value::as_str)
+}
+
+#[test]
+fn require_double_quoted_module_path_emits_only_file_link() {
+    let links = compute_links(URI, r#"require \"Foo/Bar.pm\";"#, &[]);
+    assert_eq!(links.len(), 1, "quoted require should produce exactly one file link");
+    assert_eq!(data_type(&links[0]), Some("file"));
+}
+
+#[test]
+fn require_single_quoted_value_with_colons_emits_only_file_link() {
+    let links = compute_links(URI, "require 'Foo::Bar';", &[]);
+    assert_eq!(links.len(), 1, "quoted require should not be interpreted as module-form require");
+    assert_eq!(data_type(&links[0]), Some("file"));
+}
+
+#[test]
+fn require_module_form_with_colons_emits_module_link() {
+    let links = compute_links(URI, "require Foo::Bar::Baz;", &[]);
+    assert_eq!(links.len(), 1, "module-form require should emit one link");
+    assert_eq!(data_type(&links[0]), Some("module"));
+    assert_eq!(links[0].pointer("/data/module").and_then(Value::as_str), Some("Foo::Bar::Baz"));
+}
+
+#[test]
+fn require_quoted_without_closing_quote_emits_no_link() {
+    let links = compute_links(URI, "require 'Foo/Bar.pm;", &[]);
+    assert!(links.is_empty(), "unterminated quoted require must not emit a partial link");
+}
+
+#[test]
+fn require_numeric_version_emits_no_link() {
+    let links = compute_links(URI, "require 5.038;", &[]);
+    assert!(links.is_empty(), "version-only require should not emit module or file links");
+}


### PR DESCRIPTION
### Motivation

- Improve mutation-hardening coverage for `require` parsing branches in the document link extraction logic to prevent surviving mutants around quoted vs module-form `require` handling.
- Fix an observed edge case where quoted `require` tokens could be emitted both as a file link and a module link, producing duplicate/incorrect links.

### Description

- Add a focused mutation-hardening test file `crates/perl-lsp-document-links/tests/require_mutation_coverage.rs` covering quoted requires, module-form requires, unterminated quotes, and numeric-version requires.
- Change `compute_links` in `crates/perl-lsp-document-links/src/lib.rs` to detect when a parsed `require` token is quoted in the source (`is_quoted_require`) and skip module-form link generation for quoted tokens.
- Keep existing file-form `require` extraction intact while ensuring module links are only emitted for unquoted module-form tokens containing `::` and not pragmas.

### Testing

- Ran `cargo test -p perl-lsp-document-links` and the updated suite completed with all tests passing (previous failing case fixed by the code change).
- Ran `cargo fmt --all` to format code and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bc7670c833389f6beef4ff76b71)