### PR TITLE
feat(workspace): request client workspace/configuration (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -72,6 +72,14 @@ impl LspServer {
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
 
+                // Check if client supports server-to-client workspace/configuration requests
+                caps.workspace_configuration_support = params
+                    .get("capabilities")
+                    .and_then(|c| c.get("workspace"))
+                    .and_then(|w| w.get("configuration"))
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
+
                 // Check if client supports snippet syntax in completion items
                 caps.snippet_support = params
                     .get("capabilities")
@@ -219,6 +227,7 @@ impl LspServer {
 
         // Load .perl-lsp.toml from workspace root (base layer; LSP config overrides later)
         self.load_and_apply_project_config();
+        self.request_workspace_configuration();
 
         // Construct the AI inline-completion backend if enabled in config
         self.refresh_ai_backend();

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -142,6 +142,43 @@ impl Drop for IndexingGuard {
 }
 
 impl LspServer {
+    /// Request client-scoped configuration for each workspace folder.
+    ///
+    /// This is a best-effort reverse request. If unsupported or failed, the
+    /// server continues using local/default configuration.
+    pub(crate) fn request_workspace_configuration(&self) {
+        if !self.client_capabilities.lock().workspace_configuration_support {
+            return;
+        }
+
+        let items: Vec<Value> = self
+            .workspace_folders
+            .lock()
+            .iter()
+            .filter_map(|folder| {
+                url::Url::parse(&folder.uri).ok().map(|scope_uri| {
+                    json!({
+                        "scopeUri": scope_uri.to_string(),
+                        "section": "perl",
+                    })
+                })
+            })
+            .collect();
+
+        if items.is_empty() {
+            return;
+        }
+
+        let request_id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
+        if let Err(error) = self.outbound.send_request(
+            request_id,
+            crate::protocol::methods::WORKSPACE_CONFIGURATION,
+            json!({ "items": items }),
+        ) {
+            tracing::warn!(%error, "Failed to send workspace/configuration request");
+        }
+    }
+
     /// Handle workspace/symbol request (v2 implementation with lifecycle-aware dispatch)
     ///
     /// Uses routing helper for state-aware behavior:
@@ -558,6 +595,7 @@ impl LspServer {
 
                     // Refresh AI backend when config changes (constructs or clears provider)
                     self.refresh_ai_backend();
+                    self.request_workspace_configuration();
 
                     // Trigger client refresh for configuration-dependent features
                     if let Err(e) = self.refresh_controller.refresh_all(self) {
@@ -1163,6 +1201,7 @@ impl LspServer {
 
                 // Load config for all folders after changes
                 self.load_and_apply_project_config();
+                self.request_workspace_configuration();
 
                 // Update workspace index with new folder list
                 #[cfg(feature = "workspace")]

--- a/crates/perl-lsp/src/state/document.rs
+++ b/crates/perl-lsp/src/state/document.rs
@@ -272,6 +272,8 @@ pub fn normalize_package_separator(s: &str) -> Cow<'_, str> {
 /// Client capabilities received during initialization
 #[derive(Debug, Clone, Default)]
 pub struct ClientCapabilities {
+    /// Supports server-to-client `workspace/configuration` requests.
+    pub workspace_configuration_support: bool,
     /// Supports LocationLink for goto declaration
     pub declaration_link_support: bool,
     /// Supports LocationLink for goto definition

--- a/crates/perl-lsp/tests/lsp_workspace_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_tests.rs
@@ -55,6 +55,46 @@ fn test_did_change_configuration_empty_settings() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_initialize_requests_workspace_configuration_when_supported() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "workspace": {
+            "configuration": true
+        }
+    })))?;
+
+    let requests = harness.drain_server_requests(1_000);
+    let config_request = requests
+        .iter()
+        .find(|request| request["method"] == "workspace/configuration")
+        .ok_or("expected workspace/configuration request")?;
+
+    assert_eq!(config_request["jsonrpc"], "2.0");
+    assert!(config_request.get("id").is_some());
+    let items = config_request["params"]["items"].as_array().ok_or("items must be array")?;
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["section"], "perl");
+    assert_eq!(items[0]["scopeUri"], "file:///workspace");
+    Ok(())
+}
+
+#[test]
+fn test_initialize_skips_workspace_configuration_when_unsupported() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "workspace": {
+            "configuration": false
+        }
+    })))?;
+
+    let requests = harness.drain_server_requests(300);
+    let has_workspace_config =
+        requests.iter().any(|request| request["method"] == "workspace/configuration");
+    assert!(!has_workspace_config);
+    Ok(())
+}
+
 // ==================== didChangeWatchedFiles ====================
 
 #[test]


### PR DESCRIPTION
### Motivation
- The server did not proactively request LSP `workspace/configuration` from clients, preventing per-folder scoping and dynamic client-side overrides in multi-root workspaces.
- Provide a capability-gated, best-effort reverse request path so client settings can be fetched without breaking existing `.perl-lsp.toml` fallback behavior.

### Description
- Parse and cache the client capability `capabilities.workspace.configuration` into `ClientCapabilities` as `workspace_configuration_support` (`crates/perl-lsp/src/state/document.rs`).
- Emit a server→client `workspace/configuration` request (one `section: "perl"` item per workspace folder) via the new `request_workspace_configuration()` helper in `crates/perl-lsp/src/runtime/workspace.rs` when the client advertises support.
- Invoke the configuration request after project TOML bootstrap during initialize, on `workspace/didChangeConfiguration`, and after workspace-folder add/remove events to refresh client-scoped overlays (`crates/perl-lsp/src/runtime/lifecycle/capabilities.rs` and `crates/perl-lsp/src/runtime/workspace.rs`).
- Add integration coverage in `crates/perl-lsp/tests/lsp_workspace_tests.rs` validating the request is sent when supported and skipped when unsupported.

### Testing
- Ran formatting with `cargo fmt --all` (succeeded).
- Ran targeted integration tests: `cargo test -p perl-lsp-rs --test lsp_workspace_tests workspace_configuration_when_` (tests passed).
- Ran targeted test `cargo test -p perl-lsp-rs --test lsp_workspace_tests test_did_change_configuration_notification` (test passed).
- Added tests in `crates/perl-lsp/tests/lsp_workspace_tests.rs` and executed them as part of the above test runs (all added tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1f08a2308333b48a2a582749b6dc)