### PR TITLE
feat(pod): render POD L<> links as clickable markdown links in hover (#3406)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -266,23 +266,33 @@ fn strip_pod_formatting(text: &str) -> String {
     result
 }
 
-/// Extract display text from a POD L<> link.
+/// Extract a markdown link from a POD `L<>` formatting code.
 ///
-/// Handles common forms:
-/// - `L<Module::Name>` -> `Module::Name`
-/// - `L<text|Module::Name>` -> `text`
-/// - `L<text|Module::Name/section>` -> `text`
-/// - `L<Module::Name/section>` -> `Module::Name`
+/// Returns `[display](perl-module://target)` so LSP clients (VS Code) render
+/// the link as clickable in hover tooltips.
+///
+/// Handles all standard POD link forms:
+/// - `L<Module::Name>` → `[Module::Name](perl-module://Module::Name)`
+/// - `L<text|Module::Name>` → `[text](perl-module://Module::Name)`
+/// - `L<Module::Name/section>` → `[Module::Name](perl-module://Module::Name/section)`
+/// - `L<text|Module::Name/section>` → `[text](perl-module://Module::Name/section)`
 fn extract_link_display(link: &str) -> String {
-    // L<text|target> -> show text
+    // L<text|target> — explicit display text before the pipe
     if let Some(pipe_pos) = link.find('|') {
-        return strip_pod_formatting(&link[..pipe_pos]);
+        let display = strip_pod_formatting(&link[..pipe_pos]);
+        let target = link[pipe_pos + 1..].trim();
+        return format!("[{display}](perl-module://{target})");
     }
-    // L<Module/section> -> show Module
+    // L<Module/section> — module + section, display is just the module part
     if let Some(slash_pos) = link.find('/') {
-        return strip_pod_formatting(&link[..slash_pos]);
+        let module = strip_pod_formatting(&link[..slash_pos]);
+        let target = link.trim();
+        return format!("[{module}](perl-module://{target})");
     }
-    strip_pod_formatting(link)
+    // L<Module::Name> — simple module reference
+    let display = strip_pod_formatting(link);
+    let target = link.trim();
+    format!("[{display}](perl-module://{target})")
 }
 
 fn decode_pod_entity(entity: &str) -> String {

--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -266,10 +266,19 @@ fn strip_pod_formatting(text: &str) -> String {
     result
 }
 
+/// Percent-encode characters that are invalid in a markdown link URL.
+///
+/// Encodes spaces (most common in POD section names like `L<Module/"Section Name">`)
+/// and other characters that would break the markdown `[text](url)` parser.
+fn encode_pod_link_target(target: &str) -> String {
+    target.replace(' ', "%20")
+}
+
 /// Extract a markdown link from a POD `L<>` formatting code.
 ///
 /// Returns `[display](perl-module://target)` so LSP clients (VS Code) render
-/// the link as clickable in hover tooltips.
+/// the link as clickable in hover tooltips.  Spaces in section names are
+/// percent-encoded so the URL is well-formed.
 ///
 /// Handles all standard POD link forms:
 /// - `L<Module::Name>` → `[Module::Name](perl-module://Module::Name)`
@@ -280,18 +289,18 @@ fn extract_link_display(link: &str) -> String {
     // L<text|target> — explicit display text before the pipe
     if let Some(pipe_pos) = link.find('|') {
         let display = strip_pod_formatting(&link[..pipe_pos]);
-        let target = link[pipe_pos + 1..].trim();
+        let target = encode_pod_link_target(link[pipe_pos + 1..].trim());
         return format!("[{display}](perl-module://{target})");
     }
     // L<Module/section> — module + section, display is just the module part
     if let Some(slash_pos) = link.find('/') {
         let module = strip_pod_formatting(&link[..slash_pos]);
-        let target = link.trim();
+        let target = encode_pod_link_target(link.trim());
         return format!("[{module}](perl-module://{target})");
     }
     // L<Module::Name> — simple module reference
     let display = strip_pod_formatting(link);
-    let target = link.trim();
+    let target = encode_pod_link_target(link.trim());
     format!("[{display}](perl-module://{target})")
 }
 

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -463,6 +463,34 @@ fn link_display_text_with_section_target_renders_markdown() {
     );
 }
 
+/// `L<Module::Name/Section With Spaces>` — section names with spaces must be
+/// percent-encoded in the URL so the markdown link is well-formed.
+/// This is common in CPAN POD: `L<perlfunc/"use Module LIST">`.
+#[test]
+fn link_section_with_spaces_encodes_url() {
+    let doc = extract_pod("=head1 NAME\n\nL<File::Find/The wanted function>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[File::Find]"), "expected '[File::Find]' but got: {name}");
+    // Spaces must be encoded — a raw space makes the markdown URL malformed
+    assert!(
+        name.contains("perl-module://File::Find/The%20wanted%20function"),
+        "expected percent-encoded URL but got: {name}"
+    );
+    assert!(!name.contains("The wanted function"), "raw space in URL — should be encoded: {name}");
+}
+
+/// `L<click here|Module/Section With Spaces>` — pipe form with spaces in section.
+#[test]
+fn link_pipe_with_spaced_section_encodes_url() {
+    let doc = extract_pod("=head1 NAME\n\nL<click here|File::Find/The wanted function>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[click here]"), "expected '[click here]' but got: {name}");
+    assert!(
+        name.contains("perl-module://File::Find/The%20wanted%20function"),
+        "expected percent-encoded URL but got: {name}"
+    );
+}
+
 #[test]
 fn multiple_pod_blocks() {
     let source = r#"

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -124,20 +124,29 @@ fn strips_code_formatting() {
 
 #[test]
 fn strips_link_simple() {
+    // L<Module::Name> now renders as a markdown link (Option B)
     let doc = extract_pod("=head1 NAME\n\nL<Module::Name>\n\n=cut\n");
-    assert_eq!(doc.name.as_deref(), Some("Module::Name"));
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[Module::Name]"), "got: {name}");
+    assert!(name.contains("perl-module://Module::Name"), "got: {name}");
 }
 
 #[test]
 fn strips_link_with_display_text() {
+    // L<click here|Module::Name> displays the explicit text as a markdown link
     let doc = extract_pod("=head1 NAME\n\nL<click here|Module::Name>\n\n=cut\n");
-    assert_eq!(doc.name.as_deref(), Some("click here"));
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[click here]"), "got: {name}");
+    assert!(name.contains("perl-module://Module::Name"), "got: {name}");
 }
 
 #[test]
 fn strips_link_with_section() {
+    // L<Module::Name/method> displays module as link, target includes section
     let doc = extract_pod("=head1 NAME\n\nL<Module::Name/method>\n\n=cut\n");
-    assert_eq!(doc.name.as_deref(), Some("Module::Name"));
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[Module::Name]"), "got: {name}");
+    assert!(name.contains("perl-module://Module::Name/method"), "got: {name}");
 }
 
 #[test]
@@ -357,6 +366,101 @@ fn f_format_code_for_filenames() {
 fn e_format_code_decodes_common_entities() {
     let doc = extract_pod("=head1 NAME\n\nE<lt> E<gt> E<amp> E<quot> E<apos>\n\n=cut\n");
     assert_eq!(doc.name.as_deref(), Some("< > & \" '"));
+}
+
+// ── POD L<> link → markdown link tests (Option B) ───────────────────────
+
+/// `L<Module::Name>` should produce a markdown link with target `perl-module://Module::Name`.
+#[test]
+fn link_simple_module_renders_markdown() {
+    let doc = extract_pod("=head1 NAME\n\nL<File::Path>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        name.contains("[File::Path]"),
+        "expected markdown display '[File::Path]' but got: {name}"
+    );
+    assert!(
+        name.contains("perl-module://File::Path"),
+        "expected markdown target 'perl-module://File::Path' but got: {name}"
+    );
+}
+
+/// `L<text|Module::Name>` should use the display text and link to the module.
+#[test]
+fn link_with_display_text_renders_markdown() {
+    let doc = extract_pod("=head1 NAME\n\nL<detailed guide|File::Path>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        name.contains("[detailed guide]"),
+        "expected markdown display '[detailed guide]' but got: {name}"
+    );
+    assert!(
+        name.contains("perl-module://File::Path"),
+        "expected markdown target 'perl-module://File::Path' but got: {name}"
+    );
+}
+
+/// `L<Module::Name/section>` should link to module and include section in URI.
+#[test]
+fn link_with_section_renders_markdown() {
+    let doc = extract_pod("=head1 NAME\n\nL<File::Path/DESCRIPTION>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        name.contains("[File::Path]"),
+        "expected markdown display '[File::Path]' but got: {name}"
+    );
+    assert!(
+        name.contains("perl-module://File::Path/DESCRIPTION"),
+        "expected markdown target 'perl-module://File::Path/DESCRIPTION' but got: {name}"
+    );
+}
+
+/// `B<L<Module::Name>>` — nested: bold outer, link inner. Both should be preserved.
+#[test]
+fn nested_bold_around_link_preserves_markdown() {
+    let doc = extract_pod("=head1 NAME\n\nB<L<File::Path>>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        name.contains("[File::Path]"),
+        "expected markdown display '[File::Path]' in nested B<L<>> but got: {name}"
+    );
+    assert!(
+        name.contains("perl-module://"),
+        "expected 'perl-module://' in nested B<L<>> but got: {name}"
+    );
+}
+
+/// Inline link inside a sentence: "See L<File::Path> for details."
+#[test]
+fn inline_link_in_description_renders_markdown() {
+    let source = "=head1 DESCRIPTION\n\nSee L<File::Path> for details.\n\n=cut\n";
+    let doc = extract_pod(source);
+    let desc = doc.description.as_deref().unwrap_or("");
+    assert!(
+        desc.contains("[File::Path]"),
+        "expected '[File::Path]' in description but got: {desc}"
+    );
+    assert!(
+        desc.contains("perl-module://File::Path"),
+        "expected 'perl-module://File::Path' in description but got: {desc}"
+    );
+    // The surrounding text should also be preserved
+    assert!(
+        desc.contains("See") && desc.contains("for details"),
+        "surrounding text lost; got: {desc}"
+    );
+}
+
+/// `L<text|Module::Name/section>` — display text with section target.
+#[test]
+fn link_display_text_with_section_target_renders_markdown() {
+    let doc = extract_pod("=head1 NAME\n\nL<the docs|File::Path/DESCRIPTION>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("[the docs]"), "expected '[the docs]' but got: {name}");
+    assert!(
+        name.contains("perl-module://File::Path/DESCRIPTION"),
+        "expected 'perl-module://File::Path/DESCRIPTION' but got: {name}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Modify `extract_link_display()` in `crates/perl-pod/src/lib.rs` to return `[display](perl-module://target)` markdown syntax instead of plain text
- VS Code natively renders markdown links in hover tooltips as clickable — no structural changes to `PodDoc` needed (Option B from scout spec)
- Handles all four standard POD link forms: `L<Module>`, `L<text|Module>`, `L<Module/section>`, `L<text|Module/section>`

## Changes

- `crates/perl-pod/src/lib.rs` — `extract_link_display()`: rewritten to produce markdown link syntax; doc comment updated with all four forms
- `crates/perl-pod/tests/pod_extraction_tests.rs` — 6 new tests added covering all link forms + inline-in-sentence + nested `B<L<>>` case; 3 existing link tests updated to match new markdown output

## Evidence

- **Commits**: 1
- **Tests**: 34 passed, 0 failed (`cargo test -p perl-pod`)
- **Lint**: clean (`cargo clippy -p perl-pod --tests`)
- **Fmt**: clean (`cargo fmt -p perl-pod`)
- **Files**: 2 changed, +128/-14 lines

## Test Plan

1. `cargo test -p perl-pod` — all 34 tests pass
2. Open a Perl module with `L<>` links in its POD (e.g., `use File::Path; # hover over File::Path`) — hover tooltip should show `[File::Path](perl-module://File::Path)` as a clickable link in VS Code
3. Test all four forms: `L<Module>`, `L<text|Module>`, `L<Module/section>`, `L<text|Module/section>`
4. Verify `B<L<Module>>` (bold+link) still renders correctly

## Unknowns

- **`perl-module://` URI resolution**: Links render as clickable but clicking them will open a "no handler" error until a `perl-module://` URI handler is wired up. This is a follow-up enhancement (module resolution → file URI). The scout spec marks this as "future enhancement".
- **`L</section>` form** (link to section in current doc, no module): Not explicitly handled — produces `[](perl-module:///section)` with empty display. This edge case is not in the acceptance criteria; a follow-up can address it.
- **5 pre-existing failures in `perl-lsp` hover tests** (`test_hover_begin_block`, `test_hover_end_block`, `test_hover_check_block`, `test_hover_init_block`, `test_hover_unitcheck_block`) — confirmed pre-existing, unrelated to POD link rendering.

Closes #3406