### PR TITLE
docs(agents): add orthogonal-pass checklist (#4105)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@
 
 ## Verification
 - [ ] `cargo fmt --all` — clean
+- [ ] I used a narrow orthogonal pass first (freshness check, truth-check, or targeted repro) before the broader gate.
 - [ ] `cargo clippy -p <crate> --tests` — clean
 - [ ] `cargo test -p <crate>` — pass
 - [ ] This PR introduces UX-visible changes. I have verified that error messages are actionable and the UX test harness still passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ just status-check
 
 Run `just status-update` and `just status-check` when you change capability docs, generated status sections, or other docs that depend on computed project metrics.
 
+### Verification Ladder
+
+Prefer cheap, orthogonal passes over one broad gate:
+
+1. Check recent merged/open PRs and issues for the area before scoping new work.
+2. Use the narrowest truth-check first for claims: targeted repro/test for behavior, history/doc verification for attribution or status claims.
+3. Escalate to `just pr-fast` or `nix develop -c just ci-gate` only after the narrow pass is green.
+
 ## PR Hygiene
 
 - Use isolated worktrees and focused branches for agent-driven PR work.


### PR DESCRIPTION
## Summary

- add a short verification-ladder section to `AGENTS.md`
- add a PR-template checkbox that asks for a narrow orthogonal pass before the broader gate
- make the cheap-pass expectation visible at author time instead of only in retrospective docs

## Why

The current scorecard and verification work is converging on the same lesson: the cheapest high-leverage guard is usually a freshness check, truth-check, or targeted repro before the full merge gate. Encoding that in the agent contract and PR template reduces drift and makes the conveyor easier to trust.

## Validation

- `git diff --check`
- `git status --short --branch`
