### PR TITLE
feat(vscode): add gherkin outline providers (#3551)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -54,6 +54,7 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:perl",
+    "onLanguage:gherkin",
     "onWalkthrough:perl-lsp.gettingStarted",
     "onCommand:perl-lsp.restart",
     "onCommand:perl-lsp.showVersion",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -13,6 +13,7 @@ import { generateBoilerplate } from './fileCreation';
 import { handleFormattingError } from './formattingErrors';
 import { HealthWidget, ClientState } from './healthWidget';
 import { registerPodPreview } from './podPreview';
+import { registerGherkinProviders } from './gherkinProviders';
 import { StreamingCompletionController } from './streamingCompletion';
 import {
     classifyStartupError,
@@ -850,6 +851,7 @@ export async function activate(context: vscode.ExtensionContext) {
         configurationWatcher,
         fileCreationWatcher,
         arrowCompletionWatcher,
+        ...registerGherkinProviders(),
         ...registerPodPreview(context),
     );
 

--- a/vscode-extension/src/gherkinProviders.ts
+++ b/vscode-extension/src/gherkinProviders.ts
@@ -1,0 +1,219 @@
+import * as vscode from 'vscode';
+
+type OutlineKind = 'feature' | 'rule' | 'background' | 'scenario' | 'examples' | 'step';
+
+interface OutlineNode {
+    name: string;
+    detail: string;
+    kind: OutlineKind;
+    level: number;
+    line: number;
+    startCharacter: number;
+    endCharacter: number;
+    endLine: number;
+    children: OutlineNode[];
+}
+
+const HEADER_RE =
+    /^\s*(Feature|Rule|Background|Scenario(?: Outline| Template)?|Examples)\s*:(.*)$/;
+const STEP_RE = /^\s*(Given|When|Then|And|But|\*)\b(.*)$/;
+
+export function registerGherkinProviders(): vscode.Disposable[] {
+    const selector: vscode.DocumentSelector = [{ language: 'gherkin' }];
+
+    const symbolProvider: vscode.DocumentSymbolProvider = {
+        provideDocumentSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
+            return provideGherkinDocumentSymbols(document.getText());
+        },
+    };
+
+    const foldingProvider: vscode.FoldingRangeProvider = {
+        provideFoldingRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
+            return provideGherkinFoldingRanges(document.getText());
+        },
+    };
+
+    return [
+        vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider),
+        vscode.languages.registerFoldingRangeProvider(selector, foldingProvider),
+    ];
+}
+
+export function provideGherkinDocumentSymbols(text: string): vscode.DocumentSymbol[] {
+    return buildOutline(text).map(toDocumentSymbol);
+}
+
+export function provideGherkinFoldingRanges(text: string): vscode.FoldingRange[] {
+    const ranges: vscode.FoldingRange[] = [];
+
+    const visit = (node: OutlineNode): void => {
+        if (node.kind !== 'step' && node.endLine > node.line) {
+            ranges.push({ start: node.line, end: node.endLine } as vscode.FoldingRange);
+        }
+        for (const child of node.children) {
+            visit(child);
+        }
+    };
+
+    for (const root of buildOutline(text)) {
+        visit(root);
+    }
+
+    return ranges;
+}
+
+function buildOutline(text: string): OutlineNode[] {
+    const lines = text.split(/\r?\n/);
+    const roots: OutlineNode[] = [];
+    const stack: OutlineNode[] = [];
+
+    for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
+        const line = lines[lineNumber];
+        const headerMatch = line.match(HEADER_RE);
+        const stepMatch = line.match(STEP_RE);
+
+        let node: OutlineNode | null = null;
+        if (headerMatch) {
+            node = createHeaderNode(line, lineNumber, headerMatch[1], headerMatch[2].trim());
+        } else if (stepMatch) {
+            node = createStepNode(line, lineNumber, stepMatch[1], stepMatch[2].trim());
+        }
+
+        if (!node) {
+            continue;
+        }
+
+        while (stack.length > 0 && stack[stack.length - 1].level >= node.level) {
+            finalizeNode(stack.pop()!, lineNumber - 1);
+        }
+
+        if (stack.length > 0) {
+            stack[stack.length - 1].children.push(node);
+        } else {
+            roots.push(node);
+        }
+
+        stack.push(node);
+    }
+
+    const lastLine = Math.max(lines.length - 1, 0);
+    while (stack.length > 0) {
+        finalizeNode(stack.pop()!, lastLine);
+    }
+
+    return roots;
+}
+
+function createHeaderNode(
+    line: string,
+    lineNumber: number,
+    keyword: string,
+    title: string
+): OutlineNode {
+    const trimmed = line.trim();
+    const startCharacter = line.search(/\S|$/);
+    const displayName = title.length > 0 ? `${keyword}: ${title}` : trimmed;
+
+    return {
+        name: displayName,
+        detail: keyword,
+        kind: outlineKindForHeader(keyword),
+        level: outlineLevelForHeader(keyword),
+        line: lineNumber,
+        startCharacter,
+        endCharacter: line.length,
+        endLine: lineNumber,
+        children: [],
+    };
+}
+
+function createStepNode(
+    line: string,
+    lineNumber: number,
+    keyword: string,
+    remainder: string
+): OutlineNode {
+    const startCharacter = line.search(/\S|$/);
+    const displayName = remainder.length > 0 ? `${keyword} ${remainder}` : keyword;
+
+    return {
+        name: displayName,
+        detail: keyword,
+        kind: 'step',
+        level: 4,
+        line: lineNumber,
+        startCharacter,
+        endCharacter: line.length,
+        endLine: lineNumber,
+        children: [],
+    };
+}
+
+function outlineKindForHeader(keyword: string): OutlineKind {
+    switch (keyword) {
+        case 'Feature':
+            return 'feature';
+        case 'Rule':
+            return 'rule';
+        case 'Background':
+            return 'background';
+        case 'Examples':
+            return 'examples';
+        default:
+            return 'scenario';
+    }
+}
+
+function outlineLevelForHeader(keyword: string): number {
+    switch (keyword) {
+        case 'Feature':
+            return 0;
+        case 'Rule':
+            return 1;
+        case 'Background':
+        case 'Scenario':
+        case 'Scenario Outline':
+        case 'Scenario Template':
+            return 2;
+        case 'Examples':
+            return 3;
+        default:
+            return 2;
+    }
+}
+
+function finalizeNode(node: OutlineNode, endLine: number): void {
+    node.endLine = Math.max(node.line, endLine);
+}
+
+function toDocumentSymbol(node: OutlineNode): vscode.DocumentSymbol {
+    return {
+        name: node.name,
+        detail: node.detail,
+        kind: symbolKind(node.kind),
+        range: new vscode.Range(node.line, node.startCharacter, node.endLine, node.endCharacter),
+        selectionRange: new vscode.Range(
+            node.line,
+            node.startCharacter,
+            node.line,
+            node.endCharacter
+        ),
+        children: node.children.map(toDocumentSymbol),
+    } as vscode.DocumentSymbol;
+}
+
+function symbolKind(kind: OutlineKind): vscode.SymbolKind {
+    switch (kind) {
+        case 'feature':
+        case 'rule':
+            return vscode.SymbolKind.Namespace;
+        case 'background':
+            return vscode.SymbolKind.Object;
+        case 'scenario':
+            return vscode.SymbolKind.Method;
+        case 'examples':
+            return vscode.SymbolKind.Array;
+        case 'step':
+            return vscode.SymbolKind.String;
+    }
+}

--- a/vscode-extension/src/test/__mocks__/vscode.ts
+++ b/vscode-extension/src/test/__mocks__/vscode.ts
@@ -46,6 +46,35 @@ export class Range {
   ) {}
 }
 
+export enum SymbolKind {
+  File = 0,
+  Module = 1,
+  Namespace = 2,
+  Package = 3,
+  Class = 4,
+  Method = 5,
+  Property = 6,
+  Field = 7,
+  Constructor = 8,
+  Enum = 9,
+  Interface = 10,
+  Function = 11,
+  Variable = 12,
+  Constant = 13,
+  String = 15,
+  Number = 16,
+  Boolean = 17,
+  Array = 18,
+  Object = 19,
+  Key = 20,
+  Null = 21,
+  EnumMember = 22,
+  Struct = 23,
+  Event = 24,
+  Operator = 25,
+  TypeParameter = 26,
+}
+
 export class TestMessage {
   constructor(public message: string) {}
 }
@@ -205,4 +234,6 @@ export enum ConfigurationTarget {
 export const languages = {
   onDidChangeDiagnostics: jest.fn(() => ({ dispose: jest.fn() })),
   getDiagnostics: jest.fn(() => [] as Array<[any, any[]]>),
+  registerDocumentSymbolProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerFoldingRangeProvider: jest.fn(() => ({ dispose: jest.fn() })),
 };

--- a/vscode-extension/src/test/configuration.test.ts
+++ b/vscode-extension/src/test/configuration.test.ts
@@ -198,6 +198,10 @@ describe('package.json contributes', () => {
       expect(pkg.activationEvents).toContain('onLanguage:perl');
     });
 
+    test('activates on gherkin language', () => {
+      expect(pkg.activationEvents).toContain('onLanguage:gherkin');
+    });
+
     test('activates on restart command', () => {
       expect(pkg.activationEvents).toContain('onCommand:perl-lsp.restart');
     });

--- a/vscode-extension/src/test/gherkinProviders.test.ts
+++ b/vscode-extension/src/test/gherkinProviders.test.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import {
+  provideGherkinDocumentSymbols,
+  provideGherkinFoldingRanges,
+  registerGherkinProviders,
+} from '../gherkinProviders';
+
+describe('gherkin outline providers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('registers document symbol and folding providers for gherkin', () => {
+    registerGherkinProviders();
+
+    expect(vscode.languages.registerDocumentSymbolProvider).toHaveBeenCalledTimes(1);
+    expect(vscode.languages.registerFoldingRangeProvider).toHaveBeenCalledTimes(1);
+    expect((vscode.languages.registerDocumentSymbolProvider as jest.Mock).mock.calls[0][0]).toEqual([
+      { language: 'gherkin' },
+    ]);
+  });
+
+  test('builds hierarchical document symbols for feature structure', () => {
+    const text = [
+      '@smoke',
+      'Feature: Checkout flow',
+      '  Background: signed-in user',
+      '    Given I am logged in',
+      '  Scenario Outline: buying a product',
+      '    When I add <item> to the cart',
+      '    Then the total should be <total>',
+      '    Examples: happy path',
+      '      | item   | total |',
+      '      | Widget | 10    |',
+    ].join('\n');
+
+    const symbols = provideGherkinDocumentSymbols(text);
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].name).toBe('Feature: Checkout flow');
+    expect(symbols[0].children.map((child) => child.name)).toEqual([
+      'Background: signed-in user',
+      'Scenario Outline: buying a product',
+    ]);
+
+    const background = symbols[0].children[0];
+    expect(background.children.map((child) => child.name)).toEqual(['Given I am logged in']);
+
+    const outline = symbols[0].children[1];
+    expect(outline.children.map((child) => child.name)).toEqual([
+      'When I add <item> to the cart',
+      'Then the total should be <total>',
+      'Examples: happy path',
+    ]);
+  });
+
+  test('returns folding ranges for feature sections', () => {
+    const text = [
+      'Feature: Checkout flow',
+      '  Background: signed-in user',
+      '    Given I am logged in',
+      '  Scenario: buying a product',
+      '    When I add the item to the cart',
+      '    Then the total should be 10',
+    ].join('\n');
+
+    const ranges = provideGherkinFoldingRanges(text);
+    expect(ranges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ start: 0, end: 5 }),
+        expect.objectContaining({ start: 1, end: 2 }),
+        expect.objectContaining({ start: 3, end: 5 }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
Summary
- add document symbol and folding providers for gherkin files in the VS Code extension
- activate the extension when a gherkin file opens so the providers register
- cover the provider behavior and activation contract with focused extension tests

Validation
- npm test -- --runInBand src/test/gherkinProviders.test.ts src/test/configuration.test.ts
