### PR TITLE
fix(workspace): handle workspace/symbol in Building state and rank by folder (#4152)

### DIFF
--- a/crates/perl-lsp/src/fallback/text.rs
+++ b/crates/perl-lsp/src/fallback/text.rs
@@ -114,6 +114,7 @@ pub fn extract_text_based_symbols(
                             ),
                         ),
                         container_name: None,
+                        workspace_folder_uri: None,
                     });
                 }
             }
@@ -143,6 +144,7 @@ pub fn extract_text_based_symbols(
                             ),
                         ),
                         container_name: None,
+                        workspace_folder_uri: None,
                     });
                 }
             }

--- a/crates/perl-lsp/src/runtime/symbol_extraction.rs
+++ b/crates/perl-lsp/src/runtime/symbol_extraction.rs
@@ -62,6 +62,7 @@ impl LspServer {
                         ),
                         container_name: container
                             .map(|s| normalize_package_separator(s).into_owned()),
+                        workspace_folder_uri: None,
                     });
 
                     // Recurse into body with this subroutine as container
@@ -91,6 +92,7 @@ impl LspServer {
                         ),
                     ),
                     container_name: container.map(|s| normalize_package_separator(s).into_owned()),
+                    workspace_folder_uri: None,
                 });
 
                 // Recurse into block with this package as container
@@ -121,6 +123,7 @@ impl LspServer {
                         ),
                     ),
                     container_name: container.map(|s| normalize_package_separator(s).into_owned()),
+                    workspace_folder_uri: None,
                 });
 
                 // Recurse into body with this class as container
@@ -143,6 +146,7 @@ impl LspServer {
                         ),
                     ),
                     container_name: container.map(|s| normalize_package_separator(s).into_owned()),
+                    workspace_folder_uri: None,
                 });
 
                 // Recurse into body with this method as container

--- a/crates/perl-lsp/src/runtime/test_api.rs
+++ b/crates/perl-lsp/src/runtime/test_api.rs
@@ -328,4 +328,31 @@ impl LspServer {
     pub fn test_has_document(&self, uri: &str) -> bool {
         self.documents.lock().contains_key(uri)
     }
+
+    /// Force the workspace coordinator into Building/Indexing state and index a
+    /// file directly into the underlying index, simulating the background scan
+    /// path without transitioning to Ready.
+    ///
+    /// This is used in tests for Gap 2 (#4152): workspace/symbol during Building
+    /// state should still return results from the partial index.
+    ///
+    /// # Parameters
+    /// - `uri`: File URI string (e.g. `"file:///project/lib/Foo.pm"`)
+    /// - `text`: Perl source text to index
+    ///
+    /// # Returns
+    /// `Ok(())` if the file was indexed; `Err` if URI parse failed or indexing failed.
+    #[cfg(feature = "workspace")]
+    pub fn test_index_file_in_building_state(&self, uri: &str, text: &str) -> Result<(), String> {
+        let Some(coordinator) = self.index_coordinator.as_ref() else {
+            return Err("No coordinator available".to_string());
+        };
+        // Move to Building/Indexing phase so the state machine won't auto-transition
+        // to Ready when index_file is called (simulates background scan in progress).
+        coordinator.transition_to_scanning();
+        coordinator.transition_to_indexing(10);
+
+        let url = url::Url::parse(uri).map_err(|e| e.to_string())?;
+        coordinator.index().index_file(url, text.to_string())
+    }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -218,7 +218,8 @@ impl LspServer {
     ///
     /// Uses routing helper for state-aware behavior:
     /// - **Ready state**: Full workspace index search with cooperative yielding
-    /// - **Building/Degraded state**: Open document search only (partial results)
+    /// - **Building/Degraded state**: Query partial index first; fall through to open-doc
+    ///   search only when the partial index is also empty (Gap 2 fix, issue #4152)
     pub(super) fn handle_workspace_symbols_v2(
         &self,
         params: Option<Value>,

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -263,7 +263,35 @@ impl LspServer {
                     // If index is empty, fall through to open-doc search
                 }
                 IndexAccessMode::Partial(reason) => {
-                    tracing::debug!(reason, "Workspace symbol: using open-doc fallback");
+                    // Building/Degraded: still query the partial index so users get
+                    // results from files already scanned.  Fall through to the
+                    // open-doc path only when the partial index is also empty.
+                    tracing::debug!(reason, "Workspace symbol: querying partial index");
+                    if let Some(coordinator) = self.coordinator() {
+                        let symbols = coordinator.index().search_symbols(query);
+                        let lsp_symbols: Vec<LspWorkspaceSymbol> = symbols
+                            .iter()
+                            .take(cap)
+                            .enumerate()
+                            .map(|(i, sym)| {
+                                if i & 0x3f == 0 {
+                                    std::thread::yield_now();
+                                }
+                                sym.into()
+                            })
+                            .collect();
+                        if !lsp_symbols.is_empty() {
+                            tracing::debug!(
+                                count = lsp_symbols.len(),
+                                "Workspace symbol: returned results from partial index"
+                            );
+                            return Ok(Some(json!(lsp_symbols)));
+                        }
+                    }
+                    tracing::debug!(
+                        reason,
+                        "Workspace symbol: partial index empty, falling back to open-docs"
+                    );
                 }
                 IndexAccessMode::None => {
                     tracing::debug!(

--- a/crates/perl-lsp/tests/multi_root_workspace_tests.rs
+++ b/crates/perl-lsp/tests/multi_root_workspace_tests.rs
@@ -1018,3 +1018,152 @@ fn test_folder_aware_ranking() -> TestResult {
 
     Ok(())
 }
+
+// =============================================================================
+// Test 9: workspace/symbol during Building state returns partial index results
+// Gap 2 — #4152
+// =============================================================================
+
+/// Verify that `workspace/symbol` returns results from the partially-indexed
+/// workspace even when the index coordinator is still in Building state.
+///
+/// Before the fix: the handler falls through to the open-documents-only path
+/// when the mode is `Partial`, returning empty results for files not yet opened.
+///
+/// After the fix: the handler queries the underlying index directly and returns
+/// whatever data it has accumulated so far.
+#[test]
+#[cfg(all(feature = "workspace", feature = "expose_lsp_test_api"))]
+fn test_workspace_symbol_during_building_state() -> TestResult {
+    use perl_lsp::LspServer;
+
+    // Create a server — the coordinator starts in Building/Idle state by default.
+    let server = LspServer::new();
+
+    // Index a file directly into the underlying index while forcing the coordinator
+    // to stay in Building/Indexing state (not transitioning to Ready).
+    // This simulates the background file scan path: files get indexed while the
+    // coordinator is still in Building state.
+    server
+        .test_index_file_in_building_state(
+            "file:///building_state_test/scanned_module.pm",
+            "package ScannedModule;\nsub building_func { return 42; }\n1;\n",
+        )
+        .map_err(|e| e)?;
+
+    // NO documents are open via didOpen — so the open-documents-only fallback
+    // returns nothing. This is the key condition: the file is indexed but not open.
+
+    // Query workspace/symbol for "building_func" while coordinator is in Building state.
+    // Before the fix: returns empty (Partial arm -> open-docs fallback -> nothing found).
+    // After the fix: returns results from the partial index.
+    let result = server
+        .test_handle_workspace_symbols(Some(serde_json::json!({"query": "building_func"})))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let symbol_count = result.as_ref().and_then(|v| v.as_array()).map(|a| a.len()).unwrap_or(0);
+
+    // ASSERT: must find at least one result from the partial index.
+    // This fails before the fix (returns 0 results) and passes after (returns 1+).
+    assert!(
+        symbol_count > 0,
+        "workspace/symbol must return results from the partial index during Building state, \
+         but got 0 results. The open-document fallback alone is insufficient."
+    );
+
+    Ok(())
+}
+
+// =============================================================================
+// Test 10: workspace/symbol includes workspace_folder_uri for disambiguation
+// Gap 3 — #4152
+// =============================================================================
+
+/// Verify that `workspace/symbol` response includes `workspaceFolderUri` for each
+/// symbol so that clients can disambiguate same-named symbols across folders.
+///
+/// Before the fix: the `LspWorkspaceSymbol` struct omits the `workspace_folder_uri`
+/// field, so clients cannot distinguish which folder's symbol is which.
+///
+/// After the fix: each symbol in the response serializes `workspaceFolderUri`
+/// when the underlying `WorkspaceSymbol` has a populated `workspace_folder_uri`.
+#[test]
+#[cfg(all(feature = "workspace", feature = "expose_lsp_test_api"))]
+fn test_workspace_symbol_includes_folder_uri_for_disambiguation() -> TestResult {
+    use url::Url;
+
+    // Build a standalone index with two workspace folders, each containing a `sub run`.
+    // This tests the wire format: after the Gap 3 fix, `workspaceFolderUri` must be
+    // included in `LspWorkspaceSymbol` so clients can distinguish same-named symbols.
+    use perl_parser::workspace_index::WorkspaceIndex;
+    let index = WorkspaceIndex::new();
+    index.set_workspace_folders(vec![
+        "file:///disambiguation_test/svc-a/".to_string(),
+        "file:///disambiguation_test/svc-b/".to_string(),
+    ]);
+    index
+        .index_file(
+            Url::parse("file:///disambiguation_test/svc-a/lib/Runner.pm")
+                .map_err(|e| e.to_string())?,
+            "package Runner;\nsub run { return 'from-a'; }\n1;\n".to_string(),
+        )
+        .map_err(|e| e)?;
+    index
+        .index_file(
+            Url::parse("file:///disambiguation_test/svc-b/lib/Runner.pm")
+                .map_err(|e| e.to_string())?,
+            "package Runner;\nsub run { return 'from-b'; }\n1;\n".to_string(),
+        )
+        .map_err(|e| e)?;
+
+    // Search for "run" — both folders define it.
+    let symbols = index.search_symbols("run");
+    assert!(symbols.len() >= 2, "Expected at least 2 'run' symbols, got {}", symbols.len());
+
+    // Each symbol from the index must have workspace_folder_uri set.
+    for sym in &symbols {
+        if sym.name == "run" {
+            assert!(
+                sym.workspace_folder_uri.is_some(),
+                "WorkspaceSymbol 'run' must have workspace_folder_uri set in index, got: {:?}",
+                sym
+            );
+        }
+    }
+
+    // Convert to LspWorkspaceSymbol (the wire format) and verify the field survives.
+    use perl_parser::workspace_index::LspWorkspaceSymbol;
+    let lsp_symbols: Vec<LspWorkspaceSymbol> = symbols.iter().map(|s| s.into()).collect();
+
+    for lsp_sym in &lsp_symbols {
+        if lsp_sym.name == "run" {
+            // This is the key assertion: workspaceFolderUri must be present in the
+            // LspWorkspaceSymbol after the Gap 3 fix.
+            // FAILS before the fix (field is absent from the struct).
+            // PASSES after the fix (field is included and set to the folder URI).
+            assert!(
+                lsp_sym.workspace_folder_uri.is_some(),
+                "LspWorkspaceSymbol 'run' must include workspaceFolderUri for multi-folder \
+                 disambiguation, got: {:?}",
+                lsp_sym
+            );
+        }
+    }
+
+    // Also verify the JSON serialization includes the field.
+    let json_symbols = serde_json::to_value(&lsp_symbols).map_err(|e| e.to_string())?;
+    let json_array = json_symbols.as_array().ok_or("Expected array")?;
+
+    for json_sym in json_array {
+        if json_sym["name"].as_str() == Some("run") {
+            let folder_uri_field = json_sym.get("workspaceFolderUri");
+            assert!(
+                folder_uri_field.is_some() && !folder_uri_field.unwrap().is_null(),
+                "Serialized workspace symbol must include workspaceFolderUri, got: {:?}",
+                json_sym
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -1069,6 +1069,9 @@ pub struct LspWorkspaceSymbol {
     /// Name of the containing symbol (package, class)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_name: Option<String>,
+    /// Workspace folder URI this symbol belongs to (for multi-root workspace disambiguation)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_folder_uri: Option<String>,
 }
 
 impl From<&WorkspaceSymbol> for LspWorkspaceSymbol {
@@ -1083,6 +1086,7 @@ impl From<&WorkspaceSymbol> for LspWorkspaceSymbol {
             kind: sym.kind.to_lsp_kind(),
             location: WireLocation { uri: sym.uri.clone(), range },
             container_name: sym.container_name.clone(),
+            workspace_folder_uri: sym.workspace_folder_uri.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes two gaps in `workspace/symbol` identified in issue #4152:

- **Gap 2** (`workspace.rs`): When the index coordinator is in `Building/Indexing` state, `workspace/symbol` now queries the partial index directly instead of falling through to the open-documents-only path. Result: files already scanned during background indexing are discoverable before indexing completes. Falls through to the open-doc search only when the partial index is also empty.

- **Gap 3** (`workspace_index.rs`): `LspWorkspaceSymbol` now includes a `workspace_folder_uri` field (serialized as `workspaceFolderUri`, omitted when null). This field is propagated from `WorkspaceSymbol` via the `From` impl, allowing LSP clients to disambiguate same-named symbols across workspace folders in multi-root workspaces.

## Implementation Notes

- **Gap 2 root cause**: The `IndexAccessMode::Partial(reason)` arm in `handle_workspace_symbols_v2` dropped the coordinator reference (storing only a `&'static str`). The fix calls `self.coordinator()` directly in the Partial arm to re-acquire the coordinator and query its index.

- **Gap 3 root cause**: `LspWorkspaceSymbol` was missing the `workspace_folder_uri` field. The field already existed on the internal `WorkspaceSymbol` struct and was populated by `FileIndexer` (via `set_workspace_folders`). Adding it to `LspWorkspaceSymbol` and updating the `From` impl was sufficient.

- **Test helper**: Added `test_index_file_in_building_state()` to `test_api.rs`. It transitions the coordinator to `Building/Indexing` state _before_ indexing the file, preventing the auto-transition to `Ready` that `test_handle_did_open()` causes.

## Test Plan

- [x] `test_workspace_symbol_during_building_state` — verifies Gap 2: queries a file indexed while coordinator is in Building/Indexing state returns ≥1 result
- [x] `test_workspace_symbol_includes_folder_uri_for_disambiguation` — verifies Gap 3: `WorkspaceSymbol`, `LspWorkspaceSymbol`, and JSON serialization all include `workspaceFolderUri` for multi-folder disambiguation
- [x] All 10 multi_root_workspace_tests pass (including 8 pre-existing)
- [x] All 346 perl-workspace-index tests pass
- [x] Full perl-lsp-rs test suite: 356 pass (3 pre-existing perltidy formatting failures on machines without perltidy installed)

## Pre-existing failures (not caused by this PR)

- `perl-module-resolution use_lib` — 2 tests fail on master and on this branch identically; environmental/pre-existing issue
- Formatting tests — require `perltidy` installed on PATH; pre-existing on this machine