### PR TITLE
docs(marketplace): scope metric framing in VSCode listing (#4045)

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -7,7 +7,7 @@
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 
-> **0.12.3 Public Alpha** -- This extension is under active development. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems.
+> **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please [report issues](https://github.com/EffortlessMetrics/perl-lsp/issues/new/choose) if you encounter problems. For what the project's headline numbers mean (and do not mean), see the [status overview](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md).
 
 ## Features
 


### PR DESCRIPTION
## Summary

Expand the "Public Alpha" callout in `vscode-extension/README.md` with a one-line scoping note so marketplace readers do not conflate "every feature listed below is wired up" with per-capability correctness or UX quality. Points curious readers at [`docs/project/status/index.md`](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/project/status/index.md) for live parser and LSP numbers.

Closes the third checkbox (PR C) in #4045.

## Findings

The current marketplace README cites **no explicit metrics**:

- No percentages (no 95.3%, 97.1%, 100%)
- No X/Y capability counts (no "102/102", no feature totals)
- No CPAN/corpus references
- No "all N features" style framing

The feature section is a pure enumeration of LSP/DAP capabilities with one-line descriptions. Because there are no numbers to rewrite, this PR is deliberately a very small edit — the minimum change needed to scope what the feature list does and does not guarantee. Marketplace voice is preserved; the sales pitch is intact.

Nothing in the file looked factually inaccurate. The `### Complete Syntax Support` section (line 167) scopes the bullet list that follows (which Perl syntax forms the parser recognizes), so it reads in context as marketing-voice shorthand, not a global correctness claim, and was left alone.

## Change

Single-line diff in `vscode-extension/README.md`. The existing alpha callout:

> **0.12.3 Public Alpha** -- This extension is under active development. Please report issues if you encounter problems.

becomes:

> **0.12.3 Public Alpha** -- This extension is under active development. Every feature listed below is wired up and exercised by tests, but as an alpha you will find edge cases where behavior is incomplete or wrong. Please report issues if you encounter problems. For what the project's headline numbers mean (and do not mean), see the status overview.

This mirrors the top-level README scoping language being introduced under #4045 (PR A, branch `docs/readme-metric-scoping-4045`).

## Test plan

- [ ] Visual diff review — verify the callout still reads in marketplace voice and does not leak emojis, feature additions, or editorializing beyond scoping
- [ ] Link check — confirm the `docs/project/status/index.md` absolute URL resolves on master after merge
- [ ] No markdown rendering regression in the Public Alpha blockquote