### PR TITLE
fix(ci): key CPAN corpus cache on manifest, move ratchet to nightly (#4186)

### DIFF
--- a/.github/workflows/post-merge-corpus-ratchet.yml
+++ b/.github/workflows/post-merge-corpus-ratchet.yml
@@ -17,19 +17,12 @@ name: Post-Merge Corpus Ratchet
 # See issue #2026 (automate corpus ratchet after parser fix merges).
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'crates/perl-parser/**'
-      - 'crates/perl-parser-core/**'
-      - 'crates/perl-parser-pest/**'
-      - 'xtask/src/main.rs'
-      - 'xtask/src/tasks/cpan_corpus.rs'
-      - 'xtask/src/tasks/parser_corpus_sweep.rs'
-      - 'justfile'
-      - '.ci/cpan-corpus-baseline.json'
-      - '.ci/cpan-corpus-manifest.txt'
+  schedule:
+    # Nightly at 08:00 UTC. The ratchet is periodic bookkeeping, not a
+    # per-merge gate (post-merge-status.yml handles per-merge regeneration).
+    # Nightly cadence avoids concurrency-cancel storms from rapid parser merges.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
 
 # Only one ratchet at a time; cancel stale runs if a new parser merge lands.
 concurrency:
@@ -73,7 +66,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: target/cpan-corpus
-          key: cpan-corpus-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          key: cpan-corpus-${{ runner.os }}-${{ hashFiles('.ci/cpan-top-1000-distributions.txt') }}
           restore-keys: |
             cpan-corpus-${{ runner.os }}-
 

--- a/.github/workflows/post-merge-corpus-ratchet.yml
+++ b/.github/workflows/post-merge-corpus-ratchet.yml
@@ -1,20 +1,17 @@
 name: Post-Merge Corpus Ratchet
 
 # Automatically refreshes the CPAN full-corpus baseline and ratchets the
-# known-clean CPAN manifest after merges that touch parser crates.
+# known-clean CPAN manifest on a nightly schedule.
 # This prevents the stale-baseline problem: parser fixes sit unrecorded,
 # making it look like the corpus clean rate and strict-clean set did not improve.
 #
-# Triggers only when pushes to master touch:
-#   - crates/perl-parser/
-#   - crates/perl-parser-core/
-#   - crates/perl-parser-pest/
-#   - The justfile (ratchet recipe changes)
-#   - xtask corpus sweep / ratchet plumbing
-#   - .ci/cpan-corpus-baseline.json (full-corpus receipt)
-#   - .ci/cpan-corpus-manifest.txt (strict known-clean receipt)
+# Runs nightly at 08:00 UTC (not on every push). The ratchet is periodic
+# bookkeeping; post-merge-status.yml handles per-merge status regeneration.
+# Nightly cadence avoids the concurrency-cancel storms that killed ~40% of
+# per-merge runs (exit 143, runner shutdown) when rapid parser merges triggered
+# concurrent 18-min cold CPAN installs. Manual runs available via workflow_dispatch.
 #
-# See issue #2026 (automate corpus ratchet after parser fix merges).
+# See issue #4186 (corpus ratchet fails intermittently on cold cache).
 
 on:
   schedule:
@@ -24,7 +21,7 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 
-# Only one ratchet at a time; cancel stale runs if a new parser merge lands.
+# Only one ratchet at a time; cancel stale in-progress runs on re-trigger.
 concurrency:
   group: post-merge-corpus-ratchet-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Fixes the CPAN corpus cache invalidating on every parser merge by keying on `.ci/cpan-top-1000-distributions.txt` instead of `Cargo.lock` — CPAN content has nothing to do with Rust dependencies
- Moves the workflow trigger from `push: branches: [master]` to a nightly cron (`0 8 * * *`) plus `workflow_dispatch` — the ratchet is periodic bookkeeping, not a per-merge gate; `post-merge-status.yml` handles per-merge regeneration

## Root cause

`.github/workflows/post-merge-corpus-ratchet.yml:76` was keyed on `hashFiles('Cargo.lock')`. Every parser merge changes `Cargo.lock`, so the CPAN install always ran cold (~18 min) even though CPAN module content is independent of Rust deps. Combined with the per-push trigger, rapid parser merges caused concurrency-cancel storms that killed ~40% of runs (exit 143, runner shutdown signal).

## Diff

- `.github/workflows/post-merge-corpus-ratchet.yml`: 2 logical changes (trigger block + cache key line)

## Verification

```
YAML syntax OK  (python3 yaml.safe_load)
.ci/cpan-top-1000-distributions.txt  (manifest file confirmed present)
```

## Test plan

- [ ] Confirm no YAML parse errors in CI
- [ ] After merge, verify next nightly run at 08:00 UTC hits cache (cache-hit: true) and skips the 18-min install step
- [ ] Manual `workflow_dispatch` trigger available for on-demand runs

Closes #4186