### PR TITLE
test(perl-dap): add BDD workflow coverage (#0000)

### DIFF
--- a/crates/perl-dap/Cargo.toml
+++ b/crates/perl-dap/Cargo.toml
@@ -182,6 +182,11 @@ path = "tests/dap_step_through_tests.rs"
 # AC:3535 Comprehensive step-through debugging tests: stepIn, stepOut, stepOver, continue, pause, gotoTargets, cancel
 
 [[test]]
+name = "dap_bdd_workflows"
+path = "tests/dap_bdd_workflows.rs"
+# BDD scenarios for core request/response workflows in the native adapter
+
+[[test]]
 name = "dap_syntax_check_tests"
 path = "tests/dap_syntax_check_tests.rs"
 # AC:3477 Pre-launch syntax check using perl -c, clear error messages before debug start

--- a/crates/perl-dap/tests/dap_bdd_workflows.rs
+++ b/crates/perl-dap/tests/dap_bdd_workflows.rs
@@ -1,0 +1,126 @@
+//! BDD-style workflow coverage for perl-dap request/response behavior.
+//!
+//! These scenarios use Given/When/Then logging to describe the user-facing
+//! debugging workflow while asserting concrete protocol outcomes.
+
+use perl_dap::{DapMessage, DebugAdapter};
+use serde_json::{Value, json};
+use std::sync::mpsc::{Receiver, channel};
+
+struct BddScenario {
+    name: &'static str,
+}
+
+impl BddScenario {
+    fn new(name: &'static str) -> Self {
+        eprintln!("Scenario: {name}");
+        Self { name }
+    }
+
+    fn given(&self, message: &str) {
+        eprintln!("[{}] Given {message}", self.name);
+    }
+
+    fn when(&self, message: &str) {
+        eprintln!("[{}] When {message}", self.name);
+    }
+
+    fn then(&self, message: &str) {
+        eprintln!("[{}] Then {message}", self.name);
+    }
+}
+
+fn assert_success_response(message: DapMessage, command: &str) -> Option<Value> {
+    match message {
+        DapMessage::Response { success, command: actual, body, message, .. } => {
+            assert_eq!(actual, command, "response command mismatch");
+            assert!(
+                success,
+                "expected `{command}` request to succeed but failed: {}",
+                message.unwrap_or_else(|| "<no message>".to_string())
+            );
+            body
+        }
+        other => panic!("expected response for `{command}`, got: {other:?}"),
+    }
+}
+
+fn recv_initialized_event(rx: &Receiver<DapMessage>) -> DapMessage {
+    let event = rx.recv().unwrap_or_else(|error| panic!("failed to receive event: {error}"));
+    match &event {
+        DapMessage::Event { event, .. } => assert_eq!(event, "initialized"),
+        other => panic!("expected initialized event, got: {other:?}"),
+    }
+    event
+}
+
+#[test]
+fn bdd_initialize_advertises_capabilities_and_emits_initialized_event() {
+    let scenario = BddScenario::new(
+        "Initialize handshake advertises capabilities and emits initialized event",
+    );
+    scenario.given("a new debug adapter and an event channel");
+
+    let mut adapter = DebugAdapter::new();
+    let (tx, rx) = channel();
+    adapter.set_event_sender(tx);
+
+    scenario.when("the client sends initialize");
+    let body = assert_success_response(
+        adapter.handle_request(
+            1,
+            "initialize",
+            Some(json!({
+                "clientID": "vscode",
+                "adapterID": "perl-dap",
+                "linesStartAt1": true,
+                "columnsStartAt1": true
+            })),
+        ),
+        "initialize",
+    )
+    .unwrap_or(Value::Null);
+
+    scenario.then("the adapter reports core capabilities and emits initialized");
+    assert_eq!(body.get("supportsConfigurationDoneRequest").and_then(Value::as_bool), Some(true));
+    assert_eq!(body.get("supportsEvaluateForHovers").and_then(Value::as_bool), Some(true));
+    assert_eq!(body.get("supportsSetVariable").and_then(Value::as_bool), Some(true));
+
+    let _initialized = recv_initialized_event(&rx);
+}
+
+#[test]
+fn bdd_configuration_done_is_tolerated_before_initialize() {
+    let scenario = BddScenario::new("Configuration done is tolerated before initialize");
+    scenario.given("a fresh debug adapter with no initialize request");
+
+    let mut adapter = DebugAdapter::new();
+
+    scenario.when("the client sends configurationDone immediately");
+    let response = adapter.handle_request(1, "configurationDone", None);
+
+    scenario.then("the adapter tolerates the call and responds successfully");
+    let body = assert_success_response(response, "configurationDone");
+    assert!(body.is_none() || body == Some(Value::Null));
+}
+
+#[test]
+fn bdd_disconnect_succeeds_without_active_session() {
+    let scenario = BddScenario::new("Disconnect succeeds even when no debug session is active");
+    scenario.given("an initialized adapter that has not launched or attached a program");
+
+    let mut adapter = DebugAdapter::new();
+    let (tx, _rx) = channel();
+    adapter.set_event_sender(tx);
+
+    let _ = assert_success_response(adapter.handle_request(1, "initialize", None), "initialize");
+
+    scenario.when("the client sends disconnect");
+    let response_body = assert_success_response(
+        adapter.handle_request(2, "disconnect", Some(json!({ "terminateDebuggee": false }))),
+        "disconnect",
+    );
+
+    scenario.then("the adapter returns a successful disconnect response body");
+    assert!(response_body.is_none() || response_body == Some(Value::Null));
+}


### PR DESCRIPTION
### Motivation
- Provide BDD-style, Given/When/Then integration coverage for core `perl-dap` request/response workflows to document expected runtime behavior and guard regressions.

### Description
- Add a new integration test file `crates/perl-dap/tests/dap_bdd_workflows.rs` with a `BddScenario` helper and assertion helpers for DAP responses and events.
- Implement three scenarios: `initialize` advertises capabilities and emits `initialized`, `configurationDone` is tolerated before `initialize`, and `disconnect` succeeds without an active debug session.
- Register the new test target in `crates/perl-dap/Cargo.toml` as `dap_bdd_workflows`.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-dap --test dap_bdd_workflows` and iterated on the assertions after an initial failure; the final run succeeded with all scenarios passing (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93740c1b08333b9410d579266a565)