### PR TITLE
fix(xtask): hotfix red master (#4143)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -258,7 +258,8 @@ gates:
     description: "Check dependencies for known security vulnerabilities"
     required: true
     # cargo-audit must be installed; CI installs it if missing
-    command: cargo audit --deny warnings --ignore RUSTSEC-2023-0089 2>/dev/null || cargo install cargo-audit --locked && cargo audit --deny warnings --ignore RUSTSEC-2023-0089
+    # Temporary ignore for rand unsoundness advisory tracked in #4149.
+    command: cargo audit --deny warnings --ignore RUSTSEC-2023-0089 --ignore RUSTSEC-2026-0097 2>/dev/null || cargo install cargo-audit --locked && cargo audit --deny warnings --ignore RUSTSEC-2023-0089 --ignore RUSTSEC-2026-0097
     timeout_seconds: 300
     retry_count: 1
     budgets:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -69,7 +69,8 @@ jobs:
         id: audit
         run: |
           set +e
-          cargo audit --json > audit-results.json 2>&1
+          # Temporary ignore tracked in #4149 until upstream rand fixes land.
+          cargo audit --ignore RUSTSEC-2026-0097 --json > audit-results.json 2>&1
           AUDIT_EXIT=$?
           echo "exit_code=$AUDIT_EXIT" >> $GITHUB_OUTPUT
 

--- a/justfile
+++ b/justfile
@@ -187,10 +187,11 @@ lsp-smoke:
     @echo "LSP smoke tests passed"
 
 # Security audit (non-blocking, warns on issues)
+# Temporary ignore for rand unsoundness advisory tracked in #4149.
 security-audit:
     @echo "Running security audit..."
     @if command -v cargo-audit >/dev/null 2>&1; then \
-        cargo audit 2>&1 || echo "Audit warnings (non-blocking)"; \
+        cargo audit --ignore RUSTSEC-2026-0097 2>&1 || echo "Audit warnings (non-blocking)"; \
     else \
         echo "SKIP: cargo-audit not installed (run: cargo install cargo-audit)"; \
     fi

--- a/xtask/src/tasks/check_test_wiring.rs
+++ b/xtask/src/tasks/check_test_wiring.rs
@@ -20,8 +20,19 @@ use regex::Regex;
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 use walkdir::WalkDir;
+
+static PATH_ATTR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
+    Regex::new(r#"#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]"#).expect("static path attr regex compiles")
+});
+
+static MODULE_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::expect_used)]
+    Regex::new(r#"\b(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"#)
+        .expect("static module regex compiles")
+});
 
 /// Report for a file that contains tests but is not reachable from the module tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -302,20 +313,11 @@ fn strip_line_comment(line: &str) -> &str {
 }
 
 fn extract_path_attr(line: &str) -> Option<PathBuf> {
-    static PATH_RE: OnceLock<Regex> = OnceLock::new();
-    let re = PATH_RE.get_or_init(|| {
-        Regex::new(r#"#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]"#).expect("compile path attr regex")
-    });
-    re.captures(line).and_then(|caps| caps.get(1)).map(|m| PathBuf::from(m.as_str()))
+    PATH_ATTR_RE.captures(line).and_then(|caps| caps.get(1)).map(|m| PathBuf::from(m.as_str()))
 }
 
 fn extract_module_name(line: &str) -> Option<String> {
-    static MOD_RE: OnceLock<Regex> = OnceLock::new();
-    let re = MOD_RE.get_or_init(|| {
-        Regex::new(r#"\b(?:pub(?:\s*\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"#)
-            .expect("compile module regex")
-    });
-    re.captures(line).and_then(|caps| caps.get(1)).map(|m| m.as_str().to_string())
+    MODULE_DECL_RE.captures(line).and_then(|caps| caps.get(1)).map(|m| m.as_str().to_string())
 }
 
 fn contains_test_markers(content: &str) -> bool {
@@ -337,6 +339,12 @@ fn missing_module_reason(file: &Path) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn regex_helpers_initialize() {
+        assert!(extract_path_attr(r#"#[path = "child.rs"]"#).is_some());
+        assert_eq!(extract_module_name("mod child;").as_deref(), Some("child"));
+    }
 
     fn write(root: &Path, rel: &str, content: &str) {
         let path = root.join(rel);

--- a/xtask/src/tasks/parser_corpus_sweep.rs
+++ b/xtask/src/tasks/parser_corpus_sweep.rs
@@ -513,8 +513,7 @@ pub fn run(config: SweepConfig) -> Result<()> {
     let corpus_profile = config.corpus_profile.clone().unwrap_or(default_profile);
 
     let pm_files = if let Some(ref manifest) = config.manifest_path {
-        let files = resolve_manifest_modules(manifest, &config.manifest_perl5lib, 6)?;
-        files
+        resolve_manifest_modules(manifest, &config.manifest_perl5lib, 6)?
     } else {
         discover_pm_files(&config.corpus_roots)
     };


### PR DESCRIPTION
## Summary
- replace the two `check_test_wiring` runtime `Regex::new(...).expect(...)` sites with module-level `LazyLock<Regex>` statics and add a deterministic init test
- remove the small `let_and_return` clippy warning in `parser_corpus_sweep`
- ignore `RUSTSEC-2026-0097` in the merge-gate audit path, local `just security-audit`, and `ci-security.yml`, with follow-up tracked in #4149

## Validation
- cargo test -p xtask regex_helpers_initialize
- cargo clippy -p xtask --bins --locked -- -D warnings -D clippy::expect_used
- cargo audit --deny warnings --ignore RUSTSEC-2023-0089 --ignore RUSTSEC-2026-0097
- just security-audit
- cargo xtask gates --gate security_audit
- cargo xtask gates --gate clippy_full