### PR TITLE
fix(review): add docs-only fast-track gate (#4097)

### DIFF
--- a/.claude/commands/ops-check-queue.md
+++ b/.claude/commands/ops-check-queue.md
@@ -25,7 +25,7 @@ Find PRs that are ready to merge.
    ```
 
 4. Classify:
-   - **MERGE NOW**: MERGEABLE + CI green
+   - **MERGE NOW**: MERGEABLE + CI green + `just pre-merge-check <number>` passes
    - **WAIT**: CI still running
    - **BLOCKED**: CI failures — note which check failed
    - **NEEDS REBASE**: CONFLICTING

--- a/.claude/commands/ops-merge-batch.md
+++ b/.claude/commands/ops-merge-batch.md
@@ -25,14 +25,16 @@ Merge up to 3 PRs from the candidates identified in step 1.
    - CI checks green on the current HEAD SHA
    - No blocking review comments
 
-3. **Deep review check (defense-in-depth)** — verify `reviewed-deep` label is present:
+3. **Policy gate (defense-in-depth)** — run the scripted pre-merge guard:
    ```bash
-   gh pr view <number> --json labels --jq '[.labels[].name] | contains(["reviewed-deep"])'
+   just pre-merge-check <number>
+   # or: bash scripts/pre-merge-check.sh <number>
    ```
-   If `false`, **skip this PR** with reason: "missing deep review signal — route to reviewer-deep."
-   This is a defense-in-depth check. The `pr-ready` gate should have already caught this, but
-   we verify again at merge time because labels can be manually removed or PRs can be
-   marked ready through non-standard paths.
+   This codifies the policy:
+   - non-docs PRs need `reviewed-deep`
+   - docs-only PRs may merge with `merge-ready` alone
+   - draft/title/label mistakes still fail loud
+   If it fails, **skip this PR** with the script's reason.
 
 4. **Build a good commit message** for each PR:
    ```bash
@@ -69,7 +71,7 @@ Merge up to 3 PRs from the candidates identified in step 1.
    - CI red or pending → skip, note "CI not green on current HEAD"
    - CI green on old SHA → skip, note "stale CI — needs rerun"
    - Draft → skip, note "still in review"
-   - Missing `reviewed-deep` → skip, note "missing deep review signal"
+   - Missing `reviewed-deep` on a non-docs PR → skip, note "missing deep review signal"
 
 ## Rules
 

--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -25,17 +25,18 @@ gh pr view $NUMBER --json isDraft,title,state
 If the PR is not a draft, report: "PR #N is already marked ready" and stop.
 If the PR is not open, report the current state and stop.
 
-### 3. Verify deep review completed
-
-**Before marking ready, confirm the `reviewed-deep` label is present.** This is a hard gate — no PR can be marked merge-ready without passing deep review.
+### 3. Verify review coverage
 
 ```bash
-gh pr view $NUMBER --json labels --jq '[.labels[].name] | if (. | contains(["reviewed-deep"])) then "PASS" else "FAIL" end'
+gh pr view $NUMBER --json labels,files
 ```
 
-If the result is `FAIL`: **STOP.** Report: "PR #$NUMBER cannot be marked ready — missing `reviewed-deep` label. Route to reviewer-deep first."
+Policy:
+- If the PR has the `reviewed-deep` label, proceed.
+- If it does not have `reviewed-deep`, it may proceed **only** when every changed file is docs-only (`docs/**` or doc-text files such as `.md`, `.mdx`, `.txt`, `.rst`, `.adoc`).
+- Otherwise: **STOP.** Report: "PR #$NUMBER cannot be marked ready — missing `reviewed-deep` on a non-docs PR. Route to reviewer-deep first."
 
-Optionally validate receipt freshness to ensure the deep review covers the current HEAD:
+Optionally validate receipt freshness when `reviewed-deep` is present to ensure the deep review covers the current HEAD:
 ```
 /label-receipt-validate pr $NUMBER reviewed-deep
 ```

--- a/.claude/commands/reviewer-decide.md
+++ b/.claude/commands/reviewer-decide.md
@@ -9,6 +9,24 @@ Based on steps 1-3, make a decision.
 
 ## Decision tree
 
+### Docs-only PRs → Fast-track without `reviewed-deep`
+
+If every changed file is documentation-only (`docs/**` or doc-text files such as `.md`, `.mdx`, `.txt`, `.rst`, `.adoc`), do the standards pass, push any doc fixes, and route straight to `/pr-ready`.
+
+```bash
+gh pr checkout <number>
+# ... improve wording / links / receipts as needed ...
+git push
+gh pr comment <number> --body "Standards review complete. Docs-only fast-track used; no reviewer-deep pass required."
+```
+
+Then call:
+```
+/pr-ready <number>
+```
+
+**Do NOT add `reviewed-deep` yourself.** That label is reserved for the deep reviewer only.
+
 ### Default path → Improve and route to deep review
 
 Every PR has room for improvement. Check out the branch, push improvements (edge case tests, naming, simplification), then route to deep review. **Never approve directly** — the standards reviewer does NOT approve PRs.
@@ -46,7 +64,7 @@ If you must send back:
 ## Rules
 
 - **Fix forward is the default.** If you can fix it where you are, fix it.
-- **ALWAYS route to deep review.** Never approve directly. The reviewer does the standards pass; the deep reviewer does the correctness pass and approves.
+- **Route non-docs PRs to deep review.** Docs-only PRs may use the fast-track path above; everything else still requires reviewer-deep.
 - Never request changes for style preferences.
 - "I would have done it differently" is not a blocker — make it how you'd do it and push.
 - **Recommend next steps.** Typical recommendations:

--- a/.claude/commands/reviewer-deep-decide.md
+++ b/.claude/commands/reviewer-deep-decide.md
@@ -27,7 +27,7 @@ After approval, write a version-bound receipt:
 /label-receipt-write pr <number> reviewed-deep reviewer-deep
 ```
 
-The `reviewed-deep` label is **required** before a PR can be marked `merge-ready`. Without it, `/pr-ready` and `ops-merge-batch` will refuse to proceed.
+The `reviewed-deep` label is **required for non-docs PRs** before a PR can be marked `merge-ready`. Docs-only PRs may use the reviewer fast-track path instead; do not set `reviewed-deep` unless you actually performed the deep review.
 
 ### Logic issues → Fix them on the branch
 You're a sonnet agent on an isolated branch. If the logic is wrong but the approach is right, fix the logic yourself. Only send back if the approach is fundamentally wrong.

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -155,7 +155,7 @@ Labels are the authoritative state of every issue and PR. Agents write labels; t
 | `merge-ready` | reviewer (/pr-ready) | ops agent | Ready for merge pickup |
 | `structural-blocker` | any agent | orchestrator | Blocks parallel work |
 | `needs-deep-review` | reviewer (/reviewer-decide) | orchestrator | Standards review done, awaiting deep correctness review |
-| `reviewed-deep` | reviewer-deep (/reviewer-deep-decide) | pr-ready, ops | Deep correctness review complete |
+| `reviewed-deep` | reviewer-deep (/reviewer-deep-decide) | pr-ready, ops | Deep correctness review complete — required for non-docs PRs |
 | `follow-up-recommended` | wisdom or reviewer | orchestrator | Related follow-up issue needed |
 | `already-fixed` | plan-reviewer or scout | orchestrator | Close without build |
 

--- a/.github/workflows/pipeline-labels.yml
+++ b/.github/workflows/pipeline-labels.yml
@@ -83,8 +83,33 @@ jobs:
               pull_number: prNumber,
             });
             const prLabels = pr.data.labels.map(l => l.name);
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            }, response => response.data.map(file => file.filename));
+            const isDocsOnlyPath = (filename) =>
+              filename.startsWith('docs/') || /\.(md|mdx|txt|rst|adoc)$/i.test(filename);
+            const docsOnly = changedFiles.length > 0 && changedFiles.every(isDocsOnlyPath);
 
             if (!prLabels.includes('reviewed-deep')) {
+              if (docsOnly) {
+                // Docs-only PRs can take the reviewer fast-track path.
+                // Do not manufacture a misleading needs-deep-review label.
+                if (prLabels.includes('needs-deep-review')) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: prNumber,
+                      name: 'needs-deep-review',
+                    });
+                  } catch (e) { /* label might not exist */ }
+                }
+                return;
+              }
+
               // Flag for deep review - do not merge without reviewer-deep sign-off
               if (!prLabels.includes('needs-deep-review')) {
                 await github.rest.issues.addLabels({

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ Labels are the authoritative state for every issue and PR. The orchestrator read
 | `builder-ready` | plan-reviewer (/plan-review-improve) | Ready for builder pickup |
 | `in-build` | builder (/builder-read-spec) | Builder claimed this issue |
 | `in-review` | reviewer (/reviewer-read-handoff) | PR actively in review — set at review start |
-| `merge-ready` | reviewer (/pr-ready) | Ready for ops merge |
+| `merge-ready` | reviewer (/pr-ready) | Ready for ops merge; docs-only PRs may reach this without `reviewed-deep` |
 | `structural-blocker` | any agent | Architecture issue; blocks parallel work |
 | `needs-deep-review` | reviewer (/reviewer-decide) | Standards review done, awaiting deep correctness review |
-| `reviewed-deep` | reviewer-deep (/reviewer-deep-decide) | Deep correctness review complete — required before merge |
+| `reviewed-deep` | reviewer-deep (/reviewer-deep-decide) | Deep correctness review complete — required before merge for non-docs PRs |
 | `follow-up-recommended` | wisdom or reviewer | Related follow-up issue needed |
 | `already-fixed` | plan-reviewer or scout | Close without build |
 

--- a/docs/reference/PROCESS_LESSONS.md
+++ b/docs/reference/PROCESS_LESSONS.md
@@ -104,9 +104,9 @@ Fails non-zero (skip this PR) if any of:
 
 Source: draft/label race hit 5 PRs in the 2026-04-08 session (issues #3321, feedback_pr_draft_label_race.md, feedback_validate_title_issue_ref.md).
 
-## §2 — Two-pass review is mandatory
+## §2 — Two-pass review is mandatory for non-docs PRs
 
-Every PR needs both reviewer (haiku, standards) and reviewer-deep (sonnet, correctness). Two-pass review caught 4 real bugs at 12-16x ROI. Never merge on `merge-ready` alone — verify `reviewed-deep` label is also present.
+Every non-docs PR needs both reviewer (haiku, standards) and reviewer-deep (sonnet, correctness). Two-pass review caught 4 real bugs at 12-16x ROI. Docs-only PRs are the exception: they may merge with `merge-ready` alone if the pre-merge guard classifies every changed file as docs-only.
 
 ## §3 — Merge in batches of 3
 

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -5,6 +5,7 @@
 #   1. Not in draft state
 #   2. Has the merge-ready label
 #   3. Title contains an issue reference (#NNN)
+#   4. Has deep-review coverage, unless the PR is docs-only
 #
 # Usage:
 #   scripts/pre-merge-check.sh <pr-number>
@@ -21,13 +22,43 @@ set -euo pipefail
 
 PR="${1:?usage: $0 <pr-number>}"
 
+json_read() {
+    local filter="$1"
+    printf '%s' "$PR_JSON" | jq -r "$filter" | tr -d '\r'
+}
+
 # ── Fetch PR metadata ─────────────────────────────────────────────────────────
 
-PR_JSON="$(gh pr view "$PR" --json isDraft,labels,title)"
+PR_JSON="$(gh pr view "$PR" --json isDraft,labels,title,files)"
 
-IS_DRAFT="$(printf '%s' "$PR_JSON" | jq -r '.isDraft')"
-HAS_MERGE_READY="$(printf '%s' "$PR_JSON" | jq -r '[.labels[].name] | any(. == "merge-ready")')"
-TITLE="$(printf '%s' "$PR_JSON" | jq -r '.title')"
+IS_DRAFT="$(json_read '.isDraft')"
+HAS_MERGE_READY="$(json_read '[.labels[].name] | any(. == "merge-ready")')"
+HAS_REVIEWED_DEEP="$(json_read '[.labels[].name] | any(. == "reviewed-deep")')"
+TITLE="$(json_read '.title')"
+
+is_docs_only_path() {
+    local path="$1"
+    case "$path" in
+        docs/*) return 0 ;;
+        *.md|*.mdx|*.txt|*.rst|*.adoc) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+DOCS_ONLY=true
+FILE_COUNT=0
+while IFS= read -r changed_path; do
+    [[ -z "$changed_path" ]] && continue
+    FILE_COUNT=$((FILE_COUNT + 1))
+    if ! is_docs_only_path "$changed_path"; then
+        DOCS_ONLY=false
+        break
+    fi
+done < <(json_read '.files[]?.path // empty')
+
+if [[ "$FILE_COUNT" -eq 0 ]]; then
+    DOCS_ONLY=false
+fi
 
 # ── Run checks ────────────────────────────────────────────────────────────────
 
@@ -52,10 +83,20 @@ if ! printf '%s' "$TITLE" | grep -qE '\(#[0-9]+\)'; then
     FAILED=1
 fi
 
+# Check 4: Non-docs PRs require reviewed-deep
+if [[ "$HAS_REVIEWED_DEEP" != "true" && "$DOCS_ONLY" != "true" ]]; then
+    echo "FAIL PR #$PR: missing 'reviewed-deep' label on a non-docs PR — route through reviewer-deep first" >&2
+    FAILED=1
+fi
+
 # ── Result ────────────────────────────────────────────────────────────────────
 
 if [[ "$FAILED" -eq 0 ]]; then
-    echo "OK   PR #$PR: pre-merge checks passed (not draft, merge-ready label present, issue ref in title)"
+    if [[ "$DOCS_ONLY" == "true" && "$HAS_REVIEWED_DEEP" != "true" ]]; then
+        echo "OK   PR #$PR: pre-merge checks passed (docs-only fast track, merge-ready label present, issue ref in title)"
+    else
+        echo "OK   PR #$PR: pre-merge checks passed (not draft, merge-ready label present, issue ref in title, deep review covered)"
+    fi
     exit 0
 else
     exit 1

--- a/scripts/tests/test-pre-merge-check.sh
+++ b/scripts/tests/test-pre-merge-check.sh
@@ -63,7 +63,7 @@ run_check_with_output() {
 # ── Test 1: Draft PR fails ────────────────────────────────────────────────────
 
 test_draft_pr_fails() {
-    local json='{"isDraft":true,"labels":[{"name":"merge-ready"}],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":true,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -81,7 +81,7 @@ test_draft_pr_fails() {
 # ── Test 2: Missing merge-ready label fails ───────────────────────────────────
 
 test_missing_merge_ready_label_fails() {
-    local json='{"isDraft":false,"labels":[{"name":"in-review"}],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":false,"labels":[{"name":"in-review"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -99,7 +99,7 @@ test_missing_merge_ready_label_fails() {
 # ── Test 3: Missing issue ref in title fails ──────────────────────────────────
 
 test_missing_issue_ref_fails() {
-    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"feat: add thing without issue ref"}'
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing without issue ref","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -117,7 +117,7 @@ test_missing_issue_ref_fails() {
 # ── Test 4: Clean PR passes ───────────────────────────────────────────────────
 
 test_clean_pr_passes() {
-    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -135,7 +135,7 @@ test_clean_pr_passes() {
 # ── Test 5: Error message names the failure (draft) ──────────────────────────
 
 test_draft_error_message_is_clear() {
-    local json='{"isDraft":true,"labels":[{"name":"merge-ready"}],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":true,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -153,7 +153,7 @@ test_draft_error_message_is_clear() {
 # ── Test 6: Error message names the failure (label) ──────────────────────────
 
 test_label_error_message_is_clear() {
-    local json='{"isDraft":false,"labels":[],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":false,"labels":[],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -171,7 +171,7 @@ test_label_error_message_is_clear() {
 # ── Test 7: Error message names the failure (title) ──────────────────────────
 
 test_title_error_message_is_clear() {
-    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"feat: no issue ref here"}'
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: no issue ref here","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -202,7 +202,7 @@ test_no_pr_number_fails() {
 # ── Test 9: Multiple labels — merge-ready present passes ─────────────────────
 
 test_merge_ready_among_multiple_labels_passes() {
-    local json='{"isDraft":false,"labels":[{"name":"in-build"},{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)"}'
+    local json='{"isDraft":false,"labels":[{"name":"in-build"},{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat: add thing (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -222,7 +222,7 @@ test_merge_ready_among_multiple_labels_passes() {
 test_issue_ref_middle_of_title_passes() {
     # Spec requires (#NNN) anywhere — the CI validate-title pattern uses end-of-title,
     # but our guard just checks presence. Test that (#NNN) in the middle is acceptable.
-    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"feat(ops): pre-merge guard (#3321)"}'
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"},{"name":"reviewed-deep"}],"title":"feat(ops): pre-merge guard (#3321)","files":[{"path":"crates/perl-lsp/src/main.rs"}]}'
     local mock
     mock="$(make_mock_gh "$json")"
 
@@ -234,6 +234,60 @@ test_issue_ref_middle_of_title_passes() {
         pass "issue ref in title (canonical form) passes"
     else
         fail "issue ref in title (canonical form) — expected exit 0, got $code"
+    fi
+}
+
+# ── Test 11: Docs-only PR can skip reviewed-deep ────────────────────────────
+
+test_docs_only_pr_passes_without_reviewed_deep() {
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"docs(process): clarify review gate (#4097)","files":[{"path":".claude/agents/reviewer.md"},{"path":"docs/reference/PROCESS_LESSONS.md"}]}'
+    local mock
+    mock="$(make_mock_gh "$json")"
+
+    local code
+    code="$(run_check "$mock")"
+    cleanup "$mock"
+
+    if [[ "$code" -eq 0 ]]; then
+        pass "docs-only PR passes without reviewed-deep"
+    else
+        fail "docs-only PR without reviewed-deep — expected exit 0, got $code"
+    fi
+}
+
+# ── Test 12: Non-docs PR without reviewed-deep fails ────────────────────────
+
+test_non_docs_pr_requires_reviewed_deep() {
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"fix(lsp): add thing (#4097)","files":[{"path":"crates/perl-lsp/src/runtime/mod.rs"}]}'
+    local mock
+    mock="$(make_mock_gh "$json")"
+
+    local code
+    code="$(run_check "$mock")"
+    cleanup "$mock"
+
+    if [[ "$code" -ne 0 ]]; then
+        pass "non-docs PR without reviewed-deep exits non-zero (exit $code)"
+    else
+        fail "non-docs PR without reviewed-deep — expected non-zero exit, got 0"
+    fi
+}
+
+# ── Test 13: Deep-review failure message is clear ────────────────────────────
+
+test_review_gate_error_message_is_clear() {
+    local json='{"isDraft":false,"labels":[{"name":"merge-ready"}],"title":"fix(lsp): add thing (#4097)","files":[{"path":"crates/perl-lsp/src/runtime/mod.rs"}]}'
+    local mock
+    mock="$(make_mock_gh "$json")"
+
+    local output
+    output="$(run_check_with_output "$mock")"
+    cleanup "$mock"
+
+    if echo "$output" | grep -qi "reviewed-deep\|docs"; then
+        pass "deep-review error message mentions reviewed-deep/docs policy"
+    else
+        fail "deep-review error message unclear — got: $output"
     fi
 }
 
@@ -252,6 +306,9 @@ test_title_error_message_is_clear
 test_no_pr_number_fails
 test_merge_ready_among_multiple_labels_passes
 test_issue_ref_middle_of_title_passes
+test_docs_only_pr_passes_without_reviewed_deep
+test_non_docs_pr_requires_reviewed_deep
+test_review_gate_error_message_is_clear
 
 echo ""
 echo "=== Results: $PASS_COUNT passed, $FAIL_COUNT failed ==="


### PR DESCRIPTION
## Summary
- add a docs-only fast-track path to the review/merge policy without falsely requiring `reviewed-deep`
- enforce that policy in `scripts/pre-merge-check.sh` and cover it with shell tests
- align reviewer/ops docs and label automation with the same docs-only heuristic

## Validation
- `bash -n scripts/pre-merge-check.sh scripts/tests/test-pre-merge-check.sh`
- `bash scripts/tests/test-pre-merge-check.sh`
- `git diff --check`
