### PR TITLE
docs(crates): refresh stale crate docs metadata (#3212)

### DIFF
--- a/crates/perl-ast-utils/CLAUDE.md
+++ b/crates/perl-ast-utils/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Centralise generic AST and source-text helper logic (e.g., `find_node_at_range`, `find_statement_start`, `find_function_insert_position`, `get_indent_at`) so multiple LSP feature crates can reuse them without duplicating code.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-ast/CLAUDE.md
+++ b/crates/perl-ast/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Typed representation of Perl syntax constructs used by the parser, semantic analyzer, and LSP server.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-builtins/CLAUDE.md
+++ b/crates/perl-builtins/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Crate**: `perl-builtins`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: Tier 1 leaf crate (no internal workspace dependencies)
 - **Purpose**: Supply signature information for 200+ Perl built-in functions (including 27 file test operators) to enable code completion, signature help, hover info, and inlay hints in the LSP.
 

--- a/crates/perl-corpus/CLAUDE.md
+++ b/crates/perl-corpus/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Tier**: 7 (testing/legacy crate)
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Purpose**: Test corpus management, property-based generators, and edge case fixtures for Perl parsers and LSP/DAP testing.
 
 ## Commands

--- a/crates/perl-dap-breakpoint/CLAUDE.md
+++ b/crates/perl-dap-breakpoint/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Validates breakpoint locations against parsed Perl source to ensure breakpoints land on executable lines, rejecting comments, blank lines, heredoc interiors, and out-of-range lines.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-dap-eval/CLAUDE.md
+++ b/crates/perl-dap-eval/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Validates Perl expressions before evaluation during debugging, blocking dangerous operations that could mutate state, execute code, or perform I/O.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-dap-stack/CLAUDE.md
+++ b/crates/perl-dap-stack/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Parses Perl debugger stack output into DAP-compatible `StackFrame` structures and classifies frames as user code, library code, core, or eval.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-dap-variables/CLAUDE.md
+++ b/crates/perl-dap-variables/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Parses Perl debugger text output into structured `PerlValue` representations, then renders them into DAP-compatible `RenderedVariable` structs for display in VSCode and other DAP-compatible editors.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-dap/CLAUDE.md
+++ b/crates/perl-dap/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 - **Tier**: 6 (application/executable crate)
 - **Purpose**: Debug Adapter Protocol server for Perl. Provides a native adapter that drives `perl -d` directly, and a `BridgeAdapter` library that proxies DAP messages to Perl::LanguageServer.
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-diagnostics-codes/CLAUDE.md
+++ b/crates/perl-diagnostics-codes/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Crate Overview
 
 - **Tier**: 1 (leaf crate, no internal workspace dependencies)
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Purpose**: Defines stable diagnostic codes, severity levels, tags, and categories for the Perl LSP ecosystem. All codes have fixed string representations that persist across versions.
 
 ## Commands

--- a/crates/perl-edit/CLAUDE.md
+++ b/crates/perl-edit/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Represents text edits with byte and line/column coordinates, computes positional shifts, and applies edits to positions and ranges.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-error/CLAUDE.md
+++ b/crates/perl-error/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 ## Crate Overview
 
 - **Name**: `perl-error`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: Tier 1 leaf crate (depends on `perl-ast`, `perl-regex`, `perl-position-tracking`, `perl-lexer`)
 - **Purpose**: Unified error types, budget tracking, error classification, and recovery traits for the Perl parser ecosystem.
 

--- a/crates/perl-heredoc/CLAUDE.md
+++ b/crates/perl-heredoc/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Given a queue of `PendingHeredoc` declarations and source bytes, walks lines from a starting offset, matches terminators, and returns span-based content with indentation stripping and CRLF normalization.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-incremental-parsing/CLAUDE.md
+++ b/crates/perl-incremental-parsing/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Minimize re-parsing overhead when Perl documents change by reusing unaffected AST subtrees, lexer checkpoints, and cached token streams.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-code-actions/CLAUDE.md
+++ b/crates/perl-lsp-code-actions/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Generate LSP code actions from diagnostics and AST analysis -- quick fixes for common Perl mistakes, and refactoring operations for code improvement.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-completion/CLAUDE.md
+++ b/crates/perl-lsp-completion/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Generates ranked completion items from parsed ASTs, semantic symbols, and workspace indexes for the `textDocument/completion` LSP request.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-diagnostics/CLAUDE.md
+++ b/crates/perl-lsp-diagnostics/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Converts parse errors, scope analysis issues, and lint findings into structured diagnostics consumed by the LSP server.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-formatting/CLAUDE.md
+++ b/crates/perl-lsp-formatting/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Wraps perltidy execution behind a generic `SubprocessRuntime` trait, producing LSP-compatible text edits for full-document and range formatting.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-inlay-hints/CLAUDE.md
+++ b/crates/perl-lsp-inlay-hints/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 ## Crate Overview
 
 - **Name**: `perl-lsp-inlay-hints`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: LSP feature crate (depends on Tier 4 `perl-semantic-analyzer`)
 - **Purpose**: Generates LSP inlay hints for Perl -- parameter name hints on built-in function calls and lightweight type hints on literals.
 

--- a/crates/perl-lsp-navigation/CLAUDE.md
+++ b/crates/perl-lsp-navigation/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: LSP navigation providers consumed by `perl-lsp` request handlers for code navigation features.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-protocol/CLAUDE.md
+++ b/crates/perl-lsp-protocol/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Isolates protocol types from the LSP runtime so they can be shared across binaries and provider layers.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-providers/CLAUDE.md
+++ b/crates/perl-lsp-providers/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 ## Crate Overview
 
 - **Crate**: `perl-lsp-providers`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: 4 (three-level dependencies)
 - **Purpose**: Central aggregation crate that re-exports all LSP feature provider microcrates and provides IDE integration shims for the `perl-lsp` server.
 

--- a/crates/perl-lsp-rename/CLAUDE.md
+++ b/crates/perl-lsp-rename/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 ## Crate Overview
 
-- **Crate**: `perl-lsp-rename` (workspace, currently 0.12.2)
+- **Crate**: `perl-lsp-rename` (workspace, currently 0.12.3)
 - **Tier**: Listed under Tier 2 in workspace `Cargo.toml` (single-level workspace dependency)
 - **Purpose**: LSP rename provider for Perl -- validates rename requests, resolves symbol references, and produces text edits for single-file renames.
 

--- a/crates/perl-lsp-semantic-tokens/CLAUDE.md
+++ b/crates/perl-lsp-semantic-tokens/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Combines lexer token classification with AST overlays to produce delta-encoded semantic tokens per the LSP 3.17+ specification.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-tooling/CLAUDE.md
+++ b/crates/perl-lsp-tooling/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Subprocess abstraction for perltidy/perlcritic, AST caching, incremental parsing, symbol indexing, and parallel file processing.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-lsp-transport/CLAUDE.md
+++ b/crates/perl-lsp-transport/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Synchronous Content-Length based message framing for reading JSON-RPC requests and writing responses/notifications, used by the `perl-lsp` server binary.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-parser-pest/CLAUDE.md
+++ b/crates/perl-parser-pest/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Crate**: `perl-parser-pest`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: 7 (Legacy/testing)
 - **Purpose**: Legacy Pest-based Perl parser (v2) -- maintained as a learning tool, compatibility reference, and benchmark baseline. NOT in the default CI gate.
 

--- a/crates/perl-parser/CLAUDE.md
+++ b/crates/perl-parser/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Crate Overview
 
 - **Tier**: 6 (application/composition crate)
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Purpose**: Central hub crate that aggregates and re-exports the core parser, semantic analyzer, workspace indexer, refactoring engine, TDD support, and all LSP provider crates into a single public API surface. Also provides the `perl-parse` CLI binary.
 
 ## Commands

--- a/crates/perl-position-tracking/CLAUDE.md
+++ b/crates/perl-position-tracking/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 - **Tier**: 1 (leaf crate, no internal workspace dependencies)
 - **Purpose**: UTF-8/UTF-16 position tracking, byte-span types, and line-index caching for the Perl LSP ecosystem. Bridges the gap between Rust byte offsets and LSP UTF-16 code-unit positions.
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-pragma/CLAUDE.md
+++ b/crates/perl-pragma/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Walks an AST to build a range-indexed map of `use strict`, `no strict`, `use warnings`, and `no warnings` effects, enabling scope-aware pragma queries at any byte offset.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-quote/CLAUDE.md
+++ b/crates/perl-quote/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Parse regex (`qr//`, `m//`), substitution (`s///`), and transliteration (`tr///`, `y///`) operators, handling all Perl delimiter styles and modifier validation.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-refactoring/CLAUDE.md
+++ b/crates/perl-refactoring/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Tier**: 3 (two-level internal dependencies)
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Purpose**: Refactoring and modernization utilities for Perl -- provides automated code transformations including import optimization, symbol rename, module extraction, inline variable, and legacy code modernization.
 
 ## Commands

--- a/crates/perl-regex/CLAUDE.md
+++ b/crates/perl-regex/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Detect dangerous or expensive regex constructs (nested quantifiers, embedded code, excessive nesting/branching) and report offset-aware diagnostics for IDE integration.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-semantic-analyzer/CLAUDE.md
+++ b/crates/perl-semantic-analyzer/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Name**: `perl-semantic-analyzer`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: 4 (three-level internal dependencies)
 - **Purpose**: Semantic analysis, symbol extraction, type inference, scope analysis, and dead code detection for Perl source code. Provides the core analysis layer consumed by LSP provider crates.
 

--- a/crates/perl-symbol-surface/CLAUDE.md
+++ b/crates/perl-symbol-surface/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 **Purpose**: Derive stable, reusable symbol-bearing views from the AST so that every IDE feature uses the same extraction logic rather than each implementing its own AST pattern-match.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-symbol-types/CLAUDE.md
+++ b/crates/perl-symbol-types/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with code in this crate.
 
 - **Tier**: 1 (leaf crate, no internal workspace dependencies)
 - **Purpose**: Single source of truth for Perl symbol classification across the perl-lsp ecosystem
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-tdd-support/CLAUDE.md
+++ b/crates/perl-tdd-support/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Safe unwrap replacements (`must`/`must_some`/`must_err`), Perl test code generation from ASTs, test discovery/execution with TAP parsing, TDD workflow state management, refactoring analysis, and ignored test governance.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-token/CLAUDE.md
+++ b/crates/perl-token/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 **Purpose**: Defines `Token` and `TokenKind` -- the shared token contract used by lexer, tokenizer, and parser crates.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-tokenizer/CLAUDE.md
+++ b/crates/perl-tokenizer/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Crate**: `perl-tokenizer`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: 2 (single-level internal dependencies)
 - **Purpose**: Bridge between raw `perl-lexer` output and the recursive descent parser. Provides buffered token stream with lookahead, trivia preservation (comments, whitespace, POD), position tracking, and `__DATA__`/`__END__` marker utilities.
 

--- a/crates/perl-uri/CLAUDE.md
+++ b/crates/perl-uri/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 `perl-uri` is a **Tier 1 leaf crate** providing URI-to-filesystem-path conversion and normalization utilities for the Perl LSP ecosystem.
 
-**Version**: workspace (currently 0.12.2)
+**Version**: workspace (currently 0.12.3)
 
 ## Commands
 

--- a/crates/perl-workspace-index/CLAUDE.md
+++ b/crates/perl-workspace-index/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 ## Crate Overview
 
 - **Crate**: `perl-workspace-index`
-- **Version**: workspace (currently 0.12.2)
+- **Version**: workspace (currently 0.12.3)
 - **Tier**: 3 (two-level internal dependencies)
 - **Purpose**: Central workspace indexing engine providing cross-file symbol lookup, document management, lifecycle state machine, bounded caching, and SLO monitoring for the Perl LSP server.
 

--- a/crates/tree-sitter-perl-c/CLAUDE.md
+++ b/crates/tree-sitter-perl-c/CLAUDE.md
@@ -14,7 +14,7 @@ scanner (`scanner.c`) from `c-src/` via the `cc` crate and expose a
 tree-sitter `Language` for compatibility testing and benchmarking against
 the native Rust parser.
 
-**Version**: tracks the workspace (currently `0.12.2`).
+**Version**: tracks the workspace (currently `0.12.3`).
 
 This crate is a workspace member and is published to crates.io. It
 requires only a C compiler at build time — no `libclang` / `bindgen`

--- a/crates/tree-sitter-perl-rs/CLAUDE.md
+++ b/crates/tree-sitter-perl-rs/CLAUDE.md
@@ -73,7 +73,7 @@ cargo clippy -p tree-sitter-perl-rs         # Lint
 cargo doc -p tree-sitter-perl-rs --open     # View documentation
 ```
 
-## Phase 2 follow-ups
+## Backlog follow-ups
 
 - Tree cursor / walk API
 - Edit/incremental parsing API

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -74,9 +74,9 @@ This means you can pipe any Perl source through this parser and rely on getting 
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
 - `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::to_sexp()` for grammar-canonical output.
 
-## Phase 2 roadmap
+## Backlog roadmap
 
-The following features are planned but not yet implemented:
+The following APIs are not yet implemented and remain on the backlog:
 
 - Tree cursor / walk API (streaming traversal without per-call allocation)
 - Edit / incremental parsing API


### PR DESCRIPTION
### Motivation

- Bring crate-level documentation metadata up to date by aligning `CLAUDE.md` version strings with the current workspace version. 
- Remove phase-specific roadmap wording that no longer matches the repository tone and replace it with backlog-oriented language for `tree-sitter-perl-rs` docs. 
- Keep crate guidance files consistent so tooling and AI agents consuming `CLAUDE.md`/README files see current, non-misleading information.

### Description

- Replaced `0.12.2` → `0.12.3` in many crate `CLAUDE.md` files across the workspace to reflect the current workspace version. 
- Updated `crates/tree-sitter-perl-rs/README.md` wording: changed the `Phase 2 roadmap` section to `Backlog roadmap` and adjusted the explanatory sentence to indicate these APIs are backlog items. 
- Updated `crates/tree-sitter-perl-rs/CLAUDE.md` heading from `Phase 2 follow-ups` to `Backlog follow-ups` for consistent terminology.

### Testing

- Ran `rg -n "0\.12\.2" crates/*/{README.md,CLAUDE.md}` after edits and confirmed there are no remaining matches (validation succeeded). 
- Verified files were staged and committed successfully (documentation-only change, no runtime code modified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9311ba79483338dea34de14499f3c)