### PR TITLE
test(perl-corpus): add BDD scenario catalog for corpus workflows (#0000)

### DIFF
--- a/crates/perl-corpus/src/bdd.rs
+++ b/crates/perl-corpus/src/bdd.rs
@@ -1,0 +1,148 @@
+//! Behavior-driven scenario catalog for `perl-corpus`.
+//!
+//! These scenarios provide stable, human-readable acceptance criteria that
+//! downstream tests and docs can reference.
+
+/// A behavior-driven scenario for a `perl-corpus` workflow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BddScenario {
+    /// Stable scenario identifier.
+    pub id: &'static str,
+    /// Functional area this scenario belongs to.
+    pub area: &'static str,
+    /// Preconditions for the scenario.
+    pub given: &'static str,
+    /// Trigger or action being executed.
+    pub when: &'static str,
+    /// Expected user-observable outcome.
+    pub then: &'static str,
+}
+
+const BDD_SCENARIOS: &[BddScenario] = &[
+    BddScenario {
+        id: "corpus.parse-file.metadata-and-body",
+        area: "parsing",
+        given: "a corpus file with section metadata and an AST block separated by ---",
+        when: "parse_file is called",
+        then: "metadata is parsed, body code is preserved, and expected output blocks are excluded",
+    },
+    BddScenario {
+        id: "corpus.parse-file.auto-id",
+        area: "parsing",
+        given: "a section without an explicit @id",
+        when: "parse_file is called",
+        then: "a deterministic slug-based id is generated for the section",
+    },
+    BddScenario {
+        id: "corpus.parse-dir.stable-order",
+        area: "parsing",
+        given: "a corpus directory with multiple .txt files",
+        when: "parse_dir is called",
+        then: "all sections are returned in stable file-and-id sorted order",
+    },
+    BddScenario {
+        id: "corpus.query.by-tag",
+        area: "query",
+        given: "parsed sections containing heterogeneous tags",
+        when: "find_by_tag is called with a tag",
+        then: "only sections carrying that tag are returned",
+    },
+    BddScenario {
+        id: "corpus.query.by-flag",
+        area: "query",
+        given: "parsed sections containing validation flags",
+        when: "find_by_flag is called with a flag",
+        then: "only sections carrying that flag are returned",
+    },
+    BddScenario {
+        id: "corpus.codegen.seeded-determinism",
+        area: "generation",
+        given: "a statement count and fixed random seed",
+        when: "generate_perl_code_with_seed is called repeatedly with the same seed",
+        then: "identical generated code is produced",
+    },
+    BddScenario {
+        id: "corpus.codegen.options-kinds",
+        area: "generation",
+        given: "codegen options scoped to selected statement kinds",
+        when: "generate_perl_code_with_options is called",
+        then: "output reflects the selected generation strategy constraints",
+    },
+    BddScenario {
+        id: "corpus.fixtures.edge-cases",
+        area: "fixtures",
+        given: "the static edge case catalog",
+        when: "edge_cases or EdgeCaseGenerator APIs are used",
+        then: "fixtures remain deterministic and searchable by id or tag",
+    },
+    BddScenario {
+        id: "corpus.fixtures.specialized-domains",
+        area: "fixtures",
+        given: "specialized fixture modules for continue/redo, format, glob, and tie",
+        when: "domain-specific accessors are called",
+        then: "focused fixture collections are available for parser and tooling tests",
+    },
+    BddScenario {
+        id: "corpus.discovery.layers",
+        area: "filesystem",
+        given: "a workspace with test corpus and fuzz fixtures",
+        when: "get_corpus_files or layer-specific helpers are called",
+        then: "files are discovered and labeled by corpus layer",
+    },
+    BddScenario {
+        id: "corpus.lint.validation",
+        area: "quality",
+        given: "corpus sections with ids, tags, and flags",
+        when: "lint workflows are run",
+        then: "duplicate ids, unknown metadata, and structural violations are reported",
+    },
+    BddScenario {
+        id: "corpus.index.coverage-artifacts",
+        area: "quality",
+        given: "a corpus directory ready for indexing",
+        when: "index workflows are run",
+        then: "index and coverage summary artifacts are generated for tooling",
+    },
+];
+
+/// Return all behavior-driven scenarios for the crate.
+pub const fn bdd_scenarios() -> &'static [BddScenario] {
+    BDD_SCENARIOS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BDD_SCENARIOS, bdd_scenarios};
+    use std::collections::HashSet;
+
+    #[test]
+    fn scenario_catalog_is_non_empty() {
+        assert!(!bdd_scenarios().is_empty());
+    }
+
+    #[test]
+    fn scenario_ids_are_unique_and_complete() {
+        let mut ids = HashSet::new();
+
+        for row in BDD_SCENARIOS {
+            assert!(!row.id.is_empty(), "scenario id must not be empty");
+            assert!(!row.area.is_empty(), "scenario area must not be empty: {}", row.id);
+            assert!(!row.given.is_empty(), "given must not be empty: {}", row.id);
+            assert!(!row.when.is_empty(), "when must not be empty: {}", row.id);
+            assert!(!row.then.is_empty(), "then must not be empty: {}", row.id);
+            assert!(ids.insert(row.id), "duplicate scenario id: {}", row.id);
+        }
+    }
+
+    #[test]
+    fn scenario_areas_cover_core_workflows() {
+        let areas: HashSet<_> = BDD_SCENARIOS.iter().map(|row| row.area).collect();
+
+        assert!(areas.contains("parsing"));
+        assert!(areas.contains("query"));
+        assert!(areas.contains("generation"));
+        assert!(areas.contains("fixtures"));
+        assert!(areas.contains("filesystem"));
+        assert!(areas.contains("quality"));
+    }
+}

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -219,6 +219,7 @@
 #![deny(clippy::print_stderr, clippy::print_stdout)]
 #![cfg_attr(test, allow(clippy::print_stderr, clippy::print_stdout))]
 
+pub mod bdd;
 pub mod cases;
 pub mod codegen;
 pub mod continue_redo;
@@ -232,6 +233,7 @@ pub mod meta;
 pub mod tie_interface;
 
 use anyhow::{Context, Result};
+pub use bdd::{BddScenario, bdd_scenarios};
 pub use cases::{
     ComplexDataStructureCase, EdgeCase, EdgeCaseGenerator, complex_data_structure_cases,
     edge_cases, find_complex_case, get_complex_data_structure_tests, sample_complex_case,


### PR DESCRIPTION
### Motivation
- Provide a stable, human-readable behavior-driven scenario contract for `perl-corpus` to document expected acceptance criteria for parsing, querying, generation, fixtures, discovery, linting, and indexing workflows.
- Make those scenarios discoverable by downstream tests and tooling so they can be referenced from integration suites and documentation.

### Description
- Add a new `bdd` module at `crates/perl-corpus/src/bdd.rs` introducing the `BddScenario` type and a curated `BDD_SCENARIOS` catalog with `bdd_scenarios()` accessor.
- Export the new API from the crate root by adding `pub mod bdd;` and `pub use bdd::{BddScenario, bdd_scenarios};` in `crates/perl-corpus/src/lib.rs`.
- Include unit tests in the `bdd` module that assert the catalog is non-empty, scenario IDs are unique and fields are complete, and that scenario areas cover core workflows.
- Run formatting via `cargo fmt --all` to keep the repository style consistent.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-corpus` which completed successfully; unit test output shows all tests passed (`127` unit tests passed and doctests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d933ea70ac83338a8f1bbb8fc8c64b)