### PR TITLE
fix(clippy): remove needless borrows in workspace file-ops (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -957,9 +957,9 @@ impl LspServer {
 
                         tracing::debug!(uri, "File will be deleted");
                         let mut dependents: std::collections::BTreeSet<String> =
-                            collect_cross_file_delete_dependents(&idx, uri, &deleting_uris);
+                            collect_cross_file_delete_dependents(idx, uri, &deleting_uris);
                         dependents.extend(collect_open_document_delete_dependents(
-                            &idx,
+                            idx,
                             uri,
                             &deleting_uris,
                             &open_documents,


### PR DESCRIPTION
Fixes needless_borrow clippy error that appeared after merges #4052 and #4088. The code was taking unnecessary references to the workspace index that clippy correctly flagged as redundant.