### PR TITLE
test(perl-quote): expand property coverage for modifier parsing (#3998)

### DIFF
--- a/crates/perl-quote/tests/prop_modifier_validation.rs
+++ b/crates/perl-quote/tests/prop_modifier_validation.rs
@@ -1,0 +1,104 @@
+use perl_quote::{
+    SubstitutionError, extract_substitution_parts, extract_substitution_parts_strict,
+    validate_substitution_modifiers,
+};
+use proptest::prelude::*;
+
+fn modifier_candidate_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec(any::<u8>(), 0..64)
+        .prop_map(|bytes| bytes.into_iter().map(char::from).collect())
+}
+
+fn valid_modifier_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![
+            Just('g'),
+            Just('i'),
+            Just('m'),
+            Just('s'),
+            Just('x'),
+            Just('o'),
+            Just('e'),
+            Just('r'),
+            Just('a'),
+            Just('d'),
+            Just('l'),
+            Just('u'),
+            Just('n'),
+            Just('p'),
+            Just('c'),
+        ],
+        0..16,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn invalid_alpha_modifier_strategy() -> impl Strategy<Value = char> {
+    prop::char::range('a', 'z').prop_filter("must not be valid substitution modifier", |c| {
+        !matches!(
+            c,
+            'g' | 'i' | 'm' | 's' | 'x' | 'o' | 'e' | 'r' | 'a' | 'd' | 'l' | 'u' | 'n' | 'p' | 'c'
+        )
+    })
+}
+
+fn modifier_oracle(input: &str) -> Result<String, char> {
+    let mut out = String::new();
+
+    for c in input.chars() {
+        if !c.is_ascii_alphabetic() {
+            if c.is_whitespace() || c == ';' || c == '\n' || c == '\r' {
+                break;
+            }
+            return Err(c);
+        }
+
+        if matches!(
+            c,
+            'g' | 'i' | 'm' | 's' | 'x' | 'o' | 'e' | 'r' | 'a' | 'd' | 'l' | 'u' | 'n' | 'p' | 'c'
+        ) {
+            out.push(c);
+        } else {
+            return Err(c);
+        }
+    }
+
+    Ok(out)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn prop_validate_substitution_modifiers_matches_oracle(modifiers in modifier_candidate_strategy()) {
+        prop_assert_eq!(validate_substitution_modifiers(&modifiers), modifier_oracle(&modifiers));
+    }
+
+    #[test]
+    fn prop_strict_and_lenient_agree_for_valid_modifier_sequences(
+        pattern in "[A-Za-z0-9_]{0,24}",
+        replacement in "[A-Za-z0-9_]{0,24}",
+        modifiers in valid_modifier_strategy(),
+    ) {
+        let text = format!("s/{pattern}/{replacement}/{modifiers}");
+
+        let lenient = extract_substitution_parts(&text);
+        let strict = extract_substitution_parts_strict(&text);
+
+        prop_assert_eq!(strict.ok(), Some(lenient));
+    }
+
+    #[test]
+    fn prop_strict_rejects_invalid_alphabetic_modifier(
+        pattern in "[A-Za-z0-9_]{0,16}",
+        replacement in "[A-Za-z0-9_]{0,16}",
+        valid_prefix in valid_modifier_strategy(),
+        invalid in invalid_alpha_modifier_strategy(),
+    ) {
+        let text = format!("s/{pattern}/{replacement}/{valid_prefix}{invalid}");
+
+        let strict = extract_substitution_parts_strict(&text);
+
+        prop_assert_eq!(strict, Err(SubstitutionError::InvalidModifier(invalid)));
+    }
+}


### PR DESCRIPTION
### Motivation

- Increase randomized property-test coverage around substitution modifier parsing to catch regressions and edge cases in modifier handling.
- Ensure the strict validator (`validate_substitution_modifiers` / `extract_substitution_parts_strict`) and the lenient parser (`extract_substitution_parts`) behave consistently for valid inputs and reject invalid alphabetic modifiers.

### Description

- Add a new proptest integration suite at `crates/perl-quote/tests/prop_modifier_validation.rs` containing generators and tests for modifier validation and parser round-trips.
- Implement `modifier_candidate_strategy`, `valid_modifier_strategy`, and `invalid_alpha_modifier_strategy` to generate randomized inputs for the property tests.
- Add an independent `modifier_oracle` that models expected behavior and assert `validate_substitution_modifiers` matches the oracle on randomized byte sequences.
- Add property tests that assert `extract_substitution_parts_strict` and `extract_substitution_parts` agree on valid modifier sequences and that strict parsing returns `SubstitutionError::InvalidModifier` for invalid alphabetic modifiers.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-quote --test prop_modifier_validation` and the three proptest cases passed (`3 passed; 0 failed`).
- Also ran `cargo test -p perl-quote prop_modifier_validation` during development; the targeted test binary completed with all property tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92f266d5883338f8f9b06aebd5a64)