### PR TITLE
test(quality): burn down P0 idiom fixes and test deps (#3237)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ name = "perl-ast-utils"
 version = "0.12.3"
 dependencies = [
  "perl-ast",
+ "perl-tdd-support",
 ]
 
 [[package]]
@@ -1662,6 +1663,7 @@ dependencies = [
 name = "perl-dap-types"
 version = "0.12.3"
 dependencies = [
+ "perl-tdd-support",
  "serde",
  "serde_json",
 ]
@@ -2718,6 +2720,7 @@ version = "0.12.3"
 dependencies = [
  "perl-ast",
  "perl-symbol-types",
+ "perl-tdd-support",
 ]
 
 [[package]]

--- a/crates/perl-ast-utils/Cargo.toml
+++ b/crates/perl-ast-utils/Cargo.toml
@@ -30,6 +30,7 @@ perl-ast = { workspace = true }
 
 [dev-dependencies]
 perl-ast = { workspace = true }
+perl-tdd-support = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-dap-types/Cargo.toml
+++ b/crates/perl-dap-types/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/lib.rs"
 serde = { workspace = true }
 
 [dev-dependencies]
+perl-tdd-support.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/perl-lsp/tests/fixtures/mocks/test_infrastructure_mocks.rs
+++ b/crates/perl-lsp/tests/fixtures/mocks/test_infrastructure_mocks.rs
@@ -338,7 +338,7 @@ sub process_data {
         for symbol in symbols {
             self.symbol_index
                 .entry(symbol.name.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(symbol);
         }
     }

--- a/crates/perl-lsp/tests/lsp_cancellation_performance_tests.rs
+++ b/crates/perl-lsp/tests/lsp_cancellation_performance_tests.rs
@@ -753,9 +753,9 @@ fn test_end_to_end_cancellation_response_time_ac12() -> Result<(), Box<dyn std::
         println!("  Maximum: {}ms", max.as_millis());
 
         // Provider-specific analysis
-        let mut provider_stats = HashMap::new();
+        let mut provider_stats: HashMap<_, Vec<Duration>> = HashMap::new();
         for (provider, duration) in response_time_measurements {
-            provider_stats.entry(provider).or_insert_with(Vec::new).push(duration);
+            provider_stats.entry(provider).or_default().push(duration);
         }
 
         for (provider, durations) in provider_stats {

--- a/crates/perl-parser/tests/documentation_validation_mutation_hardening.rs
+++ b/crates/perl-parser/tests/documentation_validation_mutation_hardening.rs
@@ -193,8 +193,8 @@ mod mock_doc_analysis {
     /// Enhanced cross-reference validation with comprehensive pattern detection
     pub fn find_invalid_cross_references_hardened(lines: &[&str]) -> Vec<String> {
         let mut invalid_refs = Vec::new();
-        let mut known_functions = HashMap::new();
-        let mut reference_map = HashMap::new();
+        let mut known_functions: HashMap<String, usize> = HashMap::new();
+        let mut reference_map: HashMap<String, Vec<usize>> = HashMap::new();
 
         // First pass: collect function definitions
         for (line_num, line) in lines.iter().enumerate() {
@@ -255,7 +255,7 @@ mod mock_doc_analysis {
                     }
 
                     // Track circular references
-                    reference_map.entry(ref_text.clone()).or_insert_with(Vec::new).push(line_num);
+                    reference_map.entry(ref_text.clone()).or_default().push(line_num);
                 }
             }
         }

--- a/crates/perl-symbol-surface/Cargo.toml
+++ b/crates/perl-symbol-surface/Cargo.toml
@@ -31,6 +31,7 @@ perl-symbol-types = { workspace = true }
 [dev-dependencies]
 perl-ast = { workspace = true }
 perl-symbol-types = { workspace = true }
+perl-tdd-support = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
### Motivation

- Normalize a few remaining test-side modern-Rust idioms (prefer `.or_default()` over `.or_insert_with(Vec::new)`) and unblock upcoming test unwrap/expect migration by ensuring crates have the `perl-tdd-support` test helper dep.

### Description

- Replace three `.or_insert_with(Vec::new)` occurrences in test code with `.or_default()` to follow the modern-Rust idiom in `perl-lsp` and `perl-parser` test files. 
- Add `perl-tdd-support` as a `[dev-dependencies]` entry to `crates/perl-dap-types`, `crates/perl-symbol-surface`, and `crates/perl-ast-utils` to unblock planned test refactors. 
- Add explicit `HashMap` value-type annotations in two test modules where type inference became ambiguous after switching to `.or_default()` to preserve compilation (`HashMap<_, Vec<Duration>>` and `HashMap<String, Vec<usize>>`).

### Testing

- Ran `cargo test -p perl-lsp-rs --test lsp_cancellation_performance_tests --no-run` which compiled the test executable successfully. (Succeeded.)
- Ran `cargo test -p perl-parser --test documentation_validation_mutation_hardening --no-run` which compiled the test executable successfully. (Succeeded.)
- Ran `cargo test -p perl-dap-types -p perl-symbol-surface -p perl-ast-utils --tests --no-run` which compiled the tests for those crates successfully. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93d44f3b88333b3eb1658d207816e)