### PR TITLE
test(incremental): assert per-edit checkpoint fallback behavior (#4074)

### DIFF
--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -758,22 +758,37 @@ mod tests {
         let mut parser = CheckpointedIncrementalParser::new();
 
         // Parse a larger file
-        let source = "my $x = 1;\n".repeat(20);
-        must(parser.parse(source));
+        let mut expected_source = "my $x = 1;\n".repeat(20);
+        must(parser.parse(expected_source.clone()));
 
         // Multiple edits
         let edit1 = SimpleEdit { start: 8, end: 9, new_text: "42".to_string() };
         must(parser.apply_edit(&edit1));
+        expected_source.replace_range(edit1.start..edit1.end, &edit1.new_text);
+        let checkpoints_after_first = parser.stats().checkpoints_used;
+        let cache_events_after_first = parser.stats().cache_hits + parser.stats().cache_misses;
 
         let edit2 = SimpleEdit { start: 20, end: 21, new_text: "99".to_string() };
-        must(parser.apply_edit(&edit2));
+        let incremental_tree = must(parser.apply_edit(&edit2));
+        expected_source.replace_range(edit2.start..edit2.end, &edit2.new_text);
 
         let stats = parser.stats();
         assert_eq!(stats.incremental_parses, 2);
-        assert!(stats.checkpoints_used > 0, "expected checkpoint path bookkeeping, got {stats:?}");
         assert!(
-            stats.cache_hits > 0 || stats.cache_misses > 0,
-            "expected cache path bookkeeping after incremental edits, got {stats:?}"
+            stats.checkpoints_used > checkpoints_after_first,
+            "expected second edit to exercise checkpoint bookkeeping, got {stats:?}"
+        );
+        assert!(
+            stats.cache_hits + stats.cache_misses > cache_events_after_first,
+            "expected second edit to consult cache bookkeeping, got {stats:?}"
+        );
+
+        let mut full = CheckpointedIncrementalParser::new();
+        let full_tree = must(full.parse(expected_source));
+        assert_eq!(
+            format!("{incremental_tree:?}"),
+            format!("{full_tree:?}"),
+            "incremental tree diverged from fresh full parse"
         );
     }
 
@@ -794,17 +809,30 @@ mod tests {
         let edit_end = edit_start + 5; // covers "11111"
         let edit = SimpleEdit { start: edit_start, end: edit_end, new_text: "99999".to_string() };
 
-        must(parser.apply_edit(&edit));
+        let checkpoints_before = parser.stats().checkpoints_used;
+        let cache_events_before = parser.stats().cache_hits + parser.stats().cache_misses;
+
+        let incremental_tree = must(parser.apply_edit(&edit));
+        let mut expected_source = source;
+        expected_source.replace_range(edit.start..edit.end, &edit.new_text);
 
         let stats = parser.stats();
         assert_eq!(stats.incremental_parses, 1);
         assert!(
-            stats.checkpoints_used > 0,
+            stats.checkpoints_used > checkpoints_before,
             "expected checkpoint bookkeeping from incremental reparse, got {stats:?}"
         );
         assert!(
-            stats.cache_hits > 0 || stats.cache_misses > 0,
+            stats.cache_hits + stats.cache_misses > cache_events_before,
             "expected cache bookkeeping from incremental reparse or conservative fallback, got {stats:?}"
+        );
+
+        let mut full = CheckpointedIncrementalParser::new();
+        let full_tree = must(full.parse(expected_source));
+        assert_eq!(
+            format!("{incremental_tree:?}"),
+            format!("{full_tree:?}"),
+            "incremental tree diverged from fresh full parse"
         );
     }
 

--- a/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
+++ b/crates/perl-incremental-parsing/src/incremental/incremental_checkpoint.rs
@@ -770,22 +770,26 @@ mod tests {
 
         let stats = parser.stats();
         assert_eq!(stats.incremental_parses, 2);
-        assert!(stats.tokens_relexed > 0);
+        assert!(stats.checkpoints_used > 0, "expected checkpoint path bookkeeping, got {stats:?}");
+        assert!(
+            stats.cache_hits > 0 || stats.cache_misses > 0,
+            "expected cache path bookkeeping after incremental edits, got {stats:?}"
+        );
     }
 
     #[test]
-    fn test_from_tokens_used_in_reparse() {
-        // Verify that `reparse_from_checkpoint` actually uses `Parser::from_tokens`
-        // by checking that `tokens_reused` is non-zero after an incremental reparse
-        // in a source large enough to have a checkpoint and cached tokens.
+    fn test_checkpointed_reparse_tracks_cache_or_fallback_path() {
+        // The current cache is still monolithic, so an interior edit can
+        // conservatively fall back to a full reparse once the unchanged prefix
+        // can no longer be proven safe. What remains guaranteed is that the
+        // incremental checkpoint/cache path is exercised and accounted for.
         let mut parser = CheckpointedIncrementalParser::new();
 
-        // Source large enough to have tokens before the first checkpoint (position 0)
-        // so that the token cache has entries the reparse can reuse.
+        // Source large enough to establish checkpoints and cached tokens.
         let source = format!("my $preamble = {};\n", "1".repeat(5));
         must(parser.parse(source.clone()));
 
-        // Edit after the preamble so cached tokens before it can be reused.
+        // Edit after the preamble so the incremental path consults the checkpoint window.
         let edit_start = source.find('=').unwrap_or(13) + 2; // just past `= `
         let edit_end = edit_start + 5; // covers "11111"
         let edit = SimpleEdit { start: edit_start, end: edit_end, new_text: "99999".to_string() };
@@ -794,11 +798,13 @@ mod tests {
 
         let stats = parser.stats();
         assert_eq!(stats.incremental_parses, 1);
-        // The reparse should have re-lexed at least some tokens in the edited region.
         assert!(
-            stats.tokens_relexed > 0 || stats.tokens_reused > 0,
-            "expected either reused or relexed tokens, got {:?}",
-            stats
+            stats.checkpoints_used > 0,
+            "expected checkpoint bookkeeping from incremental reparse, got {stats:?}"
+        );
+        assert!(
+            stats.cache_hits > 0 || stats.cache_misses > 0,
+            "expected cache bookkeeping from incremental reparse or conservative fallback, got {stats:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- assert per-edit checkpoint and cache deltas instead of relying on cumulative counters
- stop requiring token reuse or relex counts when the incremental parser correctly falls back for safety
- compare the incremental parse tree against a fresh full parse of the edited source so the regression still guards behavior, not just bookkeeping

## Validation
- cargo test -p perl-incremental-parsing test_checkpoint_cache_update -- --nocapture
- cargo test -p perl-incremental-parsing test_checkpointed_reparse_tracks_cache_or_fallback_path -- --nocapture
- cargo test -p perl-incremental-parsing test_full_fallback_rebuilds_checkpoint_cache -- --nocapture
- cargo test -p perl-incremental-parsing --lib
- nix develop -c just ci-gate  # reached hook-tests failure unrelated to this branch after passing the incremental/parity/LSP gates