### PR TITLE
test(lexer): replace panic catch arms in interpolation tests (#3258)

### DIFF
--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -704,24 +704,30 @@ fn interpolated_string_preserves_complex_tails() -> R {
 
     for (input, expected_parts) in cases {
         let tok = first_token(input).ok_or_else(|| format!("no token for {input:?}"))?;
-        match tok.token_type {
-            TokenType::InterpolatedString(parts) => assert_eq!(parts, expected_parts),
-            other => panic!("expected interpolated string token for {input:?}, got {other:?}"),
-        }
+        assert!(
+            matches!(
+                &tok.token_type,
+                TokenType::InterpolatedString(parts) if parts == &expected_parts
+            ),
+            "expected interpolated string token for {input:?}, got {:?}",
+            tok.token_type
+        );
     }
 
     let simple = first_token(r#""hello $x world""#).ok_or("no token")?;
-    match simple.token_type {
-        TokenType::InterpolatedString(parts) => assert_eq!(
-            parts,
-            vec![
-                StringPart::Literal(Arc::from("hello ")),
-                StringPart::Variable(Arc::from("$x")),
-                StringPart::Literal(Arc::from(" world")),
-            ]
+    assert!(
+        matches!(
+            &simple.token_type,
+            TokenType::InterpolatedString(parts) if parts
+                == &vec![
+                    StringPart::Literal(Arc::from("hello ")),
+                    StringPart::Variable(Arc::from("$x")),
+                    StringPart::Literal(Arc::from(" world")),
+                ]
         ),
-        other => panic!("expected interpolated string token, got {other:?}"),
-    }
+        "expected interpolated string token, got {:?}",
+        simple.token_type
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- `#3258` is a multi-crate cleanup, so this keeps to a single low-risk lexer slice.
- The interpolation tests in `perl-lexer` still used `match ... { ..., other => panic!(...) }` catch arms.

### Description
- Replace the panic catch arms in `crates/perl-lexer/tests/comprehensive_unit_tests.rs` with `assert!(matches!(...))` assertions.
- Keep the change scoped to the interpolation-token tests in one file.
- Like `#4030`, this uses stable `matches!` instead of `std::assert_matches`, which is still unstable on this toolchain.

### Testing
- `cargo test -p perl-lexer interpolated_string_preserves_complex_tails -- --nocapture`
- `cargo test -p perl-lexer`
