### PR TITLE
fix(pragma): keep phase-block pragmas lexically scoped (#4100)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -72,31 +72,10 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         "Mojo::Base",
     ];
 
-    // Phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) run at compile time and their
-    // pragma effects are semantically file-level, but PragmaTracker does not model them
-    // as scoped bodies.  Scan phase block bodies directly so that
-    // `BEGIN { use strict; }` still suppresses PL100.
-    if let NodeKind::Program { statements } = &node.kind {
-        for stmt in statements {
-            if let NodeKind::PhaseBlock { block, .. } = &stmt.kind {
-                walk_node(block, &mut |n| {
-                    if let NodeKind::Use { module, .. } = &n.kind {
-                        if module == "strict" {
-                            has_strict = true;
-                        } else if module == "warnings" {
-                            has_warnings = true;
-                        }
-                    }
-                });
-            }
-        }
-    }
-
     // Detect OO implicit strict modules and misspelled pragmas.
     // The strict/warnings arms are intentionally absent: state_for_offset above
     // is the authoritative source of truth. Walking the full AST for strict/warnings
     // would bypass lexical scoping (finding eval-block or sub-scoped pragmas).
-    // Phase block bodies are handled above via the targeted PhaseBlock scan.
     walk_node(node, &mut |n| {
         if let NodeKind::Use { module, .. } = &n.kind {
             if module.starts_with('v') || module.chars().next().is_some_and(|c| c.is_ascii_digit())

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -170,39 +170,38 @@ fn lint_pipeline_moose_suppresses_pl100_pl101() {
 }
 
 // =========================================================================
-// 7. use strict inside BEGIN block suppresses missing-strict (issue #2360)
+// 7. use strict inside BEGIN block remains block-scoped (issue #4100)
 // =========================================================================
 
 #[test]
-fn lint_pipeline_strict_inside_begin_suppresses_pl100() {
-    // use strict declared inside BEGIN { } must still suppress the missing-strict advisory.
-    // This tests the walker.rs PhaseBlock recursion fix.
+fn lint_pipeline_strict_inside_begin_emits_pl100() {
+    // BEGIN blocks execute early, but pragma scope is still lexical to the block body.
+    // The file still lacks top-level strict, so PL100 must fire.
     let source = "BEGIN { use strict; }\nuse warnings;\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_strict: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
     assert!(
-        missing_strict.is_empty(),
-        "use strict inside BEGIN should suppress PL100, got {} missing-strict diags",
+        !missing_strict.is_empty(),
+        "use strict inside BEGIN must not suppress PL100, got {} missing-strict diags",
         missing_strict.len()
     );
 }
 
 // =========================================================================
-// 8. use warnings inside END block suppresses missing-warnings (issue #2360)
+// 8. use warnings inside END block remains block-scoped (issue #4100)
 // =========================================================================
 
 #[test]
-fn lint_pipeline_warnings_inside_end_suppresses_pl101() {
-    // use warnings declared inside END { } must still suppress PL101.
-    // All 5 phase keyword bodies are walked by the PhaseBlock fix.
+fn lint_pipeline_warnings_inside_end_emits_pl101() {
+    // END blocks do not make warnings file-wide; PL101 must still fire.
     let source = "use strict;\nEND { use warnings; }\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_warnings: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL101")).collect();
     assert!(
-        missing_warnings.is_empty(),
-        "use warnings inside END should suppress PL101, got {} missing-warnings diags",
+        !missing_warnings.is_empty(),
+        "use warnings inside END must not suppress PL101, got {} missing-warnings diags",
         missing_warnings.len()
     );
 }
@@ -255,19 +254,19 @@ fn lint_pipeline_use_if_nonpragma_version_condition_still_emits_missing_pragmas(
 }
 
 // =========================================================================
-// 10. use strict inside non-BEGIN phase block (INIT) suppresses PL100 (#2360)
+// 10. use strict inside non-BEGIN phase block (INIT) remains block-scoped (#4100)
 // =========================================================================
 
 #[test]
-fn lint_pipeline_strict_inside_init_suppresses_pl100() {
-    // All phase block keywords (not just BEGIN) must be recursed into.
+fn lint_pipeline_strict_inside_init_emits_pl100() {
+    // Other phase blocks are lexical too; INIT-scoped strict must not suppress PL100.
     let source = "INIT { use strict; }\nuse warnings;\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_strict: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
     assert!(
-        missing_strict.is_empty(),
-        "use strict inside INIT should suppress PL100, got {} missing-strict diags",
+        !missing_strict.is_empty(),
+        "use strict inside INIT must not suppress PL100, got {} missing-strict diags",
         missing_strict.len()
     );
 }

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -445,6 +445,11 @@ impl PragmaTracker {
         if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() }
     }
 
+    /// Process a lexically scoped body and then restore the caller state.
+    ///
+    /// This applies to ordinary blocks and phase blocks alike. `BEGIN`/`END`/
+    /// `INIT`/`CHECK`/`UNITCHECK` execute at special times, but their pragma
+    /// effects are still lexical to the block body rather than file-wide.
     fn build_scoped_body(
         body: &Node,
         current_state: &mut PragmaState,
@@ -800,6 +805,9 @@ impl PragmaTracker {
                 }
             }
             NodeKind::Eval { block } | NodeKind::Do { block } | NodeKind::Defer { block } => {
+                Self::build_scoped_body(block, current_state, ranges);
+            }
+            NodeKind::PhaseBlock { block, .. } => {
                 Self::build_scoped_body(block, current_state, ranges);
             }
             NodeKind::Given { body, .. }

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -48,6 +48,17 @@ fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
     }
 }
 
+fn phase_block(phase: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: Some(loc(start, start + phase.len())),
+            block: Box::new(body),
+        },
+        location: loc(start, end),
+    }
+}
+
 fn program(stmts: Vec<Node>) -> Node {
     let end = stmts.last().map_or(0, |n| n.location.end);
     Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
@@ -171,4 +182,112 @@ fn given_package_block_with_inner_no_strict_when_execution_continues_then_outer_
     let after_package = PragmaTracker::state_for_offset(&map, 50);
     assert!(after_package.strict_subs);
     assert!(after_package.warnings);
+}
+
+#[test]
+fn given_begin_block_with_use_strict_when_querying_inside_block_then_strict_is_active() {
+    let ast = program(vec![phase_block(
+        "BEGIN",
+        block(vec![use_node("strict", &[], 8, 20)], 6, 22),
+        0,
+        22,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let inside_begin = PragmaTracker::state_for_offset(&map, 12);
+    assert!(inside_begin.strict_vars);
+    assert!(inside_begin.strict_subs);
+    assert!(inside_begin.strict_refs);
+}
+
+#[test]
+fn given_begin_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    let ast = program(vec![phase_block(
+        "BEGIN",
+        block(vec![use_node("strict", &[], 8, 20)], 6, 22),
+        0,
+        22,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_begin = PragmaTracker::state_for_offset(&map, 24);
+    assert!(!after_begin.strict_vars);
+    assert!(!after_begin.strict_subs);
+    assert!(!after_begin.strict_refs);
+}
+
+#[test]
+fn given_begin_block_with_use_warnings_when_querying_after_block_then_warnings_is_not_active() {
+    let ast = program(vec![phase_block(
+        "BEGIN",
+        block(vec![use_node("warnings", &[], 8, 22)], 6, 24),
+        0,
+        24,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_begin = PragmaTracker::state_for_offset(&map, 26);
+    assert!(!after_begin.warnings);
+}
+
+#[test]
+fn given_end_block_with_use_warnings_when_querying_after_block_then_warnings_is_not_active() {
+    let ast = program(vec![phase_block(
+        "END",
+        block(vec![use_node("warnings", &[], 6, 20)], 4, 22),
+        0,
+        22,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_end = PragmaTracker::state_for_offset(&map, 24);
+    assert!(!after_end.warnings);
+}
+
+#[test]
+fn given_init_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    let ast = program(vec![phase_block(
+        "INIT",
+        block(vec![use_node("strict", &[], 7, 19)], 5, 21),
+        0,
+        21,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_init = PragmaTracker::state_for_offset(&map, 23);
+    assert!(!after_init.strict_vars);
+    assert!(!after_init.strict_subs);
+    assert!(!after_init.strict_refs);
+}
+
+#[test]
+fn given_check_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    let ast = program(vec![phase_block(
+        "CHECK",
+        block(vec![use_node("strict", &[], 8, 20)], 6, 22),
+        0,
+        22,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_check = PragmaTracker::state_for_offset(&map, 24);
+    assert!(!after_check.strict_vars);
+    assert!(!after_check.strict_subs);
+    assert!(!after_check.strict_refs);
+}
+
+#[test]
+fn given_unitcheck_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    let ast = program(vec![phase_block(
+        "UNITCHECK",
+        block(vec![use_node("strict", &[], 12, 24)], 10, 26),
+        0,
+        26,
+    )]);
+    let map = PragmaTracker::build(&ast);
+
+    let after_unitcheck = PragmaTracker::state_for_offset(&map, 28);
+    assert!(!after_unitcheck.strict_vars);
+    assert!(!after_unitcheck.strict_subs);
+    assert!(!after_unitcheck.strict_refs);
 }


### PR DESCRIPTION
## Summary
- keep phase-block pragmas lexically scoped in `PragmaTracker` instead of treating them as file-wide
- remove the `strict_warnings` phase-block override that incorrectly suppressed PL100/PL101
- replace the bad phase-block expectations with behavior-spec and integration coverage for block-local semantics

## Validation
- `cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests`
- `cargo test -p perl-pragma --test behavior_spec_tests -- --skip given_use_feature_qw_when_querying_state_then_requested_features_and_unicode_strings_are_enabled`

## Notes
- `cargo test -p perl-pragma --test behavior_spec_tests given_use_feature_qw_when_querying_state_then_requested_features_and_unicode_strings_are_enabled` also fails on clean `master`; this PR does not change that unrelated baseline.
