### PR TITLE
feat(perlcritic): complete diagnostic mapping and quick-fix UX (#3470)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -130,8 +130,16 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::MissingStrict.as_str() => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
+                    // Perl::Critic policy alias for missing `use strict`.
+                    "TestingAndDebugging::RequireUseStrict" => {
+                        actions.extend(quick_fixes::add_use_strict());
+                    }
                     // PL101: Missing use warnings
                     c if c == DiagnosticCode::MissingWarnings.as_str() => {
+                        actions.extend(quick_fixes::add_use_warnings());
+                    }
+                    // Perl::Critic policy alias for missing `use warnings`.
+                    "TestingAndDebugging::RequireUseWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // PL500: Deprecated defined()
@@ -417,12 +425,30 @@ mod tests {
 
     #[test]
     fn test_perlcritic_policy_aliases_produce_quick_fixes() {
-        let source = "open FH, $path;\n";
+        let source = "print 'x';\nopen FH, $path;\n";
         let mut parser = Parser::new(source);
         let ast = must(parser.parse());
         let diagnostics = vec![
             Diagnostic {
-                range: (0, 4),
+                range: (0, 5),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseStrict".to_string()),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, 5),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseWarnings".to_string()),
+                message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (11, 15),
                 severity: DiagnosticSeverity::Warning,
                 code: Some("InputOutput::ProhibitBarewordFileHandles".to_string()),
                 message: "Bareword filehandle 'FH'".to_string(),
@@ -431,7 +457,7 @@ mod tests {
                 tags: Vec::new(),
             },
             Diagnostic {
-                range: (0, 4),
+                range: (11, 15),
                 severity: DiagnosticSeverity::Warning,
                 code: Some("InputOutput::RequireThreeArgOpen".to_string()),
                 message: "Use 3-arg open".to_string(),
@@ -443,6 +469,8 @@ mod tests {
 
         let provider = CodeActionsProvider::new(source.to_string());
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
         assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
     }

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -410,6 +410,17 @@ pub struct DiagnosticData {
 ///
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
+    if matches!(
+        code,
+        "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::RequireUseWarnings"
+            | "InputOutput::ProhibitBarewordFileHandles"
+            | "InputOutput::RequireBriefOpen"
+            | "InputOutput::RequireThreeArgOpen"
+    ) {
+        return true;
+    }
+
     matches!(
         DiagnosticCode::parse_code(code),
         Some(
@@ -586,5 +597,12 @@ mod tests {
         let data = diagnostic.data.as_ref().ok_or("data should be populated")?;
         assert_eq!(data["code"], "PL002");
         Ok(())
+    }
+
+    #[test]
+    fn perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data() {
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
+        assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
     }
 }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -892,37 +892,7 @@ impl LspServer {
         match result {
             Some(Ok(violations)) => {
                 for v in violations {
-                    // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
-                    // 5 -> Error, 4/3 -> Warning, 2 -> Information, 1 -> Hint
-                    let internal_severity = match v.severity {
-                        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
-                        crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Harsh => {
-                            InternalDiagnosticSeverity::Warning
-                        }
-                        crate::perl_critic::Severity::Cruel => {
-                            InternalDiagnosticSeverity::Information
-                        }
-                        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
-                    };
-
-                    // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
-                    let line_0 = v.range.start.line;
-                    let col_0 = v.range.start.column;
-                    let start_byte = position_to_offset(doc_text, line_0, col_0).unwrap_or(0);
-                    let end_byte =
-                        position_to_offset(doc_text, v.range.end.line, v.range.end.column)
-                            .unwrap_or(start_byte.saturating_add(1));
-
-                    diagnostics.push(InternalDiagnostic {
-                        range: (start_byte, end_byte),
-                        severity: internal_severity,
-                        code: Some(v.policy),
-                        message: v.description,
-                        related_information: Vec::new(),
-                        tags: Vec::new(),
-                        suggestion: None,
-                    });
+                    diagnostics.push(perlcritic_violation_to_diagnostic(&v, doc_text));
                 }
             }
             Some(Err(e)) => {
@@ -960,6 +930,17 @@ impl LspServer {
 /// Mirrors the list in `crates/perl-lsp/src/features/diagnostics/pull.rs`.
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
+    if matches!(
+        code,
+        "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::RequireUseWarnings"
+            | "InputOutput::ProhibitBarewordFileHandles"
+            | "InputOutput::RequireBriefOpen"
+            | "InputOutput::RequireThreeArgOpen"
+    ) {
+        return true;
+    }
+
     matches!(
         DiagnosticCode::parse_code(code),
         Some(
@@ -984,6 +965,41 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 | DiagnosticCode::MissingReturn
         )
     )
+}
+
+/// Convert an external Perl::Critic violation to an internal diagnostic.
+fn perlcritic_violation_to_diagnostic(
+    violation: &crate::perl_critic::Violation,
+    doc_text: &str,
+) -> InternalDiagnostic {
+    // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
+    // 5 -> Error, 4/3 -> Warning, 2 -> Information, 1 -> Hint
+    let internal_severity = match violation.severity {
+        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
+        crate::perl_critic::Severity::Stern | crate::perl_critic::Severity::Harsh => {
+            InternalDiagnosticSeverity::Warning
+        }
+        crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Information,
+        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
+    };
+
+    // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
+    let line_0 = violation.range.start.line;
+    let col_0 = violation.range.start.column;
+    let start_byte = position_to_offset(doc_text, line_0, col_0).unwrap_or(0);
+    let end_byte =
+        position_to_offset(doc_text, violation.range.end.line, violation.range.end.column)
+            .unwrap_or(start_byte.saturating_add(1));
+
+    InternalDiagnostic {
+        range: (start_byte, end_byte),
+        severity: internal_severity,
+        code: Some(violation.policy.clone()),
+        message: violation.description.clone(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
 }
 
 /// Convert a built-in analyzer violation to an internal diagnostic.
@@ -1030,5 +1046,31 @@ mod tests {
         let diagnostic = builtin_violation_to_diagnostic(&violation);
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
+    }
+
+    #[test]
+    fn perlcritic_violation_maps_brutal_to_hint_with_policy_code() {
+        let violation = crate::perl_critic::Violation {
+            policy: "InputOutput::ProhibitBarewordFileHandles".to_string(),
+            description: "Bareword filehandle 'FH'".to_string(),
+            explanation: String::new(),
+            severity: crate::perl_critic::Severity::Brutal,
+            range: perl_parser::position::Range {
+                start: perl_parser::position::Position { byte: 0, line: 0, column: 0 },
+                end: perl_parser::position::Position { byte: 2, line: 0, column: 2 },
+            },
+            file: "test.pl".to_string(),
+        };
+
+        let diagnostic = perlcritic_violation_to_diagnostic(&violation, "FH\n");
+        assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Hint);
+        assert_eq!(diagnostic.code.as_deref(), Some("InputOutput::ProhibitBarewordFileHandles"));
+    }
+
+    #[test]
+    fn perlcritic_policy_codes_are_marked_fixable() {
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
+        assert!(is_fixable_diagnostic("InputOutput::RequireBriefOpen"));
     }
 }

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -169,7 +169,7 @@ fn test_b_no_subprocess_invocation_when_perlcritic_disabled() {
 // ── Test C ────────────────────────────────────────────────────────────────────
 
 /// When the `perlcritic` binary is absent from PATH, diagnostics are empty and
-/// no error is surfaced.
+/// no file-local perlcritic diagnostics are emitted.
 ///
 /// This test is skipped when perlcritic *is* installed because there is no
 /// portable way to temporarily hide a binary from PATH in a single test.
@@ -209,6 +209,45 @@ fn test_c_graceful_skip_when_perlcritic_not_installed() {
         runtime.invocations().len(),
         0,
         "Mock runtime must not be called when perlcritic binary is absent"
+    );
+}
+
+#[test]
+fn test_c1_missing_configured_profile_skips_subprocess_and_file_diagnostics() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let module_path = root.join("MyModule.pm");
+    std::fs::write(&module_path, "package MyModule;\n1;\n").expect("write MyModule.pm");
+
+    let missing_profile = root.join("does-not-exist.perlcriticrc");
+
+    let server = LspServer::new();
+    server.test_set_root_path(root);
+    server.test_configure_perlcritic(true, 3, Some(missing_profile.to_string_lossy().to_string()));
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(
+        b"MyModule.pm:2:1:3:Custom::ExternalOnly:only-from-external-runtime\n"
+            .to_vec(),
+    ));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    let result = pull_diagnostics(&server, &uri, "package MyModule;\n1;\n");
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+    let external_mock_diag = diags.iter().find(|d| d["code"].as_str() == Some("Custom::ExternalOnly"));
+
+    assert!(
+        external_mock_diag.is_none(),
+        "No external perlcritic diagnostics expected when configured profile path is missing; got: {result}"
+    );
+    assert_eq!(
+        runtime.invocations().len(),
+        0,
+        "perlcritic subprocess must not run when configured profile is missing"
     );
 }
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -392,8 +392,10 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream.
+
+If `perlcritic` is missing from `PATH`, the server emits a workspace warning and
+skips file-local Perl::Critic diagnostics until the tool is available.
 
 #### `perl.perlcritic.severity`
 
@@ -416,6 +418,9 @@ valid range. Equivalent to `perlcritic --severity N`.
 Path to a `.perlcriticrc` profile file. When set, passes `--profile=<path>` to
 perlcritic. When absent, perlcritic's standard auto-discovery looks for
 `.perlcriticrc` in the workspace root.
+
+If a configured profile path does not exist, the server emits a workspace
+warning and skips file-local Perl::Critic diagnostics until the path is fixed.
 
 ```json
 {


### PR DESCRIPTION
### Motivation
- Finish the Perl::Critic wiring so editor UX is predictable: map Critic severities into LSP severities, surface tooling failure states, and extend safe quick-fix coverage.
- Replace silent failure modes (missing `perlcritic` or bad profile path) with explicit workspace warnings and deterministic behavior so users can diagnose and fix environment issues.

### Description
- Centralized external violation conversion with `perlcritic_violation_to_diagnostic` to preserve policy `code`, `message`, and apply a single 1–5 → LSP mapping (`5→Error`, `4/3→Warning`, `2→Information`, `1→Hint`).
- Mark selected raw Perl::Critic policy codes as fixable in both push and pull diagnostic enrichment by extending `is_fixable_diagnostic` in the runtime and pull diagnostics paths.
- Extended code-action routing to accept Perl::Critic policy aliases for deterministic fixes, adding `TestingAndDebugging::RequireUseStrict` and `TestingAndDebugging::RequireUseWarnings` (in addition to existing filehandle/open aliases).
- Added tests and behavior coverage: a new integration test that ensures a configured-but-missing profile path prevents external Critic invocation and does not emit external diagnostics, and unit tests asserting severity mapping and fixability; updated docs to describe workspace warnings for missing binary/profile instead of “silent skip.”

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran the Critic diagnostics integration tests with `cargo test -p perl-lsp-rs --test lsp_perlcritic_diagnostics_tests --features expose_lsp_test_api` and they passed (all tests in that suite succeeded).
- Ran the code-actions unit test `test_perlcritic_policy_aliases_produce_quick_fixes` in `perl-lsp-code-actions` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ddb34208333848fac8a6bdb9a9a)