### PR TITLE
fix(pragma): correct phase-block pragma scoping to match Perl lexical semantics (#4100)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -72,31 +72,11 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         "Mojo::Base",
     ];
 
-    // Phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) run at compile time and their
-    // pragma effects are semantically file-level, but PragmaTracker does not model them
-    // as scoped bodies.  Scan phase block bodies directly so that
-    // `BEGIN { use strict; }` still suppresses PL100.
-    if let NodeKind::Program { statements } = &node.kind {
-        for stmt in statements {
-            if let NodeKind::PhaseBlock { block, .. } = &stmt.kind {
-                walk_node(block, &mut |n| {
-                    if let NodeKind::Use { module, .. } = &n.kind {
-                        if module == "strict" {
-                            has_strict = true;
-                        } else if module == "warnings" {
-                            has_warnings = true;
-                        }
-                    }
-                });
-            }
-        }
-    }
-
     // Detect OO implicit strict modules and misspelled pragmas.
     // The strict/warnings arms are intentionally absent: state_for_offset above
     // is the authoritative source of truth. Walking the full AST for strict/warnings
-    // would bypass lexical scoping (finding eval-block or sub-scoped pragmas).
-    // Phase block bodies are handled above via the targeted PhaseBlock scan.
+    // would bypass lexical scoping (finding eval-block, sub-scoped, or phase-block
+    // pragmas that have no effect at file scope).
     walk_node(node, &mut |n| {
         if let NodeKind::Use { module, .. } = &n.kind {
             if module.starts_with('v') || module.chars().next().is_some_and(|c| c.is_ascii_digit())

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -170,39 +170,48 @@ fn lint_pipeline_moose_suppresses_pl100_pl101() {
 }
 
 // =========================================================================
-// 7. use strict inside BEGIN block suppresses missing-strict (issue #2360)
+// 7. use strict inside BEGIN block does NOT suppress missing-strict (issue #4100)
+//
+// Perl phase blocks are lexically scoped for pragmas.  A `use strict` inside
+// `BEGIN { }` applies only to the body of that block, not to the surrounding
+// file scope.  Verified against Perl 5.38.2:
+//   $ perl -e 'BEGIN { use strict; } $x = 1; print "ok: strict not active\n"'
+//   ok: strict not active
+// The LSP must match this behavior: PL100 (missing-strict) should fire.
 // =========================================================================
 
 #[test]
-fn lint_pipeline_strict_inside_begin_suppresses_pl100() {
-    // use strict declared inside BEGIN { } must still suppress the missing-strict advisory.
-    // This tests the walker.rs PhaseBlock recursion fix.
+fn lint_pipeline_strict_inside_begin_reports_missing_strict() {
+    // use strict declared inside BEGIN { } is lexically scoped to that block.
+    // The file still lacks top-level strict — PL100 must fire.
     let source = "BEGIN { use strict; }\nuse warnings;\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_strict: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
     assert!(
-        missing_strict.is_empty(),
-        "use strict inside BEGIN should suppress PL100, got {} missing-strict diags",
+        !missing_strict.is_empty(),
+        "use strict inside BEGIN must NOT suppress PL100: the file lacks top-level strict. \
+         Got {} missing-strict diags (expected at least 1)",
         missing_strict.len()
     );
 }
 
 // =========================================================================
-// 8. use warnings inside END block suppresses missing-warnings (issue #2360)
+// 8. use warnings inside END block does NOT suppress missing-warnings (issue #4100)
 // =========================================================================
 
 #[test]
-fn lint_pipeline_warnings_inside_end_suppresses_pl101() {
-    // use warnings declared inside END { } must still suppress PL101.
-    // All 5 phase keyword bodies are walked by the PhaseBlock fix.
+fn lint_pipeline_warnings_inside_end_reports_missing_warnings() {
+    // use warnings declared inside END { } is lexically scoped to that block.
+    // The file still lacks top-level warnings — PL101 must fire.
     let source = "use strict;\nEND { use warnings; }\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_warnings: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL101")).collect();
     assert!(
-        missing_warnings.is_empty(),
-        "use warnings inside END should suppress PL101, got {} missing-warnings diags",
+        !missing_warnings.is_empty(),
+        "use warnings inside END must NOT suppress PL101: the file lacks top-level warnings. \
+         Got {} missing-warnings diags (expected at least 1)",
         missing_warnings.len()
     );
 }
@@ -255,19 +264,22 @@ fn lint_pipeline_use_if_nonpragma_version_condition_still_emits_missing_pragmas(
 }
 
 // =========================================================================
-// 10. use strict inside non-BEGIN phase block (INIT) suppresses PL100 (#2360)
+// 10. use strict inside non-BEGIN phase block (INIT) does NOT suppress PL100 (#4100)
 // =========================================================================
 
 #[test]
-fn lint_pipeline_strict_inside_init_suppresses_pl100() {
-    // All phase block keywords (not just BEGIN) must be recursed into.
+fn lint_pipeline_strict_inside_init_reports_missing_strict() {
+    // All phase block keywords share the same lexical scoping rule.
+    // use strict inside INIT { } is scoped to that block; the file still needs
+    // top-level strict and PL100 must fire.
     let source = "INIT { use strict; }\nuse warnings;\nmy $x = 42;\nprint $x;\n";
     let diags = diagnostics_for(source);
     let missing_strict: Vec<_> =
         diags.iter().filter(|d| d.code.as_deref() == Some("PL100")).collect();
     assert!(
-        missing_strict.is_empty(),
-        "use strict inside INIT should suppress PL100, got {} missing-strict diags",
+        !missing_strict.is_empty(),
+        "use strict inside INIT must NOT suppress PL100: the file lacks top-level strict. \
+         Got {} missing-strict diags (expected at least 1)",
         missing_strict.len()
     );
 }

--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -456,6 +456,25 @@ impl PragmaTracker {
         ranges.push((body.location.end..body.location.end, current_state.clone()));
     }
 
+    /// Recursively walk `node` and populate `ranges` with `(offset_range, state)` entries.
+    ///
+    /// # Phase block semantics
+    ///
+    /// Phase blocks (`BEGIN`, `END`, `INIT`, `CHECK`, `UNITCHECK`) execute at different
+    /// compile/runtime phases but share **normal lexical pragma scope** — pragmas declared
+    /// inside a phase block body apply only to that body, not to the surrounding file.
+    ///
+    /// This matches Perl's actual behavior, verified against Perl 5.38.2:
+    ///
+    /// ```text
+    /// $ perl -e 'BEGIN { use strict; } $x = 1; print "ok: strict not active\n"'
+    /// ok: strict not active
+    /// ```
+    ///
+    /// The common misconception that `BEGIN { use strict; }` enables strict file-wide is
+    /// **incorrect**.  `PragmaTracker` correctly treats phase blocks as opaque — their
+    /// body is not walked, so pragmas inside cannot leak to file scope.  This is the
+    /// `_ => {}` arm at the bottom of the match, which implicitly covers `NodeKind::PhaseBlock`.
     fn build_ranges(
         node: &Node,
         current_state: &mut PragmaState,
@@ -832,7 +851,11 @@ impl PragmaTracker {
             NodeKind::Package { block: Some(pkg_block), .. } => {
                 Self::build_scoped_body(pkg_block, current_state, ranges);
             }
-            // Other node types don't contain use/no statements
+            // Other node types — including `NodeKind::PhaseBlock` — are intentionally
+            // not recursed into.  Phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) have
+            // normal lexical pragma scope: pragmas inside their body do not propagate
+            // to file scope.  Treating them as opaque here is the correct behavior.
+            // See the doc comment on `build_ranges` for Perl 5.38.2 verification.
             _ => {}
         }
     }

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -48,6 +48,17 @@ fn package_block(name: &str, body: Node, start: usize, end: usize) -> Node {
     }
 }
 
+fn phase_block(phase: &str, body: Node, start: usize, end: usize) -> Node {
+    Node {
+        kind: NodeKind::PhaseBlock {
+            phase: phase.to_string(),
+            phase_span: None,
+            block: Box::new(body),
+        },
+        location: loc(start, end),
+    }
+}
+
 fn program(stmts: Vec<Node>) -> Node {
     let end = stmts.last().map_or(0, |n| n.location.end);
     Node { kind: NodeKind::Program { statements: stmts }, location: loc(0, end) }
@@ -171,4 +182,114 @@ fn given_package_block_with_inner_no_strict_when_execution_continues_then_outer_
     let after_package = PragmaTracker::state_for_offset(&map, 50);
     assert!(after_package.strict_subs);
     assert!(after_package.warnings);
+}
+
+// ── Phase block pragma scoping (issue #4100) ──────────────────────────────────
+//
+// Perl phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) share *normal lexical
+// pragma scope*.  A pragma declared inside a phase block body applies only to
+// that body — it does NOT propagate to the surrounding file scope.  This is
+// verified against Perl 5.38.2:
+//
+//   $ perl -e 'BEGIN { use strict; } $x = 1; print "ok: strict not active\n"'
+//   ok: strict not active
+//
+// The following 6 tests encode this invariant so any regression is caught.
+
+#[test]
+fn given_begin_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    // `BEGIN { use strict; }` — strict declared inside the BEGIN block body must NOT
+    // propagate to file scope.  PragmaTracker treats PhaseBlock as opaque (no save/restore
+    // needed because it never recurses into the body), so the effective state after the
+    // phase block is unchanged from before it — the default (no strict).
+    let body = block(vec![use_node("strict", &[], 8, 20)], 6, 22);
+    let ast = program(vec![
+        phase_block("BEGIN", body, 0, 22),
+        // A statement after the block so we have an offset to query against.
+        use_node("warnings", &[], 23, 36),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    // After the block, strict must NOT be active — pragma inside phase block doesn't leak.
+    let after = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!after.strict_vars, "strict_vars must NOT propagate out of BEGIN block");
+    assert!(!after.strict_subs, "strict_subs must NOT propagate out of BEGIN block");
+    assert!(!after.strict_refs, "strict_refs must NOT propagate out of BEGIN block");
+}
+
+#[test]
+fn given_end_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    // Same invariant for `END { use strict; }`.
+    let body = block(vec![use_node("strict", &[], 6, 18)], 4, 20);
+    let ast = program(vec![phase_block("END", body, 0, 20), use_node("warnings", &[], 21, 34)]);
+    let map = PragmaTracker::build(&ast);
+
+    let after = PragmaTracker::state_for_offset(&map, 28);
+    assert!(!after.strict_vars, "strict_vars must NOT propagate out of END block");
+    assert!(!after.strict_subs, "strict_subs must NOT propagate out of END block");
+    assert!(!after.strict_refs, "strict_refs must NOT propagate out of END block");
+}
+
+#[test]
+fn given_init_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    // Same invariant for `INIT { use strict; }`.
+    let body = block(vec![use_node("strict", &[], 7, 19)], 5, 21);
+    let ast = program(vec![phase_block("INIT", body, 0, 21), use_node("warnings", &[], 22, 35)]);
+    let map = PragmaTracker::build(&ast);
+
+    let after = PragmaTracker::state_for_offset(&map, 29);
+    assert!(!after.strict_vars, "strict_vars must NOT propagate out of INIT block");
+    assert!(!after.strict_subs, "strict_subs must NOT propagate out of INIT block");
+    assert!(!after.strict_refs, "strict_refs must NOT propagate out of INIT block");
+}
+
+#[test]
+fn given_check_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    // Same invariant for `CHECK { use strict; }`.
+    let body = block(vec![use_node("strict", &[], 8, 20)], 6, 22);
+    let ast = program(vec![phase_block("CHECK", body, 0, 22), use_node("warnings", &[], 23, 36)]);
+    let map = PragmaTracker::build(&ast);
+
+    let after = PragmaTracker::state_for_offset(&map, 30);
+    assert!(!after.strict_vars, "strict_vars must NOT propagate out of CHECK block");
+    assert!(!after.strict_subs, "strict_subs must NOT propagate out of CHECK block");
+    assert!(!after.strict_refs, "strict_refs must NOT propagate out of CHECK block");
+}
+
+#[test]
+fn given_unitcheck_block_with_use_strict_when_querying_after_block_then_strict_is_not_active() {
+    // Same invariant for `UNITCHECK { use strict; }`.
+    let body = block(vec![use_node("strict", &[], 12, 24)], 10, 26);
+    let ast =
+        program(vec![phase_block("UNITCHECK", body, 0, 26), use_node("warnings", &[], 27, 40)]);
+    let map = PragmaTracker::build(&ast);
+
+    let after = PragmaTracker::state_for_offset(&map, 34);
+    assert!(!after.strict_vars, "strict_vars must NOT propagate out of UNITCHECK block");
+    assert!(!after.strict_subs, "strict_subs must NOT propagate out of UNITCHECK block");
+    assert!(!after.strict_refs, "strict_refs must NOT propagate out of UNITCHECK block");
+}
+
+#[test]
+fn given_begin_block_with_use_warnings_when_querying_after_block_then_warnings_is_not_active() {
+    // `BEGIN { use warnings; }` — warnings applies only inside BEGIN, not file-wide.
+    // PragmaTracker treats PhaseBlock as opaque so the state after the block is the
+    // same as before it entered (strict=true from the preceding `use strict;`, but
+    // warnings=false since that only appeared inside the phase block body).
+    let body = block(vec![use_node("warnings", &[], 8, 21)], 6, 23);
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        phase_block("BEGIN", body, 13, 35),
+        // Statement after block at offset 36+
+        use_node("utf8", &[], 36, 44),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    // After the block, warnings must NOT be active — it was only declared inside the
+    // phase block body and must not leak to file scope.
+    let after = PragmaTracker::state_for_offset(&map, 40);
+    // strict WAS declared at file level before the phase block, so it IS active after.
+    assert!(after.strict_vars, "strict_vars from before the BEGIN block must still be active");
+    // warnings was only inside BEGIN body — must NOT be active after.
+    assert!(!after.warnings, "warnings must NOT propagate out of BEGIN block");
 }


### PR DESCRIPTION
## Summary

The research-verifier on PR #4090 caught that our pragma tracker and diagnostics were based on a false premise: that `BEGIN { use strict; }` propagates strict to file scope. Direct Perl 5.38.2 verification proves otherwise:

```bash
$ perl -e 'BEGIN { use strict; } $x = 1; print "ok: strict not active\n"'
ok: strict not active

$ perl -e 'use strict; $x = 1; print "ok\n"'
Global symbol "$x" requires explicit package name (did you forget to declare "my $x"?) at -e line 1.
```

Phase blocks (BEGIN/END/INIT/CHECK/UNITCHECK) have **normal lexical pragma scope** — pragmas inside their body do not propagate to the surrounding file scope. This is a revert of the false-premise workaround that landed in PR #4052's rebase.

## Files Changed

### `crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs`
Removes the `NodeKind::PhaseBlock` body-scan arm (19 lines) that was added during #4052's rebase. This arm incorrectly set `has_strict = true` / `has_warnings = true` when a pragma appeared inside a phase block body, suppressing PL100/PL101 for files that lack top-level strict/warnings. The `state_for_offset(usize::MAX)` fix and removal of redundant `module == "strict"` arms from #4052 are **kept intact** — those are correct.

### `crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs`
Rewrites 3 integration tests with inverted assertions:
- `lint_pipeline_strict_inside_begin_reports_missing_strict` — asserts PL100 **fires** (was: suppressed)
- `lint_pipeline_warnings_inside_end_reports_missing_warnings` — asserts PL101 **fires** (was: suppressed)
- `lint_pipeline_strict_inside_init_reports_missing_strict` — asserts PL100 **fires** (was: suppressed)

### `crates/perl-pragma/src/lib.rs`
Adds a doc comment to `build_ranges()` documenting correct phase-block lexical scoping with Perl 5.38.2 verification. Clarifies the `_ => {}` arm to explicitly note that `NodeKind::PhaseBlock` is intentionally not walked — this is correct behavior, not an omission.

### `crates/perl-pragma/tests/behavior_spec_tests.rs`
Adds 6 new BDD tests encoding the correct invariant for all phase block keywords:
- `given_begin_block_with_use_strict_when_querying_after_block_then_strict_is_not_active`
- `given_end_block_with_use_strict_when_querying_after_block_then_strict_is_not_active`
- `given_init_block_with_use_strict_when_querying_after_block_then_strict_is_not_active`
- `given_check_block_with_use_strict_when_querying_after_block_then_strict_is_not_active`
- `given_unitcheck_block_with_use_strict_when_querying_after_block_then_strict_is_not_active`
- `given_begin_block_with_use_warnings_when_querying_after_block_then_warnings_is_not_active`

## Cascade

This is a targeted revert of a single 19-line block from #4052's rebase. #4052's other correct changes (state_for_offset fix, redundant arm removal) are preserved. PR #4090 was closed by the orchestrator before merge, so `PragmaTracker::build_ranges` has no `NodeKind::PhaseBlock` arm to revert there.

## Related

- Closes #4100
- Source of workaround: #4052 (merged) — only the PhaseBlock body scan is reverted
- Correctly-closed PR: #4090 (the PhaseBlock tracker arm — not merged)
- Research-verifier finding: https://github.com/EffortlessMetrics/perl-lsp/pull/4090#issuecomment-4229309824

## Test Plan

- [ ] `cargo test -p perl-pragma --test behavior_spec_tests` — 14 pass (6 new phase-block tests + 8 existing); 1 pre-existing failure in `given_use_feature_qw` unrelated to this PR
- [ ] `cargo test -p perl-lsp-diagnostics` — 67 pass, 0 fail
- [ ] `cargo clippy -p perl-pragma -p perl-lsp-diagnostics --lib -- -D warnings` — clean
- [ ] `cargo fmt -p perl-pragma -p perl-lsp-diagnostics` — applied