### PR TITLE
fix(incremental-parsing): preserve prefix correctness at checkpoint boundaries (#3527)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -478,6 +478,12 @@ impl CheckpointedIncrementalParser {
     /// set of **parser** tokens (trivia-filtered) so they can be reused during
     /// subsequent incremental reparses.
     fn parse_with_checkpoints(&mut self) -> ParseResult<Node> {
+        // A full reparse must rebuild both caches from the current source
+        // state; carrying forward shifted checkpoints from a prior incremental
+        // edit can poison later checkpoint selection.
+        self.checkpoint_cache.clear();
+        self.token_cache = TokenCache::new();
+
         let mut lexer = PerlLexer::new(&self.source);
         let mut raw_tokens = Vec::new();
         let mut checkpoint_positions = vec![0, 100, 500, 1000, 5000];
@@ -611,6 +617,7 @@ impl CheckpointedIncrementalParser {
         }
 
         if let Some(cached) = cached_before {
+            self.stats.cache_hits += 1;
             let reused_count = cached.len();
             parser_tokens.extend(cached);
             self.stats.tokens_reused += reused_count;
@@ -793,5 +800,33 @@ mod tests {
             "expected either reused or relexed tokens, got {:?}",
             stats
         );
+    }
+
+    #[test]
+    fn test_full_fallback_rebuilds_checkpoint_cache() {
+        let source = "my $value = 1;\n".repeat(80);
+        let edit = SimpleEdit { start: 125, end: 126, new_text: "999".to_string() };
+
+        let mut edited_source = source.clone();
+        edited_source.replace_range(edit.start..edit.end, &edit.new_text);
+
+        let mut incremental = CheckpointedIncrementalParser::new();
+        must(incremental.parse(source));
+        must(incremental.apply_edit(&edit));
+
+        let mut full = CheckpointedIncrementalParser::new();
+        must(full.parse(edited_source.clone()));
+
+        for query in (0..=edited_source.len()).step_by(17) {
+            let incremental_before =
+                incremental.checkpoint_cache.find_before(query).map(|cp| cp.position);
+            let full_before = full.checkpoint_cache.find_before(query).map(|cp| cp.position);
+            assert_eq!(incremental_before, full_before, "mismatched left checkpoint at {query}");
+
+            let incremental_after =
+                incremental.checkpoint_cache.find_after(query).map(|cp| cp.position);
+            let full_after = full.checkpoint_cache.find_after(query).map(|cp| cp.position);
+            assert_eq!(incremental_after, full_after, "mismatched right checkpoint at {query}");
+        }
     }
 }

--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -597,7 +597,20 @@ impl CheckpointedIncrementalParser {
         // --- Phase 1: reuse cached tokens before the left checkpoint ---
         let segments_before = self.token_cache.get_segments_before(relex_start);
         self.stats.segments_reused_before += segments_before.len();
-        if let Some(cached) = self.token_cache.get_tokens_before(relex_start) {
+        let cached_before = self.token_cache.get_tokens_before(relex_start);
+
+        // The cache is still populated as a single whole-file segment. After an
+        // interior edit, invalidation can remove that entire segment and leave us
+        // with no prefix tokens for a nonzero checkpoint window. In that state,
+        // feeding a suffix-only token stream into `Parser::from_tokens` would
+        // drop the unchanged prefix, so preserve correctness by falling back to a
+        // full reparse until the cache becomes genuinely segment-granular.
+        if relex_start > 0 && cached_before.is_none() {
+            self.stats.cache_misses += 1;
+            return self.parse_with_checkpoints();
+        }
+
+        if let Some(cached) = cached_before {
             let reused_count = cached.len();
             parser_tokens.extend(cached);
             self.stats.tokens_reused += reused_count;

--- a/crates/perl-incremental-parsing/tests/segment_cache_checkpoint_window_tests.rs
+++ b/crates/perl-incremental-parsing/tests/segment_cache_checkpoint_window_tests.rs
@@ -189,6 +189,31 @@ fn test_source_length_decrease_correctness() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+/// Test that an interior edit past the first checkpoint still matches a full parse.
+#[test]
+fn test_interior_edit_past_checkpoint_matches_full_parse() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = "my $value = 1;\n".repeat(20);
+    let edit = SimpleEdit { start: 125, end: 126, new_text: "9".to_string() };
+
+    let mut expected_source = source.clone();
+    expected_source.replace_range(edit.start..edit.end, &edit.new_text);
+
+    let mut incremental_parser = CheckpointedIncrementalParser::new();
+    incremental_parser.parse(source)?;
+    let incremental_tree = incremental_parser.apply_edit(&edit)?;
+
+    let mut full_parser = CheckpointedIncrementalParser::new();
+    let full_tree = full_parser.parse(expected_source)?;
+
+    assert_eq!(
+        format!("{:?}", incremental_tree),
+        format!("{:?}", full_tree),
+        "incremental parse should match a full parse for edits past the first checkpoint"
+    );
+    Ok(())
+}
+
 // =========================================================================
 // 2. Reuse Behavior Tests
 // =========================================================================


### PR DESCRIPTION
## Summary
- fall back to a full reparse when a nonzero checkpoint window has no cached prefix tokens
- document why the current cache layout cannot safely feed a suffix-only stream into `Parser::from_tokens`
- add a regression that compares incremental vs full parse for an edit past the first checkpoint boundary

## Validation
- `cargo fmt --all`
- `cargo test -p perl-incremental-parsing --test segment_cache_checkpoint_window_tests checkpoint_matches_full_parse -- --nocapture`
- `cargo test -p perl-incremental-parsing --test segment_cache_checkpoint_window_tests repeated_edits_large_file -- --nocapture`
- `cargo test -p perl-incremental-parsing --test segment_cache_checkpoint_window_tests`

## Notes
- This is a correctness follow-up to the merged checkpoint-window work. It keeps the implementation narrow: until the cache is truly segment-granular, interior edits that invalidate the only cached segment must fall back to a full parse instead of assembling a suffix-only token stream.