### PR TITLE
test(semantic-analyzer): fix stale method attribute assertion (#4072)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/comprehensive_unit_tests.rs
@@ -110,8 +110,8 @@ fn symbol_extraction_method_preserves_attributes() -> Result<(), Box<dyn std::er
         table.symbols.get("size").ok_or("expected method symbol `size` to be extracted")?;
     let method = methods
         .iter()
-        .find(|symbol| symbol.kind == SymbolKind::Subroutine)
-        .ok_or("expected subroutine symbol for method `size`")?;
+        .find(|symbol| symbol.kind == SymbolKind::Method)
+        .ok_or("expected method symbol for method `size`")?;
 
     assert!(method.attributes.contains(&"method".to_string()));
     assert!(method.attributes.contains(&"lvalue".to_string()));


### PR DESCRIPTION
## Summary
- align the method attribute regression with the current symbol contract
- look up extracted methods as  instead of 
- keep the attribute-preservation assertion intact once the correct symbol is selected

## Testing
- cargo test -p perl-semantic-analyzer symbol_extraction_method_preserves_attributes
- cargo test -p perl-semantic-analyzer --test comprehensive_unit_tests