### PR TITLE
test(ux): ratchet workspace regression harness (#4066)

### DIFF
--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -19,7 +19,10 @@ Scenarios currently include:
 - large-file handling,
 - shebang/encoding behavior,
 - multi-file workspace interactions,
-- hover, goto-definition, strict diagnostics, and document symbols flows.
+- hover, goto-definition, strict diagnostics, and document symbols flows, and
+- multi-root `workspace/symbol` disambiguation via `workspaceFolderUri`, and
+- workspace-folder removal evicting stale symbols from search results, and
+- deleted-file churn evicting stale search results and definition targets.
 
 ## Running the tests
 
@@ -28,6 +31,11 @@ From the workspace root:
 ```bash
 cargo test -p perl-lsp-ux-tests
 ```
+
+The local `just ux-tests` and `just ux-tests-full` recipes build
+`target/debug/perl-lsp` first and set `PERL_LSP_BIN` automatically. Raw
+`cargo test` runs still require a prebuilt binary or an explicit
+`PERL_LSP_BIN=/path/to/perl-lsp`.
 
 To force integration-gated tests (if present):
 

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -134,43 +134,69 @@ impl UxClient {
         };
 
         // ── LSP handshake ─────────────────────────────────────────────────────
-        client.handshake(&workspace.root_uri, config.timeout)?;
+        client.handshake(workspace, config, config.timeout)?;
 
         Ok(client)
     }
 
-    fn handshake(&self, root_uri: &str, timeout: Duration) -> Result<()> {
-        let init_resp = self.request(
-            "initialize",
-            json!({
-                "processId": null,
-                "rootUri": root_uri,
-                "capabilities": {
-                    "general": {
-                        "positionEncodings": ["utf-16"]
+    fn handshake(
+        &self,
+        workspace: &FakeWorkspace,
+        config: &ScenarioConfig,
+        timeout: Duration,
+    ) -> Result<()> {
+        let workspace_folders = config
+            .workspace_folders
+            .iter()
+            .map(|(relative_path, name)| {
+                Ok(json!({
+                    "uri": workspace.dir_uri(relative_path)?,
+                    "name": name,
+                }))
+            })
+            .collect::<Result<Vec<Value>>>()?;
+
+        let root_uri = if workspace_folders.is_empty() {
+            Value::String(workspace.root_uri.clone())
+        } else {
+            Value::Null
+        };
+
+        let mut params = json!({
+            "processId": null,
+            "rootUri": root_uri,
+            "capabilities": {
+                "general": {
+                    "positionEncodings": ["utf-16"]
+                },
+                "textDocument": {
+                    "hover": {
+                        "contentFormat": ["markdown", "plaintext"]
                     },
-                    "textDocument": {
-                        "hover": {
-                            "contentFormat": ["markdown", "plaintext"]
-                        },
-                        "completion": {
-                            "completionItem": {
-                                "snippetSupport": true
-                            }
-                        },
-                        "formatting": {},
-                        "definition": {},
-                        "publishDiagnostics": {
-                            "relatedInformation": true
+                    "completion": {
+                        "completionItem": {
+                            "snippetSupport": true
                         }
                     },
-                    "window": {
-                        "showMessage": {}
+                    "formatting": {},
+                    "definition": {},
+                    "publishDiagnostics": {
+                        "relatedInformation": true
                     }
+                },
+                "workspace": {
+                    "workspaceFolders": true
+                },
+                "window": {
+                    "showMessage": {}
                 }
-            }),
-            timeout,
-        )?;
+            }
+        });
+        if !workspace_folders.is_empty() {
+            params["workspaceFolders"] = Value::Array(workspace_folders);
+        }
+
+        let init_resp = self.request("initialize", params, timeout)?;
 
         if let Some(err) = init_resp.get("error") {
             return Err(anyhow!("LSP initialize returned error: {}", err));

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -78,6 +78,9 @@ pub struct ScenarioConfig {
     pub extra_env: Vec<(String, Option<String>)>,
     /// Initial workspace files: (relative_path, content) pairs.
     pub workspace_files: Vec<(String, String)>,
+    /// Optional workspace folders for multi-root initialization.
+    /// Each entry is `(relative_path, name)`.
+    pub workspace_folders: Vec<(String, String)>,
 }
 
 impl Default for ScenarioConfig {
@@ -93,6 +96,7 @@ impl Default for ScenarioConfig {
             echo_stderr,
             extra_env: Vec::new(),
             workspace_files: Vec::new(),
+            workspace_folders: Vec::new(),
         }
     }
 }
@@ -125,6 +129,16 @@ impl ScenarioConfig {
         self.workspace_files.push((path.into(), content.into()));
         self
     }
+
+    /// Add a workspace folder for multi-root initialization.
+    pub fn with_workspace_folder(
+        mut self,
+        relative_path: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        self.workspace_folders.push((relative_path.into(), name.into()));
+        self
+    }
 }
 
 /// The main UX test harness.
@@ -146,6 +160,10 @@ impl UxHarness {
         // Write any pre-seeded workspace files.
         for (path, content) in &config.workspace_files {
             workspace.write(path, content)?;
+        }
+
+        for (path, _) in &config.workspace_folders {
+            workspace.ensure_dir(path)?;
         }
 
         let binary_path = resolve_binary()?;
@@ -258,6 +276,97 @@ impl UxHarness {
                 }
             }
         }
+    }
+
+    /// Request workspace symbols (`workspace/symbol`).
+    ///
+    /// Returns the flat list of workspace symbol objects, or an empty vec if
+    /// the server returned null/empty.
+    pub fn workspace_symbols(&self, query: &str) -> Result<Vec<Value>> {
+        let resp = self.client.request(
+            "workspace/symbol",
+            json!({
+                "query": query
+            }),
+            self.config.timeout,
+        )?;
+        if resp.get("error").is_some() {
+            return Err(anyhow!("workspace/symbol returned error: {}", resp["error"]));
+        }
+        match resp["result"].as_array() {
+            Some(symbols) => Ok(symbols.clone()),
+            None => {
+                if resp["result"].is_null() {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![resp["result"].clone()])
+                }
+            }
+        }
+    }
+
+    /// Notify the server that workspace folders changed.
+    ///
+    /// Each tuple is `(relative_path, name)` and is resolved relative to the
+    /// temporary workspace root.
+    pub fn change_workspace_folders(
+        &self,
+        added: &[(&str, &str)],
+        removed: &[(&str, &str)],
+    ) -> Result<()> {
+        let added = added
+            .iter()
+            .map(|(relative_path, name)| {
+                Ok(json!({
+                    "uri": self.workspace.dir_uri(relative_path)?,
+                    "name": name,
+                }))
+            })
+            .collect::<Result<Vec<Value>>>()?;
+
+        let removed = removed
+            .iter()
+            .map(|(relative_path, name)| {
+                Ok(json!({
+                    "uri": self.workspace.dir_uri(relative_path)?,
+                    "name": name,
+                }))
+            })
+            .collect::<Result<Vec<Value>>>()?;
+
+        self.client.notify(
+            "workspace/didChangeWorkspaceFolders",
+            json!({
+                "event": {
+                    "added": added,
+                    "removed": removed,
+                }
+            }),
+        )
+    }
+
+    /// Notify the server about file watcher changes.
+    ///
+    /// Each tuple is `(relative_path, change_type)` where `change_type`
+    /// follows the LSP `FileChangeType` numeric values:
+    /// 1 = Created, 2 = Changed, 3 = Deleted.
+    pub fn notify_watched_files(&self, changes: &[(&str, u32)]) -> Result<()> {
+        let changes = changes
+            .iter()
+            .map(|(relative_path, change_type)| {
+                json!({
+                    "uri": self.workspace.uri(relative_path),
+                    "type": change_type,
+                })
+            })
+            .collect::<Vec<Value>>();
+
+        self.client.notify(
+            "workspace/didChangeWatchedFiles",
+            json!({
+                "changes": changes,
+            }),
+        )
     }
 
     /// Wait up to `timeout` for a `textDocument/publishDiagnostics` notification

--- a/crates/perl-lsp-ux-tests/src/workspace.rs
+++ b/crates/perl-lsp-ux-tests/src/workspace.rs
@@ -41,6 +41,24 @@ impl FakeWorkspace {
         Ok(())
     }
 
+    /// Ensure a directory exists at `relative_path`.
+    pub fn ensure_dir(&self, relative_path: &str) -> Result<()> {
+        let path = self.dir.path().join(relative_path);
+        fs::create_dir_all(&path)
+            .with_context(|| format!("Failed to create workspace directory {:?}", path))?;
+        Ok(())
+    }
+
+    /// Delete a file at `relative_path` if it exists.
+    pub fn delete(&self, relative_path: &str) -> Result<()> {
+        let path = self.dir.path().join(relative_path);
+        if path.exists() {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to delete workspace file {:?}", path))?;
+        }
+        Ok(())
+    }
+
     /// Get the full `file://` URI for a relative path.
     pub fn uri(&self, relative_path: &str) -> String {
         let path = self.dir.path().join(relative_path);
@@ -51,6 +69,14 @@ impl FakeWorkspace {
                 format!("{}/{}", self.root_uri.trim_end_matches('/'), relative_path)
             }
         }
+    }
+
+    /// Get the full `file://` URI for a relative directory path.
+    pub fn dir_uri(&self, relative_path: &str) -> Result<String> {
+        let path = self.dir.path().join(relative_path);
+        Url::from_directory_path(&path)
+            .map(|url| url.to_string())
+            .map_err(|_| anyhow::anyhow!("Failed to produce file:// URI for directory {:?}", path))
     }
 
     /// Get the filesystem path for a relative path.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -1,0 +1,116 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 15 — workspace symbol search across multiple workspace folders.
+//!
+//! Verifies that the UX harness can drive `workspace/symbol` in a multi-root
+//! workspace and that same-named symbols from different folders remain
+//! disambiguatable via `workspaceFolderUri`.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const RUNNER_A: &str = "\
+package Runner;\n\
+\n\
+sub run {\n\
+    return 'from-a';\n\
+}\n\
+\n\
+1;\n\
+";
+
+const RUNNER_B: &str = "\
+package Runner;\n\
+\n\
+sub run {\n\
+    return 'from-b';\n\
+}\n\
+\n\
+1;\n\
+";
+
+fn matching_run_symbols(symbols: &[Value]) -> Vec<&Value> {
+    symbols.iter().filter(|symbol| symbol["name"].as_str() == Some("run")).collect()
+}
+
+#[test]
+fn scenario_15_workspace_symbol_multi_root_disambiguation() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_15: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .env("PERL_LSP_WORKSPACE", "1")
+            .with_workspace_folder("svc-a", "svc-a")
+            .with_workspace_folder("svc-b", "svc-b")
+            .with_file("svc-a/lib/Runner.pm", RUNNER_A)
+            .with_file("svc-b/lib/Runner.pm", RUNNER_B),
+    )
+    .expect("Failed to create UX harness");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut latest_symbols = Vec::new();
+
+    while Instant::now() < deadline {
+        latest_symbols = harness
+            .workspace_symbols("run")
+            .expect("workspace/symbol must not return an error in multi-root mode");
+
+        let run_symbols = matching_run_symbols(&latest_symbols);
+        let folder_uris: BTreeSet<&str> = run_symbols
+            .iter()
+            .filter_map(|symbol| symbol.get("workspaceFolderUri").and_then(|uri| uri.as_str()))
+            .collect();
+
+        if run_symbols.len() >= 2
+            && folder_uris.len() >= 2
+            && folder_uris.iter().any(|uri| uri.contains("/svc-a/"))
+            && folder_uris.iter().any(|uri| uri.contains("/svc-b/"))
+        {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    let run_symbols = matching_run_symbols(&latest_symbols);
+    assert!(
+        run_symbols.len() >= 2,
+        "Expected workspace/symbol to find same-named 'run' entries across both workspace \
+         folders, got: {:?}",
+        latest_symbols
+    );
+
+    let folder_uris: BTreeSet<&str> = run_symbols
+        .iter()
+        .filter_map(|symbol| symbol.get("workspaceFolderUri").and_then(|uri| uri.as_str()))
+        .collect();
+
+    assert!(
+        folder_uris.len() >= 2,
+        "Expected workspace symbols to carry distinct workspaceFolderUri values for multi-root \
+         disambiguation, got: {:?}",
+        latest_symbols
+    );
+    assert!(
+        folder_uris.iter().any(|uri| uri.contains("/svc-a/")),
+        "Expected one workspace symbol to point at svc-a, got: {:?}",
+        folder_uris
+    );
+    assert!(
+        folder_uris.iter().any(|uri| uri.contains("/svc-b/")),
+        "Expected one workspace symbol to point at svc-b, got: {:?}",
+        folder_uris
+    );
+
+    harness.assert_no_crash();
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
@@ -1,0 +1,121 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 16 — workspace folder removal updates workspace-symbol results.
+//!
+//! Verifies that removing a folder via `workspace/didChangeWorkspaceFolders`
+//! evicts its symbols from `workspace/symbol` results instead of leaving stale
+//! cross-folder state behind.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const MODULE_A: &str = "\
+package ModuleA;\n\
+\n\
+sub alpha {\n\
+    return 'a';\n\
+}\n\
+\n\
+1;\n\
+";
+
+const MODULE_B: &str = "\
+package ModuleB;\n\
+\n\
+sub beta {\n\
+    return 'b';\n\
+}\n\
+\n\
+1;\n\
+";
+
+fn contains_symbol_in_folder(symbols: &[Value], symbol_name: &str, folder_fragment: &str) -> bool {
+    symbols.iter().any(|symbol| {
+        symbol["name"].as_str() == Some(symbol_name)
+            && symbol
+                .pointer("/location/uri")
+                .and_then(|uri| uri.as_str())
+                .is_some_and(|uri| uri.contains(folder_fragment))
+    })
+}
+
+#[test]
+fn scenario_16_removed_workspace_folder_symbols_disappear() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_16: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .env("PERL_LSP_WORKSPACE", "1")
+            .with_workspace_folder("svc-a", "svc-a")
+            .with_workspace_folder("svc-b", "svc-b")
+            .with_file("svc-a/lib/ModuleA.pm", MODULE_A)
+            .with_file("svc-b/lib/ModuleB.pm", MODULE_B),
+    )
+    .expect("Failed to create UX harness");
+
+    let before_deadline = Instant::now() + Duration::from_secs(10);
+    let mut symbols_before = Vec::new();
+    while Instant::now() < before_deadline {
+        symbols_before = harness
+            .workspace_symbols("Module")
+            .expect("workspace/symbol must not error before folder removal");
+        if contains_symbol_in_folder(&symbols_before, "ModuleA", "/svc-a/")
+            && contains_symbol_in_folder(&symbols_before, "ModuleB", "/svc-b/")
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        contains_symbol_in_folder(&symbols_before, "ModuleA", "/svc-a/"),
+        "Expected ModuleA to be present before folder removal, got: {:?}",
+        symbols_before
+    );
+    assert!(
+        contains_symbol_in_folder(&symbols_before, "ModuleB", "/svc-b/"),
+        "Expected ModuleB to be present before folder removal, got: {:?}",
+        symbols_before
+    );
+
+    harness
+        .change_workspace_folders(&[], &[("svc-b", "svc-b")])
+        .expect("workspace folder removal notification must not fail");
+
+    let after_deadline = Instant::now() + Duration::from_secs(10);
+    let mut symbols_after = Vec::new();
+    while Instant::now() < after_deadline {
+        symbols_after = harness
+            .workspace_symbols("Module")
+            .expect("workspace/symbol must not error after folder removal");
+
+        if contains_symbol_in_folder(&symbols_after, "ModuleA", "/svc-a/")
+            && !contains_symbol_in_folder(&symbols_after, "ModuleB", "/svc-b/")
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        contains_symbol_in_folder(&symbols_after, "ModuleA", "/svc-a/"),
+        "Expected ModuleA to remain after removing svc-b, got: {:?}",
+        symbols_after
+    );
+    assert!(
+        !contains_symbol_in_folder(&symbols_after, "ModuleB", "/svc-b/"),
+        "Expected ModuleB symbols to disappear after removing svc-b, got: {:?}",
+        symbols_after
+    );
+
+    harness.assert_no_crash();
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
@@ -1,0 +1,118 @@
+// Test infrastructure — allow test-friendly patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+//! Scenario 17 — deleting a watched file evicts stale symbols and definition targets.
+//!
+//! Verifies that a real `workspace/didChangeWatchedFiles` Deleted event removes
+//! stale search results and cross-file definitions from the UX surface.
+
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const MODULE_SOURCE: &str = "\
+package ModuleGone;\n\
+\n\
+sub gone_value_4068 {\n\
+    return 42;\n\
+}\n\
+\n\
+1;\n\
+";
+
+const SCRIPT_SOURCE: &str = "\
+use strict;\n\
+use warnings;\n\
+use lib 'lib';\n\
+use ModuleGone;\n\
+\n\
+my $value = ModuleGone::gone_value_4068();\n\
+print \"$value\\n\";\n\
+";
+
+fn symbol_names(symbols: &[Value]) -> Vec<&str> {
+    symbols.iter().filter_map(|symbol| symbol["name"].as_str()).collect()
+}
+
+#[test]
+fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_17: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .env("PERL_LSP_WORKSPACE", "1")
+            .with_file("main.pl", SCRIPT_SOURCE)
+            .with_file("lib/ModuleGone.pm", MODULE_SOURCE),
+    )
+    .expect("Failed to create UX harness");
+
+    harness.open_file("main.pl", SCRIPT_SOURCE).expect("didOpen should succeed");
+
+    let before_deadline = Instant::now() + Duration::from_secs(10);
+    let mut symbols_before = Vec::new();
+    let mut defs_before = Vec::new();
+    while Instant::now() < before_deadline {
+        symbols_before = harness
+            .workspace_symbols("gone_value_4068")
+            .expect("workspace/symbol must not error before delete");
+        defs_before =
+            harness.definition("main.pl", 5, 25).expect("definition must not error before delete");
+
+        if !symbols_before.is_empty() && !defs_before.is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        !symbols_before.is_empty(),
+        "Expected gone_value_4068 to be searchable before delete, got names {:?}",
+        symbol_names(&symbols_before)
+    );
+    assert!(
+        !defs_before.is_empty(),
+        "Expected definition to resolve before delete, got {:?}",
+        defs_before
+    );
+
+    harness.workspace.delete("lib/ModuleGone.pm").expect("module delete should succeed");
+    harness
+        .notify_watched_files(&[("lib/ModuleGone.pm", 3)])
+        .expect("didChangeWatchedFiles Deleted notification must not fail");
+
+    let after_deadline = Instant::now() + Duration::from_secs(10);
+    let mut symbols_after = Vec::new();
+    let mut defs_after = Vec::new();
+    while Instant::now() < after_deadline {
+        symbols_after = harness
+            .workspace_symbols("gone_value_4068")
+            .expect("workspace/symbol must not error after delete");
+        defs_after =
+            harness.definition("main.pl", 5, 25).expect("definition must not error after delete");
+
+        if symbols_after.is_empty() && defs_after.is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    assert!(
+        symbols_after.is_empty(),
+        "Expected deleted symbol gone_value_4068 to disappear from workspace/symbol, got names {:?}",
+        symbol_names(&symbols_after)
+    );
+    assert!(
+        defs_after.is_empty(),
+        "Expected deleted module definition target to disappear after delete, got {:?}",
+        defs_after
+    );
+
+    harness.assert_no_crash();
+}

--- a/docs/project/protocols/verification.md
+++ b/docs/project/protocols/verification.md
@@ -14,6 +14,10 @@ just ci-gate  # ~2-5 min
 just ci-full  # ~10-20 min
 ```
 
+`just ci-full` is the automated release-confidence lane. It should include the
+broader integration surfaces that are too expensive for Tier A, including the
+`perl-lsp-ux-tests` first-5-minutes workflow harness.
+
 ## Tier C: Real User Confirmation
 
 Manual editor smoke test: diagnostics, completion, hover, go-to-definition, rename

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -7,6 +7,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
+- **UX workflow harness**: 17 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->

--- a/docs/reference/UX_TESTING.md
+++ b/docs/reference/UX_TESTING.md
@@ -8,10 +8,10 @@ in each scenario — not just "didn't crash" but "returned a useful response."
 ## Quick Start
 
 ```bash
-# Run all base scenarios (scenarios 01–09, excluding large-file):
+# Run all default UX scenarios (currently 17 scenario files):
 just ux-tests
 
-# Run full suite including large-file scenario:
+# Run full suite including the integration-only 10k-line large-file scenario:
 just ux-tests-full
 
 # Run with verbose server stderr output:
@@ -21,7 +21,11 @@ UX_TEST_ECHO_STDERR=1 just ux-tests
 cargo test -p perl-lsp-ux-tests --test ux_scenario_01_simple_file
 ```
 
-## V1 Scenarios
+`just ux-tests` and `just ux-tests-full` build `target/debug/perl-lsp` first and
+export `PERL_LSP_BIN` automatically. Direct `cargo test` invocations still need
+either a prebuilt binary or an explicit `PERL_LSP_BIN=/path/to/perl-lsp`.
+
+## Current Scenarios
 
 | # | Scenario | What it tests |
 |---|----------|---------------|
@@ -34,6 +38,17 @@ cargo test -p perl-lsp-ux-tests --test ux_scenario_01_simple_file
 | 07 | Multi-file workspace | Multiple modules + cross-file definition |
 | 08 | Shebang detection | Files without `.pl` extension but `languageId=perl` |
 | 09 | BOM and encoding | UTF-8 BOM, `use utf8`, Unicode in comments |
+| 10 | Go-to-definition | Request succeeds end-to-end and returns location-or-empty without crashing |
+| 11 | Hover | Request succeeds end-to-end and returns useful structure-or-empty without crashing |
+| 12 | Strict diagnostics | `use strict` / `use warnings` diagnostics surface with expected codes |
+| 13 | Document symbols | Parsable files return structured document symbols |
+| 14 | `@INC` conformance | PL701, hover, and goto-definition stay consistent across 5 module-resolution modes |
+| 15 | Workspace symbols | `workspace/symbol` finds same-named symbols across workspace folders and carries `workspaceFolderUri` |
+| 16 | Folder removal | removing a workspace folder evicts its symbols from `workspace/symbol` results |
+| 17 | Deleted file churn | a `didChangeWatchedFiles` Deleted event removes stale symbols and definition targets |
+
+`just ux-tests` runs every default scenario above. `just ux-tests-full` adds the
+feature-gated 10k-line large-file case from Scenario 06.
 
 ## How to Add a New Scenario
 

--- a/justfile
+++ b/justfile
@@ -791,6 +791,7 @@ ci-full:
     @just ci-test-lsp
     @just ci-lsp-microcrates
     @just ci-lsp-bdd
+    @just ux-tests
     @just ci-docs
     @echo "✅ Full CI passed!"
 
@@ -915,19 +916,26 @@ ci-lsp-smoke-e2e:
     @echo "✅ LSP smoke E2E passed"
 
 # UX regression test harness — systematic first-5-minutes scenario testing.
-# Runs all 9 base scenarios (scenarios 01-09, excluding the large-file integration-test tier).
-# For the full large-file tier: just ux-tests-full
+# Runs all default `perl-lsp-ux-tests` scenarios (currently 17 scenario files).
+# `ux-tests-full` adds the integration-only 10k-line large-file coverage.
 ux-tests:
     @echo "Running UX regression test harness (base scenarios)..."
+    @env -u RUSTC_WRAPPER CARGO_BUILD_JOBS=1 \
+        cargo build -p perl-lsp-rs --bin perl-lsp
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        PERL_LSP_BIN={{justfile_directory()}}/target/debug/perl-lsp \
         cargo test -p perl-lsp-ux-tests -- --test-threads=1
     @echo "UX tests passed"
 
-# UX regression test harness — full suite including large-file scenario.
-# Slower (~5-10 min).  Run before releases or after large LSP changes.
+# UX regression test harness — full suite including the integration-only
+# 10k-line large-file scenario. Slower (~5-10 min). Run before releases or
+# after large LSP changes.
 ux-tests-full:
     @echo "Running UX regression test harness (full, including large-file)..."
+    @env -u RUSTC_WRAPPER CARGO_BUILD_JOBS=1 \
+        cargo build -p perl-lsp-rs --bin perl-lsp
     @env -u RUSTC_WRAPPER RUST_TEST_THREADS=1 CARGO_BUILD_JOBS=1 \
+        PERL_LSP_BIN={{justfile_directory()}}/target/debug/perl-lsp \
         cargo test -p perl-lsp-ux-tests --features integration-test -- --test-threads=1
     @echo "UX tests (full) passed"
 

--- a/xtask/src/tasks/update_status.rs
+++ b/xtask/src/tasks/update_status.rs
@@ -910,9 +910,23 @@ fn format_crate_quality_table(
     lines.join("\n")
 }
 
+fn count_ux_scenarios(root: &Path) -> usize {
+    let tests_dir = root.join("crates/perl-lsp-ux-tests/tests");
+    let Ok(entries) = fs::read_dir(tests_dir) else {
+        return 0;
+    };
+
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.starts_with("ux_scenario_") && name.ends_with(".rs"))
+        .count()
+}
+
 fn generate_quality_status(root: &Path, original: &str) -> Result<String> {
     let mutation_by_crate = collect_per_crate_mutation(root);
     let tests_by_crate = collect_per_crate_test_counts(root);
+    let ux_scenarios = count_ux_scenarios(root);
 
     let has_mutation_data = !mutation_by_crate.is_empty();
     let mutation_note = if has_mutation_data {
@@ -923,6 +937,9 @@ fn generate_quality_status(root: &Path, original: &str) -> Result<String> {
 
     let bullets_content = format!(
         "- **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing\n\
+         - **UX workflow harness**: {ux_scenarios} scenario files in `perl-lsp-ux-tests`; \
+           `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds \
+           the integration-only 10k-line large-file case\n\
          - **Mutation testing**: {mutation_note}\n\
          - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
     );

--- a/xtask/tests/ci_full_ux_lane_tests.rs
+++ b/xtask/tests/ci_full_ux_lane_tests.rs
@@ -1,0 +1,68 @@
+//! Release-confidence lane wiring tests for automated UX coverage.
+//!
+//! Guards the contract that `just ci-full` includes the `perl-lsp-ux-tests`
+//! harness so local release-confidence runs do not silently miss the same UX
+//! surface that CI exercises.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn project_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.pop();
+    dir
+}
+
+#[test]
+fn test_ci_full_runs_ux_tests() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let justfile = fs::read_to_string(root.join("justfile"))?;
+
+    let ci_full_start =
+        justfile.find("\nci-full:\n").ok_or("ci-full recipe must exist in justfile")?;
+    let ci_full_body = &justfile[ci_full_start..];
+    let next_recipe = ci_full_body
+        .find("\n# Local CI parity")
+        .ok_or("ci-full recipe terminator marker must exist in justfile")?;
+    let ci_full_body = &ci_full_body[..next_recipe];
+
+    assert!(
+        ci_full_body.contains("@just ux-tests"),
+        "ci-full must run `just ux-tests` so the local release-confidence lane \
+         includes automated first-5-minutes UX workflows.\n\
+         Current ci-full recipe:\n{}",
+        ci_full_body
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_ux_tests_recipe_builds_and_exports_binary() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let justfile = fs::read_to_string(root.join("justfile"))?;
+
+    let ux_tests_start =
+        justfile.find("\nux-tests:\n").ok_or("ux-tests recipe must exist in justfile")?;
+    let ux_tests_body = &justfile[ux_tests_start..];
+    let next_recipe = ux_tests_body
+        .find("\n# @INC consumer-consistency conformance harness.")
+        .ok_or("ux-tests recipe terminator marker must exist in justfile")?;
+    let ux_tests_body = &ux_tests_body[..next_recipe];
+
+    assert!(
+        ux_tests_body.contains("cargo build -p perl-lsp-rs --bin perl-lsp"),
+        "ux-tests must build the perl-lsp binary explicitly so local runs do not depend on a \
+         prebuilt artifact.\nCurrent ux-tests recipe:\n{}",
+        ux_tests_body
+    );
+    assert!(
+        ux_tests_body.contains("PERL_LSP_BIN={{justfile_directory()}}/target/debug/perl-lsp"),
+        "ux-tests must export an absolute PERL_LSP_BIN rooted at the justfile so the harness \
+         does not depend on the crate working directory.\n\
+         Current ux-tests recipe:\n{}",
+        ux_tests_body
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add the UX harness to `ci-full` and guard the lane in `xtask`
- make `just ux-tests` build and export an absolute `PERL_LSP_BIN` so the local lane is deterministic
- extend the UX harness with multi-root/workspace-folder and watched-file churn coverage, including scenarios 15-17
- surface the workflow harness in generated quality status and refresh the supporting docs

## Validation
- `env -u RUSTC_WRAPPER cargo test -p xtask --test ci_full_ux_lane_tests`
- `env -u RUSTC_WRAPPER cargo test -p perl-lsp-ux-tests --test ux_scenario_17_deleted_file_churn -- --test-threads=1 --nocapture`
- `env -u RUSTC_WRAPPER cargo xtask update-status --check --only quality`
- `env -u RUSTC_WRAPPER just ux-tests`
- local pre-push `nix develop -c just pr-fast`