### PR TITLE
test(perl-parser): expand line-cache property coverage (#3995)

### DIFF
--- a/crates/perl-parser/tests/line_cache_fuzz.rs
+++ b/crates/perl-parser/tests/line_cache_fuzz.rs
@@ -1,12 +1,32 @@
 #[cfg(test)]
 mod fuzz {
     use perl_parser::position::LineStartsCache;
+    use proptest::prelude::*;
 
-    // Quick property test without proptest dependency for now
-    // Can upgrade to proptest later if desired
+    fn mixed_content_strategy() -> impl Strategy<Value = String> {
+        prop::collection::vec(
+            prop_oneof![
+                Just("a".to_string()),
+                Just("Z".to_string()),
+                Just("0".to_string()),
+                Just(" ".to_string()),
+                Just("\t".to_string()),
+                Just("\n".to_string()),
+                Just("\r".to_string()),
+                Just("\r\n".to_string()),
+                Just("\u{FEFF}".to_string()),
+                Just("é".to_string()),
+                Just("你".to_string()),
+                Just("𝐀".to_string()),
+                Just("👨\u{200D}👩\u{200D}👧\u{200D}👦".to_string()),
+            ],
+            0..96,
+        )
+        .prop_map(|parts| parts.concat())
+    }
 
-    /// Slow reference implementation for testing
-    /// This matches the actual cache behavior: \r counts as a column before CRLF
+    /// Slow reference implementation for testing.
+    /// Matches cache behavior where `\r` contributes one UTF-16 column in CRLF.
     fn slow_offset_to_position(content: &str, offset: usize) -> (u32, u32) {
         let mut line = 0u32;
         let mut col_utf16 = 0u32;
@@ -22,18 +42,14 @@ mod fuzz {
                 line += 1;
                 col_utf16 = 0;
             } else if ch == '\r' {
-                // Check if this is part of CRLF
                 if byte_offset + 1 < bytes.len() && bytes[byte_offset + 1] == b'\n' {
-                    // \r counts as a column, \n will reset on next iteration
                     col_utf16 += 1;
                 } else {
-                    // Standalone \r is a line break
                     line += 1;
                     col_utf16 = 0;
                 }
             } else {
-                // Count UTF-16 code units for the character
-                col_utf16 += if ch as u32 >= 0x10000 { 2 } else { 1 };
+                col_utf16 += ch.len_utf16() as u32;
             }
 
             byte_offset += ch.len_utf8();
@@ -42,124 +58,56 @@ mod fuzz {
         (line, col_utf16)
     }
 
-    #[test]
-    fn fuzz_mixed_content() {
-        // Test various combinations manually for now
-        let long_line = format!("{}{}\n", "x".repeat(10000), "𝐀".repeat(1000));
-        let many_lines = "a\n".repeat(1000);
+    fn char_boundary_offsets(content: &str) -> Vec<usize> {
+        let mut offsets = Vec::with_capacity(content.chars().count() + 2);
+        offsets.push(0);
+        for (i, _) in content.char_indices() {
+            offsets.push(i);
+        }
+        offsets.push(content.len());
+        offsets.sort_unstable();
+        offsets.dedup();
+        offsets
+    }
 
-        let test_cases = vec![
-            // Plain ASCII
-            "hello world\ntest",
-            // CRLF line endings
-            "line1\r\nline2\r\nline3",
-            // Mixed line endings
-            "unix\nmixed\r\nwindows\r\nend",
-            // Unicode with surrogates
-            "before𝐀after\n𝐁test",
-            // ZWJ emoji sequences
-            "start👨‍👩‍👧‍👦end\nmore",
-            // BOM at start
-            "\u{FEFF}content\nhere",
-            // Mixed everything
-            "\u{FEFF}test\r\n𝐀𝐁\n👨‍👩‍👧‍👦\r\nASCII",
-            // Very long lines
-            &long_line,
-            // Many short lines
-            &many_lines,
-            // Edge cases
-            "",
-            "\n",
-            "\r\n",
-            "\r",
-            "𝐀",
-            "👨‍👩‍👧‍👦",
-        ];
+    proptest! {
+        #[test]
+        fn prop_cache_matches_reference(content in mixed_content_strategy()) {
+            let cache = LineStartsCache::new(&content);
 
-        for content in test_cases {
-            let cache = LineStartsCache::new(content);
-
-            // Test various offsets (only valid char boundaries)
-            let mut offsets = vec![0];
-            if !content.is_empty() {
-                offsets.push(content.len());
-
-                // Add char boundary offsets
-                let mut char_boundaries = vec![0];
-                for (i, _) in content.char_indices() {
-                    char_boundaries.push(i);
-                }
-                char_boundaries.push(content.len());
-
-                // Sample some of them
-                for i in 0..char_boundaries.len().min(20) {
-                    let idx = (i * 7) % char_boundaries.len();
-                    offsets.push(char_boundaries[idx]);
-                }
+            for offset in char_boundary_offsets(&content) {
+                let cached = cache.offset_to_position(&content, offset);
+                let slow = slow_offset_to_position(&content, offset);
+                prop_assert_eq!(cached, slow, "offset mismatch at {}", offset);
             }
+        }
 
-            for offset in offsets {
-                let cached = cache.offset_to_position(content, offset);
-                let slow = slow_offset_to_position(content, offset);
+        #[test]
+        fn prop_round_trip_for_non_crlf_byte_offsets(content in mixed_content_strategy()) {
+            let cache = LineStartsCache::new(&content);
+            let bytes = content.as_bytes();
 
-                assert_eq!(
-                    cached,
-                    slow,
-                    "Mismatch at offset {} in content {:?}",
-                    offset,
-                    content.chars().take(50).collect::<String>()
-                );
-
-                // Test round-trip (skip CRLF positions which don't round-trip correctly)
-                // Both \r and \n in CRLF sequence have issues:
-                // - \r at offset N maps to (line, col) but (line, col) maps back to N
-                // - \n at offset N+1 maps to (line, col+1) but (line, col+1) maps back to N
-                let is_crlf_r = content.as_bytes().get(offset) == Some(&b'\r')
-                    && content.as_bytes().get(offset + 1) == Some(&b'\n');
+            for offset in char_boundary_offsets(&content) {
+                let is_crlf_r = bytes.get(offset) == Some(&b'\r') && bytes.get(offset + 1) == Some(&b'\n');
                 let is_crlf_n = offset > 0
-                    && content.as_bytes().get(offset - 1) == Some(&b'\r')
-                    && content.as_bytes().get(offset) == Some(&b'\n');
+                    && bytes.get(offset - 1) == Some(&b'\r')
+                    && bytes.get(offset) == Some(&b'\n');
 
                 if !is_crlf_r && !is_crlf_n {
-                    let rt_offset = cache.position_to_offset(content, cached.0, cached.1);
-                    assert_eq!(
-                        rt_offset,
-                        offset,
-                        "Round-trip failed for offset {} in content {:?}",
-                        offset,
-                        content.chars().take(50).collect::<String>()
-                    );
+                    let (line, col) = cache.offset_to_position(&content, offset);
+                    let rt_offset = cache.position_to_offset(&content, line, col);
+                    prop_assert_eq!(rt_offset, offset, "round-trip mismatch at {}", offset);
                 }
             }
         }
-    }
 
-    #[test]
-    fn fuzz_edge_boundaries() {
-        // Test boundary conditions around line breaks
-        // NOTE: Only test valid UTF-8 char boundaries
-        let cases = vec![
-            ("a\nb", vec![0, 1, 2, 3]),
-            ("a\r\nb", vec![0, 1, 3, 4]), // Skip offset 2 (middle of CRLF)
-            ("𝐀\n𝐁", vec![0, 4, 5, 9]),   // Only char boundaries for 4-byte chars
-            ("👨‍👩‍👧‍👦", vec![0, 25]),          // Only start and end for ZWJ sequence
-        ];
+        #[test]
+        fn prop_position_lookup_is_bounded(content in mixed_content_strategy(), line in 0u32..128, col in 0u32..2048) {
+            let cache = LineStartsCache::new(&content);
+            let offset = cache.position_to_offset(&content, line, col);
 
-        for (content, offsets) in cases {
-            let cache = LineStartsCache::new(content);
-
-            for offset in offsets {
-                if offset <= content.len() {
-                    let cached = cache.offset_to_position(content, offset);
-                    let slow = slow_offset_to_position(content, offset);
-
-                    assert_eq!(
-                        cached, slow,
-                        "Boundary mismatch at offset {} in {:?}",
-                        offset, content
-                    );
-                }
-            }
+            prop_assert!(offset <= content.len());
+            prop_assert!(content.is_char_boundary(offset));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Improve and broaden property-based coverage for the line-starts cache to catch edge cases around line endings and Unicode handling.

### Description
- Replace the previous manual/table-driven fuzz tests in `crates/perl-parser/tests/line_cache_fuzz.rs` with `proptest`-driven properties and a reusable mixed-content generator.
- Add `mixed_content_strategy()` covering ASCII, whitespace, `\n`, `\r`, `\r\n`, BOM, BMP and non-BMP Unicode, and ZWJ emoji sequences, plus a `char_boundary_offsets()` helper for valid UTF-8 boundary sampling.
- Keep a slow reference `slow_offset_to_position` and assert equivalence with the cached `LineStartsCache::offset_to_position`, add a round-trip `offset -> position -> offset` check that skips CRLF middle offsets, and assert `position_to_offset` yields bounded UTF-8 char-boundary offsets.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p perl-parser --test line_cache_fuzz` and all property tests passed (`3 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92f266d5883338f8f9b06aebd5a64)