### PR TITLE
test(tree-sitter-perl-c): expand BDD coverage for parser APIs (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/tests/tree_sitter_c_bdd.rs
+++ b/crates/tree-sitter-perl-c/tests/tree_sitter_c_bdd.rs
@@ -1,0 +1,74 @@
+use std::{
+    error::Error,
+    fs,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use tree_sitter_perl_c::{
+    create_parser, get_scanner_config, language, parse_perl_code, parse_perl_file,
+    try_create_parser,
+};
+
+#[test]
+fn given_language_binding_when_loading_then_node_kinds_are_available() {
+    let lang = language();
+    assert!(lang.node_kind_count() > 0);
+}
+
+#[test]
+fn given_simple_perl_code_when_parsing_then_tree_has_no_errors() -> Result<(), Box<dyn Error>> {
+    let code = "my $value = 42;";
+    let tree = parse_perl_code(code)?;
+
+    assert_eq!(tree.root_node().kind(), "source_file");
+    assert!(!tree.root_node().has_error());
+
+    Ok(())
+}
+
+#[test]
+fn given_invalid_perl_fragment_when_parsing_then_tree_reports_errors() -> Result<(), Box<dyn Error>>
+{
+    let code = "my $value = ;";
+    let tree = parse_perl_code(code)?;
+
+    assert!(tree.root_node().has_error());
+
+    Ok(())
+}
+
+#[test]
+fn given_perl_source_file_when_parsing_then_file_and_string_paths_match()
+-> Result<(), Box<dyn Error>> {
+    let code = "package Demo;\nmy $name = 'tree-sitter';\n1;\n";
+    let mut path = std::env::temp_dir();
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    path.push(format!("tree_sitter_perl_c_bdd_{ts}.pl"));
+
+    fs::write(&path, code)?;
+
+    let parsed_from_file = parse_perl_file(&path)?;
+    let parsed_from_string = parse_perl_code(code)?;
+
+    assert_eq!(parsed_from_file.root_node().to_sexp(), parsed_from_string.root_node().to_sexp());
+
+    fs::remove_file(&path)?;
+
+    Ok(())
+}
+
+#[test]
+fn given_parser_constructors_when_initialized_then_language_is_set() -> Result<(), Box<dyn Error>> {
+    let parser = create_parser();
+    let checked_parser = try_create_parser()?;
+
+    assert!(parser.language().is_some());
+    assert!(checked_parser.language().is_some());
+
+    Ok(())
+}
+
+#[test]
+fn given_c_backend_crate_when_querying_scanner_config_then_c_scanner_is_reported() {
+    assert_eq!(get_scanner_config(), "c-scanner");
+}


### PR DESCRIPTION
### Motivation

- Provide behavioral (BDD) integration coverage for the C-backed tree-sitter Perl grammar to validate the crate's public parser APIs and detect regressions between file- and string-based parsing.

### Description

- Add a new integration test suite at `crates/tree-sitter-perl-c/tests/tree_sitter_c_bdd.rs` that follows Given/When/Then-style names for readability.
- Cover language loading, parser constructors (`create_parser`, `try_create_parser`), scanner backend identity (`get_scanner_config`), a happy-path parse (`parse_perl_code`), parse-error behavior, and parity between `parse_perl_file` and `parse_perl_code`.

### Testing

- Ran `cargo fmt --all` to format the workspace.
- Ran `cargo test -p tree-sitter-perl-c` and all tests for the crate (unit tests, doctests, and the new BDD tests) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93396a5ac8333b6a115c838e89e48)