### PR TITLE
docs(roadmap): defer coroutine syntax pending upstream contract (#3539)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -117,6 +117,12 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Seamless install story verified across all distribution channels
 - Announcement blog post / release notes
 
+### Deferred investigation track (language scope clarification)
+
+- Coroutine request `#3539` is treated as a scoping investigation first: core-language syntax vs CPAN library ergonomics
+- Core parser syntax work is deferred until upstream Perl docs publish a stable coroutine language contract
+- User-facing value can proceed as CPAN-focused LSP support (for example Coro hover/completion) without grammar changes
+
 ## Milestone Ladder
 
 ### v0.11.0


### PR DESCRIPTION
### Motivation
- Re-scope the coroutine request `#3539` as an investigation (core-language syntax vs CPAN-library ergonomics) and avoid implementing parser/grammar for an upstream feature that is not yet documented as a released Perl language contract.

### Description
- Added a `Deferred investigation track (language scope clarification)` section to `docs/project/ROADMAP.md` that treats `#3539` as a scoping investigation, defers core parser syntax work until an upstream contract exists, and documents that CPAN-focused LSP improvements (for example Coro hover/completion) can proceed without grammar changes.

### Testing
- Attempted to run `just status-check` in this environment but it failed because `just` is not installed, and no other automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4a9bd7c08333b598d761adbc51ae)