### PR TITLE
docs(contributing): require reference-implementation verification for PRs citing external specs (#4101)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,14 @@ You will see pipeline labels added to your PR:
 
 The CI merge gate only runs on `merge-ready` PRs. This keeps the queue clean — do not worry if CI looks quiet on your draft.
 
+#### External-claim verification
+
+If a PR's description or commit message cites an external specification (Perl language semantics, LSP protocol spec, DAP protocol spec) or a third-party crate API, the review process **must** include running the claimed behavior against the reference implementation, not just reading the documentation. For Perl claims, a short `perl -e` snippet against the runtime is authoritative. For LSP/DAP claims, the published spec text is authoritative. For crate APIs, the current `docs.rs` entry is authoritative.
+
+This rule exists because on 2026-04-11, [PR #4090](https://github.com/EffortlessMetrics/perl-lsp/pull/4090) was approved by multiple reviewers on the basis of a false claim about Perl phase-block pragma semantics that every reviewer had independently assumed was true. The false claim was caught only by a research-verifier agent running `perl -e 'BEGIN { use strict; } $x = 1'` and observing the script succeeds — proving `use strict` inside `BEGIN { }` stays lexically scoped to the block and is **not** active at file scope. The resulting revert is tracked in [#4100](https://github.com/EffortlessMetrics/perl-lsp/issues/4100) and the correct positive-direction lint in [#4101](https://github.com/EffortlessMetrics/perl-lsp/issues/4101). See also related process context in [#4062](https://github.com/EffortlessMetrics/perl-lsp/issues/4062).
+
+For code review automation: the `research-verifier` agent should be invoked on any PR whose body references `perlmod`, `perlop`, `LSP 3.`, `DAP`, or a `docs.rs` URL. The `reviewer-deep` agent's definition at `.claude/agents/reviewer-deep.md` will be updated separately to reference this rule (tracked as a follow-up).
+
 For more detail on the CI structure see [docs/project/CI.md](docs/project/CI.md) and [docs/project/CI_TEST_LANES.md](docs/project/CI_TEST_LANES.md).
 
 ## Coding Standards


### PR DESCRIPTION
## Summary

Adds a new **External-claim verification** subsection to `CONTRIBUTING.md` under the existing "What Happens After You Open a PR" heading. The rule requires that PRs citing external specs (Perl language semantics, LSP/DAP protocol, third-party crate APIs) be verified against the reference implementation — not just documentation — during review.

## Rationale

On 2026-04-11, [PR #4090](https://github.com/EffortlessMetrics/perl-lsp/pull/4090) was approved by a first-pass reviewer, a deep reviewer, test authors, and the original scout on the basis of a shared false belief about Perl phase-block pragma propagation. A `research-verifier` agent caught the error at the last minute by actually running `perl -e 'BEGIN { use strict; } \$x = 1'` against the Perl runtime and observing the script succeeds — proving `use strict` inside `BEGIN { }` stays lexically scoped to the block and is NOT active at file scope. The resulting revert is tracked in #4100 and the correct positive-direction lint in #4101.

A follow-up audit verified 30 of 31 other semantic claims in the codebase are correct, so this is not a systemic bug — but the one incident demonstrates that multiple reviewers can collectively share a misconception that only reference-implementation testing will break. This standing process rule exists to prevent recurrence.

## Scope

- **Only** `CONTRIBUTING.md` is modified — one subsection added (~221 words)
- Cross-links #4090, #4100, #4101, #4062
- A follow-up update to `.claude/agents/reviewer-deep.md` is noted in the rule text as a separate task (subagent edit permissions on that path are restricted)

## Test plan

- [ ] Visual review: the new subsection renders cleanly on GitHub
- [ ] Cross-references #4090, #4100, #4101 resolve to correct issues/PRs
- [ ] No other sections of `CONTRIBUTING.md` were touched (`git diff` is a single insertion block)
- [ ] Rule text stands alone for readers who weren't in the 2026-04-11 session

## Related

- #4090 (closed, reverted) — the incident that motivated this rule
- #4100 — revert tracking
- #4101 — correct positive-direction phase-block lint
- #4062 — related review-process context