### PR TITLE
feat(workspace): add safe-delete cross-file reference warnings (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -935,6 +935,41 @@ impl LspServer {
                     };
 
                     tracing::debug!(uri, "File will be deleted");
+
+                    #[cfg(feature = "workspace")]
+                    if let Some(coordinator) = self.coordinator() {
+                        let index = coordinator.index();
+                        let symbols = index.file_symbols(uri);
+                        let mut external_reference_count = 0usize;
+                        let mut checked_symbols = std::collections::HashSet::new();
+
+                        for symbol in symbols {
+                            let candidate_names =
+                                [symbol.qualified_name.clone(), Some(symbol.name.clone())];
+
+                            for candidate in candidate_names.into_iter().flatten() {
+                                if !checked_symbols.insert(candidate.clone()) {
+                                    continue;
+                                }
+                                let refs = index.find_references(&candidate);
+                                external_reference_count +=
+                                    refs.into_iter().filter(|loc| loc.uri != uri).count();
+                            }
+                        }
+
+                        if external_reference_count > 0 {
+                            let message = format!(
+                                "Safe delete check: '{}' has {external_reference_count} references in other files. Deleting may break workspace references.",
+                                uri
+                            );
+                            if let Err(e) = self.show_message(
+                                crate::runtime::window::MessageType::Warning,
+                                &message,
+                            ) {
+                                tracing::debug!("Failed to send safe-delete warning: {}", e);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -3,6 +3,7 @@
 use parking_lot::Mutex;
 use perl_lsp::{JsonRpcRequest, LspServer};
 use serde_json::{Value, json};
+use std::io::Write;
 use std::sync::Arc;
 
 /// Helper to create a test LSP server
@@ -47,6 +48,49 @@ fn send_initialized(server: &LspServer) {
     server.handle_request(initialized_notification);
 }
 
+#[derive(Clone)]
+struct OutputCapture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl OutputCapture {
+    fn new() -> Self {
+        Self { buffer: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    fn get_messages(&self) -> Vec<Value> {
+        let buffer = self.buffer.lock();
+        let content = String::from_utf8_lossy(&buffer);
+        let mut messages = Vec::new();
+
+        for chunk in content.split("\r\n\r\n") {
+            if chunk.trim().is_empty() {
+                continue;
+            }
+            if let Some(json_str) = chunk.lines().nth(1) {
+                if let Ok(msg) = serde_json::from_str::<Value>(json_str) {
+                    messages.push(msg);
+                }
+            } else if !chunk.starts_with("Content-Length")
+                && let Ok(msg) = serde_json::from_str::<Value>(chunk)
+            {
+                messages.push(msg);
+            }
+        }
+        messages
+    }
+}
+
+impl Write for OutputCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.lock().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.buffer.lock().flush()
+    }
+}
+
 #[test]
 fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();
@@ -75,6 +119,76 @@ fn test_did_change_watched_files_created() -> Result<(), Box<dyn std::error::Err
     // This is a notification, should return None
     assert!(result.is_ok());
     assert_eq!(result?, None);
+    Ok(())
+}
+
+#[test]
+fn test_will_delete_files_warns_when_cross_file_references_exist()
+-> Result<(), Box<dyn std::error::Error>> {
+    let output = OutputCapture::new();
+    let output_box: Box<dyn Write + Send> = Box::new(output.clone());
+    let server = LspServer::with_output(Arc::new(Mutex::new(output_box)));
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+
+    let module_uri = "file:///test/workspace/lib/Legacy.pm";
+    let module_text = "package Legacy;\nsub process { return 1; }\n1;\n";
+    let _ = make_request(
+        &server,
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": module_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": module_text
+            }
+        })),
+    );
+
+    let user_uri = "file:///test/workspace/bin/run.pl";
+    let user_text = "use Legacy;\nLegacy::process();\n";
+    let _ = make_request(
+        &server,
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": user_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": user_text
+            }
+        })),
+    );
+
+    let edit = make_request(
+        &server,
+        "workspace/willDeleteFiles",
+        Some(json!({
+            "files": [
+                { "uri": module_uri }
+            ]
+        })),
+    )?;
+    assert!(edit.is_some(), "willDeleteFiles should return a WorkspaceEdit object");
+
+    let messages = output.get_messages();
+    let warning = messages
+        .into_iter()
+        .find(|m| {
+            m["method"].as_str() == Some("window/showMessage")
+                && m["params"]["message"]
+                    .as_str()
+                    .is_some_and(|msg| msg.contains("Safe delete check"))
+        })
+        .ok_or("Expected safe-delete warning notification")?;
+    assert_eq!(warning["params"]["type"], 2, "warning severity should be MessageType::Warning");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental workspace breakage when a file containing public symbols is deleted by warning the user if those symbols have references in other files.

### Description
- Add a preflight safe-delete check in `handle_will_delete_files` that calls `index.file_symbols()` and `index.find_references()` to count external references and emits a `window/showMessage` warning when cross-file references are found.
- Preserve symbol heuristics by checking both `qualified_name` and bare `name` for each file symbol and deduplicating candidates before counting references.
- Add an integration-style test `test_will_delete_files_warns_when_cross_file_references_exist` that opens a module and a consumer file, calls `workspace/willDeleteFiles`, and asserts a `window/showMessage` warning was emitted using a small `OutputCapture` helper.
- Files changed: `crates/perl-lsp/src/runtime/workspace.rs` and `crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs`.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Executed the focused test via `cargo test -p perllsp lsp_workspace_file_ops_tests::test_will_delete_files_warns_when_cross_file_references_exist` which passed in this environment.
- Attempted a focused run against the `perl-lsp` library (`perl-lsp-rs`) to exercise the same test but the run could not complete here due to build-directory lock contention in the environment (did not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fb85c98883339e2ea97d6de7381c)