### PR TITLE
docs(vscode-extension): refresh README walkthrough media and known issues (#3993)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -63,16 +63,15 @@ Perl::Critic, and PerlTidy can overlap with perl-lsp features. If you see
 duplicate hover, completion, or formatting results, disable the competing
 feature in one extension and keep the other as the source of truth.
 
-### Walkthrough Previews
+### Walkthrough Media
 
-These storyboard SVGs are preview assets for the walkthrough flow. They are not
-the final recorded GIFs.
+The extension includes a "Get Started" walkthrough in VS Code. Walkthrough
+media assets and recording notes live in:
 
-- [Install, auto-download, and health check storyboard](media/walkthrough/install-health.svg)
-- [Go to definition and find references storyboard](media/walkthrough/find-references.svg)
-- [Extract variable code action storyboard](media/walkthrough/extract-variable.svg)
-
-See [media/walkthrough/README.md](media/walkthrough/README.md) for the capture plan, recommended render inputs, and GIF size checks.
+- [media/walkthrough/README.md](media/walkthrough/README.md)
+- [media/walkthrough/install-health.svg](media/walkthrough/install-health.svg)
+- [media/walkthrough/find-references.svg](media/walkthrough/find-references.svg)
+- [media/walkthrough/extract-variable.svg](media/walkthrough/extract-variable.svg)
 
 ## Installation
 
@@ -218,6 +217,17 @@ The `perllsp` binary works with any editor that supports the Language Server Pro
 **Diagnostics too noisy?**
 - Set `perl-lsp.enableDiagnostics` to `false` to disable
 - File an issue if you see false positives
+
+## Known Issues
+
+- Variable/watch rendering in debugger sessions is still evolving; complex Perl
+  structures may appear with placeholder values in some scenarios.
+- The `Format Document` shortcut (`Shift+Alt+F`) is provided by VS Code's
+  built-in formatter binding. perl-lsp participates through the registered
+  formatting provider when `perl-lsp.enableFormatting` is enabled.
+- On first activation, environments with strict proxies or blocked outbound
+  traffic may fail auto-download. Use `perl-lsp.serverPath` or
+  `perl-lsp.downloadBaseUrl` for managed/internal deployment.
 
 ## Resources
 


### PR DESCRIPTION
### Motivation

- Fill missing user-facing guidance in the extension README by converting a developer-facing "Walkthrough Previews" note into a clear, discoverable media section that points to the walkthrough assets. 
- Surface current UX limitations so users and integrators understand debugger value-rendering, formatting shortcut ownership, and auto-download behavior in constrained networks.

### Description

- Replaced the developer-facing `Walkthrough Previews` wording with a `Walkthrough Media` section and added explicit links to `media/walkthrough/README.md` and the three storyboard SVGs. 
- Added a `Known Issues` section documenting debugger variable/watch placeholder rendering, clarifying that `Shift+Alt+F` is the editor-provided format shortcut while perl-lsp supplies the formatter, and calling out first-activation auto-download failures in strict proxy/air-gapped environments with guidance to use `perl-lsp.serverPath` or `perl-lsp.downloadBaseUrl`. 
- Change is documentation-only and limited to `vscode-extension/README.md` with no runtime behavior or code changes.

### Testing

- Ran `npm --prefix vscode-extension run -s verify:marketplace`, which failed in this environment with `TS2307: Cannot find module 'vscode-jsonrpc'` and therefore could not complete the marketplace verification. 
- Committed the README update and validated the file diff locally; no automated doc-build or lint gate was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9311019c48333a1880e20908f9777)