### PR TITLE
test(parser-core): harden use v-string mutation coverage (#3997)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -509,8 +509,7 @@ impl<'a> Parser<'a> {
                     if let Ok(dot_token) = self.tokens.peek() {
                         if dot_token.text.as_ref() == "." {
                             self.consume_token()?; // consume dot
-                            if self.peek_kind() != /* ~ changed by cargo-mutants ~ */ Some(TokenKind::Number)
-                            {
+                            if self.peek_kind() == Some(TokenKind::Number) {
                                 let num = self.consume_token()?;
                                 version.push('.');
                                 version.push_str(&num.text);

--- a/crates/perl-parser-core/tests/expected_module_name_tests.rs
+++ b/crates/perl-parser-core/tests/expected_module_name_tests.rs
@@ -1,5 +1,6 @@
 mod cpan_test_helpers;
 use cpan_test_helpers::*;
+use perl_parser_core::NodeKind;
 
 // --- VString version directives in `use` ---
 
@@ -100,6 +101,36 @@ use warnings;
 1;
 "#,
     );
+}
+
+#[test]
+fn test_use_vstring_preserves_full_version_segment() {
+    let ast = parse("use v5.38;");
+    if let NodeKind::Program { statements } = &ast.kind {
+        assert_eq!(statements.len(), 1);
+        if let NodeKind::Use { module, .. } = &statements[0].kind {
+            assert_eq!(module, "v5.38");
+        } else {
+            panic!("expected top-level Use node");
+        }
+    } else {
+        panic!("expected Program node");
+    }
+}
+
+#[test]
+fn test_use_vstring_three_part_preserves_patch_segment() {
+    let ast = parse("use v5.12.0;");
+    if let NodeKind::Program { statements } = &ast.kind {
+        assert_eq!(statements.len(), 1);
+        if let NodeKind::Use { module, .. } = &statements[0].kind {
+            assert_eq!(module, "v5.12.0");
+        } else {
+            panic!("expected top-level Use node");
+        }
+    } else {
+        panic!("expected Program node");
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Fix a parsing gap where dotted v-string `use` directives could lose numeric segments and add mutation-hardening assertions so future mutants cannot revert correct v-string handling.

### Description
- Update `parse_use` in `crates/perl-parser-core/src/engine/parser/declarations.rs` to only consume the token after `.` when `peek_kind()` is `Some(TokenKind::Number)` so dotted v-strings append the numeric segment correctly.
- Add AST-level tests in `crates/perl-parser-core/tests/expected_module_name_tests.rs` that parse `use v5.38;` and `use v5.12.0;` and assert the resulting `NodeKind::Use` contains the full `module` string (e.g., `"v5.38"`, `"v5.12.0"`).
- Import `NodeKind` into the test module to enable structural assertions and run `cargo fmt --all` for formatting.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-parser-core --test expected_module_name_tests` and all tests passed (`18 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bc7670c833389f6beef4ff76b71)