### PR TITLE
fix(diagnostics): warn on undefined goto labels (#3373)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -163,6 +163,8 @@ pub enum DiagnosticCode {
     EvalErrorFlow,
     /// Duplicate key in a hash literal or hash reference constructor
     DuplicateHashKey,
+    /// `goto LABEL` references a label that does not exist in this file
+    GotoUndefinedLabel,
 
     // Deprecated syntax (PL500-PL599)
     /// Use of deprecated defined(@array) / defined(%hash)
@@ -260,6 +262,7 @@ impl DiagnosticCode {
             DiagnosticCode::UnreachableCode => "PL406",
             DiagnosticCode::EvalErrorFlow => "PL407",
             DiagnosticCode::DuplicateHashKey => "PL408",
+            DiagnosticCode::GotoUndefinedLabel => "PL409",
             DiagnosticCode::DeprecatedDefined => "PL500",
             DiagnosticCode::DeprecatedArrayBase => "PL501",
             DiagnosticCode::SecurityStringEval => "PL600",
@@ -327,6 +330,7 @@ impl DiagnosticCode {
             "PL406" => "https://docs.perl-lsp.org/errors/PL406",
             "PL407" => "https://docs.perl-lsp.org/errors/PL407",
             "PL408" => "https://docs.perl-lsp.org/errors/PL408",
+            "PL409" => "https://docs.perl-lsp.org/errors/PL409",
             "PL500" => "https://docs.perl-lsp.org/errors/PL500",
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
             "PL600" => "https://docs.perl-lsp.org/errors/PL600",
@@ -384,6 +388,7 @@ impl DiagnosticCode {
             | DiagnosticCode::NumericComparisonWithUndef
             | DiagnosticCode::PrintfFormatMismatch
             | DiagnosticCode::DuplicateHashKey
+            | DiagnosticCode::GotoUndefinedLabel
             | DiagnosticCode::DeprecatedDefined
             | DiagnosticCode::DeprecatedArrayBase
             | DiagnosticCode::SecurityStringEval
@@ -524,6 +529,10 @@ impl DiagnosticCode {
             DiagnosticCode::DuplicateHashKey => Some(
                 "This hash key appears more than once in the same literal. \
                 Only the last value will be used; the earlier assignment is silently discarded.",
+            ),
+            DiagnosticCode::GotoUndefinedLabel => Some(
+                "This goto target label is not defined in the current file. \
+                Define the label or use a dynamic goto form only when the target is known at runtime.",
             ),
             DiagnosticCode::PrintfFormatMismatch => Some(
                 "The number of format specifiers does not match the number of arguments. \
@@ -710,6 +719,7 @@ impl DiagnosticCode {
             "PL406" => Some(DiagnosticCode::UnreachableCode),
             "PL407" => Some(DiagnosticCode::EvalErrorFlow),
             "PL408" => Some(DiagnosticCode::DuplicateHashKey),
+            "PL409" => Some(DiagnosticCode::GotoUndefinedLabel),
             "PL500" => Some(DiagnosticCode::DeprecatedDefined),
             "PL501" => Some(DiagnosticCode::DeprecatedArrayBase),
             "PL600" => Some(DiagnosticCode::SecurityStringEval),
@@ -810,7 +820,8 @@ impl DiagnosticCode {
             | DiagnosticCode::PrintfFormatMismatch
             | DiagnosticCode::UnreachableCode
             | DiagnosticCode::EvalErrorFlow
-            | DiagnosticCode::DuplicateHashKey => DiagnosticCategory::BestPractices,
+            | DiagnosticCode::DuplicateHashKey
+            | DiagnosticCode::GotoUndefinedLabel => DiagnosticCategory::BestPractices,
 
             DiagnosticCode::DeprecatedDefined | DiagnosticCode::DeprecatedArrayBase => {
                 DiagnosticCategory::Deprecated
@@ -858,6 +869,7 @@ mod tests {
         assert_eq!(DiagnosticCode::EvalErrorFlow.as_str(), "PL407");
         assert_eq!(DiagnosticCode::CriticSeverity1.as_str(), "PC001");
         assert_eq!(DiagnosticCode::SecuritySignalHandler.as_str(), "PL602");
+        assert_eq!(DiagnosticCode::GotoUndefinedLabel.as_str(), "PL409");
     }
 
     #[test]

--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -16,6 +16,7 @@ use crate::lints::deprecated::check_deprecated_syntax;
 use crate::lints::duplicate_hash_keys::check_duplicate_hash_keys;
 use crate::lints::eval_error_flow::check_eval_error_flow;
 use crate::lints::ffi_checklib::check_ffi_checklib;
+use crate::lints::goto_label::check_goto_labels;
 use crate::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -146,6 +147,7 @@ impl DiagnosticsProvider {
 
         // Moo/Moose role conflict diagnostics (same-file only)
         check_role_conflicts(ast, &symbol_table, &mut diagnostics);
+        check_goto_labels(ast, &symbol_table, &mut diagnostics);
 
         // Security anti-pattern detection (string eval, two-arg open, backtick exec)
         check_security(ast, &mut diagnostics);

--- a/crates/perl-lsp-diagnostics/src/lints/goto_label.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/goto_label.rs
@@ -1,0 +1,66 @@
+//! Conservative `goto LABEL` validation.
+//!
+//! This lint only warns when a `goto` target is a plain identifier and no
+//! matching label symbol exists anywhere in the current file. Dynamic goto
+//! forms (`goto &sub`, `goto $expr`, etc.) are intentionally ignored.
+//!
+//! # Diagnostic codes
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL409` | Warning | `goto LABEL` references a label that is not defined in the file |
+
+use perl_diagnostics_codes::DiagnosticCode;
+use perl_lsp_diagnostic_types::{Diagnostic, DiagnosticSeverity, RelatedInformation};
+use perl_parser_core::ast::{Node, NodeKind};
+use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
+
+use super::super::walker::walk_node;
+
+fn has_label(symbol_table: &SymbolTable, label: &str) -> bool {
+    symbol_table
+        .symbols
+        .get(label)
+        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == SymbolKind::Label))
+}
+
+fn goto_target_is_plain_label(target: &Node) -> Option<&str> {
+    match &target.kind {
+        NodeKind::Identifier { name } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+/// Warn when a `goto LABEL` target does not have a matching label symbol.
+pub fn check_goto_labels(
+    root: &Node,
+    symbol_table: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    walk_node(root, &mut |node| {
+        let NodeKind::Goto { target } = &node.kind else {
+            return;
+        };
+
+        let Some(label) = goto_target_is_plain_label(target) else {
+            return;
+        };
+
+        if has_label(symbol_table, label) {
+            return;
+        }
+
+        diagnostics.push(Diagnostic {
+            range: (target.location.start, target.location.end),
+            severity: DiagnosticSeverity::Warning,
+            code: Some(DiagnosticCode::GotoUndefinedLabel.as_str().to_string()),
+            message: format!("Goto label '{label}' is not defined in this file"),
+            related_information: vec![RelatedInformation {
+                location: (target.location.start, target.location.end),
+                message: "Define the label or use a dynamic goto form only when the target is known at runtime.".to_string(),
+            }],
+            tags: Vec::new(),
+            suggestion: Some(format!("Add a '{label}:' label or remove the goto")),
+        });
+    });
+}

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -13,6 +13,7 @@
 //! - **common_mistakes**: Frequent programming errors (assignment in conditions, etc.)
 //! - **security**: Security anti-patterns (two-arg open, string eval, backtick execution, global signal handlers)
 //! - **eval_error_flow**: Conservative `$@` / `$EVAL_ERROR` flow checks after `eval` / `try`
+//! - **goto_label**: Conservative `goto LABEL` validation when no matching label exists in-file
 //!
 //! # Diagnostic Code Reference
 //!
@@ -106,6 +107,12 @@
 //! |------|----------|-------------|
 //! | `PL408` | Warning | Hash key appears more than once in the same literal |
 //!
+//! ## Goto labels (`goto_label.rs`)
+//!
+//! | Code | Severity | Description |
+//! |------|----------|-------------|
+//! | `PL409` | Warning | `goto LABEL` references a label that is not defined in the file |
+//!
 //! # Severity Levels
 //!
 //! Each lint produces diagnostics with appropriate severity:
@@ -131,6 +138,8 @@ pub mod duplicate_hash_keys;
 pub mod eval_error_flow;
 /// FFI::CheckLib native-library validation hints
 pub mod ffi_checklib;
+/// Conservative `goto LABEL` validation
+pub mod goto_label;
 /// Missing module detection (PL701)
 pub mod missing_module;
 /// Package and subroutine diagnostics (PL200, PL201, PL300, PL303)

--- a/crates/perl-lsp-diagnostics/tests/goto_label_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/goto_label_tests.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use perl_lsp_diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn pl409_messages(source: &str) -> Vec<String> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("PL409"))
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn goto_to_missing_label_warns() {
+    let source = "use v5.40;\ngoto MISSING;\n";
+    let messages = pl409_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains("not defined in this file")),
+        "expected PL409 for missing goto label, got: {messages:?}"
+    );
+}
+
+#[test]
+fn goto_to_existing_label_is_allowed() {
+    let source = "use v5.40;\nSTART: goto START;\n";
+    let messages = pl409_messages(source);
+    assert!(messages.is_empty(), "goto to an existing label should not warn, got: {messages:?}");
+}
+
+#[test]
+fn dynamic_goto_forms_are_ignored() {
+    let source = "use v5.40;\ngoto &target;\ngoto $label;\n";
+    let messages = pl409_messages(source);
+    assert!(
+        messages.is_empty(),
+        "dynamic goto forms should not be validated as labels, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Adds a conservative PL409 diagnostic for obvious  misses while ignoring dynamic goto forms. Validation is covered by focused diagnostics tests.