### PR TITLE
feat(workspace): request workspace/configuration when supported (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/client_requests.rs
+++ b/crates/perl-lsp/src/runtime/client_requests.rs
@@ -3,6 +3,7 @@
 //! Each method checks the relevant client capability before sending.
 
 use super::*;
+use lsp_types::{ConfigurationItem, Uri};
 
 #[allow(dead_code)]
 impl LspServer {
@@ -10,6 +11,35 @@ impl LspServer {
     pub(crate) fn send_request(&self, method: &str, params: Value) -> io::Result<()> {
         let request_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
         self.outbound.send_request(request_id, method, params)
+    }
+
+    /// Request client-scoped Perl configuration for all known workspace folders.
+    ///
+    /// When the client does not advertise `workspace.configuration`, this is a
+    /// no-op and returns `Ok(())`.
+    pub(crate) fn request_workspace_configuration_for_all_folders(&self) -> io::Result<()> {
+        if !self.client_capabilities.lock().workspace_configuration_support {
+            return Ok(());
+        }
+
+        let items: Vec<ConfigurationItem> = self
+            .all_workspace_folders()
+            .into_iter()
+            .filter_map(|folder| {
+                folder.uri.parse::<Uri>().ok().map(|scope_uri| ConfigurationItem {
+                    scope_uri: Some(scope_uri),
+                    section: Some("perl".to_string()),
+                })
+            })
+            .collect();
+
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        self.send_request("workspace/configuration", json!({ "items": items }))?;
+        tracing::debug!(count = items.len(), "Requested workspace/configuration overlays");
+        Ok(())
     }
 
     /// Request client to refresh code lenses (workspace/codeLens/refresh)

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -147,6 +147,12 @@ impl LspServer {
                         .and_then(|v| v.as_bool())
                         .unwrap_or(false);
 
+                    // workspace/configuration
+                    caps.workspace_configuration_support = cap_val
+                        .pointer("/workspace/configuration")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+
                     // textDocument/inlayHint resolveSupport.properties
                     // Collect the property names the client can resolve (e.g. "label.location")
                     if let Some(properties) =
@@ -219,6 +225,11 @@ impl LspServer {
 
         // Load .perl-lsp.toml from workspace root (base layer; LSP config overrides later)
         self.load_and_apply_project_config();
+
+        // Request client-scoped workspace configuration overlays when supported.
+        if let Err(error) = self.request_workspace_configuration_for_all_folders() {
+            tracing::debug!(%error, "Unable to request workspace/configuration overlays");
+        }
 
         // Construct the AI inline-completion backend if enabled in config
         self.refresh_ai_backend();
@@ -393,7 +404,10 @@ pub(crate) fn apply_disabled_feature_id(
 #[cfg(test)]
 mod tests {
     use super::apply_disabled_feature_id;
+    use crate::LspServer;
     use crate::protocol::capabilities::BuildFlags;
+    use serde_json::json;
+    use std::io::Cursor;
 
     #[test]
     fn apply_disabled_feature_id_zeros_correct_field() {
@@ -452,5 +466,37 @@ mod tests {
                  apply_disabled_feature_id — add one to keep the two in sync"
             );
         }
+    }
+
+    #[test]
+    fn initialize_parses_workspace_configuration_capability() {
+        let server =
+            LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
+        let params = json!({
+            "capabilities": {
+                "workspace": {
+                    "configuration": true
+                }
+            }
+        });
+
+        server.handle_initialize(Some(params)).expect("initialize must not error");
+        assert!(
+            server.client_capabilities.lock().workspace_configuration_support,
+            "workspace.configuration support should be captured from initialize capabilities"
+        );
+    }
+
+    #[test]
+    fn initialize_defaults_workspace_configuration_capability_to_false() {
+        let server =
+            LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
+        server
+            .handle_initialize(Some(json!({ "capabilities": {} })))
+            .expect("initialize must not error");
+        assert!(
+            !server.client_capabilities.lock().workspace_configuration_support,
+            "workspace.configuration support should default to false"
+        );
     }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -556,6 +556,14 @@ impl LspServer {
                         tracing::debug!("Updated workspace config from perl settings");
                     }
 
+                    // Invalidate and refresh per-folder client-scoped overlays.
+                    if let Err(error) = self.request_workspace_configuration_for_all_folders() {
+                        tracing::debug!(
+                            %error,
+                            "Unable to refresh workspace/configuration after didChangeConfiguration"
+                        );
+                    }
+
                     // Refresh AI backend when config changes (constructs or clears provider)
                     self.refresh_ai_backend();
 

--- a/crates/perl-lsp/src/state/document.rs
+++ b/crates/perl-lsp/src/state/document.rs
@@ -307,6 +307,8 @@ pub struct ClientCapabilities {
     pub show_document_support: bool,
     /// Supports window/workDoneProgress/create request
     pub work_done_progress_support: bool,
+    /// Supports workspace/configuration reverse request
+    pub workspace_configuration_support: bool,
     /// Properties the client can resolve via inlayHint/resolve
     ///
     /// Parsed from `capabilities.textDocument.inlayHint.resolveSupport.properties`.


### PR DESCRIPTION
### Motivation
- Enable the server to fetch per-folder client configuration via the LSP reverse `workspace/configuration` request so multi-root per-folder settings and dynamic client-scoped overrides work correctly.
- Today the server only loads `.perl-lsp.toml` at startup and handles `didChangeConfiguration` without actively requesting client-scoped values, which prevents correct precedence and per-folder overrides.

### Description
- Add a tracked client capability flag `workspace_configuration_support` to `ClientCapabilities` and parse it during `initialize` so the server can gate reverse configuration requests.
- Implement `request_workspace_configuration_for_all_folders()` in the client-requests runtime layer that builds a `ConfigurationItem` for each workspace folder (section `perl`) and sends a `workspace/configuration` server→client request when the client advertises support, and call it after project config load and on `workspace/didChangeConfiguration` to refresh overlays.
- Feature is implemented as a graceful no-op when the client does not support `workspace.configuration` and preserves existing `.perl-lsp.toml`-derived behavior as the fallback (client overlays are intended to override TOML when present).

### Testing
- Ran `cargo fmt --all` to ensure formatting (succeeded).
- Ran targeted unit tests with `cargo test -p perl-lsp-rs --lib workspace_configuration` which exercises `initialize_parses_workspace_configuration_capability` and `initialize_defaults_workspace_configuration_capability_to_false`, and both tests passed.
- Verified the workspace crate compiles and the targeted tests ran successfully during local test runs (no test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f08a2308333b48a2a582749b6dc)