### PR TITLE
fix(pragma): model BEGIN/END/INIT/CHECK/UNITCHECK phase blocks as compile-time scope (#4084)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -832,6 +832,22 @@ impl PragmaTracker {
             NodeKind::Package { block: Some(pkg_block), .. } => {
                 Self::build_scoped_body(pkg_block, current_state, ranges);
             }
+            // Phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) share compile-time
+            // scope with the enclosing file.  Per Perl semantics (perlmod,
+            // perlop), pragmas declared inside a phase block propagate outward
+            // to the surrounding compilation unit.  We bypass the inner
+            // `Block` node's save/restore semantics by walking its statements
+            // directly, so pragmas escape into the surrounding scope.
+            NodeKind::PhaseBlock { block, .. } => {
+                if let NodeKind::Block { statements } = &block.kind {
+                    for stmt in statements {
+                        Self::build_ranges(stmt, current_state, ranges);
+                    }
+                } else {
+                    // Fallback: recurse normally (non-Block inner node is unusual)
+                    Self::build_ranges(block, current_state, ranges);
+                }
+            }
             // Other node types don't contain use/no statements
             _ => {}
         }

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -48,6 +48,17 @@ fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
     }
 }
 
+fn phase_block(phase: &str, inner_block: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: None,
+            block: Box::new(inner_block),
+        },
+        location: loc(start, end),
+    }
+}
+
 fn program(stmts: Vec<Node>) -> Node {
     let end = stmts.last().map_or(0, |n| n.location.end);
     Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
@@ -171,4 +182,121 @@ fn given_package_block_with_inner_no_strict_when_execution_continues_then_outer_
     let after_package = PragmaTracker::state_for_offset(&map, 50);
     assert!(after_package.strict_subs);
     assert!(after_package.warnings);
+}
+
+// ---------------------------------------------------------------------------
+// Phase block (BEGIN/END/INIT/CHECK/UNITCHECK) pragma propagation
+// ---------------------------------------------------------------------------
+//
+// Per Perl semantics (perlmod, perlop): all phase blocks execute at compile
+// time with respect to pragma state.  Pragmas declared inside a phase block
+// propagate to the surrounding file scope — they are NOT lexically scoped like
+// a regular subroutine body.
+
+#[test]
+fn given_begin_block_with_use_strict_when_querying_after_block_then_strict_is_active() {
+    // BEGIN { use strict; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "BEGIN",
+        block(vec![use_node("strict", &[], 10, 22)], 8, 24),
+        0,
+        25,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    // Strict should be active after the BEGIN block
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.strict_vars, "strict_vars should propagate out of BEGIN block");
+    assert!(state.strict_subs, "strict_subs should propagate out of BEGIN block");
+    assert!(state.strict_refs, "strict_refs should propagate out of BEGIN block");
+}
+
+#[test]
+fn given_end_block_with_use_strict_when_querying_after_block_then_strict_is_active() {
+    // END { use strict; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "END",
+        block(vec![use_node("strict", &[], 8, 20)], 6, 22),
+        0,
+        23,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    // Pragmas in END blocks share compile-time scope with the surrounding file
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.strict_vars, "strict_vars should propagate out of END block");
+    assert!(state.strict_subs, "strict_subs should propagate out of END block");
+    assert!(state.strict_refs, "strict_refs should propagate out of END block");
+}
+
+#[test]
+fn given_init_block_with_use_strict_when_querying_after_block_then_strict_is_active() {
+    // INIT { use strict; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "INIT",
+        block(vec![use_node("strict", &[], 9, 21)], 7, 23),
+        0,
+        24,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.strict_vars, "strict_vars should propagate out of INIT block");
+    assert!(state.strict_subs, "strict_subs should propagate out of INIT block");
+    assert!(state.strict_refs, "strict_refs should propagate out of INIT block");
+}
+
+#[test]
+fn given_check_block_with_use_strict_when_querying_after_block_then_strict_is_active() {
+    // CHECK { use strict; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "CHECK",
+        block(vec![use_node("strict", &[], 10, 22)], 8, 24),
+        0,
+        25,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.strict_vars, "strict_vars should propagate out of CHECK block");
+    assert!(state.strict_subs, "strict_subs should propagate out of CHECK block");
+    assert!(state.strict_refs, "strict_refs should propagate out of CHECK block");
+}
+
+#[test]
+fn given_unitcheck_block_with_use_strict_when_querying_after_block_then_strict_is_active() {
+    // UNITCHECK { use strict; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "UNITCHECK",
+        block(vec![use_node("strict", &[], 14, 26)], 12, 28),
+        0,
+        29,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.strict_vars, "strict_vars should propagate out of UNITCHECK block");
+    assert!(state.strict_subs, "strict_subs should propagate out of UNITCHECK block");
+    assert!(state.strict_refs, "strict_refs should propagate out of UNITCHECK block");
+}
+
+#[test]
+fn given_begin_block_with_use_warnings_when_querying_after_block_then_warnings_is_active() {
+    // BEGIN { use warnings; }
+    // <code at offset 40>
+    let ast = program(vec![phase_block(
+        "BEGIN",
+        block(vec![use_node("warnings", &[], 10, 24)], 8, 26),
+        0,
+        27,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 40);
+    assert!(state.warnings, "warnings should propagate out of BEGIN block");
 }


### PR DESCRIPTION
## Summary

- `PragmaTracker::build_ranges()` in `crates/perl-pragma/src/lib.rs` had no match arm for `NodeKind::PhaseBlock`, causing pragmas declared inside `BEGIN`/`END`/`INIT`/`CHECK`/`UNITCHECK` blocks to be silently dropped (falling through to `_ => {}`).
- Per Perl semantics (perlmod, perlop), phase blocks are compile-time-transparent: pragmas declared inside propagate to the surrounding file scope, not confined to the block.
- Fix: add a `NodeKind::PhaseBlock` arm that walks the inner block's statements directly, bypassing `Block`'s save/restore semantics. All 5 phase types covered.
- Add 6 BDD-style regression tests (all 5 phase types for strict propagation + warnings from BEGIN).

## Root cause

The `NodeKind::Block` arm in `build_ranges` saves/restores pragma state, which correctly models lexical scoping for regular blocks. `PhaseBlock.block` is a `Block` node, so calling `Self::build_ranges(block, ...)` on it would trigger that save/restore and incorrectly confine pragmas to the block. The fix iterates `block.statements` directly to bypass the `Block` save/restore arm.

## Test plan

- [x] 6 new tests in `crates/perl-pragma/tests/behavior_spec_tests.rs` go red before fix, green after
- [x] `cargo test -p perl-pragma` — 22 pass, 1 pre-existing failure (`given_use_feature_qw`, unrelated to this change)
- [x] `cargo test -p perl-lsp-diagnostics` — 412 pass, 0 fail (diagnostics walker workaround continues to work alongside the now-correct pragma model)
- [x] `cargo fmt -p perl-pragma` — clean
- [x] `cargo clippy -p perl-pragma` — no issues

## Coordination note

Fourth pragma tracker edit in the 2026-04-11 cycle. Previously merged: #4038 (feature bundles), #4050 (use if), #4052 (eval STRING). No merge conflict — rebased on current master.

Closes #4084