### PR TITLE
feat(workspace): add VFS-aware URI handling (#3521)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "perl-subprocess-runtime",
  "perl-symbol-cursor",
  "perl-tdd-support",
+ "perl-uri",
  "perl-workspace-discovery",
  "perl-workspace-folder",
  "perl-workspace-ignore",

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -40,6 +40,7 @@ perl-lsp-color-provider = { workspace = true }
 perl-lsp-input-validation = { workspace = true }
 perl-lsp-limits = { workspace = true }
 perl-lsp-uri = { workspace = true }
+perl-uri = { workspace = true }
 perl-lsp-feature-governance = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-subprocess-runtime = { workspace = true }

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -3,6 +3,7 @@
 //! Handles client capability parsing and server capabilities construction.
 
 use super::super::*;
+use perl_uri::VfsUri;
 use perl_workspace_folder::{extract_workspace_folder_uris, root_path_to_file_uri};
 use serde_json::{Value, json};
 
@@ -186,15 +187,27 @@ impl LspServer {
                 let mut folders = self.workspace_folders.lock();
                 for uri in extract_workspace_folder_uris(workspace_folders) {
                     tracing::debug!(uri, "Initialized with workspace folder");
-                    folders.push(super::super::workspace_folder::WorkspaceFolderState::new(uri));
+                    let mut folder =
+                        super::super::workspace_folder::WorkspaceFolderState::new(uri.clone());
+                    if let Ok(vfs_uri) = VfsUri::parse(&uri)
+                        && let Some(path) = vfs_uri.as_file_path()
+                    {
+                        folder = folder.with_path(path.to_path_buf());
+                    }
+                    folders.push(folder);
                 }
             } else if let Some(root_uri) = params.get("rootUri").and_then(|u| u.as_str()) {
                 // Fallback to rootUri if workspaceFolders is not provided
                 let mut folders = self.workspace_folders.lock();
                 tracing::debug!(root_uri, "Initialized with root URI");
-                folders.push(super::super::workspace_folder::WorkspaceFolderState::new(
-                    root_uri.to_string(),
-                ));
+                let mut folder =
+                    super::super::workspace_folder::WorkspaceFolderState::new(root_uri.to_string());
+                if let Ok(vfs_uri) = VfsUri::parse(root_uri)
+                    && let Some(path) = vfs_uri.as_file_path()
+                {
+                    folder = folder.with_path(path.to_path_buf());
+                }
+                folders.push(folder);
                 // Also set the root path for module resolution
                 self.set_root_uri(root_uri);
             } else if let Some(root_path) = params.get("rootPath").and_then(|p| p.as_str()) {

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -4,12 +4,14 @@
 
 use super::super::*;
 use perl_lsp_config::WorkspaceConfig;
-use url::Url;
+use perl_uri::VfsUri;
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
     pub(crate) fn set_root_uri(&self, root_uri: &str) {
-        let root_path = Url::parse(root_uri).ok().and_then(|u| u.to_file_path().ok());
+        let root_path = VfsUri::parse(root_uri)
+            .ok()
+            .and_then(|uri| uri.as_file_path().map(std::path::Path::to_path_buf));
         *self.root_path.lock() = root_path;
     }
 
@@ -87,6 +89,13 @@ mod tests {
         let server = LspServer::new();
         // Should not panic with empty workspace folders
         server.load_and_apply_project_config();
+    }
+
+    #[test]
+    fn set_root_uri_ignores_virtual_scheme() {
+        let server = LspServer::new();
+        server.set_root_uri("untitled:workspace");
+        assert!(server.root_path.lock().is_none());
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -96,6 +96,7 @@ use crate::{
 };
 use md5;
 use parking_lot::Mutex;
+use perl_uri::VfsUri;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -118,11 +119,11 @@ use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 use crate::fallback::text::extract_text_based_symbols;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    Url::parse(uri).ok().and_then(|value| value.to_file_path().ok())
+    VfsUri::parse(uri).ok().and_then(|value| value.as_file_path().map(std::path::Path::to_path_buf))
 }
 
 fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
-    folder.path.clone().or_else(|| Url::parse(&folder.uri).ok().and_then(|u| u.to_file_path().ok()))
+    folder.path.clone().or_else(|| source_path_from_uri(&folder.uri))
 }
 
 fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str) -> bool {

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -18,6 +18,7 @@ use perl_module_rename::plan_module_rename_edits;
 use perl_parser::workspace_index::{DegradationReason, EarlyExitReason, ResourceKind};
 #[cfg(feature = "workspace")]
 use perl_source_file::{is_perl_source_path, is_perl_source_uri};
+use perl_uri::VfsUri;
 use perl_workspace_folder::extract_workspace_folder_change;
 #[cfg(feature = "workspace")]
 use perl_workspace_ignore::is_skipped_dir_name;
@@ -1127,10 +1128,10 @@ impl LspServer {
                             super::workspace_folder::WorkspaceFolderState::new(uri.clone());
 
                         // Resolve the folder path
-                        if let Ok(url) = Url::parse(uri) {
-                            if let Ok(path) = url.to_file_path() {
-                                folder_state = folder_state.with_path(path);
-                            }
+                        if let Ok(vfs_uri) = VfsUri::parse(uri)
+                            && let Some(path) = vfs_uri.as_file_path()
+                        {
+                            folder_state = folder_state.with_path(path.to_path_buf());
                         }
 
                         workspace_folders.push(folder_state);

--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -34,6 +34,49 @@
 
 use url::Url;
 
+/// URI abstraction for file-backed and virtual documents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VfsUri {
+    /// Local filesystem URI (`file://`).
+    File(std::path::PathBuf),
+    /// Any non-file URI scheme (e.g. `untitled:`, `vscode-remote://`, `git:`).
+    Virtual(Url),
+}
+
+impl VfsUri {
+    /// Parse an LSP URI into a virtual-filesystem aware representation.
+    pub fn parse(uri: &str) -> Result<Self, url::ParseError> {
+        let parsed = Url::parse(uri)?;
+        if parsed.scheme() == "file" {
+            if let Ok(path) = parsed.to_file_path() {
+                return Ok(Self::File(path));
+            }
+            if let Some(path) = windows_rooted_file_uri_to_path(&parsed) {
+                return Ok(Self::File(path));
+            }
+        }
+        Ok(Self::Virtual(parsed))
+    }
+
+    /// Return the URI scheme.
+    #[must_use]
+    pub fn scheme(&self) -> &str {
+        match self {
+            Self::File(_) => "file",
+            Self::Virtual(url) => url.scheme(),
+        }
+    }
+
+    /// Return the local filesystem path when available.
+    #[must_use]
+    pub fn as_file_path(&self) -> Option<&std::path::Path> {
+        match self {
+            Self::File(path) => Some(path.as_path()),
+            Self::Virtual(_) => None,
+        }
+    }
+}
+
 /// Convert a `file://` URI to a filesystem path.
 ///
 /// Properly handles percent-encoding and works with spaces, Windows paths,
@@ -291,6 +334,20 @@ mod tests {
     fn test_is_special_scheme() {
         assert!(is_special_scheme("untitled:Untitled-1"));
         assert!(!is_special_scheme("file:///tmp/test.pl"));
+    }
+
+    #[test]
+    fn test_vfs_uri_parse_file() {
+        let parsed = VfsUri::parse("file:///tmp/test.pl").expect("valid URI");
+        assert_eq!(parsed.scheme(), "file");
+        assert!(parsed.as_file_path().is_some());
+    }
+
+    #[test]
+    fn test_vfs_uri_parse_virtual() {
+        let parsed = VfsUri::parse("untitled:Untitled-1").expect("valid URI");
+        assert_eq!(parsed.scheme(), "untitled");
+        assert!(parsed.as_file_path().is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The server assumed all LSP URIs were file:// and converted them unconditionally to filesystem paths, which breaks virtual schemes (e.g., `untitled:`, remote URIs) and prevents VFS scenarios from working.
- Introduce a small VFS-aware abstraction so lifecycle and workspace code can preserve non-file URIs while still accessing local paths for file-backed URIs.

### Description
- Added a `VfsUri` abstraction to `crates/perl-uri/src/lib.rs` that parses LSP URIs, exposes `as_file_path()` when the URI is file-backed, and preserves non-file schemes as `Virtual(Url)`.
- Replaced direct `Url::to_file_path()` usages in runtime helpers with `VfsUri::parse(...).as_file_path()` via changes in `crates/perl-lsp/src/runtime/mod.rs`, `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs`, `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`, and `crates/perl-lsp/src/runtime/workspace.rs` so folder `path` and root path are only set for file-backed URIs.
- Populated `workspace_folder.path` only when the workspace folder URI maps to a filesystem path, leaving virtual workspace URIs intact and supported without forced path coercion.
- Added unit tests for `VfsUri` parsing and a regression test `set_root_uri_ignores_virtual_scheme` for lifecycle behavior, and added `perl-uri` to the `crates/perl-lsp/Cargo.toml` dependencies.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-uri --lib` and all unit tests passed (17 passed, 0 failed).
- Built and ran targeted server tests: `cargo test -p perl-lsp-rs set_root_uri_ignores_virtual_scheme --lib` and `cargo test -p perllsp set_root_uri_ignores_virtual_scheme --lib`, both completed and the regression test passed.
- Verified workspace build and test flows compiled the workspace components required for the changes and the added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fba366d48333ba53fba4b78161bb)