### PR TITLE
test(perl-parser): add BDD parser behavior coverage (#3990)

### DIFF
--- a/crates/perl-parser/tests/README.md
+++ b/crates/perl-parser/tests/README.md
@@ -24,6 +24,15 @@ This directory contains comprehensive tests for the Perl LSP server implementati
 - `lsp_selection_range_tests.rs` - Smart selection
 - `lsp_on_type_formatting_tests.rs` - Auto-formatting
 
+
+### Behavior-Driven Parser Scenarios
+- `parser_bdd_scenarios.rs` - Given/When/Then coverage for parser stories:
+  - subroutine and assignment flow
+  - regex substitution with flags
+  - `given/when/default` control flow
+  - malformed input recovery behavior
+  - multi-statement realistic script stability
+
 ### Stress & Performance Tests
 - `lsp_stress_tests.rs` - Resource exhaustion tests
 - `lsp_memory_pressure.rs` - Memory limits testing

--- a/crates/perl-parser/tests/parser_bdd_scenarios.rs
+++ b/crates/perl-parser/tests/parser_bdd_scenarios.rs
@@ -1,0 +1,141 @@
+//! Behavior-driven parser scenarios for core Perl workflows.
+//!
+//! The goal of this suite is to keep high-value parser behavior readable as
+//! executable user stories.
+
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn parse_sexp(code: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let mut parser = Parser::new(code);
+    let ast = parser.parse()?;
+    Ok(ast.to_sexp())
+}
+
+#[test]
+fn bdd_given_named_sub_with_assignment_when_parsed_then_ast_contains_subroutine_and_assignment()
+-> TestResult {
+    // Given: a developer writes a basic subroutine that mutates a lexical scalar.
+    let code = r#"
+        sub greet {
+            my $name = "world";
+            $name = "perl";
+            return $name;
+        }
+    "#;
+
+    // When: the parser processes the source.
+    let sexp = parse_sexp(code)?;
+
+    // Then: core semantic structure appears in the AST.
+    assert!(sexp.contains("sub "), "Expected Subroutine node in: {sexp}");
+    assert!(sexp.contains("assignment_"), "Expected Assignment node in: {sexp}");
+    assert!(sexp.contains("(return"), "Expected Return node in: {sexp}");
+    assert!(!sexp.contains("ERROR"), "Did not expect recovery ERROR nodes for valid code: {sexp}");
+
+    Ok(())
+}
+
+#[test]
+fn bdd_given_regex_substitution_when_parsed_then_pattern_replacement_and_flags_are_retained()
+-> TestResult {
+    // Given: a developer normalizes identifiers with substitution flags.
+    let code = r#"$value =~ s/(\w+)/prefix_$1/gi;"#;
+
+    // When: the parser processes the statement.
+    let sexp = parse_sexp(code)?;
+
+    // Then: regex substitution semantics are preserved in AST text form.
+    assert!(sexp.contains("substitution"), "Expected Substitution node in: {sexp}");
+    assert!(sexp.contains("prefix_$1"), "Expected replacement text in: {sexp}");
+    assert!(sexp.contains("gi"), "Expected modifier flags in: {sexp}");
+    assert!(
+        !sexp.contains("ERROR"),
+        "Did not expect recovery ERROR nodes for valid substitution: {sexp}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn bdd_given_match_switch_when_parsed_then_given_and_when_constructs_are_present() -> TestResult {
+    // Given: a developer uses Perl given/when smart-match control flow.
+    let code = r#"
+        given ($topic) {
+            when (/^foo/) { print "foo"; }
+            when (/^bar/) { print "bar"; }
+            default { print "other"; }
+        }
+    "#;
+
+    // When: the parser builds syntax trees.
+    let sexp = parse_sexp(code)?;
+
+    // Then: control-flow specific nodes are present and parse is clean.
+    assert!(sexp.contains("(given "), "Expected Given node in: {sexp}");
+    assert!(sexp.contains("(when "), "Expected When node in: {sexp}");
+    assert!(sexp.contains("(default "), "Expected Default node in: {sexp}");
+    assert!(
+        !sexp.contains("ERROR"),
+        "Did not expect recovery ERROR nodes for valid given/when: {sexp}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn bdd_given_incomplete_if_when_parsed_then_parser_recovers_with_error_nodes_instead_of_crashing() {
+    // Given: a developer is in the middle of editing incomplete syntax.
+    let code = "if ($x > 10 { print $x;";
+
+    // When: the parser processes malformed incremental text.
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+
+    // Then: parser should recover, producing either ParseError or ERROR AST node.
+    match result {
+        Ok(ast) => {
+            let sexp = ast.to_sexp();
+            assert!(
+                sexp.contains("ERROR"),
+                "Expected ERROR recovery node for malformed input: {sexp}"
+            );
+        }
+        Err(err) => {
+            let message = err.to_string();
+            assert!(!message.is_empty(), "Expected diagnostic message when parse returns Err");
+        }
+    }
+}
+
+#[test]
+fn bdd_given_multiple_realistic_statements_when_parsed_then_program_shape_is_stable() {
+    // Given: a small realistic script using strict/warnings, loops, and conditionals.
+    let code = r#"
+        use strict;
+        use warnings;
+
+        my @values = (1, 2, 3);
+        for my $v (@values) {
+            if ($v % 2 == 0) {
+                print "even";
+            } else {
+                print "odd";
+            }
+        }
+    "#;
+
+    // When: the parser builds the full AST.
+    let sexp = must(parse_sexp(code));
+
+    // Then: top-level shape includes declarations and structured control flow.
+    assert!(sexp.contains("(use "), "Expected Use declarations in: {sexp}");
+    assert!(sexp.contains("(for") || sexp.contains("(foreach"), "Expected loop node in: {sexp}");
+    assert!(sexp.contains("(if "), "Expected If node in: {sexp}");
+    assert!(
+        !sexp.contains("ERROR"),
+        "Did not expect recovery ERROR nodes for valid script: {sexp}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide readable behavior-driven (Given/When/Then) tests for high-value parser behaviors to improve reviewability and regression protection.
- Surface core parser expectations (control flow, substitutions, subroutines, recovery) as executable user stories useful for storybooking and future test additions.

### Description
- Add `crates/perl-parser/tests/parser_bdd_scenarios.rs` containing BDD-style scenarios for subroutine+assignment, substitution with flags, `given/when/default` control flow, malformed-input recovery, and a small realistic script stability case.
- Add a small test helper API in the new file: `parse_sexp` and `TestResult` to keep assertions concise and consistent.
- Update `crates/perl-parser/tests/README.md` to document the new "Behavior-Driven Parser Scenarios" suite and list the new file.

### Testing
- Ran `cargo fmt --all` and the workspace formatting step completed successfully.
- Ran `cargo test -p perl-parser --test parser_bdd_scenarios` and the new BDD test suite completed with all tests passing (`5 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d933a564bc83339d3609441bf7ad70)