### PR TITLE
feat(xtask): metrics subcommand tree and parser-stats leaf (#4106)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 use tasks::check_test_wiring;
 use tasks::dead_code::{DeadCodeConfig, DeadCodeMode};
 use tasks::gates::{GateTier, OutputFormat};
+use tasks::metrics;
 use tasks::targeted_checks::CheckMode;
 use tasks::unwired_scan::UnwiredScanConfig;
 use tasks::*;
@@ -873,6 +874,12 @@ enum Commands {
     /// Check that test-bearing Rust files are reachable from their module tree.
     CheckTestWiring,
 
+    /// Emit per-subsystem engineering-health metrics.
+    Metrics {
+        #[command(subcommand)]
+        command: MetricsCommand,
+    },
+
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
 
@@ -1111,6 +1118,36 @@ enum FeaturesCommand {
 
     /// Generate compliance report
     Report,
+}
+
+#[derive(Subcommand)]
+enum MetricsCommand {
+    /// Emit parser phase timings and benchmark summary.
+    ParserStats {
+        /// Path to benchmark JSON (default: most recent in benchmarks/results/)
+        #[arg(long)]
+        input: Option<PathBuf>,
+        /// Write output to .ci/metrics/parser.json
+        #[arg(long)]
+        json: bool,
+    },
+    /// [stub] LSP request latency statistics.
+    LspStats,
+    /// [stub] Workspace index memory and timing statistics.
+    WorkspaceStats,
+    /// [stub] Diagnostics accuracy and latency statistics.
+    DiagnosticsStats,
+    /// [stub] Hierarchical memory breakdown across LSP subsystems.
+    Memory,
+    /// [stub] Release-health dashboard.
+    ReleaseHealth {
+        /// Number of days of history to analyze
+        #[arg(long, default_value_t = 30)]
+        days: u64,
+        /// Write output to .ci/metrics/release-health.json
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(ValueEnum, Clone)]
@@ -1397,6 +1434,16 @@ fn main() -> Result<()> {
             unwired_scan::run(UnwiredScanConfig { lsp_crate, json, check })
         }
         Commands::CheckTestWiring => check_test_wiring::run(),
+        Commands::Metrics { command } => match command {
+            MetricsCommand::ParserStats { input, json } => metrics::parser_stats::run(input, json),
+            MetricsCommand::LspStats => metrics::lsp_stats::run(),
+            MetricsCommand::WorkspaceStats => metrics::workspace_stats::run(),
+            MetricsCommand::DiagnosticsStats => metrics::diagnostics_stats::run(),
+            MetricsCommand::Memory => metrics::memory::run(),
+            MetricsCommand::ReleaseHealth { days, json } => {
+                metrics::release_health::run(days, json)
+            }
+        },
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {
             e2e_validate::run(e2e_validate::E2eConfig {

--- a/xtask/src/tasks/metrics/diagnostics_stats.rs
+++ b/xtask/src/tasks/metrics/diagnostics_stats.rs
@@ -1,0 +1,9 @@
+//! [stub] Diagnostics accuracy and latency statistics subcommand.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask metrics diagnostics-stats`.
+pub fn run() -> Result<()> {
+    println!("[stub] diagnostics-stats not yet implemented");
+    Ok(())
+}

--- a/xtask/src/tasks/metrics/lsp_stats.rs
+++ b/xtask/src/tasks/metrics/lsp_stats.rs
@@ -1,0 +1,9 @@
+//! [stub] LSP request latency statistics subcommand.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask metrics lsp-stats`.
+pub fn run() -> Result<()> {
+    println!("[stub] lsp-stats not yet implemented");
+    Ok(())
+}

--- a/xtask/src/tasks/metrics/memory.rs
+++ b/xtask/src/tasks/metrics/memory.rs
@@ -1,0 +1,9 @@
+//! [stub] Hierarchical memory breakdown across LSP subsystems.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask metrics memory`.
+pub fn run() -> Result<()> {
+    println!("[stub] memory accounting not yet implemented");
+    Ok(())
+}

--- a/xtask/src/tasks/metrics/mod.rs
+++ b/xtask/src/tasks/metrics/mod.rs
@@ -1,0 +1,10 @@
+//! `cargo xtask metrics` subcommand tree.
+//!
+//! Each leaf module implements one user-facing subcommand.
+
+pub mod diagnostics_stats;
+pub mod lsp_stats;
+pub mod memory;
+pub mod parser_stats;
+pub mod release_health;
+pub mod workspace_stats;

--- a/xtask/src/tasks/metrics/parser_stats.rs
+++ b/xtask/src/tasks/metrics/parser_stats.rs
@@ -208,6 +208,7 @@ fn write_json_output(root: &Path, file: &BenchmarkFile) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_parse_benchmark_entry() -> Result<()> {
@@ -235,5 +236,84 @@ mod tests {
         // print_table must not panic even with missing source_lines
         print_table(&file);
         Ok(())
+    }
+
+    /// Verify the JSON output schema: correct keys, schema_version=1, subsystem="parser",
+    /// benchmark_count reflects total entries, and slowest is sorted descending by mean_us.
+    #[test]
+    fn test_write_json_output_schema() -> Result<()> {
+        let json = r#"{"benchmarks":{
+            "fast":{"mean":{"nanoseconds":1000.0,"microseconds":1.0},"median":{"nanoseconds":900.0,"microseconds":0.9},"std_dev":{"nanoseconds":50.0,"microseconds":0.05},"source_lines":10},
+            "slow":{"mean":{"nanoseconds":50000.0,"microseconds":50.0},"median":{"nanoseconds":48000.0,"microseconds":48.0},"std_dev":{"nanoseconds":2000.0,"microseconds":2.0},"source_lines":null},
+            "incomplete":{"source_lines":42}
+        }}"#;
+        let file: BenchmarkFile = serde_json::from_str(json)?;
+        let tmp = TempDir::new()?;
+        write_json_output(tmp.path(), &file)?;
+
+        let out_path = tmp.path().join(".ci").join("metrics").join("parser.json");
+        let raw = fs::read_to_string(&out_path)?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)?;
+
+        // Schema contract checks
+        assert_eq!(parsed["schema_version"], 1, "schema_version must be 1");
+        assert_eq!(parsed["subsystem"], "parser", "subsystem must be 'parser'");
+        assert!(parsed["measured_at"].is_string(), "measured_at must be a string");
+        assert_eq!(
+            parsed["metrics"]["benchmark_count"], 3,
+            "benchmark_count must include incomplete entries"
+        );
+
+        // slowest must contain only timed entries, sorted descending by mean_us
+        let slowest = parsed["metrics"]["slowest"].as_array().expect("slowest must be an array");
+        assert_eq!(slowest.len(), 2, "slowest must only contain timed entries");
+        assert_eq!(slowest[0]["name"], "slow", "first entry must be the slowest benchmark");
+        assert!(
+            (slowest[0]["mean_us"].as_f64().unwrap() - 50.0).abs() < 0.01,
+            "mean_us must match"
+        );
+        assert_eq!(slowest[1]["name"], "fast", "second entry must be the faster benchmark");
+
+        Ok(())
+    }
+
+    /// When all benchmark entries are incomplete (real-world scenario: 3 of 4 current benchmarks),
+    /// write_json_output must succeed and emit an empty slowest list, not panic or emit wrong data.
+    #[test]
+    fn test_write_json_output_all_incomplete() -> Result<()> {
+        let json = r#"{"benchmarks":{
+            "a":{"source_lines":10},
+            "b":{"source_lines":null},
+            "c":{}
+        }}"#;
+        let file: BenchmarkFile = serde_json::from_str(json)?;
+        let tmp = TempDir::new()?;
+        write_json_output(tmp.path(), &file)?;
+
+        let out_path = tmp.path().join(".ci").join("metrics").join("parser.json");
+        let raw = fs::read_to_string(&out_path)?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)?;
+
+        assert_eq!(parsed["metrics"]["benchmark_count"], 3);
+        let slowest = parsed["metrics"]["slowest"].as_array().expect("slowest must be an array");
+        assert!(slowest.is_empty(), "slowest must be empty when no entries have timing data");
+
+        Ok(())
+    }
+
+    /// When benchmarks/results/ exists but contains no JSON files, the error message must
+    /// mention the directory path so the user knows where to look.
+    #[test]
+    fn test_find_latest_benchmark_json_empty_dir() {
+        let tmp = TempDir::new().expect("tempdir");
+        let results_dir = tmp.path().join("benchmarks").join("results");
+        fs::create_dir_all(&results_dir).expect("create results dir");
+        // No JSON files in results_dir
+        let err = find_latest_benchmark_json(tmp.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no *.json files found"),
+            "error must mention 'no *.json files found', got: {msg}"
+        );
     }
 }

--- a/xtask/src/tasks/metrics/parser_stats.rs
+++ b/xtask/src/tasks/metrics/parser_stats.rs
@@ -1,0 +1,239 @@
+//! Parser benchmark statistics subcommand.
+//!
+//! Reads the most-recently-modified benchmark JSON from `benchmarks/results/`
+//! (or an explicit `--input` path), emits a human-readable table, and
+//! optionally writes `.ci/metrics/parser.json`.
+
+use crate::utils::project_root;
+use chrono::Utc;
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Benchmark JSON schema
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct BenchmarkFile {
+    pub benchmarks: BTreeMap<String, BenchmarkEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BenchmarkEntry {
+    pub mean: Option<TimingStat>,
+    pub median: Option<TimingStat>,
+    pub std_dev: Option<TimingStat>,
+    pub source_lines: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TimingStat {
+    pub nanoseconds: f64,
+    pub microseconds: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Output schema for .ci/metrics/parser.json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct ParserMetricsOutput {
+    schema_version: u32,
+    measured_at: String,
+    subsystem: &'static str,
+    metrics: ParserMetrics,
+}
+
+#[derive(Debug, Serialize)]
+struct ParserMetrics {
+    benchmark_count: usize,
+    slowest: Vec<SlowEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct SlowEntry {
+    name: String,
+    mean_us: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run `cargo xtask metrics parser-stats`.
+pub fn run(input: Option<PathBuf>, json: bool) -> Result<()> {
+    let root = project_root()?;
+
+    // Resolve input path: explicit or most-recent in benchmarks/results/
+    let input_path = match input {
+        Some(p) => p,
+        None => find_latest_benchmark_json(&root)?,
+    };
+
+    let raw = fs::read_to_string(&input_path)
+        .with_context(|| format!("reading benchmark file: {}", input_path.display()))?;
+
+    let file: BenchmarkFile =
+        serde_json::from_str(&raw).with_context(|| "parsing benchmark JSON")?;
+
+    print_table(&file);
+
+    if json {
+        write_json_output(&root, &file)?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return the most-recently modified `*.json` in `benchmarks/results/`.
+fn find_latest_benchmark_json(root: &Path) -> Result<PathBuf> {
+    let results_dir = root.join("benchmarks").join("results");
+    let mut candidates: Vec<(std::time::SystemTime, PathBuf)> = fs::read_dir(&results_dir)
+        .with_context(|| format!("reading {}", results_dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("json"))
+        .filter_map(|e| {
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((mtime, e.path()))
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| b.0.cmp(&a.0)); // newest first
+
+    candidates.into_iter().map(|(_, p)| p).next().ok_or_else(|| {
+        color_eyre::eyre::eyre!("no *.json files found in {}", results_dir.display())
+    })
+}
+
+/// Print a human-readable table sorted by mean descending.
+/// Entries without timing data (status: incomplete / not_run) are listed at the bottom.
+fn print_table(file: &BenchmarkFile) {
+    let mut timed: Vec<(&str, &BenchmarkEntry)> = file
+        .benchmarks
+        .iter()
+        .filter(|(_, v)| v.mean.is_some())
+        .map(|(k, v)| (k.as_str(), v))
+        .collect();
+    timed.sort_by(|a, b| {
+        let an = a.1.mean.as_ref().map(|s| s.nanoseconds).unwrap_or(0.0);
+        let bn = b.1.mean.as_ref().map(|s| s.nanoseconds).unwrap_or(0.0);
+        bn.partial_cmp(&an).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let no_timing: Vec<(&str, &BenchmarkEntry)> = file
+        .benchmarks
+        .iter()
+        .filter(|(_, v)| v.mean.is_none())
+        .map(|(k, v)| (k.as_str(), v))
+        .collect();
+
+    println!(
+        "{:<40} {:>12} {:>12} {:>12} {:>8}",
+        "Benchmark", "Mean (µs)", "Median (µs)", "Std Dev (µs)", "LOC"
+    );
+    println!("{}", "-".repeat(88));
+    for (name, entry) in &timed {
+        let mean_us = entry.mean.as_ref().map(|s| s.microseconds).unwrap_or(0.0);
+        let median_us = entry.median.as_ref().map(|s| s.microseconds).unwrap_or(0.0);
+        let std_dev_us = entry.std_dev.as_ref().map(|s| s.microseconds).unwrap_or(0.0);
+        let loc = entry.source_lines.map(|n| n.to_string()).unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<40} {:>12.2} {:>12.2} {:>12.2} {:>8}",
+            name, mean_us, median_us, std_dev_us, loc
+        );
+    }
+    for (name, entry) in &no_timing {
+        let loc = entry.source_lines.map(|n| n.to_string()).unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<40} {:>12} {:>12} {:>12} {:>8}",
+            name, "(no data)", "(no data)", "(no data)", loc
+        );
+    }
+    println!();
+    println!("{} benchmark(s) loaded ({} with timing data).", file.benchmarks.len(), timed.len());
+}
+
+/// Write `.ci/metrics/parser.json`.
+fn write_json_output(root: &Path, file: &BenchmarkFile) -> Result<()> {
+    let metrics_dir = root.join(".ci").join("metrics");
+    fs::create_dir_all(&metrics_dir)
+        .with_context(|| format!("creating {}", metrics_dir.display()))?;
+
+    let mut entries: Vec<(&str, &BenchmarkEntry)> = file
+        .benchmarks
+        .iter()
+        .filter(|(_, v)| v.mean.is_some())
+        .map(|(k, v)| (k.as_str(), v))
+        .collect();
+    entries.sort_by(|a, b| {
+        let an = a.1.mean.as_ref().map(|s| s.nanoseconds).unwrap_or(0.0);
+        let bn = b.1.mean.as_ref().map(|s| s.nanoseconds).unwrap_or(0.0);
+        bn.partial_cmp(&an).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let slowest: Vec<SlowEntry> = entries
+        .iter()
+        .take(5)
+        .map(|(name, e)| SlowEntry {
+            name: (*name).to_string(),
+            mean_us: e.mean.as_ref().map(|s| s.microseconds).unwrap_or(0.0),
+        })
+        .collect();
+
+    let output = ParserMetricsOutput {
+        schema_version: 1,
+        measured_at: Utc::now().to_rfc3339(),
+        subsystem: "parser",
+        metrics: ParserMetrics { benchmark_count: file.benchmarks.len(), slowest },
+    };
+
+    let out_path = metrics_dir.join("parser.json");
+    let json = serde_json::to_string_pretty(&output).with_context(|| "serializing metrics")?;
+    fs::write(&out_path, &json).with_context(|| format!("writing {}", out_path.display()))?;
+    println!("Wrote {}", out_path.display());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_benchmark_entry() -> Result<()> {
+        let json = r#"{"benchmarks":{"parse_simple":{"mean":{"nanoseconds":21255.87,"microseconds":21.26},"median":{"nanoseconds":19773.55,"microseconds":19.77},"std_dev":{"nanoseconds":5731.70,"microseconds":5.73},"source_lines":15}}}"#;
+        let file: BenchmarkFile = serde_json::from_str(json)?;
+        assert_eq!(file.benchmarks.len(), 1);
+        let mean_us =
+            file.benchmarks["parse_simple"].mean.as_ref().map(|s| s.microseconds).unwrap_or(0.0);
+        assert!((mean_us - 21.26).abs() < 0.01);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_benchmarks_does_not_panic() -> Result<()> {
+        let json = r#"{"benchmarks":{}}"#;
+        let file: BenchmarkFile = serde_json::from_str(json)?;
+        assert_eq!(file.benchmarks.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_print_table_does_not_panic_with_multiple_entries() -> Result<()> {
+        let json = r#"{"benchmarks":{"fast":{"mean":{"nanoseconds":1000.0,"microseconds":1.0},"median":{"nanoseconds":900.0,"microseconds":0.9},"std_dev":{"nanoseconds":50.0,"microseconds":0.05},"source_lines":10},"slow":{"mean":{"nanoseconds":50000.0,"microseconds":50.0},"median":{"nanoseconds":48000.0,"microseconds":48.0},"std_dev":{"nanoseconds":2000.0,"microseconds":2.0},"source_lines":null}}}"#;
+        let file: BenchmarkFile = serde_json::from_str(json)?;
+        // print_table must not panic even with missing source_lines
+        print_table(&file);
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/metrics/release_health.rs
+++ b/xtask/src/tasks/metrics/release_health.rs
@@ -1,0 +1,9 @@
+//! [stub] Release-health dashboard subcommand.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask metrics release-health`.
+pub fn run(_days: u64, _json: bool) -> Result<()> {
+    println!("[stub] release-health not yet implemented");
+    Ok(())
+}

--- a/xtask/src/tasks/metrics/workspace_stats.rs
+++ b/xtask/src/tasks/metrics/workspace_stats.rs
@@ -1,0 +1,9 @@
+//! [stub] Workspace index memory and timing statistics subcommand.
+
+use color_eyre::eyre::Result;
+
+/// Run `cargo xtask metrics workspace-stats`.
+pub fn run() -> Result<()> {
+    println!("[stub] workspace-stats not yet implemented");
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -45,6 +45,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod metrics;
 pub mod parse_rust;
 pub mod parser_corpus_sweep;
 pub mod parser_matrix;


### PR DESCRIPTION
## Summary

- Adds `cargo xtask metrics <subcommand>` dispatch tree with a `MetricsCommand` clap enum
- Implements `cargo xtask metrics parser-stats` fully: reads most-recent `benchmarks/results/*.json` by mtime (or `--input` override), prints a human-readable table, and optionally writes `.ci/metrics/parser.json` via `--json`
- Stubs `lsp-stats`, `workspace-stats`, `diagnostics-stats`, `memory`, and `release-health` — all exit 0 with a `[stub] ... not yet implemented` message

## Changes

- `xtask/src/main.rs` — add `Metrics { command: MetricsCommand }` variant to `Commands` enum; add `MetricsCommand` enum with 6 variants; add dispatch match arm; add `use tasks::metrics` import
- `xtask/src/tasks/mod.rs` — add `pub mod metrics`
- `xtask/src/tasks/metrics/mod.rs` — new: declares all 6 leaf modules
- `xtask/src/tasks/metrics/parser_stats.rs` — new: full implementation with `BenchmarkFile` schema, mtime-sort discovery, table output, JSON ratchet artifact emission, 3 tests
- `xtask/src/tasks/metrics/lsp_stats.rs`, `workspace_stats.rs`, `diagnostics_stats.rs`, `memory.rs`, `release_health.rs` — new stubs
- `.ci/metrics/.gitkeep` — creates tracked directory for future ratchet artifacts

## Evidence

- **Commits**: 1
- **Tests**: 3 new passing (`test_parse_benchmark_entry`, `test_empty_benchmarks_does_not_panic`, `test_print_table_does_not_panic_with_multiple_entries`); 232 passing overall (2 pre-existing Windows failures in `check_test_wiring` from PR #4119 — not caused by this change)
- **Lint**: clippy clean — zero warnings with `-D warnings`
- **Fmt**: auto-fixed and verified
- **Files**: 10 changed, +342 lines

## Test Plan

```bash
# Run parser-stats against the existing benchmark file
cargo xtask metrics parser-stats
# Expected: human-readable table with 4 benchmarks (1 with timing data, 3 "no data")

# Test --json output
cargo xtask metrics parser-stats --json
# Expected: writes .ci/metrics/parser.json with schema_version=1

# Test all stubs exit 0
cargo xtask metrics lsp-stats
cargo xtask metrics workspace-stats
cargo xtask metrics diagnostics-stats
cargo xtask metrics memory
cargo xtask metrics release-health

# Run the unit tests
cargo test -p xtask -- tasks::metrics
```

## Unknowns / Notes

- `benchmarks/results/latest.json` does not exist (plan-review correctly noted this). The implementation uses mtime sort over `*.json` files instead — correct per spec.
- `BenchmarkEntry` fields are `Option<TimingStat>` rather than required — the actual benchmark JSON has 3 of 4 entries without timing data (status: incomplete / not_run). This was not in the original spec but required for the command to succeed against real data.
- 2 pre-existing `check_test_wiring` test failures on Windows (hardcoded forward-slash paths vs Windows backslash). Recommend a follow-up scout for issue #4119's Windows path portability.
- `.ci/metrics/parser.json` (generated by `--json`) is not committed — it's an artifact, not source.

Closes part of #4106 (PR 2 of 5).