### PR TITLE
test(dap): add deeply-nested structure truncation tests (#3487)

### DIFF
--- a/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
+++ b/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
@@ -154,6 +154,21 @@ fn test_render_cyclic_reference_safe() {
     assert_eq!(rendered.type_name, Some("HASH".to_string()));
     assert_eq!(rendered.named_variables, Some(1));
     assert!(rendered.value.len() < 500);
+
+    // Expanding children of the hash must also be safe
+    let children = renderer.render_children(&value, 0, 10);
+    assert_eq!(children.len(), 1, "hash has 1 child key");
+    assert_eq!(children[0].name, "self");
+    assert!(!children[0].value.is_empty(), "ref child should render a non-empty value");
+
+    // Expanding the Reference inner value (the Truncated sentinel) must not panic
+    let ref_value = PerlValue::Reference(Box::new(PerlValue::Truncated {
+        summary: "HASH(0x7f1234567890)".to_string(),
+        total_count: None,
+    }));
+    let ref_children = renderer.render_children(&ref_value, 0, 10);
+    assert_eq!(ref_children.len(), 1, "Reference expands to its single inner value");
+    assert!(!ref_children[0].value.is_empty(), "Truncated sentinel renders non-empty");
 }
 
 #[test]
@@ -243,6 +258,13 @@ fn test_large_array_child_access() {
     let children_end = renderer.render_children(&value, 990, 100);
     assert_eq!(children_end.len(), 10, "only 10 items from 990 to 1000");
     assert_eq!(children_end[9].name, "[999]");
+
+    // Past-end start: DAP may request a page beyond the array bounds — must return empty, not panic
+    let past_end = renderer.render_children(&value, 1000, 10);
+    assert_eq!(past_end.len(), 0, "start == len should return empty");
+
+    let way_past = renderer.render_children(&value, 9999, 10);
+    assert_eq!(way_past.len(), 0, "start far past len should return empty");
 }
 
 #[test]

--- a/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
+++ b/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
@@ -1,0 +1,358 @@
+//! Integration tests for DAP variable truncation with deeply nested structures.
+//! Tests #3487: deeply nested data structures, large arrays, cyclic references.
+//!
+//! This test suite validates that:
+//! 1. DAP renders 7+ level nested hashes/arrays without exponential output
+//! 2. 200+ element arrays/hashes paginate correctly
+//! 3. Cyclic references are marked as truncated safely
+//! 4. All variables remain clickable/expandable even when truncated
+
+use perl_dap_variables::{PerlValue, PerlVariableRenderer, VariableParser, VariableRenderer};
+
+#[test]
+fn test_render_7level_nested_hash_structure() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Build a 7-level nested hash: config { level1 { level2 { ... } } }
+    let mut value = PerlValue::Hash(vec![("level7".to_string(), PerlValue::Integer(7))]);
+    for level in (1..=6).rev() {
+        value = PerlValue::Hash(vec![(format!("level{}", level), value)]);
+    }
+
+    let rendered = renderer.render("$config", &value);
+
+    // Should not panic or produce exponential output
+    assert!(rendered.value.len() < 1000, "7-level nested value should be bounded");
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert_eq!(rendered.named_variables, Some(1));
+
+    // Should be expandable
+    assert!(
+        rendered.variables_reference == 0,
+        "render() doesn't set reference, need render_with_reference"
+    );
+}
+
+#[test]
+fn test_render_7level_nested_hash_expandable() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Build a 7-level nested hash
+    let mut value = PerlValue::Hash(vec![("level7".to_string(), PerlValue::Integer(7))]);
+    for level in (1..=6).rev() {
+        value = PerlValue::Hash(vec![(format!("level{}", level), value)]);
+    }
+
+    // Render with reference for expansion
+    let rendered = renderer.render_with_reference("$config", &value, 1);
+
+    assert_eq!(rendered.variables_reference, 1);
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert!(rendered.value.len() < 1000);
+}
+
+#[test]
+fn test_render_500element_array_with_preview_truncation() {
+    let renderer = PerlVariableRenderer::new();
+
+    let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+    let value = PerlValue::Array(elements);
+
+    let rendered = renderer.render("@big", &value);
+
+    assert_eq!(rendered.type_name, Some("ARRAY".to_string()));
+    assert_eq!(rendered.indexed_variables, Some(500));
+
+    // Preview should be truncated to max_array_preview (3) + "... (500 total)"
+    assert!(rendered.value.contains("..."), "should have truncation marker");
+    assert!(rendered.value.contains("500 total"), "should show total count");
+    assert!(rendered.value.len() < 500, "preview should be bounded");
+}
+
+#[test]
+fn test_render_500element_array_pagination() {
+    let renderer = PerlVariableRenderer::new();
+
+    let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+    let value = PerlValue::Array(elements);
+
+    // Request first page
+    let page1 = renderer.render_children(&value, 0, 50);
+    assert_eq!(page1.len(), 50);
+    assert_eq!(page1[0].name, "[0]");
+    assert_eq!(page1[49].name, "[49]");
+
+    // Request middle page
+    let page_mid = renderer.render_children(&value, 250, 50);
+    assert_eq!(page_mid.len(), 50);
+    assert_eq!(page_mid[0].name, "[250]");
+
+    // Request final page
+    let page_end = renderer.render_children(&value, 450, 100);
+    assert_eq!(page_end.len(), 50, "only 50 items left [450..500]");
+    assert_eq!(page_end[0].name, "[450]");
+}
+
+#[test]
+fn test_render_500key_hash_with_preview_truncation() {
+    let renderer = PerlVariableRenderer::new();
+
+    let pairs: Vec<(String, PerlValue)> =
+        (0..500).map(|i| (format!("key_{:03}", i), PerlValue::Integer(i))).collect();
+    let value = PerlValue::Hash(pairs);
+
+    let rendered = renderer.render("%big", &value);
+
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert_eq!(rendered.named_variables, Some(500));
+
+    // Preview should be truncated
+    assert!(rendered.value.contains("..."), "should have truncation marker");
+    assert!(rendered.value.contains("500 keys"), "should show key count");
+    assert!(rendered.value.len() < 500, "preview should be bounded");
+}
+
+#[test]
+fn test_render_500key_hash_pagination() {
+    let renderer = PerlVariableRenderer::new();
+
+    let pairs: Vec<(String, PerlValue)> =
+        (0..500).map(|i| (format!("key_{:03}", i), PerlValue::Integer(i))).collect();
+    let value = PerlValue::Hash(pairs);
+
+    // Request first page
+    let page1 = renderer.render_children(&value, 0, 50);
+    assert_eq!(page1.len(), 50);
+    assert_eq!(page1[0].name, "key_000");
+
+    // Request middle page
+    let page_mid = renderer.render_children(&value, 250, 50);
+    assert_eq!(page_mid.len(), 50);
+    assert_eq!(page_mid[0].name, "key_250");
+
+    // Request final page
+    let page_end = renderer.render_children(&value, 450, 100);
+    assert_eq!(page_end.len(), 50);
+    assert_eq!(page_end[0].name, "key_450");
+}
+
+#[test]
+fn test_render_cyclic_reference_safe() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Simulate a self-referential hash
+    let truncated_marker =
+        PerlValue::Truncated { summary: "HASH(0x7f1234567890)".to_string(), total_count: None };
+    let value = PerlValue::Hash(vec![(
+        "self".to_string(),
+        PerlValue::Reference(Box::new(truncated_marker)),
+    )]);
+
+    let rendered = renderer.render("$c", &value);
+
+    // Should not panic
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert_eq!(rendered.named_variables, Some(1));
+    assert!(rendered.value.len() < 500);
+}
+
+#[test]
+fn test_render_deep_reference_chain_bounded() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Build 150-level deep reference chain
+    let mut value = PerlValue::Integer(42);
+    for _ in 0..150 {
+        value = PerlValue::Reference(Box::new(value));
+    }
+
+    let rendered = renderer.render("$deep", &value);
+
+    // Should be bounded, not exponential
+    assert!(rendered.value.len() < 200, "deep reference chain should be truncated");
+    assert_eq!(rendered.type_name, Some("REF".to_string()));
+
+    // Should contain truncation marker
+    assert!(rendered.value.contains("REF(...)"), "should truncate with REF(...) marker");
+}
+
+#[test]
+fn test_parser_max_depth_safety() {
+    let parser = VariableParser::new().with_max_depth(3);
+
+    // Try to parse 7-level nested hash
+    let text = "$x = { a => { b => { c => { d => 1 } } } }";
+    let result = parser.parse_assignment(text);
+
+    // Should fail gracefully due to max_depth
+    assert!(result.is_err(), "parser should reject depth > 3");
+}
+
+#[test]
+fn test_parser_default_max_depth_succeeds_7levels() {
+    let parser = VariableParser::new(); // default max_depth=50
+
+    // Try to parse 7-level nested hash
+    let text = "$x = { a => { b => { c => { d => { e => { f => { g => 1 } } } } } } }";
+    let result = parser.parse_assignment(text);
+
+    // Should succeed with default max_depth
+    assert!(result.is_ok(), "parser with default max_depth=50 should accept 7 levels");
+}
+
+#[test]
+fn test_mixed_nested_array_hash_rendering() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Create: { pools => [ { host => "localhost", port => 5432 } ] }
+    let db_hash = PerlValue::Hash(vec![
+        ("host".to_string(), PerlValue::Scalar("localhost".to_string())),
+        ("port".to_string(), PerlValue::Integer(5432)),
+    ]);
+
+    let pools_array = PerlValue::Array(vec![db_hash]);
+
+    let value = PerlValue::Hash(vec![("pools".to_string(), pools_array)]);
+
+    let rendered = renderer.render("$config", &value);
+
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert!(rendered.value.len() < 500);
+    assert!(rendered.named_variables.is_some());
+}
+
+#[test]
+fn test_large_array_child_access() {
+    let renderer = PerlVariableRenderer::new();
+
+    // Create a 1000-element array
+    let elements: Vec<PerlValue> = (0..1000).map(PerlValue::Integer).collect();
+    let value = PerlValue::Array(elements);
+
+    // Access specific indices
+    let children_100 = renderer.render_children(&value, 100, 10);
+    assert_eq!(children_100.len(), 10);
+    assert_eq!(children_100[0].name, "[100]");
+    assert_eq!(children_100[0].value, "100");
+    assert_eq!(children_100[9].value, "109");
+
+    let children_500 = renderer.render_children(&value, 500, 10);
+    assert_eq!(children_500[0].name, "[500]");
+    assert_eq!(children_500[0].value, "500");
+
+    let children_end = renderer.render_children(&value, 990, 100);
+    assert_eq!(children_end.len(), 10, "only 10 items from 990 to 1000");
+    assert_eq!(children_end[9].name, "[999]");
+}
+
+#[test]
+fn test_string_truncation_in_large_structures() {
+    let renderer = PerlVariableRenderer::new().with_max_string_length(50);
+
+    let long_string = "a".repeat(200);
+    let value = PerlValue::Scalar(long_string);
+
+    let rendered = renderer.render("$s", &value);
+
+    // Should truncate at 50 characters + "..."
+    assert!(rendered.value.contains("..."), "should have truncation marker");
+    assert!(rendered.value.len() < 100, "should be bounded");
+}
+
+#[test]
+fn test_nested_hash_in_array_in_hash() {
+    let renderer = PerlVariableRenderer::new();
+
+    // { data => [ { id => 1, name => "Alice" }, { id => 2, name => "Bob" } ] }
+    let person1 = PerlValue::Hash(vec![
+        ("id".to_string(), PerlValue::Integer(1)),
+        ("name".to_string(), PerlValue::Scalar("Alice".to_string())),
+    ]);
+
+    let person2 = PerlValue::Hash(vec![
+        ("id".to_string(), PerlValue::Integer(2)),
+        ("name".to_string(), PerlValue::Scalar("Bob".to_string())),
+    ]);
+
+    let people_array = PerlValue::Array(vec![person1, person2]);
+
+    let value = PerlValue::Hash(vec![("data".to_string(), people_array)]);
+
+    let rendered = renderer.render("$db", &value);
+
+    assert_eq!(rendered.type_name, Some("HASH".to_string()));
+    assert_eq!(rendered.named_variables, Some(1));
+    assert!(rendered.value.len() < 500);
+}
+
+#[test]
+fn test_object_with_deep_hash_backing() {
+    let renderer = PerlVariableRenderer::new();
+
+    // A blessed object backed by a deep hash structure
+    let inner = PerlValue::Hash(vec![
+        (
+            "config".to_string(),
+            PerlValue::Hash(vec![
+                ("host".to_string(), PerlValue::Scalar("localhost".to_string())),
+                ("port".to_string(), PerlValue::Integer(5432)),
+            ]),
+        ),
+        ("state".to_string(), PerlValue::Scalar("connected".to_string())),
+    ]);
+
+    let value =
+        PerlValue::Object { class: "Database::Connection".to_string(), value: Box::new(inner) };
+
+    let rendered = renderer.render("$db", &value);
+
+    assert_eq!(rendered.type_name, Some("Database::Connection".to_string()));
+    assert!(rendered.value.len() < 500);
+    assert!(rendered.named_variables.is_some());
+}
+
+#[test]
+fn test_reference_to_large_array() {
+    let renderer = PerlVariableRenderer::new();
+
+    let elements: Vec<PerlValue> = (0..200).map(PerlValue::Integer).collect();
+    let array = PerlValue::Array(elements);
+    let value = PerlValue::Reference(Box::new(array));
+
+    let rendered = renderer.render("$aref", &value);
+
+    // Should show as REF with expandable children
+    assert_eq!(rendered.type_name, Some("REF".to_string()));
+    // The reference renders the dereferenced array, which shows as "[...]"
+    assert!(
+        rendered.value.contains("[") && rendered.value.contains("]"),
+        "ref to array should show array notation, got: {}",
+        rendered.value
+    );
+}
+
+#[test]
+fn test_empty_arrays_and_hashes_dont_truncate() {
+    let renderer = PerlVariableRenderer::new();
+
+    let empty_array = PerlValue::Array(vec![]);
+    let rendered_arr = renderer.render("@empty", &empty_array);
+    assert_eq!(rendered_arr.value, "[]");
+
+    let empty_hash = PerlValue::Hash(vec![]);
+    let rendered_hash = renderer.render("%empty", &empty_hash);
+    assert_eq!(rendered_hash.value, "{}");
+}
+
+#[test]
+fn test_undef_values_safe() {
+    let renderer = PerlVariableRenderer::new();
+
+    let value = PerlValue::Undef;
+    let rendered = renderer.render("$u", &value);
+
+    // Undef renders as "undef" string
+    assert_eq!(rendered.value, "undef");
+    // Type should reflect it's undefined, not SCALAR
+    assert!(rendered.type_name.is_some(), "undef should have a type");
+}

--- a/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
+++ b/crates/perl-dap-variables/tests/dap_deep_structure_truncation.rs
@@ -354,5 +354,9 @@ fn test_undef_values_safe() {
     // Undef renders as "undef" string
     assert_eq!(rendered.value, "undef");
     // Type should reflect it's undefined, not SCALAR
-    assert!(rendered.type_name.is_some(), "undef should have a type");
+    assert_eq!(
+        rendered.type_name,
+        Some("undef".to_string()),
+        "undef type_name should be 'undef', not 'SCALAR'"
+    );
 }

--- a/crates/perl-dap-variables/tests/deep_truncation.rs
+++ b/crates/perl-dap-variables/tests/deep_truncation.rs
@@ -1,0 +1,152 @@
+// Minimal test to reproduce deep nesting, large arrays, and cyclic reference behavior
+// Run with: cargo test --test test_deep_truncation -- --nocapture
+
+#[cfg(test)]
+mod deep_truncation_tests {
+    use perl_dap_variables::{PerlValue, PerlVariableRenderer, VariableParser, VariableRenderer};
+
+    #[test]
+    fn test_7level_nested_hash_rendering() {
+        let renderer = PerlVariableRenderer::new();
+
+        // Build a 7-level nested hash
+        let mut value = PerlValue::Hash(vec![("g".to_string(), PerlValue::Integer(1))]);
+        for level in ['f', 'e', 'd', 'c', 'b', 'a'].iter() {
+            value = PerlValue::Hash(vec![(level.to_string(), value)]);
+        }
+
+        let rendered = renderer.render("$config", &value);
+        println!("7-level nested hash:");
+        println!("  value: {}", rendered.value);
+        println!("  type_name: {:?}", rendered.type_name);
+        println!("  named_variables: {:?}", rendered.named_variables);
+
+        // Should not panic or produce exponential output
+        assert!(rendered.value.len() < 1000, "value should be bounded");
+        assert_eq!(rendered.type_name, Some("HASH".to_string()));
+        assert_eq!(rendered.named_variables, Some(1));
+    }
+
+    #[test]
+    fn test_500element_array_rendering() {
+        let renderer = PerlVariableRenderer::new();
+
+        let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+        let value = PerlValue::Array(elements);
+
+        let rendered = renderer.render("@big", &value);
+        println!("500-element array:");
+        println!("  value: {}", rendered.value);
+        println!("  type_name: {:?}", rendered.type_name);
+        println!("  indexed_variables: {:?}", rendered.indexed_variables);
+
+        // Should show truncation marker
+        assert!(rendered.value.contains("..."), "should have truncation marker");
+        assert!(rendered.value.contains("500 total"), "should show total count");
+        assert!(rendered.indexed_variables.is_some());
+        assert!(rendered.value.len() < 500, "preview should be bounded");
+    }
+
+    #[test]
+    fn test_500element_array_pagination() {
+        let renderer = PerlVariableRenderer::new();
+
+        let elements: Vec<PerlValue> = (0..500).map(PerlValue::Integer).collect();
+        let value = PerlValue::Array(elements);
+
+        // Request children at various positions
+        let start = renderer.render_children(&value, 0, 50);
+        assert_eq!(start.len(), 50);
+        assert_eq!(start[0].name, "[0]");
+
+        let mid = renderer.render_children(&value, 250, 50);
+        assert_eq!(mid.len(), 50);
+        assert_eq!(mid[0].name, "[250]");
+
+        let end = renderer.render_children(&value, 450, 100);
+        assert_eq!(end.len(), 50, "only 50 items left at [450..500]");
+        assert_eq!(end[0].name, "[450]");
+
+        println!("500-element array pagination: OK");
+    }
+
+    #[test]
+    fn test_cyclic_reference_rendering() {
+        let renderer = PerlVariableRenderer::new();
+
+        // Simulate a self-referential hash: my %c; $c{self} = \%c;
+        // In reality, PerlValue uses Box (no Rc), so true cycles can't exist.
+        // The debugger would emit a Truncated marker instead.
+        let truncated_marker =
+            PerlValue::Truncated { summary: "HASH(0x7f1234567890)".to_string(), total_count: None };
+        let value = PerlValue::Hash(vec![(
+            "self".to_string(),
+            PerlValue::Reference(Box::new(truncated_marker)),
+        )]);
+
+        let rendered = renderer.render("$c", &value);
+        println!("Cyclic reference hash:");
+        println!("  value: {}", rendered.value);
+        println!("  type_name: {:?}", rendered.type_name);
+
+        // Should not panic
+        assert_eq!(rendered.type_name, Some("HASH".to_string()));
+        assert_eq!(rendered.named_variables, Some(1));
+        assert!(rendered.value.len() < 500);
+    }
+
+    #[test]
+    fn test_parser_max_depth_parsing() {
+        let parser = VariableParser::new();
+
+        // Try to parse a 7-level nested literal
+        let text = "$x = { a => { b => { c => { d => { e => { f => { g => 1 } } } } } } }";
+        let result = parser.parse_assignment(text);
+
+        // Should parse successfully with default max_depth=50
+        assert!(result.is_ok(), "parser should accept 7-level nested hash: {:?}", result.err());
+        if let Ok((name, value)) = result {
+            println!("Parsed 7-level nested hash:");
+            println!("  name: {}", name);
+            println!("  value: {:?}", value);
+            assert_eq!(name, "$x");
+        }
+    }
+
+    #[test]
+    fn test_parser_exceeds_max_depth() {
+        let parser = VariableParser::new().with_max_depth(3);
+
+        // Try to parse a 7-level nested literal with shallow max_depth
+        let text = "$x = { a => { b => { c => { d => 1 } } } }";
+        let result = parser.parse_assignment(text);
+
+        // Should fail due to max_depth exceeded
+        assert!(result.is_err(), "should fail with max_depth=3");
+        println!("Parser correctly rejects depth > 3: OK");
+    }
+
+    #[test]
+    fn test_render_deeply_nested_hash_with_children() {
+        let renderer = PerlVariableRenderer::new();
+
+        // Build nested structure and check children expansion
+        let mut value = PerlValue::Hash(vec![("level7".to_string(), PerlValue::Integer(7))]);
+        for level in (1..=6).rev() {
+            value = PerlValue::Hash(vec![(format!("level{}", level), value)]);
+        }
+
+        let rendered = renderer.render("$root", &value);
+        let children = renderer.render_children(&value, 0, 10);
+
+        println!("Nested hash children:");
+        println!("  root_value: {}", rendered.value);
+        println!("  children_count: {}", children.len());
+        if !children.is_empty() {
+            println!("  first_child: name={}, value={}", children[0].name, children[0].value);
+        }
+
+        assert_eq!(children.len(), 1, "root should have 1 child");
+        assert_eq!(children[0].name, "level1");
+    }
+}


### PR DESCRIPTION
## Summary

- Rescues 522 lines of leaked test work from the 2026-04-11 session where an agent contaminated the main checkout instead of its worktree (see `feedback_worktree_file_leak` pattern)
- Files were recovered from `H:\Code\Rust\perl-lsp-rescue\dap-3487\` and placed in `crates/perl-dap-variables/tests/` (both import from `perl_dap_variables` directly, so this is the correct crate)
- 25 new tests pass 25/25, compile clean, no `[[test]]` wiring needed (Cargo auto-discovers `tests/*.rs`)

## Test coverage added

**`dap_deep_structure_truncation.rs`** (18 tests):
- 7-level nested hash rendering — bounded output, correct type/child counts
- `render_with_reference` assigns correct reference ID on nested hashes
- 500-element array preview truncation with `"... (500 total)"` marker
- 500-element array pagination via `render_children(start, count)`
- 500-key hash preview truncation with `"... (500 keys)"` marker
- 500-key hash pagination (insertion-order stable)
- Cyclic reference safety via `PerlValue::Truncated` sentinel
- 150-level deep reference chain bounded at 10 levels with `"REF(...)"` marker
- `VariableParser::with_max_depth(3)` rejects 4-level nesting
- `VariableParser::new()` (max_depth=50) accepts 7-level nesting
- Mixed nested array/hash structures
- Nested hash-in-array-in-hash structures
- Object (blessed ref) with deep hash backing — `type_name` = class name
- Reference to large array — shows array notation
- Empty arrays/hashes render without truncation markers
- Undef rendering

**`deep_truncation.rs`** (7 tests):
- Duplicate coverage with `--nocapture`-friendly `println!` diagnostics for debugging

## Rescue provenance

The original author agent on 2026-04-11 wrote these files to the main checkout path instead of its worktree. When the orchestrator cleaned the main checkout, the files were moved to a rescue location (`H:\Code\Rust\perl-lsp-rescue\dap-3487\`) rather than discarded. This PR recovers that work into a proper PR with verified passing tests.

The only surgery required:
1. `cargo fmt` reformatting (import ordering, brace placement)
2. Replace `panic!()` in `test_parser_max_depth_parsing` with `assert!(result.is_ok(), ...)` + `if let Ok(...)` (workspace lints ban `panic!` in test code)
3. Change `///` doc comment to `//` line comment (clippy `empty_line_after_doc_comments`)

## Pre-push bypass note

The gate failed on 2 pre-existing `perl-module-resolution` test failures (`use_lib::resolve_absolute_path_*`) that exist on master and are unrelated to this change. Pushed with `--no-verify` per bypass policy (out-of-band environmental failure).

## Test plan

- [x] `cargo test -p perl-dap-variables --test dap_deep_structure_truncation` — 18/18 pass
- [x] `cargo test -p perl-dap-variables --test deep_truncation` — 7/7 pass
- [x] `cargo fmt --check -p perl-dap-variables` — clean
- [x] `cargo clippy -p perl-dap-variables --test dap_deep_structure_truncation --test deep_truncation` — clean
- [x] `cargo xtask check-test-wiring` — new files not in offenders list (auto-discovered)

Closes #3487