### PR TITLE
feat(perlcritic): expose critic state in health output (#4114)

### DIFF
--- a/crates/perl-lsp/README.md
+++ b/crates/perl-lsp/README.md
@@ -42,7 +42,7 @@ perllsp --health
 ```bash
 perllsp --stdio           # stdio mode (default, for editor integration)
 perllsp --socket --port 9257   # TCP socket mode
-perllsp --health          # health check
+perllsp --health          # health check + Perl::Critic status
 perllsp --version         # version info
 ```
 

--- a/crates/perl-lsp/src/cli.rs
+++ b/crates/perl-lsp/src/cli.rs
@@ -11,7 +11,7 @@ use perl_lsp_launcher::{
     logging_filter, parse_args, port_in_use_message, shell_completion, should_enable_logging,
 };
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -43,7 +43,7 @@ where
         }
         LaunchAction::Health => {
             let use_color = is_terminal_stdout();
-            println!("{}", format_health_output(env!("CARGO_PKG_VERSION"), use_color));
+            println!("{}", format_health_report(env!("CARGO_PKG_VERSION"), use_color));
             0
         }
         LaunchAction::Info => {
@@ -87,6 +87,129 @@ where
             0
         }
     }
+}
+
+fn format_health_report(version: &str, use_color: bool) -> String {
+    let mut lines = vec![format_health_output(version, use_color), String::new()];
+
+    let cwd = match env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(error) => {
+            lines.push(format!("Perl::Critic: unavailable (failed to read cwd: {error})"));
+            return lines.join("\n");
+        }
+    };
+
+    let mut config = perl_lsp_config::ServerConfig::default();
+    let mut config_error = None;
+    match perl_lsp_config::load_project_config(&cwd) {
+        Ok(Some(project)) => {
+            project.apply_to_server_config(&mut config);
+        }
+        Ok(None) => {}
+        Err(error) => {
+            config_error = Some(error);
+        }
+    }
+
+    let perlcritic_path = command_path("perlcritic");
+    let configured_profile =
+        config.perlcritic_profile.as_ref().map(|profile| resolve_profile_path(&cwd, profile));
+    let discovered_profile =
+        if configured_profile.is_none() { discover_perlcritic_profile(&cwd) } else { None };
+    let selected_profile = configured_profile
+        .as_ref()
+        .or(discovered_profile.as_ref())
+        .map(|path| path.display().to_string());
+
+    let status = if !config.perlcritic_enabled {
+        "disabled".to_string()
+    } else if perlcritic_path.is_none() {
+        "enabled (binary missing)".to_string()
+    } else if let Some(profile) = configured_profile.as_ref() {
+        if profile.exists() {
+            "enabled (healthy)".to_string()
+        } else {
+            "enabled (bad profile)".to_string()
+        }
+    } else {
+        "enabled (healthy)".to_string()
+    };
+
+    lines.push("Perl::Critic:".to_string());
+    lines.push(format!("  status: {status}"));
+    lines.push(format!("  enabled: {}", config.perlcritic_enabled));
+    lines.push(format!(
+        "  binary: {}",
+        perlcritic_path.unwrap_or_else(|| "not found on PATH".to_string())
+    ));
+    lines.push(format!("  severity: {}", config.perlcritic_severity));
+    lines.push(format!(
+        "  configured_profile: {}",
+        config.perlcritic_profile.unwrap_or_else(|| "<none>".to_string())
+    ));
+    lines.push(format!(
+        "  resolved_profile: {}",
+        selected_profile.unwrap_or_else(|| "<none>".to_string())
+    ));
+    lines.push(format!(
+        "  walkup_discovery: {}",
+        if discovered_profile.is_some() { "found" } else { "not used/found" }
+    ));
+
+    if let Some(profile) = configured_profile.as_ref() {
+        if !profile.exists() {
+            lines
+                .push(format!("  last_check: profile path does not exist ({})", profile.display()));
+        }
+    }
+
+    if let Some(error) = config_error {
+        lines.push(format!("  config_warning: {error}"));
+    }
+
+    lines.join("\n")
+}
+
+fn resolve_profile_path(cwd: &Path, profile: &str) -> PathBuf {
+    let configured = PathBuf::from(profile);
+    if configured.is_absolute() { configured } else { cwd.join(configured) }
+}
+
+fn discover_perlcritic_profile(start: &Path) -> Option<PathBuf> {
+    let mut current = Some(start.to_path_buf());
+    while let Some(dir) = current {
+        let candidate = dir.join(".perlcriticrc");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        current = dir.parent().map(std::path::Path::to_path_buf);
+    }
+    None
+}
+
+fn command_path(program: &str) -> Option<String> {
+    if Path::new(program).is_file() {
+        return Some(program.to_string());
+    }
+    env::var_os("PATH").and_then(|paths| {
+        env::split_paths(&paths).find_map(|path| {
+            #[cfg(windows)]
+            {
+                let exe = path.join(format!("{program}.exe"));
+                if exe.is_file() {
+                    return Some(exe.to_string_lossy().to_string());
+                }
+                let bat = path.join(format!("{program}.bat"));
+                if bat.is_file() {
+                    return Some(bat.to_string_lossy().to_string());
+                }
+            }
+
+            let candidate = path.join(program);
+            if candidate.is_file() { Some(candidate.to_string_lossy().to_string()) } else { None }
+        })
+    })
 }
 
 fn invocation_name(args: &[std::ffi::OsString]) -> String {

--- a/crates/perl-lsp/tests/cli_smoke.rs
+++ b/crates/perl-lsp/tests/cli_smoke.rs
@@ -3,7 +3,14 @@ use assert_cmd::cargo::cargo_bin_cmd;
 #[test]
 fn health_prints_ok() {
     let mut cmd = cargo_bin_cmd!("perl-lsp");
-    cmd.arg("--health").assert().success().stdout(predicates::str::contains("ok"));
+    cmd.arg("--health")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("ok"))
+        .stdout(predicates::str::contains("Perl::Critic:"))
+        .stdout(predicates::str::contains("status:"))
+        .stdout(predicates::str::contains("enabled:"))
+        .stdout(predicates::str::contains("severity:"));
 }
 
 #[test]

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -527,7 +527,7 @@ Flags passed when launching the `perl-lsp` binary. Source:
 
 | Flag | Description |
 |---|---|
-| `--health` | Print `ok <version>` and exit |
+| `--health` | Print `ok <version>` plus Perl::Critic health status (enabled, binary path, severity, profile resolution) and exit |
 | `--info` | Print version, parser, profile, feature count, and executable path |
 | `--version` | Print version string and exit |
 | `--features-json` | Print the active feature catalog as JSON and exit |


### PR DESCRIPTION
### Motivation
- Improve observability of the Perl::Critic integration by making `--health` surface the runtime Critic state so users can quickly answer whether Critic is enabled, found, and which profile/severity is in effect.
- This implements the first follow-up (health/doctor visibility) to the earlier perlcritic work to avoid inferring state from scattered warnings.

### Description
- Expanded `perllsp --health` to a structured report via a new `format_health_report` function in `crates/perl-lsp/src/cli.rs` that prints a `Perl::Critic` section alongside the one-line health line.
- Health now reports `status` classification (`disabled`, `enabled (binary missing)`, `enabled (bad profile)`, `enabled (healthy)`), `enabled`, resolved `binary` path, `severity`, `configured_profile`, `resolved_profile`, and `walkup_discovery` results, and surfaces project-config parse failures as `config_warning`.
- Added small helper functions in `crates/perl-lsp/src/cli.rs`: `resolve_profile_path`, `discover_perlcritic_profile`, and a cross-platform `command_path` that includes Windows `.exe`/`.bat` handling.
- Updated docs in `docs/reference/CONFIG.md` and `crates/perl-lsp/README.md` to document the richer `--health` output and updated the CLI smoke test `crates/perl-lsp/tests/cli_smoke.rs` to assert presence of the new Critic health section.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Executed the smoke test suite with `cargo test -p perl-lsp-rs --test cli_smoke` and observed all tests pass (`13 passed; 0 failed`).
- Manually exercised the new output with `cargo run -p perl-lsp-rs -- --health` to confirm the `Perl::Critic` section prints and reflects local state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f2cd6448333a03dd4c78325774f)