### PR TITLE
feat(diagnostics): detect smartmatch deprecation (#3396)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/version_compat.rs
@@ -81,6 +81,8 @@ const BUILTIN_FUNCTION_VERSIONS: &[(&str, u32, u32)] = &[
 
 const GIVEN_WHEN_DEPRECATION_VERSION: PerlVersion = PerlVersion::new(5, 38);
 const GIVEN_WHEN_REMOVAL_VERSION: PerlVersion = PerlVersion::new(5, 42);
+const SMARTMATCH_DEPRECATION_VERSION: PerlVersion = PerlVersion::new(5, 38);
+const SMARTMATCH_REMOVAL_VERSION: PerlVersion = PerlVersion::new(5, 42);
 
 /// Check for Perl version compatibility issues.
 ///
@@ -311,6 +313,26 @@ pub fn check_version_compat(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
                 }
             }
 
+            // Smartmatch operator `~~` — enabled by `use feature 'switch'` in v5.10+,
+            // deprecated in v5.38, and removed in v5.42.
+            NodeKind::Binary { op, .. } if op == "~~" => {
+                if declared_version >= SMARTMATCH_REMOVAL_VERSION {
+                    diagnostics.push(make_smartmatch_diagnostic(
+                        n,
+                        declared_version,
+                        DiagnosticSeverity::Error,
+                    ));
+                } else if declared_version >= SMARTMATCH_DEPRECATION_VERSION {
+                    diagnostics.push(make_smartmatch_diagnostic(
+                        n,
+                        declared_version,
+                        DiagnosticSeverity::Warning,
+                    ));
+                } else if !effective_features.contains(&"switch") {
+                    diagnostics.push(make_smartmatch_feature_diagnostic(n, declared_version));
+                }
+            }
+
             _ => {}
         }
     });
@@ -412,6 +434,58 @@ fn make_given_when_default_diagnostic(
             min_version.1
         )),
     }
+}
+
+fn make_smartmatch_diagnostic(
+    node: &Node,
+    declared_version: PerlVersion,
+    severity: DiagnosticSeverity,
+) -> Diagnostic {
+    let (message, min_version) = match severity {
+        DiagnosticSeverity::Error => (
+            format!(
+                "smartmatch operator `~~` was removed in Perl v5.42; declared version is v{}.{}",
+                declared_version.major, declared_version.minor
+            ),
+            (5, 42),
+        ),
+        _ => (
+            format!(
+                "smartmatch operator `~~` is deprecated starting in Perl v5.38; declared version is v{}.{}",
+                declared_version.major, declared_version.minor
+            ),
+            (5, 38),
+        ),
+    };
+
+    Diagnostic {
+        range: (node.location.start, node.location.end),
+        severity,
+        code: Some(DiagnosticCode::VersionIncompatFeature.as_str().to_string()),
+        message,
+        related_information: vec![],
+        tags: vec![],
+        suggestion: Some(format!(
+            "Replace smartmatch `~~` with `if` / `elsif`, `grep`, or `any` from List::Util; this operator is {} in v{}.{}.",
+            if severity == DiagnosticSeverity::Error { "removed" } else { "deprecated" },
+            min_version.0,
+            min_version.1
+        )),
+    }
+}
+
+fn make_smartmatch_feature_diagnostic(node: &Node, declared_version: PerlVersion) -> Diagnostic {
+    make_diagnostic_with_details(
+        node,
+        "smartmatch operator `~~`",
+        declared_version,
+        (5, 10),
+        DiagnosticSeverity::Warning,
+        Some(format!(
+            "Update 'use v{}.{}' to 'use v5.10' or add 'use feature \"switch\";'",
+            declared_version.major, declared_version.minor
+        )),
+    )
 }
 
 fn make_diagnostic_with_details(

--- a/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/version_compat_tests.rs
@@ -801,6 +801,23 @@ fn issue_3344_default_node() -> Node {
     Node::new(NodeKind::Default { body: Box::new(block(vec![])) }, loc(20, 40))
 }
 
+fn smartmatch_node() -> Node {
+    Node::new(
+        NodeKind::Binary {
+            op: "~~".to_string(),
+            left: Box::new(Node::new(
+                NodeKind::Variable { sigil: "$".to_string(), name: "value".to_string() },
+                loc(20, 26),
+            )),
+            right: Box::new(Node::new(
+                NodeKind::String { value: "pattern".to_string(), interpolated: false },
+                loc(30, 39),
+            )),
+        },
+        loc(20, 39),
+    )
+}
+
 fn defer_call() -> Node {
     // `defer { }` is now parsed as NodeKind::Defer (Perl 5.36+ experimental, stable in 5.40).
     Node::new(
@@ -952,6 +969,104 @@ fn test_given_ok_with_use_feature_switch() -> Result<(), Box<dyn std::error::Err
     assert!(
         no_compat_warnings(&diagnostics),
         "Expected no PL900 warning when 'use feature 'switch'' is present on v5.8, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests for smartmatch (`~~`) (#3396)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_smartmatch_warns_on_v5_8() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), smartmatch_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for smartmatch in v5.8, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(
+        msg.message.contains("smartmatch") || msg.message.contains("~~"),
+        "Message should mention smartmatch: {}",
+        msg.message
+    );
+    assert!(
+        msg.message.contains("v5.10") || msg.message.contains("5.10"),
+        "Message should mention minimum version v5.10: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+#[test]
+fn test_smartmatch_ok_on_v5_10() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.10"), smartmatch_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning for smartmatch in v5.10, got: {:?}",
+        diagnostics
+    );
+    Ok(())
+}
+
+#[test]
+fn test_smartmatch_warns_on_v5_38() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.38"), smartmatch_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 warning for smartmatch in v5.38, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(
+        msg.message.contains("deprecated") || msg.message.contains("v5.38"),
+        "Message should mention deprecation: {}",
+        msg.message
+    );
+    Ok(())
+}
+
+#[test]
+fn test_smartmatch_errors_on_v5_42() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.42"), smartmatch_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        diagnostics_have_code(&diagnostics, "PL900"),
+        "Expected PL900 error for smartmatch in v5.42, got: {:?}",
+        diagnostics
+    );
+    let msg = must_some(diagnostics.iter().find(|d| d.code.as_deref() == Some("PL900")));
+    assert!(
+        msg.message.contains("removed") || msg.message.contains("v5.42"),
+        "Message should mention removal: {}",
+        msg.message
+    );
+    assert_eq!(msg.severity, DiagnosticSeverity::Error, "Expected removal severity to be an error");
+    Ok(())
+}
+
+#[test]
+fn test_smartmatch_ok_with_use_feature_switch() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("v5.8"), use_feature("switch"), smartmatch_node()]);
+    let mut diagnostics = vec![];
+    check_version_compat(&ast, &mut diagnostics);
+
+    assert!(
+        no_compat_warnings(&diagnostics),
+        "Expected no PL900 warning when 'use feature \\'switch\\'' is present on v5.8, got: {:?}",
         diagnostics
     );
     Ok(())


### PR DESCRIPTION
Add PL900 coverage for smartmatch (`~~`) deprecation/removal by reusing the existing switch/given/when version-compat machinery.

Behavior:
- v5.8 without `use feature 'switch'` warns that smartmatch needs `switch`
- v5.10 is accepted
- v5.38 warns as deprecated
- v5.42 errors as removed
- explicit `use feature 'switch'` still suppresses the pre-5.10 warning

Validation:
- cargo fmt --all
- cargo test -p perl-lsp-diagnostics --test version_compat_tests smartmatch -- --nocapture