### PR TITLE
fix(lexer): preserve complex string interpolation tails (#3376)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -859,6 +859,40 @@ impl<'a> PerlLexer<'a> {
         }
     }
 
+    #[inline]
+    fn consume_balanced_segment(&mut self, open: char, close: char) -> Option<usize> {
+        if self.current_char() != Some(open) {
+            return None;
+        }
+
+        let mut depth = 1usize;
+        self.advance();
+        while let Some(ch) = self.current_char() {
+            match ch {
+                '\\' => {
+                    self.advance();
+                    if self.current_char().is_some() {
+                        self.advance();
+                    }
+                }
+                c if c == open => {
+                    depth += 1;
+                    self.advance();
+                }
+                c if c == close => {
+                    self.advance();
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(self.position);
+                    }
+                }
+                _ => self.advance(),
+            }
+        }
+
+        None
+    }
+
     /// Fast byte-level check for ASCII characters
     #[inline]
     fn peek_byte(&self, offset: usize) -> Option<u8> {
@@ -2737,34 +2771,116 @@ impl<'a> PerlLexer<'a> {
                         current_literal = String::new(); // Clear without cloning
                     }
 
-                    // Parse variable - optimized using byte-level checks where possible
+                    let part_start = self.position;
                     self.advance();
-                    let var_start = self.position;
+                    match self.current_char() {
+                        Some('{') => {
+                            if let Some(end) = self.consume_balanced_segment('{', '}') {
+                                parts.push(StringPart::Expression(Arc::from(
+                                    &self.input[part_start..end],
+                                )));
+                            }
+                        }
+                        Some(ch) if is_perl_identifier_start(ch) => {
+                            let var_start = self.position;
 
-                    // Fast path for ASCII identifier continuation
-                    while self.position < self.input_bytes.len() {
-                        let byte = self.input_bytes[self.position];
-                        if byte.is_ascii_alphanumeric() || byte == b'_' {
-                            self.position += 1;
-                        } else if byte >= 128 {
-                            // Only use UTF-8 parsing for non-ASCII
-                            if let Some(ch) = self.current_char() {
-                                if is_perl_identifier_continue(ch) {
-                                    self.advance();
+                            // Fast path for ASCII identifier continuation
+                            while self.position < self.input_bytes.len() {
+                                let byte = self.input_bytes[self.position];
+                                if byte.is_ascii_alphanumeric() || byte == b'_' {
+                                    self.position += 1;
+                                } else if byte >= 128 {
+                                    // Only use UTF-8 parsing for non-ASCII
+                                    if let Some(ch) = self.current_char() {
+                                        if is_perl_identifier_continue(ch) {
+                                            self.advance();
+                                        } else {
+                                            break;
+                                        }
+                                    } else {
+                                        break;
+                                    }
                                 } else {
                                     break;
                                 }
-                            } else {
-                                break;
                             }
-                        } else {
-                            break;
-                        }
-                    }
 
-                    if self.position > var_start {
-                        let var_name = &self.input[var_start - 1..self.position];
-                        parts.push(StringPart::Variable(Arc::from(var_name)));
+                            if self.position > var_start {
+                                let var_name = &self.input[part_start..self.position];
+                                parts.push(StringPart::Variable(Arc::from(var_name)));
+
+                                if self.matches_bytes(b"->") {
+                                    let tail_start = self.position;
+                                    self.advance();
+                                    self.advance();
+
+                                    match self.current_char() {
+                                        Some('[') => {
+                                            let _ = self.consume_balanced_segment('[', ']');
+                                            parts.push(StringPart::MethodCall(Arc::from(
+                                                &self.input[tail_start..self.position],
+                                            )));
+                                        }
+                                        Some('{') => {
+                                            let _ = self.consume_balanced_segment('{', '}');
+                                            parts.push(StringPart::MethodCall(Arc::from(
+                                                &self.input[tail_start..self.position],
+                                            )));
+                                        }
+                                        Some('(') => {
+                                            let _ = self.consume_balanced_segment('(', ')');
+                                            parts.push(StringPart::MethodCall(Arc::from(
+                                                &self.input[tail_start..self.position],
+                                            )));
+                                        }
+                                        Some(ch) if is_perl_identifier_start(ch) => {
+                                            while self.position < self.input_bytes.len() {
+                                                let byte = self.input_bytes[self.position];
+                                                if byte.is_ascii_alphanumeric() || byte == b'_' {
+                                                    self.position += 1;
+                                                } else if byte >= 128 {
+                                                    if let Some(ch) = self.current_char() {
+                                                        if is_perl_identifier_continue(ch) {
+                                                            self.advance();
+                                                        } else {
+                                                            break;
+                                                        }
+                                                    } else {
+                                                        break;
+                                                    }
+                                                } else {
+                                                    break;
+                                                }
+                                            }
+                                            if self.current_char() == Some('(') {
+                                                let _ = self.consume_balanced_segment('(', ')');
+                                            }
+                                            parts.push(StringPart::MethodCall(Arc::from(
+                                                &self.input[tail_start..self.position],
+                                            )));
+                                        }
+                                        _ => {
+                                            parts.push(StringPart::MethodCall(Arc::from(
+                                                &self.input[tail_start..self.position],
+                                            )));
+                                        }
+                                    }
+                                } else if self.current_char() == Some('[') {
+                                    let tail_start = self.position;
+                                    let _ = self.consume_balanced_segment('[', ']');
+                                    parts.push(StringPart::ArraySlice(Arc::from(
+                                        &self.input[tail_start..self.position],
+                                    )));
+                                } else if self.current_char() == Some('{') {
+                                    let tail_start = self.position;
+                                    let _ = self.consume_balanced_segment('{', '}');
+                                    parts.push(StringPart::Expression(Arc::from(
+                                        &self.input[tail_start..self.position],
+                                    )));
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 _ => {

--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -672,6 +672,61 @@ fn double_quoted_string() -> R {
 }
 
 #[test]
+fn interpolated_string_preserves_complex_tails() -> R {
+    let cases = [
+        (r#""${expr}""#, vec![StringPart::Expression(Arc::from("${expr}"))]),
+        (
+            r#""$arr[0]""#,
+            vec![StringPart::Variable(Arc::from("$arr")), StringPart::ArraySlice(Arc::from("[0]"))],
+        ),
+        (
+            r#""$hash{key}""#,
+            vec![
+                StringPart::Variable(Arc::from("$hash")),
+                StringPart::Expression(Arc::from("{key}")),
+            ],
+        ),
+        (
+            r#""$var->[0]""#,
+            vec![
+                StringPart::Variable(Arc::from("$var")),
+                StringPart::MethodCall(Arc::from("->[0]")),
+            ],
+        ),
+        (
+            r#""$obj->{key}""#,
+            vec![
+                StringPart::Variable(Arc::from("$obj")),
+                StringPart::MethodCall(Arc::from("->{key}")),
+            ],
+        ),
+    ];
+
+    for (input, expected_parts) in cases {
+        let tok = first_token(input).ok_or_else(|| format!("no token for {input:?}"))?;
+        match tok.token_type {
+            TokenType::InterpolatedString(parts) => assert_eq!(parts, expected_parts),
+            other => panic!("expected interpolated string token for {input:?}, got {other:?}"),
+        }
+    }
+
+    let simple = first_token(r#""hello $x world""#).ok_or("no token")?;
+    match simple.token_type {
+        TokenType::InterpolatedString(parts) => assert_eq!(
+            parts,
+            vec![
+                StringPart::Literal(Arc::from("hello ")),
+                StringPart::Variable(Arc::from("$x")),
+                StringPart::Literal(Arc::from(" world")),
+            ]
+        ),
+        other => panic!("expected interpolated string token, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
 fn single_quoted_string() -> R {
     let tok = first_token("'hello'").ok_or("no token")?;
     assert!(


### PR DESCRIPTION
Improve double-quoted string interpolation handling for complex tails while preserving simple `$name` interpolation.

Changed only the lexer and focused lexer tests.

Validation:
- cargo fmt --all
- cargo test -p perl-lexer interpolated_string_preserves_complex_tails -- --nocapture
- cargo test -p perl-lexer double_quoted_string -- --nocapture
- cargo test -p perl-lexer string_with_escape_sequences -- --nocapture