### PR TITLE
test(lexer): replace panic catch arms in interpolation tests (#3258)

### DIFF
--- a/crates/perl-lexer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-lexer/tests/comprehensive_unit_tests.rs
@@ -704,24 +704,30 @@ fn interpolated_string_preserves_complex_tails() -> R {
 
     for (input, expected_parts) in cases {
         let tok = first_token(input).ok_or_else(|| format!("no token for {input:?}"))?;
-        match tok.token_type {
-            TokenType::InterpolatedString(parts) => assert_eq!(parts, expected_parts),
-            other => panic!("expected interpolated string token for {input:?}, got {other:?}"),
-        }
+        assert!(
+            matches!(
+                &tok.token_type,
+                TokenType::InterpolatedString(parts) if parts == &expected_parts
+            ),
+            "expected interpolated string token for {input:?}, got {:?}",
+            tok.token_type
+        );
     }
 
     let simple = first_token(r#""hello $x world""#).ok_or("no token")?;
-    match simple.token_type {
-        TokenType::InterpolatedString(parts) => assert_eq!(
-            parts,
-            vec![
-                StringPart::Literal(Arc::from("hello ")),
-                StringPart::Variable(Arc::from("$x")),
-                StringPart::Literal(Arc::from(" world")),
-            ]
+    assert!(
+        matches!(
+            &simple.token_type,
+            TokenType::InterpolatedString(parts) if parts
+                == &vec![
+                    StringPart::Literal(Arc::from("hello ")),
+                    StringPart::Variable(Arc::from("$x")),
+                    StringPart::Literal(Arc::from(" world")),
+                ]
         ),
-        other => panic!("expected interpolated string token, got {other:?}"),
-    }
+        "expected interpolated string token, got {:?}",
+        simple.token_type
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Issue #3258 is a broad test-quality campaign; this PR takes a narrow, low-risk first slice in `perl-lexer`.
- Two interpolation tests used panic-based catch arms to report unexpected token variants.

### Description
- Replace the panic-based match catch arms with `assert!(matches!(...))` guards.
- Keep the same failure context while removing ad hoc catch-arm panics.
- Limit the change to the two `InterpolatedString` assertions in `comprehensive_unit_tests.rs`.

### Testing
- `cargo test -p perl-lexer interpolated_string_preserves_complex_tails -- --nocapture`
- `cargo test -p perl-lexer`
