### PR TITLE
test(perlcritic): cover missing configured profile path (#4135)

### DIFF
--- a/crates/perl-lsp-config/src/lib.rs
+++ b/crates/perl-lsp-config/src/lib.rs
@@ -47,8 +47,8 @@ pub struct ServerConfig {
     ///
     /// When enabled, the server will run `perlcritic` on open documents and
     /// merge violations into the diagnostic stream. Requires `perlcritic` to
-    /// be installed on the system; missing tool/profile failures are surfaced
-    /// through workspace warning messages.
+    /// be installed on the system; missing binary/profile/runtime failures are
+    /// surfaced as workspace warnings.
     pub perlcritic_enabled: bool,
 
     /// Minimum Perl::Critic severity level to report (1-5, where 5 = most severe).

--- a/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
+++ b/crates/perl-lsp/tests/lsp_perlcritic_diagnostics_tests.rs
@@ -316,3 +316,41 @@ fn test_e_empty_profile_falls_back_to_walkup_config() {
         invocations[0].args
     );
 }
+
+#[test]
+fn test_f_missing_configured_profile_skips_subprocess_and_diagnostics() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let missing_profile = root.join("missing.perlcriticrc");
+    let module_path = root.join("NoProfile.pm");
+    std::fs::write(&module_path, "package NoProfile;\n1;\n").expect("write module");
+
+    let server = LspServer::new();
+    server.test_configure_perlcritic(true, 3, Some(missing_profile.to_string_lossy().to_string()));
+    server.test_set_root_path(root);
+
+    let runtime = Arc::new(MockSubprocessRuntime::new());
+    runtime.add_response(MockResponse::success(b"".to_vec()));
+    server.test_install_mock_critic_runtime(runtime.clone());
+    server.test_bypass_perlcritic_command_check();
+
+    let uri = url::Url::from_file_path(&module_path).expect("file url").to_string();
+    let result = pull_diagnostics(&server, &uri, "package NoProfile;\n1;\n");
+
+    let diags = result["items"].as_array().cloned().unwrap_or_default();
+    let critic_diags: Vec<_> = diags
+        .iter()
+        .filter(|diag| diag["code"].as_str().is_some_and(|code| code.contains("::")))
+        .collect();
+    assert!(
+        critic_diags.is_empty(),
+        "no perlcritic diagnostics expected when profile path is invalid; got: {result}"
+    );
+    assert_eq!(
+        runtime.invocations().len(),
+        0,
+        "subprocess should not run when configured profile path does not exist"
+    );
+}

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -392,9 +392,9 @@ Controls optional Perl::Critic static analysis integration.
 | Default | `false` |
 
 **Opt-in.** When `true`, the server runs `perlcritic` on open documents and
-merges violations into the diagnostic stream. If `perlcritic` is not installed
-or the configured profile path is invalid, perl-lsp surfaces a workspace
-warning and reports the issue through health-check output.
+merges violations into the diagnostic stream. If `perlcritic` is missing,
+profile resolution fails, or the command execution fails, the server emits a
+workspace warning instead of silently skipping.
 
 #### `perl.perlcritic.severity`
 


### PR DESCRIPTION
## Summary
- add a regression test for an explicitly configured but missing Perl::Critic profile path
- assert the Perl::Critic subprocess is skipped and no policy diagnostics are returned for that failure path
- align the Perl::Critic config wording with the current workspace-warning behavior

## Testing
- cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_f_missing_configured_profile_skips_subprocess_and_diagnostics
- cargo test -p perl-lsp-rs --features expose_lsp_test_api --test lsp_perlcritic_diagnostics_tests test_e_empty_profile_falls_back_to_walkup_config