### PR TITLE
feat(metrics): add scorecard ratchet-check command and parser/engineering-health baselines (#4105)

### DIFF
--- a/.ci/metrics/baselines/engineering_health.json
+++ b/.ci/metrics/baselines/engineering_health.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-04-09T18:13:43Z",
+  "subsystem": "engineering_health",
+  "commit": "3f7ede36",
+  "floor_metrics": {
+    "strict_clean_subset_pass_rate": 1.0
+  },
+  "improvement_metrics": {
+    "unwrap_count": null,
+    "dead_code_items": null,
+    "doc_coverage_pct": null
+  },
+  "tolerance_pct": 0.0
+}

--- a/.ci/metrics/baselines/parser.json
+++ b/.ci/metrics/baselines/parser.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-04-09T18:13:43Z",
+  "subsystem": "parser",
+  "commit": "3f7ede36",
+  "floor_metrics": {
+    "system_clean_rate": 0.971,
+    "cpan_clean_rate": 0.953,
+    "system_crash_count": 0,
+    "system_files_unreadable": 48,
+    "system_total_error_nodes": 604,
+    "cpan_total_error_nodes": 3015,
+    "strict_clean_subset_pass_rate": 1.0
+  },
+  "improvement_metrics": {
+    "node_kind_coverage": 0.941,
+    "error_density_per_1k_loc": null,
+    "recovery_salvage_rate": null
+  },
+  "tolerance_pct": 0.005
+}

--- a/justfile
+++ b/justfile
@@ -2324,6 +2324,24 @@ cpan-corpus-check:
 cpan-corpus-ratchet:
     cargo run -p xtask -- cpan-corpus ratchet
 
+# ============================================================================
+# Scorecard Metrics Ratchet
+# ============================================================================
+
+# Check scorecard floor metrics for a single subsystem (soft gate: warn, not block)
+ci-metrics-ratchet-check subsystem:
+    @echo "Checking scorecard floor metrics for {{subsystem}}..."
+    cargo run -p xtask -- metrics ratchet-check {{subsystem}}
+    @echo "Scorecard ratchet passed for {{subsystem}}"
+
+# Check all committed scorecard baselines (parser + engineering_health).
+# Soft gate: run after ci-gate, warns on violation, does not block PR in v1.
+ci-metrics-ratchet:
+    @echo "Checking scorecard floor metrics..."
+    cargo run -p xtask -- metrics ratchet-check parser
+    cargo run -p xtask -- metrics ratchet-check engineering_health
+    @echo "Scorecard ratchet passed"
+
 # Tier C: full suite (nightly, all integration tests)
 lsp-tier-c:
     @echo "Running LSP Tier C (full suite)..."

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1148,6 +1148,28 @@ enum MetricsCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Check scorecard floor metrics against the committed baseline.
+    ///
+    /// Loads `.ci/metrics/baselines/<subsystem>.json` and compares against the
+    /// current metric receipt.  Exits nonzero on any floor breach.
+    RatchetCheck {
+        /// Subsystem name (e.g. "parser", "engineering_health").
+        subsystem: String,
+        /// Path to current-metrics JSON (default: target/receipts/metrics/<subsystem>.json).
+        #[arg(long)]
+        current: Option<PathBuf>,
+        /// Record this run in target/metrics/stable_wins/<subsystem>.json.
+        #[arg(long)]
+        record: bool,
+    },
+    /// Show which improvement metrics are stable enough to raise the floor baseline.
+    PromoteBaseline {
+        /// Subsystem name.
+        subsystem: String,
+        /// Minimum fractional improvement required (default: 1%).
+        #[arg(long, default_value_t = 0.01)]
+        delta_pct: f64,
+    },
 }
 
 #[derive(ValueEnum, Clone)]
@@ -1442,6 +1464,14 @@ fn main() -> Result<()> {
             MetricsCommand::Memory => metrics::memory::run(),
             MetricsCommand::ReleaseHealth { days, json } => {
                 metrics::release_health::run(days, json)
+            }
+            MetricsCommand::RatchetCheck { subsystem, current, record } => {
+                let root = utils::project_root()?;
+                metrics::ratchet::run_ratchet_check(&root, &subsystem, current, record)
+            }
+            MetricsCommand::PromoteBaseline { subsystem, delta_pct } => {
+                let root = utils::project_root()?;
+                metrics::ratchet::run_promote_baseline(&root, &subsystem, delta_pct)
             }
         },
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),

--- a/xtask/src/tasks/metrics/mod.rs
+++ b/xtask/src/tasks/metrics/mod.rs
@@ -6,5 +6,7 @@ pub mod diagnostics_stats;
 pub mod lsp_stats;
 pub mod memory;
 pub mod parser_stats;
+pub mod ratchet;
 pub mod release_health;
+pub mod stable_wins;
 pub mod workspace_stats;

--- a/xtask/src/tasks/metrics/ratchet.rs
+++ b/xtask/src/tasks/metrics/ratchet.rs
@@ -1,0 +1,479 @@
+//! Scorecard floor-metric ratchet checker.
+//!
+//! Loads a committed baseline JSON (`.ci/metrics/baselines/<subsystem>.json`)
+//! and checks a set of current metric values against it.  Violations are
+//! returned as a `Vec<RatchetViolation>`; an empty vec means all checks
+//! passed.
+//!
+//! # Naming convention for direction
+//!
+//! Metrics whose names end with `_count`, `_nodes`, or `_unreadable` are
+//! treated as **lower-is-better** (a higher current value is a regression).
+//! All other metrics are **higher-is-better** (a lower current value is a
+//! regression).
+//!
+//! If you add a lower-is-better metric that does not fit these suffixes (e.g.
+//! `latency_p95_ms`), add its name to the `lower_is_better` field on
+//! `SubsystemBaseline` rather than extending the suffix list.
+
+use chrono::Utc;
+use color_eyre::eyre::{Context, Result, eyre};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Schema version this module writes / expects.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Committed floor-metric baseline for a single subsystem.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubsystemBaseline {
+    pub schema_version: u32,
+    /// ISO-8601 timestamp of the measurement.
+    pub measured_at: String,
+    /// Subsystem identifier (e.g. `"parser"`).
+    pub subsystem: String,
+    /// Git SHA of the commit this baseline was measured on.
+    pub commit: String,
+    /// Hard-floor metrics.  `None` means not yet instrumented — skipped.
+    pub floor_metrics: BTreeMap<String, Option<f64>>,
+    /// Aspirational improvement metrics.  `None` means not yet instrumented.
+    /// These are informational only; violations here never block.
+    pub improvement_metrics: BTreeMap<String, Option<f64>>,
+    /// Fractional noise band.  A regression must exceed this fraction of the
+    /// baseline value to count as a violation.  Default 0.005 (0.5 %).
+    #[serde(default = "default_tolerance")]
+    pub tolerance_pct: f64,
+    /// Extra metric names that are lower-is-better regardless of their suffix.
+    #[serde(default)]
+    pub lower_is_better: Vec<String>,
+}
+
+fn default_tolerance() -> f64 {
+    0.005
+}
+
+/// A single floor-metric regression.
+#[derive(Debug, Clone)]
+pub struct RatchetViolation {
+    pub metric: String,
+    pub baseline_value: f64,
+    pub current_value: f64,
+    /// Fractional regression magnitude (0.0 … 1.0+).
+    pub regression_pct: f64,
+}
+
+/// Load a `SubsystemBaseline` from the committed baselines directory.
+///
+/// `repo_root` is the workspace root; the file is expected at
+/// `.ci/metrics/baselines/<subsystem>.json`.
+pub fn load_baseline(repo_root: &Path, subsystem: &str) -> Result<SubsystemBaseline> {
+    let path = repo_root.join(".ci/metrics/baselines").join(format!("{subsystem}.json"));
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read baseline: {}", path.display()))?;
+    let baseline: SubsystemBaseline = serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse baseline: {}", path.display()))?;
+    if baseline.schema_version != SCHEMA_VERSION {
+        return Err(eyre!(
+            "Baseline schema version mismatch: expected {SCHEMA_VERSION}, got {}",
+            baseline.schema_version
+        ));
+    }
+    Ok(baseline)
+}
+
+/// Check `current` floor-metric values against `baseline`.
+///
+/// Returns the list of violations (empty ⇒ all checks passed).
+/// `null` (absent) values in either map are skipped silently.
+pub fn check_floor_metrics(
+    baseline: &SubsystemBaseline,
+    current: &BTreeMap<String, Option<f64>>,
+) -> Vec<RatchetViolation> {
+    let mut violations = Vec::new();
+
+    for (metric, baseline_val) in &baseline.floor_metrics {
+        // Skip unset baseline entries.
+        let Some(bv) = baseline_val else {
+            continue;
+        };
+
+        // Skip if current measurement is absent.
+        let Some(cv) = current.get(metric).and_then(|v| *v) else {
+            continue;
+        };
+
+        let is_lower_better = is_lower_better_metric(metric, &baseline.lower_is_better);
+
+        let regression_pct = if is_lower_better {
+            // Higher current value = regression.
+            if cv > *bv { (cv - bv) / bv.max(1.0) } else { 0.0 }
+        } else {
+            // Lower current value = regression.
+            if cv < *bv { (bv - cv) / bv.max(f64::EPSILON) } else { 0.0 }
+        };
+
+        if regression_pct > baseline.tolerance_pct {
+            violations.push(RatchetViolation {
+                metric: metric.clone(),
+                baseline_value: *bv,
+                current_value: cv,
+                regression_pct,
+            });
+        }
+    }
+
+    violations
+}
+
+/// Determine whether a metric is lower-is-better.
+///
+/// Returns `true` if the metric name ends with `_count`, `_nodes`, or
+/// `_unreadable`, or if it is present in the explicit `lower_is_better` list.
+fn is_lower_better_metric(metric: &str, explicit: &[String]) -> bool {
+    if explicit.iter().any(|s| s == metric) {
+        return true;
+    }
+    metric.ends_with("_count") || metric.ends_with("_nodes") || metric.ends_with("_unreadable")
+}
+
+// =============================================================================
+// Receipt format (runtime, not committed)
+// =============================================================================
+
+/// Runtime metric receipt produced by a subsystem sweep.
+///
+/// Written to `target/receipts/metrics/<subsystem>.json`.
+/// The #4063 builder emits this format from `parser-stats --json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricReceipt {
+    pub subsystem: String,
+    pub generated_at: String,
+    pub commit: String,
+    pub floor_metrics: BTreeMap<String, Option<f64>>,
+    pub improvement_metrics: BTreeMap<String, Option<f64>>,
+}
+
+// =============================================================================
+// CLI handlers
+// =============================================================================
+
+/// Run `cargo xtask metrics ratchet-check`.
+///
+/// - Loads `.ci/metrics/baselines/<subsystem>.json`
+/// - Loads current metrics from `--current` path or `target/receipts/metrics/<subsystem>.json`
+/// - Reports violations; exits nonzero if any floor metric is breached
+/// - Optionally records this run in the stable-wins state file
+pub fn run_ratchet_check(
+    repo_root: &Path,
+    subsystem: &str,
+    current_path: Option<PathBuf>,
+    record: bool,
+) -> Result<()> {
+    let baseline = load_baseline(repo_root, subsystem)?;
+
+    // Resolve the current-metrics file.
+    let receipt_path = current_path.unwrap_or_else(|| {
+        repo_root.join("target/receipts/metrics").join(format!("{subsystem}.json"))
+    });
+
+    // Load current metrics from receipt file, falling back to the baseline
+    // values themselves when no receipt exists yet (bootstrapping).
+    let current_metrics: BTreeMap<String, Option<f64>> = if receipt_path.exists() {
+        let raw = std::fs::read_to_string(&receipt_path)
+            .with_context(|| format!("Failed to read receipt: {}", receipt_path.display()))?;
+        let receipt: MetricReceipt = serde_json::from_str(&raw)
+            .with_context(|| format!("Failed to parse receipt: {}", receipt_path.display()))?;
+        receipt.floor_metrics
+    } else {
+        // No receipt yet — fall back to baseline values (idempotent, always
+        // passes, confirms infrastructure is wired).
+        eprintln!(
+            "note: no receipt at {} — using baseline values as current (bootstrap mode)",
+            receipt_path.display()
+        );
+        baseline.floor_metrics.clone()
+    };
+
+    let violations = check_floor_metrics(&baseline, &current_metrics);
+
+    if violations.is_empty() {
+        println!("ratchet-check [{subsystem}]: all floor metrics passed");
+    } else {
+        for v in &violations {
+            eprintln!(
+                "VIOLATION [{subsystem}] {}: baseline={:.4} current={:.4} regression={:.2}%",
+                v.metric,
+                v.baseline_value,
+                v.current_value,
+                v.regression_pct * 100.0
+            );
+        }
+        return Err(eyre!(
+            "{} floor metric violation(s) for subsystem '{subsystem}'",
+            violations.len()
+        ));
+    }
+
+    // Informational: summarize improvement metrics.
+    let instrumented: Vec<_> =
+        baseline.improvement_metrics.iter().filter_map(|(k, v)| v.map(|val| (k, val))).collect();
+    if !instrumented.is_empty() {
+        println!("  improvement metrics (informational):");
+        for (k, v) in &instrumented {
+            println!("    {k}: {v:.4}");
+        }
+    }
+
+    // Record this run in stable-wins state if requested.
+    if record {
+        use crate::tasks::metrics::stable_wins::{StableWinsState, record_run};
+
+        let state_dir = repo_root.join("target/metrics/stable_wins");
+        std::fs::create_dir_all(&state_dir)
+            .with_context(|| format!("Failed to create {}", state_dir.display()))?;
+        let state_path = state_dir.join(format!("{subsystem}.json"));
+
+        let mut state: StableWinsState = if state_path.exists() {
+            let raw = std::fs::read_to_string(&state_path).with_context(|| {
+                format!("Failed to read stable-wins state: {}", state_path.display())
+            })?;
+            serde_json::from_str(&raw).with_context(|| {
+                format!("Failed to parse stable-wins state: {}", state_path.display())
+            })?
+        } else {
+            StableWinsState { subsystem: subsystem.to_string(), recent_runs: BTreeMap::new() }
+        };
+
+        let commit = std::env::var("GITHUB_SHA").unwrap_or_else(|_| "unknown".to_string());
+        let timestamp = Utc::now().to_rfc3339();
+        record_run(&mut state, &commit, &timestamp, &current_metrics);
+
+        let json = serde_json::to_string_pretty(&state)
+            .context("Failed to serialize stable-wins state")?;
+        std::fs::write(&state_path, json).with_context(|| {
+            format!("Failed to write stable-wins state: {}", state_path.display())
+        })?;
+
+        println!("  stable-wins state updated: {}", state_path.display());
+    }
+
+    Ok(())
+}
+
+/// Run `cargo xtask metrics promote-baseline`.
+///
+/// Reads the stable-wins state and reports which improvement metrics have
+/// been consistently above the floor for at least `STABLE_WIN_THRESHOLD`
+/// consecutive runs by at least `delta_pct`.
+pub fn run_promote_baseline(repo_root: &Path, subsystem: &str, delta_pct: f64) -> Result<()> {
+    use crate::tasks::metrics::stable_wins::{
+        STABLE_WIN_THRESHOLD, StableWinsState, stable_improvements,
+    };
+
+    let baseline = load_baseline(repo_root, subsystem)?;
+
+    let state_path = repo_root.join("target/metrics/stable_wins").join(format!("{subsystem}.json"));
+
+    if !state_path.exists() {
+        println!("No stable-wins state found for '{subsystem}'. Run ratchet-check --record first.");
+        return Ok(());
+    }
+
+    let raw = std::fs::read_to_string(&state_path)
+        .with_context(|| format!("Failed to read stable-wins state: {}", state_path.display()))?;
+    let state: StableWinsState = serde_json::from_str(&raw)
+        .with_context(|| format!("Failed to parse stable-wins state: {}", state_path.display()))?;
+
+    let eligible = stable_improvements(&state, &baseline.improvement_metrics, delta_pct);
+
+    if eligible.is_empty() {
+        println!(
+            "No improvement metrics for '{subsystem}' are stable across {STABLE_WIN_THRESHOLD} runs at +{:.1}%.",
+            delta_pct * 100.0
+        );
+    } else {
+        println!(
+            "Eligible for baseline promotion (stable {STABLE_WIN_THRESHOLD} runs, +{:.1}%):",
+            delta_pct * 100.0
+        );
+        for name in &eligible {
+            println!("  {name}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_baseline(floor: BTreeMap<String, Option<f64>>) -> SubsystemBaseline {
+        SubsystemBaseline {
+            schema_version: SCHEMA_VERSION,
+            measured_at: "2026-01-01T00:00:00Z".to_string(),
+            subsystem: "test".to_string(),
+            commit: "deadbeef".to_string(),
+            floor_metrics: floor,
+            improvement_metrics: BTreeMap::new(),
+            tolerance_pct: 0.005,
+            lower_is_better: Vec::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // No violation when current equals baseline
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_no_violation_on_exact_match() {
+        let baseline = make_baseline(BTreeMap::from([
+            ("system_clean_rate".to_string(), Some(0.971)),
+            ("system_crash_count".to_string(), Some(0.0)),
+        ]));
+
+        let current = BTreeMap::from([
+            ("system_clean_rate".to_string(), Some(0.971)),
+            ("system_crash_count".to_string(), Some(0.0)),
+        ]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert!(violations.is_empty(), "expected no violations, got: {violations:?}");
+    }
+
+    // -------------------------------------------------------------------------
+    // Violation fires when higher-is-better rate drops below floor
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_violation_on_rate_regression() {
+        let baseline =
+            make_baseline(BTreeMap::from([("system_clean_rate".to_string(), Some(0.971))]));
+
+        // 0.90 is well below 0.971 — must trigger a violation.
+        let current = BTreeMap::from([("system_clean_rate".to_string(), Some(0.90))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert_eq!(violations.len(), 1, "expected exactly one violation");
+        assert_eq!(violations[0].metric, "system_clean_rate");
+        assert!(violations[0].regression_pct > 0.005, "regression_pct should exceed tolerance");
+    }
+
+    // -------------------------------------------------------------------------
+    // No violation within tolerance band
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_no_violation_within_tolerance() {
+        let mut baseline =
+            make_baseline(BTreeMap::from([("system_clean_rate".to_string(), Some(0.971))]));
+        baseline.tolerance_pct = 0.005;
+
+        // 0.3 % drop — within the 0.5 % tolerance band.
+        // 0.971 * (1 - 0.003) ≈ 0.96808
+        let current = BTreeMap::from([("system_clean_rate".to_string(), Some(0.96808))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert!(
+            violations.is_empty(),
+            "0.3% drop within 0.5% band should not be a violation; got {violations:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Violation fires when lower-is-better count increases (_count suffix)
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_violation_on_count_increase() {
+        let baseline =
+            make_baseline(BTreeMap::from([("system_crash_count".to_string(), Some(0.0))]));
+
+        let current = BTreeMap::from([("system_crash_count".to_string(), Some(1.0))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].metric, "system_crash_count");
+    }
+
+    // -------------------------------------------------------------------------
+    // Violation fires when lower-is-better _nodes metric increases
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_violation_on_nodes_increase() {
+        let baseline =
+            make_baseline(BTreeMap::from([("system_total_error_nodes".to_string(), Some(604.0))]));
+
+        let current = BTreeMap::from([("system_total_error_nodes".to_string(), Some(700.0))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].metric, "system_total_error_nodes");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null baseline metrics are silently skipped
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_null_baseline_skipped() {
+        let baseline = make_baseline(BTreeMap::from([
+            ("system_clean_rate".to_string(), Some(0.971)),
+            ("node_kind_coverage".to_string(), None),
+        ]));
+
+        // Provide a terrible value for the null metric — must be ignored.
+        let current = BTreeMap::from([
+            ("system_clean_rate".to_string(), Some(0.972)),
+            ("node_kind_coverage".to_string(), Some(0.0)),
+        ]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert!(violations.is_empty(), "null baseline metric must be skipped; got {violations:?}");
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing current measurement is silently skipped
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_missing_current_skipped() {
+        let baseline =
+            make_baseline(BTreeMap::from([("system_clean_rate".to_string(), Some(0.971))]));
+
+        // Current map is empty — metric is absent.
+        let current: BTreeMap<String, Option<f64>> = BTreeMap::new();
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert!(
+            violations.is_empty(),
+            "missing current metric must be skipped; got {violations:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Explicit lower_is_better list overrides suffix convention
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_explicit_lower_is_better() {
+        let mut baseline =
+            make_baseline(BTreeMap::from([("latency_p95_ms".to_string(), Some(100.0))]));
+        baseline.lower_is_better = vec!["latency_p95_ms".to_string()];
+
+        // Increase in latency is a regression.
+        let current = BTreeMap::from([("latency_p95_ms".to_string(), Some(120.0))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].metric, "latency_p95_ms");
+    }
+
+    // -------------------------------------------------------------------------
+    // No violation when lower-is-better metric actually decreases (improves)
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_no_violation_on_count_decrease() {
+        let baseline =
+            make_baseline(BTreeMap::from([("system_crash_count".to_string(), Some(5.0))]));
+
+        let current = BTreeMap::from([("system_crash_count".to_string(), Some(3.0))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert!(violations.is_empty(), "count decrease is an improvement, not a violation");
+    }
+}

--- a/xtask/src/tasks/metrics/ratchet.rs
+++ b/xtask/src/tasks/metrics/ratchet.rs
@@ -107,7 +107,10 @@ pub fn check_floor_metrics(
 
         let regression_pct = if is_lower_better {
             // Higher current value = regression.
-            if cv > *bv { (cv - bv) / bv.max(1.0) } else { 0.0 }
+            // Use bv.max(f64::EPSILON) so that sub-1.0 baselines (e.g. an
+            // error_rate of 0.05) produce a correct fractional regression rather
+            // than being attenuated by a hard floor of 1.0.
+            if cv > *bv { (cv - bv) / bv.max(f64::EPSILON) } else { 0.0 }
         } else {
             // Lower current value = regression.
             if cv < *bv { (bv - cv) / bv.max(f64::EPSILON) } else { 0.0 }
@@ -475,5 +478,57 @@ mod tests {
 
         let violations = check_floor_metrics(&baseline, &current);
         assert!(violations.is_empty(), "count decrease is an improvement, not a violation");
+    }
+
+    // -------------------------------------------------------------------------
+    // Lower-is-better with sub-1.0 baseline: doubling must be a violation.
+    // Previously bv.max(1.0) attenuated this to ~0.1 % — below any tolerance.
+    // After fix to bv.max(f64::EPSILON), it registers as 100 % regression.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_ratchet_lower_is_better_sub_one_baseline_regression() {
+        let mut baseline =
+            make_baseline(BTreeMap::from([("error_rate_count".to_string(), Some(0.05))]));
+        baseline.tolerance_pct = 0.005; // 0.5 % band
+
+        // Doubling 0.05 -> 0.10 is a 100 % regression; must exceed tolerance.
+        let current = BTreeMap::from([("error_rate_count".to_string(), Some(0.10))]);
+
+        let violations = check_floor_metrics(&baseline, &current);
+        assert_eq!(violations.len(), 1, "doubling a sub-1.0 lower-is-better metric must violate");
+        assert_eq!(violations[0].metric, "error_rate_count");
+        // regression_pct = (0.10 - 0.05) / 0.05 = 1.0 (100 %)
+        assert!(
+            violations[0].regression_pct > 0.5,
+            "regression_pct should be ~1.0 (100%), got {}",
+            violations[0].regression_pct
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Schema version mismatch must return an error.
+    // load_baseline is tested here via a temp file since it reads from disk.
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_load_baseline_schema_version_mismatch() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let baselines_dir = dir.path().join(".ci/metrics/baselines");
+        std::fs::create_dir_all(&baselines_dir).unwrap();
+        let path = baselines_dir.join("test.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            r#"{{"schema_version":99,"measured_at":"2026-01-01T00:00:00Z","subsystem":"test","commit":"abc","floor_metrics":{{}},"improvement_metrics":{{}}}}"#
+        )
+        .unwrap();
+
+        let result = load_baseline(dir.path(), "test");
+        assert!(result.is_err(), "schema version mismatch must return Err");
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("schema version mismatch"),
+            "error message must mention schema version mismatch; got: {msg}"
+        );
     }
 }

--- a/xtask/src/tasks/metrics/stable_wins.rs
+++ b/xtask/src/tasks/metrics/stable_wins.rs
@@ -1,0 +1,169 @@
+//! Multi-run stability tracker for scorecard improvement metrics.
+//!
+//! Before raising the committed floor baseline, we want N consecutive CI runs
+//! to all show improvement.  This module persists that per-subsystem history
+//! in `target/metrics/stable_wins/<subsystem>.json` (gitignored ephemeral
+//! CI state).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Minimum consecutive runs required before an improvement is considered stable.
+pub const STABLE_WIN_THRESHOLD: usize = 3;
+
+/// Persisted state for the stable-wins tracker.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StableWinsState {
+    pub subsystem: String,
+    /// Recent runs keyed by metric name.
+    pub recent_runs: BTreeMap<String, Vec<MetricRun>>,
+}
+
+/// A single data point for one metric on one CI run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricRun {
+    pub commit: String,
+    pub value: f64,
+    pub timestamp: String,
+}
+
+/// Append the current run's metric values to `state`.
+///
+/// `null` values are skipped.  The window is capped at
+/// `STABLE_WIN_THRESHOLD + 1` entries per metric.
+pub fn record_run(
+    state: &mut StableWinsState,
+    commit: &str,
+    timestamp: &str,
+    metrics: &BTreeMap<String, Option<f64>>,
+) {
+    for (name, val) in metrics {
+        let Some(v) = val else {
+            continue;
+        };
+        let runs = state.recent_runs.entry(name.clone()).or_default();
+        runs.push(MetricRun {
+            commit: commit.to_string(),
+            value: *v,
+            timestamp: timestamp.to_string(),
+        });
+        // Keep one extra entry beyond threshold for context.
+        let cap = STABLE_WIN_THRESHOLD + 1;
+        if runs.len() > cap {
+            runs.drain(0..runs.len() - cap);
+        }
+    }
+}
+
+/// Return the names of improvement metrics that have been stable across at
+/// least `STABLE_WIN_THRESHOLD` consecutive runs AND whose recent values all
+/// exceed `baseline_value * (1 + material_delta_pct)`.
+///
+/// Only higher-is-better metrics are considered here; pass a pre-filtered
+/// `baseline` map if you need lower-is-better support.
+pub fn stable_improvements(
+    state: &StableWinsState,
+    baseline: &BTreeMap<String, Option<f64>>,
+    material_delta_pct: f64,
+) -> Vec<String> {
+    let mut result = Vec::new();
+
+    for (name, runs) in &state.recent_runs {
+        if runs.len() < STABLE_WIN_THRESHOLD {
+            continue;
+        }
+        let Some(Some(bv)) = baseline.get(name) else {
+            continue;
+        };
+        let threshold = bv * (1.0 + material_delta_pct);
+        let last_n = &runs[runs.len() - STABLE_WIN_THRESHOLD..];
+        if last_n.iter().all(|r| r.value >= threshold) {
+            result.push(name.clone());
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_run_appends_values() {
+        let mut state =
+            StableWinsState { subsystem: "parser".to_string(), recent_runs: BTreeMap::new() };
+        let metrics = BTreeMap::from([("system_clean_rate".to_string(), Some(0.972_f64))]);
+        record_run(&mut state, "abc123", "2026-01-01T00:00:00Z", &metrics);
+
+        assert_eq!(state.recent_runs["system_clean_rate"].len(), 1);
+        assert!((state.recent_runs["system_clean_rate"][0].value - 0.972).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_record_run_caps_window() {
+        let mut state =
+            StableWinsState { subsystem: "parser".to_string(), recent_runs: BTreeMap::new() };
+        let metrics = BTreeMap::from([("system_clean_rate".to_string(), Some(0.972_f64))]);
+
+        // Insert more entries than the cap.
+        for i in 0..(STABLE_WIN_THRESHOLD + 5) {
+            record_run(&mut state, &format!("commit{i}"), "2026-01-01T00:00:00Z", &metrics);
+        }
+
+        let runs = &state.recent_runs["system_clean_rate"];
+        assert!(
+            runs.len() <= STABLE_WIN_THRESHOLD + 1,
+            "window should be capped at THRESHOLD+1, got {}",
+            runs.len()
+        );
+    }
+
+    #[test]
+    fn test_stable_improvements_requires_threshold_runs() {
+        let mut state =
+            StableWinsState { subsystem: "parser".to_string(), recent_runs: BTreeMap::new() };
+        let baseline = BTreeMap::from([("system_clean_rate".to_string(), Some(0.971_f64))]);
+
+        // Only 2 runs — not enough.
+        let metrics = BTreeMap::from([("system_clean_rate".to_string(), Some(0.985_f64))]);
+        record_run(&mut state, "c1", "2026-01-01T00:00:00Z", &metrics);
+        record_run(&mut state, "c2", "2026-01-01T00:00:00Z", &metrics);
+
+        let stable = stable_improvements(&state, &baseline, 0.01);
+        assert!(stable.is_empty(), "need {STABLE_WIN_THRESHOLD} runs, only have 2");
+    }
+
+    #[test]
+    fn test_stable_improvements_detected_after_threshold() {
+        let mut state =
+            StableWinsState { subsystem: "parser".to_string(), recent_runs: BTreeMap::new() };
+        let baseline = BTreeMap::from([("system_clean_rate".to_string(), Some(0.971_f64))]);
+
+        // 3 runs all above baseline + 1% delta.
+        let metrics = BTreeMap::from([("system_clean_rate".to_string(), Some(0.985_f64))]);
+        for i in 0..STABLE_WIN_THRESHOLD {
+            record_run(&mut state, &format!("c{i}"), "2026-01-01T00:00:00Z", &metrics);
+        }
+
+        let stable = stable_improvements(&state, &baseline, 0.01);
+        assert_eq!(stable, vec!["system_clean_rate".to_string()]);
+    }
+
+    #[test]
+    fn test_stable_improvements_not_triggered_below_delta() {
+        let mut state =
+            StableWinsState { subsystem: "parser".to_string(), recent_runs: BTreeMap::new() };
+        let baseline = BTreeMap::from([("system_clean_rate".to_string(), Some(0.971_f64))]);
+
+        // 3 runs only 0.5 % above baseline — below the 1 % material_delta_pct.
+        let marginal = 0.971 * 1.005; // just 0.5% above
+        let metrics = BTreeMap::from([("system_clean_rate".to_string(), Some(marginal))]);
+        for i in 0..STABLE_WIN_THRESHOLD {
+            record_run(&mut state, &format!("c{i}"), "2026-01-01T00:00:00Z", &metrics);
+        }
+
+        let stable = stable_improvements(&state, &baseline, 0.01);
+        assert!(stable.is_empty(), "0.5% improvement below 1% delta should not trigger");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the 4-layer scorecard ratchet model (Layer 1-2 + stub Layer 3), building on the metrics subcommand tree from PR #4160.

- **`.ci/metrics/baselines/parser.json`** and **`engineering_health.json`**: committed floor baselines with real values sourced from `.ci/parser-corpus-baseline.json` (not hand-waved)
- **`xtask/src/tasks/metrics/ratchet.rs`**: `SubsystemBaseline` struct, `load_baseline`, `check_floor_metrics` with tolerance band, schema version validation, lower-is-better naming convention (`_count`, `_nodes`, `_unreadable` suffixes + explicit override list)
- **`xtask/src/tasks/metrics/stable_wins.rs`**: N-run stability tracker with `record_run` and `stable_improvements` (Layer 3 stub, fully tested)
- **`cargo xtask metrics ratchet-check <subsystem>`**: loads baseline, reads receipt or falls back to bootstrap mode (no receipt yet), reports violations, exits nonzero on floor breach
- **`cargo xtask metrics promote-baseline <subsystem>`**: reports which improvement metrics are stable enough to raise the floor
- **justfile `ci-metrics-ratchet`**: soft gate (warns but does not block in v1)
- **All 7 `scorecard/*` GitHub labels** created; retroactive labels applied to 10 issues (#3496, #3499, #3485, #3489, #3513, #3515, #3472, #3475, #3476, #3482)

## Key design decisions

- Bootstrapping: when no runtime receipt exists, `ratchet-check` uses baseline values as current (idempotent pass). Real enforcement kicks in once the #4063 builder emits `target/receipts/metrics/parser.json`.
- Soft gate: `just ci-metrics-ratchet` is NOT wired into `ci-gate` in v1. It is a standalone recipe. Hard-gating comes in a follow-up issue.
- Tolerance band: 0.5% default noise band prevents flaky corpus sweeps from firing violations.

## Test plan

- [x] `cargo xtask metrics ratchet-check parser` exits 0 on current master (bootstrap mode)
- [x] `cargo clippy -p xtask -- -D warnings` passes clean
- [x] 8 unit tests for `ratchet`: exact-match pass, rate regression violation, tolerance band no-violation, `_count`/`_nodes` lower-is-better violation and improvement, null-baseline skip, missing-current skip, explicit lower_is_better list
- [x] 5 unit tests for `stable_wins`: append, window cap, threshold requirement, improvement detection, insufficient delta
- [x] All 7 `scorecard/*` labels exist in the repo
- [x] Retroactive labels applied to the 10 issues listed in the spec
- [x] `pr-fast` gate passed locally (fmt, clippy, test-core)