### PR TITLE
feat(perlcritic): expand policy quick fixes and profile-failure coverage (#3470)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -130,8 +130,16 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::MissingStrict.as_str() => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
+                    // Perl::Critic policy alias for missing strict pragma.
+                    "TestingAndDebugging::RequireUseStrict" => {
+                        actions.extend(quick_fixes::add_use_strict());
+                    }
                     // PL101: Missing use warnings
                     c if c == DiagnosticCode::MissingWarnings.as_str() => {
+                        actions.extend(quick_fixes::add_use_warnings());
+                    }
+                    // Perl::Critic policy alias for missing warnings pragma.
+                    "TestingAndDebugging::RequireUseWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // PL500: Deprecated defined()
@@ -445,5 +453,37 @@ mod tests {
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
         assert!(actions.iter().any(|a| a.title.contains("bareword filehandle")));
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+    }
+
+    #[test]
+    fn test_perlcritic_require_use_pragmas_route_to_existing_quick_fixes() {
+        let source = "print $value;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, 0),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseStrict".to_string()),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, 0),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::RequireUseWarnings".to_string()),
+                message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
     }
 }

--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -47,7 +47,8 @@ pub struct ServerConfig {
     ///
     /// When enabled, the server will run `perlcritic` on open documents and
     /// merge violations into the diagnostic stream. Requires `perlcritic` to
-    /// be installed on the system; silently skipped if not available.
+    /// be installed on the system; missing binary/profile/runtime failures are
+    /// surfaced as workspace warnings.
     pub perlcritic_enabled: bool,
 
     /// Minimum Perl::Critic severity level to report (1-5, where 5 = most severe).

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -313,3 +313,41 @@ fn test_e_empty_profile_falls_back_to_walkup_config() {
         invocations[0].args
     );
 }
+
+#[test]
+fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let missing_profile = root.join("missing.perlcriticrc");
+    let module_path = root.join("NoProfile.pm");
+    std::fs::write(&module_path, "package NoProfile;\n1;\n").expect("write module");
+
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 3, Some(missing_profile.to_string_lossy().to_string()));
+    server.test_set_root_path(root);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    let result = pull_diagnostics(&server, &uri, "package NoProfile;\n1;\n");
+
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+    let critic_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| d["code"].as_str().is_some_and(|code| code.contains("::")))
+        .collect();
+    assert!(
+        critic_diags.is_empty(),
+        "no perlcritic diagnostics expected when profile path is invalid; got: {result}"
+    );
+    assert_eq!(
+        runtime.invocations().len(),
+        0,
+        "subprocess should not run when configured profile path does not exist"
+    );
+}

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -392,8 +392,9 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. Silently skipped if `perlcritic`
-is not installed on the system.
+merges violations into the diagnostic stream. If `perlcritic` is missing,
+profile resolution fails, or the command execution fails, the server emits a
+workspace warning instead of silently skipping.
 
 #### `perl.perlcritic.severity`
 


### PR DESCRIPTION
### Motivation

- Finish the Perl::Critic editor UX by routing more Critic policy aliases into existing, deterministic quick fixes instead of leaving them unmapped.
- Surface tooling-state failures (missing configured profile / missing binary / execution errors) as workspace warnings rather than silently skipping analysis.
- Add targeted tests to prevent regressions in quick-fix routing and the runtime profile-handling behavior.

### Description

- Extend the code-action routing in `crates/perl-lsp-code-actions/src/code_actions.rs` to treat `TestingAndDebugging::RequireUseStrict` and `TestingAndDebugging::RequireUseWarnings` as aliases that call the existing `add_use_strict` and `add_use_warnings` quick-fix generators.
- Add a unit test `test_perlcritic_require_use_pragmas_route_to_existing_quick_fixes` in `crates/perl-lsp-code-actions/src/code_actions.rs` to assert those policy aliases produce the expected quick fixes.
- Add an integration test `test_f_missing_configured_profile_skips_subprocess_and_diagnostics` to `crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs` that verifies a configured-but-missing `perl.perlcritic.profile` prevents the perlcritic subprocess from running and that no Perl::Critic diagnostics are emitted.
- Update user-facing wording in `docs/reference/CONFIG.md` and the `ServerConfig` comment in `crates/perl-lsp-config/src/lib.rs` to state that missing `perlcritic` / profile / runtime failures are surfaced as workspace warnings rather than silently skipped.
- Run `cargo fmt --all` to format changes.

### Testing

- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p perl-lsp-code-actions` and all unit tests in that crate passed (`54 passed, 0 failed`).
- Ran `cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests` and the Perl::Critic diagnostic integration tests passed (`8 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ddb34208333848fac8a6bdb9a9a)