### PR TITLE
fix(hooks): make pre-push run pr-fast instead of ci-gate (#4083)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,9 @@ just doctor     # Deeper workspace health check — finds drift, stale files, co
 just pr-fast    # Fastest checks: fmt + clippy + tests (~1-2 min). Run this often.
 ```
 
-### 4. Run the canonical pre-push gate
+### 4. Run the canonical merge gate
 
-This is required before opening a PR. It runs the same checks CI runs:
+This is the explicit full validation step before merge. It runs the same checks CI runs:
 
 ```bash
 nix develop -c just ci-gate   # Recommended: reproducible env (~3-5 min)
@@ -113,11 +113,14 @@ nix develop -c just ci-gate   # Recommended: reproducible env (~3-5 min)
 just ci-gate
 ```
 
-The pre-push git hook runs this automatically if you installed it:
+If you install the pre-push git hook, it runs the faster Tier A gate automatically on push:
 
 ```bash
 bash scripts/install-githooks.sh
 ```
+
+That hook runs `nix develop -c just pr-fast` (or `just pr-fast` without Nix).
+It is a quick push guard, not the full merge gate.
 
 ### 5. Expand for larger changes or release prep
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 cargo test --workspace --lib
 cargo fmt --all
 cargo clippy --workspace
-nix develop -c just ci-gate   # required before push
+nix develop -c just ci-gate   # required before merge
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1887,7 +1887,7 @@ if [ "$DOC_ONLY" = true ]; then
     exit 0
 fi
 
-echo "Running local gate before push: nix develop -c just ci-gate"
+echo "Running local fast gate before push: nix develop -c just pr-fast"
 echo "   (Skip with: git push --no-verify)"
 echo ""
 
@@ -1914,9 +1914,9 @@ trap 'rm -f "$GATE_LOG"' EXIT
 
 run_gate() {
     if command -v nix &>/dev/null && [ -f flake.nix ]; then
-        nix develop -c just ci-gate
+        nix develop -c just pr-fast
     elif command -v just &>/dev/null; then
-        just ci-gate
+        just pr-fast
     else
         echo "⚠️  Neither 'nix develop' nor 'just' available, skipping pre-push gate"
         echo "   Install just: cargo install just"
@@ -1931,7 +1931,7 @@ set -e
 
 if [ "$GATE_STATUS" -ne 0 ]; then
     echo ""
-    echo "❌ ci-gate failed (exit $GATE_STATUS) — checking for known issues..."
+    echo "❌ pr-fast failed (exit $GATE_STATUS) — checking for known issues..."
     HINTED=false
     if grep -q 'ci-parser-features-check' "$GATE_LOG" 2>/dev/null && \
        grep -qE 'os error 5|Access is denied' "$GATE_LOG" 2>/dev/null; then
@@ -1990,7 +1990,7 @@ fi
 
     println!("✅ Installed pre-commit and pre-push hooks");
     println!("   The pre-commit hook blocks known placeholder git identities");
-    println!("   The pre-push hook runs 'nix develop -c just ci-gate' before each push");
+    println!("   The pre-push hook runs 'nix develop -c just pr-fast' before each push");
     println!("   Skip with: git commit --no-verify / git push --no-verify");
     Ok(0)
 }
@@ -4107,7 +4107,7 @@ mod tests {
     }
 
     #[test]
-    fn pre_push_hook_skips_ci_gate_on_delete_only_push() {
+    fn pre_push_hook_skips_gate_on_delete_only_push() {
         let hook = pre_push_hook_script();
         // The hook must detect when all refs have a zero local SHA (deletion).
         assert!(
@@ -4122,10 +4122,10 @@ mod tests {
             hook.contains("Branch deletion"),
             "hook must print a message when skipping due to deletion"
         );
-        // Normal pushes (non-zero SHA) must still run the gate.
+        // Normal pushes (non-zero SHA) must still run the fast push gate.
         assert!(
-            hook.contains("just ci-gate"),
-            "hook must still invoke the CI gate for normal pushes"
+            hook.contains("just pr-fast"),
+            "hook must invoke the fast PR gate for normal pushes"
         );
     }
 

--- a/docs/project/CI_LOCAL_VALIDATION.md
+++ b/docs/project/CI_LOCAL_VALIDATION.md
@@ -25,7 +25,7 @@ shell is only there to make the toolchain and external helpers reproducible.
 
 - `just devex` checks the local environment and highlights missing tools.
 - `just pr-fast` is the quick edit loop for normal PR iteration.
-- `nix develop -c just ci-gate` is the canonical pre-push gate.
+- `nix develop -c just ci-gate` is the canonical full local merge gate.
 - `just ci-full` is the broader validation pass for large refactors or release
   confidence.
 - `just status-update` and `just status-check` keep generated status docs in


### PR DESCRIPTION
## Summary
- switch the generated pre-push hook from the full `ci-gate` path to the Tier A `pr-fast` path
- keep `ci-gate` documented as the explicit full merge gate instead of an automatic push hook
- update contributor docs to match the new hook contract

## Testing
- `cargo test -p perl-ci-hygiene pre_push_hook`
