### PR TITLE
test(perl-pod): add BDD workflow coverage (#3981)

### DIFF
--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -20,6 +20,23 @@ sub new { bless {}, shift }
 }
 
 #[test]
+fn code_before_pod_still_allows_extraction() {
+    let source = r#"
+package Inventory;
+
+sub add_item { }
+
+=head1 NAME
+
+Inventory - Tracks stock
+
+=cut
+"#;
+    let doc = extract_pod(source);
+    assert_eq!(doc.name.as_deref(), Some("Inventory - Tracks stock"));
+}
+
+#[test]
 fn extracts_name_section() {
     let source = r#"
 =head1 NAME


### PR DESCRIPTION
Adds one focused regression in `crates/perl-pod/tests/pod_extraction_tests.rs` for POD extraction after a code preamble.

This is the unique leftover from the overlap cluster and keeps the PR test-only.

Fixes #3981.

Validation:
- `cargo fmt --all`
- `cargo test -p perl-pod code_before_pod_still_allows_extraction -- --nocapture`
- `cargo test -p perl-pod`