### PR TITLE
fix(semantic-analyzer): descend into Error partial nodes for symbol extraction (#3499)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -986,9 +986,21 @@ impl SymbolExtractor {
             | NodeKind::MissingStatement
             | NodeKind::MissingIdentifier
             | NodeKind::MissingBlock
-            | NodeKind::UnknownRest
-            | NodeKind::Error { .. } => {
+            | NodeKind::UnknownRest => {
                 // No symbols to extract
+            }
+
+            NodeKind::Error { partial, .. } => {
+                // Descend into the partial sub-tree if present. The parser stores
+                // the partially-parsed node inside Error when it managed to build
+                // some structure before failing (e.g. a variable expression whose
+                // postfix chain was truncated). Visiting it keeps symbol.rs in
+                // parity with every other traversal in the codebase (semantic
+                // tokens, class model, scope analyzer via children()) that already
+                // descends into partial.
+                if let Some(partial_node) = partial {
+                    self.visit_node(partial_node);
+                }
             }
 
             _ => {

--- a/crates/perl-semantic-analyzer/tests/error_node_symbol_visibility.rs
+++ b/crates/perl-semantic-analyzer/tests/error_node_symbol_visibility.rs
@@ -1,0 +1,190 @@
+//! Tests for symbol visibility in and around Error nodes.
+//!
+//! ## Background
+//!
+//! `NodeKind::Error` has a `partial: Option<Box<Node>>` field that stores a
+//! partially-parsed sub-tree when the parser managed to build some structure
+//! before failing.  In the current parser, `partial: Some(...)` is produced by
+//! the postfix arrow-expression recovery path (when `$expr->` is encountered
+//! but the token after `->` is not a valid continuation such as a method name,
+//! opening paren, bracket, or brace).
+//!
+//! Before the fix, `SymbolExtractor::visit_node()` treated `NodeKind::Error {
+//! .. }` as an opaque no-op leaf and never descended into `partial`, while
+//! every other traversal in the codebase (semantic tokens, class model, scope
+//! analyzer via children()) already visited `partial`.
+//!
+//! ## What these tests cover
+//!
+//! 1. **Arrow truncation** — `$r` declared via `my $r = $obj->;` is still
+//!    extracted even though the initializer is an Error node.
+//! 2. **Regression: variables on both sides of an arrow-truncation Error** —
+//!    declarations before and after the error are both visible.
+//! 3. **Regression: unclosed sub** — the parser currently returns a `Subroutine`
+//!    node directly (not `Error { partial: Some(Subroutine) }`), so `sub foo`
+//!    is visible without the partial-descent fix.  This test guards that
+//!    behaviour against future parser changes.
+//! 4. **Regression: missing RHS** — `my $x = ;` produces a
+//!    `VariableDeclaration` with a `MissingExpression` initializer, not an
+//!    Error node.  Symbols before and after are both visible.
+
+use perl_semantic_analyzer::Parser;
+use perl_semantic_analyzer::symbol::{SymbolExtractor, SymbolKind, SymbolTable};
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_and_extract(code: &str) -> SymbolTable {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    SymbolExtractor::new_with_source(code).extract(&ast)
+}
+
+fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
+    table.symbols.get(name).is_some_and(|syms| syms.iter().any(|s| s.kind == kind))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The declared variable (`$r`) is visible even when its initializer is an
+/// Error node produced by a truncated arrow expression.
+///
+/// Parser produces:
+/// ```text
+/// VariableDeclaration($r,
+///   Error { partial: Some(Variable($before)) })
+/// ```
+///
+/// `$r` must be extracted from the `VariableDeclaration` wrapper.  The partial
+/// node contains `Variable($before)` which is a read reference — not a new
+/// declaration — so partial descent does not add new symbols here, but it must
+/// not panic or skip siblings.
+#[test]
+fn decl_visible_when_initializer_is_error_node() -> Result<(), Box<dyn std::error::Error>> {
+    // Terminating semicolon after `->` triggers the arrow-truncation recovery.
+    let source = "my $before = 1;\nmy $r = $before->;\nmy $after = 2;\n";
+    let table = parse_and_extract(source);
+
+    assert!(
+        has_symbol(&table, "before", SymbolKind::scalar()),
+        "$before should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    assert!(
+        has_symbol(&table, "r", SymbolKind::scalar()),
+        "$r should be visible even though its initializer is Error{{partial}}; \
+         symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    assert!(
+        has_symbol(&table, "after", SymbolKind::scalar()),
+        "$after (declared after the Error node) should be visible; \
+         symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Arrow truncation at EOF: the declared variable is still indexed.
+///
+/// Parser produces:
+/// ```text
+/// VariableDeclaration($r, Error { partial: Some(Variable($before)) })
+/// ```
+/// No subsequent statements, so this is a pure "is the decl visible" check.
+#[test]
+fn decl_visible_when_rhs_is_truncated_arrow_at_eof() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $obj = {};\nmy $r = $obj->";
+    let table = parse_and_extract(source);
+
+    assert!(
+        has_symbol(&table, "obj", SymbolKind::scalar()),
+        "$obj should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    assert!(
+        has_symbol(&table, "r", SymbolKind::scalar()),
+        "$r should be visible even when its initializer arrow is truncated at EOF; \
+         symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Subroutine whose block is unclosed at EOF is still indexed.
+///
+/// The parser currently produces a `Subroutine` node directly (not wrapped in
+/// `Error { partial: Some(Subroutine) }`).  This test guards that existing
+/// recovery path against future parser changes.
+#[test]
+fn unclosed_sub_at_eof_is_visible() -> Result<(), Box<dyn std::error::Error>> {
+    // Missing closing `}` — parser recovers and returns a Subroutine node.
+    let source = "sub foo { my $x = 1; ";
+    let table = parse_and_extract(source);
+
+    assert!(
+        has_symbol(&table, "foo", SymbolKind::Subroutine),
+        "sub foo should be visible even when its block is unclosed at EOF; \
+         symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// When two subroutines are present and the second is unclosed, both are
+/// indexed.  This exercises the statement-level recovery path where parsing
+/// continues after an error statement.
+#[test]
+fn second_unclosed_sub_is_visible() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "sub foo { } sub bar { my $x = 1;";
+    let table = parse_and_extract(source);
+
+    assert!(
+        has_symbol(&table, "foo", SymbolKind::Subroutine),
+        "sub foo (closed) should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    assert!(
+        has_symbol(&table, "bar", SymbolKind::Subroutine),
+        "sub bar (unclosed at EOF) should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Variables before and after a missing-RHS error are both visible.
+///
+/// `my $broken = ;` triggers Phase 2 recovery and produces a
+/// `VariableDeclaration` with a `MissingExpression` initializer — not an
+/// `Error { partial }` node.  This tests an independent recovery path.
+#[test]
+fn variables_around_missing_rhs_are_visible() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $before = 1;\nmy $broken = ;\nmy $after = 2;\n";
+    let table = parse_and_extract(source);
+
+    assert!(
+        has_symbol(&table, "before", SymbolKind::scalar()),
+        "$before should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    assert!(
+        has_symbol(&table, "after", SymbolKind::scalar()),
+        "$after declared after error should be visible; symbols: {:?}",
+        table.symbols.keys().collect::<Vec<_>>()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Splits `NodeKind::Error { .. }` out of the no-op match arm in `SymbolExtractor::visit_node()` and adds a new arm that recurses into `self.visit_node(partial_node)` when `partial` is `Some`.
- Brings `SymbolExtractor` into parity with every other traversal in the codebase (`semantic_tokens`, `class_model`, `scope_analyzer` via `children()`, `for_each_child`) that already descends into the `partial` sub-tree.
- Adds a new test file documenting symbol visibility guarantees around Error nodes and existing error-recovery paths.

## Changes

- `crates/perl-semantic-analyzer/src/analysis/symbol.rs` (+14/-2): split Error arm, add partial descent
- `crates/perl-semantic-analyzer/tests/error_node_symbol_visibility.rs` (new, +190): 5 tests covering arrow-truncation errors, unclosed-sub recovery, missing-RHS recovery

## Background (from plan-review on issue #3499)

The plan-reviewer corrected the scout's analysis. The real fix is a missing match arm, not an architectural change:

- `NodeKind::Error` already has `partial: Option<Box<Node>>` (added in PR #2873)
- Statement-level error recovery already continues parsing after errors
- `SymbolExtractor::visit_node()` at ~line 990 was the only traversal that treated Error as an opaque leaf — all other traversals already descend into `partial`

**Investigation finding:** During TDD the builder discovered that the current parser's `partial: Some(...)` path is only triggered by the postfix arrow-expression truncation (`$expr->;`), which wraps an expression node (not a declaration). The tests therefore pass before the fix as well as after — they are regression guards and documentation. The fix is still correct: it future-proofs symbol.rs for parser changes that may produce declarations inside `partial`, and it eliminates the inconsistency that existed relative to all other traversals.

## Evidence

- **Commits**: 1
- **Tests**: 5 new tests (all pass), 0 regressions
- **Lint**: Clean on changed crate (pre-existing failures in `frameworks_web.rs` and `frameworks_catalyst.rs` are unrelated)
- **Files**: 2 changed, +204/-2 lines
- **Pre-existing gate issue**: Local pre-push gate fails on Windows due to path-separator bug in `is_allowlisted_prod_panic_hit()` (backslash vs forward-slash comparison for `perl-heredoc-anti-patterns/src/lib.rs`). This is environmental and unrelated to this PR. GitHub CI provides the authoritative gate.

## Test Plan

```bash
export CARGO_TARGET_DIR="/tmp/agent-worktree-agent-af1ef8c3-target"
cargo test -p perl-semantic-analyzer --test error_node_symbol_visibility
cargo test -p perl-semantic-analyzer
cargo clippy -p perl-semantic-analyzer
```

## Unknowns

- The partial-descent fix has no observable effect with current parser inputs (since `partial: Some(...)` only wraps expression nodes, not declarations). If the parser ever changes to wrap a declaration in an Error node, the fix will start producing new symbols. This is the intended behaviour.
- `symbol_extraction_method_preserves_attributes` in `comprehensive_unit_tests.rs` fails on master — pre-existing, unrelated to this change.

## Follow-ups Recommended

- Windows path separator bug in `is_allowlisted_prod_panic_hit()` in `crates/perl-ci-hygiene/src/main.rs:3030` — allowlist uses `/` but `display_path` produces `\` on Windows, causing 7 allowlisted `unreachable!()` calls in `perl-heredoc-anti-patterns/src/lib.rs` to fail the ratchet check on Windows.