### PR TITLE
feat(workspace): tolerate non-file workspace URIs (#3521)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "perl-subprocess-runtime",
  "perl-symbol-cursor",
  "perl-tdd-support",
+ "perl-uri",
  "perl-workspace-discovery",
  "perl-workspace-folder",
  "perl-workspace-ignore",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -89,6 +89,7 @@ perl-module-import = { workspace = true }
 perl-pod = { workspace = true }
 perl-module-resolution = { workspace = true }
 perl-source-file = { workspace = true }
+perl-uri = { workspace = true }
 perl-workspace-discovery = { workspace = true }
 perl-workspace-folder = { workspace = true }
 perl-workspace-ignore = { workspace = true }

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -186,15 +186,23 @@ impl LspServer {
                 let mut folders = self.workspace_folders.lock();
                 for uri in extract_workspace_folder_uris(workspace_folders) {
                     tracing::debug!(uri, "Initialized with workspace folder");
-                    folders.push(super::super::workspace_folder::WorkspaceFolderState::new(uri));
+                    let mut folder_state =
+                        super::super::workspace_folder::WorkspaceFolderState::new(uri.clone());
+                    if let Some(path) = super::super::source_path_from_uri(&uri) {
+                        folder_state.path = Some(path);
+                    }
+                    folders.push(folder_state);
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
                 let mut folders = self.workspace_folders.lock();
                 tracing::debug!(root_uri, "Initialized with root URI");
-                folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
-                    root_uri.to_string(),
-                ));
+                let mut folder_state =
+                    super::super::workspace_folder::WorkspaceFolderState::new(root_uri.to_string());
+                if let Some(path) = super::super::source_path_from_uri(root_uri) {
+                    folder_state.path = Some(path);
+                }
+                folders.push(folder_state);
                 // Also set the root path for module resolution
                 self.set_root_uri(root_uri);
             } else if let Some(root_path) = params.get("rootPath").and_then(|p| p.as_str()) {

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -64,14 +64,12 @@ fn prepend_use_lib_paths(
 }
 
 fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -> Option<PathBuf> {
-    let doc_path =
-        doc_uri.and_then(|u| url::Url::parse(u).ok()).and_then(|u| u.to_file_path().ok());
+    let doc_path = doc_uri.and_then(super::super::source_path_from_uri);
 
     if let Some(doc_path) = doc_path {
         let mut best_match: Option<(PathBuf, usize)> = None;
         for folder in workspace_folders {
-            let Some(candidate) = url::Url::parse(folder).ok().and_then(|u| u.to_file_path().ok())
-            else {
+            let Some(candidate) = super::super::source_path_from_uri(folder) else {
                 continue;
             };
             if doc_path.starts_with(&candidate) {
@@ -87,10 +85,7 @@ fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -
         }
     }
 
-    workspace_folders
-        .first()
-        .and_then(|u| url::Url::parse(u).ok())
-        .and_then(|u| u.to_file_path().ok())
+    workspace_folders.first().and_then(|u| super::super::source_path_from_uri(u))
 }
 
 fn workspace_config_for_doc(
@@ -239,8 +234,7 @@ impl LspServer {
 
         if let Some(text) = doc_text {
             let file_dir = doc_uri
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.to_file_path().ok())
+                .and_then(super::super::source_path_from_uri)
                 .and_then(|p| p.parent().map(|d| d.to_path_buf()));
             if file_dir.is_none() && doc_uri.is_some() {
                 tracing::trace!("Module URI resolution failed for doc_uri: {:?}", doc_uri);
@@ -356,8 +350,7 @@ impl LspServer {
         let mut lexical_paths = Vec::new();
         if let Some(text) = doc_text {
             let file_dir = doc_uri
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.to_file_path().ok())
+                .and_then(super::super::source_path_from_uri)
                 .and_then(|p| p.parent().map(|d| d.to_path_buf()));
             if file_dir.is_none() && doc_uri.is_some() {
                 tracing::trace!("Module URI resolution failed for doc_uri: {:?}", doc_uri);

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -4,12 +4,17 @@
 
 use super::super::*;
 use perl_lsp_config::WorkspaceConfig;
-use url::Url;
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
     pub(crate) fn set_root_uri(&self, root_uri: &str) {
-        let root_path = Url::parse(root_uri).ok().and_then(|u| u.to_file_path().ok());
+        let root_path = perl_uri::uri_to_fs_path(root_uri);
+        if root_path.is_none() {
+            tracing::debug!(
+                root_uri,
+                "Workspace root URI is non-file; filesystem root path disabled"
+            );
+        }
         *self.root_path.lock() = root_path;
     }
 
@@ -187,5 +192,12 @@ include_paths = ["other_lib"]
         assert!(folder_state.project_config.is_none());
         // Should have default include paths
         assert!(!folder_state.effective_workspace_config.include_paths.is_empty());
+    }
+
+    #[test]
+    fn set_root_uri_non_file_scheme_keeps_root_path_none() {
+        let server = LspServer::new();
+        server.set_root_uri("vscode-remote://ssh-remote+devbox/workspace");
+        assert!(server.root_path.lock().is_none());
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -118,15 +118,15 @@ use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 use crate::fallback::text::extract_text_based_symbols;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    Url::parse(uri).ok().and_then(|value| value.to_file_path().ok())
+    perl_uri::uri_to_fs_path(uri)
 }
 
 fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
-    folder.path.clone().or_else(|| Url::parse(&folder.uri).ok().and_then(|u| u.to_file_path().ok()))
+    folder.path.clone().or_else(|| perl_uri::uri_to_fs_path(&folder.uri))
 }
 
 fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str) -> bool {
-    let doc_path = Url::parse(doc_uri).ok().and_then(|u| u.to_file_path().ok());
+    let doc_path = perl_uri::uri_to_fs_path(doc_uri);
     match (doc_path, workspace_folder_path(folder)) {
         (Some(doc_path), Some(folder_path)) => doc_path.starts_with(folder_path),
         _ => doc_uri == folder.uri,

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1248,7 +1248,10 @@ impl LspServer {
             let mut early_exit: Option<(EarlyExitReason, u64, usize, usize)> = None;
 
             'scan: for folder_state in workspace_folders {
-                let Some(root) = uri_to_fs_path(&folder_state.uri) else {
+                let Some(root) =
+                    folder_state.path.clone().or_else(|| uri_to_fs_path(&folder_state.uri))
+                else {
+                    tracing::debug!(uri = %folder_state.uri, "Skipping non-filesystem workspace folder during indexing scan");
                     continue;
                 };
 


### PR DESCRIPTION
### Motivation

- The server currently assumes all workspace/document URIs are `file://` and converts them with `Url::to_file_path()`, which fails silently for remote/virtual schemes and prevents VFS workflows from integrating correctly.
- Handle non-file URI schemes gracefully so remote/devcontainer/untitled URIs do not crash features that only need URI identity and so filesystem-dependent features degrade cleanly.

### Description

- Use the shared URI helper `perl_uri::uri_to_fs_path` across runtime modules instead of `Url::to_file_path()` to centralize file-URI handling and preserve non-file URIs when conversion fails.
- During initialize, populate `WorkspaceFolderState.path` only when the workspace folder URI is file-backed and keep the original `uri` for LSP communication, avoiding forced conversions on non-file schemes.
- Make module-resolution and folder-matching helpers use the shared `source_path_from_uri`/`uri_to_fs_path` flow so `resolve_module_*` and `workspace_root` logic degrade when no filesystem path exists for a URI.
- Skip non-filesystem workspace folders during the workspace indexing scan with a debug trace instead of treating conversion failure as an error path.
- Add the `perl-uri` workspace dependency and a unit test `set_root_uri_non_file_scheme_keeps_root_path_none` that verifies `root_path` remains `None` for non-file URIs.

### Testing

- Ran formatter: `cargo fmt --all` which completed successfully.
- Built/check: `cargo check -p perl-lsp-rs` which completed successfully.
- Unit test: `cargo test -p perl-lsp-rs --lib set_root_uri_non_file_scheme_keeps_root_path_none -- --nocapture` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fba366d48333ba53fba4b78161bb)