### PR TITLE
fix(execute-command): strip Windows extended-length prefix before external command (#4085)

### DIFF
--- a/crates/perl-lsp/src/execute_command/mod.rs
+++ b/crates/perl-lsp/src/execute_command/mod.rs
@@ -14,6 +14,6 @@ mod tests;
 mod types;
 
 pub use executor::CommandExecutor;
-pub use provider::{ExecuteCommandProvider, command_exists, get_supported_commands};
 pub(crate) use provider::normalize_path_for_external_command;
+pub use provider::{ExecuteCommandProvider, command_exists, get_supported_commands};
 pub use types::{CommandResult, PerlCommand};

--- a/crates/perl-lsp/src/execute_command/mod.rs
+++ b/crates/perl-lsp/src/execute_command/mod.rs
@@ -15,4 +15,5 @@ mod types;
 
 pub use executor::CommandExecutor;
 pub use provider::{ExecuteCommandProvider, command_exists, get_supported_commands};
+pub(crate) use provider::normalize_path_for_external_command;
 pub use types::{CommandResult, PerlCommand};

--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -3,6 +3,24 @@ use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Strip the Windows extended-length path prefix (`\\?\`) before passing a path
+/// to an external command such as `perl`, `prove`, or `yath`.
+///
+/// On Windows, `Path::canonicalize` returns paths prefixed with `\\?\`, which is
+/// understood by Win32 APIs but not by external programs (e.g. `perl.exe`).  This
+/// helper strips that prefix so the resulting path is usable as a command-line
+/// argument.  On non-Windows platforms the function is a no-op identity.
+pub(crate) fn normalize_path_for_external_command(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped.to_string());
+        }
+    }
+    path.to_path_buf()
+}
+
 /// Execute command provider implementing the LSP executeCommand method.
 pub struct ExecuteCommandProvider {
     workspace_roots: Vec<PathBuf>,
@@ -88,11 +106,12 @@ impl ExecuteCommandProvider {
             self.command_exists("yath"),
             self.command_exists("prove"),
         );
+        let ext_path = normalize_path_for_external_command(file_path);
 
         match runner {
             TestRunner::Yath => {
                 let mut yath_cmd = Command::new("yath");
-                yath_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                yath_cmd.arg("-v").arg("--").arg(ext_path.as_os_str());
                 match crate::util::run_command_with_timeout(yath_cmd, 30) {
                     Ok(result) => {
                         Ok(self.format_command_result(result, Some(("command", "yath".into()))))
@@ -100,7 +119,7 @@ impl ExecuteCommandProvider {
                     Err(error) => {
                         if self.command_exists("prove") {
                             let mut prove_cmd = Command::new("prove");
-                            prove_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                            prove_cmd.arg("-v").arg("--").arg(ext_path.as_os_str());
                             match crate::util::run_command_with_timeout(prove_cmd, 30) {
                                 Ok(result) => Ok(self.format_command_result(
                                     result,
@@ -108,7 +127,7 @@ impl ExecuteCommandProvider {
                                 )),
                                 Err(fallback_error) => {
                                     let mut perl_cmd = Command::new("perl");
-                                    perl_cmd.arg("--").arg(file_path.as_os_str());
+                                    perl_cmd.arg("--").arg(ext_path.as_os_str());
                                     match crate::util::run_command_with_timeout(perl_cmd, 30) {
                                         Ok(result) => Ok(self.format_command_result(
                                             result,
@@ -125,7 +144,7 @@ impl ExecuteCommandProvider {
                             }
                         } else {
                             let mut perl_cmd = Command::new("perl");
-                            perl_cmd.arg("--").arg(file_path.as_os_str());
+                            perl_cmd.arg("--").arg(ext_path.as_os_str());
                             match crate::util::run_command_with_timeout(perl_cmd, 30) {
                                 Ok(result) => Ok(self
                                     .format_command_result(result, Some(("command", "perl".into())))),
@@ -142,14 +161,14 @@ impl ExecuteCommandProvider {
             }
             TestRunner::Prove => {
                 let mut prove_cmd = Command::new("prove");
-                prove_cmd.arg("-v").arg("--").arg(file_path.as_os_str());
+                prove_cmd.arg("-v").arg("--").arg(ext_path.as_os_str());
                 match crate::util::run_command_with_timeout(prove_cmd, 30) {
                     Ok(result) => {
                         Ok(self.format_command_result(result, Some(("command", "prove".into()))))
                     }
                     Err(error) => {
                         let mut perl_cmd = Command::new("perl");
-                        perl_cmd.arg("--").arg(file_path.as_os_str());
+                        perl_cmd.arg("--").arg(ext_path.as_os_str());
                         match crate::util::run_command_with_timeout(perl_cmd, 30) {
                             Ok(result) => Ok(self
                                 .format_command_result(result, Some(("command", "perl".into())))),
@@ -165,7 +184,7 @@ impl ExecuteCommandProvider {
             }
             TestRunner::Perl => {
                 let mut perl_cmd = Command::new("perl");
-                perl_cmd.arg("--").arg(file_path.as_os_str());
+                perl_cmd.arg("--").arg(ext_path.as_os_str());
                 match crate::util::run_command_with_timeout(perl_cmd, 30) {
                     Ok(result) => {
                         Ok(self.format_command_result(result, Some(("command", "perl".into()))))
@@ -190,9 +209,10 @@ impl ExecuteCommandProvider {
                 die "Subroutine $sub not found";
             }
         "#;
+        let ext_path = normalize_path_for_external_command(file_path);
 
         let mut perl_cmd = Command::new("perl");
-        perl_cmd.arg("-e").arg(perl_code).arg("--").arg(file_path.as_os_str()).arg(sub_name);
+        perl_cmd.arg("-e").arg(perl_code).arg("--").arg(ext_path.as_os_str()).arg(sub_name);
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => {
                 Ok(self.format_command_result(result, Some(("subroutine", sub_name.into()))))
@@ -205,8 +225,9 @@ impl ExecuteCommandProvider {
     }
 
     pub(crate) fn run_file(&self, file_path: &Path) -> Result<Value, String> {
+        let ext_path = normalize_path_for_external_command(file_path);
         let mut perl_cmd = Command::new("perl");
-        perl_cmd.arg("--").arg(file_path.as_os_str());
+        perl_cmd.arg("--").arg(ext_path.as_os_str());
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => Ok(self.format_command_result(result, None)),
             Err(error) => {
@@ -908,4 +929,57 @@ pub fn get_supported_commands() -> Vec<String> {
         "perl.goToTest".to_string(),
         "perl.goToImplementation".to_string(),
     ]
+}
+
+#[cfg(test)]
+mod normalize_path_tests {
+    use super::normalize_path_for_external_command;
+    use std::path::{Path, PathBuf};
+
+    /// On Windows the `\\?\` extended-length prefix must be stripped so that
+    /// external commands (perl.exe, prove, yath) can accept the path.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn strips_extended_length_prefix_on_windows() {
+        let prefixed = Path::new(r"\\?\C:\Users\test\file.pl");
+        let result = normalize_path_for_external_command(prefixed);
+        assert_eq!(
+            result,
+            PathBuf::from(r"C:\Users\test\file.pl"),
+            "Extended-length prefix should be stripped: got {:?}",
+            result
+        );
+    }
+
+    /// On Windows, paths without the prefix are returned unchanged.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn passthrough_plain_windows_path() {
+        let plain = Path::new(r"C:\Users\test\file.pl");
+        let result = normalize_path_for_external_command(plain);
+        assert_eq!(result, PathBuf::from(r"C:\Users\test\file.pl"));
+    }
+
+    /// On non-Windows, the helper is a pass-through identity — paths are
+    /// returned exactly as given regardless of content.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn passthrough_on_non_windows() {
+        let path = Path::new("/tmp/test_valid.pl");
+        let result = normalize_path_for_external_command(path);
+        assert_eq!(result, PathBuf::from("/tmp/test_valid.pl"));
+    }
+
+    /// Verify the helper handles a synthetic Windows extended-length prefix
+    /// as a string: even on non-Windows the conditional compilation means the
+    /// prefix is left untouched (since there is no `\\?\` on Unix paths).
+    /// This test documents the cross-platform contract.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn no_stripping_on_non_windows_even_for_unc_like_string() {
+        // On Linux/macOS this is just a literal path string — no stripping.
+        let path = Path::new(r"\\?\C:\foo\bar");
+        let result = normalize_path_for_external_command(path);
+        assert_eq!(result, PathBuf::from(r"\\?\C:\foo\bar"));
+    }
 }

--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -10,10 +10,24 @@ use std::process::Command;
 /// understood by Win32 APIs but not by external programs (e.g. `perl.exe`).  This
 /// helper strips that prefix so the resulting path is usable as a command-line
 /// argument.  On non-Windows platforms the function is a no-op identity.
+///
+/// Two prefix forms are handled:
+/// - `\\?\C:\...`         (local drive) → `C:\...`
+/// - `\\?\UNC\server\...` (network UNC) → `\\server\...`
+///
+/// The UNC form requires special treatment: stripping `\\?\` alone would leave
+/// `UNC\server\...` which is not a valid path.  Instead we replace `\\?\UNC\`
+/// with `\\` so the result is a conventional UNC path (`\\server\share\...`).
 pub(crate) fn normalize_path_for_external_command(path: &Path) -> PathBuf {
     #[cfg(windows)]
     {
         let s = path.to_string_lossy();
+        // Network UNC extended-length paths: \\?\UNC\server\share\...
+        // Must become \\server\share\... (not UNC\server\share\...)
+        if let Some(unc_rest) = s.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{}", unc_rest));
+        }
+        // Local drive extended-length paths: \\?\C:\... → C:\...
         if let Some(stripped) = s.strip_prefix(r"\\?\") {
             return PathBuf::from(stripped.to_string());
         }
@@ -981,5 +995,34 @@ mod normalize_path_tests {
         let path = Path::new(r"\\?\C:\foo\bar");
         let result = normalize_path_for_external_command(path);
         assert_eq!(result, PathBuf::from(r"\\?\C:\foo\bar"));
+    }
+
+    /// On Windows, the UNC extended-length form `\\?\UNC\server\share\...` must
+    /// become `\\server\share\...` — NOT `UNC\server\share\...`.
+    ///
+    /// `Path::canonicalize` on Windows returns `\\?\UNC\...` for network paths.
+    /// Simply stripping `\\?\` would leave `UNC\server\share\...` which perl.exe
+    /// cannot resolve.  The correct result is a plain UNC path `\\server\share\...`.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn strips_extended_length_unc_prefix_on_windows() {
+        let prefixed = Path::new(r"\\?\UNC\fileserver\share\project\test.pl");
+        let result = normalize_path_for_external_command(prefixed);
+        assert_eq!(
+            result,
+            PathBuf::from(r"\\fileserver\share\project\test.pl"),
+            "UNC extended-length prefix should become plain UNC path: got {:?}",
+            result
+        );
+    }
+
+    /// On non-Windows, a UNC extended-length string is also left untouched —
+    /// the conditional compilation means the entire stripping block is absent.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn no_stripping_on_non_windows_even_for_unc_extended_string() {
+        let path = Path::new(r"\\?\UNC\fileserver\share\project\test.pl");
+        let result = normalize_path_for_external_command(path);
+        assert_eq!(result, PathBuf::from(r"\\?\UNC\fileserver\share\project\test.pl"));
     }
 }

--- a/crates/perl-lsp/src/execute_command/provider.rs
+++ b/crates/perl-lsp/src/execute_command/provider.rs
@@ -1,5 +1,11 @@
 use crate::perl_critic::{BuiltInAnalyzer, CriticAnalyzer, CriticConfig};
 use serde_json::{Value, json};
+#[cfg(windows)]
+use std::ffi::OsString;
+#[cfg(windows)]
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+#[cfg(windows)]
+use std::path::{Component, Prefix};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -18,20 +24,35 @@ use std::process::Command;
 /// The UNC form requires special treatment: stripping `\\?\` alone would leave
 /// `UNC\server\...` which is not a valid path.  Instead we replace `\\?\UNC\`
 /// with `\\` so the result is a conventional UNC path (`\\server\share\...`).
+#[cfg(windows)]
 pub(crate) fn normalize_path_for_external_command(path: &Path) -> PathBuf {
-    #[cfg(windows)]
-    {
-        let s = path.to_string_lossy();
-        // Network UNC extended-length paths: \\?\UNC\server\share\...
-        // Must become \\server\share\... (not UNC\server\share\...)
-        if let Some(unc_rest) = s.strip_prefix(r"\\?\UNC\") {
-            return PathBuf::from(format!(r"\\{}", unc_rest));
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix_component)) = components.next() else {
+        return path.to_path_buf();
+    };
+
+    match prefix_component.kind() {
+        Prefix::VerbatimDisk(drive) => {
+            let mut normalized = PathBuf::from(format!("{}:", char::from(drive)));
+            normalized.push(components.as_path());
+            normalized
         }
-        // Local drive extended-length paths: \\?\C:\... → C:\...
-        if let Some(stripped) = s.strip_prefix(r"\\?\") {
-            return PathBuf::from(stripped.to_string());
+        Prefix::VerbatimUNC(server, share) => {
+            let mut wide = vec![b'\\' as u16, b'\\' as u16];
+            wide.extend(server.encode_wide());
+            wide.push(b'\\' as u16);
+            wide.extend(share.encode_wide());
+
+            let mut normalized = PathBuf::from(OsString::from_wide(&wide));
+            normalized.push(components.as_path());
+            normalized
         }
+        _ => path.to_path_buf(),
     }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn normalize_path_for_external_command(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -1562,11 +1562,17 @@ impl LspServer {
                             data: Some(json!({"file": file_path})),
                         })?;
 
+                    // Strip \\?\ extended-length prefix so perl.exe can accept the path.
+                    // resolve_debug_file_path calls canonicalize() which on Windows returns
+                    // paths with the \\?\ prefix that external programs cannot handle.
+                    let ext_resolved =
+                        crate::execute_command::normalize_path_for_external_command(&resolved);
+
                     // Launch perl -d as a detached child process
                     match std::process::Command::new("perl")
                         .arg("-d")
                         .arg("--")
-                        .arg(&resolved)
+                        .arg(&ext_resolved)
                         .stdin(std::process::Stdio::null())
                         .stdout(std::process::Stdio::null())
                         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
## Root cause

`Path::canonicalize` on Windows returns paths with the `\?\` extended-length prefix (e.g. `\?\C:\Users\steven\AppData\Local\Temp\.tmp\test_valid.pl`). Win32 APIs accept this prefix, but external programs invoked as child processes — `perl.exe`, `prove`, and `yath` — do not. This caused `test_valid_file_execution` to fail with:

```
Can't open perl script "\?C:UsersstevenAppDataLocalTemp.tmpWGjyqEtest_valid.pl": No such file or directory
```

The path mangling (all backslashes dropped after the drive letter) is how CMD.EXE renders the UNC-style prefix when Perl re-echoes it in the error message.

## Fix

Added `normalize_path_for_external_command(path: &Path) -> PathBuf` in `crates/perl-lsp/src/execute_command/provider.rs`. On Windows it strips the `\?\` prefix; on non-Windows it is a zero-cost identity (the `#[cfg(windows)]` block compiles away entirely).

## Call sites updated (all in `provider.rs`)

| Method | External command | Arg site |
|--------|-----------------|----------|
| `run_tests` (yath primary) | `yath` | `.arg(file_path.as_os_str())` → `.arg(ext_path.as_os_str())` |
| `run_tests` (prove fallback from yath) | `prove` | same |
| `run_tests` (perl fallback from yath+prove) | `perl` | same |
| `run_tests` (perl fallback from yath, no prove) | `perl` | same |
| `run_tests` (prove primary) | `prove` | same |
| `run_tests` (perl fallback from prove) | `perl` | same |
| `run_tests` (perl primary) | `perl` | same |
| `run_test_sub` | `perl -e` | same |
| `run_file` | `perl` | same |

Before (Windows): `\?\C:\Users\steven\AppData\Local\Temp\.tmp\test_valid.pl`
After (Windows):  `C:\Users\steven\AppData\Local\Temp\.tmp\test_valid.pl`

## Unit tests

Added `#[cfg(test)] mod normalize_path_tests` with 4 tests:
- `strips_extended_length_prefix_on_windows` — `#[cfg(target_os = "windows")]`
- `passthrough_plain_windows_path` — `#[cfg(target_os = "windows")]`
- `passthrough_on_non_windows` — `#[cfg(not(target_os = "windows"))]`
- `no_stripping_on_non_windows_even_for_unc_like_string` — `#[cfg(not(target_os = "windows"))]`

## Test results

Run on Windows (this worktree runs on Windows):
- `execute_command_security_tests`: **13/13 passed** (including `test_valid_file_execution`)
- `execute_command` lib tests: **60/60 passed** (58 pre-existing + 2 new helper unit tests)

Note: The Windows-gated tests (`strips_extended_length_prefix_on_windows`, `passthrough_plain_windows_path`) were directly exercised here. The non-Windows CI will exercise the two `#[cfg(not(target_os = "windows"))]` tests.

## Pre-push gate note

The pre-push hook failed on `perl-module-resolution::use_lib::tests` — a pre-existing master failure unrelated to this change (confirmed on master HEAD). Pushed with `--no-verify` per the bypass policy ("hook is failing for an environmental reason out of band of your change").

Closes #4085