### PR TITLE
ci: gate generated status drift (#4070)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -175,10 +175,10 @@ The LSP compliance table is auto-generated from `features.toml`.
 | debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
-| text_document | 48 | 48 | 100% |
+| text_document | 49 | 49 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **118** | **118** | **100%** |
+| **Overall** | **119** | **119** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->
 
 For live capability posture, run `just status-check` or read [CURRENT_STATUS.md](CURRENT_STATUS.md).

--- a/docs/project/status/lsp.md
+++ b/docs/project/status/lsp.md
@@ -6,14 +6,14 @@
 ## LSP Coverage
 
 <!-- BEGIN: LSP_COVERAGE -->
-| **LSP Coverage** | 100% (59/59 advertised features, `features.toml`) | 100% | PASS |
+| **LSP Coverage** | 100% (60/60 advertised features, `features.toml`) | 100% | PASS |
 <!-- END: LSP_COVERAGE -->
 
 ## Computed Metrics
 
 <!-- BEGIN: LSP_METRICS_BULLETS -->
-- **LSP Coverage**: 100% user-visible feature coverage (59/59 advertised features from `features.toml`)
-- **Protocol Compliance**: 100% overall LSP protocol support (117/117 including plumbing)
+- **LSP Coverage**: 100% user-visible feature coverage (60/60 advertised features from `features.toml`)
+- **Protocol Compliance**: 100% overall LSP protocol support (119/119 including plumbing)
 
 **Target**: maintain 100% LSP coverage (no regressions)
 <!-- END: LSP_METRICS_BULLETS -->
@@ -26,8 +26,8 @@
 | debug | 24 | 24 | 100% |
 | notebook | 2 | 2 | 100% |
 | protocol | 9 | 9 | 100% |
-| text_document | 47 | 47 | 100% |
+| text_document | 49 | 49 | 100% |
 | window | 9 | 9 | 100% |
 | workspace | 26 | 26 | 100% |
-| **Overall** | **117** | **117** | **100%** |
+| **Overall** | **119** | **119** | **100%** |
 <!-- END: COMPLIANCE_TABLE -->

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 3043 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 3051 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 3043 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 3051 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->

--- a/justfile
+++ b/justfile
@@ -740,6 +740,7 @@ ci-gate:
     just ci-check-no-nested-lock && \
     just ci-format && \
     just ci-docs-check && \
+    just status-check && \
     just ci-clippy-gate && \
     just ci-unwrap-panic-ratchet && \
     just ci-unsafe-ratchet && \


### PR DESCRIPTION
## Summary
- add `just status-check` to `ci-gate` so stale generated status docs fail the fast merge gate
- regenerate the current roadmap and status docs so the branch starts from checked-in truth

## Validation
- `env -u RUSTC_WRAPPER just status-check`
- `just --dry-run ci-gate`
- local pre-push `nix develop -c just pr-fast`