### PR TITLE
test(parser): regression tests for postfix deref chain on method call results (#4167)

### DIFF
--- a/crates/perl-parser-core/tests/fix_postfix_method_deref_chain_4167.rs
+++ b/crates/perl-parser-core/tests/fix_postfix_method_deref_chain_4167.rs
@@ -1,0 +1,41 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Issue #4167: postfix deref chain on method call result
+// Perl: $obj->method()->[0]->name() is valid and should parse cleanly.
+
+#[test]
+fn test_method_result_array_deref() {
+    // $obj->method()->[0]
+    assert_clean_parse("my $item = $obj->get_items()->[0];");
+}
+
+#[test]
+fn test_method_result_array_deref_then_method() {
+    // $obj->method()->[0]->name()
+    assert_clean_parse("my $name = $obj->get_items()->[0]->name();");
+}
+
+#[test]
+fn test_method_result_hash_deref() {
+    // $obj->method()->{key}
+    assert_clean_parse("my $val = $obj->get_data()->{key};");
+}
+
+#[test]
+fn test_method_result_hash_deref_then_method() {
+    // $obj->method()->{key}->value()
+    assert_clean_parse("my $v = $obj->get_data()->{key}->value();");
+}
+
+#[test]
+fn test_method_result_chained_array_hash_deref() {
+    // $obj->method()->[0]->{key}
+    assert_clean_parse("my $v = $obj->get_items()->[0]->{name};");
+}
+
+#[test]
+fn test_full_deref_chain() {
+    // Full chain: method()->[0]->{key}->method()
+    assert_clean_parse("my $x = $obj->method()->[0]->{key}->name();");
+}


### PR DESCRIPTION
## Summary

- Issue #4167 reported a suspected parser bug where `$obj->method()->[0]->name()` would emit Error nodes
- Verification shows the postfix chain parsing was already correctly implemented (fixed via PR #1474 on 2026-03-15)
- The `parse_postfix_chain` loop correctly handles sequential `Arrow -> MethodCall -> Arrow -> LeftBracket/LeftBrace/MethodName` transitions
- Adding 6 regression tests to guard against future regressions in this behavior

## Verification

Confirmed with `perl -c` that all test patterns are valid Perl syntax. Confirmed all patterns parse cleanly with no Error nodes in the AST. The `"Incomplete arrow expression"` error bucket that the scout referenced does not appear in `.ci/parser-corpus-baseline.json` — the fix from PR #1474 already cleared it.

## Tests added

`crates/perl-parser-core/tests/fix_postfix_method_deref_chain_4167.rs` — 6 tests covering:
1. `$obj->method()->[0]` — array deref on method result
2. `$obj->method()->[0]->name()` — method call on deref result
3. `$obj->method()->{key}` — hash deref on method result  
4. `$obj->method()->{key}->value()` — method on hash deref result
5. `$obj->method()->[0]->{name}` — chained array-then-hash deref
6. `$obj->method()->[0]->{key}->name()` — full multi-step chain

## Pre-existing failures

3 pre-existing test failures exist on master (`test_cpan_undef_parens_in_ternary`, `test_mojo_log_format`, `test_cpan_coderef_call_in_ternary`) — verified against master, not caused by this PR.

## Knowledge artifacts

- **Root cause of scout confidence=medium**: The scout filed this based on pattern matching against corpus error buckets. PR #1474 (2026-03-15) already fixed the `parse_postfix_chain` to handle `->[]` and `->{}` after method calls. The corpus baseline shows no "Incomplete arrow expression" bucket active.
- **Recommended action**: Close #4167 as already-fixed. This PR adds regression tests.

Closes #4167