### PR TITLE
fix(devex): detect stale installed pre-push hooks (#4122)

### DIFF
--- a/justfile
+++ b/justfile
@@ -546,8 +546,19 @@ doctor:
     # Check 5: pre-push hook installed
     # ------------------------------------------------------------------
     hook_path="$main_git_dir/hooks/pre-push"
+    expected_hook="$main_root/hooks/pre-push"
     if [ -f "$hook_path" ] && [ -x "$hook_path" ]; then
-        echo "✅ pre-push hook installed"
+        if [ -f "$expected_hook" ] && diff -q \
+            <(awk '{ sub(/\r$/, ""); lines[NR]=$0 } END { last=NR; while (last > 0 && lines[last] == "") last--; for (i = 1; i <= last; i++) print lines[i] }' "$hook_path") \
+            <(awk '{ sub(/\r$/, ""); lines[NR]=$0 } END { last=NR; while (last > 0 && lines[last] == "") last--; for (i = 1; i <= last; i++) print lines[i] }' "$expected_hook") >/dev/null; then
+            echo "✅ pre-push hook installed and current"
+        elif [ -f "$expected_hook" ]; then
+            echo "⚠️  pre-push hook installed but stale: $hook_path"
+            echo "   Fix: cargo xtask ci-hygiene install-githooks   # refresh from hooks/pre-push"
+            issues=$((issues + 1))
+        else
+            echo "✅ pre-push hook installed"
+        fi
     elif [ -f "$hook_path" ]; then
         echo "⚠️  pre-push hook present but not executable: $hook_path"
         echo "   Fix: chmod +x \"$hook_path\""


### PR DESCRIPTION
## Summary
- make `just status-check` compare the installed `.git/hooks/pre-push` hook against the canonical checked-in `hooks/pre-push`
- normalize CRLF and trailing blank-line noise so the check only flags real hook drift
- keep the remediation explicit: re-run `cargo xtask ci-hygiene install-githooks`

## Validation
- observed the old installed hook report `stale` against the canonical checked-in hook
- refreshed hooks with `cargo xtask ci-hygiene install-githooks`
- re-ran the normalized comparison and observed `current`

## Note
- `just status-check` currently fails earlier on `master` because `xtask update-status --check` rejects `features.toml` entry `maturity = "beta"`; that is a separate fast-follow regression from #4131, not part of this hook-freshness change