### PR TITLE
feat(diagnostics): flag phase-scoped pragmas (#4101)

### DIFF
--- a/crates/perl-diagnostics-codes/src/lib.rs
+++ b/crates/perl-diagnostics-codes/src/lib.rs
@@ -166,11 +166,15 @@ pub enum DiagnosticCode {
     /// `goto LABEL` references a label that does not exist in this file
     GotoUndefinedLabel,
 
-    // Deprecated syntax (PL500-PL599)
+    // Pragma pitfalls / deprecated syntax (PL500-PL599)
     /// Use of deprecated defined(@array) / defined(%hash)
     DeprecatedDefined,
     /// Use of deprecated $[ array base variable
     DeprecatedArrayBase,
+    /// `use strict` appears only inside a phase block and does not affect file scope
+    PhaseScopedStrictPragma,
+    /// `use warnings` appears only inside a phase block and does not affect file scope
+    PhaseScopedWarningsPragma,
 
     // Security (PL600-PL699)
     /// String eval is a security risk
@@ -265,6 +269,8 @@ impl DiagnosticCode {
             DiagnosticCode::GotoUndefinedLabel => "PL409",
             DiagnosticCode::DeprecatedDefined => "PL500",
             DiagnosticCode::DeprecatedArrayBase => "PL501",
+            DiagnosticCode::PhaseScopedStrictPragma => "PL502",
+            DiagnosticCode::PhaseScopedWarningsPragma => "PL503",
             DiagnosticCode::SecurityStringEval => "PL600",
             DiagnosticCode::SecurityBacktickExec => "PL601",
             DiagnosticCode::SecuritySignalHandler => "PL602",
@@ -333,6 +339,8 @@ impl DiagnosticCode {
             "PL409" => "https://docs.perl-lsp.org/errors/PL409",
             "PL500" => "https://docs.perl-lsp.org/errors/PL500",
             "PL501" => "https://docs.perl-lsp.org/errors/PL501",
+            "PL502" => "https://docs.perl-lsp.org/errors/PL502",
+            "PL503" => "https://docs.perl-lsp.org/errors/PL503",
             "PL600" => "https://docs.perl-lsp.org/errors/PL600",
             "PL601" => "https://docs.perl-lsp.org/errors/PL601",
             "PL602" => "https://docs.perl-lsp.org/errors/PL602",
@@ -391,6 +399,8 @@ impl DiagnosticCode {
             | DiagnosticCode::GotoUndefinedLabel
             | DiagnosticCode::DeprecatedDefined
             | DiagnosticCode::DeprecatedArrayBase
+            | DiagnosticCode::PhaseScopedStrictPragma
+            | DiagnosticCode::PhaseScopedWarningsPragma
             | DiagnosticCode::SecurityStringEval
             | DiagnosticCode::SecurityBacktickExec
             | DiagnosticCode::SecuritySignalHandler
@@ -582,6 +592,14 @@ impl DiagnosticCode {
                 "The `$[` variable is deprecated. Array indices always start at 0 \
                 in modern Perl. Remove any assignment to `$[`.",
             ),
+            DiagnosticCode::PhaseScopedStrictPragma => Some(
+                "`use strict` inside a phase block only applies inside that block. \
+                Move `use strict;` to file scope for file-wide strict enforcement.",
+            ),
+            DiagnosticCode::PhaseScopedWarningsPragma => Some(
+                "`use warnings` inside a phase block only applies inside that block. \
+                Move `use warnings;` to file scope for file-wide warnings coverage.",
+            ),
             DiagnosticCode::SecurityStringEval => Some(
                 "String `eval` executes arbitrary code and is a security risk. \
                 Use block eval `eval { ... }` or safer alternatives.",
@@ -662,7 +680,15 @@ impl DiagnosticCode {
     /// Try to infer a diagnostic code from a message.
     pub fn from_message(msg: &str) -> Option<DiagnosticCode> {
         let msg_lower = msg.to_lowercase();
-        if msg_lower.contains("use strict") {
+        if msg_lower.contains("inside a begin block does not enable strict")
+            || msg_lower.contains("inside a phase block does not enable strict")
+        {
+            Some(DiagnosticCode::PhaseScopedStrictPragma)
+        } else if msg_lower.contains("inside a begin block does not enable warnings")
+            || msg_lower.contains("inside a phase block does not enable warnings")
+        {
+            Some(DiagnosticCode::PhaseScopedWarningsPragma)
+        } else if msg_lower.contains("use strict") {
             Some(DiagnosticCode::MissingStrict)
         } else if msg_lower.contains("use warnings") {
             Some(DiagnosticCode::MissingWarnings)
@@ -722,6 +748,8 @@ impl DiagnosticCode {
             "PL409" => Some(DiagnosticCode::GotoUndefinedLabel),
             "PL500" => Some(DiagnosticCode::DeprecatedDefined),
             "PL501" => Some(DiagnosticCode::DeprecatedArrayBase),
+            "PL502" => Some(DiagnosticCode::PhaseScopedStrictPragma),
+            "PL503" => Some(DiagnosticCode::PhaseScopedWarningsPragma),
             "PL600" => Some(DiagnosticCode::SecurityStringEval),
             "PL601" => Some(DiagnosticCode::SecurityBacktickExec),
             "PL602" => Some(DiagnosticCode::SecuritySignalHandler),
@@ -827,6 +855,10 @@ impl DiagnosticCode {
                 DiagnosticCategory::Deprecated
             }
 
+            DiagnosticCode::PhaseScopedStrictPragma | DiagnosticCode::PhaseScopedWarningsPragma => {
+                DiagnosticCategory::StrictWarnings
+            }
+
             DiagnosticCode::SecurityStringEval
             | DiagnosticCode::SecurityBacktickExec
             | DiagnosticCode::SecuritySignalHandler
@@ -870,6 +902,8 @@ mod tests {
         assert_eq!(DiagnosticCode::CriticSeverity1.as_str(), "PC001");
         assert_eq!(DiagnosticCode::SecuritySignalHandler.as_str(), "PL602");
         assert_eq!(DiagnosticCode::GotoUndefinedLabel.as_str(), "PL409");
+        assert_eq!(DiagnosticCode::PhaseScopedStrictPragma.as_str(), "PL502");
+        assert_eq!(DiagnosticCode::PhaseScopedWarningsPragma.as_str(), "PL503");
     }
 
     #[test]
@@ -878,6 +912,7 @@ mod tests {
         assert_eq!(DiagnosticCode::UnusedVariable.severity(), DiagnosticSeverity::Warning);
         assert_eq!(DiagnosticCode::EvalErrorFlow.severity(), DiagnosticSeverity::Warning);
         assert_eq!(DiagnosticCode::CriticSeverity5.severity(), DiagnosticSeverity::Hint);
+        assert_eq!(DiagnosticCode::PhaseScopedStrictPragma.severity(), DiagnosticSeverity::Warning);
     }
 
     #[test]
@@ -885,6 +920,12 @@ mod tests {
         assert_eq!(
             DiagnosticCode::from_message("Missing 'use strict' pragma"),
             Some(DiagnosticCode::MissingStrict)
+        );
+        assert_eq!(
+            DiagnosticCode::from_message(
+                "`use strict` inside a BEGIN block does not enable strict for the rest of the file"
+            ),
+            Some(DiagnosticCode::PhaseScopedStrictPragma)
         );
         assert_eq!(
             DiagnosticCode::from_message("Unused variable $foo"),
@@ -899,6 +940,10 @@ mod tests {
             DiagnosticCode::parse_code("PL602"),
             Some(DiagnosticCode::SecuritySignalHandler)
         );
+        assert_eq!(
+            DiagnosticCode::parse_code("PL503"),
+            Some(DiagnosticCode::PhaseScopedWarningsPragma)
+        );
         assert_eq!(DiagnosticCode::parse_code("INVALID"), None);
     }
 
@@ -909,6 +954,10 @@ mod tests {
         assert_eq!(DiagnosticCode::SecuritySignalHandler.category(), DiagnosticCategory::Security);
         assert_eq!(DiagnosticCode::EvalErrorFlow.category(), DiagnosticCategory::BestPractices);
         assert_eq!(DiagnosticCode::CriticSeverity1.category(), DiagnosticCategory::PerlCritic);
+        assert_eq!(
+            DiagnosticCode::PhaseScopedStrictPragma.category(),
+            DiagnosticCategory::StrictWarnings
+        );
     }
 
     #[test]

--- a/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics-codes/tests/comprehensive_unit_tests.rs
@@ -20,6 +20,8 @@ const ALL_CODES: &[DiagnosticCode] = &[
     DiagnosticCode::UnexpectedEof,
     DiagnosticCode::MissingStrict,
     DiagnosticCode::MissingWarnings,
+    DiagnosticCode::PhaseScopedStrictPragma,
+    DiagnosticCode::PhaseScopedWarningsPragma,
     DiagnosticCode::UnusedVariable,
     DiagnosticCode::UndefinedVariable,
     DiagnosticCode::CaptureVarWithoutRegexMatch,
@@ -180,6 +182,13 @@ fn code_as_str_strict_warnings_range() -> Result<(), Box<dyn std::error::Error>>
     assert_eq!(DiagnosticCode::UnusedVariable.as_str(), "PL102");
     assert_eq!(DiagnosticCode::UndefinedVariable.as_str(), "PL103");
     assert_eq!(DiagnosticCode::CaptureVarWithoutRegexMatch.as_str(), "PL112");
+    Ok(())
+}
+
+#[test]
+fn code_as_str_phase_scoped_pragma_range() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(DiagnosticCode::PhaseScopedStrictPragma.as_str(), "PL502");
+    assert_eq!(DiagnosticCode::PhaseScopedWarningsPragma.as_str(), "PL503");
     Ok(())
 }
 
@@ -454,6 +463,8 @@ fn category_strict_warnings() -> Result<(), Box<dyn std::error::Error>> {
     let sw_codes = [
         DiagnosticCode::MissingStrict,
         DiagnosticCode::MissingWarnings,
+        DiagnosticCode::PhaseScopedStrictPragma,
+        DiagnosticCode::PhaseScopedWarningsPragma,
         DiagnosticCode::UnusedVariable,
         DiagnosticCode::UndefinedVariable,
         DiagnosticCode::CaptureVarWithoutRegexMatch,
@@ -1192,7 +1203,7 @@ fn unused_variable_tag_is_exactly_unnecessary() {
 
 #[test]
 fn all_codes_count_is_24() {
-    assert_eq!(ALL_CODES.len(), 24, "expected 24 diagnostic codes total");
+    assert_eq!(ALL_CODES.len(), 26, "expected 26 diagnostic codes total");
 }
 
 // --- DiagnosticCode: parse_code boundary values ---
@@ -1201,7 +1212,7 @@ fn all_codes_count_is_24() {
 fn parse_code_all_valid_pl_codes() {
     let valid_pl = [
         "PL001", "PL002", "PL003", "PL100", "PL101", "PL102", "PL103", "PL200", "PL201", "PL300",
-        "PL301", "PL302", "PL303", "PL400", "PL401", "PL402", "PL602",
+        "PL301", "PL302", "PL303", "PL400", "PL401", "PL402", "PL602", "PL502", "PL503",
     ];
     for s in &valid_pl {
         assert!(DiagnosticCode::parse_code(s).is_some(), "expected valid parse for {}", s);
@@ -1219,11 +1230,11 @@ fn parse_code_all_valid_pc_codes() {
 #[test]
 fn parse_code_gaps_return_none() {
     // Codes that fall in valid ranges but aren't assigned.
-    // Note: PL104-PL111, PL303, PL403-PL404, PL500-PL501, PL600-PL602, PL700, PL800-PL806
+    // Note: PL104-PL111, PL303, PL403-PL404, PL500-PL503, PL600-PL602, PL700, PL800-PL806
     // are now assigned; only truly unassigned gaps are listed here.
     let gaps = [
-        "PL004", "PL050", "PL099", "PL150", "PL199", "PL202", "PL250", "PL399", "PL499", "PL502",
-        "PL599", "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
+        "PL004", "PL050", "PL099", "PL150", "PL199", "PL202", "PL250", "PL399", "PL499", "PL599",
+        "PL699", "PL702", "PL799", "PL807", "PL899", "PC006", "PC010",
     ];
     for s in &gaps {
         assert!(DiagnosticCode::parse_code(s).is_none(), "expected None for unassigned code {}", s);

--- a/crates/perl-diagnostics-codes/tests/diagnostic_code_completeness.rs
+++ b/crates/perl-diagnostics-codes/tests/diagnostic_code_completeness.rs
@@ -172,6 +172,42 @@ fn deprecated_array_base_code_exists() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
+#[test]
+fn phase_scoped_strict_pragma_code_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let code = DiagnosticCode::PhaseScopedStrictPragma;
+    assert_eq!(code.as_str(), "PL502", "PhaseScopedStrictPragma should have code PL502");
+    assert_eq!(
+        code.severity(),
+        perl_diagnostics_codes::DiagnosticSeverity::Warning,
+        "PhaseScopedStrictPragma should have Warning severity"
+    );
+    assert!(code.context_hint().is_some(), "PhaseScopedStrictPragma should have a context hint");
+    assert_eq!(
+        DiagnosticCode::parse_code("PL502"),
+        Some(DiagnosticCode::PhaseScopedStrictPragma),
+        "parse_code('PL502') should return PhaseScopedStrictPragma"
+    );
+    Ok(())
+}
+
+#[test]
+fn phase_scoped_warnings_pragma_code_exists() -> Result<(), Box<dyn std::error::Error>> {
+    let code = DiagnosticCode::PhaseScopedWarningsPragma;
+    assert_eq!(code.as_str(), "PL503", "PhaseScopedWarningsPragma should have code PL503");
+    assert_eq!(
+        code.severity(),
+        perl_diagnostics_codes::DiagnosticSeverity::Warning,
+        "PhaseScopedWarningsPragma should have Warning severity"
+    );
+    assert!(code.context_hint().is_some(), "PhaseScopedWarningsPragma should have a context hint");
+    assert_eq!(
+        DiagnosticCode::parse_code("PL503"),
+        Some(DiagnosticCode::PhaseScopedWarningsPragma),
+        "parse_code('PL503') should return PhaseScopedWarningsPragma"
+    );
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Security diagnostic codes (PL6xx range)
 // ---------------------------------------------------------------------------

--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -134,6 +134,20 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::MissingWarnings.as_str() => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
+                    // PL502: Phase-scoped use strict misconception
+                    c if c == DiagnosticCode::PhaseScopedStrictPragma.as_str() => {
+                        actions.extend(quick_fixes::move_use_strict_to_file_scope(
+                            &self.source,
+                            &qf_diag,
+                        ));
+                    }
+                    // PL503: Phase-scoped use warnings misconception
+                    c if c == DiagnosticCode::PhaseScopedWarningsPragma.as_str() => {
+                        actions.extend(quick_fixes::move_use_warnings_to_file_scope(
+                            &self.source,
+                            &qf_diag,
+                        ));
+                    }
                     // PL500: Deprecated defined()
                     c if c == DiagnosticCode::DeprecatedDefined.as_str() => {
                         actions.extend(quick_fixes::fix_deprecated_defined(&self.source, &qf_diag));
@@ -258,6 +272,17 @@ mod tests {
             tags: Vec::new(),
             suggestion: None,
         }
+    }
+
+    fn apply_action(source: &str, action: &CodeAction) -> String {
+        let mut edits = action.edit.changes.clone();
+        edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+
+        let mut output = source.to_string();
+        for edit in edits {
+            output.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+        }
+        output
     }
 
     #[test]
@@ -499,5 +524,57 @@ mod tests {
         assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
         assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
+    }
+
+    #[test]
+    fn test_phase_scoped_strict_quick_fix_moves_pragma_to_file_scope() {
+        let source = "BEGIN { use strict; }\nmy $x = 1;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("use strict;").unwrap();
+        let end = start + "use strict;".len();
+        let diagnostics = vec![make_diagnostic(
+            start,
+            end,
+            "PL502",
+            "`use strict` inside a BEGIN block does not enable strict for the rest of the file",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+        let action = actions
+            .iter()
+            .find(|action| action.title == "Move 'use strict' to file scope")
+            .expect("phase-scoped strict quick fix");
+
+        let rewritten = apply_action(source, action);
+        assert!(rewritten.starts_with("use strict;\nBEGIN { "));
+        assert!(rewritten.contains("BEGIN {  }"));
+    }
+
+    #[test]
+    fn test_phase_scoped_warnings_quick_fix_preserves_shebang() {
+        let source = "#!/usr/bin/perl\nBEGIN { use warnings; }\nprint 1;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("use warnings;").unwrap();
+        let end = start + "use warnings;".len();
+        let diagnostics = vec![make_diagnostic(
+            start,
+            end,
+            "PL503",
+            "`use warnings` inside a BEGIN block does not enable warnings for the rest of the file",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+        let action = actions
+            .iter()
+            .find(|action| action.title == "Move 'use warnings' to file scope")
+            .expect("phase-scoped warnings quick fix");
+
+        let rewritten = apply_action(source, action);
+        assert!(rewritten.starts_with("#!/usr/bin/perl\nuse warnings;\n"));
+        assert!(rewritten.contains("BEGIN {  }"));
     }
 }

--- a/crates/perl-lsp-code-actions/src/quick_fixes.rs
+++ b/crates/perl-lsp-code-actions/src/quick_fixes.rs
@@ -179,6 +179,78 @@ pub fn add_use_warnings() -> Vec<CodeAction> {
     }]
 }
 
+fn file_scope_pragma_insertion_offset(source: &str) -> usize {
+    if source.starts_with("#!") {
+        source.find('\n').map(|offset| offset + 1).unwrap_or(source.len())
+    } else {
+        0
+    }
+}
+
+/// Move a phase-scoped `use strict` pragma to file scope.
+pub fn move_use_strict_to_file_scope(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let insert_at = file_scope_pragma_insertion_offset(source);
+    let delete_end = if source.as_bytes().get(diagnostic.range.1).copied() == Some(b';') {
+        diagnostic.range.1 + 1
+    } else {
+        diagnostic.range.1
+    };
+
+    vec![CodeAction {
+        title: "Move 'use strict' to file scope".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::PhaseScopedStrictPragma.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![
+                TextEdit {
+                    location: SourceLocation { start: diagnostic.range.0, end: delete_end },
+                    new_text: String::new(),
+                },
+                TextEdit {
+                    location: SourceLocation { start: insert_at, end: insert_at },
+                    new_text: "use strict;\n".to_string(),
+                },
+            ],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Move a phase-scoped `use warnings` pragma to file scope.
+pub fn move_use_warnings_to_file_scope(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let insert_at = file_scope_pragma_insertion_offset(source);
+    let delete_end = if source.as_bytes().get(diagnostic.range.1).copied() == Some(b';') {
+        diagnostic.range.1 + 1
+    } else {
+        diagnostic.range.1
+    };
+
+    vec![CodeAction {
+        title: "Move 'use warnings' to file scope".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::PhaseScopedWarningsPragma.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![
+                TextEdit {
+                    location: SourceLocation { start: diagnostic.range.0, end: delete_end },
+                    new_text: String::new(),
+                },
+                TextEdit {
+                    location: SourceLocation { start: insert_at, end: insert_at },
+                    new_text: "use warnings;\n".to_string(),
+                },
+            ],
+        },
+        is_preferred: true,
+    }]
+}
+
 /// Fix deprecated 'defined @array' or 'defined %hash'
 pub fn fix_deprecated_defined(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
     let mut actions = Vec::new();

--- a/crates/perl-lsp-diagnostics/src/lints/mod.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/mod.rs
@@ -53,6 +53,8 @@
 //! |------|----------|-------------|
 //! | `missing-strict` | Information | `use strict` not found |
 //! | `missing-warnings` | Information | `use warnings` not found |
+//! | `PL502` | Warning | `use strict` only appears inside a phase block |
+//! | `PL503` | Warning | `use warnings` only appears inside a phase block |
 //! | `misspelled-pragma` | Warning | Pragma name appears misspelled |
 //!
 //! ## Common mistakes (`common_mistakes.rs`)

--- a/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/strict_warnings.rs
@@ -33,6 +33,16 @@ const PRAGMA_TYPOS: &[(&str, &[&str])] = &[
     ("Carp", &["Carb", "Crap"]),
 ];
 
+const PHASE_PRAGMA_SCOPES: &[&str] = &["BEGIN", "END", "INIT", "CHECK", "UNITCHECK"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PhaseScopedPragmaUse {
+    module: String,
+    phase: String,
+    use_range: (usize, usize),
+    phase_range: (usize, usize),
+}
+
 /// Check for common strict/warnings issues
 ///
 /// This function checks if 'use strict' and 'use warnings' pragmas are present
@@ -91,6 +101,8 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         }
     });
 
+    emit_phase_scoped_pragma_diagnostics(node, has_strict, has_warnings, diagnostics);
+
     // Add diagnostics if missing
     if !has_strict {
         diagnostics.push(Diagnostic {
@@ -132,6 +144,110 @@ pub fn check_strict_warnings(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
             tags: Vec::new(),
             suggestion: Some("Add 'use warnings;' at the top of the file".to_string()),
         });
+    }
+}
+
+fn emit_phase_scoped_pragma_diagnostics(
+    node: &Node,
+    has_strict: bool,
+    has_warnings: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for pragma_use in collect_phase_scoped_pragma_uses(node) {
+        match pragma_use.module.as_str() {
+            "strict" if !has_strict => diagnostics.push(phase_scoped_pragma_diagnostic(
+                &pragma_use,
+                DiagnosticCode::PhaseScopedStrictPragma,
+                "strict",
+            )),
+            "warnings" if !has_warnings => diagnostics.push(phase_scoped_pragma_diagnostic(
+                &pragma_use,
+                DiagnosticCode::PhaseScopedWarningsPragma,
+                "warnings",
+            )),
+            _ => {}
+        }
+    }
+}
+
+fn collect_phase_scoped_pragma_uses(node: &Node) -> Vec<PhaseScopedPragmaUse> {
+    let mut hits = Vec::new();
+    collect_phase_scoped_pragma_uses_inner(node, None, None, &mut hits);
+    hits
+}
+
+fn collect_phase_scoped_pragma_uses_inner(
+    node: &Node,
+    current_phase: Option<&str>,
+    current_phase_range: Option<(usize, usize)>,
+    hits: &mut Vec<PhaseScopedPragmaUse>,
+) {
+    match &node.kind {
+        NodeKind::PhaseBlock { phase, phase_span, block }
+            if PHASE_PRAGMA_SCOPES.contains(&phase.as_str()) =>
+        {
+            let phase_range = phase_span
+                .as_ref()
+                .map(|span| (span.start, span.end))
+                .unwrap_or((node.location.start, node.location.end));
+            collect_phase_scoped_pragma_uses_inner(
+                block,
+                Some(phase.as_str()),
+                Some(phase_range),
+                hits,
+            );
+        }
+        NodeKind::Use { module, .. } if matches!(module.as_str(), "strict" | "warnings") => {
+            if let (Some(phase), Some(phase_range)) = (current_phase, current_phase_range) {
+                hits.push(PhaseScopedPragmaUse {
+                    module: module.clone(),
+                    phase: phase.to_string(),
+                    use_range: (node.location.start, node.location.end),
+                    phase_range,
+                });
+            }
+        }
+        _ => {
+            for child in node.children() {
+                collect_phase_scoped_pragma_uses_inner(
+                    child,
+                    current_phase,
+                    current_phase_range,
+                    hits,
+                );
+            }
+        }
+    }
+}
+
+fn phase_scoped_pragma_diagnostic(
+    pragma_use: &PhaseScopedPragmaUse,
+    code: DiagnosticCode,
+    pragma_name: &str,
+) -> Diagnostic {
+    Diagnostic {
+        range: pragma_use.use_range,
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.as_str().to_string()),
+        message: format!(
+            "`use {pragma_name}` inside a {} block does not enable {pragma_name} for the rest of the file",
+            pragma_use.phase
+        ),
+        related_information: vec![
+            RelatedInformation {
+                location: pragma_use.phase_range,
+                message: format!(
+                    "Perl phase blocks are lexically scoped: `use {pragma_name}` only applies inside `{}` {{ ... }}.",
+                    pragma_use.phase
+                ),
+            },
+            RelatedInformation {
+                location: (0, 0),
+                message: format!("Move `use {pragma_name};` to file scope for file-wide effect."),
+            },
+        ],
+        tags: Vec::new(),
+        suggestion: Some(format!("Move `use {pragma_name};` to the top of the file")),
     }
 }
 
@@ -374,6 +490,42 @@ mod tests {
         assert!(
             diags.iter().any(|d| d.code.as_deref() == Some("PL100")),
             "sub-scoped strict must not suppress missing-strict (PL100)"
+        );
+    }
+
+    #[test]
+    fn begin_scoped_strict_emits_phase_scoped_strict_diagnostic() {
+        let diags = strict_warnings_diags("BEGIN { use strict; }\nmy $x = 1;\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL502")),
+            "BEGIN-scoped strict should emit PL502"
+        );
+    }
+
+    #[test]
+    fn begin_scoped_strict_with_top_level_strict_does_not_emit_phase_diagnostic() {
+        let diags = strict_warnings_diags("BEGIN { use strict; }\nuse strict;\nmy $x = 1;\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL502")),
+            "top-level strict should suppress PL502"
+        );
+    }
+
+    #[test]
+    fn end_scoped_warnings_emits_phase_scoped_warnings_diagnostic() {
+        let diags = strict_warnings_diags("use strict;\nEND { use warnings; }\nmy $x = 1;\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL503")),
+            "END-scoped warnings should emit PL503"
+        );
+    }
+
+    #[test]
+    fn phase_scoped_non_strict_pragma_does_not_emit_phase_diagnostic() {
+        let diags = strict_warnings_diags("BEGIN { use utf8; }\nmy $x = 1;\n");
+        assert!(
+            diags.iter().all(|d| !matches!(d.code.as_deref(), Some("PL502") | Some("PL503"))),
+            "non-strict pragmas inside phase blocks should not emit PL502/PL503"
         );
     }
 

--- a/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
+++ b/crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs
@@ -206,6 +206,32 @@ fn lint_pipeline_warnings_inside_end_emits_pl101() {
     );
 }
 
+#[test]
+fn lint_pipeline_strict_inside_begin_emits_pl502() {
+    let source = "BEGIN { use strict; }\nuse warnings;\nmy $x = 42;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+    let phase_scoped: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL502")).collect();
+    assert!(
+        !phase_scoped.is_empty(),
+        "use strict inside BEGIN should emit PL502, got codes: {:?}",
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_pipeline_warnings_inside_end_emits_pl503() {
+    let source = "use strict;\nEND { use warnings; }\nmy $x = 42;\nprint $x;\n";
+    let diags = diagnostics_for(source);
+    let phase_scoped: Vec<_> =
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL503")).collect();
+    assert!(
+        !phase_scoped.is_empty(),
+        "use warnings inside END should emit PL503, got codes: {:?}",
+        diags.iter().map(|d| d.code.as_deref().unwrap_or("none")).collect::<Vec<_>>()
+    );
+}
+
 // =========================================================================
 // 9. conditional `use if` pragmas conservatively suppress missing-pragmas
 // =========================================================================

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -428,6 +428,8 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             DiagnosticCode::ParseError
                 | DiagnosticCode::MissingStrict
                 | DiagnosticCode::MissingWarnings
+                | DiagnosticCode::PhaseScopedStrictPragma
+                | DiagnosticCode::PhaseScopedWarningsPragma
                 | DiagnosticCode::UnusedVariable
                 | DiagnosticCode::UndefinedVariable
                 | DiagnosticCode::VariableShadowing
@@ -581,6 +583,8 @@ mod tests {
 
     #[test]
     fn perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data() {
+        assert!(is_fixable_diagnostic("PL502"));
+        assert!(is_fixable_diagnostic("PL503"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -967,6 +967,8 @@ fn is_fixable_diagnostic(code: &str) -> bool {
                 DiagnosticCode::ParseError
                     | DiagnosticCode::MissingStrict
                     | DiagnosticCode::MissingWarnings
+                    | DiagnosticCode::PhaseScopedStrictPragma
+                    | DiagnosticCode::PhaseScopedWarningsPragma
                     | DiagnosticCode::UnusedVariable
                     | DiagnosticCode::UndefinedVariable
                     | DiagnosticCode::VariableShadowing

--- a/features.toml
+++ b/features.toml
@@ -226,6 +226,18 @@ tests = ["crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs"]
 description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .pm/.pl files lack warnings enforcement, recognizes framework equivalents (Moo, Moose, Modern::Perl)"
 
 [[feature]]
+id = "lsp.diagnostic.phase_scoped_pragmas"
+spec = "perl-lsp"
+area = "text_document"
+maturity = "beta"
+advertised = true
+tests = [
+  "crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs",
+  "crates/perl-lsp-code-actions/src/code_actions.rs",
+]
+description = "Phase-scoped pragma misconception diagnostics (PL502/PL503) — warns when `use strict` or `use warnings` appears only inside BEGIN/END/INIT/CHECK/UNITCHECK and offers a quick fix to move it to file scope"
+
+[[feature]]
 id = "lsp.diagnostic.unreachable_code"
 spec = "perl-lsp"
 area = "text_document"


### PR DESCRIPTION
## Summary
- add `PL502` and `PL503` for `use strict` / `use warnings` placed inside phase blocks
- surface quick fixes that move those pragmas to file scope, preserving shebangs
- cover the new diagnostics in code tables, lint tests, code action tests, and `features.toml`

## Testing
- cargo test -p perl-diagnostics-codes
- cargo test -p perl-lsp-diagnostics phase_scoped --lib
- cargo test -p perl-lsp-diagnostics begin_scoped_strict_with_top_level_strict_does_not_emit_phase_diagnostic --lib
- cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests lint_pipeline_strict_inside_begin_emits_pl502
- cargo test -p perl-lsp-diagnostics --test lint_pipeline_integration_tests lint_pipeline_warnings_inside_end_emits_pl503
- cargo test -p perl-lsp-code-actions phase_scoped --lib
- cargo test -p perl-lsp-rs perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data --lib