### PR TITLE
build(ai): drop unused dev-dependency (#3210)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ name = "perl-lsp-ai-provider"
 version = "0.12.3"
 dependencies = [
  "perl-lsp-inline-completion",
- "perl-tdd-support",
  "serde_json",
  "ureq",
 ]

--- a/crates/perl-lsp-ai-provider/Cargo.toml
+++ b/crates/perl-lsp-ai-provider/Cargo.toml
@@ -22,8 +22,6 @@ ureq = { version = "3", features = ["json"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-perl-tdd-support = { workspace = true }
-
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 


### PR DESCRIPTION
## Summary
- remove the unused `perl-tdd-support` dev-dependency from `perl-lsp-ai-provider`
- refresh `Cargo.lock` so the crate no longer records that unused dependency

## Validation
- `env -u RUSTC_WRAPPER cargo test -p perl-lsp-ai-provider`
- local pre-push `nix develop -c just pr-fast`