### PR TITLE
feat(vscode): add gherkin step navigation and stubs (#3548)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,6 +14,7 @@ import { handleFormattingError } from './formattingErrors';
 import { HealthWidget, ClientState } from './healthWidget';
 import { registerPodPreview } from './podPreview';
 import { registerGherkinProviders } from './gherkinProviders';
+import { registerGherkinStepDefinitionSupport } from './gherkinStepDefinitions';
 import { StreamingCompletionController } from './streamingCompletion';
 import {
     classifyStartupError,
@@ -852,6 +853,7 @@ export async function activate(context: vscode.ExtensionContext) {
         fileCreationWatcher,
         arrowCompletionWatcher,
         ...registerGherkinProviders(),
+        ...registerGherkinStepDefinitionSupport(),
         ...registerPodPreview(context),
     );
 

--- a/vscode-extension/src/gherkinProviders.ts
+++ b/vscode-extension/src/gherkinProviders.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 
 type OutlineKind = 'feature' | 'rule' | 'background' | 'scenario' | 'examples' | 'step';
+type StepKeyword = 'Given' | 'When' | 'Then' | 'And' | 'But' | '*';
+type StepDefinitionKeyword = Exclude<StepKeyword, '*'>;
 
 interface OutlineNode {
     name: string;
@@ -14,9 +16,56 @@ interface OutlineNode {
     children: OutlineNode[];
 }
 
+interface GherkinStepReference {
+    keyword: StepKeyword;
+    effectiveKeyword?: StepDefinitionKeyword;
+    text: string;
+    originSelectionRange: vscode.Range;
+}
+
+export interface StepDefinitionDocument {
+    uri: vscode.Uri;
+    text: string;
+}
+
+interface ParsedStepDefinition {
+    keyword: StepDefinitionKeyword;
+    matcher: StepMatcher;
+    range: vscode.Range;
+    uri: vscode.Uri;
+    score: number;
+}
+
+type StepMatcher =
+    | {
+        kind: 'exact';
+        text: string;
+    }
+    | {
+        kind: 'regex';
+        source: string;
+        flags: string;
+    };
+
 const HEADER_RE =
     /^\s*(Feature|Rule|Background|Scenario(?: Outline| Template)?|Examples)\s*:(.*)$/;
-const STEP_RE = /^\s*(Given|When|Then|And|But|\*)\b(.*)$/;
+const STEP_RE = /^\s*(Given|When|Then|And|But|\*)(?:\s+|$)(.*)$/;
+const STEP_DEFINITION_RE = /^\s*(Given|When|Then|And|But)\b/gm;
+const STEP_DEFINITION_FILE_GLOBS = [
+    '**/features/step_definitions/**/*.pm',
+    '**/step_definitions/**/*.pm',
+    '**/*.pm',
+    '**/*.pl',
+    '**/*.t',
+] as const;
+const STEP_DEFINITION_EXCLUDE_GLOB = '{**/node_modules/**,**/blib/**,**/.git/**}';
+const STEP_DEFINITION_FILE_LIMIT = 1000;
+const DELIMITER_PAIRS: Record<string, string> = {
+    '{': '}',
+    '[': ']',
+    '(': ')',
+    '<': '>',
+};
 
 export function registerGherkinProviders(): vscode.Disposable[] {
     const selector: vscode.DocumentSelector = [{ language: 'gherkin' }];
@@ -33,9 +82,26 @@ export function registerGherkinProviders(): vscode.Disposable[] {
         },
     };
 
+    const definitionProvider: vscode.DefinitionProvider = {
+        async provideDefinition(
+            document: vscode.TextDocument,
+            position: vscode.Position,
+            token: vscode.CancellationToken
+        ): Promise<vscode.LocationLink[] | undefined> {
+            const candidates = await loadStepDefinitionDocuments(token);
+            if (token.isCancellationRequested) {
+                return undefined;
+            }
+
+            const links = provideGherkinStepDefinitionLinks(document.getText(), position, candidates);
+            return links.length > 0 ? links : undefined;
+        },
+    };
+
     return [
         vscode.languages.registerDocumentSymbolProvider(selector, symbolProvider),
         vscode.languages.registerFoldingRangeProvider(selector, foldingProvider),
+        vscode.languages.registerDefinitionProvider(selector, definitionProvider),
     ];
 }
 
@@ -60,6 +126,51 @@ export function provideGherkinFoldingRanges(text: string): vscode.FoldingRange[]
     }
 
     return ranges;
+}
+
+export function provideGherkinStepDefinitionLinks(
+    featureText: string,
+    position: vscode.Position,
+    documents: readonly StepDefinitionDocument[]
+): vscode.LocationLink[] {
+    const step = extractStepReference(featureText, position);
+    if (!step) {
+        return [];
+    }
+
+    const matches: ParsedStepDefinition[] = [];
+    for (const document of documents) {
+        matches.push(...findMatchingStepDefinitions(step, document));
+    }
+
+    matches.sort((left, right) => {
+        if (right.score !== left.score) {
+            return right.score - left.score;
+        }
+
+        const leftUri = left.uri.toString();
+        const rightUri = right.uri.toString();
+        if (leftUri !== rightUri) {
+            return leftUri.localeCompare(rightUri);
+        }
+
+        return compareRanges(left.range, right.range);
+    });
+
+    const deduped = new Map<string, vscode.LocationLink>();
+    for (const match of matches) {
+        const key = `${match.uri.toString()}:${match.range.start.line}:${match.range.start.character}`;
+        if (!deduped.has(key)) {
+            deduped.set(key, {
+                originSelectionRange: step.originSelectionRange,
+                targetUri: match.uri,
+                targetRange: match.range,
+                targetSelectionRange: match.range,
+            });
+        }
+    }
+
+    return Array.from(deduped.values());
 }
 
 function buildOutline(text: string): OutlineNode[] {
@@ -102,6 +213,346 @@ function buildOutline(text: string): OutlineNode[] {
     }
 
     return roots;
+}
+
+async function loadStepDefinitionDocuments(
+    token: vscode.CancellationToken
+): Promise<StepDefinitionDocument[]> {
+    const seen = new Map<string, vscode.Uri>();
+
+    for (const pattern of STEP_DEFINITION_FILE_GLOBS) {
+        if (token.isCancellationRequested) {
+            return [];
+        }
+
+        const uris = await vscode.workspace.findFiles(
+            pattern,
+            STEP_DEFINITION_EXCLUDE_GLOB,
+            STEP_DEFINITION_FILE_LIMIT
+        );
+
+        for (const uri of uris) {
+            seen.set(uri.toString(), uri);
+        }
+    }
+
+    const documents: StepDefinitionDocument[] = [];
+    for (const uri of seen.values()) {
+        if (token.isCancellationRequested) {
+            break;
+        }
+
+        try {
+            const document = await vscode.workspace.openTextDocument(uri);
+            documents.push({ uri, text: document.getText() });
+        } catch {
+            // Ignore unreadable files and continue.
+        }
+    }
+
+    return documents;
+}
+
+function extractStepReference(
+    text: string,
+    position: vscode.Position
+): GherkinStepReference | null {
+    const lines = text.split(/\r?\n/);
+    const line = lines[position.line];
+    if (line === undefined) {
+        return null;
+    }
+
+    const match = line.match(STEP_RE);
+    if (!match) {
+        return null;
+    }
+
+    const keyword = match[1] as StepKeyword;
+    const remainder = match[2].trim();
+    if (remainder.length === 0) {
+        return null;
+    }
+
+    const startCharacter = line.search(/\S|$/);
+    if (position.character < startCharacter || position.character > line.length) {
+        return null;
+    }
+
+    return {
+        keyword,
+        effectiveKeyword: resolveEffectiveKeyword(lines, position.line, keyword),
+        text: remainder,
+        originSelectionRange: new vscode.Range(position.line, startCharacter, position.line, line.length),
+    };
+}
+
+function resolveEffectiveKeyword(
+    lines: readonly string[],
+    line: number,
+    keyword: StepKeyword
+): StepDefinitionKeyword | undefined {
+    if (keyword === 'Given' || keyword === 'When' || keyword === 'Then') {
+        return keyword;
+    }
+
+    for (let index = line - 1; index >= 0; index -= 1) {
+        const match = lines[index]?.match(STEP_RE);
+        if (!match) {
+            continue;
+        }
+
+        const previousKeyword = match[1] as StepKeyword;
+        if (previousKeyword === 'Given' || previousKeyword === 'When' || previousKeyword === 'Then') {
+            return previousKeyword;
+        }
+    }
+
+    return undefined;
+}
+
+function findMatchingStepDefinitions(
+    step: GherkinStepReference,
+    document: StepDefinitionDocument
+): ParsedStepDefinition[] {
+    const matches: ParsedStepDefinition[] = [];
+
+    for (const definition of parseStepDefinitions(document)) {
+        if (!keywordsAreCompatible(step, definition.keyword)) {
+            continue;
+        }
+
+        if (!stepTextMatches(step.text, definition.matcher)) {
+            continue;
+        }
+
+        matches.push(definition);
+    }
+
+    return matches;
+}
+
+function parseStepDefinitions(document: StepDefinitionDocument): ParsedStepDefinition[] {
+    const results: ParsedStepDefinition[] = [];
+    const lineStarts = computeLineStarts(document.text);
+
+    for (const match of document.text.matchAll(STEP_DEFINITION_RE)) {
+        const keyword = match[1] as StepDefinitionKeyword;
+        const startOffset = match.index ?? 0;
+        let cursor = startOffset + match[0].length;
+        cursor = skipWhitespace(document.text, cursor);
+
+        const parsedMatcher = parseStepMatcher(document.text, cursor);
+        if (!parsedMatcher) {
+            continue;
+        }
+
+        const commaOffset = skipWhitespace(document.text, parsedMatcher.endOffset);
+        if (document.text[commaOffset] !== ',') {
+            continue;
+        }
+
+        const rangeStart = startOffset + match[0].search(/\S|$/);
+        results.push({
+            keyword,
+            matcher: parsedMatcher.matcher,
+            range: rangeFromOffsets(lineStarts, rangeStart, parsedMatcher.endOffset),
+            uri: document.uri,
+            score: definitionScore(document.uri, keyword),
+        });
+    }
+
+    return results;
+}
+
+function parseStepMatcher(
+    text: string,
+    startOffset: number
+): { matcher: StepMatcher; endOffset: number } | null {
+    if (text.startsWith('qr', startOffset)) {
+        return parseRegexStepMatcher(text, startOffset);
+    }
+
+    const first = text[startOffset];
+    if (first === '\'' || first === '"') {
+        return parseQuotedStepMatcher(text, startOffset, first);
+    }
+
+    return null;
+}
+
+function parseRegexStepMatcher(
+    text: string,
+    startOffset: number
+): { matcher: StepMatcher; endOffset: number } | null {
+    let cursor = skipWhitespace(text, startOffset + 2);
+    const open = text[cursor];
+    if (!open || /\s/.test(open)) {
+        return null;
+    }
+
+    const close = DELIMITER_PAIRS[open] ?? open;
+    const paired = close !== open;
+    const patternStart = cursor + 1;
+    cursor = patternStart;
+
+    let depth = paired ? 1 : 0;
+    while (cursor < text.length) {
+        const current = text[cursor];
+        if (current === '\\') {
+            cursor += 2;
+            continue;
+        }
+
+        if (paired) {
+            if (current === open) {
+                depth += 1;
+                cursor += 1;
+                continue;
+            }
+
+            if (current === close) {
+                depth -= 1;
+                if (depth === 0) {
+                    const source = text.slice(patternStart, cursor);
+                    cursor += 1;
+                    const flagsStart = cursor;
+                    while (/[A-Za-z]/.test(text[cursor] ?? '')) {
+                        cursor += 1;
+                    }
+                    return {
+                        matcher: {
+                            kind: 'regex',
+                            source,
+                            flags: text.slice(flagsStart, cursor),
+                        },
+                        endOffset: cursor,
+                    };
+                }
+            }
+
+            cursor += 1;
+            continue;
+        }
+
+        if (current === close) {
+            const source = text.slice(patternStart, cursor);
+            cursor += 1;
+            const flagsStart = cursor;
+            while (/[A-Za-z]/.test(text[cursor] ?? '')) {
+                cursor += 1;
+            }
+            return {
+                matcher: {
+                    kind: 'regex',
+                    source,
+                    flags: text.slice(flagsStart, cursor),
+                },
+                endOffset: cursor,
+            };
+        }
+
+        cursor += 1;
+    }
+
+    return null;
+}
+
+function parseQuotedStepMatcher(
+    text: string,
+    startOffset: number,
+    quote: '\'' | '"'
+): { matcher: StepMatcher; endOffset: number } | null {
+    let cursor = startOffset + 1;
+    while (cursor < text.length) {
+        const current = text[cursor];
+        if (current === '\\') {
+            cursor += 2;
+            continue;
+        }
+
+        if (current === quote) {
+            return {
+                matcher: {
+                    kind: 'exact',
+                    text: unescapeQuotedStepText(text.slice(startOffset + 1, cursor), quote),
+                },
+                endOffset: cursor + 1,
+            };
+        }
+
+        cursor += 1;
+    }
+
+    return null;
+}
+
+function unescapeQuotedStepText(text: string, quote: '\'' | '"'): string {
+    if (quote === '\'') {
+        return text.replace(/\\\\/g, '\\').replace(/\\'/g, '\'');
+    }
+
+    return text.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
+}
+
+function keywordsAreCompatible(
+    step: GherkinStepReference,
+    definitionKeyword: StepDefinitionKeyword
+): boolean {
+    if (step.keyword === '*') {
+        return true;
+    }
+
+    if (step.keyword === 'And' || step.keyword === 'But') {
+        return definitionKeyword === 'And' ||
+            definitionKeyword === 'But' ||
+            definitionKeyword === step.effectiveKeyword;
+    }
+
+    return definitionKeyword === step.keyword ||
+        definitionKeyword === 'And' ||
+        definitionKeyword === 'But';
+}
+
+function stepTextMatches(stepText: string, matcher: StepMatcher): boolean {
+    if (matcher.kind === 'exact') {
+        return matcher.text === stepText;
+    }
+
+    try {
+        return new RegExp(matcher.source, normalizeRegexFlags(matcher.flags)).test(stepText);
+    } catch {
+        return false;
+    }
+}
+
+function normalizeRegexFlags(flags: string): string {
+    let normalized = '';
+    for (const flag of flags.toLowerCase()) {
+        if ((flag === 'i' || flag === 'm' || flag === 's') && !normalized.includes(flag)) {
+            normalized += flag;
+        }
+    }
+    return normalized;
+}
+
+function definitionScore(uri: vscode.Uri, keyword: StepDefinitionKeyword): number {
+    let score = 0;
+    const normalizedPath = uri.fsPath.replace(/\\/g, '/').toLowerCase();
+
+    if (normalizedPath.includes('/step_definitions/')) {
+        score += 20;
+    }
+    if (normalizedPath.endsWith('.pm')) {
+        score += 10;
+    } else if (normalizedPath.endsWith('.pl')) {
+        score += 5;
+    }
+    if (keyword === 'Given' || keyword === 'When' || keyword === 'Then') {
+        score += 5;
+    }
+
+    return score;
 }
 
 function createHeaderNode(
@@ -216,4 +667,64 @@ function symbolKind(kind: OutlineKind): vscode.SymbolKind {
         case 'step':
             return vscode.SymbolKind.String;
     }
+}
+
+function skipWhitespace(text: string, offset: number): number {
+    let cursor = offset;
+    while (cursor < text.length && /\s/.test(text[cursor]!)) {
+        cursor += 1;
+    }
+    return cursor;
+}
+
+function computeLineStarts(text: string): number[] {
+    const starts = [0];
+    for (let index = 0; index < text.length; index += 1) {
+        if (text[index] === '\n') {
+            starts.push(index + 1);
+        }
+    }
+    return starts;
+}
+
+function rangeFromOffsets(
+    lineStarts: readonly number[],
+    startOffset: number,
+    endOffset: number
+): vscode.Range {
+    const start = offsetToPosition(lineStarts, startOffset);
+    const end = offsetToPosition(lineStarts, endOffset);
+    return new vscode.Range(start.line, start.character, end.line, end.character);
+}
+
+function offsetToPosition(
+    lineStarts: readonly number[],
+    offset: number
+): { line: number; character: number } {
+    let low = 0;
+    let high = lineStarts.length - 1;
+
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const lineStart = lineStarts[mid]!;
+        const nextLineStart = lineStarts[mid + 1] ?? Number.POSITIVE_INFINITY;
+
+        if (offset < lineStart) {
+            high = mid - 1;
+        } else if (offset >= nextLineStart) {
+            low = mid + 1;
+        } else {
+            return { line: mid, character: offset - lineStart };
+        }
+    }
+
+    const lastLine = Math.max(lineStarts.length - 1, 0);
+    return { line: lastLine, character: Math.max(offset - (lineStarts[lastLine] ?? 0), 0) };
+}
+
+function compareRanges(left: vscode.Range, right: vscode.Range): number {
+    if (left.start.line !== right.start.line) {
+        return left.start.line - right.start.line;
+    }
+    return left.start.character - right.start.character;
 }

--- a/vscode-extension/src/gherkinStepDefinitions.ts
+++ b/vscode-extension/src/gherkinStepDefinitions.ts
@@ -1,0 +1,371 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const CREATE_STEP_DEFINITION_COMMAND = 'perl-lsp.createGherkinStepDefinition';
+const GHERKIN_STEP_RE = /^\s*(Given|When|Then|And|But)\b\s*(.*)$/;
+const STEP_DEFINITION_RE = /^\s*(Given|When|Then|And|But)\s+qr\//;
+const QUOTED_CAPTURE_RE = /"[^"\r\n]*"/y;
+const OUTLINE_PLACEHOLDER_RE = /<[^>\r\n]+>/y;
+const DEFAULT_STEP_DEFINITION_GLOB = '**/*.pm';
+const DEFAULT_EXCLUDE_GLOB = '{**/node_modules/**,**/blib/**}';
+const MAX_STEP_DEFINITION_FILES = 500;
+
+export type StepKeyword = 'Given' | 'When' | 'Then' | 'And' | 'But';
+export type StepDefinitionStatus = 'defined' | 'undefined' | 'ambiguous';
+
+export interface GherkinStepLine {
+    keyword: StepKeyword;
+    text: string;
+    line: number;
+    rawLine: string;
+}
+
+export interface ExtractedStepDefinition {
+    keyword: StepKeyword;
+    pattern: string;
+}
+
+export interface StepDefinitionScan {
+    definitions: ExtractedStepDefinition[];
+    ambiguous: boolean;
+}
+
+interface CreateStepDefinitionArgs {
+    featureUri: string;
+    line: number;
+}
+
+export function registerGherkinStepDefinitionSupport(): vscode.Disposable[] {
+    const selector: vscode.DocumentSelector = [{ language: 'gherkin' }];
+
+    const provider: vscode.CodeActionProvider = {
+        async provideCodeActions(document, range) {
+            return provideGherkinStepDefinitionActions(document, range);
+        },
+    };
+
+    return [
+        vscode.languages.registerCodeActionsProvider(selector, provider),
+        vscode.commands.registerCommand(
+            CREATE_STEP_DEFINITION_COMMAND,
+            async (args: CreateStepDefinitionArgs) => {
+                await createStepDefinitionFromFeature(args);
+            }
+        ),
+    ];
+}
+
+export function parseGherkinStepLine(lineText: string, line: number): GherkinStepLine | null {
+    const match = lineText.match(GHERKIN_STEP_RE);
+    if (!match) {
+        return null;
+    }
+
+    const text = match[2].trim();
+    if (text.length === 0) {
+        return null;
+    }
+
+    return {
+        keyword: match[1] as StepKeyword,
+        text,
+        line,
+        rawLine: lineText,
+    };
+}
+
+export function buildGeneratedStepPattern(stepText: string): string {
+    let pattern = '^';
+    let cursor = 0;
+
+    while (cursor < stepText.length) {
+        QUOTED_CAPTURE_RE.lastIndex = cursor;
+        const quoted = QUOTED_CAPTURE_RE.exec(stepText);
+        if (quoted && quoted.index === cursor) {
+            pattern += '"([^"]+)"';
+            cursor += quoted[0].length;
+            continue;
+        }
+
+        OUTLINE_PLACEHOLDER_RE.lastIndex = cursor;
+        const placeholder = OUTLINE_PLACEHOLDER_RE.exec(stepText);
+        if (placeholder && placeholder.index === cursor) {
+            pattern += '(.+)';
+            cursor += placeholder[0].length;
+            continue;
+        }
+
+        pattern += escapeRegexLiteral(stepText[cursor]);
+        cursor += 1;
+    }
+
+    pattern += '$';
+    return pattern;
+}
+
+export function buildGeneratedStepStub(
+    step: GherkinStepLine,
+    relativeFeaturePath: string
+): string {
+    return [
+        `# Auto-generated from ${relativeFeaturePath}:${step.line + 1}`,
+        `${step.keyword} qr/${buildGeneratedStepPattern(step.text)}/, sub {`,
+        '    # TODO: implement step',
+        '    return;',
+        '};',
+    ].join('\n');
+}
+
+export function buildStepDefinitionFileContent(
+    step: GherkinStepLine,
+    relativeFeaturePath: string
+): string {
+    return [
+        'use Test::BDD::Cucumber::StepFile;',
+        'use strict;',
+        'use warnings;',
+        '',
+        buildGeneratedStepStub(step, relativeFeaturePath),
+        '',
+    ].join('\n');
+}
+
+export function suggestStepDefinitionPath(featurePath: string, workspaceRoot: string): string {
+    const normalisedFeaturePath = path.normalize(featurePath);
+    const featureBasename = path.basename(normalisedFeaturePath, '.feature');
+    const safeStem = featureBasename
+        .replace(/[^A-Za-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .toLowerCase();
+    const filename = `${safeStem || 'generated'}_steps.pm`;
+    const featureParts = normalisedFeaturePath.split(path.sep);
+    const featuresIndex = featureParts.lastIndexOf('features');
+
+    if (featuresIndex !== -1) {
+        const featuresRoot = featureParts.slice(0, featuresIndex + 1).join(path.sep) || path.sep;
+        return path.join(featuresRoot, 'step_definitions', filename);
+    }
+
+    return path.join(workspaceRoot, 'features', 'step_definitions', filename);
+}
+
+export function scanStepDefinitions(source: string): StepDefinitionScan {
+    const definitions: ExtractedStepDefinition[] = [];
+    let ambiguous = false;
+
+    for (const line of source.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed.match(/^(Given|When|Then|And|But)\b/)) {
+            continue;
+        }
+
+        if (!STEP_DEFINITION_RE.test(trimmed)) {
+            ambiguous = true;
+            continue;
+        }
+
+        const match = trimmed.match(/^(Given|When|Then|And|But)\s+qr\//);
+        if (!match) {
+            ambiguous = true;
+            continue;
+        }
+
+        const pattern = extractSlashDelimitedPattern(trimmed, match[0].length - 1);
+        if (!pattern) {
+            ambiguous = true;
+            continue;
+        }
+
+        definitions.push({
+            keyword: match[1] as StepKeyword,
+            pattern,
+        });
+    }
+
+    return { definitions, ambiguous };
+}
+
+export function classifyStepDefinitionStatus(
+    step: GherkinStepLine,
+    sources: string[]
+): StepDefinitionStatus {
+    let ambiguous = false;
+
+    for (const source of sources) {
+        const scan = scanStepDefinitions(source);
+        ambiguous = ambiguous || scan.ambiguous;
+
+        for (const definition of scan.definitions) {
+            const matches = testExtractedDefinition(definition, step.text);
+            if (matches === true) {
+                return 'defined';
+            }
+            if (matches === null) {
+                ambiguous = true;
+            }
+        }
+    }
+
+    return ambiguous ? 'ambiguous' : 'undefined';
+}
+
+async function provideGherkinStepDefinitionActions(
+    document: vscode.TextDocument,
+    range: vscode.Range
+): Promise<vscode.CodeAction[]> {
+    const step = parseGherkinStepLine(document.lineAt(range.start.line).text, range.start.line);
+    if (!step) {
+        return [];
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (!workspaceFolder) {
+        return [];
+    }
+
+    const sources = await collectWorkspaceStepDefinitionSources(workspaceFolder);
+    const status = classifyStepDefinitionStatus(step, sources);
+    if (status !== 'undefined') {
+        return [];
+    }
+
+    const targetPath = suggestStepDefinitionPath(document.uri.fsPath, workspaceFolder.uri.fsPath);
+    const action = {
+        title: `Create step definition stub in ${vscode.workspace.asRelativePath(vscode.Uri.file(targetPath))}`,
+        kind: vscode.CodeActionKind.QuickFix,
+        command: {
+            command: CREATE_STEP_DEFINITION_COMMAND,
+            title: 'Create step definition stub',
+            arguments: [{ featureUri: document.uri.toString(), line: step.line }],
+        },
+    } as vscode.CodeAction;
+
+    return [action];
+}
+
+async function createStepDefinitionFromFeature(args: CreateStepDefinitionArgs): Promise<void> {
+    const featureUri = vscode.Uri.parse(args.featureUri);
+    const document = await vscode.workspace.openTextDocument(featureUri);
+    const step = parseGherkinStepLine(document.lineAt(args.line).text, args.line);
+    if (!step) {
+        void vscode.window.showWarningMessage('No Gherkin step found on the selected line.');
+        return;
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(featureUri);
+    if (!workspaceFolder) {
+        void vscode.window.showWarningMessage(
+            'Step definition generation requires an open workspace folder.'
+        );
+        return;
+    }
+
+    const sources = await collectWorkspaceStepDefinitionSources(workspaceFolder);
+    const status = classifyStepDefinitionStatus(step, sources);
+    if (status === 'defined') {
+        void vscode.window.showInformationMessage(
+            `A matching step definition already exists for "${step.text}".`
+        );
+        return;
+    }
+    if (status === 'ambiguous') {
+        void vscode.window.showWarningMessage(
+            'Step definition generation is unavailable because existing step definitions could not be matched confidently.'
+        );
+        return;
+    }
+
+    const targetPath = suggestStepDefinitionPath(featureUri.fsPath, workspaceFolder.uri.fsPath);
+    const relativeFeaturePath = vscode.workspace.asRelativePath(featureUri);
+    await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+
+    if (fs.existsSync(targetPath)) {
+        const existing = await fs.promises.readFile(targetPath, 'utf8');
+        const stub = buildGeneratedStepStub(step, relativeFeaturePath);
+        const separator = existing.trimEnd().length === 0 ? '' : '\n\n';
+        await fs.promises.writeFile(
+            targetPath,
+            `${existing.replace(/\s*$/, '')}${separator}${stub}\n`,
+            'utf8'
+        );
+    } else {
+        const content = buildStepDefinitionFileContent(step, relativeFeaturePath);
+        await fs.promises.writeFile(targetPath, content, 'utf8');
+    }
+
+    const targetDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(targetPath));
+    await vscode.window.showTextDocument(targetDocument);
+}
+
+async function collectWorkspaceStepDefinitionSources(
+    workspaceFolder: vscode.WorkspaceFolder
+): Promise<string[]> {
+    const files = await vscode.workspace.findFiles(
+        DEFAULT_STEP_DEFINITION_GLOB,
+        DEFAULT_EXCLUDE_GLOB,
+        MAX_STEP_DEFINITION_FILES
+    );
+    const workspacePrefix = ensureTrailingSeparator(workspaceFolder.uri.fsPath);
+    const candidateFiles = files.filter((uri) =>
+        ensureTrailingSeparator(uri.fsPath).startsWith(workspacePrefix)
+    );
+
+    const sources = await Promise.all(candidateFiles.map(async (uri) => {
+        const text = await fs.promises.readFile(uri.fsPath, 'utf8');
+        if (!uri.fsPath.includes(`${path.sep}step_definitions${path.sep}`)
+            && !text.includes('Test::BDD::Cucumber::StepFile')) {
+            return null;
+        }
+        return text;
+    }));
+
+    return sources.filter((value): value is string => typeof value === 'string');
+}
+
+function ensureTrailingSeparator(value: string): string {
+    return value.endsWith(path.sep) ? value : `${value}${path.sep}`;
+}
+
+function escapeRegexLiteral(text: string): string {
+    return text.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/\//g, '\\/');
+}
+
+function extractSlashDelimitedPattern(line: string, delimiterIndex: number): string | null {
+    let pattern = '';
+    let escaped = false;
+
+    for (let index = delimiterIndex + 1; index < line.length; index += 1) {
+        const char = line[index];
+        if (escaped) {
+            pattern += char;
+            escaped = false;
+            continue;
+        }
+
+        if (char === '\\') {
+            pattern += char;
+            escaped = true;
+            continue;
+        }
+
+        if (char === '/') {
+            return pattern;
+        }
+
+        pattern += char;
+    }
+
+    return null;
+}
+
+function testExtractedDefinition(
+    definition: ExtractedStepDefinition,
+    stepText: string
+): boolean | null {
+    try {
+        return new RegExp(definition.pattern).test(stepText);
+    } catch {
+        return null;
+    }
+}

--- a/vscode-extension/src/test/__mocks__/vscode.ts
+++ b/vscode-extension/src/test/__mocks__/vscode.ts
@@ -38,12 +38,18 @@ export enum ProgressLocation {
 }
 
 export class Range {
+  public start: { line: number; character: number };
+  public end: { line: number; character: number };
+
   constructor(
     public startLine: number,
     public startCharacter: number,
     public endLine: number,
     public endCharacter: number,
-  ) {}
+  ) {
+    this.start = { line: startLine, character: startCharacter };
+    this.end = { line: endLine, character: endCharacter };
+  }
 }
 
 export enum SymbolKind {
@@ -144,7 +150,10 @@ export const workspace = {
   onDidChangeConfiguration: jest.fn(),
   textDocuments: [],
   findFiles: jest.fn(async () => []),
-  openTextDocument: jest.fn(async (p: string) => ({ uri: { fsPath: p } })),
+  openTextDocument: jest.fn(async (value: any) => ({
+    uri: typeof value === 'string' ? { fsPath: value } : value,
+    getText: jest.fn(() => ''),
+  })),
   workspaceFolders: undefined as any[] | undefined,
 };
 
@@ -236,4 +245,6 @@ export const languages = {
   getDiagnostics: jest.fn(() => [] as Array<[any, any[]]>),
   registerDocumentSymbolProvider: jest.fn(() => ({ dispose: jest.fn() })),
   registerFoldingRangeProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerCodeActionsProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDefinitionProvider: jest.fn(() => ({ dispose: jest.fn() })),
 };

--- a/vscode-extension/src/test/gherkinProviders.test.ts
+++ b/vscode-extension/src/test/gherkinProviders.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
   provideGherkinDocumentSymbols,
   provideGherkinFoldingRanges,
+  provideGherkinStepDefinitionLinks,
   registerGherkinProviders,
 } from '../gherkinProviders';
 
@@ -10,11 +11,12 @@ describe('gherkin outline providers', () => {
     jest.clearAllMocks();
   });
 
-  test('registers document symbol and folding providers for gherkin', () => {
+  test('registers document symbol, folding, and definition providers for gherkin', () => {
     registerGherkinProviders();
 
     expect(vscode.languages.registerDocumentSymbolProvider).toHaveBeenCalledTimes(1);
     expect(vscode.languages.registerFoldingRangeProvider).toHaveBeenCalledTimes(1);
+    expect(vscode.languages.registerDefinitionProvider).toHaveBeenCalledTimes(1);
     expect((vscode.languages.registerDocumentSymbolProvider as jest.Mock).mock.calls[0][0]).toEqual([
       { language: 'gherkin' },
     ]);
@@ -71,5 +73,99 @@ describe('gherkin outline providers', () => {
         expect.objectContaining({ start: 3, end: 5 }),
       ])
     );
+  });
+
+  test('finds regex-based Perl step definitions for Given steps', () => {
+    const featureText = [
+      'Feature: Login',
+      '  Scenario: Successful login',
+      '    Given a user exists with username "alice"',
+    ].join('\n');
+
+    const links = provideGherkinStepDefinitionLinks(
+      featureText,
+      { line: 2, character: 15 } as vscode.Position,
+      [
+        {
+          uri: vscode.Uri.file('/project/features/step_definitions/user_steps.pm'),
+          text: [
+            'use Test::BDD::Cucumber::StepFile;',
+            '',
+            'Given qr/a user exists with username "([^"]+)"/, sub {',
+            '    my $username = $1;',
+            '};',
+          ].join('\n'),
+        },
+      ]
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0].targetUri.fsPath).toBe('/project/features/step_definitions/user_steps.pm');
+    expect(links[0].targetSelectionRange?.start.line).toBe(2);
+  });
+
+  test('resolves And steps using the previous Given/When/Then context', () => {
+    const featureText = [
+      'Feature: Checkout',
+      '  Scenario: Purchase',
+      '    Given I am authenticated',
+      '    And the cart is empty',
+    ].join('\n');
+
+    const links = provideGherkinStepDefinitionLinks(
+      featureText,
+      { line: 3, character: 12 } as vscode.Position,
+      [
+        {
+          uri: vscode.Uri.file('/project/t/steps/cart_steps.pm'),
+          text: [
+            'use Test::BDD::Cucumber::StepFile;',
+            '',
+            'Given qr/the cart is empty/, sub {',
+            '};',
+          ].join('\n'),
+        },
+      ]
+    );
+
+    expect(links).toHaveLength(1);
+    expect(links[0].targetSelectionRange?.start.line).toBe(2);
+  });
+
+  test('uses the registered definition provider to scan workspace step files', async () => {
+    registerGherkinProviders();
+
+    const provider = (vscode.languages.registerDefinitionProvider as jest.Mock).mock.calls[0][1];
+    (vscode.workspace.findFiles as jest.Mock)
+      .mockResolvedValueOnce([vscode.Uri.file('/project/features/step_definitions/login_steps.pm')])
+      .mockResolvedValue([]);
+    (vscode.workspace.openTextDocument as jest.Mock).mockResolvedValue({
+      uri: vscode.Uri.file('/project/features/step_definitions/login_steps.pm'),
+      getText: () => [
+        'use Test::BDD::Cucumber::StepFile;',
+        '',
+        'When qr/the user logs in with valid credentials/, sub {',
+        '};',
+      ].join('\n'),
+    });
+
+    const links = await provider.provideDefinition(
+      {
+        getText: () => [
+          'Feature: Login',
+          '  Scenario: Happy path',
+          '    When the user logs in with valid credentials',
+        ].join('\n'),
+      } as vscode.TextDocument,
+      { line: 2, character: 12 } as vscode.Position,
+      { isCancellationRequested: false } as vscode.CancellationToken
+    );
+
+    expect(vscode.workspace.findFiles).toHaveBeenCalled();
+    expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '/project/features/step_definitions/login_steps.pm' })
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0].targetUri.fsPath).toBe('/project/features/step_definitions/login_steps.pm');
   });
 });

--- a/vscode-extension/src/test/gherkinStepDefinitions.test.ts
+++ b/vscode-extension/src/test/gherkinStepDefinitions.test.ts
@@ -1,0 +1,121 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+  buildGeneratedStepPattern,
+  buildGeneratedStepStub,
+  buildStepDefinitionFileContent,
+  classifyStepDefinitionStatus,
+  parseGherkinStepLine,
+  registerGherkinStepDefinitionSupport,
+  scanStepDefinitions,
+  suggestStepDefinitionPath,
+} from '../gherkinStepDefinitions';
+
+describe('gherkin step definition support', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('registers code actions for gherkin documents', () => {
+    registerGherkinStepDefinitionSupport();
+
+    expect(vscode.languages.registerCodeActionsProvider).toHaveBeenCalledTimes(1);
+    expect((vscode.languages.registerCodeActionsProvider as jest.Mock).mock.calls[0][0]).toEqual([
+      { language: 'gherkin' },
+    ]);
+  });
+
+  test('parses Given/When/Then step lines and skips non-step lines', () => {
+    expect(parseGherkinStepLine('    Given a signed-in user', 4)).toEqual({
+      keyword: 'Given',
+      text: 'a signed-in user',
+      line: 4,
+      rawLine: '    Given a signed-in user',
+    });
+    expect(parseGherkinStepLine('Feature: Checkout', 0)).toBeNull();
+    expect(parseGherkinStepLine('    * a bullet step', 2)).toBeNull();
+  });
+
+  test('builds conservative generated regex patterns', () => {
+    expect(buildGeneratedStepPattern('a user exists with name "alice"')).toBe(
+      '^a user exists with name "([^"]+)"$'
+    );
+    expect(buildGeneratedStepPattern('I add <item> to the cart')).toBe(
+      '^I add (.+) to the cart$'
+    );
+    expect(buildGeneratedStepPattern('the total is 19.99')).toBe(
+      '^the total is 19\\.99$'
+    );
+  });
+
+  test('extracts slash-delimited step definitions and flags unsupported forms as ambiguous', () => {
+    const supported = scanStepDefinitions([
+      'use Test::BDD::Cucumber::StepFile;',
+      '',
+      'Given qr/^a user exists with name "([^"]+)"$/, sub {',
+      '    return;',
+      '};',
+    ].join('\n'));
+
+    expect(supported.ambiguous).toBe(false);
+    expect(supported.definitions).toEqual([
+      {
+        keyword: 'Given',
+        pattern: '^a user exists with name "([^"]+)"$',
+      },
+    ]);
+
+    const ambiguous = scanStepDefinitions('Then qr{^the total is \\d+$}, sub { return; };');
+    expect(ambiguous.ambiguous).toBe(true);
+    expect(ambiguous.definitions).toHaveLength(0);
+  });
+
+  test('classifies step status conservatively', () => {
+    const step = parseGherkinStepLine('Then the total should be "10"', 6);
+    expect(step).not.toBeNull();
+
+    expect(classifyStepDefinitionStatus(step!, [
+      'Then qr/^the total should be "([^"]+)"$/, sub { return; };',
+    ])).toBe('defined');
+
+    expect(classifyStepDefinitionStatus(step!, [
+      'Then qr{^the total should be "([^"]+)"$}, sub { return; };',
+    ])).toBe('ambiguous');
+
+    expect(classifyStepDefinitionStatus(step!, [
+      'Given qr/^some other step$/, sub { return; };',
+    ])).toBe('undefined');
+  });
+
+  test('suggests a deterministic feature-relative target file', () => {
+    expect(
+      suggestStepDefinitionPath(
+        path.join('/workspace', 'features', 'checkout.feature'),
+        '/workspace'
+      )
+    ).toBe(path.join('/workspace', 'features', 'step_definitions', 'checkout_steps.pm'));
+
+    expect(
+      suggestStepDefinitionPath(
+        path.join('/workspace', 'spec', 'features', 'login.feature'),
+        '/workspace'
+      )
+    ).toBe(path.join('/workspace', 'spec', 'features', 'step_definitions', 'login_steps.pm'));
+  });
+
+  test('builds new-file step definition content with boilerplate and TODO stub', () => {
+    const step = parseGherkinStepLine('When I add <item> to the cart', 8);
+    expect(step).not.toBeNull();
+
+    const stub = buildGeneratedStepStub(step!, 'features/checkout.feature');
+    expect(stub).toContain('# Auto-generated from features/checkout.feature:9');
+    expect(stub).toContain('When qr/^I add (.+) to the cart$/, sub {');
+    expect(stub).toContain('# TODO: implement step');
+
+    const content = buildStepDefinitionFileContent(step!, 'features/checkout.feature');
+    expect(content).toContain('use Test::BDD::Cucumber::StepFile;');
+    expect(content).toContain('use strict;');
+    expect(content).toContain('use warnings;');
+    expect(content).toContain('When qr/^I add (.+) to the cart$/, sub {');
+  });
+});


### PR DESCRIPTION
Adds the smallest shippable VS Code extension slice for Gherkin step tooling.

Scope:
- add step-definition navigation from `.feature` steps to Perl `Given`/`When`/`Then` definitions
- add a quick-fix / command path to generate step-definition stubs
- wire both providers into extension activation
- add focused unit coverage for matching, generation, and registration

Closes #3548.
Also addresses #3549.

Validation:
- `cd vscode-extension && npm run compile`
- `cd vscode-extension && npm test -- --runInBand src/test/gherkinProviders.test.ts src/test/gherkinStepDefinitions.test.ts`
- local pre-push gate: `nix develop -c just ci-gate`