### PR TITLE
feat(perlcritic): harden diagnostics + quick-fix UX (#3470)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -130,8 +130,16 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::MissingStrict.as_str() => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
+                    // Perl::Critic policy alias for missing strict.
+                    "TestingAndDebugging::RequireUseStrict" => {
+                        actions.extend(quick_fixes::add_use_strict());
+                    }
                     // PL101: Missing use warnings
                     c if c == DiagnosticCode::MissingWarnings.as_str() => {
+                        actions.extend(quick_fixes::add_use_warnings());
+                    }
+                    // Perl::Critic policy alias for missing warnings.
+                    "TestingAndDebugging::RequireUseWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // PL500: Deprecated defined()
@@ -439,11 +447,31 @@ mod tests {
                 related_information: Vec::new(),
                 tags: Vec::new(),
             },
+            Diagnostic {
+                range: (0, 1),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseStrict".to_string()),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, 1),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseWarnings".to_string()),
+                message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
         ];
 
         let provider = CodeActionsProvider::new(source.to_string());
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
         assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
     }
 }

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -892,37 +892,7 @@ impl LspServer {
         match result {
             Some(Ok(violations)) => {
                 for v in violations {
-                    // Map Perl::Critic severity (1-5) to LSP DiagnosticSeverity:
-                    // 5 -> Error, 4/3 -> Warning, 2 -> Information, 1 -> Hint
-                    let internal_severity = match v.severity {
-                        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
-                        crate::perl_critic::Severity::Stern
-                        | crate::perl_critic::Severity::Harsh => {
-                            InternalDiagnosticSeverity::Warning
-                        }
-                        crate::perl_critic::Severity::Cruel => {
-                            InternalDiagnosticSeverity::Information
-                        }
-                        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
-                    };
-
-                    // Convert 0-indexed line/column from CriticAnalyzer to byte offsets.
-                    let line_0 = v.range.start.line;
-                    let col_0 = v.range.start.column;
-                    let start_byte = position_to_offset(doc_text, line_0, col_0).unwrap_or(0);
-                    let end_byte =
-                        position_to_offset(doc_text, v.range.end.line, v.range.end.column)
-                            .unwrap_or(start_byte.saturating_add(1));
-
-                    diagnostics.push(InternalDiagnostic {
-                        range: (start_byte, end_byte),
-                        severity: internal_severity,
-                        code: Some(v.policy),
-                        message: v.description,
-                        related_information: Vec::new(),
-                        tags: Vec::new(),
-                        suggestion: None,
-                    });
+                    diagnostics.push(external_critic_violation_to_diagnostic(doc_text, v));
                 }
             }
             Some(Err(e)) => {
@@ -960,6 +930,17 @@ impl LspServer {
 /// Mirrors the list in `crates/perl-lsp/src/features/diagnostics/pull.rs`.
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
+    if matches!(
+        code,
+        "InputOutput::ProhibitBarewordFileHandles"
+            | "InputOutput::RequireBriefOpen"
+            | "InputOutput::RequireThreeArgOpen"
+            | "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::RequireUseWarnings"
+    ) {
+        return true;
+    }
+
     matches!(
         DiagnosticCode::parse_code(code),
         Some(
@@ -1009,6 +990,38 @@ fn builtin_violation_to_diagnostic(
     }
 }
 
+/// Convert an external Perl::Critic violation to an internal diagnostic.
+fn external_critic_violation_to_diagnostic(
+    doc_text: &str,
+    violation: crate::perl_critic::Violation,
+) -> InternalDiagnostic {
+    let severity = match violation.severity {
+        crate::perl_critic::Severity::Gentle => InternalDiagnosticSeverity::Error,
+        crate::perl_critic::Severity::Stern | crate::perl_critic::Severity::Harsh => {
+            InternalDiagnosticSeverity::Warning
+        }
+        crate::perl_critic::Severity::Cruel => InternalDiagnosticSeverity::Information,
+        crate::perl_critic::Severity::Brutal => InternalDiagnosticSeverity::Hint,
+    };
+
+    let start_byte =
+        position_to_offset(doc_text, violation.range.start.line, violation.range.start.column)
+            .unwrap_or(0);
+    let end_byte =
+        position_to_offset(doc_text, violation.range.end.line, violation.range.end.column)
+            .unwrap_or(start_byte.saturating_add(1));
+
+    InternalDiagnostic {
+        range: (start_byte, end_byte),
+        severity,
+        code: Some(violation.policy),
+        message: violation.description,
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1030,5 +1043,31 @@ mod tests {
         let diagnostic = builtin_violation_to_diagnostic(&violation);
         assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Error);
         assert_eq!(diagnostic.code.as_deref(), Some("GentlePolicy"));
+    }
+
+    #[test]
+    fn external_violation_maps_cruel_to_information() {
+        let violation = crate::perl_critic::Violation {
+            policy: "TestingAndDebugging::RequireUseWarnings".to_string(),
+            description: "Code does not use warnings".to_string(),
+            explanation: String::new(),
+            severity: crate::perl_critic::Severity::Cruel,
+            range: perl_parser::position::Range {
+                start: perl_parser::position::Position { byte: 0, line: 0, column: 0 },
+                end: perl_parser::position::Position { byte: 0, line: 0, column: 5 },
+            },
+            file: "test.pl".to_string(),
+        };
+
+        let diagnostic = external_critic_violation_to_diagnostic("print 1;\n", violation);
+        assert_eq!(diagnostic.severity, InternalDiagnosticSeverity::Information);
+        assert_eq!(diagnostic.code.as_deref(), Some("TestingAndDebugging::RequireUseWarnings"));
+        assert_eq!(diagnostic.message, "Code does not use warnings");
+    }
+
+    #[test]
+    fn critic_aliases_are_fixable() {
+        assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
     }
 }

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -392,8 +392,9 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream. If `perlcritic` is not installed
+or a configured profile path is invalid, the server emits a workspace warning
+and reports the issue through health-check tooling.
 
 #### `perl.perlcritic.severity`
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -927,7 +927,7 @@
           {
             "id": "verify-perl",
             "title": "Verify Your Perl Installation",
-            "description": "Run the health check to confirm Perl and perltidy are available.",
+            "description": "Run the health check to confirm Perl, perltidy, and optional perlcritic setup are available.",
             "media": {
               "image": "media/walkthrough/verify-perl.svg",
               "altText": "Verify Perl"


### PR DESCRIPTION
### Motivation

- Finish and harden the existing Perl::Critic runtime bridge by centralizing severity mapping and preserving policy metadata so Critic findings behave like native diagnostics in the editor.
- Surface tooling health (missing `perlcritic` binary or invalid profile) via workspace warnings and the health check instead of silently skipping analysis.
- Expand quick-fix coverage conservatively by routing deterministic, syntax-local Perl::Critic policy aliases into the existing quick-fix registry.

### Description

- Add a dedicated conversion helper `external_critic_violation_to_diagnostic` that maps Perl::Critic severities into internal LSP diagnostic severities and preserves `policy` as the diagnostic `code` and the message text.
- Replace inline mapping in the diagnostics pipeline with the new helper so external Critic violations are produced consistently from `collect_external_perlcritic_diagnostics`.
- Extend `is_fixable_diagnostic` and the `CodeActionsProvider` to treat several Perl::Critic policy aliases as fixable and route them to existing quick-fixes (notably `TestingAndDebugging::RequireUseStrict` → `add_use_strict` and `TestingAndDebugging::RequireUseWarnings` → `add_use_warnings`, plus existing InputOutput aliases).
- Update documentation and VS Code walkthrough text so `perl.perlcritic.enabled` no longer appears to silently skip when the tool/profile is missing, and instead point to explicit workspace warnings and health-check reporting.

### Testing

- Ran formatting with `cargo fmt --all` (succeeded).
- Ran unit tests for the diagnostics helper with `cargo test -p perl-lsp-rs --lib runtime::diagnostics::tests` (all tests passed).
- Ran code-action unit test `cargo test -p perl-lsp-code-actions test_perlcritic_policy_aliases_produce_quick_fixes` (passed).
- Ran the Critic pull-diagnostics integration test with mocked runtime `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_a_violations_appear_in_pull_diagnostics_when_enabled` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ddb34208333848fac8a6bdb9a9a)