### PR TITLE
docs(readme): correct framing per scorecard split (#4175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 | Commands reference | [docs/reference/COMMANDS_REFERENCE.md](docs/reference/COMMANDS_REFERENCE.md) |
 | Upgrade guide | [docs/how-to/UPGRADING.md](docs/how-to/UPGRADING.md) |
 | Troubleshooting | [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md) |
-| Current status and metrics | [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) |
+| Current status and metrics | [docs/project/status/index.md](docs/project/status/index.md) |
 | Release roadmap | [docs/project/ROADMAP.md](docs/project/ROADMAP.md) |
 | Full docs index | [docs/INDEX.md](docs/INDEX.md) |
 

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -7,7 +7,7 @@
 
 - **Release posture**: GitHub Releases plus the editor channels (VS Code Marketplace and Open VSX) are live on `v0.12.3` as of 2026-04-09, the workspace version line is `v0.12.3`, crates.io intentionally remains on `v0.12.2`, and the active milestone is the `v0.13.0` public alpha announcement
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
-- **LSP server**: `features.toml` is the canonical capability catalog; 58 user-visible features at 100% coverage (116/116 including plumbing protocol methods and DAP handlers — corrected in PR #4107 after the DAP catalog undercount audit) — computed coverage is generated from it
+- **LSP server**: `features.toml` is the canonical capability catalog; 53 advertised features at 100% coverage (119/119 total including plumbing protocol methods, DAP handlers, and extension features — count corrected in PR #4107 after the DAP catalog undercount audit, then updated to 117 in PR #4146 and 119 after Stage 2 catalog additions) — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `cargo xtask ignored-tests` is the tracked-test-debt source
 - **Parser stack**: the default parser path is the native recursive-descent stack backed by the Rust lexer and parser-core crates, with three named coverage lanes: Ubuntu system Perl as the compatibility baseline, CPAN top 1000 as the ecosystem-breadth baseline, and the repo-owned corpus as the deterministic regression baseline
 - **Refactoring engine**: inline and move-code flows exist; broader refactoring hardening is still roadmap work
@@ -16,12 +16,15 @@
 
 ## Subsystem Status
 
+The project tracks metrics across several dimensions that answer different questions. Parser corpus coverage (clean-parse rate) is a floor metric: it measures how broadly the parser handles real-world Perl syntax, not whether the IDE experience is good. LSP/DAP capability coverage is a catalog metric: it measures whether each protocol feature has an implementation wired up, not per-capability correctness or UX quality. End-to-end UX quality is qualitative: validated through manual editor smoke workflows and open-issue burn-down, not a dashboard number. Numbers ratchet forward — they are checked in CI and cannot regress without a deliberate override.
+
 | Subsystem | File | Owner | Updated when |
 |-----------|------|-------|-------------|
 | LSP coverage & compliance | [lsp.md](lsp.md) | Generator | Every LSP-touching merge |
 | Test counts & debt | [tests.md](tests.md) | Generator | Every merge |
 | Parser corpus & coverage | [parser.md](parser.md) | Generator | Every parser-touching merge |
 | Quality metrics | [quality.md](quality.md) | Generator | Every merge |
+| Module resolution conformance | [module_resolution.md](module_resolution.md) | Human | After module-resolution changes |
 | Release readiness | [release.md](release.md) | Human | Ship readiness changes |
 
 ## What's Next


### PR DESCRIPTION
## Summary

- Fix stale `116/116` capability count in `docs/project/status/index.md` (features.toml is now at 119 after PRs #4146 and Stage 2 catalog additions; `53 advertised` matches `features.toml` meta comment)
- Add scorecard framing paragraph to `docs/project/status/index.md` explaining parser corpus rate = floor metric, capability count = catalog metric, UX quality = qualitative; ratchet model noted
- Add `module_resolution.md` to subsystem table in `docs/project/status/index.md` (file has existed since PR #4067 consumer consistency harness but was never linked from the index)
- Update README Documentation table to link directly to `docs/project/status/index.md` instead of the `CURRENT_STATUS.md` stub (per spec requirement)

## Files changed

- `README.md` — Documentation table: `CURRENT_STATUS.md` → `status/index.md`
- `docs/project/status/index.md` — stale count fix, scorecard framing paragraph, module_resolution.md subsystem row

## Test plan

- [x] No `<!-- BEGIN: -->` / `<!-- END: -->` auto-generated markers touched
- [x] No invented numbers — all counts verified against `features.toml` meta comment
- [x] `module_resolution.md` confirmed to exist at `docs/project/status/module_resolution.md`
- [x] `pr-fast` exit code 0 (docs-only path)
- [x] Docs-only change — no Cargo.toml, no code, no xtask

## Closes

Resolves #4175