### PR TITLE
feat(xtask): wire check-test-wiring CLI command and fix integration_example orphan (#4102)

### DIFF
--- a/crates/perl-lsp/tests/fixtures/mod.rs
+++ b/crates/perl-lsp/tests/fixtures/mod.rs
@@ -12,6 +12,10 @@
 //! - Thread-safe fixture loading with adaptive threading support
 //! - Unicode-safe test data with UTF-8/UTF-16 boundary validation
 
+// Example integration tests — wired by check-test-wiring guard (#4102).
+#[cfg(test)]
+mod integration_example;
+
 // Module declarations for fixture categories
 pub mod parser {
     pub mod comprehensive_syntax_fixtures;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 mod tasks;
 mod types;
 mod utils;
+use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
 use tasks::gates::{GateTier, OutputFormat};
 use tasks::targeted_checks::CheckMode;


### PR DESCRIPTION
## Summary

- Complete the wiring of `cargo xtask check-test-wiring` CLI command: PR #4119 added `check_test_wiring.rs` and `pub mod check_test_wiring;` but forgot to add the `use tasks::check_test_wiring;` import in `main.rs`. The command was returning "unrecognized subcommand" on master.
- Fix one genuine orphan discovered by the guard: `crates/perl-lsp/tests/fixtures/integration_example.rs` had `#[cfg(test)]` but no `mod integration_example;` declaration in `tests/fixtures/mod.rs`.

## Changes

- `xtask/src/main.rs` — add `use tasks::check_test_wiring;` import so the dispatch table (`Commands::CheckTestWiring => check_test_wiring::run()`) can resolve the module path
- `crates/perl-lsp/tests/fixtures/mod.rs` — add `#[cfg(test)] mod integration_example;` to wire the discovered orphan

## Evidence

- **Tests**: `cargo xtask check-test-wiring` compiles and runs on this branch
- **Lint**: `cargo clippy -p xtask` — 0 errors, 0 new warnings (1 pre-existing warning in `parser_corpus_sweep.rs`)
- **Files**: 2 changed, 5 insertions
- **Guard output**: scans 134 crates, 1560 files; reports 35 pre-existing orphans (down from 36 before the `integration_example` fix)

## Test Plan

1. Checkout this branch
2. Run `cargo xtask check-test-wiring` — should compile and print `[INFO] Test wiring audit` with the list of 35 pre-existing orphaned files
3. Verify `cargo xtask --help | grep test-wiring` shows the command (it was previously missing)

## Unknowns / Deferred

- **ci-gate wiring is intentionally deferred.** The guard currently finds 35 pre-existing orphaned files (mostly generated corpus files in `perl-corpus/src/gen/` and ide compat stubs in `perl-parser/src/ide/lsp_compat/`). Wiring the failing guard into `ci-gate` now would break the gate for all concurrent PRs. A follow-up should track clearing the 35-orphan backlog, then add `just ci-check-test-wiring` to `ci-gate`.
- The 35 orphans include `variables.rs` in `perl-parser-core` (uses `include!()` — our implementation handled this correctly; master's implementation uses a different algorithm that misses it), and 4 completion files that use the Rust 2018 `dir.rs` pattern.

## Related

- Closes follow-on from #4102 (original issue closed by #4119)
- PR #4119 — the base implementation that added `check_test_wiring.rs`