### PR TITLE
feat(perlcritic): expand safe fix aliases and health status detail (#4114)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -192,14 +192,18 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policy aliases for two-arg open.
-                    "InputOutput::RequireBriefOpen" | "InputOutput::RequireThreeArgOpen" => {
+                    "InputOutput::RequireBriefOpen"
+                    | "InputOutput::RequireThreeArgOpen"
+                    | "InputOutput::ProhibitTwoArgOpen" => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policies for missing strict/warnings.
-                    "TestingAndDebugging::RequireUseStrict" => {
+                    "TestingAndDebugging::RequireUseStrict"
+                    | "TestingAndDebugging::ProhibitNoStrict" => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
-                    "TestingAndDebugging::RequireUseWarnings" => {
+                    "TestingAndDebugging::RequireUseWarnings"
+                    | "TestingAndDebugging::ProhibitNoWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // Perl::Critic policy alias for unused variables.
@@ -524,6 +528,49 @@ mod tests {
         assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
         assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
+    }
+
+    #[test]
+    fn test_additional_perlcritic_aliases_route_to_existing_safe_fixes() {
+        let source = "open FH, $path;\nprint $unused;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("InputOutput::ProhibitTwoArgOpen".to_string()),
+                message: "Two-argument open used".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::ProhibitNoStrict".to_string()),
+                message: "Code disables strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("TestingAndDebugging::ProhibitNoWarnings".to_string()),
+                message: "Code disables warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
     }
 
     #[test]

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -413,10 +413,13 @@ fn is_fixable_diagnostic(code: &str) -> bool {
     if matches!(
         code,
         "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::ProhibitNoStrict"
             | "TestingAndDebugging::RequireUseWarnings"
+            | "TestingAndDebugging::ProhibitNoWarnings"
             | "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
+            | "InputOutput::ProhibitTwoArgOpen"
             | "Variables::ProhibitUnusedVariables"
     ) {
         return true;
@@ -586,8 +589,11 @@ mod tests {
         assert!(is_fixable_diagnostic("PL502"));
         assert!(is_fixable_diagnostic("PL503"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::ProhibitNoStrict"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
+        assert!(is_fixable_diagnostic("TestingAndDebugging::ProhibitNoWarnings"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
+        assert!(is_fixable_diagnostic("InputOutput::ProhibitTwoArgOpen"));
         assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
     }
 

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -995,8 +995,11 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
         "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
+            | "InputOutput::ProhibitTwoArgOpen"
             | "TestingAndDebugging::RequireUseStrict"
+            | "TestingAndDebugging::ProhibitNoStrict"
             | "TestingAndDebugging::RequireUseWarnings"
+            | "TestingAndDebugging::ProhibitNoWarnings"
             | "Variables::ProhibitUnusedVariables"
     )
 }

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -209,14 +209,20 @@ export class OnboardingManager {
     const label = 'perlcritic';
     const perlcriticConfig = vscode.workspace.getConfiguration('perl-lsp').get<any>('perlcritic', {});
     const enabled = Boolean(perlcriticConfig?.enabled);
+    const severity = Number.isFinite(perlcriticConfig?.severity)
+      ? Number(perlcriticConfig.severity)
+      : 3;
     const profile = typeof perlcriticConfig?.profile === 'string' ? perlcriticConfig.profile.trim() : '';
+    let profileState = profile
+      ? `profile: ${profile}`
+      : 'profile: auto-discovery (.perlcriticrc walk-up)';
 
     if (!enabled) {
       return {
         label,
         ok: true,
         status: HealthCheckStatus.Ok,
-        detail: 'Perl::Critic is disabled',
+        detail: `Perl::Critic disabled (severity: ${severity}; ${profileState})`,
       };
     }
 
@@ -225,17 +231,23 @@ export class OnboardingManager {
         label,
         ok: false,
         status: HealthCheckStatus.Warning,
-        detail: `Configured perlcritic profile was not found: ${profile}`,
+        detail:
+          `Perl::Critic enabled but configured profile was not found: ${profile} ` +
+          `(severity: ${severity}; walk-up disabled while explicit profile is set)`,
       };
     }
 
     try {
-      await this._execCheck('perlcritic', ['--version']);
+      const { stdout } = await this._execCheck('perlcritic', ['--version']);
+      const version = stdout.trim() || '(unknown version)';
+      if (profile) {
+        profileState = `profile: ${profile}`;
+      }
       return {
         label,
         ok: true,
         status: HealthCheckStatus.Ok,
-        detail: 'perlcritic found',
+        detail: `Perl::Critic enabled (binary: ${version}; severity: ${severity}; ${profileState})`,
       };
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -244,8 +256,8 @@ export class OnboardingManager {
         ok: false,
         status: HealthCheckStatus.Warning,
         detail:
-          `Perl::Critic is enabled but perlcritic was not found on PATH. (${msg}) ` +
-          'Install via: cpanm Perl::Critic',
+          `Perl::Critic enabled but perlcritic was not found on PATH (${msg}). ` +
+          `Current settings: severity ${severity}; ${profileState}. Install via: cpanm Perl::Critic`,
       };
     }
   }

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import {
   OnboardingManager,
   HealthCheckResult,
@@ -142,6 +143,53 @@ describe('OnboardingManager.checkPerltidyInstalled', () => {
     const result = await mgr.checkPerltidyInstalled();
     expect(result.ok).toBe(false);
     expect(result.status).toBe(HealthCheckStatus.Warning);
+  });
+});
+
+describe('OnboardingManager.checkPerlcriticSetup', () => {
+  const workspaceGetConfiguration = vscode.workspace
+    .getConfiguration as jest.MockedFunction<typeof vscode.workspace.getConfiguration>;
+
+  afterEach(() => {
+    workspaceGetConfiguration.mockReset();
+  });
+
+  test('reports disabled state with config summary', async () => {
+    workspaceGetConfiguration.mockReturnValue({
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        if (key === 'perlcritic') {
+          return { enabled: false, severity: 4, profile: '' };
+        }
+        return defaultValue;
+      }),
+    } as any);
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = await mgr.checkPerlcriticSetup();
+
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('Perl::Critic disabled');
+    expect(result.detail).toContain('severity: 4');
+  });
+
+  test('reports explicit profile-missing warning when enabled', async () => {
+    const missingProfile = '/tmp/definitely-missing-perlcriticrc';
+    workspaceGetConfiguration.mockReturnValue({
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        if (key === 'perlcritic') {
+          return { enabled: true, severity: 2, profile: missingProfile };
+        }
+        return defaultValue;
+      }),
+    } as any);
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = await mgr.checkPerlcriticSetup();
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(HealthCheckStatus.Warning);
+    expect(result.detail).toContain('configured profile was not found');
+    expect(result.detail).toContain(missingProfile);
   });
 });
 


### PR DESCRIPTION
### Motivation

- Increase the usable, low-risk Perl::Critic quick-fix surface by recognizing additional policy aliases that map to existing deterministic edits.  
- Improve observability so the extension health check clearly communicates perlcritic enabled/disabled state, configured severity, profile mode (explicit vs walk-up), and binary resolution status.

### Description

- Add support for additional Perl::Critic alias policies (`InputOutput::ProhibitTwoArgOpen`, `TestingAndDebugging::ProhibitNoStrict`, `TestingAndDebugging::ProhibitNoWarnings`) in code-action routing so they reuse existing safe quick fixes in `crates/perl-lsp-code-actions/src/code_actions.rs`.  
- Keep the `fixable` metadata in sync by updating the fixable-policy registries used by pull and runtime diagnostics in `crates/perl-lsp/src/features/diagnostics/pull.rs` and `crates/perl-lsp/src/runtime/diagnostics.rs`.  
- Improve VS Code onboarding health output in `vscode-extension/src/onboarding.ts` to include `severity`, an explicit `profile` state (explicit path vs auto-discovery), and the resolved `perlcritic` version when available, and clarify messages for missing-profile and missing-binary cases.  
- Add focused unit tests: a new quick-fix alias routing test in `crates/perl-lsp-code-actions/src/code_actions.rs` and health-check tests in `vscode-extension/src/test/onboarding.test.ts` that assert disabled-state summary and configured-profile missing warning.

### Testing

- Ran formatting: `cargo fmt --all` and it completed successfully.  
- Ran unit test: `cargo test -p perl-lsp-code-actions test_additional_perlcritic_aliases_route_to_existing_safe_fixes` and it passed.  
- Ran unit test: `cargo test -p perl-lsp-rs --lib features::diagnostics::pull::tests::perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data` and it passed.  
- Ran extension tests: `npm test -- --runTestsByPath src/test/onboarding.test.ts --testNamePattern checkPerlcriticSetup` (from `vscode-extension/`) and the targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f2cd6448333a03dd4c78325774f)