### PR TITLE
test(perl-parser-pest): add BDD parser behavior tests (#0000)

### DIFF
--- a/crates/perl-parser-pest/tests/bdd_parser_behaviors.rs
+++ b/crates/perl-parser-pest/tests/bdd_parser_behaviors.rs
@@ -1,0 +1,65 @@
+use perl_parser_pest::PureRustPerlParser;
+use perl_tdd_support::must;
+
+fn parse_source(source: &str) -> String {
+    let mut parser = PureRustPerlParser::new();
+    let ast = must(parser.parse(source));
+    parser.to_sexp(&ast)
+}
+
+#[test]
+fn bdd_given_scalar_assignment_when_parsed_then_sexp_contains_assignment_shape() {
+    // Given
+    let source = "my $answer = 42;";
+
+    // When
+    let sexp = parse_source(source);
+
+    // Then
+    assert!(sexp.contains("source_file"), "Expected root node in S-expression: {sexp}");
+    assert!(sexp.contains("variable_declaration"), "Expected variable declaration: {sexp}");
+    assert!(sexp.contains("$answer"), "Expected scalar variable name in output: {sexp}");
+    assert!(sexp.contains("number"), "Expected numeric literal node: {sexp}");
+}
+
+#[test]
+fn bdd_given_if_else_when_parsed_then_sexp_contains_both_branches() {
+    // Given
+    let source = r#"if ($x > 0) { print "positive"; } else { print "non-positive"; }"#;
+
+    // When
+    let sexp = parse_source(source);
+
+    // Then
+    assert!(sexp.contains("if_statement"), "Expected if statement: {sexp}");
+    assert!(sexp.contains("binary_expression"), "Expected condition expression: {sexp}");
+    assert!(sexp.contains("function_call"), "Expected body statement in S-expression: {sexp}");
+    assert!(sexp.contains("positive"), "Expected then branch content in S-expression: {sexp}");
+}
+
+#[test]
+fn bdd_given_subroutine_when_parsed_then_sexp_contains_sub_and_body() {
+    // Given
+    let source = r#"sub greet { return "hello"; }"#;
+
+    // When
+    let sexp = parse_source(source);
+
+    // Then
+    assert!(sexp.contains("subroutine"), "Expected sub declaration: {sexp}");
+    assert!(sexp.contains("return_statement"), "Expected return statement: {sexp}");
+    assert!(sexp.contains("string"), "Expected string literal in body: {sexp}");
+}
+
+#[test]
+fn bdd_given_invalid_program_when_parsed_then_parser_returns_error() {
+    // Given
+    let source = "my = ;";
+    let mut parser = PureRustPerlParser::new();
+
+    // When
+    let result = parser.parse(source);
+
+    // Then
+    assert!(result.is_err(), "Expected parse failure for invalid input");
+}


### PR DESCRIPTION
### Motivation
- Provide BDD-style, high-level behavioral tests for the legacy `perl-parser-pest` parser to improve confidence in core parse shapes and regression coverage.

### Description
- Add a new integration test file `crates/perl-parser-pest/tests/bdd_parser_behaviors.rs` with a `parse_source` helper and four Given/When/Then scenarios covering scalar declaration/assignment, `if`/`else` statements, subroutine parsing, and invalid input handling.
- Use the workspace test helper `perl_tdd_support::must` to convert parse `Result` into test-friendly values.
- Adjust assertions to match the crate's S-expression output shape (asserting on actual node labels and literal contents present in `to_sexp` output).
- Run `cargo fmt --all` to apply formatting.

### Testing
- Ran `cargo test -p perl-parser-pest --test bdd_parser_behaviors` and the new test binary passed (4 tests, 0 failures).
- Ran the full crate test suite with `cargo test -p perl-parser-pest` and all unit tests passed (10 unit tests + integration tests shown as passed).
- Ran `cargo fmt --all` to ensure formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d933a12ba88333b6fc516d0ceb5e70)