### PR TITLE
fix(status): restore valid feature maturity metadata (#4101)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -175,10 +175,10 @@ The LSP compliance table is auto-generated from `features.toml`.
 | debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
-| text_document | 46 | 46 | 100% |
+| text_document | 47 | 47 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **116** | **116** | **100%** |
+| **Overall** | **117** | **117** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->
 
 For live capability posture, run `just status-check` or read [CURRENT_STATUS.md](CURRENT_STATUS.md).

--- a/docs/project/status/lsp.md
+++ b/docs/project/status/lsp.md
@@ -6,14 +6,14 @@
 ## LSP Coverage
 
 <!-- BEGIN: LSP_COVERAGE -->
-| **LSP Coverage** | 100% (58/58 advertised features, `features.toml`) | 100% | PASS |
+| **LSP Coverage** | 100% (59/59 advertised features, `features.toml`) | 100% | PASS |
 <!-- END: LSP_COVERAGE -->
 
 ## Computed Metrics
 
 <!-- BEGIN: LSP_METRICS_BULLETS -->
-- **LSP Coverage**: 100% user-visible feature coverage (58/58 advertised features from `features.toml`)
-- **Protocol Compliance**: 100% overall LSP protocol support (116/116 including plumbing)
+- **LSP Coverage**: 100% user-visible feature coverage (59/59 advertised features from `features.toml`)
+- **Protocol Compliance**: 100% overall LSP protocol support (117/117 including plumbing)
 
 **Target**: maintain 100% LSP coverage (no regressions)
 <!-- END: LSP_METRICS_BULLETS -->
@@ -26,8 +26,8 @@
 | debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
-| text_document | 46 | 46 | 100% |
+| text_document | 47 | 47 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **116** | **116** | **100%** |
+| **Overall** | **117** | **117** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 2973 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 3043 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 2973 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 3043 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->

--- a/features.toml
+++ b/features.toml
@@ -229,7 +229,7 @@ description = "Missing 'use warnings' pragma diagnostic (PL101) — warns when .
 id = "lsp.diagnostic.phase_scoped_pragmas"
 spec = "perl-lsp"
 area = "text_document"
-maturity = "beta"
+maturity = "ga"
 advertised = true
 tests = [
   "crates/perl-lsp-diagnostics/tests/lint_pipeline_integration_tests.rs",


### PR DESCRIPTION
## Summary
- restore a valid `features.toml` maturity value for the phase-scoped pragma diagnostic capability
- regenerate the status docs so `xtask update-status --check` is green again
- keep the follow-up narrowly scoped to the regression introduced by #4131

## Validation
- cargo xtask update-status --check