### PR TITLE
docs(project): re-scope coroutine planning (#3539)

### DIFF
--- a/docs/project/ISSUE_3539_COROUTINES_SCOPE.md
+++ b/docs/project/ISSUE_3539_COROUTINES_SCOPE.md
@@ -1,0 +1,57 @@
+# Issue #3539 Coroutine Scope Decision
+
+## Summary
+
+`#3539` should not be implemented as core-language parser support in its current form.
+
+Current project direction:
+
+1. **Defer core syntax work** (`coro sub`, `yield`) until upstream Perl publishes a stable, documented syntax contract.
+2. **Split delivery into two tracks**:
+   - upstream-tracking issue (core status + syntax contract)
+   - user-value issue for CPAN coroutine ecosystems (for example, `Coro` hover/completion support)
+
+## Why This Is Deferred
+
+The current issue draft conflates three different scopes:
+
+- hypothetical core syntax (`coro sub`, `yield`)
+- version/status claims for core Perl experimental features
+- CPAN library APIs (`Coro`/`async` style workflows)
+
+These require different implementation paths and should not ship under one mixed issue.
+
+## Scope Split
+
+### Track A: Upstream Core Status (no parser changes)
+
+Question to resolve:
+
+> Is there a released and documented core Perl coroutine syntax target that perl-lsp should parse?
+
+Until this answer is yes, parser/AST semantics for core coroutine syntax remain deferred.
+
+### Track B: CPAN Ecosystem Support (user value now)
+
+Potential scope (no grammar changes):
+
+- hover/completion support for known coroutine APIs from CPAN packages (for example, `Coro`)
+- method completion/hover for known coroutine object methods where inference is reliable
+- tests proving no parser regressions and no new grammar surface
+
+## Implementation Guidance
+
+If follow-up work is scheduled now, prioritize **Track B** and keep parser grammar unchanged.
+
+If parser groundwork is desired, keep it infrastructure-only (extensibility hooks, feature gating plumbing), without introducing unshipped syntax behavior.
+
+## Decision Checklist for Reopening Core Syntax Work
+
+Before any core coroutine parser implementation starts, capture all of the following in the issue:
+
+- authoritative upstream syntax documentation link(s)
+- explicit version/feature gate and warning behavior
+- syntax examples that define parse shape and error recovery expectations
+- compatibility notes for existing identifiers named `yield` or `coro`
+
+Without this checklist, core syntax implementation remains deferred.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -109,6 +109,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Test coverage gaps and broken integration tests
 - VSCode extension lint/quality audit (eslint v10 landed in #3179)
 - AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
+- Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
 
 ### Next (v0.13.0 — public alpha announcement)
 


### PR DESCRIPTION
### Motivation

- The existing issue conflated hypothetical core-language coroutine syntax and CPAN coroutine ecosystems, so the project needs a clear scope decision before any parser/AST work is attempted.
- The change documents the decision to defer speculative `coro sub` / `yield` core syntax work until an authoritative upstream syntax contract exists and to split follow-up into upstream-tracking and CPAN-ecosystem IDE support tracks.

### Description

- Add `docs/project/ISSUE_3539_COROUTINES_SCOPE.md` which records the scope decision, the two-track split (upstream core-status vs CPAN `Coro`-style IDE support), and a checklist required to reopen core-syntax work. 
- Update the roadmap `docs/project/ROADMAP.md` "Now" section with a short bullet referencing the re-scope decision. 
- This PR is documentation-only and makes no changes to lexer, parser, AST, or runtime code.

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Attempted `just status-check` but the `just` command is not available in this environment so the status-check step was not executed. 
- No code-level automated tests were required because this change touches only documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4a9bd7c08333b598d761adbc51ae)