### PR TITLE
fix(pragma): track conditional use-if pragmas (#3485)

### DIFF
--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -208,7 +208,37 @@ fn lint_pipeline_warnings_inside_end_suppresses_pl101() {
 }
 
 // =========================================================================
-// 9. use strict inside non-BEGIN phase block (INIT) suppresses PL100 (#2360)
+// 9. conditional `use if` pragmas conservatively suppress missing-pragmas
+// =========================================================================
+
+#[test]
+fn lint_pipeline_use_if_strict_suppresses_pl100() {
+    let source = "use if $^O eq 'MSWin32', 'strict';\nuse warnings;\nmy $x = 42;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+    let missing_strict: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
+    assert!(
+        missing_strict.is_empty(),
+        "conditional use-if strict should conservatively suppress PL100, got {} missing-strict diags",
+        missing_strict.len()
+    );
+}
+
+#[test]
+fn lint_pipeline_use_if_warnings_suppresses_pl101() {
+    let source = "use strict;\nuse if $^O eq 'MSWin32', 'warnings';\nmy $x = 42;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+    let missing_warnings: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL101")).collect();
+    assert!(
+        missing_warnings.is_empty(),
+        "conditional use-if warnings should conservatively suppress PL101, got {} missing-warnings diags",
+        missing_warnings.len()
+    );
+}
+
+// =========================================================================
+// 10. use strict inside non-BEGIN phase block (INIT) suppresses PL100 (#2360)
 // =========================================================================
 
 #[test]
@@ -226,7 +256,7 @@ fn lint_pipeline_strict_inside_init_suppresses_pl100() {
 }
 
 // =========================================================================
-// 10. Security lint: string eval fires through the full pipeline (#2693)
+// 11. Security lint: string eval fires through the full pipeline (#2693)
 // =========================================================================
 
 #[test]
@@ -253,7 +283,7 @@ fn lint_pipeline_string_eval_emits_pl600() {
 }
 
 // =========================================================================
-// 11. Eval error flow lint fires through the full pipeline (#3380)
+// 12. Eval error flow lint fires through the full pipeline (#3380)
 // =========================================================================
 
 #[test]

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -237,6 +237,23 @@ fn lint_pipeline_use_if_warnings_suppresses_pl101() {
     );
 }
 
+#[test]
+fn lint_pipeline_use_if_nonpragma_version_condition_still_emits_missing_pragmas() {
+    let source = "use if $] >= 5.036, 'Some::Module';\nmy $x = 42;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+
+    let missing_strict: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
+    let missing_warnings: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL101")).collect();
+
+    assert!(!missing_strict.is_empty(), "non-pragma conditional use-if should not suppress PL100");
+    assert!(
+        !missing_warnings.is_empty(),
+        "non-pragma conditional use-if should not suppress PL101"
+    );
+}
+
 // =========================================================================
 // 10. use strict inside non-BEGIN phase block (INIT) suppresses PL100 (#2360)
 // =========================================================================
@@ -304,7 +321,7 @@ fn lint_pipeline_eval_error_flow_emits_pl407() {
 }
 
 // =========================================================================
-// 12. Security lint: global SIG handlers fire through the full pipeline
+// 13. Security lint: global SIG handlers fire through the full pipeline
 // =========================================================================
 
 #[test]

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -254,6 +254,25 @@ fn pragma_arg_items(arg: &str) -> Vec<String> {
     vec![trimmed.to_string()]
 }
 
+fn normalized_pragma_token(arg: &str) -> &str {
+    arg.trim().trim_matches('\'').trim_matches('"')
+}
+
+fn is_tracked_pragma_module(module: &str) -> bool {
+    matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
+}
+
+fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
+    args.iter().enumerate().rev().find_map(|(idx, arg)| {
+        let module = normalized_pragma_token(arg);
+        if is_tracked_pragma_module(module) || parse_perl_version(module).is_some() {
+            Some((module, &args[idx + 1..]))
+        } else {
+            None
+        }
+    })
+}
+
 /// Tracks pragma state throughout a Perl file
 pub struct PragmaTracker;
 
@@ -304,6 +323,135 @@ impl PragmaTracker {
     ) {
         match &node.kind {
             NodeKind::Use { module, args, .. } => {
+                if (module == "if" || module == "unless")
+                    && let Some((conditional_module, conditional_args)) =
+                        conditional_pragma_target(args)
+                {
+                    match conditional_module {
+                        "strict" => {
+                            if conditional_args.is_empty() {
+                                current_state.strict_vars = true;
+                                current_state.strict_subs = true;
+                                current_state.strict_refs = true;
+                            } else {
+                                for arg in conditional_args {
+                                    match arg.as_str() {
+                                        "vars" | "'vars'" | "\"vars\"" => {
+                                            current_state.strict_vars = true
+                                        }
+                                        "subs" | "'subs'" | "\"subs\"" => {
+                                            current_state.strict_subs = true
+                                        }
+                                        "refs" | "'refs'" | "\"refs\"" => {
+                                            current_state.strict_refs = true
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "warnings" => {
+                            current_state.warnings = true;
+                            current_state.disabled_warning_categories.clear();
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "utf8" => {
+                            current_state.utf8 = true;
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "encoding" => {
+                            current_state.encoding = conditional_args.first().map(|arg| {
+                                arg.trim().trim_matches('\'').trim_matches('"').to_string()
+                            });
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "locale" => {
+                            current_state.locale = true;
+                            current_state.locale_scope = conditional_args.first().map(|arg| {
+                                arg.trim().trim_matches('\'').trim_matches('"').to_string()
+                            });
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        "feature" => {
+                            let mut changed = false;
+                            for arg in conditional_args {
+                                for item in pragma_arg_items(arg) {
+                                    match item.as_str() {
+                                        "signatures" => {
+                                            current_state.strict_vars = true;
+                                            current_state.strict_subs = true;
+                                            current_state.strict_refs = true;
+                                            changed = true;
+                                        }
+                                        "unicode_strings" => {
+                                            current_state.unicode_strings = true;
+                                            changed = true;
+                                        }
+                                        item if item.starts_with(':') => {
+                                            if let Some(version) =
+                                                parse_perl_version(item.trim_start_matches(':'))
+                                            {
+                                                if version >= PerlVersion::new(5, 12) {
+                                                    current_state.unicode_strings = true;
+                                                    changed = true;
+                                                }
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+
+                            if changed {
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
+                            return;
+                        }
+                        "builtin" => {
+                            apply_builtin_imports(current_state, conditional_args);
+                            ranges.push((
+                                node.location.start..node.location.end,
+                                current_state.clone(),
+                            ));
+                            return;
+                        }
+                        _ => {
+                            if let Some(version) = parse_perl_version(conditional_module) {
+                                enable_effective_version_semantics(current_state, version);
+                                ranges.push((
+                                    node.location.start..node.location.end,
+                                    current_state.clone(),
+                                ));
+                            }
+                            return;
+                        }
+                    }
+                }
+
                 // Handle use statements
                 match module.as_str() {
                     "strict" => {

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -262,11 +262,39 @@ fn is_tracked_pragma_module(module: &str) -> bool {
     matches!(module, "strict" | "warnings" | "utf8" | "encoding" | "locale" | "feature" | "builtin")
 }
 
+fn valid_strict_args(args: &[String]) -> bool {
+    args.iter()
+        .flat_map(|arg| pragma_arg_items(arg))
+        .all(|item| matches!(item.as_str(), "vars" | "subs" | "refs"))
+}
+
+fn conditional_target_tail_is_valid(module: &str, tail: &[String]) -> bool {
+    if parse_perl_version(module).is_some() {
+        return tail.is_empty();
+    }
+
+    match module {
+        "strict" => tail.is_empty() || valid_strict_args(tail),
+        "warnings" => true,
+        "utf8" => tail.is_empty(),
+        "encoding" => tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty(),
+        "locale" => {
+            tail.is_empty() || (tail.len() == 1 && !normalized_pragma_token(&tail[0]).is_empty())
+        }
+        "feature" => !tail.is_empty(),
+        "builtin" => tail.iter().any(|arg| !builtin_import_names(arg).is_empty()),
+        _ => false,
+    }
+}
+
 fn conditional_pragma_target(args: &[String]) -> Option<(&str, &[String])> {
-    args.iter().enumerate().rev().find_map(|(idx, arg)| {
+    args.iter().enumerate().find_map(|(idx, arg)| {
         let module = normalized_pragma_token(arg);
-        if is_tracked_pragma_module(module) || parse_perl_version(module).is_some() {
-            Some((module, &args[idx + 1..]))
+        let tail = &args[idx + 1..];
+        if (is_tracked_pragma_module(module) || parse_perl_version(module).is_some())
+            && conditional_target_tail_is_valid(module, tail)
+        {
+            Some((module, tail))
         } else {
             None
         }
@@ -335,16 +363,10 @@ impl PragmaTracker {
                                 current_state.strict_refs = true;
                             } else {
                                 for arg in conditional_args {
-                                    match arg.as_str() {
-                                        "vars" | "'vars'" | "\"vars\"" => {
-                                            current_state.strict_vars = true
-                                        }
-                                        "subs" | "'subs'" | "\"subs\"" => {
-                                            current_state.strict_subs = true
-                                        }
-                                        "refs" | "'refs'" | "\"refs\"" => {
-                                            current_state.strict_refs = true
-                                        }
+                                    match normalized_pragma_token(arg) {
+                                        "vars" => current_state.strict_vars = true,
+                                        "subs" => current_state.strict_subs = true,
+                                        "refs" => current_state.strict_refs = true,
                                         _ => {}
                                     }
                                 }
@@ -373,9 +395,9 @@ impl PragmaTracker {
                             return;
                         }
                         "encoding" => {
-                            current_state.encoding = conditional_args.first().map(|arg| {
-                                arg.trim().trim_matches('\'').trim_matches('"').to_string()
-                            });
+                            current_state.encoding = conditional_args
+                                .first()
+                                .map(|arg| normalized_pragma_token(arg).to_string());
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),
@@ -384,9 +406,9 @@ impl PragmaTracker {
                         }
                         "locale" => {
                             current_state.locale = true;
-                            current_state.locale_scope = conditional_args.first().map(|arg| {
-                                arg.trim().trim_matches('\'').trim_matches('"').to_string()
-                            });
+                            current_state.locale_scope = conditional_args
+                                .first()
+                                .map(|arg| normalized_pragma_token(arg).to_string());
                             ranges.push((
                                 node.location.start..node.location.end,
                                 current_state.clone(),

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -212,7 +212,7 @@ fn use_if_strict_conditionally_enables_strict() -> Result<(), Box<dyn std::error
 }
 
 #[test]
-fn use_if_version_uses_last_recognized_target() -> Result<(), Box<dyn std::error::Error>> {
+fn use_if_version_target_applies_version_semantics() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("if", &["$]", ">=", "5.034", "v5.40"], 0, 28)]);
     let map = PragmaTracker::build(&ast);
     let state = &map[0].1;
@@ -220,6 +220,32 @@ fn use_if_version_uses_last_recognized_target() -> Result<(), Box<dyn std::error
     assert!(state.strict_vars, "v5.40 should imply strict");
     assert!(state.warnings, "v5.40 should imply warnings");
     assert!(state.has_feature("builtin"), "v5.40 should imply builtin feature bundle");
+    Ok(())
+}
+
+#[test]
+fn use_if_version_condition_does_not_apply_version_semantics()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$]", ">=", "5.036", "Some::Module"], 0, 38)]);
+    let map = PragmaTracker::build(&ast);
+    let state = PragmaTracker::state_for_offset(&map, 20);
+
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(!state.strict_refs);
+    assert!(!state.warnings);
+    assert!(!state.has_feature("builtin"));
+    Ok(())
+}
+
+#[test]
+fn use_if_encoding_targets_encoding_not_argument() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "encoding", "'utf8'"], 0, 32)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert_eq!(state.encoding.as_deref(), Some("utf8"));
+    assert!(!state.utf8, "encoding pragma should not be mistaken for utf8 pragma");
     Ok(())
 }
 

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -200,6 +200,30 @@ fn use_strict_quoted_args_double_quotes() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn use_if_strict_conditionally_enables_strict() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$^O", "eq", "'MSWin32'", "'strict'"], 0, 35)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn use_if_version_uses_last_recognized_target() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$]", ">=", "5.034", "v5.40"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert!(state.strict_vars, "v5.40 should imply strict");
+    assert!(state.warnings, "v5.40 should imply warnings");
+    assert!(state.has_feature("builtin"), "v5.40 should imply builtin feature bundle");
+    Ok(())
+}
+
+#[test]
 fn no_strict_disables_all() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("strict", &[], 0, 12), no_node("strict", &[], 13, 23)]);
     let map = PragmaTracker::build(&ast);


### PR DESCRIPTION
## Summary
- recognize `use if` / `use unless` forms in `PragmaTracker` and conservatively apply tracked pragma semantics from the conditional target
- add pragma regression coverage for conditional strict and version targets
- add lint-pipeline regressions showing conditional `strict` / `warnings` suppress the missing-pragma hints

## Validation
- `cargo fmt --all`
- `cargo test -p perl-pragma --test comprehensive_unit_tests`
- `cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests`

## Notes
- The parser flattens `use if/unless CONDITION, MODULE, ...` into a single arg list, so the tracker uses a conservative suffix heuristic to identify tracked pragma targets without changing the AST shape in this PR.