### PR TITLE
fix(navigation): resolve AUTOLOAD-backed method calls (#3386)

### DIFF
--- a/crates/perl-lsp/src/runtime/language/hover.rs
+++ b/crates/perl-lsp/src/runtime/language/hover.rs
@@ -978,6 +978,49 @@ impl LspServer {
         let mut queue = VecDeque::new();
         let mut related_package_cache: HashMap<String, Vec<String>> = HashMap::new();
 
+        let build_package_hover = |package_name: &str| -> Option<Value> {
+            let members = workspace_index.get_package_members(package_name);
+            if members.iter().any(|symbol| symbol.name == method_name) {
+                let detail = if package_name == receiver_pkg {
+                    format!("Defined in `{package_name}`")
+                } else {
+                    format!("Inherited from `{package_name}`")
+                };
+                return Some(json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": format!(
+                            "**Method**\n\n`sub {}::{}`\n\n{}",
+                            package_name, method_name, detail
+                        ),
+                    },
+                }));
+            }
+
+            if members.iter().any(|symbol| symbol.name == "AUTOLOAD") {
+                let detail = if package_name == receiver_pkg {
+                    format!("Resolved via `AUTOLOAD` in `{package_name}`")
+                } else {
+                    format!("Resolved via inherited `AUTOLOAD` in `{package_name}`")
+                };
+                return Some(json!({
+                    "contents": {
+                        "kind": "markdown",
+                        "value": format!(
+                            "**Method**\n\n`sub {}::AUTOLOAD`\n\n{}\n\nRequested method: `{}`",
+                            package_name, detail, method_name
+                        ),
+                    },
+                }));
+            }
+
+            None
+        };
+
+        if let Some(hover) = build_package_hover(receiver_pkg) {
+            return Some(hover);
+        }
+
         // Inner closure: enqueue parent and role packages not yet visited.
         // Mirrors the logic in `inherited_method_definition_location` (navigation.rs)
         // but also includes model.roles so that composed roles are traversed.
@@ -1033,18 +1076,8 @@ impl LspServer {
                 continue;
             }
 
-            // Check if this package defines the method
-            let members = workspace_index.get_package_members(&package_name);
-            if members.iter().any(|s| s.name == method_name) {
-                return Some(json!({
-                    "contents": {
-                        "kind": "markdown",
-                        "value": format!(
-                            "**Method**\n\n`sub {}::{}`\n\nInherited from `{}`",
-                            package_name, method_name, package_name
-                        ),
-                    },
-                }));
+            if let Some(hover) = build_package_hover(&package_name) {
+                return Some(hover);
             }
 
             enqueue_related(&package_name, &mut queue, &visited);

--- a/crates/perl-lsp/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp/src/runtime/language/navigation.rs
@@ -387,6 +387,18 @@ fn find_workspace_definition_location(
 }
 
 #[cfg(feature = "workspace")]
+fn autoload_definition_location(
+    workspace_index: &crate::workspace_index::WorkspaceIndex,
+    receiver_pkg: &str,
+    include_receiver: bool,
+) -> Option<crate::workspace_index::Location> {
+    include_receiver
+        .then(|| find_workspace_definition_location(workspace_index, receiver_pkg, "AUTOLOAD"))
+        .flatten()
+        .or_else(|| inherited_method_definition_location(workspace_index, receiver_pkg, "AUTOLOAD"))
+}
+
+#[cfg(feature = "workspace")]
 fn find_plack_middleware_definition_location(
     workspace_index: &crate::workspace_index::WorkspaceIndex,
     module_name: &str,
@@ -1074,11 +1086,19 @@ impl LspServer {
                             #[cfg(feature = "workspace")]
                             {
                                 if let Some(coordinator) = self.coordinator()
-                                    && let Some(def_location) = inherited_method_definition_location(
-                                        coordinator.index(),
-                                        current_package,
-                                        method_match.as_str(),
-                                    )
+                                    && let Some(def_location) =
+                                        inherited_method_definition_location(
+                                            coordinator.index(),
+                                            current_package,
+                                            method_match.as_str(),
+                                        )
+                                        .or_else(|| {
+                                            autoload_definition_location(
+                                                coordinator.index(),
+                                                current_package,
+                                                false,
+                                            )
+                                        })
                                     && let Some(lsp_location) =
                                         crate::workspace_index::lsp_adapter::to_lsp_location(
                                             &def_location,
@@ -1134,6 +1154,22 @@ impl LspServer {
                                 ) {
                                     return Ok(Some(result));
                                 }
+                                #[cfg(feature = "workspace")]
+                                {
+                                    if let Some(coordinator) = self.coordinator()
+                                        && let Some(def_location) = autoload_definition_location(
+                                            coordinator.index(),
+                                            package_name,
+                                            true,
+                                        )
+                                        && let Some(lsp_location) =
+                                            crate::workspace_index::lsp_adapter::to_lsp_location(
+                                                &def_location,
+                                            )
+                                    {
+                                        return Ok(Some(json!([lsp_location])));
+                                    }
+                                }
                                 if is_universal_method(method_name)
                                     && let Some(result) = lookup_workspace_definition(
                                         self.coordinator(),
@@ -1178,6 +1214,23 @@ impl LspServer {
                                             Some(uri),
                                         ) {
                                             return Ok(Some(result));
+                                        }
+                                        #[cfg(feature = "workspace")]
+                                        {
+                                            if let Some(coordinator) = self.coordinator()
+                                                && let Some(def_location) =
+                                                    autoload_definition_location(
+                                                        coordinator.index(),
+                                                        current_package,
+                                                        true,
+                                                    )
+                                                && let Some(lsp_location) =
+                                                    crate::workspace_index::lsp_adapter::to_lsp_location(
+                                                        &def_location,
+                                                    )
+                                            {
+                                                return Ok(Some(json!([lsp_location])));
+                                            }
                                         }
                                     }
                                 }

--- a/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
+++ b/crates/perl-lsp/tests/cross_file_goto_definition_tests.rs
@@ -1802,6 +1802,68 @@ MyModule->process();
     Ok(())
 }
 
+#[test]
+fn go_to_definition_cross_file_package_method_falls_back_to_autoload() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    harness.open(
+        "file:///lib/AutoDispatch.pm",
+        r#"package AutoDispatch;
+
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
+sub AUTOLOAD {
+    our $AUTOLOAD;
+    return $AUTOLOAD;
+}
+
+1;
+"#,
+    )?;
+
+    harness.open(
+        "file:///app.pl",
+        r#"#!/usr/bin/perl
+use strict;
+use warnings;
+use lib 'lib';
+use AutoDispatch;
+
+AutoDispatch->dynamic_method();
+"#,
+    )?;
+
+    harness.barrier();
+
+    let result = harness.request(
+        "textDocument/definition",
+        json!({
+            "textDocument": {"uri": "file:///app.pl"},
+            "position": {"line": 6, "character": 16}
+        }),
+    )?;
+
+    let locations = result
+        .as_array()
+        .ok_or_else(|| format!("expected goto-def array for AUTOLOAD fallback, got: {result:?}"))?;
+    assert!(!locations.is_empty(), "AUTOLOAD-backed method call should resolve to a definition");
+
+    let first = &locations[0];
+    assert_valid_location(first);
+
+    let uri = first["uri"].as_str().ok_or("expected URI in goto-def result")?;
+    assert!(
+        uri.contains("AutoDispatch.pm"),
+        "AUTOLOAD fallback should point to AutoDispatch.pm, got: {uri}"
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tests for issue #3482: plain OO inheritance goto-def (use parent / use base / @ISA)
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp/tests/lsp_hover_tests.rs
+++ b/crates/perl-lsp/tests/lsp_hover_tests.rs
@@ -776,3 +776,54 @@ $c->hover_greet();
 
     Ok(())
 }
+
+#[test]
+fn hover_shows_autoload_resolution_for_missing_method() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    harness.open(
+        "file:///lib/HoverAuto.pm",
+        r#"package HoverAuto;
+
+sub AUTOLOAD {
+    our $AUTOLOAD;
+    return $AUTOLOAD;
+}
+
+1;
+"#,
+    )?;
+
+    let main_content = r#"#!/usr/bin/perl
+use lib 'lib';
+use HoverAuto;
+HoverAuto->dynamic_hover();
+"#;
+    harness.open("file:///app.pl", main_content)?;
+
+    harness.barrier();
+
+    let result = harness
+        .request(
+            "textDocument/hover",
+            json!({
+                "textDocument": {"uri": "file:///app.pl"},
+                "position": {"line": 3, "character": 13}
+            }),
+        )
+        .unwrap_or(json!(null));
+
+    assert!(!result.is_null(), "AUTOLOAD-backed method hover should not be null");
+
+    let value =
+        result.get("contents").and_then(|c| c.get("value")).and_then(|v| v.as_str()).unwrap_or("");
+
+    assert!(value.contains("AUTOLOAD"), "hover should mention AUTOLOAD resolution, got: {value}");
+    assert!(
+        value.contains("dynamic_hover"),
+        "hover should mention the requested method name, got: {value}"
+    );
+
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/mod.rs
@@ -381,6 +381,25 @@ impl SemanticAnalyzer {
                 details,
             });
         }
+        if model.methods.iter().any(|m| m.name == "AUTOLOAD") {
+            let is_direct = model.name == receiver_class;
+            let details = if is_direct {
+                vec![
+                    format!("Resolved via AUTOLOAD in {}", model.name),
+                    format!("Requested method: {method_name}"),
+                ]
+            } else {
+                vec![
+                    format!("Resolved via inherited AUTOLOAD from {}", model.name),
+                    format!("Requested method: {method_name}"),
+                ]
+            };
+            return Some(HoverInfo {
+                signature: format!("sub {}::AUTOLOAD", model.name),
+                documentation: None,
+                details,
+            });
+        }
         None
     }
 
@@ -389,7 +408,12 @@ impl SemanticAnalyzer {
         model: &ClassModel,
         method_name: &str,
     ) -> Option<SourceLocation> {
-        model.methods.iter().find(|method| method.name == method_name).map(|method| method.location)
+        model
+            .methods
+            .iter()
+            .find(|method| method.name == method_name)
+            .or_else(|| model.methods.iter().find(|method| method.name == "AUTOLOAD"))
+            .map(|method| method.location)
     }
 
     fn resolve_plain_package_method_hover(
@@ -410,6 +434,25 @@ impl SemanticAnalyzer {
                 signature: format!("sub {}::{}", package_name, method_name),
                 documentation: None,
                 details: vec![format!("Inherited from {}", package_name)],
+            });
+        }
+
+        let qualified_autoload = format!("{}::AUTOLOAD", package_name);
+        let autoload_in_table = self.symbol_table.symbols.get("AUTOLOAD").is_some_and(|syms| {
+            syms.iter().any(|s| {
+                matches!(s.kind, crate::symbol::SymbolKind::Subroutine)
+                    && s.qualified_name == qualified_autoload
+            })
+        }) || self.symbol_table.symbols.contains_key(&qualified_autoload);
+
+        if autoload_in_table {
+            return Some(HoverInfo {
+                signature: format!("sub {}::AUTOLOAD", package_name),
+                documentation: None,
+                details: vec![
+                    format!("Resolved via AUTOLOAD in {}", package_name),
+                    format!("Requested method: {}", method_name),
+                ],
             });
         }
 
@@ -681,6 +724,39 @@ sub new { bless {}, shift }
         assert!(
             hover.details.iter().any(|detail| detail.contains("UNIVERSAL")),
             "expected UNIVERSAL hover details, got: {:?}",
+            hover.details
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_autoload_hover_fallback() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+package Foo;
+sub AUTOLOAD { 1 }
+"#;
+
+        let mut parser = Parser::new(code);
+        let ast = parser.parse()?;
+        let analyzer = SemanticAnalyzer::analyze_with_source(&ast, code);
+
+        let hover = analyzer
+            .resolve_inherited_method_hover("Foo", "dynamic_method")
+            .ok_or("expected AUTOLOAD hover fallback")?;
+
+        assert!(
+            hover.signature.contains("Foo::AUTOLOAD"),
+            "expected AUTOLOAD hover signature, got: {}",
+            hover.signature
+        );
+        assert!(
+            hover.details.iter().any(|detail| detail.contains("AUTOLOAD")),
+            "expected AUTOLOAD hover details, got: {:?}",
+            hover.details
+        );
+        assert!(
+            hover.details.iter().any(|detail| detail.contains("dynamic_method")),
+            "expected requested method detail, got: {:?}",
             hover.details
         );
         Ok(())


### PR DESCRIPTION
## Summary
- resolve explicit method-call navigation through `AUTOLOAD` when the named method is absent
- surface `AUTOLOAD` fallback in inherited-method hover output
- add regressions for semantic hover fallback and cross-file goto-definition behavior

## Testing
- `cargo fmt --all`
- `cargo test -p perl-semantic-analyzer test_autoload_hover_fallback -- --exact`
- `cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests go_to_definition_cross_file_package_method_falls_back_to_autoload -- --exact`
- `cargo test -p perl-lsp-rs --test lsp_hover_tests hover_shows_autoload_resolution_for_missing_method -- --exact`
- `cargo test -p perl-lsp-rs --test cross_file_goto_definition_tests`
- `cargo test -p perl-lsp-rs --test lsp_hover_tests`

Closes #3386