### PR TITLE
feat(status): surface parser scorecard + per-crate engineering-health metrics (#4070)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -73,6 +73,13 @@ jobs:
           key: ${{ runner.os }}-mutation-${{ hashFiles('Cargo.lock') }}
       - run: cargo install cargo-mutants --locked || true
       - run: cargo mutants --timeout 60 --no-shuffle || true
+      - name: Upload mutation results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-results-${{ github.sha }}
+          path: mutants.out/mutants.json
+          retention-days: 30
 
   benchmark:
     name: Performance Benchmarks

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -13,6 +13,20 @@
 | **Project corpus** | 100.0% clean (`91/91`) | Deterministic regression baseline; `69` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
+## Parser Scorecard
+
+| Metric | Value | Notes | Source |
+| --- | --- | --- | --- |
+<!-- BEGIN: PARSER_NODEKIND_ROW -->
+| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds | `corpus_audit` |
+<!-- END: PARSER_NODEKIND_ROW -->
+<!-- BEGIN: PARSER_RELIABILITY_ROW -->
+| **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
+<!-- END: PARSER_RELIABILITY_ROW -->
+<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
+| **Strict-clean subset** | 10/10 (receipt pending) | 10 pinned modules — run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
+<!-- END: PARSER_STRICT_CLEAN_ROW -->
+
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.
 - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -24,7 +24,7 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (receipt pending) | 10 pinned modules — run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -6,6 +6,15 @@
 ## Quality Metrics
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
-- **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing
+- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
+- **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->
+
+## Per-Crate Engineering Health
+
+<!-- BEGIN: QUALITY_CRATE_TABLE -->
+| Crate | Mutants listed | Tests (lib) |
+|-------|---------------|-------------|
+| — | no data yet | no data yet |
+<!-- END: QUALITY_CRATE_TABLE -->

--- a/xtask/src/tasks/update_status.rs
+++ b/xtask/src/tasks/update_status.rs
@@ -748,7 +748,7 @@ fn generate_parser_status(metrics: &ParserMetrics, original: &str) -> Result<Str
     let strict_clean_row = metrics.common_corpus_receipt.as_ref().map_or_else(
         || {
             format!(
-                "| **Strict-clean subset** | {pinned}/{pinned} (receipt pending) | {pinned} pinned modules — run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |"
+                "| **Strict-clean subset** | {pinned} modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |"
             )
         },
         |receipt| {
@@ -1136,6 +1136,43 @@ mod tests {
         assert!(result.contains("65/69"), "nodekind row missing 65/69");
         assert!(result.contains("94.2"), "nodekind row missing 94.2%");
         assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+        // No-receipt path: must show "unverified" not a misleading pass ratio.
+        assert!(
+            result.contains("unverified"),
+            "strict-clean no-receipt row should say 'unverified', not a false pass ratio"
+        );
+        assert!(
+            !result.contains("10/10"),
+            "strict-clean no-receipt row must not show 10/10 (implies verified pass)"
+        );
+        Ok(())
+    }
+
+    /// Parser scorecard: strict-clean row shows "unverified" when no receipt exists.
+    #[test]
+    fn test_parser_strict_clean_row_no_receipt() -> Result<()> {
+        let metrics = ParserMetrics {
+            syntax_sections: 611,
+            system_receipt: None,
+            cpan_receipt: None,
+            project_corpus: None,
+            common_corpus_receipt: None,
+            common_corpus_pinned: 10,
+        };
+        let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
+                        <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
+                        <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
+                        <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+        let result = generate_parser_status(&metrics, template)?;
+        assert!(
+            result.contains("10 modules (unverified)"),
+            "strict-clean no-receipt row must say '10 modules (unverified)'"
+        );
+        assert!(
+            result.contains("common-corpus-check"),
+            "strict-clean no-receipt row must mention the command"
+        );
         Ok(())
     }
 

--- a/xtask/src/tasks/update_status.rs
+++ b/xtask/src/tasks/update_status.rs
@@ -143,7 +143,7 @@ pub fn run(write: bool, check: bool, only: Option<StatusSubsystem>) -> Result<()
         let quality_path = root.join("docs/project/status/quality.md");
         let original_quality =
             fs::read_to_string(&quality_path).context("reading docs/project/status/quality.md")?;
-        let updated_quality = generate_quality_status(&original_quality)?;
+        let updated_quality = generate_quality_status(&root, &original_quality)?;
         if updated_quality != original_quality {
             files_to_update.push(("docs/project/status/quality.md", quality_path, updated_quality));
         }
@@ -440,16 +440,34 @@ struct ParserMetrics {
     system_receipt: Option<super::parser_corpus_sweep::SweepReport>,
     cpan_receipt: Option<super::parser_corpus_sweep::SweepReport>,
     project_corpus: Option<super::corpus_audit::StatusSummary>,
+    /// Receipt from `just common-corpus-check` — the strict-clean pinned-module gate.
+    common_corpus_receipt: Option<super::parser_corpus_sweep::SweepReport>,
+    /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
+    common_corpus_pinned: usize,
 }
 
 fn collect_parser_metrics(root: &Path) -> ParserMetrics {
+    let common_corpus_receipt =
+        read_sweep_report(&root.join("target/receipts/common-corpus-sweep.json"));
+    let common_corpus_pinned = count_common_corpus_pinned(root);
     ParserMetrics {
         syntax_sections: count_corpus_sections(root),
         system_receipt: read_sweep_report(&root.join(".ci/parser-corpus-baseline.json")),
         cpan_receipt: read_sweep_report(&root.join(".ci/cpan-corpus-baseline.json")),
         project_corpus: super::corpus_audit::compute_status_summary(root, Duration::from_secs(5))
             .ok(),
+        common_corpus_receipt,
+        common_corpus_pinned,
     }
+}
+
+/// Count the non-comment, non-blank lines in `.ci/common-corpus-manifest.txt`.
+fn count_common_corpus_pinned(root: &Path) -> usize {
+    let path = root.join(".ci/common-corpus-manifest.txt");
+    let Ok(raw) = fs::read_to_string(path) else {
+        return 0;
+    };
+    raw.lines().filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#')).count()
 }
 
 fn read_sweep_report(path: &Path) -> Option<super::parser_corpus_sweep::SweepReport> {
@@ -683,6 +701,66 @@ fn generate_parser_status(metrics: &ParserMetrics, original: &str) -> Result<Str
         },
     );
 
+    // --- New scorecard rows ---
+
+    // Node-kind coverage: promote from buried footnote to dedicated headline row.
+    let nodekind_row = metrics.project_corpus.as_ref().map_or_else(
+        || {
+            "| **Node-kind coverage** | UNVERIFIED | live repo scan unavailable | `corpus_audit` |"
+                .to_string()
+        },
+        |summary| {
+            let pct = if summary.nodekind_total == 0 {
+                0.0
+            } else {
+                100.0 * summary.nodekind_covered as f64 / summary.nodekind_total as f64
+            };
+            let never_seen = summary.nodekind_total.saturating_sub(summary.nodekind_covered);
+            format!(
+                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds | `corpus_audit` |",
+                summary.nodekind_covered, summary.nodekind_total, pct, never_seen,
+            )
+        },
+    );
+
+    // Reliability row: timeouts / panics / unreadable surfaced from existing receipts.
+    let reliability_row = {
+        let sys_unread = metrics
+            .system_receipt
+            .as_ref()
+            .map_or_else(|| "?".to_string(), |r| r.files_unreadable.to_string());
+        let cpan_unread = metrics
+            .cpan_receipt
+            .as_ref()
+            .map_or_else(|| "?".to_string(), |r| r.files_unreadable.to_string());
+        let proj_detail = metrics.project_corpus.as_ref().map_or_else(
+            || "Project: UNVERIFIED".to_string(),
+            |s| format!("Project: {} timeout, {} panic, 0 unread", s.timeout_files, s.panic_files,),
+        );
+        format!(
+            "| **Reliability** | Ubuntu: {} unread / CPAN: {} unread / {} | -- | `.ci/*-baseline.json` |",
+            sys_unread, cpan_unread, proj_detail,
+        )
+    };
+
+    // Strict-clean subset: 10 pinned modules that must parse with zero errors.
+    let pinned = metrics.common_corpus_pinned;
+    let strict_clean_row = metrics.common_corpus_receipt.as_ref().map_or_else(
+        || {
+            format!(
+                "| **Strict-clean subset** | {pinned}/{pinned} (receipt pending) | {pinned} pinned modules — run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |"
+            )
+        },
+        |receipt| {
+            let pass = receipt.clean_files;
+            let total = receipt.total_files;
+            let pct = if total == 0 { 100.0 } else { 100.0 * pass as f64 / total as f64 };
+            format!(
+                "| **Strict-clean subset** | {pass}/{total} ({pct:.0}%) | {pinned} pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |",
+            )
+        },
+    );
+
     let tracking_table = [system_row, cpan_row, project_row].join("\n");
 
     let parser_coverage_bullets = format!(
@@ -706,19 +784,165 @@ fn generate_parser_status(metrics: &ParserMetrics, original: &str) -> Result<Str
         "<!-- END: PARSER_METRICS_BULLETS -->",
         &parser_coverage_bullets,
     )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_NODEKIND_ROW -->",
+        "<!-- END: PARSER_NODEKIND_ROW -->",
+        &nodekind_row,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_RELIABILITY_ROW -->",
+        "<!-- END: PARSER_RELIABILITY_ROW -->",
+        &reliability_row,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->",
+        "<!-- END: PARSER_STRICT_CLEAN_ROW -->",
+        &strict_clean_row,
+    )?;
     Ok(text)
 }
 
-fn generate_quality_status(original: &str) -> Result<String> {
-    let bullets_content = "- **Quality Metrics**: 87% mutation score, <50ms LSP response times, 931ns incremental parsing\n\
-                           - **Production Status**: LSP server public alpha (`just ci-gate` passing)";
+// ---------------------------------------------------------------------------
+// Per-crate quality metrics helpers
+// ---------------------------------------------------------------------------
 
-    replace_block(
-        original,
+/// Read `mutants.out/mutants.json` (created by `cargo mutants` in the workspace root)
+/// and group the listed mutations by crate package name.
+///
+/// Returns an empty map (not an error) when the file is absent — this is expected
+/// before the first nightly CI run.
+fn collect_per_crate_mutation(root: &Path) -> BTreeMap<String, usize> {
+    let path = root.join("mutants.out").join("mutants.json");
+    let Ok(raw) = fs::read_to_string(&path) else {
+        return BTreeMap::new();
+    };
+    let Ok(entries) = serde_json::from_str::<Vec<serde_json::Value>>(&raw) else {
+        return BTreeMap::new();
+    };
+    let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
+    for entry in entries {
+        if let Some(pkg) = entry.get("package").and_then(|v| v.as_str()) {
+            *by_crate.entry(pkg.to_string()).or_default() += 1;
+        }
+    }
+    by_crate
+}
+
+/// Parse `cargo test --workspace --lib -- --list` output and return a map of
+/// crate-name → test count, grouped by the crate prefix before the first `::`.
+///
+/// The `--list` output lines look like `some_module::test_name: test`.  The
+/// "Running" header lines (`Running unittests …`) embed the crate binary name
+/// which we use to anchor the current crate.
+fn collect_per_crate_test_counts(root: &Path) -> BTreeMap<String, usize> {
+    let output = run_cmd(
+        root,
+        &["cargo", "test", "--workspace", "--lib", "--exclude", "tree-sitter-perl", "--", "--list"],
+        Duration::from_secs(180),
+    );
+    if output.is_empty() {
+        return BTreeMap::new();
+    }
+
+    // Pattern for "Running unittests src/lib.rs (target/debug/deps/crate_name-HASH)"
+    let running_re =
+        Regex::new(r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)")
+            .ok();
+    // Pattern for individual test lines: "path::test_name: test"
+    let test_re = Regex::new(r":\s*test\s*$").ok();
+
+    let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
+    let mut current_crate: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(caps) = running_re.as_ref().and_then(|r| r.captures(line)) {
+            // Binary names use underscores; normalize to hyphens to match Cargo.toml names.
+            let name = caps[1].replace('_', "-");
+            current_crate = Some(name);
+            continue;
+        }
+        if let Some(re) = test_re.as_ref()
+            && re.is_match(line)
+            && let Some(ref crate_name) = current_crate
+        {
+            *by_crate.entry(crate_name.clone()).or_default() += 1;
+        }
+    }
+    by_crate
+}
+
+/// Format a combined per-crate markdown table showing mutation count and test count.
+///
+/// Columns: Crate | Mutants listed | Tests (lib)
+/// When either map is empty the corresponding column shows "—".
+fn format_crate_quality_table(
+    mutation: &BTreeMap<String, usize>,
+    tests: &BTreeMap<String, usize>,
+) -> String {
+    // Union of all crate names seen in either map.
+    let mut crates: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for k in mutation.keys() {
+        crates.insert(k.as_str());
+    }
+    for k in tests.keys() {
+        crates.insert(k.as_str());
+    }
+
+    if crates.is_empty() {
+        return "| Crate | Mutants listed | Tests (lib) |\n\
+                |-------|---------------|-------------|\n\
+                | — | no data yet | no data yet |"
+            .to_string();
+    }
+
+    let mut lines = vec![
+        "| Crate | Mutants listed | Tests (lib) |".to_string(),
+        "|-------|---------------|-------------|".to_string(),
+    ];
+    for crate_name in crates {
+        let mutants = mutation.get(crate_name).map_or_else(|| "—".to_string(), |n| n.to_string());
+        let test_count = tests.get(crate_name).map_or_else(|| "—".to_string(), |n| n.to_string());
+        lines.push(format!("| {crate_name} | {mutants} | {test_count} |"));
+    }
+    lines.join("\n")
+}
+
+fn generate_quality_status(root: &Path, original: &str) -> Result<String> {
+    let mutation_by_crate = collect_per_crate_mutation(root);
+    let tests_by_crate = collect_per_crate_test_counts(root);
+
+    let has_mutation_data = !mutation_by_crate.is_empty();
+    let mutation_note = if has_mutation_data {
+        "per-crate data from `mutants.out/mutants.json` (written by nightly CI `cargo mutants` run)"
+    } else {
+        "mutation data pending first nightly CI run — run `just mutation-subset` locally to populate"
+    };
+
+    let bullets_content = format!(
+        "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
+         - **Mutation testing**: {mutation_note}\n\
+         - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
+    );
+
+    let crate_table = format_crate_quality_table(&mutation_by_crate, &tests_by_crate);
+
+    let mut text = original.to_string();
+    text = replace_block(
+        &text,
         "<!-- BEGIN: QUALITY_METRICS_BULLETS -->",
         "<!-- END: QUALITY_METRICS_BULLETS -->",
-        bullets_content,
-    )
+        &bullets_content,
+    )?;
+    text = replace_block(
+        &text,
+        "<!-- BEGIN: QUALITY_CRATE_TABLE -->",
+        "<!-- END: QUALITY_CRATE_TABLE -->",
+        &crate_table,
+    )?;
+    Ok(text)
 }
 
 // ---------------------------------------------------------------------------
@@ -857,7 +1081,154 @@ mod tests {
             quality.contains("<!-- BEGIN: QUALITY_METRICS_BULLETS -->"),
             "quality.md missing QUALITY_METRICS_BULLETS block"
         );
+        assert!(
+            quality.contains("<!-- BEGIN: QUALITY_CRATE_TABLE -->"),
+            "quality.md missing QUALITY_CRATE_TABLE block"
+        );
 
+        let parser = fs::read_to_string(status_dir.join("parser.md"))?;
+        assert!(
+            parser.contains("<!-- BEGIN: PARSER_NODEKIND_ROW -->"),
+            "parser.md missing PARSER_NODEKIND_ROW block"
+        );
+        assert!(
+            parser.contains("<!-- BEGIN: PARSER_RELIABILITY_ROW -->"),
+            "parser.md missing PARSER_RELIABILITY_ROW block"
+        );
+        assert!(
+            parser.contains("<!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->"),
+            "parser.md missing PARSER_STRICT_CLEAN_ROW block"
+        );
+
+        Ok(())
+    }
+
+    /// Parser scorecard: node-kind row renders with correct values from mock metrics.
+    #[test]
+    fn test_parser_nodekind_row_renders() -> Result<()> {
+        let summary = super::super::corpus_audit::StatusSummary {
+            total_files: 91,
+            ok_files: 91,
+            error_files: 0,
+            timeout_files: 0,
+            panic_files: 0,
+            test_corpus_files: 69,
+            perl_corpus_files: 22,
+            nodekind_covered: 65,
+            nodekind_total: 69,
+            ga_covered: 12,
+            ga_total: 12,
+        };
+        let metrics = ParserMetrics {
+            syntax_sections: 611,
+            system_receipt: None,
+            cpan_receipt: None,
+            project_corpus: Some(summary),
+            common_corpus_receipt: None,
+            common_corpus_pinned: 10,
+        };
+        let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
+                        <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
+                        <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
+                        <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+        let result = generate_parser_status(&metrics, template)?;
+        assert!(result.contains("65/69"), "nodekind row missing 65/69");
+        assert!(result.contains("94.2"), "nodekind row missing 94.2%");
+        assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+        Ok(())
+    }
+
+    /// Parser scorecard: strict-clean row shows "10/10 (100%)" when receipt is available.
+    #[test]
+    fn test_parser_strict_clean_row_with_receipt() -> Result<()> {
+        use std::collections::BTreeMap;
+        let receipt = super::super::parser_corpus_sweep::SweepReport {
+            schema_version: "1".to_string(),
+            commit: "abc".to_string(),
+            timestamp: "2026-04-11T00:00:00Z".to_string(),
+            corpus_profile: "common".to_string(),
+            corpus_roots: vec![],
+            resolved_roots_count: 0,
+            perl_version: "5.038".to_string(),
+            total_files: 10,
+            files_unreadable: 0,
+            clean_files: 10,
+            files_with_errors: 0,
+            total_error_nodes: 0,
+            first_error_buckets: BTreeMap::new(),
+            files_by_bucket: BTreeMap::new(),
+            file_results: vec![],
+            elapsed_secs: 1.0,
+        };
+        let metrics = ParserMetrics {
+            syntax_sections: 611,
+            system_receipt: None,
+            cpan_receipt: None,
+            project_corpus: None,
+            common_corpus_receipt: Some(receipt),
+            common_corpus_pinned: 10,
+        };
+        let template = "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\
+                        <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
+                        <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
+                        <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+                        <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n";
+        let result = generate_parser_status(&metrics, template)?;
+        assert!(result.contains("10/10"), "strict-clean row missing 10/10");
+        assert!(result.contains("100%"), "strict-clean row missing 100%");
+        assert!(
+            result.contains("10 pinned modules"),
+            "strict-clean row missing pinned modules note"
+        );
+        Ok(())
+    }
+
+    /// Quality scorecard: per-crate mutation table renders correctly with mock data.
+    #[test]
+    fn test_collect_per_crate_mutation_from_mock_file() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let out_dir = dir.path().join("mutants.out");
+        fs::create_dir_all(&out_dir)?;
+        let json = r#"[
+            {"package":"perl-quote","file":"crates/perl-quote/src/lib.rs","genre":"FnValue"},
+            {"package":"perl-quote","file":"crates/perl-quote/src/lib.rs","genre":"BinaryOperator"},
+            {"package":"perl-parser","file":"crates/perl-parser/src/lib.rs","genre":"FnValue"}
+        ]"#;
+        fs::write(out_dir.join("mutants.json"), json)?;
+        let result = collect_per_crate_mutation(dir.path());
+        assert_eq!(result.get("perl-quote"), Some(&2), "expected 2 mutants for perl-quote");
+        assert_eq!(result.get("perl-parser"), Some(&1), "expected 1 mutant for perl-parser");
+        Ok(())
+    }
+
+    /// Quality scorecard: table renders with both header and data rows.
+    #[test]
+    fn test_format_crate_quality_table_has_header_and_data() {
+        let mut mutation = BTreeMap::new();
+        mutation.insert("perl-quote".to_string(), 249);
+        let mut tests = BTreeMap::new();
+        tests.insert("perl-quote".to_string(), 42);
+        let table = format_crate_quality_table(&mutation, &tests);
+        assert!(table.contains("Crate"), "missing header");
+        assert!(table.contains("perl-quote"), "missing crate name");
+        assert!(table.contains("249"), "missing mutant count");
+        assert!(table.contains("42"), "missing test count");
+    }
+
+    /// Quality scorecard: table shows "no data yet" when both maps are empty.
+    #[test]
+    fn test_format_crate_quality_table_empty_maps() {
+        let table = format_crate_quality_table(&BTreeMap::new(), &BTreeMap::new());
+        assert!(table.contains("no data yet"), "expected 'no data yet' for empty maps");
+    }
+
+    /// count_common_corpus_pinned returns 10 for the live manifest.
+    #[test]
+    fn test_count_common_corpus_pinned() -> Result<()> {
+        let root = project_root()?;
+        let count = count_common_corpus_pinned(&root);
+        assert_eq!(count, 10, "expected 10 pinned modules in common-corpus-manifest.txt");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Combined atomic PR for parser scorecard (issue #4063 PR 1) and engineering health scorecard (issue #4070 PR 1). Both specs target `xtask/src/tasks/update_status.rs` so a single PR avoids file conflicts and is easier to review together.

### Parser scorecard — PR 1 of #4063

Surfaces 4 metrics that were already computed but buried or missing from the dashboard:

- **Node-kind coverage** promoted from embedded footnote in the Project corpus row to a dedicated `PARSER_NODEKIND_ROW` marker block: 65/69 (94.2%), 4 never-seen kinds
- **Reliability row** (`PARSER_RELIABILITY_ROW`): Ubuntu unreadable / CPAN unreadable / Project timeout+panic counts — all zero for project corpus
- **Strict-clean subset** (`PARSER_STRICT_CLEAN_ROW`): 10 pinned modules in `.ci/common-corpus-manifest.txt` (plan-reviewer correction: 10 not 8). Shows "receipt pending" until `just common-corpus-check` is run; shows `N/N (100%)` once receipt exists at `target/receipts/common-corpus-sweep.json`
- `ParserMetrics` struct extended with `common_corpus_receipt` and `common_corpus_pinned` fields

New section in `docs/project/status/parser.md`: **Parser Scorecard** with a 3-row table + 3 new BEGIN/END marker blocks. This is required for `just status-update --check` CI gate to pass.

### Engineering health scorecard — PR 1 of #4070

Replaces the hard-coded "87% mutation score" placeholder with live per-crate data:

- `collect_per_crate_mutation(root)`: reads `mutants.out/mutants.json`, groups by the `"package"` field in each mutant object — direct output of `cargo mutants`, no post-processing
- `collect_per_crate_test_counts(root)`: parses `cargo test --workspace --lib -- --list` output, anchors test counts to the crate binary name from `Running unittests` header lines
- `format_crate_quality_table()`: emits "no data yet" placeholder row when mutation data absent (graceful degradation before first nightly run)
- `generate_quality_status()` signature updated to accept `root: &Path` (call site at line 146 updated atomically)
- New `QUALITY_CRATE_TABLE` marker block in `quality.md` with the per-crate table

### CI nightly patch — load-bearing prerequisite for #4070

**Why this change must be in the same PR:** `cargo mutants` full runs always write `mutants.out/mutants.json` in the workspace root. Without uploading it as a CI artifact, the file disappears after the job ends and the per-crate table silently falls back to "no data yet" on every CI run. The change is 7 lines: one new `upload-artifact` step after the existing `cargo mutants` invocation. Do not split this out — the update_status code and the CI artifact upload must merge together.

## Files changed

| File | Lines | Purpose |
|------|-------|---------|
| `xtask/src/tasks/update_status.rs` | +379 -8 | Parser scorecard rows + per-crate quality helpers + tests |
| `docs/project/status/parser.md` | +14 | New Parser Scorecard section with 3 BEGIN/END marker blocks |
| `docs/project/status/quality.md` | +10 -1 | Replace hard-coded bullets + add QUALITY_CRATE_TABLE block |
| `.github/workflows/ci-nightly.yml` | +7 | Upload `mutants.out/mutants.json` as artifact after mutation job |

## Metrics surfaced

**Parser scorecard** (all from existing data, zero new instrumentation):
- `PARSER_NODEKIND_ROW`: node-kind coverage (65/69, 94.2%, 4 never-seen)
- `PARSER_RELIABILITY_ROW`: unreadable + timeout + panic counts per baseline
- `PARSER_STRICT_CLEAN_ROW`: strict-clean pinned-module gate (10 modules)

**Engineering health** (live after first nightly CI run):
- `QUALITY_CRATE_TABLE`: per-crate mutation count + test count table

## Deferred to PR 2+

- Phase timings (cold/warm/incremental), slowest-file reports — deferred to #4106
- `cargo xtask metrics` subcommand tree, hierarchical memory, release-health — deferred to #4106
- Schema upgrade for `features.toml` — separate issue

## Verification

```
cargo test -p xtask -- update_status  # 14/14 pass (6 new)
xtask update-status --check --only parser   # "All files are up to date"
xtask update-status --check --only quality  # "All files are up to date"
```

## Cross-references

Closes part of: #4063 (parser scorecard, PR 1 of 2)
Closes part of: #4070 (engineering health, PR 1 of 5)
Umbrella: #4062 (metric-stack)
Research: #4099
Ratchet model: #4105
Follow-up framework: #4106 (xtask-metrics-framework, PRs 2-5)
Sibling in review: #4107 (DAP catalog undercount)