### PR TITLE
test(perl-lsp-rs): expand BDD workflow coverage (#0000)

### DIFF
--- a/crates/perl-lsp/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp/tests/lsp_bdd_workflows.rs
@@ -1656,3 +1656,104 @@ sub main_func {}
 
     Ok(())
 }
+
+#[test]
+#[serial]
+fn bdd_selection_ranges_expand_from_identifier_to_enclosing_constructs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let scenario =
+        BddScenario::new("Selection ranges expand from identifier to enclosing constructs");
+
+    let script = r#"use strict;
+use warnings;
+
+sub calculate_total {
+    my ($left, $right) = @_;
+    return ($left + $right) * 2;
+}
+"#;
+
+    scenario.given("a Perl file with a nested arithmetic expression");
+    let (mut harness, workspace) = setup_workspace(&[("selection.pl", script)])?;
+    let uri = workspace.uri("selection.pl");
+    harness.open(&uri, script)?;
+
+    scenario.when("requesting selection ranges from inside an identifier");
+    let (line, character) = find_position(script, "$left +");
+    let selection_ranges = harness.request(
+        "textDocument/selectionRange",
+        json!({
+            "textDocument": { "uri": uri },
+            "positions": [{ "line": line, "character": character + 1 }]
+        }),
+    )?;
+
+    scenario.then("the server returns a parent chain for incremental selection expansion");
+    let ranges = selection_ranges.as_array().ok_or("selectionRange response should be an array")?;
+    let first = ranges.first().ok_or("selectionRange response should contain at least one item")?;
+    assert!(
+        selection_range_depth(first) >= 3,
+        "expected at least 3 nested selection levels, got: {first:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn bdd_references_respect_include_declaration_toggle() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = BddScenario::new("References respect includeDeclaration toggle");
+
+    let script = r#"use strict;
+use warnings;
+
+sub helper {
+    return 1;
+}
+
+my $x = helper();
+my $y = helper();
+"#;
+
+    scenario.given("a Perl file with one function declaration and multiple call sites");
+    let (mut harness, workspace) = setup_workspace(&[("refs.pl", script)])?;
+    let uri = workspace.uri("refs.pl");
+    harness.open(&uri, script)?;
+    harness.wait_for_symbol("helper", Some(&uri), Duration::from_secs(5)).ok();
+
+    let (line, character) = find_position(script, "helper()");
+
+    scenario.when("requesting references without declarations");
+    let without_decl = harness.request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "includeDeclaration": false }
+        }),
+    )?;
+
+    scenario.when("requesting references including declarations");
+    let with_decl = harness.request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "includeDeclaration": true }
+        }),
+    )?;
+
+    scenario.then("including declarations adds at least one extra location");
+    let without = without_decl.as_array().map_or(0, Vec::len);
+    let with = with_decl.as_array().map_or(0, Vec::len);
+    assert!(
+        with >= without,
+        "includeDeclaration=true should not reduce matches (without={without}, with={with})"
+    );
+    assert!(
+        with > without,
+        "expected declaration-inclusive references to add declaration (without={without}, with={with})"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Increase end-to-end BDD coverage for `perl-lsp-rs` to capture editor workflows that affect selection expansion and reference queries.
- Exercise `textDocument/selectionRange` and `textDocument/references` observable behavior to prevent regressions in expand-selection and declaration-inclusion semantics.

### Description
- Add a new BDD test `bdd_selection_ranges_expand_from_identifier_to_enclosing_constructs` to `crates/perl-lsp/tests/lsp_bdd_workflows.rs` that asserts `textDocument/selectionRange` returns a nested parent chain (uses `selection_range_depth`).
- Add a new BDD test `bdd_references_respect_include_declaration_toggle` to the same file that verifies `textDocument/references` returns more locations when `includeDeclaration` is `true` than when `false`.
- Keep tests in the existing Given/When/Then pattern and run them under `#[serial]` using the existing `LspHarness` and `setup_workspace` helpers.

### Testing
- Ran formatter with `cargo fmt --all` and it completed successfully.
- Ran the individual tests with `cargo test -p perl-lsp-rs --test lsp_bdd_workflows bdd_selection_ranges_expand_from_identifier_to_enclosing_constructs -- --nocapture` and `cargo test -p perl-lsp-rs --test lsp_bdd_workflows bdd_references_respect_include_declaration_toggle -- --nocapture`, and both tests passed.
- Ran the full BDD suite with `cargo test -p perl-lsp-rs --test lsp_bdd_workflows -- --nocapture` and the suite completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d933d6aa748333b97babada88d4f2a)