### PR TITLE
feat(workspace): preserve non-file workspace URIs (#3521)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "perl-subprocess-runtime",
  "perl-symbol-cursor",
  "perl-tdd-support",
+ "perl-uri",
  "perl-workspace-discovery",
  "perl-workspace-folder",
  "perl-workspace-ignore",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -92,6 +92,7 @@ perl-source-file = { workspace = true }
 perl-workspace-discovery = { workspace = true }
 perl-workspace-folder = { workspace = true }
 perl-workspace-ignore = { workspace = true }
+perl-uri = { workspace = true }
 perl-keywords = { workspace = true }
 lsp-types.workspace = true
 serde = { workspace = true }

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -186,13 +186,14 @@ impl LspServer {
                 let mut folders = self.workspace_folders.lock();
                 for uri in extract_workspace_folder_uris(workspace_folders) {
                     tracing::debug!(uri, "Initialized with workspace folder");
-                    folders.push(super::super::workspace_folder::WorkspaceFolderState::new(uri));
+                    folders
+                        .push(super::super::workspace_folder::WorkspaceFolderState::from_uri(uri));
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
                 let mut folders = self.workspace_folders.lock();
                 tracing::debug!(root_uri, "Initialized with root URI");
-                folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
+                folders.push(super::super::workspace_folder::WorkspaceFolderState::from_uri(
                     root_uri.to_string(),
                 ));
                 // Also set the root path for module resolution
@@ -202,7 +203,7 @@ impl LspServer {
                 tracing::debug!(root_path, "Initialized with legacy rootPath");
                 let root_uri = root_path_to_file_uri(root_path);
                 let mut folders = self.workspace_folders.lock();
-                folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
+                folders.push(super::super::workspace_folder::WorkspaceFolderState::from_uri(
                     root_uri.clone(),
                 ));
                 self.set_root_uri(&root_uri);

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -4,12 +4,11 @@
 
 use super::super::*;
 use perl_lsp_config::WorkspaceConfig;
-use url::Url;
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
     pub(crate) fn set_root_uri(&self, root_uri: &str) {
-        let root_path = Url::parse(root_uri).ok().and_then(|u| u.to_file_path().ok());
+        let root_path = perl_uri::uri_to_fs_path(root_uri);
         *self.root_path.lock() = root_path;
     }
 
@@ -87,6 +86,13 @@ mod tests {
         let server = LspServer::new();
         // Should not panic with empty workspace folders
         server.load_and_apply_project_config();
+    }
+
+    #[test]
+    fn set_root_uri_handles_non_file_scheme() {
+        let server = LspServer::new();
+        server.set_root_uri("vscode-remote://ssh-remote+dev/home/project");
+        assert!(server.root_path.lock().is_none());
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1123,15 +1123,8 @@ impl LspServer {
                     let mut workspace_folders = self.workspace_folders.lock();
                     for uri in &change.added {
                         tracing::debug!(uri, "Added workspace folder");
-                        let mut folder_state =
-                            super::workspace_folder::WorkspaceFolderState::new(uri.clone());
-
-                        // Resolve the folder path
-                        if let Ok(url) = Url::parse(uri) {
-                            if let Ok(path) = url.to_file_path() {
-                                folder_state = folder_state.with_path(path);
-                            }
-                        }
+                        let folder_state =
+                            super::workspace_folder::WorkspaceFolderState::from_uri(uri.clone());
 
                         workspace_folders.push(folder_state);
                     }

--- a/crates/perl-lsp/src/runtime/workspace_folder.rs
+++ b/crates/perl-lsp/src/runtime/workspace_folder.rs
@@ -48,6 +48,22 @@ impl WorkspaceFolderState {
         }
     }
 
+    /// Create a new workspace folder state from a URI and resolve filesystem path when possible.
+    ///
+    /// For non-`file://` schemes (for example `vscode-remote://` or `untitled:`),
+    /// this preserves the URI and leaves `path` as `None`.
+    #[must_use]
+    pub fn from_uri(uri: String) -> Self {
+        let path = perl_uri::uri_to_fs_path(&uri);
+        Self {
+            uri,
+            path,
+            name: None,
+            project_config: None,
+            effective_workspace_config: WorkspaceConfig::default(),
+        }
+    }
+
     /// Set the filesystem path for this workspace folder.
     #[must_use]
     pub fn with_path(mut self, path: PathBuf) -> Self {
@@ -100,6 +116,21 @@ mod tests {
         assert!(folder.path.is_none());
         assert!(folder.name.is_none());
         assert!(folder.project_config.is_none());
+    }
+
+    #[test]
+    fn from_uri_sets_path_for_file_uri() {
+        let folder = WorkspaceFolderState::from_uri("file:///tmp/project".to_string());
+        assert!(folder.path.is_some());
+    }
+
+    #[test]
+    fn from_uri_keeps_non_file_uri_without_path() {
+        let folder = WorkspaceFolderState::from_uri(
+            "vscode-remote://ssh-remote+dev/home/project".to_string(),
+        );
+        assert_eq!(folder.uri, "vscode-remote://ssh-remote+dev/home/project");
+        assert!(folder.path.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent assuming all workspace URIs are local `file://` paths so the server does not crash or lose information when clients use remote/virtual schemes (e.g. `vscode-remote://`, `untitled:`).

### Description

- Add `WorkspaceFolderState::from_uri` which preserves the original URI and only materializes `path` when `perl_uri::uri_to_fs_path` can resolve a `file://` path.
- Use `from_uri` when initializing workspace folders (`workspaceFolders`, `rootUri`, legacy `rootPath`) and when handling `workspace/didChangeWorkspaceFolders` so non-file schemes are retained without forcing a path conversion.
- Replace the previous `Url::parse(...).to_file_path()` usage in `set_root_uri` with `perl_uri::uri_to_fs_path` so root handling degrades safely for non-file schemes.
- Add `perl-uri` as a dependency to the `perl-lsp` binary crate to reuse centralized URI↔path helpers.
- Add unit tests covering `from_uri` behavior and non-file root handling to prevent regressions.

### Testing

- Ran `cargo fmt --all` to ensure formatting (succeeded).
- Ran `cargo check -p perl-lsp-rs --lib` to validate builds and dependency wiring (succeeded).
- Executed targeted unit test runs that exercise the new `from_uri` and non-file root behavior; focused test(s) compiled and ran (one run produced a compiler warning but no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fba366d48333ba53fba4b78161bb)