### PR TITLE
fix(workspace): tolerate non-file URIs for workspace roots (#3521)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -186,15 +186,23 @@ impl LspServer {
                 let mut folders = self.workspace_folders.lock();
                 for uri in extract_workspace_folder_uris(workspace_folders) {
                     tracing::debug!(uri, "Initialized with workspace folder");
-                    folders.push(super::super::workspace_folder::WorkspaceFolderState::new(uri));
+                    let mut folder =
+                        super::super::workspace_folder::WorkspaceFolderState::new(uri.clone());
+                    if let Some(path) = super::super::source_path_from_uri(&uri) {
+                        folder = folder.with_path(path);
+                    }
+                    folders.push(folder);
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
                 let mut folders = self.workspace_folders.lock();
                 tracing::debug!(root_uri, "Initialized with root URI");
-                folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
-                    root_uri.to_string(),
-                ));
+                let mut folder =
+                    super::super::workspace_folder::WorkspaceFolderState::new(root_uri.to_string());
+                if let Some(path) = super::super::source_path_from_uri(root_uri) {
+                    folder = folder.with_path(path);
+                }
+                folders.push(folder);
                 // Also set the root path for module resolution
                 self.set_root_uri(root_uri);
             } else if let Some(root_path) = params.get("rootPath").and_then(|p| p.as_str()) {

--- a/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/module_resolution.rs
@@ -64,14 +64,12 @@ fn prepend_use_lib_paths(
 }
 
 fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -> Option<PathBuf> {
-    let doc_path =
-        doc_uri.and_then(|u| url::Url::parse(u).ok()).and_then(|u| u.to_file_path().ok());
+    let doc_path = doc_uri.and_then(super::super::source_path_from_uri);
 
     if let Some(doc_path) = doc_path {
         let mut best_match: Option<(PathBuf, usize)> = None;
         for folder in workspace_folders {
-            let Some(candidate) = url::Url::parse(folder).ok().and_then(|u| u.to_file_path().ok())
-            else {
+            let Some(candidate) = super::super::source_path_from_uri(folder) else {
                 continue;
             };
             if doc_path.starts_with(&candidate) {
@@ -87,10 +85,7 @@ fn workspace_root_for_doc(workspace_folders: &[String], doc_uri: Option<&str>) -
         }
     }
 
-    workspace_folders
-        .first()
-        .and_then(|u| url::Url::parse(u).ok())
-        .and_then(|u| u.to_file_path().ok())
+    workspace_folders.first().and_then(|u| super::super::source_path_from_uri(u))
 }
 
 fn workspace_config_for_doc(
@@ -239,8 +234,7 @@ impl LspServer {
 
         if let Some(text) = doc_text {
             let file_dir = doc_uri
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.to_file_path().ok())
+                .and_then(super::super::source_path_from_uri)
                 .and_then(|p| p.parent().map(|d| d.to_path_buf()));
             if file_dir.is_none() && doc_uri.is_some() {
                 tracing::trace!("Module URI resolution failed for doc_uri: {:?}", doc_uri);
@@ -356,8 +350,7 @@ impl LspServer {
         let mut lexical_paths = Vec::new();
         if let Some(text) = doc_text {
             let file_dir = doc_uri
-                .and_then(|u| url::Url::parse(u).ok())
-                .and_then(|u| u.to_file_path().ok())
+                .and_then(super::super::source_path_from_uri)
                 .and_then(|p| p.parent().map(|d| d.to_path_buf()));
             if file_dir.is_none() && doc_uri.is_some() {
                 tracing::trace!("Module URI resolution failed for doc_uri: {:?}", doc_uri);

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -4,12 +4,11 @@
 
 use super::super::*;
 use perl_lsp_config::WorkspaceConfig;
-use url::Url;
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
     pub(crate) fn set_root_uri(&self, root_uri: &str) {
-        let root_path = Url::parse(root_uri).ok().and_then(|u| u.to_file_path().ok());
+        let root_path = super::super::source_path_from_uri(root_uri);
         *self.root_path.lock() = root_path;
     }
 
@@ -87,6 +86,13 @@ mod tests {
         let server = LspServer::new();
         // Should not panic with empty workspace folders
         server.load_and_apply_project_config();
+    }
+
+    #[test]
+    fn set_root_uri_ignores_non_file_scheme() {
+        let server = LspServer::new();
+        server.set_root_uri("untitled:Untitled-1");
+        assert!(server.root_path.lock().is_none());
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -118,18 +118,23 @@ use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 use crate::fallback::text::extract_text_based_symbols;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    Url::parse(uri).ok().and_then(|value| value.to_file_path().ok())
+    Url::parse(uri)
+        .ok()
+        .and_then(|value| if value.scheme() == "file" { value.to_file_path().ok() } else { None })
 }
 
 fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
-    folder.path.clone().or_else(|| Url::parse(&folder.uri).ok().and_then(|u| u.to_file_path().ok()))
+    folder.path.clone().or_else(|| source_path_from_uri(&folder.uri))
 }
 
 fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str) -> bool {
-    let doc_path = Url::parse(doc_uri).ok().and_then(|u| u.to_file_path().ok());
+    let doc_path = source_path_from_uri(doc_uri);
     match (doc_path, workspace_folder_path(folder)) {
         (Some(doc_path), Some(folder_path)) => doc_path.starts_with(folder_path),
-        _ => doc_uri == folder.uri,
+        _ => {
+            doc_uri == folder.uri
+                || doc_uri.strip_prefix(&folder.uri).is_some_and(|suffix| suffix.starts_with('/'))
+        }
     }
 }
 
@@ -797,6 +802,19 @@ pub(crate) fn location_from_path(p: &Path) -> serde_json::Value {
 mod tests {
     use super::*;
     use crate::features::formatting::FormatRange;
+
+    #[test]
+    fn workspace_folder_matching_supports_non_file_uri_schemes() {
+        let folder = WorkspaceFolderState::new("vscode-remote://ssh-remote+dev/workspace".into());
+        assert!(workspace_folder_matches_doc_uri(
+            &folder,
+            "vscode-remote://ssh-remote+dev/workspace/lib/Foo.pm"
+        ));
+        assert!(!workspace_folder_matches_doc_uri(
+            &folder,
+            "vscode-remote://ssh-remote+dev/other/lib/Foo.pm"
+        ));
+    }
 
     #[test]
     fn end_position_handles_trailing_final_newline() {

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -132,8 +132,10 @@ fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str
     match (doc_path, workspace_folder_path(folder)) {
         (Some(doc_path), Some(folder_path)) => doc_path.starts_with(folder_path),
         _ => {
+            let folder_uri = folder.uri.trim_end_matches('/');
             doc_uri == folder.uri
-                || doc_uri.strip_prefix(&folder.uri).is_some_and(|suffix| suffix.starts_with('/'))
+                || doc_uri == folder_uri
+                || doc_uri.strip_prefix(folder_uri).is_some_and(|suffix| suffix.starts_with('/'))
         }
     }
 }
@@ -813,6 +815,19 @@ mod tests {
         assert!(!workspace_folder_matches_doc_uri(
             &folder,
             "vscode-remote://ssh-remote+dev/other/lib/Foo.pm"
+        ));
+    }
+
+    #[test]
+    fn workspace_folder_matching_supports_non_file_uri_with_trailing_slash() {
+        let folder = WorkspaceFolderState::new("vscode-remote://ssh-remote+dev/workspace/".into());
+        assert!(workspace_folder_matches_doc_uri(
+            &folder,
+            "vscode-remote://ssh-remote+dev/workspace/lib/Foo.pm"
+        ));
+        assert!(!workspace_folder_matches_doc_uri(
+            &folder,
+            "vscode-remote://ssh-remote+dev/workspace-other/lib/Foo.pm"
         ));
     }
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1246,7 +1246,13 @@ impl LspServer {
             let mut early_exit: Option<(EarlyExitReason, u64, usize, usize)> = None;
 
             'scan: for folder_state in workspace_folders {
-                let Some(root) = uri_to_fs_path(&folder_state.uri) else {
+                let Some(root) =
+                    folder_state.path.clone().or_else(|| uri_to_fs_path(&folder_state.uri))
+                else {
+                    tracing::debug!(
+                        uri = %folder_state.uri,
+                        "Skipping non-filesystem workspace folder during indexing scan"
+                    );
                     continue;
                 };
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1127,10 +1127,8 @@ impl LspServer {
                             super::workspace_folder::WorkspaceFolderState::new(uri.clone());
 
                         // Resolve the folder path
-                        if let Ok(url) = Url::parse(uri) {
-                            if let Ok(path) = url.to_file_path() {
-                                folder_state = folder_state.with_path(path);
-                            }
+                        if let Some(path) = super::source_path_from_uri(uri) {
+                            folder_state = folder_state.with_path(path);
                         }
 
                         workspace_folders.push(folder_state);


### PR DESCRIPTION
### Motivation

- The runtime assumed all LSP URIs could be converted to local filesystem paths which breaks virtual and remote schemes such as `vscode-remote://` and `untitled:`.

### Description

- keep non-file URIs in LSP string form while only converting `file://` URIs to filesystem paths
- normalize non-file workspace folder URI matching so folders with or without trailing slashes still match child documents
- route module-resolution workspace root and document path lookups through the file-only URI helper instead of direct `to_file_path()` calls
- skip non-filesystem workspace folders during indexing scans instead of treating them as local roots

### Testing

- cargo test -p perl-lsp-rs --lib workspace_folder_matching_supports_non_file_uri -- --nocapture
- cargo test -p perl-lsp-rs --lib set_root_uri_ignores_non_file_scheme -- --nocapture
- cargo test -p perl-lsp-rs --lib workspace_root_for_doc_ -- --nocapture
- nix develop -c just ci-gate  # reached unrelated hook-tests failure after the workspace/LSP gates passed