### PR TITLE
chore(deps): remove unused dependencies flagged by cargo machete (#4176, #4179, #4181)

### DIFF
--- a/crates/perl-lsp-providers/Cargo.toml
+++ b/crates/perl-lsp-providers/Cargo.toml
@@ -42,9 +42,6 @@ rustc-hash = "2.1.2"
 serde_json.workspace = true
 lsp-types = { workspace = true, optional = true }
 
-# Unix-only dependency for signal handling in debug adapter
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.31.1", features = ["signal"] }
 
 [features]
 default = ["lsp-compat"]

--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -49,13 +49,6 @@ rustc-hash = "2.1.2"
 # Core dependencies for position mapping (unconditional, all targets)
 ropey = "1.6.1"
 
-# Filesystem traversal is only available on non-wasm targets.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-walkdir.workspace = true
-
-# Unix-only dependency for signal handling
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.31.1", features = ["signal"] }
 
 # Optional dependencies for incremental parsing
 anyhow = { workspace = true, optional = true }

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -32,8 +32,6 @@ default-target = "x86_64-unknown-linux-gnu"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
-criterion.workspace = true
-test-case = "3.3.1"
 
 [features]
 default = ["c-scanner"]


### PR DESCRIPTION
## Summary

Closes #4176, #4179, #4181

Removes unused dependencies identified by `cargo machete --with-metadata` and verified by source grep to have zero references:

| Crate | Dependency | Kind | Action |
|-------|-----------|------|--------|
| `perl-lsp-providers` | `nix` | unix dep | removed |
| `perl-parser` | `nix` | unix dep | removed |
| `perl-parser` | `walkdir` | wasm-excluded dep | removed |
| `tree-sitter-perl-c` | `criterion` | dev-dep | removed |
| `tree-sitter-perl-c` | `test-case` | dev-dep | removed |

**Not removed (false positives):**
- `perl-parser`: `anyhow` — gated behind the `incremental` feature flag
- `tree-sitter-perl-c`: `cc` — actively used by `build.rs` to compile the vendored C parser

Workspace-level entries for `walkdir` and `criterion` are retained as they are still referenced by other crates.

## Test plan

- [ ] `cargo build -p perl-lsp-providers` succeeds
- [ ] `cargo build -p perl-parser` succeeds
- [ ] `cargo build -p tree-sitter-perl-c` succeeds
- [ ] `cargo machete --with-metadata` no longer reports these deps for the affected crates