### PR TITLE
feat(execute-command): prefer yath for test files (#3533)

### DIFF
--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -8,6 +8,13 @@ pub struct ExecuteCommandProvider {
     workspace_roots: Vec<PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TestRunner {
+    Yath,
+    Prove,
+    Perl,
+}
+
 impl Default for ExecuteCommandProvider {
     fn default() -> Self {
         Self::new()
@@ -76,43 +83,98 @@ impl ExecuteCommandProvider {
     pub(crate) fn run_tests(&self, file_path: &Path) -> Result<Value, String> {
         let file_path_str = file_path.to_string_lossy();
         let is_test_file = self.is_test_file(&file_path_str);
-        if is_test_file && self.command_exists("prove") {
-            let mut prove_cmd = Command::new("prove");
-            prove_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
-            match crate::util::run_command_with_timeout(prove_cmd, 30) {
-                Ok(result) => {
-                    return Ok(
-                        self.format_command_result(result, Some(("command", "prove".into())))
-                    );
-                }
-                Err(error) => {
-                    let mut perl_cmd = Command::new("perl");
-                    perl_cmd.arg("--").arg(file_path.as_os_str());
-                    match crate::util::run_command_with_timeout(perl_cmd, 30) {
-                        Ok(result) => {
-                            return Ok(self
-                                .format_command_result(result, Some(("command", "perl".into()))));
-                        }
-                        Err(fallback_error) => {
-                            return Ok(self.format_command_launch_failure(
-                                "prove",
-                                format!(
-                                    "Failed to run prove: {error}; perl fallback also failed: {fallback_error}"
-                                ),
-                            ));
+        let runner = select_test_runner(
+            is_test_file,
+            self.command_exists("yath"),
+            self.command_exists("prove"),
+        );
+
+        match runner {
+            TestRunner::Yath => {
+                let mut yath_cmd = Command::new("yath");
+                yath_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                match crate::util::run_command_with_timeout(yath_cmd, 30) {
+                    Ok(result) => {
+                        Ok(self.format_command_result(result, Some(("command", "yath".into()))))
+                    }
+                    Err(error) => {
+                        if self.command_exists("prove") {
+                            let mut prove_cmd = Command::new("prove");
+                            prove_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                            match crate::util::run_command_with_timeout(prove_cmd, 30) {
+                                Ok(result) => Ok(self.format_command_result(
+                                    result,
+                                    Some(("command", "prove".into())),
+                                )),
+                                Err(fallback_error) => {
+                                    let mut perl_cmd = Command::new("perl");
+                                    perl_cmd.arg("--").arg(file_path.as_os_str());
+                                    match crate::util::run_command_with_timeout(perl_cmd, 30) {
+                                        Ok(result) => Ok(self.format_command_result(
+                                            result,
+                                            Some(("command", "perl".into())),
+                                        )),
+                                        Err(perl_error) => Ok(self.format_command_launch_failure(
+                                            "yath",
+                                            format!(
+                                                "Failed to run yath: {error}; prove fallback also failed: {fallback_error}; perl fallback also failed: {perl_error}"
+                                            ),
+                                        )),
+                                    }
+                                }
+                            }
+                        } else {
+                            let mut perl_cmd = Command::new("perl");
+                            perl_cmd.arg("--").arg(file_path.as_os_str());
+                            match crate::util::run_command_with_timeout(perl_cmd, 30) {
+                                Ok(result) => Ok(self
+                                    .format_command_result(result, Some(("command", "perl".into())))),
+                                Err(perl_error) => Ok(self.format_command_launch_failure(
+                                    "yath",
+                                    format!(
+                                        "Failed to run yath: {error}; perl fallback also failed: {perl_error}"
+                                    ),
+                                )),
+                            }
                         }
                     }
                 }
             }
-        }
-
-        let mut perl_cmd = Command::new("perl");
-        perl_cmd.arg("--").arg(file_path.as_os_str());
-        match crate::util::run_command_with_timeout(perl_cmd, 30) {
-            Ok(result) => Ok(self.format_command_result(result, Some(("command", "perl".into())))),
-            Err(error) => {
-                Ok(self
-                    .format_command_launch_failure("perl", format!("Failed to run perl: {error}")))
+            TestRunner::Prove => {
+                let mut prove_cmd = Command::new("prove");
+                prove_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                match crate::util::run_command_with_timeout(prove_cmd, 30) {
+                    Ok(result) => {
+                        Ok(self.format_command_result(result, Some(("command", "prove".into()))))
+                    }
+                    Err(error) => {
+                        let mut perl_cmd = Command::new("perl");
+                        perl_cmd.arg("--").arg(file_path.as_os_str());
+                        match crate::util::run_command_with_timeout(perl_cmd, 30) {
+                            Ok(result) => Ok(self
+                                .format_command_result(result, Some(("command", "perl".into())))),
+                            Err(fallback_error) => Ok(self.format_command_launch_failure(
+                                "prove",
+                                format!(
+                                    "Failed to run prove: {error}; perl fallback also failed: {fallback_error}"
+                                ),
+                            )),
+                        }
+                    }
+                }
+            }
+            TestRunner::Perl => {
+                let mut perl_cmd = Command::new("perl");
+                perl_cmd.arg("--").arg(file_path.as_os_str());
+                match crate::util::run_command_with_timeout(perl_cmd, 30) {
+                    Ok(result) => {
+                        Ok(self.format_command_result(result, Some(("command", "perl".into()))))
+                    }
+                    Err(error) => Ok(self.format_command_launch_failure(
+                        "perl",
+                        format!("Failed to run perl: {error}"),
+                    )),
+                }
             }
         }
     }
@@ -795,6 +857,22 @@ impl ExecuteCommandProvider {
         crate::util::run_command_with_timeout(cmd, 2)
             .map(|output| output.status.success())
             .unwrap_or(false)
+    }
+}
+
+pub(crate) fn select_test_runner(
+    is_test_file: bool,
+    yath_available: bool,
+    prove_available: bool,
+) -> TestRunner {
+    if !is_test_file {
+        TestRunner::Perl
+    } else if yath_available {
+        TestRunner::Yath
+    } else if prove_available {
+        TestRunner::Prove
+    } else {
+        TestRunner::Perl
     }
 }
 

--- a/crates/perl-lsp/src/execute_command/tests.rs
+++ b/crates/perl-lsp/src/execute_command/tests.rs
@@ -1,5 +1,5 @@
 use super::get_supported_commands;
-use super::provider::ExecuteCommandProvider;
+use super::provider::{ExecuteCommandProvider, TestRunner, select_test_runner};
 use super::test_support::mock_status;
 use serde_json::Value;
 use std::fs;
@@ -886,6 +886,39 @@ fn test_run_tests_logic_operators() -> Result<(), Box<dyn std::error::Error>> {
     assert!(result_value["output"].is_string(), "Should have string output");
 
     Ok(())
+}
+
+#[test]
+fn test_select_test_runner_prefers_yath_for_test_files() {
+    assert_eq!(
+        select_test_runner(true, true, true),
+        TestRunner::Yath,
+        "yath should win for test files when available"
+    );
+    assert_eq!(
+        select_test_runner(true, true, false),
+        TestRunner::Yath,
+        "yath should still win when prove is unavailable"
+    );
+}
+
+#[test]
+fn test_select_test_runner_falls_back_to_prove_then_perl() {
+    assert_eq!(
+        select_test_runner(true, false, true),
+        TestRunner::Prove,
+        "prove should be used when yath is unavailable"
+    );
+    assert_eq!(
+        select_test_runner(true, false, false),
+        TestRunner::Perl,
+        "perl fallback should be used when no test runner is available"
+    );
+    assert_eq!(
+        select_test_runner(false, true, true),
+        TestRunner::Perl,
+        "non-test files should always use perl"
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Issue #3533 calls out the current basic prove/perl fallback as the only test runner path.
- yath is a better default when it is available for test files.

### Description
- Prefer yath for test files when it is present on PATH.
- Keep the existing prove and perl fallbacks intact.
- Add unit tests for the runner-selection logic so the preference order is pinned without depending on local tool availability.

### Testing
- cargo test -p perl-lsp-rs --lib test_select_test_runner_prefers_yath_for_test_files -- --nocapture
- cargo test -p perl-lsp-rs --lib test_run_tests_logic_operators -- --nocapture
