### PR TITLE
docs(todo): refresh backlog for v0.13.0 readiness (#3992)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,107 +1,94 @@
 # TODOs & Missing Features
 
-> **Last Updated**: 2026-02-17
-> **Sources of truth**: `docs/project/ROADMAP.md` (plans), `docs/project/CURRENT_STATUS.md` (metrics), `features.toml` (capabilities)
-> **Rule**: If this file conflicts with those sources, update this file (not the sources).
+> **Last Updated**: 2026-04-10
+> **Sources of truth**: `docs/project/ROADMAP.md` (planning), `docs/project/CURRENT_STATUS.md` (evidence), `features.toml` (capabilities)
+> **Rule**: If this file conflicts with those sources, update this backlog file (not the canonical sources).
 
 ---
 
 ## How to Use This List
 
-- Treat this as an **actionable backlog**, not a status report.
-- Do **not** add metrics here; metrics live in `docs/project/CURRENT_STATUS.md`.
-- For LSP capability truth, update `features.toml` and run `just status-update`.
+- Treat this as an actionable backlog, not a status report.
+- Do not add benchmark/test metrics here; metrics and receipts belong in `docs/project/CURRENT_STATUS.md`.
+- Capability truth belongs in `features.toml`; regenerate derived docs with `just status-update`.
 
 ---
 
-## Now (v0.10.0 Close-Out) - TODOs
+## Now (post-v0.12.3 / pre-v0.13.0) - TODOs
 
-### Workspace Index State Machine
+### Quality Cleanup
 
-- [x] Define explicit indexing states + transitions (Idle -> Scanning -> Indexing -> Ready -> Error)
-- [x] Wire transitions into workspace indexing and file-change flows
-- [x] Add early-exit heuristics and performance caps (target: <100ms initial, <10ms incremental)
-- [x] Add instrumentation (state durations, early-exit reasons, transition counts)
-- [x] Add targeted tests + benchmarks (small/medium/large workspaces)
-- [x] Document invariants and failure modes (docs + inline commentary)
-- [x] Capture receipts (ci-gate + targeted tests/benchmarks)
+- [ ] Remove remaining debug `println!` usage from production library paths.
+- [ ] Complete unused dependency cleanup across targeted crates.
+- [ ] Finish production-code `unwrap()` / `expect()` audit and replacements.
+- [ ] Close lingering integration test failures and ratchet regression coverage.
 
-### Documentation Cleanup (missing_docs + module-level docs)
+### Release Surface Consistency
 
-- [x] Run `cargo test -p perl-parser --features doc-coverage --test missing_docs_ac_tests` and capture receipts
-- [x] Add or verify module-level docs for public modules (perl-parser + other public crates)
-- [x] Ensure `cargo doc --no-deps -p perl-parser` is clean
-- [x] Align wording across `START_HERE.md`, `CURRENT_STATUS.md`, `ROADMAP.md`, `CHANGELOG.md`
+- [ ] Keep release truth aligned across GitHub Releases, VS Code Marketplace, Open VSX, and crates.io.
+- [ ] Verify docs references to the shipped line (`v0.12.3`) remain consistent after each release PR.
+- [ ] Track any channel split explicitly in release docs until crates.io catches up.
+- [ ] Add a short stability statement in `docs/README.md` describing the compatibility policy for CLI flags, LSP capability advertising, and DAP preview boundaries.
+- [ ] Expand `docs/how-to/UPGRADING.md` with compatibility promises, patch/minor expectations, deprecation notice windows, and emergency-break guidance for security fixes.
+- [ ] Add a `Distribution Matrix` doc under `docs/project/` covering published crates, prebuilt artifacts, source-build-only paths, support tiers by OS/arch, and editor install-path expectations.
+- [ ] Add a receipt template in `benchmarks/results/README.md` that records command, machine/runtime metadata, before/after SHAs, and artifact location.
+- [ ] Ensure committed benchmark results link back to the initiating change or issue.
+- [ ] Document config key renames/removals and migration steps for the v0.8.x -> v0.9.x upgrade path.
+- [ ] Add known behavior deltas for parser/LSP/DAP roll-forward guidance and rollback/cache-reset steps for editor clients.
+- [ ] Capture dependency ordering and owners in `docs/project/CI_LOCAL_VALIDATION.md`.
+- [ ] Add a short "what changed after #210 lands" checklist for contributors.
 
-### Release Notes + Doc Alignment
+### Announcement Readiness
 
-- [x] v0.10.0 release notes draft (CHANGELOG + release summary)
-- [x] Ensure `features.toml` and capability snapshots remain consistent
-- [x] Verify `docs/project/CURRENT_STATUS.md` narrative matches receipts
+- [ ] Validate install flows end-to-end for all documented distribution channels.
+- [ ] Finalize announcement/blog release notes content and links.
+- [ ] Confirm demo assets and walkthrough artifacts are publish-ready.
 
 ---
 
 ## Missing Features (Derived from `features.toml`)
 
-### LSP (Not Advertised / Preview)
-
-- **`lsp.notebook_document_sync`** (preview, not advertised)
-  - [x] Implement notebook document sync handlers
-  - [x] Add capability gating and tests
-
-- **`lsp.notebook_cell_execution`** (preview, not advertised)
-  - [x] Track execution summary metadata
-  - [x] Add tests for notebook execution summary updates
-
 ### DAP (Preview / Not Advertised)
 
-- **`dap.breakpoints.hit_condition`** (preview, not advertised)
-  - [x] Validate hit-count parsing and runtime counter behavior
-  - [x] Add dedicated E2E fixture coverage for multi-hit workflows
-
 - **`dap.breakpoints.logpoints`** (preview, not advertised)
-  - [x] Implement logMessage parsing and output emission path
-  - [ ] Add dedicated E2E fixture for output+continue semantics
+  - [x] Implement logMessage parsing and output emission path.
+  - [ ] Add dedicated E2E fixture for output + continue semantics.
 
 - **`dap.exceptions.die`** (preview, not advertised)
-  - [x] Implement `setExceptionBreakpoints` filter handling
-  - [ ] Add E2E fixture proving stop behavior changes when enabled
+  - [x] Implement `setExceptionBreakpoints` filter handling.
+  - [ ] Add E2E fixture proving stop behavior changes when enabled.
+
+### Forward-Looking Gaps
+
+- [ ] Native DAP completeness: attach parity, variables/evaluate fidelity, safe eval hardening.
+- [ ] Full LSP 3.18 compliance re-audit against evolving spec and client behavior.
+- [ ] Distribution expansion (package-manager channels such as Homebrew/apt/choco).
 
 ---
 
-## Next (v0.10.0 Readiness) - TODOs
+## Later (Post v0.13.0)
 
-- [ ] Stability statement (versioning rules)
-- [ ] Packaging stance (what ships; supported platforms)
-- [ ] Benchmark receipts committed under `benchmarks/results/`
-- [ ] Upgrade notes from v0.8.x -> v0.9.x
-- [ ] Merge-gate work unblocked by CI pipeline cleanup (#211 -> #210)
-
----
-
-## Later (Post v0.9.x)
-
-- [ ] Native DAP completeness: attach, variables/evaluate, safe eval
-- [ ] Full LSP 3.18 compliance audit vs spec (add missing catalog items to `features.toml`)
-- [ ] Package manager distribution (Homebrew/apt/etc.)
+- [ ] Stabilize API/versioning policy language for the path to `v1.0.0`.
+- [ ] Harden large-workspace performance budgets and monitoring.
+- [ ] Continue parser confidence ratchet against broader CPAN corpus slices.
+- [ ] Expand security and operations runbooks with periodic audit receipts.
 
 ---
 
 ## Quick Receipts / Checks
 
 ```bash
-# Gate + metrics
+# Canonical local gate
 nix develop -c just ci-gate
-just status-check
 
-# Missing docs validation
-cargo test -p perl-parser --test missing_docs_ac_tests
-cargo doc --no-deps -p perl-parser
+# Status drift checks
+just status-update
+just status-check
 ```
 
 ---
 
 ## Notes
 
-- If a TODO becomes a claim (\"done\", \"complete\"), move it into `docs/project/CURRENT_STATUS.md` with receipts.
-- If a capability is missing, update `features.toml` first; then regenerate computed docs via `just status-update`.
+- If a TODO becomes a verified claim ("done", "complete"), move evidence-backed language to `docs/project/CURRENT_STATUS.md`.
+- If a capability is missing or reclassified, update `features.toml` first, then regenerate derived docs.

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -10,7 +10,7 @@
 <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 97.1% clean (`6890/7095`) | Compatibility baseline; Perl `5.038002`, `48` unreadable, `157` with errors, baseline `2026-04-09` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) | Ecosystem breadth baseline; `6` unreadable, `435` with errors, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `64/68` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 2846 lib tests (discovered), 3 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 2973 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 2846 lib tests (Tier A), 3 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 2973 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->


### PR DESCRIPTION
### Motivation

- Replace a stale v0.10-era backlog with an actionable TODO list aligned to the shipped `v0.12.3` line and the `v0.13.0` announcement path. 
- Focus the document on active quality, release-surface, and announcement-readiness work while preserving outstanding DAP preview gaps from `features.toml`.
- Prevent documentation drift by clarifying where metrics and capability truth must live.

### Description

- Update `docs/TODO.md` header (`Last Updated`) and guidance to reference `docs/project/CURRENT_STATUS.md` and `features.toml` for metrics and capability truth. 
- Replace the old "Now" checklist with `Quality Cleanup`, `Release Surface Consistency`, and `Announcement Readiness` sections and keep the DAP preview items under `Missing Features`. 
- Add a `Forward-Looking Gaps` section and reframe `Next`/`Later` to target the `v0.13.0` announcement path. 
- Refresh quick-receipt commands to show the canonical local gate and status drift flow with `nix develop -c just ci-gate`, `just status-update`, and `just status-check`.

### Testing

- No automated tests were run for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9311019c48333a1880e20908f9777)