### PR TITLE
docs(features): catalog implemented DAP handlers missing from features.toml (#4109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Perl has lacked a proper modern LSP implementation. Other languages — Rust, Ty
 
 ## What It Is
 
-`perl-lsp` is a workspace of Rust crates delivering a complete Perl 5 tooling stack: an LSP server (`perllsp`) implementing all 102 capabilities catalogued in `features.toml` (87 LSP + 10 DAP + 5 extension features), a DAP debug adapter, a recursive-descent parser, a context-aware lexer, and a semantic analyzer — packaged as a single native binary you can drop into any editor. It runs on Windows, macOS, and Linux.
+`perl-lsp` is a workspace of Rust crates delivering a complete Perl 5 tooling stack: an LSP server (`perllsp`) implementing all 116 capabilities catalogued in `features.toml` (87 LSP + 24 DAP + 5 extension features), a DAP debug adapter, a recursive-descent parser, a context-aware lexer, and a semantic analyzer — packaged as a single native binary you can drop into any editor. It runs on Windows, macOS, and Linux.
 
 ## Quick Start
 
@@ -148,7 +148,7 @@ The project tracks a few distinct metrics that are easy to conflate. Each one sc
 
 | Metric | Current | What it measures | What it does **not** measure |
 | --- | --- | --- | --- |
-| LSP/DAP capability coverage | 102 / 102 | Every capability catalogued in `features.toml` has an implementation wired up | Per-capability correctness, completeness on edge cases, or subjective UX quality |
+| LSP/DAP capability coverage | 116 / 116 | Every capability catalogued in `features.toml` has an implementation wired up | Per-capability correctness, completeness on edge cases, or subjective UX quality |
 | Parser corpus — CPAN top 1000 | 95.3% (8931 / 9372) | File-level clean parse rate: share of files the parser processes without recording errors | Semantic fidelity of the AST, cross-file analysis, or any LSP-level correctness |
 | Parser corpus — Ubuntu system Perl | 97.1% (6890 / 7095) | Same, against the Ubuntu system-installed Perl compatibility baseline | Same |
 | Parser corpus — project corpus | 100.0% (91 / 91) | Deterministic regression baseline that must stay clean | Same |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -172,13 +172,13 @@ The LSP compliance table is auto-generated from `features.toml`.
 <!-- BEGIN: COMPLIANCE_TABLE -->
 | Area | Implemented | Total | Coverage |
 |------|-------------|-------|----------|
-| debug | 10 | 10 | 100% |
+| debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
 | text_document | 46 | 46 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **102** | **102** | **100%** |
+| **Overall** | **116** | **116** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->
 
 For live capability posture, run `just status-check` or read [CURRENT_STATUS.md](CURRENT_STATUS.md).

--- a/docs/project/status/lsp.md
+++ b/docs/project/status/lsp.md
@@ -13,7 +13,7 @@
 
 <!-- BEGIN: LSP_METRICS_BULLETS -->
 - **LSP Coverage**: 100% user-visible feature coverage (58/58 advertised features from `features.toml`)
-- **Protocol Compliance**: 100% overall LSP protocol support (102/102 including plumbing)
+- **Protocol Compliance**: 100% overall LSP protocol support (116/116 including plumbing)
 
 **Target**: maintain 100% LSP coverage (no regressions)
 <!-- END: LSP_METRICS_BULLETS -->
@@ -23,11 +23,11 @@
 <!-- BEGIN: COMPLIANCE_TABLE -->
 | Area | Implemented | Total | Coverage |
 |------|-------------|-------|----------|
-| debug | 10 | 10 | 100% |
+| debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
 | text_document | 46 | 46 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **102** | **102** | **100%** |
+| **Overall** | **116** | **116** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->

--- a/features.toml
+++ b/features.toml
@@ -5,7 +5,7 @@
 [meta]
 version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 100  # 102 total features (87 LSP + 10 DAP + 5 perl-lsp extensions), 53/53 advertised
+compliance_percent = 100  # 116 total features (87 LSP + 24 DAP + 5 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -525,6 +525,146 @@ advertised = true
 counts_in_coverage = false
 tests = ["crates/perl-dap/tests/dap_warn_exception_tests.rs"]
 description = "Exception breakpoint handling for warn/carp/cluck warnings"
+
+[[feature]]
+id = "dap.threads"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_adapter_tests.rs", "crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "Thread listing (threads request); Perl is single-threaded so returns one synthetic thread"
+
+[[feature]]
+id = "dap.pause"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/control_flow_handlers_tests.rs", "crates/perl-dap/tests/dap_comprehensive_test.rs"]
+description = "Pause execution of a running debug session"
+
+[[feature]]
+id = "dap.breakpoints.function"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_comprehensive_test.rs", "crates/perl-dap/tests/dap_non_regression_tests.rs"]
+description = "Function breakpoints (setFunctionBreakpoints) by subroutine name"
+
+[[feature]]
+id = "dap.breakpoint_locations"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs", "crates/perl-dap/tests/dap_non_regression_tests.rs"]
+description = "Query valid breakpoint positions within a source range (breakpointLocations)"
+
+[[feature]]
+id = "dap.source"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_non_regression_tests.rs"]
+description = "Retrieve source content by reference (source request)"
+
+[[feature]]
+id = "dap.loaded_sources"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs", "crates/perl-dap/tests/dap_non_regression_tests.rs"]
+description = "List all sources loaded in the current debug session (loadedSources)"
+
+[[feature]]
+id = "dap.restart"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_non_regression_tests.rs"]
+description = "Restart the debug session (restart request)"
+
+[[feature]]
+id = "dap.set_expression"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs"]
+description = "Assign a value to an expression in the current scope (setExpression)"
+
+[[feature]]
+id = "dap.cancel"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs", "crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "Cancel a pending or running request (cancel)"
+
+[[feature]]
+id = "dap.step_in_targets"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs", "crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "List callable step-in targets for the current frame (stepInTargets)"
+
+[[feature]]
+id = "dap.goto_targets"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs", "crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "List valid goto targets for the current frame (gotoTargets)"
+
+[[feature]]
+id = "dap.goto"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_protocol_compliance_tests.rs"]
+description = "Jump execution to a target location (goto request)"
+
+[[feature]]
+id = "dap.restart_frame"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "Restart execution from the beginning of a stack frame (restartFrame)"
+
+[[feature]]
+id = "dap.terminate_threads"
+spec = "DAP 1.0"
+area = "debug"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-dap/tests/dap_step_through_tests.rs"]
+description = "Terminate one or more threads (terminateThreads)"
 
 # Protocol / Lifecycle Features
 


### PR DESCRIPTION
## Summary

- `features.toml` catalogued only 10 DAP features, but `dispatch.rs` implements 35 handler arms covering 24 distinct capabilities. This PR adds the 14 missing entries.
- Capability total corrects from 102 (87 LSP + 10 DAP + 5 extension) to 116 (87 LSP + 24 DAP + 5 extension).
- `docs/project/status/lsp.md`, `docs/project/ROADMAP.md`, and `README.md` regenerated/updated to reflect the new counts.

## New DAP entries added (14)

| Feature ID | DAP Handler | Description |
|---|---|---|
| `dap.threads` | `threads` | Thread listing; Perl is single-threaded so returns one synthetic thread |
| `dap.pause` | `pause` | Pause execution of a running debug session |
| `dap.breakpoints.function` | `setFunctionBreakpoints` | Function breakpoints by subroutine name |
| `dap.breakpoint_locations` | `breakpointLocations` | Query valid breakpoint positions within a source range |
| `dap.source` | `source` | Retrieve source content by reference |
| `dap.loaded_sources` | `loadedSources` | List all sources loaded in the current debug session |
| `dap.restart` | `restart` | Restart the debug session |
| `dap.set_expression` | `setExpression` | Assign a value to an expression in the current scope |
| `dap.cancel` | `cancel` | Cancel a pending or running request |
| `dap.step_in_targets` | `stepInTargets` | List callable step-in targets for the current frame |
| `dap.goto_targets` | `gotoTargets` | List valid goto targets for the current frame |
| `dap.goto` | `goto` | Jump execution to a target location |
| `dap.restart_frame` | `restartFrame` | Restart execution from the beginning of a stack frame |
| `dap.terminate_threads` | `terminateThreads` | Terminate one or more threads |

## New capability total

**116** (was 102): 87 LSP + 24 DAP + 5 extension features.

## Research context

- Findings originally identified in issue #4062 (comment: "24 request handlers (code-verified in dispatch.rs), catalog lists only 10 = 42% undercounting")
- Full analysis posted to issue #4069 (DAP metrics scorecard sub-issue)
- This builder verified the 35 handler arms in `dispatch.rs` directly and mapped them against existing features, confirming 14 uncataloged entries

## Evidence

- **Commits**: 1
- **Files**: 4 changed, +148/-8 lines
- **Format check**: PASS
- **Clippy**: PASS (clean)
- **Tests**: 3022/3024 passed — 2 failures are pre-existing on master (`perl-module-resolution use_lib` tests, confirmed by running on master checkout)
- **Features invariants**: PASS (`cargo xtask features invariants`: 116 features, all GA+advertised valid)
- **Status update**: `just status-update lsp` ran and updated `lsp.md` and `ROADMAP.md` from features.toml

## Out of scope (explicit non-goals)

- **Schema upgrade** (`spec_section`, `spec_optional`, `spec_proposal` fields) — separate follow-up PR per research-verifier recommendation
- **Layered metrics display** (LSP spec conformance vs DAP spec conformance as separate numbers) — requires design input from umbrella plan-reviewer
- **DAP code changes** — handlers are already implemented; this is pure metadata/docs

## Test plan

1. Run `just status-check` — should pass (lsp.md matches features.toml)
2. Run `cargo xtask features invariants` — should print "116 features" and pass
3. Run `grep -c '\[\[feature\]\]' features.toml` — should print 116
4. Verify README shows "116 capabilities... 87 LSP + 24 DAP + 5 extension"

## Unknowns

- The 2 pre-existing `perl-module-resolution` test failures on master are unrelated but will show up in CI. They exist on master and are not caused by this PR.