### PR TITLE
test(tree-sitter-perl-rs): add BDD coverage for parser facade (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/tests/tree_sitter_perl_rs_bdd.rs
+++ b/crates/tree-sitter-perl-rs/tests/tree_sitter_perl_rs_bdd.rs
@@ -1,0 +1,81 @@
+use perl_tdd_support::must_some;
+use tree_sitter_perl_rs::{Node, Parser};
+
+fn subtree_contains_leaf(node: Node<'_>) -> bool {
+    if node.is_leaf() {
+        return true;
+    }
+
+    node.children().any(subtree_contains_leaf)
+}
+
+#[test]
+fn given_valid_perl_when_parsing_then_tree_and_source_are_available() {
+    let source = "package Demo;\nsub greet { return 'hi'; }\n";
+    let mut parser = Parser::new();
+
+    let tree = must_some(parser.parse(source));
+
+    assert_eq!(tree.source(), source);
+    assert_eq!(tree.root_node().kind(), "Program");
+}
+
+#[test]
+fn given_program_with_multiple_statements_when_iterating_children_then_child_access_patterns_agree()
+{
+    let mut parser = Parser::new();
+    let tree = must_some(parser.parse("my $x = 1; my $y = 2; my $z = 3;"));
+    let root = tree.root_node();
+
+    let child_count = root.child_count();
+    let children: Vec<_> = root.children().collect();
+
+    assert_eq!(children.len(), child_count);
+    assert!(child_count >= 1);
+    assert!(root.child(0).is_some());
+    assert!(root.child(child_count).is_none());
+}
+
+#[test]
+fn given_parsed_tree_when_requesting_utf8_text_then_byte_ranges_are_clamped_safely() {
+    let source = "my $value = 42;";
+    let mut parser = Parser::new();
+    let tree = must_some(parser.parse(source));
+    let root = tree.root_node();
+
+    let full = root.utf8_text(source.as_bytes());
+    let short = root.utf8_text(b"my");
+
+    assert_eq!(full.ok(), Some(source));
+    assert_eq!(short.ok(), Some("my"));
+}
+
+#[test]
+fn given_invalid_perl_when_parsing_then_error_recovery_tree_is_returned() {
+    let mut parser = Parser::new();
+
+    let tree = parser.parse("sub broken { if ( { @@@");
+
+    assert!(tree.is_some());
+}
+
+#[test]
+fn given_tree_sitter_style_facade_when_rendering_then_sexp_uses_source_file_root() {
+    let mut parser = Parser::default();
+    let tree = must_some(parser.parse("my $count = scalar @items;"));
+
+    let sexp = tree.root_node().to_sexp();
+
+    assert!(sexp.starts_with("(source_file"));
+}
+
+#[test]
+fn given_leaf_and_non_leaf_nodes_when_checking_is_leaf_then_facade_reflects_ast_structure() {
+    let mut parser = Parser::new();
+    let tree = must_some(parser.parse("my $x = 1;"));
+    let root = tree.root_node();
+
+    assert!(!root.is_leaf());
+
+    assert!(subtree_contains_leaf(root), "expected at least one leaf node in declaration AST");
+}


### PR DESCRIPTION
### Motivation
- Provide BDD-style integration coverage for the `tree-sitter-perl-rs` facade to validate tree-sitter-compatible ergonomics and common parser invariants.

### Description
- Add a new test suite at `crates/tree-sitter-perl-rs/tests/tree_sitter_perl_rs_bdd.rs` containing six scenario-oriented tests exercising parse success, child traversal, UTF-8 extraction/clamping, error-recovery parsing, S-expression root shape, and leaf detection.
- Introduce a small recursive helper `subtree_contains_leaf` and import `Node` from `tree_sitter_perl_rs` to assert leaf presence anywhere in a subtree.
- Keep changes limited to tests; no production code was modified.

### Testing
- Ran `cargo fmt --all` which succeeded.
- Ran `cargo test -p tree-sitter-perl-rs`; an initial iteration produced a failing test which was fixed, and the final run reported all tests passing (`cargo test -p tree-sitter-perl-rs` completed with all unit, snapshot, and the new BDD tests passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9339a30888333bd61920fbba53e31)