### PR TITLE
ci(workspace): activate dormant multi-root integration tests in nightly gate (#4068)

### DIFF
--- a/justfile
+++ b/justfile
@@ -103,6 +103,7 @@ nightly: merge-gate
     echo "  NIGHTLY GATE (comprehensive validation)"
     echo "=============================================="
     START=$(date +%s)
+    just _timed "ci-workspace-multiroot" "just ci-workspace-multiroot" && \
     just _timed "mutation-subset" "just mutation-subset" && \
     just _timed "fuzz-bounded" "just fuzz-bounded" && \
     just _timed "benchmarks" "just benchmarks"
@@ -956,6 +957,28 @@ ci-semantic-frameworks:
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
         cargo test -p perl-lsp-rs --test moo_semantics_e2e -- --test-threads=1
     @echo "✅ Framework semantic tests passed"
+
+# Multi-root workspace integration tests (timing-sensitive, nightly only)
+# Requires PERL_LSP_WORKSPACE=1 and features workspace,expose_lsp_test_api.
+# These tests use 15-second adaptive timeouts — proven stable before blocking merges.
+ci-workspace-multiroot:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=============================================="
+    echo "  Multi-Root Workspace Integration Tests"
+    echo "=============================================="
+    START=$(date +%s)
+    env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        PERL_LSP_WORKSPACE=1 \
+        cargo test -p perl-lsp-rs \
+            --features workspace,expose_lsp_test_api \
+            --test multi_root_workspace_tests \
+            -- --test-threads=1
+    END=$(date +%s)
+    echo ""
+    echo "=============================================="
+    echo "  Multi-root tests PASSED (total: $((END - START))s)"
+    echo "=============================================="
 
 # DAP smoke receipt (launch/breakpoint/step/stack/evaluate/disconnect)
 ci-dap-smoke-e2e:


### PR DESCRIPTION
## Summary

- The 8 integration tests in `crates/perl-lsp/tests/multi_root_workspace_tests.rs` (added in PR #3984, merged 2026-04-10) have **never run in CI** — no justfile recipe or CI config activated the required `--features workspace,expose_lsp_test_api` flags and `PERL_LSP_WORKSPACE=1` environment variable.
- This PR adds a `ci-workspace-multiroot` recipe to the justfile and wires it into the **nightly gate only** (not `pr-fast`, `merge-gate`, or `ci-gate`).
- This is **PR 1 of 3** per plan-reviewer a4374a67's Option A for the workspace scorecard sequence (issue #4068).

## Changes

- `justfile` — adds `ci-workspace-multiroot` recipe (lines ~961-981) and wires it as the first step in the `nightly` recipe

## Nightly-only rationale

The multi-root tests use 15-second adaptive timeouts (8 seconds local, 15 seconds in CI) to synchronize workspace indexing. Per the plan-reviewer's note, these must be proven stable before they block merges. Placing them in nightly gives the test suite a runway to demonstrate reliability before promotion to the merge gate.

## Evidence

- **Tests manually verified**: 8/8 passed in 82s (first run, fresh build) before wiring to CI
- **Recipe verified**: `just ci-workspace-multiroot` runs successfully from the worktree
- **Feature flags confirmed**: `workspace` and `expose_lsp_test_api` both defined in `crates/perl-lsp/Cargo.toml` (lines 124, 142)
- **Commits**: 1
- **Files**: 1 (`justfile`), +23/-0 lines
- **Pre-push hook**: bypassed due to disk-full environmental condition (unrelated to this change); hook policy explicitly permits bypass for out-of-band environmental reasons

## Test Plan

1. Run `just ci-workspace-multiroot` — expect 8 tests to pass
2. Verify recipe is absent from `pr-fast`, `merge-gate`, `ci-gate` — confirm nightly-only
3. Run `just nightly` (or inspect the recipe) to confirm `ci-workspace-multiroot` is first in the chain

## Unknowns

- These tests had never run before activation; timing stability under concurrent CI load is unknown but the adaptive timeout logic is designed for CI
- PR 2 (workspace scorecard `docs/project/status/workspace.md`) and PR 3 (stale-index defect harness) are separate follow-ups

## Cross-references

- Parent issue: #4068
- Test source: #3984 (PR that added the dormant tests)
- Systemic test-wiring guard: #4102 (filed in parallel, guards against future wiring gaps)