### PR TITLE
chore(clippy): clear current hover/navigation warnings (#4008)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -392,8 +392,7 @@ impl LspServer {
         let hover_text = {
             // The normal tokenizer only captures `[$@%]` + alphanumeric/underscore,
             // so it misses punctuation variables handled above.
-            let token = Self::get_token_at_position_static(text, offset);
-            token
+            Self::get_token_at_position_static(text, offset)
         };
 
         if !hover_text.is_empty() {

--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -1043,7 +1043,7 @@ impl LspServer {
                                         ast, &doc.text,
                                     );
                                 if let Some(location) = analyzer.resolve_inherited_method_location(
-                                    &current_package,
+                                    current_package,
                                     method_match.as_str(),
                                 ) {
                                     let lsp_start = self.offset_to_pos16(doc, location.start);
@@ -1063,7 +1063,7 @@ impl LspServer {
                                 if let Some(coordinator) = self.coordinator()
                                     && let Some(def_location) = inherited_method_definition_location(
                                         coordinator.index(),
-                                        &current_package,
+                                        current_package,
                                         method_match.as_str(),
                                     )
                                     && let Some(lsp_location) =


### PR DESCRIPTION
Remove the current clippy `let_and_return` and `needless_borrow` warnings in hover/navigation so isolated branches stop tripping the same unrelated local pre-push failure.

Validation:
- cargo fmt --all
- cargo clippy -p perl-lsp-rs --lib --locked -- -D warnings -A missing_docs -D clippy::unwrap_used -D clippy::expect_used