### PR TITLE
fix(xtask): repair feature audit verification (#3284)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,6 +4806,7 @@ dependencies = [
  "notify",
  "peak_alloc",
  "perl-feature-catalog",
+ "perl-lsp-feature-governance",
  "perl-parser",
  "perl-parser-pest",
  "perl-tdd-support",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json.workspace = true
 anyhow.workspace = true
 perl-feature-catalog = { workspace = true }
+perl-lsp-feature-governance = { workspace = true }
 indicatif = "0.18.4"
 console = "0.16.2"
 chrono = { version = "0.4.43", features = ["serde"] }

--- a/xtask/src/tasks/features.rs
+++ b/xtask/src/tasks/features.rs
@@ -1,9 +1,10 @@
 use color_eyre::eyre::{Context, Result, bail, eyre};
 use perl_feature_catalog::{Catalog, Maturity};
+use perl_lsp_feature_governance::{FeatureProfile, catalog_advertised_feature_ids};
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // Public API functions called from main.rs
 pub fn sync_docs() -> Result<()> {
@@ -27,6 +28,39 @@ fn load_features() -> Result<Catalog> {
     let (catalog, _) = perl_feature_catalog::load_catalog_for_build(&manifest_dir)
         .context("Failed to load features catalog from features.toml")?;
     Ok(catalog)
+}
+
+fn repo_relative_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    if path.is_absolute() { path.to_path_buf() } else { PathBuf::from(path) }
+}
+
+fn lsp_feature_snapshot_path() -> PathBuf {
+    repo_relative_path(
+        "crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap",
+    )
+}
+
+fn snapshot_comparable_feature_ids() -> BTreeSet<String> {
+    let mut ids: BTreeSet<String> =
+        catalog_advertised_feature_ids(FeatureProfile::All).into_iter().map(String::from).collect();
+
+    // The capability snapshot intentionally excludes formatting because
+    // initialize capabilities depend on runtime perltidy availability.
+    ids.remove("lsp.formatting");
+    ids.remove("lsp.range_formatting");
+    ids.remove("lsp.ranges_formatting");
+
+    // These features are advertised and tested, but they do not currently round-trip
+    // through the typed `ServerCapabilities` snapshot used here:
+    // - `lsp.type_hierarchy` is injected as a raw top-level JSON field because
+    //   `lsp-types` 0.97 lacks the field.
+    // - `lsp.inline_completion` is served via proposed/experimental plumbing rather
+    //   than a stable `ServerCapabilities` field in this stack.
+    ids.remove("lsp.type_hierarchy");
+    ids.remove("lsp.inline_completion");
+
+    ids
 }
 
 fn check_invariants() -> Result<()> {
@@ -239,7 +273,12 @@ fn snapshot_caps_from_content(content: &str) -> Result<Option<BTreeSet<String>>>
         return Ok(None);
     };
 
-    let yaml_content = &content[yaml_start + 4..];
+    let after_first_doc = &content[yaml_start + 4..];
+    let yaml_content = if let Some(second_doc_start) = after_first_doc.find("\n---\n") {
+        &after_first_doc[second_doc_start + 5..]
+    } else {
+        after_first_doc
+    };
     let yaml: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml_content)?;
     let caps = yaml.get("caps").and_then(|value| value.as_sequence()).map(|caps| {
         caps.iter().filter_map(|value| value.as_str().map(String::from)).collect::<BTreeSet<_>>()
@@ -295,11 +334,10 @@ fn verify_features() -> Result<()> {
     }
 
     // Check that advertised features have at least one backing test file.
-    let test_dir = Path::new("crates/perl-parser/tests");
     for feature in catalog.features() {
         if feature.advertised && !feature.tests.is_empty() {
             for test in &feature.tests {
-                let test_file = test_dir.join(test);
+                let test_file = repo_relative_path(test);
                 if !test_file.exists() {
                     warnings.push(format!("Test file not found for {}: {}", feature.id, test));
                 }
@@ -308,14 +346,12 @@ fn verify_features() -> Result<()> {
     }
 
     // Check advertised feature IDs against the LSP snapshot.
-    let snapshot_path =
-        test_dir.join("snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap");
+    let snapshot_path = lsp_feature_snapshot_path();
     if snapshot_path.exists() {
         match fs::read_to_string(&snapshot_path) {
             Ok(content) => match snapshot_caps_from_content(&content) {
                 Ok(Some(snapshot_caps)) => {
-                    let catalog_advertised: BTreeSet<String> =
-                        catalog.advertised_feature_ids().into_iter().map(String::from).collect();
+                    let catalog_advertised = snapshot_comparable_feature_ids();
                     let (snapshot_warnings, snapshot_errors) =
                         compare_snapshot_caps(&catalog_advertised, &snapshot_caps);
 
@@ -335,7 +371,7 @@ fn verify_features() -> Result<()> {
         }
     } else {
         warnings.push(
-            "Snapshot file not found - run 'cargo test -p perl-parser --test lsp_features_snapshot_test' to generate"
+            "Snapshot file not found - run 'cargo test -p perl-lsp --test lsp_features_snapshot_test' to generate"
                 .to_string(),
         );
     }
@@ -443,10 +479,14 @@ fn generate_report() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{compare_snapshot_caps, ensure_fence, replace_fence, snapshot_caps_from_content};
+    use super::{
+        compare_snapshot_caps, ensure_fence, lsp_feature_snapshot_path, replace_fence,
+        repo_relative_path, snapshot_caps_from_content, snapshot_comparable_feature_ids,
+    };
     use color_eyre::eyre::Result;
     use perl_tdd_support::must_err;
     use std::collections::BTreeSet;
+    use std::path::PathBuf;
 
     #[test]
     fn snapshot_caps_from_content_extracts_caps_array() -> Result<()> {
@@ -468,9 +508,56 @@ mod tests {
     }
 
     #[test]
+    fn repo_relative_path_keeps_catalog_test_paths_rooted_at_repo() {
+        let path = repo_relative_path("crates/perl-lsp/tests/lsp_completion_tests.rs");
+        assert_eq!(path, PathBuf::from("crates/perl-lsp/tests/lsp_completion_tests.rs"));
+    }
+
+    #[test]
+    fn lsp_feature_snapshot_path_points_to_lsp_snapshot() {
+        assert_eq!(
+            lsp_feature_snapshot_path(),
+            PathBuf::from(
+                "crates/perl-lsp/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap"
+            )
+        );
+    }
+
+    #[test]
+    fn snapshot_comparable_feature_ids_excludes_non_capability_rows() {
+        let ids = snapshot_comparable_feature_ids();
+        assert!(!ids.contains("dap.core"));
+        assert!(!ids.contains("lsp.workspace_symbol_resolve"));
+        assert!(!ids.contains("lsp.code_lens_refresh"));
+        assert!(!ids.contains("lsp.formatting"));
+        assert!(!ids.contains("lsp.type_hierarchy"));
+        assert!(!ids.contains("lsp.inline_completion"));
+        assert!(ids.contains("lsp.completion"));
+    }
+
+    #[test]
     fn snapshot_caps_from_content_returns_none_without_caps_key() -> Result<()> {
         let content = "header\n---\nprofiles:\n  - all\n";
         assert_eq!(snapshot_caps_from_content(content)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn snapshot_caps_from_content_handles_insta_two_doc_snapshot() -> Result<()> {
+        let content = "\
+---\n\
+source: crates/perl-lsp/tests/lsp_features_snapshot_test.rs\n\
+expression: \"&snapshot_data\"\n\
+---\n\
+caps:\n\
+  - lsp.hover\n\
+  - lsp.definition\n";
+
+        let caps = snapshot_caps_from_content(content)?;
+        assert_eq!(
+            caps,
+            Some(BTreeSet::from(["lsp.definition".to_string(), "lsp.hover".to_string()]))
+        );
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- `cargo run -p xtask -- features verify` was not actually validating the feature catalog correctly.
- It checked `features.toml` test paths under the wrong crate, pointed to the wrong snapshot path, and could not parse the two-document Insta snapshot format.
- Once those false negatives were removed, the verifier also needed to compare against the capability-backed advertised subset that the snapshot can truthfully validate.

### Description
- resolve catalog test paths from repo root instead of `crates/perl-parser/tests`
- read the advertised-vs-caps snapshot from `crates/perl-lsp/tests/snapshots/...`
- parse Insta two-document snapshots correctly
- compare snapshot capabilities against the capability-backed advertised LSP subset used by this audit path
- add focused unit coverage for the new helpers

### Testing
- `cargo test -p xtask features`
- `cargo run -p xtask -- features verify`
