### PR TITLE
feat(workspace): request workspace/configuration per folder (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -72,6 +72,14 @@ impl LspServer {
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
 
+                // Check if client supports workspace/configuration reverse requests
+                caps.workspace_configuration_support = params
+                    .get("capabilities")
+                    .and_then(|c| c.get("workspace"))
+                    .and_then(|w| w.get("configuration"))
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
+
                 // Check if client supports snippet syntax in completion items
                 caps.snippet_support = params
                     .get("capabilities")
@@ -219,6 +227,10 @@ impl LspServer {
 
         // Load .perl-lsp.toml from workspace root (base layer; LSP config overrides later)
         self.load_and_apply_project_config();
+
+        // Request client-scoped configuration per workspace folder when supported.
+        // This complements `.perl-lsp.toml` with dynamic editor/workspace settings.
+        self.request_workspace_configuration_for_folders();
 
         // Construct the AI inline-completion backend if enabled in config
         self.refresh_ai_backend();

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -3,7 +3,9 @@
 //! Handles workspace folders and root URI/path management.
 
 use super::super::*;
+use lsp_types::ConfigurationItem;
 use perl_lsp_config::WorkspaceConfig;
+use serde_json::json;
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
@@ -74,6 +76,53 @@ impl LspServer {
                 }
             }
         }
+    }
+
+    /// Request `workspace/configuration` for each workspace folder.
+    ///
+    /// This sends a server->client reverse request (when supported by the client)
+    /// so each folder can provide scoped `perl` configuration values.
+    ///
+    /// Current behavior is intentionally non-blocking and fallback-friendly:
+    /// - If unsupported, no request is sent and `.perl-lsp.toml` remains authoritative.
+    /// - If sending fails, the server logs and continues with local config.
+    pub(crate) fn request_workspace_configuration_for_folders(&self) {
+        if !self.client_capabilities.lock().workspace_configuration_support {
+            tracing::debug!(
+                "Client does not advertise workspace.configuration support; skipping reverse request"
+            );
+            return;
+        }
+
+        let folders = self.workspace_folders.lock().clone();
+        if folders.is_empty() {
+            return;
+        }
+
+        let items: Vec<ConfigurationItem> = folders
+            .iter()
+            .map(|folder| ConfigurationItem {
+                scope_uri: folder.uri.parse().ok(),
+                section: Some("perl".to_string()),
+            })
+            .collect();
+
+        let params = json!({ "items": items });
+        let request_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
+        if let Err(error) = self.outbound.send_request(
+            request_id,
+            perl_lsp_protocol::methods::WORKSPACE_CONFIGURATION,
+            params,
+        ) {
+            tracing::warn!(%error, "Failed to send workspace/configuration request");
+            return;
+        }
+
+        tracing::debug!(
+            request_id,
+            item_count = folders.len(),
+            "Requested per-folder workspace configuration from client"
+        );
     }
 }
 

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -563,6 +563,10 @@ impl LspServer {
                     if let Err(e) = self.refresh_controller.refresh_all(self) {
                         tracing::warn!(error = %e, "Failed to refresh client after config change");
                     }
+
+                    // Invalidate dynamic client-scoped config by re-requesting
+                    // per-folder workspace/configuration values.
+                    self.request_workspace_configuration_for_folders();
                 }
             }
         }

--- a/crates/perl-lsp/src/state/document.rs
+++ b/crates/perl-lsp/src/state/document.rs
@@ -282,6 +282,8 @@ pub struct ClientCapabilities {
     pub implementation_link_support: bool,
     /// Supports dynamic registration for file watching
     pub dynamic_registration_support: bool,
+    /// Supports `workspace/configuration` reverse requests (server -> client)
+    pub workspace_configuration_support: bool,
     /// Supports snippet syntax in completion items
     pub snippet_support: bool,
     /// Supports markdown message content in diagnostics (LSP 3.18)

--- a/crates/perl-lsp/tests/lsp_workspace_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_tests.rs
@@ -285,3 +285,69 @@ fn test_workspace_configuration_request_contract() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn test_server_requests_workspace_configuration_on_initialize_when_supported() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "workspace": {
+            "configuration": true
+        }
+    })))?;
+
+    let requests = harness.drain_server_requests(500);
+    let config_request = requests
+        .iter()
+        .find(|req| req.get("method").and_then(|m| m.as_str()) == Some("workspace/configuration"))
+        .ok_or("expected workspace/configuration request from server")?;
+
+    let items = config_request
+        .pointer("/params/items")
+        .and_then(|v| v.as_array())
+        .ok_or("workspace/configuration params.items must be an array")?;
+    assert_eq!(items.len(), 1, "single-root initialize should request one scoped item");
+    assert_eq!(items[0]["scopeUri"], json!("file:///workspace"));
+    assert_eq!(items[0]["section"], json!("perl"));
+
+    Ok(())
+}
+
+#[test]
+fn test_did_change_configuration_re_requests_workspace_configuration() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "workspace": {
+            "configuration": true
+        }
+    })))?;
+
+    // Drain initialize-time request.
+    let _ = harness.drain_server_requests(500);
+
+    harness.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "workspace": {
+                        "includePaths": ["custom/lib"]
+                    }
+                }
+            }
+        }),
+    );
+
+    let requests = harness.drain_server_requests(500);
+    let config_request = requests
+        .iter()
+        .find(|req| req.get("method").and_then(|m| m.as_str()) == Some("workspace/configuration"))
+        .ok_or("expected workspace/configuration re-request after didChangeConfiguration")?;
+    let items_len = config_request
+        .pointer("/params/items")
+        .and_then(|v| v.as_array())
+        .map(std::vec::Vec::len)
+        .ok_or("workspace/configuration params.items must be an array")?;
+    assert_eq!(items_len, 1);
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The server currently loads `.perl-lsp.toml` and handles `didChangeConfiguration` but does not perform LSP `workspace/configuration` (server→client) reverse requests, preventing per-folder dynamic configuration in multi-root workspaces.

### Description

- Add a client capability flag `workspace_configuration_support` to record whether the client advertised support for `workspace.configuration` during `initialize`.
- Implement `request_workspace_configuration_for_folders()` which builds a `ConfigurationItem` per workspace folder and sends a `workspace/configuration` server→client request using the existing outbound request path.
- Invoke the per-folder configuration request after loading `.perl-lsp.toml` during initialization and again from `didChangeConfiguration` to refresh dynamic client-scoped overlays; fall back to TOML if the client does not support the reverse request or if the request fails.
- Add integration tests that assert the server emits `workspace/configuration` on initialize when the client advertises support and that it re-requests configuration after `workspace/didChangeConfiguration`.

### Testing

- Ran `cargo fmt --all` to apply formatting, which completed successfully. 
- Ran targeted tests: `cargo test -p perl-lsp-rs --test lsp_workspace_tests test_server_requests_workspace_configuration_on_initialize_when_supported -- --exact` and `cargo test -p perl-lsp-rs --test lsp_workspace_tests test_did_change_configuration_re_requests_workspace_configuration -- --exact`, and both tests passed.
- Verified the new code compiles as part of the workspace build during test runs (no compilation failures for the modified paths encountered during validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f08a2308333b48a2a582749b6dc)