### PR TITLE
test(utilities): expand focused unit coverage (#3865)

### DIFF
--- a/crates/perl-position-tracking/src/convert.rs
+++ b/crates/perl-position-tracking/src/convert.rs
@@ -105,4 +105,14 @@ mod tests {
         assert_eq!(utf16_line_col_to_offset(text, 1, 99), text.len());
         assert_eq!(utf16_line_col_to_offset(text, 99, 0), text.len());
     }
+
+    #[test]
+    fn utf16_helpers_handle_crlf_and_surrogates_together() {
+        let text = "a\r\nb💖c\r\n";
+
+        assert_eq!(offset_to_utf16_line_col(text, 3), (1, 0));
+        assert_eq!(offset_to_utf16_line_col(text, 8), (1, 3));
+        assert_eq!(utf16_line_col_to_offset(text, 1, 2), 4);
+        assert_eq!(utf16_line_col_to_offset(text, 1, 3), 8);
+    }
 }

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -294,6 +294,17 @@ fn use_v5_40_enables_effective_strict_and_warnings() -> Result<(), Box<dyn std::
 }
 
 #[test]
+fn use_v5_40_1_enables_builtin_and_warnings() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.40.1", &[], 0, 14)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(state.warnings);
+    assert!(state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
 fn use_numeric_version_enables_effective_strict_and_warnings()
 -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("5.040", &[], 0, 12)]);

--- a/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
+++ b/crates/perl-symbol-surface/tests/symbol_decl_tests.rs
@@ -227,6 +227,59 @@ fn test_use_constant_hash_ref_style_produces_all_symbol_decls() {
     assert_eq!(decls[2].name, "BAZ");
 }
 
+#[test]
+fn test_use_constant_qw_style_deduplicates_names() {
+    // use constant qw(ONE TWO ONE);
+    let use_node = Node::new(
+        NodeKind::Use {
+            module: "constant".to_string(),
+            args: vec!["qw(ONE TWO ONE)".to_string()],
+            has_filter_risk: false,
+        },
+        loc(0, 28),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![use_node] }, loc(0, 28));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 2);
+    assert_eq!(decls[0].kind, SymbolKind::Constant);
+    assert_eq!(decls[0].name, "ONE");
+    assert_eq!(decls[1].kind, SymbolKind::Constant);
+    assert_eq!(decls[1].name, "TWO");
+}
+
+#[test]
+fn test_variable_declaration_with_attributes_is_unwrapped() {
+    // my $count :shared;
+    let inner = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "count".to_string() },
+        loc(3, 9),
+    );
+    let wrapped = Node::new(
+        NodeKind::VariableWithAttributes { variable: Box::new(inner), attributes: vec![] },
+        loc(3, 9),
+    );
+    let decl_node = Node::new(
+        NodeKind::VariableDeclaration {
+            declarator: "my".to_string(),
+            variable: Box::new(wrapped),
+            attributes: vec![],
+            initializer: None,
+        },
+        loc(0, 9),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![decl_node] }, loc(0, 9));
+
+    let decls = extract_symbol_decls(&program, None);
+
+    assert_eq!(decls.len(), 1);
+    let decl = &decls[0];
+    assert_eq!(decl.kind, SymbolKind::Variable(VarKind::Scalar));
+    assert_eq!(decl.name, "count");
+    assert_eq!(decl.anchor_span, Some((3, 9)));
+}
+
 // ── Class (Perl 5.38+) ────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -1178,6 +1178,34 @@ fn test_index_coordinator_check_limits_none_when_ok() {
 }
 
 #[test]
+fn test_index_coordinator_check_limits_prefers_file_count_over_symbol_count()
+-> Result<(), Box<dyn std::error::Error>> {
+    use perl_workspace_index::workspace::workspace_index::{
+        DegradationReason as IxDegradationReason, IndexPerformanceCaps, ResourceKind as IxResourceKind,
+    };
+
+    let limits = IndexResourceLimits {
+        max_files: 1,
+        max_total_symbols: 1,
+        ..IndexResourceLimits::default()
+    };
+    let coord = IndexCoordinator::with_limits_and_caps(limits, IndexPerformanceCaps::default());
+    coord.transition_to_ready(0, 0);
+
+    for i in 0..2 {
+        let uri = Url::parse(&format!("file:///limit_priority_{}.pl", i))?;
+        coord.index().index_file(uri, format!("sub f{} {{ 1 }}", i))?;
+    }
+
+    let reason = coord.check_limits().expect("limits should be exceeded");
+    assert!(matches!(
+        reason,
+        IxDegradationReason::ResourceLimit { kind: IxResourceKind::MaxFiles }
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_index_coordinator_phase_transitions() {
     let coord = IndexCoordinator::new();
     coord.transition_to_scanning();

--- a/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-workspace-index/tests/comprehensive_unit_tests.rs
@@ -1181,7 +1181,8 @@ fn test_index_coordinator_check_limits_none_when_ok() {
 fn test_index_coordinator_check_limits_prefers_file_count_over_symbol_count()
 -> Result<(), Box<dyn std::error::Error>> {
     use perl_workspace_index::workspace::workspace_index::{
-        DegradationReason as IxDegradationReason, IndexPerformanceCaps, ResourceKind as IxResourceKind,
+        DegradationReason as IxDegradationReason, IndexPerformanceCaps,
+        ResourceKind as IxResourceKind,
     };
 
     let limits = IndexResourceLimits {


### PR DESCRIPTION
Add a small set of additive tests covering symbol-surface extraction edge cases, a pragma version-bundle edge case, workspace-index resource-limit precedence, and UTF-16 conversion with CRLF plus surrogate pairs.\n\nValidation:\n- cargo test -p perl-symbol-surface --test symbol_decl_tests\n- cargo test -p perl-pragma use_v5_40_1_enables_builtin_and_warnings --test comprehensive_unit_tests\n- cargo test -p perl-position-tracking utf16_helpers_handle_crlf_and_surrogates_together\n- cargo test -p perl-workspace-index test_index_coordinator_check_limits_prefers_file_count_over_symbol_count --test comprehensive_unit_tests