### PR TITLE
fix(dap-types): derive basename from Windows-style source paths (#4027)

### DIFF
--- a/crates/perl-dap-types/src/lib.rs
+++ b/crates/perl-dap-types/src/lib.rs
@@ -51,10 +51,15 @@ impl Source {
     #[must_use]
     pub fn new(path: impl Into<String>) -> Self {
         let path = path.into();
-        let name = std::path::Path::new(&path)
+        let path_name = std::path::Path::new(&path)
             .file_name()
             .and_then(|name| name.to_str())
             .map(ToOwned::to_owned);
+        let name = if path_name.as_deref() == Some(path.as_str()) && path.contains('\\') {
+            path.rsplit('\\').find(|segment| !segment.is_empty()).map(ToOwned::to_owned)
+        } else {
+            path_name
+        };
 
         Self { name, path, source_reference: None }
     }


### PR DESCRIPTION
### Motivation
- `perl-dap-types::Source::new()` derives the wrong `name` for Windows-style paths when tests run on Unix hosts.
- The existing `source_with_windows_path` regression test fails on current `master` and was uncovered while reviewing the `#3237` duplicate PR set.

### Description
- Preserve the existing `Path::file_name()` behavior for native paths.
- Add a narrow fallback for backslash-separated paths when `file_name()` returns the entire input string.
- This keeps Unix paths unchanged while deriving `Module.pm` correctly from `C:\Users\dev\project\lib\Module.pm`.

### Testing
- `cargo test -p perl-dap-types`
