### PR TITLE
test(ux): add editor UX fixture matrix (#4066)

### DIFF
--- a/.ci/schemas/editor-ux.schema.json
+++ b/.ci/schemas/editor-ux.schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/schemas/editor-ux.schema.json",
+  "title": "perl-lsp editor_ux scorecard",
+  "description": "Measured workflow UX scorecard for perl-lsp.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "measured_at",
+    "subsystem",
+    "top_line",
+    "components",
+    "workflows",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "measured_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "subsystem": {
+      "type": "string",
+      "const": "editor_ux"
+    },
+    "top_line": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
+      ],
+      "properties": {
+        "workflow_pass_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "workflow_stability_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "p95_time_to_first_useful_result_ms": {
+          "$ref": "#/definitions/latencyMetric"
+        }
+      }
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hover_correctness_rate",
+        "hover_declaration_context_accuracy",
+        "completion_top5_usefulness_rate",
+        "completion_empty_when_should_not_be_empty_rate",
+        "goto_definition_exact_hit_rate",
+        "cross_workspace_definition_success_rate",
+        "rename_success_rate",
+        "settled_diagnostics_correctness_rate",
+        "module_resolution_workflow_success_rate",
+        "multi_root_workspace_navigation_success_rate",
+        "dap_happy_path_success_rate"
+      ],
+      "properties": {
+        "hover_correctness_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "hover_declaration_context_accuracy": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "completion_top5_usefulness_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "completion_empty_when_should_not_be_empty_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "goto_definition_exact_hit_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "cross_workspace_definition_success_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "rename_success_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "settled_diagnostics_correctness_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "module_resolution_workflow_success_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "multi_root_workspace_navigation_success_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "dap_happy_path_success_rate": {
+          "$ref": "#/definitions/rateMetric"
+        }
+      }
+    },
+    "workflows": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/workflowResult"
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixture_matrix",
+        "harness",
+        "tiers"
+      ],
+      "properties": {
+        "fixture_matrix": {
+          "type": "string"
+        },
+        "harness": {
+          "type": "string"
+        },
+        "tiers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "pr",
+              "nightly",
+              "release"
+            ]
+          }
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metricProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "basis",
+        "coverage",
+        "confidence"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "measured",
+            "derived",
+            "estimated",
+            "reported"
+          ]
+        },
+        "basis": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "coverage": {
+          "type": "string",
+          "enum": [
+            "receipts_included",
+            "github_plus_agent_logs",
+            "github_only",
+            "self_attested"
+          ]
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low"
+          ]
+        },
+        "method": {
+          "type": "string"
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "rateMetric": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/metricProvenance"
+        },
+        {
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        }
+      ]
+    },
+    "latencyMetric": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/metricProvenance"
+        },
+        {
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "type": "number",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "workflowResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "scenario",
+        "subsystem_owner",
+        "pass_rate",
+        "stability_rate",
+        "p95_time_to_first_useful_result_ms"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "scenario": {
+          "type": "string"
+        },
+        "subsystem_owner": {
+          "type": "string",
+          "enum": [
+            "editor_intelligence",
+            "diagnostics",
+            "module_resolution",
+            "workspace_indexing",
+            "dap",
+            "engineering_health"
+          ]
+        },
+        "pass_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "stability_rate": {
+          "$ref": "#/definitions/rateMetric"
+        },
+        "p95_time_to_first_useful_result_ms": {
+          "$ref": "#/definitions/latencyMetric"
+        },
+        "component_metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/rateMetric"
+              },
+              {
+                "$ref": "#/definitions/latencyMetric"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/.ci/schemas/editor-ux.schema.json
+++ b/.ci/schemas/editor-ux.schema.json
@@ -51,50 +51,18 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "hover_correctness_rate",
-        "hover_declaration_context_accuracy",
-        "completion_top5_usefulness_rate",
-        "completion_empty_when_should_not_be_empty_rate",
-        "goto_definition_exact_hit_rate",
-        "cross_workspace_definition_success_rate",
-        "rename_success_rate",
-        "settled_diagnostics_correctness_rate",
+        "cross_file_definition_success_rate",
         "module_resolution_workflow_success_rate",
-        "multi_root_workspace_navigation_success_rate",
-        "dap_happy_path_success_rate"
+        "multi_root_workspace_navigation_success_rate"
       ],
       "properties": {
-        "hover_correctness_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "hover_declaration_context_accuracy": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "completion_top5_usefulness_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "completion_empty_when_should_not_be_empty_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "goto_definition_exact_hit_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "cross_workspace_definition_success_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "rename_success_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "settled_diagnostics_correctness_rate": {
+        "cross_file_definition_success_rate": {
           "$ref": "#/definitions/rateMetric"
         },
         "module_resolution_workflow_success_rate": {
           "$ref": "#/definitions/rateMetric"
         },
         "multi_root_workspace_navigation_success_rate": {
-          "$ref": "#/definitions/rateMetric"
-        },
-        "dap_happy_path_success_rate": {
           "$ref": "#/definitions/rateMetric"
         }
       }

--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -24,6 +24,18 @@ Scenarios currently include:
 - workspace-folder removal evicting stale symbols from search results, and
 - deleted-file churn evicting stale search results and definition targets.
 
+The harness is now also the source of truth for the workflow UX scorecard
+inventory:
+
+- `.ci/schemas/editor-ux.schema.json` defines the eventual measured
+  `editor_ux.json` contract.
+- `docs/project/metrics/WORKFLOW_SCORECARDS.md` explains how that workflow layer
+  fits above the subsystem scorecards.
+- `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` maps each
+  executable scenario to scorecard rows and subsystem ownership.
+- `tests/editor_ux_fixture_matrix.rs` keeps that matrix aligned with the actual
+  `ux_scenario_*.rs` files.
+
 ## Running the tests
 
 From the workspace root:

--- a/crates/perl-lsp-ux-tests/README.md
+++ b/crates/perl-lsp-ux-tests/README.md
@@ -32,7 +32,7 @@ inventory:
 - `docs/project/metrics/WORKFLOW_SCORECARDS.md` explains how that workflow layer
   fits above the subsystem scorecards.
 - `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` maps each
-  executable scenario to scorecard rows and subsystem ownership.
+  executable scenario to current scorecard rows and subsystem ownership.
 - `tests/editor_ux_fixture_matrix.rs` keeps that matrix aligned with the actual
   `ux_scenario_*.rs` files.
 

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -7,17 +7,9 @@
     "p95_time_to_first_useful_result_ms"
   ],
   "component_metrics": [
-    "hover_correctness_rate",
-    "hover_declaration_context_accuracy",
-    "completion_top5_usefulness_rate",
-    "completion_empty_when_should_not_be_empty_rate",
-    "goto_definition_exact_hit_rate",
-    "cross_workspace_definition_success_rate",
-    "rename_success_rate",
-    "settled_diagnostics_correctness_rate",
+    "cross_file_definition_success_rate",
     "module_resolution_workflow_success_rate",
-    "multi_root_workspace_navigation_success_rate",
-    "dap_happy_path_success_rate"
+    "multi_root_workspace_navigation_success_rate"
   ],
   "workflows": [
     {
@@ -28,9 +20,7 @@
       "user_journey": "open a simple Perl file and verify hover and completion work without crashing",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "hover_correctness_rate",
-        "completion_empty_when_should_not_be_empty_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "server starts cleanly",
@@ -61,8 +51,7 @@
       "user_journey": "start the server without perl on PATH and perform basic editor actions",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "hover_correctness_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "server starts in degraded mode",
@@ -77,8 +66,7 @@
       "user_journey": "publish diagnostics when perlcritic is unavailable",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "settled_diagnostics_correctness_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "diagnostics degrade gracefully",
@@ -124,11 +112,10 @@
       "user_journey": "open multiple files in a workspace and navigate across them",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "cross_workspace_definition_success_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
-        "cross-file definition works",
+        "cross-file definition request completes without error",
         "workspace interactions remain stable"
       ]
     },
@@ -169,8 +156,7 @@
       "user_journey": "run goto-definition inside a representative file",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "goto_definition_exact_hit_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "definition request returns a location or clean empty result",
@@ -185,9 +171,7 @@
       "user_journey": "run hover over names and variables in a representative file",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "hover_correctness_rate",
-        "hover_declaration_context_accuracy"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "hover request returns useful structure or clean empty result",
@@ -202,12 +186,11 @@
       "user_journey": "open a strict warnings file and wait for settled diagnostics",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "settled_diagnostics_correctness_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "publishDiagnostics arrives",
-        "diagnostic codes and shapes are valid"
+        "diagnostic payload shape stays valid"
       ]
     },
     {
@@ -218,8 +201,7 @@
       "user_journey": "request document symbols for parsable and empty files",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate",
-        "multi_root_workspace_navigation_success_rate"
+        "workflow_stability_rate"
       ],
       "expected_outcomes": [
         "document symbols return valid structure",
@@ -281,7 +263,7 @@
       "measures": [
         "workflow_pass_rate",
         "workflow_stability_rate",
-        "cross_workspace_definition_success_rate"
+        "cross_file_definition_success_rate"
       ],
       "expected_outcomes": [
         "deleted symbols disappear from workspace/symbol",

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1,0 +1,292 @@
+{
+  "schema_version": 1,
+  "subsystem": "editor_ux",
+  "top_line_metrics": [
+    "workflow_pass_rate",
+    "workflow_stability_rate",
+    "p95_time_to_first_useful_result_ms"
+  ],
+  "component_metrics": [
+    "hover_correctness_rate",
+    "hover_declaration_context_accuracy",
+    "completion_top5_usefulness_rate",
+    "completion_empty_when_should_not_be_empty_rate",
+    "goto_definition_exact_hit_rate",
+    "cross_workspace_definition_success_rate",
+    "rename_success_rate",
+    "settled_diagnostics_correctness_rate",
+    "module_resolution_workflow_success_rate",
+    "multi_root_workspace_navigation_success_rate",
+    "dap_happy_path_success_rate"
+  ],
+  "workflows": [
+    {
+      "id": "simple_file_smoke",
+      "scenario_file": "ux_scenario_01_simple_file.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "open a simple Perl file and verify hover and completion work without crashing",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "hover_correctness_rate",
+        "completion_empty_when_should_not_be_empty_rate"
+      ],
+      "expected_outcomes": [
+        "server starts cleanly",
+        "hover returns useful structure or empty without crashing",
+        "completion request succeeds"
+      ]
+    },
+    {
+      "id": "missing_perltidy_graceful_degradation",
+      "scenario_file": "ux_scenario_02_missing_perltidy.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "pr",
+      "user_journey": "request formatting when perltidy is unavailable",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "format request degrades gracefully",
+        "server stays responsive"
+      ]
+    },
+    {
+      "id": "missing_perl_graceful_degradation",
+      "scenario_file": "ux_scenario_03_missing_perl.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "pr",
+      "user_journey": "start the server without perl on PATH and perform basic editor actions",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "hover_correctness_rate"
+      ],
+      "expected_outcomes": [
+        "server starts in degraded mode",
+        "hover or completion remain available where possible"
+      ]
+    },
+    {
+      "id": "missing_perlcritic_graceful_degradation",
+      "scenario_file": "ux_scenario_04_missing_perlcritic.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "pr",
+      "user_journey": "publish diagnostics when perlcritic is unavailable",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "settled_diagnostics_correctness_rate"
+      ],
+      "expected_outcomes": [
+        "diagnostics degrade gracefully",
+        "no crash or panic-style messaging"
+      ]
+    },
+    {
+      "id": "bad_config_resilience",
+      "scenario_file": "ux_scenario_05_bad_config.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "pr",
+      "user_journey": "open a workspace with invalid tool configuration",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "invalid config does not crash the server",
+        "user-visible feedback is actionable"
+      ]
+    },
+    {
+      "id": "large_file_open",
+      "scenario_file": "ux_scenario_06_large_file.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "nightly",
+      "user_journey": "open a large file and wait for the first useful response",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
+      ],
+      "expected_outcomes": [
+        "large files do not crash the server",
+        "large-file workflow stays within latency budget"
+      ]
+    },
+    {
+      "id": "multi_file_workspace_navigation",
+      "scenario_file": "ux_scenario_07_multi_file_workspace.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "open multiple files in a workspace and navigate across them",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_workspace_definition_success_rate"
+      ],
+      "expected_outcomes": [
+        "cross-file definition works",
+        "workspace interactions remain stable"
+      ]
+    },
+    {
+      "id": "shebang_detection",
+      "scenario_file": "ux_scenario_08_shebang_detection.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "open a Perl file without a .pl extension",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "languageId-perl files without extensions still behave like Perl"
+      ]
+    },
+    {
+      "id": "encoding_and_bom_resilience",
+      "scenario_file": "ux_scenario_09_encoding.rs",
+      "subsystem_owner": "engineering_health",
+      "ci_tier": "pr",
+      "user_journey": "open files with BOMs, utf8 pragmas, and Unicode text",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "encoding edge cases do not crash the server",
+        "user workflow remains intact"
+      ]
+    },
+    {
+      "id": "goto_definition_core",
+      "scenario_file": "ux_scenario_10_goto_definition.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "run goto-definition inside a representative file",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "goto_definition_exact_hit_rate"
+      ],
+      "expected_outcomes": [
+        "definition request returns a location or clean empty result",
+        "request does not error"
+      ]
+    },
+    {
+      "id": "hover_core",
+      "scenario_file": "ux_scenario_11_hover.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "user_journey": "run hover over names and variables in a representative file",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "hover_correctness_rate",
+        "hover_declaration_context_accuracy"
+      ],
+      "expected_outcomes": [
+        "hover request returns useful structure or clean empty result",
+        "request does not error"
+      ]
+    },
+    {
+      "id": "strict_diagnostics",
+      "scenario_file": "ux_scenario_12_diagnostics_strict.rs",
+      "subsystem_owner": "diagnostics",
+      "ci_tier": "pr",
+      "user_journey": "open a strict warnings file and wait for settled diagnostics",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "settled_diagnostics_correctness_rate"
+      ],
+      "expected_outcomes": [
+        "publishDiagnostics arrives",
+        "diagnostic codes and shapes are valid"
+      ]
+    },
+    {
+      "id": "document_symbols_core",
+      "scenario_file": "ux_scenario_13_document_symbols.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "request document symbols for parsable and empty files",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "multi_root_workspace_navigation_success_rate"
+      ],
+      "expected_outcomes": [
+        "document symbols return valid structure",
+        "rich files surface known sub names"
+      ]
+    },
+    {
+      "id": "inc_conformance",
+      "scenario_file": "ux_scenario_14_inc_conformance.rs",
+      "subsystem_owner": "module_resolution",
+      "ci_tier": "pr",
+      "user_journey": "resolve modules across multiple @INC modes and compare hover, goto-definition, and diagnostics",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "module_resolution_workflow_success_rate"
+      ],
+      "expected_outcomes": [
+        "PL701, hover, and goto-definition agree across supported modes"
+      ]
+    },
+    {
+      "id": "multi_root_workspace_symbols",
+      "scenario_file": "ux_scenario_15_workspace_symbols.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "search workspace symbols across multiple folders with same-named definitions",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "multi_root_workspace_navigation_success_rate"
+      ],
+      "expected_outcomes": [
+        "workspace/symbol returns same-named symbols from multiple roots",
+        "results include workspaceFolderUri"
+      ]
+    },
+    {
+      "id": "workspace_folder_removal_freshness",
+      "scenario_file": "ux_scenario_16_workspace_folder_removal.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "remove a workspace folder after indexing and re-run workspace symbol search",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "multi_root_workspace_navigation_success_rate"
+      ],
+      "expected_outcomes": [
+        "removed folder symbols disappear from search results"
+      ]
+    },
+    {
+      "id": "deleted_file_churn_freshness",
+      "scenario_file": "ux_scenario_17_deleted_file_churn.rs",
+      "subsystem_owner": "workspace_indexing",
+      "ci_tier": "pr",
+      "user_journey": "delete a module file after indexing and verify stale symbol and definition results are evicted",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_workspace_definition_success_rate"
+      ],
+      "expected_outcomes": [
+        "deleted symbols disappear from workspace/symbol",
+        "definition no longer resolves to deleted targets"
+      ]
+    }
+  ]
+}

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -51,6 +51,7 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
         matrix.get("workflows").and_then(Value::as_array).context("workflows missing")?;
 
     let mut scenarios_in_matrix = BTreeSet::new();
+    let mut component_metrics_exercised = BTreeSet::new();
     for workflow in workflows {
         let scenario_file = workflow
             .get("scenario_file")
@@ -69,6 +70,9 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
                 allowed_metrics.contains(measure),
                 "workflow `{scenario_file}` references unknown metric `{measure}`"
             );
+            if component_metrics.contains(measure) {
+                component_metrics_exercised.insert(measure.clone());
+            }
         }
 
         let expected_outcomes = workflow
@@ -99,6 +103,10 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
     assert_eq!(
         scenarios_in_matrix, scenarios_on_disk,
         "fixture matrix must stay in lockstep with the executable UX scenarios"
+    );
+    assert_eq!(
+        component_metrics_exercised, component_metrics,
+        "every declared component metric must be exercised by at least one workflow"
     );
 
     Ok(())

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -1,0 +1,128 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+const FIXTURE_MATRIX: &str = "crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json";
+const UX_TESTS_DIR: &str = "crates/perl-lsp-ux-tests/tests";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent().and_then(Path::parent).expect("workspace root")
+}
+
+#[test]
+fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
+    let matrix_path = workspace_root().join(FIXTURE_MATRIX);
+    let matrix_text = fs::read_to_string(&matrix_path)
+        .with_context(|| format!("reading {}", matrix_path.display()))?;
+    let matrix: Value = serde_json::from_str(&matrix_text)
+        .with_context(|| format!("parsing {}", matrix_path.display()))?;
+
+    let schema_version = matrix
+        .get("schema_version")
+        .and_then(Value::as_u64)
+        .context("schema_version missing")?;
+    assert_eq!(schema_version, 1, "fixture matrix schema version drifted");
+
+    let subsystem = matrix
+        .get("subsystem")
+        .and_then(Value::as_str)
+        .context("subsystem missing")?;
+    assert_eq!(subsystem, "editor_ux");
+
+    let top_line_metrics = collect_string_set(
+        matrix.get("top_line_metrics").context("top_line_metrics missing")?,
+        "top_line_metrics",
+    )?;
+    assert_eq!(
+        top_line_metrics,
+        BTreeSet::from([
+            "workflow_pass_rate".to_string(),
+            "workflow_stability_rate".to_string(),
+            "p95_time_to_first_useful_result_ms".to_string()
+        ])
+    );
+
+    let component_metrics = collect_string_set(
+        matrix.get("component_metrics").context("component_metrics missing")?,
+        "component_metrics",
+    )?;
+    let allowed_metrics = top_line_metrics
+        .union(&component_metrics)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let workflows = matrix
+        .get("workflows")
+        .and_then(Value::as_array)
+        .context("workflows missing")?;
+
+    let mut scenarios_in_matrix = BTreeSet::new();
+    for workflow in workflows {
+        let scenario_file = workflow
+            .get("scenario_file")
+            .and_then(Value::as_str)
+            .context("workflow missing scenario_file")?;
+        let measures = collect_string_set(
+            workflow.get("measures").context("workflow missing measures")?,
+            scenario_file,
+        )?;
+        assert!(
+            !measures.is_empty(),
+            "workflow `{scenario_file}` must define at least one measure"
+        );
+        for measure in &measures {
+            assert!(
+                allowed_metrics.contains(measure),
+                "workflow `{scenario_file}` references unknown metric `{measure}`"
+            );
+        }
+
+        let expected_outcomes = workflow
+            .get("expected_outcomes")
+            .and_then(Value::as_array)
+            .context("workflow missing expected_outcomes")?;
+        assert!(
+            !expected_outcomes.is_empty(),
+            "workflow `{scenario_file}` must define expected outcomes"
+        );
+
+        let scenario_path = workspace_root().join(UX_TESTS_DIR).join(scenario_file);
+        assert!(
+            scenario_path.exists(),
+            "workflow `{scenario_file}` points at missing scenario file {}",
+            scenario_path.display()
+        );
+        scenarios_in_matrix.insert(scenario_file.to_string());
+    }
+
+    let scenarios_on_disk = fs::read_dir(workspace_root().join(UX_TESTS_DIR))
+        .context("reading UX tests dir")?
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("ux_scenario_") && name.ends_with(".rs"))
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        scenarios_in_matrix, scenarios_on_disk,
+        "fixture matrix must stay in lockstep with the executable UX scenarios"
+    );
+
+    Ok(())
+}
+
+fn collect_string_set(value: &Value, context_label: &str) -> Result<BTreeSet<String>> {
+    let values = value
+        .as_array()
+        .with_context(|| format!("{context_label} must be an array"))?;
+    let mut out = BTreeSet::new();
+    for entry in values {
+        let item = entry
+            .as_str()
+            .with_context(|| format!("{context_label} entries must be strings"))?;
+        out.insert(item.to_string());
+    }
+    Ok(out)
+}

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -20,16 +20,11 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
     let matrix: Value = serde_json::from_str(&matrix_text)
         .with_context(|| format!("parsing {}", matrix_path.display()))?;
 
-    let schema_version = matrix
-        .get("schema_version")
-        .and_then(Value::as_u64)
-        .context("schema_version missing")?;
+    let schema_version =
+        matrix.get("schema_version").and_then(Value::as_u64).context("schema_version missing")?;
     assert_eq!(schema_version, 1, "fixture matrix schema version drifted");
 
-    let subsystem = matrix
-        .get("subsystem")
-        .and_then(Value::as_str)
-        .context("subsystem missing")?;
+    let subsystem = matrix.get("subsystem").and_then(Value::as_str).context("subsystem missing")?;
     assert_eq!(subsystem, "editor_ux");
 
     let top_line_metrics = collect_string_set(
@@ -49,15 +44,11 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
         matrix.get("component_metrics").context("component_metrics missing")?,
         "component_metrics",
     )?;
-    let allowed_metrics = top_line_metrics
-        .union(&component_metrics)
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    let allowed_metrics =
+        top_line_metrics.union(&component_metrics).cloned().collect::<BTreeSet<_>>();
 
-    let workflows = matrix
-        .get("workflows")
-        .and_then(Value::as_array)
-        .context("workflows missing")?;
+    let workflows =
+        matrix.get("workflows").and_then(Value::as_array).context("workflows missing")?;
 
     let mut scenarios_in_matrix = BTreeSet::new();
     for workflow in workflows {
@@ -114,14 +105,11 @@ fn editor_ux_fixture_matrix_covers_all_scenarios() -> Result<()> {
 }
 
 fn collect_string_set(value: &Value, context_label: &str) -> Result<BTreeSet<String>> {
-    let values = value
-        .as_array()
-        .with_context(|| format!("{context_label} must be an array"))?;
+    let values = value.as_array().with_context(|| format!("{context_label} must be an array"))?;
     let mut out = BTreeSet::new();
     for entry in values {
-        let item = entry
-            .as_str()
-            .with_context(|| format!("{context_label} entries must be strings"))?;
+        let item =
+            entry.as_str().with_context(|| format!("{context_label} entries must be strings"))?;
         out.insert(item.to_string());
     }
     Ok(out)

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Rule: if a project metric appears outside [project/CURRENT_STATUS.md](project/CU
 | check known limitations and parser support | [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md) |
 | see what is true now | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) |
 | see the current release plan | [project/ROADMAP.md](project/ROADMAP.md) |
+| inspect the workflow UX scorecard contract | [project/metrics/WORKFLOW_SCORECARDS.md](project/metrics/WORKFLOW_SCORECARDS.md), [reference/UX_TESTING.md](reference/UX_TESTING.md) |
 | work on the codebase | [../CONTRIBUTING.md](../CONTRIBUTING.md) |
 | browse the full docs map | [INDEX.md](INDEX.md) |
 

--- a/docs/project/metrics/README.md
+++ b/docs/project/metrics/README.md
@@ -368,6 +368,7 @@ A: Nothing. Those are generated per-subsystem status files that describe *what i
 
 ### Related docs
 
+- [docs/project/metrics/WORKFLOW_SCORECARDS.md](WORKFLOW_SCORECARDS.md) — workflow-level scorecard contracts layered above the subsystem scorecards.
 - [docs/project/status/index.md](../status/index.md) — generated per-subsystem status surface (what is true *right now*).
 - [docs/project/ROADMAP.md](../ROADMAP.md) — milestone view of what each scorecard is aiming at.
 - [features.toml](../../../features.toml) — canonical LSP capability catalog. The catalog that the #4107 correction fixed.

--- a/docs/project/metrics/WORKFLOW_SCORECARDS.md
+++ b/docs/project/metrics/WORKFLOW_SCORECARDS.md
@@ -7,9 +7,9 @@ the subsystem scorecards. It is intentionally narrow:
 
 - top-line rows answer whether real editor workflows succeed, stay stable, and
   return useful results quickly;
-- component rows point back to subsystem-owned behavior such as hover,
-  completion, goto-definition, diagnostics, module resolution, workspace
-  freshness, and DAP happy paths; and
+- current component rows point back to the subsystem-owned behaviors the
+  harness proves today: module-resolution success, multi-root workspace
+  navigation, and cross-file definition success; and
 - the fixture matrix ties each workflow metric to an executable scenario in the
   `perl-lsp-ux-tests` harness.
 
@@ -26,19 +26,24 @@ the subsystem scorecards. It is intentionally narrow:
 - `workflow_stability_rate`
 - `p95_time_to_first_useful_result_ms`
 
-## Component Rows
+## Current Component Rows
 
-- `hover_correctness_rate`
-- `hover_declaration_context_accuracy`
-- `completion_top5_usefulness_rate`
-- `completion_empty_when_should_not_be_empty_rate`
-- `goto_definition_exact_hit_rate`
-- `cross_workspace_definition_success_rate`
-- `rename_success_rate`
-- `settled_diagnostics_correctness_rate`
+- `cross_file_definition_success_rate`
 - `module_resolution_workflow_success_rate`
 - `multi_root_workspace_navigation_success_rate`
-- `dap_happy_path_success_rate`
+
+## Planned Next Rows
+
+These stay intentionally out of the fixture-backed contract until the
+underlying scenarios assert exact user-facing outcomes rather than transport or
+shape-only success:
+
+- hover correctness and declaration context
+- completion usefulness and non-empty expectations
+- exact goto-definition hit rate
+- rename success
+- settled diagnostics correctness after edit
+- DAP happy-path success
 
 ## What This Does Not Claim
 
@@ -52,6 +57,6 @@ workflow layer exists to answer the narrower product question:
 ## Current Scope
 
 The schema and fixture matrix land before a full measured emitter. That keeps
-the contract honest: the workflow inventory is executable today, while the
-published metrics can arrive once the harness emits pass/stability/latency
-receipts per workflow.
+the contract honest: the workflow inventory is executable today, the current
+component rows are backed by exact scenario assertions today, and the broader
+UX scorecard can expand only when those stronger assertions exist.

--- a/docs/project/metrics/WORKFLOW_SCORECARDS.md
+++ b/docs/project/metrics/WORKFLOW_SCORECARDS.md
@@ -1,0 +1,57 @@
+# Workflow Scorecard Contracts
+
+This page defines machine-readable contracts for workflow-level scorecards.
+
+The first contract is `editor_ux`: a thin workflow scorecard that sits above
+the subsystem scorecards. It is intentionally narrow:
+
+- top-line rows answer whether real editor workflows succeed, stay stable, and
+  return useful results quickly;
+- component rows point back to subsystem-owned behavior such as hover,
+  completion, goto-definition, diagnostics, module resolution, workspace
+  freshness, and DAP happy paths; and
+- the fixture matrix ties each workflow metric to an executable scenario in the
+  `perl-lsp-ux-tests` harness.
+
+## Files
+
+- [`.ci/schemas/editor-ux.schema.json`](../../../.ci/schemas/editor-ux.schema.json)
+  defines the measured `editor_ux.json` output contract.
+- [`crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json`](../../../crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json)
+  maps workflow fixtures to scorecard rows and subsystem ownership.
+
+## Top-line Metrics
+
+- `workflow_pass_rate`
+- `workflow_stability_rate`
+- `p95_time_to_first_useful_result_ms`
+
+## Component Rows
+
+- `hover_correctness_rate`
+- `hover_declaration_context_accuracy`
+- `completion_top5_usefulness_rate`
+- `completion_empty_when_should_not_be_empty_rate`
+- `goto_definition_exact_hit_rate`
+- `cross_workspace_definition_success_rate`
+- `rename_success_rate`
+- `settled_diagnostics_correctness_rate`
+- `module_resolution_workflow_success_rate`
+- `multi_root_workspace_navigation_success_rate`
+- `dap_happy_path_success_rate`
+
+## What This Does Not Claim
+
+This scorecard is not parser breadth, capability count, mutation score, or a
+generic CPU/memory report. Those remain supporting subsystem metrics. The
+workflow layer exists to answer the narrower product question:
+
+> when a user opens a realistic project and performs common editor actions, how
+> often does perl-lsp behave correctly and quickly?
+
+## Current Scope
+
+The schema and fixture matrix land before a full measured emitter. That keeps
+the contract honest: the workflow inventory is executable today, while the
+published metrics can arrive once the harness emits pass/stability/latency
+receipts per workflow.

--- a/docs/reference/UX_TESTING.md
+++ b/docs/reference/UX_TESTING.md
@@ -50,6 +50,22 @@ either a prebuilt binary or an explicit `PERL_LSP_BIN=/path/to/perl-lsp`.
 `just ux-tests` runs every default scenario above. `just ux-tests-full` adds the
 feature-gated 10k-line large-file case from Scenario 06.
 
+## Workflow Scorecard Contract
+
+The UX harness is also the fixture source for the planned `editor_ux`
+scorecard:
+
+- `docs/project/metrics/WORKFLOW_SCORECARDS.md` describes the workflow layer and
+  the top-line/component rows it owns.
+- `.ci/schemas/editor-ux.schema.json` defines the measured scorecard shape.
+- `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` maps each
+  workflow fixture to scorecard rows and subsystem ownership.
+- `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs` prevents the
+  matrix from drifting away from the executable scenario files.
+
+This keeps the workflow scorecard grounded in real harness coverage instead of a
+manually curated checklist.
+
 ## How to Add a New Scenario
 
 1. Create `crates/perl-lsp-ux-tests/tests/ux_scenario_NN_my_scenario.rs`.

--- a/docs/reference/UX_TESTING.md
+++ b/docs/reference/UX_TESTING.md
@@ -40,7 +40,7 @@ either a prebuilt binary or an explicit `PERL_LSP_BIN=/path/to/perl-lsp`.
 | 09 | BOM and encoding | UTF-8 BOM, `use utf8`, Unicode in comments |
 | 10 | Go-to-definition | Request succeeds end-to-end and returns location-or-empty without crashing |
 | 11 | Hover | Request succeeds end-to-end and returns useful structure-or-empty without crashing |
-| 12 | Strict diagnostics | `use strict` / `use warnings` diagnostics surface with expected codes |
+| 12 | Strict diagnostics | `publishDiagnostics` arrives and the payload shape stays valid |
 | 13 | Document symbols | Parsable files return structured document symbols |
 | 14 | `@INC` conformance | PL701, hover, and goto-definition stay consistent across 5 module-resolution modes |
 | 15 | Workspace symbols | `workspace/symbol` finds same-named symbols across workspace folders and carries `workspaceFolderUri` |
@@ -56,10 +56,11 @@ The UX harness is also the fixture source for the planned `editor_ux`
 scorecard:
 
 - `docs/project/metrics/WORKFLOW_SCORECARDS.md` describes the workflow layer and
-  the top-line/component rows it owns.
+  the top-line/current-component rows it owns.
 - `.ci/schemas/editor-ux.schema.json` defines the measured scorecard shape.
 - `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` maps each
-  workflow fixture to scorecard rows and subsystem ownership.
+  workflow fixture to the rows it can actually back today and the owning
+  subsystem.
 - `crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs` prevents the
   matrix from drifting away from the executable scenario files.
 


### PR DESCRIPTION
## Summary

- add a machine-readable `editor_ux` schema under `.ci/schemas/`
- add a workflow fixture matrix that maps each executable UX scenario to top-line/component scorecard rows and subsystem ownership
- add a regression test that keeps the fixture matrix locked to the actual `ux_scenario_*.rs` inventory
- document the workflow scorecard contract from the UX harness and metrics docs

## Why

The editor-intelligence scorecard needs a fixture-backed contract before it can publish trustworthy pass/stability/latency numbers. This lane turns the current UX harness into an explicit inventory and ownership surface instead of leaving it as narrative-only documentation.

## Validation

- `cargo fmt --all`
- `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix`
- `git diff --check`
- `git push` pre-push hook: `nix develop -c just pr-fast`
