### PR TITLE
feat(perlcritic): expose health state and extend alias coverage (#4113)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -184,7 +184,8 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // Perl::Critic policy alias for bareword filehandle.
-                    "InputOutput::ProhibitBarewordFileHandles" => {
+                    "InputOutput::ProhibitBarewordFileHandles"
+                    | "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles" => {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // PL401: Two-arg open
@@ -192,18 +193,24 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policy aliases for two-arg open.
-                    "InputOutput::RequireBriefOpen" | "InputOutput::RequireThreeArgOpen" => {
+                    "InputOutput::RequireBriefOpen"
+                    | "InputOutput::RequireThreeArgOpen"
+                    | "Perl::Critic::Policy::InputOutput::RequireBriefOpen"
+                    | "Perl::Critic::Policy::InputOutput::RequireThreeArgOpen" => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policies for missing strict/warnings.
-                    "TestingAndDebugging::RequireUseStrict" => {
+                    "TestingAndDebugging::RequireUseStrict"
+                    | "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict" => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
-                    "TestingAndDebugging::RequireUseWarnings" => {
+                    "TestingAndDebugging::RequireUseWarnings"
+                    | "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // Perl::Critic policy alias for unused variables.
-                    "Variables::ProhibitUnusedVariables" => {
+                    "Variables::ProhibitUnusedVariables"
+                    | "Perl::Critic::Policy::Variables::ProhibitUnusedVariables" => {
                         actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
                     }
                     // PL200: Missing package declaration
@@ -475,6 +482,17 @@ mod tests {
                 related_information: Vec::new(),
                 tags: Vec::new(),
             },
+            Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some(
+                    "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles".to_string(),
+                ),
+                message: "Bareword filehandle alias".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
         ];
 
         let provider = CodeActionsProvider::new(source.to_string());
@@ -503,6 +521,17 @@ mod tests {
                 severity: DiagnosticSeverity::Warning,
                 code: Some("TestingAndDebugging::RequireUseWarnings".to_string()),
                 message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some(
+                    "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict".to_string(),
+                ),
+                message: "Code does not use strict (FQ policy)".to_string(),
                 suggestion: None,
                 related_information: Vec::new(),
                 tags: Vec::new(),

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -418,6 +418,12 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
             | "Variables::ProhibitUnusedVariables"
+            | "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict"
+            | "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings"
+            | "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles"
+            | "Perl::Critic::Policy::InputOutput::RequireBriefOpen"
+            | "Perl::Critic::Policy::InputOutput::RequireThreeArgOpen"
+            | "Perl::Critic::Policy::Variables::ProhibitUnusedVariables"
     ) {
         return true;
     }
@@ -589,6 +595,10 @@ mod tests {
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
         assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
+        assert!(is_fixable_diagnostic(
+            "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict"
+        ));
+        assert!(is_fixable_diagnostic("Perl::Critic::Policy::InputOutput::RequireThreeArgOpen"));
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -998,6 +998,12 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
             | "TestingAndDebugging::RequireUseStrict"
             | "TestingAndDebugging::RequireUseWarnings"
             | "Variables::ProhibitUnusedVariables"
+            | "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles"
+            | "Perl::Critic::Policy::InputOutput::RequireBriefOpen"
+            | "Perl::Critic::Policy::InputOutput::RequireThreeArgOpen"
+            | "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict"
+            | "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings"
+            | "Perl::Critic::Policy::Variables::ProhibitUnusedVariables"
     )
 }
 

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import { execFile } from 'child_process';
 import * as vscode from 'vscode';
 
@@ -209,45 +210,117 @@ export class OnboardingManager {
     const label = 'perlcritic';
     const perlcriticConfig = vscode.workspace.getConfiguration('perl-lsp').get<any>('perlcritic', {});
     const enabled = Boolean(perlcriticConfig?.enabled);
-    const profile = typeof perlcriticConfig?.profile === 'string' ? perlcriticConfig.profile.trim() : '';
+    const severity = Number.isFinite(Number(perlcriticConfig?.severity))
+      ? Number(perlcriticConfig?.severity)
+      : 5;
+    const rawProfile =
+      typeof perlcriticConfig?.profile === 'string' ? perlcriticConfig.profile.trim() : '';
+    const configuredProfile = rawProfile.length > 0 ? path.resolve(rawProfile) : null;
+    const walkupProfile = configuredProfile ? null : this.findWalkupPerlcriticProfile();
 
     if (!enabled) {
       return {
         label,
         ok: true,
         status: HealthCheckStatus.Ok,
-        detail: 'Perl::Critic is disabled',
+        detail: 'disabled (perl-lsp.perlcritic.enabled=false)',
       };
     }
 
-    if (profile && !fs.existsSync(profile)) {
-      return {
-        label,
-        ok: false,
-        status: HealthCheckStatus.Warning,
-        detail: `Configured perlcritic profile was not found: ${profile}`,
-      };
-    }
-
-    try {
-      await this._execCheck('perlcritic', ['--version']);
-      return {
-        label,
-        ok: true,
-        status: HealthCheckStatus.Ok,
-        detail: 'perlcritic found',
-      };
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
+    if (configuredProfile && !fs.existsSync(configuredProfile)) {
       return {
         label,
         ok: false,
         status: HealthCheckStatus.Warning,
         detail:
-          `Perl::Critic is enabled but perlcritic was not found on PATH. (${msg}) ` +
-          'Install via: cpanm Perl::Critic',
+          `enabled, severity=${severity}, profile=invalid (${configuredProfile})` +
+          '; update perl-lsp.perlcritic.profile',
       };
     }
+
+    try {
+      await this._execCheck('perlcritic', ['--version']);
+      const perlcriticPath = await this.resolveCommandPath('perlcritic');
+      const profileDetails = configuredProfile
+        ? `profile=configured (${configuredProfile})`
+        : walkupProfile
+          ? `profile=walk-up (${walkupProfile})`
+          : 'profile=default (none configured/found)';
+      const pathDetails = perlcriticPath
+        ? `binary=found (${perlcriticPath})`
+        : 'binary=found (path resolution unavailable)';
+      return {
+        label,
+        ok: true,
+        status: HealthCheckStatus.Ok,
+        detail: `enabled, severity=${severity}, ${pathDetails}, ${profileDetails}`,
+      };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const profileDetails = configuredProfile
+        ? `profile=configured (${configuredProfile})`
+        : walkupProfile
+          ? `profile=walk-up (${walkupProfile})`
+          : 'profile=default (none configured/found)';
+      return {
+        label,
+        ok: false,
+        status: HealthCheckStatus.Warning,
+        detail:
+          `enabled, severity=${severity}, binary=missing, ${profileDetails}. ` +
+          `perlcritic not found on PATH (${msg}). Install via: cpanm Perl::Critic`,
+      };
+    }
+  }
+
+  private async resolveCommandPath(command: string): Promise<string | null> {
+    try {
+      if (process.platform === 'win32') {
+        const { stdout } = await this._execCheck('where.exe', [command]);
+        return selectWindowsCommandCandidate(stdout);
+      }
+      const { stdout } = await this._execCheck('which', [command]);
+      const firstLine = stdout
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .find(line => line.length > 0);
+      return firstLine ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private findWalkupPerlcriticProfile(): string | null {
+    const startDirs: string[] = [];
+
+    const activeFile = vscode.window.activeTextEditor?.document?.uri?.fsPath;
+    if (activeFile) {
+      startDirs.push(path.dirname(activeFile));
+    }
+
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      if (folder?.uri?.fsPath) {
+        startDirs.push(folder.uri.fsPath);
+      }
+    }
+
+    for (const startDir of startDirs) {
+      let currentDir = path.resolve(startDir);
+      while (true) {
+        const candidate = path.join(currentDir, '.perlcriticrc');
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+
+        const parentDir = path.dirname(currentDir);
+        if (parentDir === currentDir) {
+          break;
+        }
+        currentDir = parentDir;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -274,6 +274,73 @@ describe('OnboardingManager.runSetupHealthCheck', () => {
   });
 });
 
+
+// ---------------------------------------------------------------------------
+// checkPerlcriticSetup
+// ---------------------------------------------------------------------------
+
+describe('OnboardingManager.checkPerlcriticSetup', () => {
+  afterEach(() => {
+    (require('vscode').workspace.getConfiguration as jest.Mock).mockClear();
+    (require('vscode').workspace as any).workspaceFolders = undefined;
+    (require('vscode').window as any).activeTextEditor = undefined;
+  });
+
+  test('reports disabled state explicitly', async () => {
+    const vscode = require('vscode');
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn((key: string, defaultValue?: any) => {
+        if (key === 'perlcritic') {
+          return { enabled: false, severity: 5, profile: '' };
+        }
+        return defaultValue;
+      }),
+    }));
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel());
+    const result = await mgr.checkPerlcriticSetup();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('disabled');
+  });
+
+  test('includes walk-up profile and severity in healthy output', async () => {
+    const vscode = require('vscode');
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ob-critic-'));
+    const moduleDir = path.join(workspaceDir, 'lib');
+    fs.mkdirSync(moduleDir, { recursive: true });
+    const modulePath = path.join(moduleDir, 'MyModule.pm');
+    fs.writeFileSync(modulePath, "package MyModule;\n1;\n");
+    const profilePath = path.join(workspaceDir, '.perlcriticrc');
+    fs.writeFileSync(profilePath, 'severity = 3\n');
+
+    (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(() => ({
+      get: jest.fn((key: string, defaultValue?: any) => {
+        if (key === 'perlcritic') {
+          return { enabled: true, severity: 3, profile: '' };
+        }
+        return defaultValue;
+      }),
+    }));
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: workspaceDir } }];
+    (vscode.window as any).activeTextEditor = { document: { uri: { fsPath: modulePath } } };
+
+    const mgr = new OnboardingManager(makeContext(), makeOutputChannel()) as any;
+    mgr._execCheck = jest.fn((cmd: string, _args: string[]) => {
+      if (cmd === 'perlcritic') return Promise.resolve({ stdout: 'perlcritic version', stderr: '' });
+      if (cmd === 'which') return Promise.resolve({ stdout: '/usr/bin/perlcritic\n', stderr: '' });
+      return Promise.reject(new Error(`unexpected command: ${cmd}`));
+    });
+
+    const result = await mgr.checkPerlcriticSetup();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain('severity=3');
+    expect(result.detail).toContain('binary=found (/usr/bin/perlcritic)');
+    expect(result.detail).toContain(`profile=walk-up (${profilePath})`);
+
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // package.json contract: healthCheck command registered
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Improve observability so users can answer whether Perl::Critic is enabled, which binary is used, which profile is active, and whether walk-up discovery succeeded.
- Make quick-fix routing more robust by accepting fully-qualified `Perl::Critic::Policy::...` names in addition to the short aliases while keeping fix coverage conservative.

### Description

- Expand the VS Code onboarding health check by enhancing `checkPerlcriticSetup` to report explicit enabled/disabled state, configured severity, configured-profile validity, resolved `perlcritic` binary path, and walk-up `.perlcriticrc` detection via the new helpers `resolveCommandPath` and `findWalkupPerlcriticProfile` (`vscode-extension/src/onboarding.ts`).
- Extend code-action routing to accept fully-qualified policy names (e.g., `Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict`) alongside short aliases for existing safe quick fixes (strict/warnings, two-arg open, bareword filehandles, unused variables) (`crates/perl-lsp-code-actions/src/code_actions.rs`).
- Keep diagnostic metadata aligned by updating fixable detection in both pull diagnostics and runtime diagnostics to include the fully-qualified policy aliases (`crates/perl-lsp/src/features/diagnostics/pull.rs` and `crates/perl-lsp/src/runtime/diagnostics.rs`).
- Add and update unit/integration tests for onboarding health output and policy-alias quick-fix behavior (`vscode-extension/src/test/onboarding.test.ts` and code-actions tests). 

### Testing

- Ran formatting: `cargo fmt --all` and it completed successfully.
- Rust unit tests: `cargo test -p perl-lsp-code-actions test_perlcritic_policy_aliases -- --nocapture` and `cargo test -p perllsp perlcritic_policy_codes_are_marked_fixable_in_diagnostic_data -- --nocapture` both completed with passing tests.
- Extension tests: `npm test -- onboarding.test.ts --runInBand` completed and all added/affected tests passed.
- All automated checks exercised in this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f2cd6448333a03dd4c78325774f)