### PR TITLE
feat(perlcritic): tighten diagnostics UX and fix routing (#3470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For a full walkthrough, see [docs/tutorials/GETTING_STARTED.md](docs/tutorials/G
 - **Fast native parser** — recursive-descent v3 parser with a context-aware lexer; validated against a curated CPAN corpus
 - **Semantic analysis** — symbol resolution, scope tracking, Moose/Moo method modifiers and role composition
 - **Refactoring** — extract variable, extract subroutine, workspace-scoped rename, subroutine inlining
-- **Diagnostics** — dead code highlighting, strict/warnings diagnostics, perlcritic integration with walk-up discovery
+- **Diagnostics** — dead code highlighting, strict/warnings diagnostics, perlcritic integration with walk-up discovery and explicit tooling warnings
 - **Zero-Perl dependency** for IDE features — the server is a single native binary
 - **Windows first-class** — install, path handling, and shell interactions are part of the release surface
 

--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -181,6 +181,17 @@ impl CodeActionsProvider {
                     "InputOutput::RequireBriefOpen" | "InputOutput::RequireThreeArgOpen" => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
+                    // Perl::Critic policies for missing strict/warnings.
+                    "TestingAndDebugging::RequireUseStrict" => {
+                        actions.extend(quick_fixes::add_use_strict());
+                    }
+                    "TestingAndDebugging::RequireUseWarnings" => {
+                        actions.extend(quick_fixes::add_use_warnings());
+                    }
+                    // Perl::Critic policy alias for unused variables.
+                    "Variables::ProhibitUnusedVariables" => {
+                        actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
+                    }
                     // PL200: Missing package declaration
                     c if c == DiagnosticCode::MissingPackageDeclaration.as_str() => {
                         actions.extend(quick_fixes::fix_missing_package_declaration(&self.source));
@@ -445,5 +456,48 @@ mod tests {
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
         assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+    }
+
+    #[test]
+    fn test_perlcritic_policy_aliases_for_strict_warnings_and_unused_variable() {
+        let source = "print $unused;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseStrict".to_string()),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseWarnings".to_string()),
+                message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (6, 13),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("Variables::ProhibitUnusedVariables".to_string()),
+                message: "Unused variable '$unused'".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
+        assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
     }
 }

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -47,7 +47,8 @@ pub struct ServerConfig {
     ///
     /// When enabled, the server will run `perlcritic` on open documents and
     /// merge violations into the diagnostic stream. Requires `perlcritic` to
-    /// be installed on the system; silently skipped if not available.
+    /// be installed on the system; missing tool/profile failures are surfaced
+    /// through workspace warning messages.
     pub perlcritic_enabled: bool,
 
     /// Minimum Perl::Critic severity level to report (1-5, where 5 = most severe).

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -410,6 +410,18 @@ pub struct DiagnosticData {
 ///
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
+    if matches!(
+        code,
+        "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::RequireUseWarnings"
+            | "InputOutput::ProhibitBarewordFileHandles"
+            | "InputOutput::RequireBriefOpen"
+            | "InputOutput::RequireThreeArgOpen"
+            | "Variables::ProhibitUnusedVariables"
+    ) {
+        return true;
+    }
+
     matches!(
         DiagnosticCode::parse_code(code),
         Some(
@@ -565,6 +577,14 @@ mod tests {
         let data = diagnostic.data.as_ref().ok_or("data should be populated")?;
         assert_eq!(data["code"], "PL302");
         Ok(())
+    }
+
+    #[test]
+    fn perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data() {
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
+        assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
+        assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -362,7 +362,7 @@ impl LspServer {
                                     InternalDiagnosticSeverity::Hint => 4,
                                 },
                                 "code": d.code.clone(),
-                                "source": "perl-lsp",
+                                "source": diagnostic_source(d.code.as_deref()),
                                 "message": message,
                             });
 
@@ -597,7 +597,7 @@ impl LspServer {
                                         InternalDiagnosticSeverity::Hint => 4,
                                     },
                                     "code": d.code.clone(),
-                                    "source": "perl-lsp",
+                                    "source": diagnostic_source(d.code.as_deref()),
                                     "message": message,
                                 });
                                 if !d.tags.is_empty() {
@@ -688,7 +688,7 @@ impl LspServer {
                                     InternalDiagnosticSeverity::Hint => 4,
                                 },
                                 "code": d.code.clone(),
-                                "source": "perl-lsp",
+                                "source": diagnostic_source(d.code.as_deref()),
                                 "message": message,
                             });
                             if !d.tags.is_empty() {
@@ -960,30 +960,52 @@ impl LspServer {
 /// Mirrors the list in `crates/perl-lsp/src/features/diagnostics/pull.rs`.
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
-    matches!(
-        DiagnosticCode::parse_code(code),
-        Some(
-            DiagnosticCode::ParseError
-                | DiagnosticCode::MissingStrict
-                | DiagnosticCode::MissingWarnings
-                | DiagnosticCode::UnusedVariable
-                | DiagnosticCode::UndefinedVariable
-                | DiagnosticCode::VariableShadowing
-                | DiagnosticCode::UnusedParameter
-                | DiagnosticCode::UnquotedBareword
-                | DiagnosticCode::BarewordFilehandle
-                | DiagnosticCode::TwoArgOpen
-                | DiagnosticCode::AssignmentInCondition
-                | DiagnosticCode::NumericComparisonWithUndef
-                | DiagnosticCode::DeprecatedDefined
-                | DiagnosticCode::MissingPackageDeclaration
-                | DiagnosticCode::VariableRedeclaration
-                | DiagnosticCode::MisspelledPragma
-                | DiagnosticCode::UnreachableCode
-                | DiagnosticCode::DuplicateSubroutine
-                | DiagnosticCode::MissingReturn
+    is_fixable_perlcritic_policy(code)
+        || matches!(
+            DiagnosticCode::parse_code(code),
+            Some(
+                DiagnosticCode::ParseError
+                    | DiagnosticCode::MissingStrict
+                    | DiagnosticCode::MissingWarnings
+                    | DiagnosticCode::UnusedVariable
+                    | DiagnosticCode::UndefinedVariable
+                    | DiagnosticCode::VariableShadowing
+                    | DiagnosticCode::UnusedParameter
+                    | DiagnosticCode::UnquotedBareword
+                    | DiagnosticCode::BarewordFilehandle
+                    | DiagnosticCode::TwoArgOpen
+                    | DiagnosticCode::AssignmentInCondition
+                    | DiagnosticCode::NumericComparisonWithUndef
+                    | DiagnosticCode::DeprecatedDefined
+                    | DiagnosticCode::MissingPackageDeclaration
+                    | DiagnosticCode::VariableRedeclaration
+                    | DiagnosticCode::MisspelledPragma
+                    | DiagnosticCode::UnreachableCode
+                    | DiagnosticCode::DuplicateSubroutine
+                    | DiagnosticCode::MissingReturn
+            )
         )
+}
+
+fn is_fixable_perlcritic_policy(code: &str) -> bool {
+    matches!(
+        code,
+        "InputOutput::ProhibitBarewordFileHandles"
+            | "InputOutput::RequireBriefOpen"
+            | "InputOutput::RequireThreeArgOpen"
+            | "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::RequireUseWarnings"
+            | "Variables::ProhibitUnusedVariables"
     )
+}
+
+fn diagnostic_source(code: Option<&str>) -> &'static str {
+    match code {
+        Some(code) if code.contains("::") && DiagnosticCode::parse_code(code).is_none() => {
+            "perlcritic"
+        }
+        _ => "perl-lsp",
+    }
 }
 
 /// Convert a built-in analyzer violation to an internal diagnostic.

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -68,7 +68,8 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
     let result = pull_diagnostics(&server, uri, "print 'hello';\n");
 
     // There must be at least one diagnostic with code
-    // "TestingAndDebugging::RequireUseStrict" and severity 2 (Warning).
+    // "TestingAndDebugging::RequireUseStrict", severity 2 (Warning),
+    // perlcritic source attribution, and fixable=true metadata.
     //
     // The pull-diagnostics response has the shape:
     //   { "kind": "full", "items": [ { "code": "...", "severity": N, ... } ], "resultId": "..." }
@@ -77,6 +78,8 @@ fn test_a_violations_appear_in_pull_diagnostics_when_enabled() {
     let found = diags.iter().any(|d| {
         d["code"].as_str() == Some("TestingAndDebugging::RequireUseStrict")
             && d["severity"].as_u64() == Some(2)
+            && d["source"].as_str() == Some("perlcritic")
+            && d["data"]["fixable"].as_bool() == Some(true)
     });
 
     assert!(
@@ -169,7 +172,7 @@ fn test_b_no_subprocess_invocation_when_perlcritic_disabled() {
 // ── Test C ────────────────────────────────────────────────────────────────────
 
 /// When the `perlcritic` binary is absent from PATH, diagnostics are empty and
-/// no error is surfaced.
+/// no subprocess runs.
 ///
 /// This test is skipped when perlcritic *is* installed because there is no
 /// portable way to temporarily hide a binary from PATH in a single test.

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -392,8 +392,9 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream. If `perlcritic` is not installed
+or the configured profile path is invalid, perl-lsp surfaces a workspace
+warning and reports the issue through health-check output.
 
 #### `perl.perlcritic.severity`
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -927,7 +927,7 @@
           {
             "id": "verify-perl",
             "title": "Verify Your Perl Installation",
-            "description": "Run the health check to confirm Perl and perltidy are available.",
+            "description": "Run the health check to confirm Perl tooling (perl, perltidy, optional perlcritic) is available.",
             "media": {
               "image": "media/walkthrough/verify-perl.svg",
               "altText": "Verify Perl"


### PR DESCRIPTION
### Motivation
- The Perl::Critic integration previously flattened policy-origin metadata and left some tooling failures silent, reducing editor UX clarity and fixability.
- The code-actions registry only routed a narrow set of Critic policy aliases, limiting deterministic quick-fix coverage.
- Docs and server config text still described a silent skip when `perlcritic` was unavailable instead of surfacing explicit health/warning information.

### Description
- Attribute pull diagnostics that look like Perl::Critic policy codes to `source: "perlcritic"` by adding `diagnostic_source` and using it in diagnostic serialization. (`crates/perl-lsp/src/runtime/diagnostics.rs`).
- Mark a small, deterministic set of Perl::Critic policies as fixable via `is_fixable_perlcritic_policy` and include them in the `data.fixable` metadata emitted for diagnostics. (`crates/perl-lsp/src/runtime/diagnostics.rs`).
- Extend code-action routing to handle additional Perl::Critic policy codes: `TestingAndDebugging::RequireUseStrict`, `TestingAndDebugging::RequireUseWarnings`, and `Variables::ProhibitUnusedVariables`, reusing existing quick-fix implementations. (`crates/perl-lsp-code-actions/src/code_actions.rs`).
- Update server config comments and user docs so missing `perlcritic` or an invalid profile are described as tooling-state issues that surface workspace warnings and health-check output. (`crates/perl-lsp-config/src/lib.rs`, `docs/reference/CONFIG.md`, `vscode-extension/package.json`, `README.md`).
- Add/adjust unit/integration tests to assert Critic `source` attribution, `data.fixable` metadata, and the expanded quick-fix alias routing. (`crates/perl-lsp-code-actions/src/code_actions.rs` tests and `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs`).

### Testing
- Ran formatting: `cargo fmt --all`, which completed successfully.
- Ran quick-fix unit tests: `cargo test -p perl-lsp-code-actions`, all tests passed (existing and newly added tests succeeded).
- Ran targeted integration tests: `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests`, which passed and verified severity mapping, `source` attribution, fixable metadata, profile walk-up, and missing-binary behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ddb34208333848fac8a6bdb9a9a)