### PR TITLE
test(runtime): expand scheduler mutation coverage (#2354)

### DIFF
--- a/crates/perl-lsp/src/runtime/scheduler.rs
+++ b/crates/perl-lsp/src/runtime/scheduler.rs
@@ -612,6 +612,27 @@ mod tests {
         assert_eq!(classify("textDocument/didOpen"), RequestClass::Mutation);
         assert_eq!(classify("textDocument/didChange"), RequestClass::Mutation);
         assert_eq!(classify("textDocument/didClose"), RequestClass::Mutation);
+        assert_eq!(classify("textDocument/didSave"), RequestClass::Mutation);
+        assert_eq!(classify("textDocument/willSave"), RequestClass::Mutation);
+        assert_eq!(classify("textDocument/willSaveWaitUntil"), RequestClass::Mutation);
+        assert_eq!(classify("workspace/didChangeConfiguration"), RequestClass::Mutation);
+        assert_eq!(classify("workspace/didCreateFiles"), RequestClass::Mutation);
+        assert_eq!(classify("workspace/didDeleteFiles"), RequestClass::Mutation);
+        assert_eq!(classify("workspace/didRenameFiles"), RequestClass::Mutation);
+        assert_eq!(classify("workspace/didChangeWorkspaceFolders"), RequestClass::Mutation);
+    }
+
+    #[test]
+    fn notebook_mutation_methods() {
+        assert_eq!(classify("notebookDocument/didOpen"), RequestClass::Mutation);
+        assert_eq!(classify("notebookDocument/didChange"), RequestClass::Mutation);
+        assert_eq!(classify("notebookDocument/didSave"), RequestClass::Mutation);
+        assert_eq!(classify("notebookDocument/didClose"), RequestClass::Mutation);
+    }
+
+    #[test]
+    fn set_trace_is_lifecycle() {
+        assert_eq!(classify("$/setTrace"), RequestClass::Lifecycle);
     }
 
     #[test]
@@ -764,6 +785,39 @@ mod tests {
         let params = serde_json::json!({
             "textDocument": { "uri": "file:///test.pl" }
             // no "position"
+        });
+        let key = extract_dedup_key("textDocument/hover", Some(&params), RequestPriority::Hover);
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn dedup_key_is_supported_for_references_priority() {
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///refs.pl" },
+            "position": { "line": 12, "character": 4 }
+        });
+        let key = extract_dedup_key(
+            "textDocument/references",
+            Some(&params),
+            RequestPriority::References,
+        );
+
+        assert_eq!(
+            key,
+            Some(RequestDedupKey {
+                method: "textDocument/references".to_string(),
+                uri: "file:///refs.pl".to_string(),
+                line: 12,
+                character: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn dedup_key_none_for_non_numeric_position_fields() {
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///bad-pos.pl" },
+            "position": { "line": "12", "character": "4" }
         });
         let key = extract_dedup_key("textDocument/hover", Some(&params), RequestPriority::Hover);
         assert!(key.is_none());

--- a/crates/perl-lsp/src/runtime/scheduler.rs
+++ b/crates/perl-lsp/src/runtime/scheduler.rs
@@ -791,6 +791,16 @@ mod tests {
     }
 
     #[test]
+    fn dedup_key_none_when_uri_missing() {
+        let params = serde_json::json!({
+            "textDocument": {},
+            "position": { "line": 1, "character": 2 }
+        });
+        let key = extract_dedup_key("textDocument/hover", Some(&params), RequestPriority::Hover);
+        assert!(key.is_none());
+    }
+
+    #[test]
     fn dedup_key_is_supported_for_references_priority() {
         let params = serde_json::json!({
             "textDocument": { "uri": "file:///refs.pl" },
@@ -818,6 +828,16 @@ mod tests {
         let params = serde_json::json!({
             "textDocument": { "uri": "file:///bad-pos.pl" },
             "position": { "line": "12", "character": "4" }
+        });
+        let key = extract_dedup_key("textDocument/hover", Some(&params), RequestPriority::Hover);
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn dedup_key_none_when_position_is_signed() {
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///bad-pos.pl" },
+            "position": { "line": 1, "character": -1 }
         });
         let key = extract_dedup_key("textDocument/hover", Some(&params), RequestPriority::Hover);
         assert!(key.is_none());


### PR DESCRIPTION
### Motivation
- Harden scheduler request classification and stale-request deduplication logic by adding targeted tests that catch mutation-induced regressions.

### Description
- Add explicit `mutation_methods` assertions for additional `textDocument/*` and `workspace/*` mutation endpoints (e.g. `didSave`, `willSave`, `workspace/didCreateFiles`, etc.).
- Add `notebook_mutation_methods` tests for `notebookDocument/*` mutation methods.
- Add lifecycle classification test for `$/setTrace` to ensure lifecycle methods remain exclusive.
- Add dedup-key tests that verify `RequestDedupKey` is produced for `References`-priority requests and that non-numeric `position` fields return `None`.

### Testing
- Ran `cargo fmt --all` and it completed successfully.
- Ran targeted unit tests with `cargo test -p perl-lsp-rs --lib runtime::scheduler::tests::set_trace_is_lifecycle -- --exact` and the test passed.
- Ran targeted unit tests with `cargo test -p perl-lsp-rs --lib runtime::scheduler::tests::dedup_key_is_supported_for_references_priority -- --exact` and the test passed.
- Ran targeted unit tests with `cargo test -p perl-lsp-rs --lib runtime::scheduler::tests::mutation_methods -- --exact` and the test passed.
- A non-`--lib` attempt to run broader tests hit an environment failure (`No space left on device`) while compiling unrelated tests; the targeted `--lib` tests above passed after cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92bc7670c833389f6beef4ff76b71)