### PR TITLE
docs(roadmap): re-scope coroutine request (#3539)

### DIFF
--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -20,6 +20,7 @@ evidence-backed status and release facts.
 - SRP microcrate extractions in flight (anti_pattern_detector, bench_parser) to free the dead `tree-sitter-perl-rs` harness for archival
 - Publishing the modern parsers as `tree-sitter-perl-c` (C tree-sitter FFI) and a new `tree-sitter-perl-rs` (Rust v3 facade with tree-sitter-compatible output)
 - Per-crate publish blockers cleared (perl-lsp-ai-provider unblocked, perl-heredoc-anti-patterns extraction in progress)
+- Coroutine request #3539 re-scope in progress: defer speculative core syntax support and split follow-up into upstream-status tracking plus CPAN coroutine API IDE support
 
 ## NEXT — v0.13.0 public alpha announcement
 
@@ -37,7 +38,7 @@ evidence-backed status and release facts.
 
 ## Working Rules
 
-- Last updated: `2026-04-09`
+- Last updated: `2026-04-11`
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@ project docs when you need exact release facts, receipts, or milestone detail.
 - crates.io intentionally remains on `0.12.2` while the registry window is still deferred
 - Pre-announcement plumbing: license badge fix, Docker arm64 timeout fix, dependency triage, harness archival, SRP microcrate extractions
 - Distribution channel verification across GitHub Releases, VS Code Marketplace, Open VSX, Docker Hub, and the delayed crates.io line
+- Coroutine request #3539 is being re-scoped: defer speculative core syntax support and split follow-up into upstream-status tracking plus CPAN API IDE support
 - See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) "Now (post-v0.12.3 / pre-v0.13.0)" for the active item list
 
 ## Next (v0.13.0 — public alpha announcement)

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -109,6 +109,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Test coverage gaps and broken integration tests
 - VSCode extension lint/quality audit (eslint v10 landed in #3179)
 - AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
+- Coroutine scope correction (#3539): defer core parser/AST syntax work until upstream Perl ships a documented coroutine feature contract; split follow-up into (1) upstream core-status tracking and (2) CPAN coroutine IDE support (e.g., Coro hover/completion) to deliver near-term user value
 
 ### Next (v0.13.0 — public alpha announcement)
 
@@ -193,4 +194,4 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |
 
-<!-- Last Updated: 2026-04-09 -->
+<!-- Last Updated: 2026-04-11 -->


### PR DESCRIPTION
### Motivation
- Prevent implementation of speculative core coroutine syntax by recording a product decision to defer parser/AST work until Perl upstream ships a documented coroutine feature contract and to split follow-up into upstream-status tracking and CPAN coroutine IDE support (e.g., Coro hover/completion).

### Description
- Add a short re-scope guidance line to `docs/project/ROADMAP.md`, mirror the same note in the top-level `ROADMAP.md` and `NOW_NEXT_LATER.md`, and refresh the "Last Updated" timestamp to 2026-04-11.

### Testing
- Ran `cargo fmt --all -- --check`, which passed; attempted `just status-check` but the `just` command is not available in this environment (could not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4a9bd7c08333b598d761adbc51ae)