### PR TITLE
feat(vscode): run test at cursor (#3534)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -74,6 +74,7 @@
     "onCommand:perl-lsp.runHealthCheck",
     "onCommand:perl-lsp.checkSyntax",
     "onCommand:perl-lsp.runCurrentTest",
+    "onCommand:perl-lsp.runTestAtCursor",
     "onCommand:perl-lsp.runAllTests",
     "onCommand:perl-lsp.formatDocument",
     "onCommand:perl-lsp.showIncPaths",
@@ -659,6 +660,12 @@
         "icon": "$(play)"
       },
       {
+        "command": "perl-lsp.runTestAtCursor",
+        "title": "Run Test at Cursor",
+        "category": "Perl",
+        "icon": "$(run)"
+      },
+      {
         "command": "perl-lsp.runAllTests",
         "title": "Run All Tests",
         "category": "Perl",
@@ -750,6 +757,10 @@
           "when": "editorLangId == perl"
         },
         {
+          "command": "perl-lsp.runTestAtCursor",
+          "when": "editorLangId == perl"
+        },
+        {
           "command": "perl-lsp.runAllTests",
           "when": "workspaceFolderCount >= 1"
         },
@@ -817,16 +828,21 @@
         }
       ],
       "editor/context": [
-        {
-          "command": "perl-lsp.runTests",
-          "when": "editorLangId == perl",
-          "group": "navigation"
-        },
-        {
-          "command": "perl-lsp.runPerlCritic",
-          "when": "editorLangId == perl",
-          "group": "navigation"
-        }
+      {
+        "command": "perl-lsp.runTests",
+        "when": "editorLangId == perl",
+        "group": "navigation"
+      },
+      {
+        "command": "perl-lsp.runTestAtCursor",
+        "when": "editorLangId == perl",
+        "group": "navigation"
+      },
+      {
+        "command": "perl-lsp.runPerlCritic",
+        "when": "editorLangId == perl",
+        "group": "navigation"
+      }
       ]
     },
     "keybindings": [
@@ -838,6 +854,11 @@
       {
         "command": "perl-lsp.runTests",
         "key": "shift+alt+t",
+        "when": "editorTextFocus && editorLangId == perl"
+      },
+      {
+        "command": "perl-lsp.runTestAtCursor",
+        "key": "ctrl+alt+shift+t",
         "when": "editorTextFocus && editorLangId == perl"
       },
       {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,7 @@ import { HealthWidget, ClientState } from './healthWidget';
 import { registerPodPreview } from './podPreview';
 import { registerGherkinProviders } from './gherkinProviders';
 import { registerGherkinStepDefinitionSupport } from './gherkinStepDefinitions';
+import { selectTestCommandAtPosition } from './runTestAtCursor';
 import { StreamingCompletionController } from './streamingCompletion';
 import {
     classifyStartupError,
@@ -511,6 +512,38 @@ export async function activate(context: vscode.ExtensionContext) {
         await runCurrentTestWithProve();
     });
 
+    const runTestAtCursorCommand = vscode.commands.registerCommand('perl-lsp.runTestAtCursor', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.languageId !== 'perl') {
+            vscode.window.showErrorMessage('Run Test at Cursor requires an active Perl file');
+            return;
+        }
+
+        if (editor.document.isDirty) {
+            await editor.document.save();
+        }
+
+        if (!client) {
+            vscode.window.showWarningMessage(serverNotRunningMessage());
+            return;
+        }
+
+        const lenses = await client.sendRequest<Array<{
+            range?: { start: { line: number; character: number }; end: { line: number; character: number } };
+            command?: { command: string; arguments?: unknown[] };
+        }> | null>('textDocument/codeLens', {
+            textDocument: { uri: editor.document.uri.toString() },
+        });
+
+        const command = selectTestCommandAtPosition(lenses ?? [], editor.selection.active);
+        if (!command) {
+            vscode.window.showWarningMessage('No runnable test was found at the cursor position');
+            return;
+        }
+
+        await vscode.commands.executeCommand(command.command, ...(command.arguments ?? []));
+    });
+
     const runAllTestsCommand = vscode.commands.registerCommand('perl-lsp.runAllTests', async () => {
         await runAllTestsWithProve();
     });
@@ -832,6 +865,7 @@ export async function activate(context: vscode.ExtensionContext) {
         setPerlCriticSeverityCommand,
         checkSyntaxCommand,
         runCurrentTestCommand,
+        runTestAtCursorCommand,
         runAllTestsCommand,
         formatDocumentCommand,
         showIncPathsCommand,

--- a/vscode-extension/src/runTestAtCursor.ts
+++ b/vscode-extension/src/runTestAtCursor.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+
+export type CursorTestCommand = {
+    command: string;
+    arguments?: unknown[];
+};
+
+type PositionLike = {
+    line: number;
+    character: number;
+};
+
+type RangeLike = {
+    start: PositionLike;
+    end: PositionLike;
+};
+
+type CodeLensLike = {
+    range?: RangeLike;
+    command?: CursorTestCommand;
+};
+
+const RUN_TEST_COMMANDS = new Set(['perl.runTest', 'perl.runSubtest', 'perl.runTestFile']);
+
+function positionBeforeOrEqual(left: PositionLike, right: PositionLike): boolean {
+    return left.line < right.line
+        || (left.line === right.line && left.character <= right.character);
+}
+
+function positionAfterOrEqual(left: PositionLike, right: PositionLike): boolean {
+    return left.line > right.line
+        || (left.line === right.line && left.character >= right.character);
+}
+
+function rangeContains(range: RangeLike, position: PositionLike): boolean {
+    return positionBeforeOrEqual(range.start, position) && positionAfterOrEqual(range.end, position);
+}
+
+function rangeSpan(range: RangeLike): number {
+    const lineSpan = Math.max(0, range.end.line - range.start.line);
+    const charSpan = Math.max(0, range.end.character - range.start.character);
+    return lineSpan * 10_000 + charSpan;
+}
+
+/**
+ * Pick the best test-related code lens that contains the cursor position.
+ */
+export function selectTestCommandAtPosition(
+    lenses: CodeLensLike[],
+    position: vscode.Position,
+): CursorTestCommand | undefined {
+    const cursor = { line: position.line, character: position.character };
+    const matches = lenses
+        .filter((lens): lens is CodeLensLike & { command: CursorTestCommand } => {
+            return !!lens.command
+                && !!lens.range
+                && RUN_TEST_COMMANDS.has(lens.command.command)
+                && rangeContains(lens.range, cursor);
+        })
+        .sort((left, right) => {
+            const leftPriority = left.command!.command === 'perl.runTest'
+                ? 0
+                : left.command!.command === 'perl.runSubtest'
+                    ? 1
+                    : 2;
+            const rightPriority = right.command!.command === 'perl.runTest'
+                ? 0
+                : right.command!.command === 'perl.runSubtest'
+                    ? 1
+                    : 2;
+            if (leftPriority !== rightPriority) {
+                return leftPriority - rightPriority;
+            }
+
+            return rangeSpan(left.range!) - rangeSpan(right.range!);
+        });
+
+    return matches[0]?.command;
+}

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -2,6 +2,7 @@
  * Contract tests for the command-palette feature set:
  *   - perl-lsp.checkSyntax
  *   - perl-lsp.runCurrentTest
+ *   - perl-lsp.runTestAtCursor
  *   - perl-lsp.runAllTests
  *   - perl-lsp.formatDocument
  *   - perl-lsp.runPerlCritic
@@ -37,6 +38,7 @@ function readPackageJson(): any {
 const NEW_COMMAND_IDS = [
   'perl-lsp.checkSyntax',
   'perl-lsp.runCurrentTest',
+  'perl-lsp.runTestAtCursor',
   'perl-lsp.runAllTests',
   'perl-lsp.formatDocument',
   'perl-lsp.runPerlCritic',
@@ -88,6 +90,11 @@ describe('perl-lsp command palette commands (issue #2058)', () => {
 
     test('runCurrentTest is guarded by editorLangId == perl', () => {
       const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.runCurrentTest');
+      expect(entry?.when).toContain('editorLangId == perl');
+    });
+
+    test('runTestAtCursor is guarded by editorLangId == perl', () => {
+      const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.runTestAtCursor');
       expect(entry?.when).toContain('editorLangId == perl');
     });
 
@@ -183,6 +190,50 @@ describe('perl-lsp.extractVariable command', () => {
     expect(kb.key.toLowerCase()).toBe('shift+alt+v');
     expect(kb.when).toContain('editorLangId == perl');
     expect(kb.when).toContain('editorHasSelection');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runTestAtCursor
+// ---------------------------------------------------------------------------
+describe('perl-lsp.runTestAtCursor command', () => {
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+  });
+
+  test('is declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map((c: any) => c.command);
+    expect(ids).toContain('perl-lsp.runTestAtCursor');
+  });
+
+  test('has title "Run Test at Cursor"', () => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === 'perl-lsp.runTestAtCursor');
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe('Run Test at Cursor');
+  });
+
+  test('has a command palette entry guarded by editorLangId == perl', () => {
+    const palette = pkg.contributes.menus.commandPalette;
+    const entry = palette.find((e: any) => e.command === 'perl-lsp.runTestAtCursor');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+  });
+
+  test('appears in the editor context menu', () => {
+    const contextMenu = pkg.contributes.menus['editor/context'];
+    const entry = contextMenu.find((e: any) => e.command === 'perl-lsp.runTestAtCursor');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+  });
+
+  test('has a keyboard shortcut', () => {
+    const keybindings: any[] = pkg.contributes.keybindings;
+    const kb = keybindings.find((k: any) => k.command === 'perl-lsp.runTestAtCursor');
+    expect(kb).toBeDefined();
+    expect(kb.key.toLowerCase()).toBe('ctrl+alt+shift+t');
+    expect(kb.when).toContain('editorLangId == perl');
   });
 });
 

--- a/vscode-extension/src/test/runTestAtCursor.test.ts
+++ b/vscode-extension/src/test/runTestAtCursor.test.ts
@@ -1,0 +1,106 @@
+import * as vscode from 'vscode';
+import { selectTestCommandAtPosition } from '../runTestAtCursor';
+
+describe('selectTestCommandAtPosition', () => {
+  test('prefers runTest lenses over broader matching lenses', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 30, character: 0 },
+          },
+          command: {
+            command: 'perl.runTestFile',
+            arguments: ['/tmp/example.t'],
+          },
+        },
+        {
+          range: {
+            start: { line: 8, character: 0 },
+            end: { line: 12, character: 0 },
+          },
+          command: {
+            command: 'perl.runTest',
+            arguments: ['file:///tmp/example.t::test_addition'],
+          },
+        },
+      ],
+      { line: 10, character: 2 } as vscode.Position,
+    );
+
+    expect(command?.command).toBe('perl.runTest');
+    expect(command?.arguments).toEqual(['file:///tmp/example.t::test_addition']);
+  });
+
+  test('returns a subtest command when that is the only matching runnable lens', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 3, character: 0 },
+            end: { line: 18, character: 0 },
+          },
+          command: {
+            command: 'perl.runSubtest',
+            arguments: ['basic math'],
+          },
+        },
+      ],
+      { line: 5, character: 8 } as vscode.Position,
+    );
+
+    expect(command?.command).toBe('perl.runSubtest');
+    expect(command?.arguments).toEqual(['basic math']);
+  });
+
+  test('falls back to a runTestFile lens when no narrower test lens exists', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 50, character: 0 },
+          },
+          command: {
+            command: 'perl.runTestFile',
+            arguments: ['/tmp/example.t'],
+          },
+        },
+        {
+          range: {
+            start: { line: 1, character: 0 },
+            end: { line: 3, character: 0 },
+          },
+          command: {
+            command: 'perl.debugTest',
+            arguments: ['file:///tmp/example.t::test_addition'],
+          },
+        },
+      ],
+      { line: 25, character: 0 } as vscode.Position,
+    );
+
+    expect(command?.command).toBe('perl.runTestFile');
+  });
+
+  test('returns undefined when no runnable lens contains the cursor', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 5, character: 0 },
+          },
+          command: {
+            command: 'perl.debugTest',
+            arguments: ['file:///tmp/example.t::test_addition'],
+          },
+        },
+      ],
+      { line: 9, character: 0 } as vscode.Position,
+    );
+
+    expect(command).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a smallest-shippable Run Test at Cursor command in the VS Code extension.

What it does:
- adds `perl-lsp.runTestAtCursor` to the command palette and editor context menu
- resolves the active cursor position against existing code lenses
- prefers runnable test lenses in this order: test subroutine, subtest, then file-level run test
- reuses the existing backend/test-command plumbing instead of introducing new protocol surface

Validation:
- `npm test -- --runInBand src/test/commands.test.ts src/test/runTestAtCursor.test.ts`
- `npm run compile`

Remaining gaps:
- assertion-level cursor execution is not implemented
- subtest execution still depends on the existing backend stub for `perl.runSubtest`
