### PR TITLE
feat(perlcritic): broaden safe policy alias coverage (#4114)

### DIFF
--- a/crates/perl-lsp-code-actions/src/code_actions.rs
+++ b/crates/perl-lsp-code-actions/src/code_actions.rs
@@ -184,7 +184,8 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // Perl::Critic policy alias for bareword filehandle.
-                    "InputOutput::ProhibitBarewordFileHandles" => {
+                    "InputOutput::ProhibitBarewordFileHandles"
+                    | "Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles" => {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // PL401: Two-arg open
@@ -192,18 +193,26 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policy aliases for two-arg open.
-                    "InputOutput::RequireBriefOpen" | "InputOutput::RequireThreeArgOpen" => {
+                    "InputOutput::RequireBriefOpen"
+                    | "InputOutput::RequireThreeArgOpen"
+                    | "InputOutput::ProhibitTwoArgOpen"
+                    | "Perl::Critic::Policy::InputOutput::RequireBriefOpen"
+                    | "Perl::Critic::Policy::InputOutput::RequireThreeArgOpen"
+                    | "Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen" => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policies for missing strict/warnings.
-                    "TestingAndDebugging::RequireUseStrict" => {
+                    "TestingAndDebugging::RequireUseStrict"
+                    | "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict" => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
-                    "TestingAndDebugging::RequireUseWarnings" => {
+                    "TestingAndDebugging::RequireUseWarnings"
+                    | "Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // Perl::Critic policy alias for unused variables.
-                    "Variables::ProhibitUnusedVariables" => {
+                    "Variables::ProhibitUnusedVariables"
+                    | "Perl::Critic::Policy::Variables::ProhibitUnusedVariables" => {
                         actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
                     }
                     // PL200: Missing package declaration
@@ -523,6 +532,51 @@ mod tests {
 
         assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
+        assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
+    }
+
+    #[test]
+    fn test_perlcritic_prefixed_policy_aliases_produce_quick_fixes() {
+        let source = "open FH, $path;\nprint $unused;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen".to_string()),
+                message: "Use 3-arg open".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, source.len()),
+                severity: DiagnosticSeverity::Warning,
+                code: Some(
+                    "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict".to_string(),
+                ),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (22, 29),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("Perl::Critic::Policy::Variables::ProhibitUnusedVariables".to_string()),
+                message: "Unused variable '$unused'".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
     }
 

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -410,13 +410,15 @@ pub struct DiagnosticData {
 ///
 /// The authoritative source is `crates/perl-lsp-code-actions/src/code_actions.rs`.
 fn is_fixable_diagnostic(code: &str) -> bool {
+    let normalized = code.strip_prefix("Perl::Critic::Policy::").unwrap_or(code);
     if matches!(
-        code,
+        normalized,
         "TestingAndDebugging::RequireUseStrict"
             | "TestingAndDebugging::RequireUseWarnings"
             | "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
+            | "InputOutput::ProhibitTwoArgOpen"
             | "Variables::ProhibitUnusedVariables"
     ) {
         return true;
@@ -588,6 +590,10 @@ mod tests {
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
+        assert!(is_fixable_diagnostic("InputOutput::ProhibitTwoArgOpen"));
+        assert!(is_fixable_diagnostic(
+            "Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict"
+        ));
         assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
     }
 

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -990,11 +990,13 @@ fn is_fixable_diagnostic(code: &str) -> bool {
 }
 
 fn is_fixable_perlcritic_policy(code: &str) -> bool {
+    let normalized = code.strip_prefix("Perl::Critic::Policy::").unwrap_or(code);
     matches!(
-        code,
+        normalized,
         "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
+            | "InputOutput::ProhibitTwoArgOpen"
             | "TestingAndDebugging::RequireUseStrict"
             | "TestingAndDebugging::RequireUseWarnings"
             | "Variables::ProhibitUnusedVariables"


### PR DESCRIPTION
### Motivation

- Make quick-fix routing robust against fully-qualified Perl::Critic policy names emitted by external tools and accept an additional safe alias for two-arg open violations.
- Keep runtime `fixable` metadata aligned with code-action routing so editor clients reliably know which Perl::Critic diagnostics can surface quick fixes.

### Description

- Extend `crates/perl-lsp-code-actions/src/code_actions.rs` to recognize fully-qualified `Perl::Critic::Policy::...` policy names and the `InputOutput::ProhibitTwoArgOpen` alias that maps to the existing 3-arg `open` quick fix.
- Normalize prefixed policy names in fixability checks by stripping the `Perl::Critic::Policy::` prefix in `crates/perl-lsp/src/features/diagnostics/pull.rs` and `crates/perl-lsp/src/runtime/diagnostics.rs` so `fixable` metadata matches routing behavior.
- Add a focused unit test `test_perlcritic_prefixed_policy_aliases_produce_quick_fixes` to verify fully-qualified Perl::Critic codes produce the expected quick fixes.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perl-lsp-code-actions test_perlcritic_policy_aliases` and `cargo test -p perl-lsp-code-actions test_perlcritic_prefixed_policy_aliases_produce_quick_fixes`, both of which passed.
- Performed a workspace check with `cargo check -p perl-lsp-rs`, which completed successfully; an initial incorrect `cargo test` invocation against the wrong package name failed due to user error and was not a regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f2cd6448333a03dd4c78325774f)