### PR TITLE
test(quality): burn down match-arm panic asserts (#3258)

### DIFF
--- a/crates/perl-error/tests/extended_unit_tests.rs
+++ b/crates/perl-error/tests/extended_unit_tests.rs
@@ -982,12 +982,11 @@ fn from_regex_error_creates_syntax_error() {
     let regex_err =
         perl_regex::RegexError::Syntax { message: "unterminated group".into(), offset: 5 };
     let parse_err: ParseError = regex_err.into();
-    if let ParseError::SyntaxError { message, location } = &parse_err {
-        assert!(message.contains("unterminated group"), "got: {message}");
-        assert_eq!(*location, 5);
-    } else {
-        panic!("Expected SyntaxError, got: {parse_err:?}");
-    }
+    assert!(matches!(
+        parse_err,
+        ParseError::SyntaxError { ref message, location }
+            if message.contains("unterminated group") && location == 5
+    ));
 }
 
 #[test]

--- a/crates/perl-lsp-feature-contracts/tests/extended_unit_tests.rs
+++ b/crates/perl-lsp-feature-contracts/tests/extended_unit_tests.rs
@@ -349,7 +349,10 @@ fn bdd_feature_rows_are_correctly_sorted() {
                 );
             }
             std::cmp::Ordering::Greater => {
-                panic!("Areas not sorted: {current:?} vs {next:?}");
+                assert!(
+                    !matches!(area_cmp, std::cmp::Ordering::Greater),
+                    "Areas not sorted: {current:?} vs {next:?}"
+                );
             }
         }
     }

--- a/crates/perl-lsp-protocol/tests/protocol_unit_tests.rs
+++ b/crates/perl-lsp-protocol/tests/protocol_unit_tests.rs
@@ -509,10 +509,7 @@ fn enhanced_error_has_correct_code() {
 #[test]
 fn req_uri_with_file_scheme() {
     let params = json!({"textDocument": {"uri": "file:///home/user/test.pl"}});
-    match req_uri(&params) {
-        Ok(uri) => assert_eq!(uri, "file:///home/user/test.pl"),
-        Err(e) => panic!("Expected Ok, got Err: {}", e),
-    }
+    assert!(matches!(req_uri(&params), Ok("file:///home/user/test.pl")));
 }
 
 #[test]
@@ -575,13 +572,7 @@ fn req_uri_empty_params() {
 #[test]
 fn req_position_typical_values() {
     let params = json!({"position": {"line": 10, "character": 25}});
-    match req_position(&params) {
-        Ok((line, character)) => {
-            assert_eq!(line, 10);
-            assert_eq!(character, 25);
-        }
-        Err(e) => panic!("Expected Ok, got Err: {}", e),
-    }
+    assert!(matches!(req_position(&params), Ok((10, 25))));
 }
 
 #[test]
@@ -645,13 +636,7 @@ fn req_range_typical_values() {
             "end": {"line": 5, "character": 20}
         }
     });
-    match req_range(&params) {
-        Ok(((sl, sc), (el, ec))) => {
-            assert_eq!((sl, sc), (5, 10));
-            assert_eq!((el, ec), (5, 20));
-        }
-        Err(e) => panic!("Expected Ok, got Err: {}", e),
-    }
+    assert!(matches!(req_range(&params), Ok(((5, 10), (5, 20)))));
 }
 
 #[test]
@@ -662,13 +647,7 @@ fn req_range_single_point_range() {
             "end": {"line": 0, "character": 0}
         }
     });
-    match req_range(&params) {
-        Ok(((sl, sc), (el, ec))) => {
-            assert_eq!((sl, sc), (0, 0));
-            assert_eq!((el, ec), (0, 0));
-        }
-        Err(e) => panic!("Expected Ok, got Err: {}", e),
-    }
+    assert!(matches!(req_range(&params), Ok(((0, 0), (0, 0)))));
 }
 
 #[test]
@@ -728,15 +707,7 @@ fn req_range_max_u32_values() {
             "end": {"line": max, "character": max}
         }
     });
-    match req_range(&params) {
-        Ok(((sl, sc), (el, ec))) => {
-            assert_eq!(sl, u32::MAX);
-            assert_eq!(sc, u32::MAX);
-            assert_eq!(el, u32::MAX);
-            assert_eq!(ec, u32::MAX);
-        }
-        Err(e) => panic!("Expected Ok, got Err: {}", e),
-    }
+    assert!(matches!(req_range(&params), Ok(((u32::MAX, u32::MAX), (u32::MAX, u32::MAX)))));
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation
- `#3258` is a large multi-crate burn-down, but it already has several tiny, low-risk test-only replacements that can land independently.
- This slice removes panic-based match catches in three crates without changing runtime code.

### Description
- replace `panic!`-style success-arm fallbacks with direct `matches!` assertions in `perl-lsp-protocol`
- replace a panic-based enum shape check with a `matches!` assertion in `perl-error`
- replace a panic branch in BDD row ordering checks with a direct assertion in `perl-lsp-feature-contracts`

### Testing
- `cargo test -p perl-lsp-protocol --test protocol_unit_tests`
- `cargo test -p perl-error --test extended_unit_tests from_regex_error_creates_syntax_error`
- `cargo test -p perl-lsp-feature-contracts --test extended_unit_tests bdd_feature_rows_are_correctly_sorted`
