### PR TITLE
policy: make research-verifier default for claim-heavy PRs (#4195)

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -18,6 +18,7 @@ You are a builder. Be proactive and fix forward.
 - One PR, one issue, one crate. Stay in your lane.
 - Every PR goes to review. No skipping validation gates.
 - **Two-pass review is mandatory.** Every PR goes through both reviewer (standards, haiku) and reviewer-deep (correctness, sonnet) before merge. Neither pass can be skipped.
+- **Research verification is mandatory for claim-heavy PRs.** Before publishing, check `/builder-self-review` for the claim-heavy criteria � dispatch `research-verifier` if any apply.
 - Note what you learn — surprises, gotchas, context that would have helped.
 
 ## Environment setup
@@ -35,7 +36,7 @@ export CARGO_TARGET_DIR="/tmp/agent-$(git branch --show-current | tr '/' '-')-ta
 2. /builder-write-test — TDD: write failing test from the spec
 3. /builder-implement — make the change, minimal diff
 4. /verify — cargo test, fmt, clippy
-5. /builder-self-review — re-read your own diff before publishing
+5. /builder-self-review — re-read your own diff before publishing (includes research-verification check)
 6. /pr-create — draft PR with knowledge artifacts
 7. /agent-wrapup — retrospective and handoff
 ```

--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -18,7 +18,7 @@ You are a builder. Be proactive and fix forward.
 - One PR, one issue, one crate. Stay in your lane.
 - Every PR goes to review. No skipping validation gates.
 - **Two-pass review is mandatory.** Every PR goes through both reviewer (standards, haiku) and reviewer-deep (correctness, sonnet) before merge. Neither pass can be skipped.
-- **Research verification is mandatory for claim-heavy PRs.** Before publishing, check `/builder-self-review` for the claim-heavy criteria � dispatch `research-verifier` if any apply.
+- **Research verification is mandatory for claim-heavy PRs.** Before publishing, check `/builder-self-review` for the claim-heavy criteria — dispatch `research-verifier` if any apply.
 - Note what you learn — surprises, gotchas, context that would have helped.
 
 ## Environment setup

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -18,6 +18,7 @@ implementation.
 - Think adversarially: what could go wrong with this approach?
 - Your output makes the builder's job unambiguous — exact files, functions, code changes, tests, verify commands.
 - Add the `builder-ready` label when the plan is solid.
+- **Research verification is mandatory for claim-heavy specs.** Run `/plan-review-stress` which checks for claim-heavy criteria and dispatches `research-verifier` when needed.
 - If the issue is already fixed, say so and recommend closing.
 
 ## Todo list

--- a/.claude/agents/reviewer-deep.md
+++ b/.claude/agents/reviewer-deep.md
@@ -14,6 +14,7 @@ mechanical issues. Your job is deeper: does the logic actually work?
 - **Fix forward aggressively.** Add missing edge case tests, fix logic bugs, improve code. Push directly to the PR branch.
 - **Every PR gets improved.** "Approved with no changes" means you didn't look hard enough.
 - **You are the final quality gate.** On approval, set the `reviewed-deep` label. Without it, the PR cannot be marked merge-ready. Both `/pr-ready` and `ops-merge-batch` enforce this.
+- **Research verification is mandatory for claim-heavy PRs.** Run `/reviewer-deep-analyze` which checks for claim-heavy criteria and dispatches `research-verifier` when needed.
 - Narrate what you verified and why you trust it.
 - Route to the best next step based on what you find.
 

--- a/.claude/commands/builder-self-review.md
+++ b/.claude/commands/builder-self-review.md
@@ -38,6 +38,24 @@ This catches dumb mistakes before a reviewer has to.
    - Are test names clear and descriptive?
    - Are there edge cases worth one more test?
 
+## Research Verification
+
+Before publishing, check whether your diff makes any external claims. A PR is **claim-heavy** if it asserts ANY of the following:
+
+- Perl language semantics (`our`, `my`, `local`, pragma behavior, signature semantics, regex flags)
+- LSP 3.17/3.18 protocol behavior
+- DAP protocol behavior
+- External crate API behavior (tower-lsp, lsp-types, tree-sitter, etc.)
+- “PR #NNNN closed this” or “this is fixed by commit SHA”
+- Standard library function behavior that the fix depends on
+
+**If ANY claim-heavy criterion is met:**
+1. Dispatch the `research-verifier` agent on the issue (not the PR) before creating the PR.
+2. Wait for the `research-verified` label or a verification comment.
+3. **Fallback — if network is unavailable:** add the `needs-research-verification` label to the PR and note it in the PR description. Do not merge blind.
+
+**If no external claims are made:** skip this step — no dispatch needed.
+
 ## Output
 
 Record in your task:
@@ -45,6 +63,7 @@ Record in your task:
 Self-review: CLEAN / FIXED <what>
 Diff size: <lines added/removed>
 Files changed: <count>
+Research verification: SKIPPED (no external claims) / DISPATCHED / FALLBACK LABEL SET
 Recommend: <next step, e.g.:
   - "Ready for review — clean implementation"
   - "Needs a follow-up builder for edge case X I discovered but is out of scope"

--- a/.claude/commands/plan-review-stress.md
+++ b/.claude/commands/plan-review-stress.md
@@ -34,6 +34,24 @@ Think adversarially about the scout's recommended approach.
    - Is there enough detail for a builder to execute without research?
    - If not, **you'll add it in step 4** — note what needs filling in.
 
+## Research Verification
+
+Before approving the spec, check whether it makes any external claims. A spec is **claim-heavy** if it asserts ANY of the following:
+
+- Perl language semantics (`our`, `my`, `local`, pragma behavior, signature semantics, regex flags)
+- LSP 3.17/3.18 protocol behavior
+- DAP protocol behavior
+- External crate API behavior (tower-lsp, lsp-types, tree-sitter, etc.)
+- “PR #NNNN closed this” or “this is fixed by commit SHA”
+- Standard library function behavior that the fix depends on
+
+**If ANY claim-heavy criterion is met:**
+1. Dispatch the `research-verifier` agent on this issue before marking it builder-ready.
+2. Wait for the `research-verified` label or a verification comment.
+3. **Fallback — if network is unavailable:** add the `needs-research-verification` label to the issue instead of proceeding blind.
+
+**If no external claims are made:** skip this step — no dispatch needed.
+
 ## Output
 
 Record in your task:
@@ -42,4 +60,5 @@ Risk assessment: LOW / MEDIUM / HIGH
 Simpler alternative: NONE / <description>
 Missed edge cases: NONE / <list>
 Test improvements: NONE / <suggestions>
+Research verification: SKIPPED (no external claims) / DISPATCHED / FALLBACK LABEL SET
 ```

--- a/.claude/commands/reviewer-deep-analyze.md
+++ b/.claude/commands/reviewer-deep-analyze.md
@@ -42,6 +42,24 @@ Read the diff carefully and verify the logic matches the issue's intent.
    - Vacuous assertion? Rewrite to test actual behavior of the code under test.
    - Regression risk from an uncovered path? Add a test for it.
 
+## Research Verification
+
+Before approving, check whether the PR makes any external claims. A PR is **claim-heavy** if it asserts ANY of the following:
+
+- Perl language semantics (`our`, `my`, `local`, pragma behavior, signature semantics, regex flags)
+- LSP 3.17/3.18 protocol behavior
+- DAP protocol behavior
+- External crate API behavior (tower-lsp, lsp-types, tree-sitter, etc.)
+- “PR #NNNN closed this” or “this is fixed by commit SHA”
+- Standard library function behavior that the fix depends on
+
+**If ANY claim-heavy criterion is met:**
+1. Dispatch the `research-verifier` agent on the original issue before approving.
+2. Wait for the `research-verified` label or a verification comment.
+3. **Fallback — if network is unavailable:** add the `needs-research-verification` label to the PR and block approval. Do not merge blind.
+
+**If no external claims are made:** skip this step — no dispatch needed.
+
 ## Output
 
 Record in your task:
@@ -49,4 +67,5 @@ Record in your task:
 Logic: CORRECT / FIXED <what you changed>
 Tests: GOOD / IMPROVED <what you added>
 Regression risk: LOW / MEDIUM / HIGH (details)
+Research verification: SKIPPED (no external claims) / DISPATCHED / FALLBACK LABEL SET
 ```


### PR DESCRIPTION
## Summary

- Encodes the research-verifier dispatch policy into skill definitions so agents don't need orchestrator reminder to use it
- Adds `## Research Verification` section to three skill files defining the claim-heavy criteria and dispatch protocol
- Adds a one-line principle to three agent definitions pointing to the policy
- Creates `needs-research-verification` label as offline fallback

## Changes

- `.claude/commands/builder-self-review.md` — new `## Research Verification` section + updated Output block
- `.claude/commands/plan-review-stress.md` — new `## Research Verification` section + updated Output block  
- `.claude/commands/reviewer-deep-analyze.md` — new `## Research Verification` section + updated Output block
- `.claude/agents/builder.md` — one-line principle + updated step 5 todo description
- `.claude/agents/plan-reviewer.md` — one-line principle
- `.claude/agents/reviewer-deep.md` — one-line principle

## Claim-heavy criteria (as defined in each section)

A PR/spec is claim-heavy if it asserts ANY of:
- Perl language semantics (`our`, `my`, `local`, pragma behavior, signature semantics, regex flags)
- LSP 3.17/3.18 protocol behavior
- DAP protocol behavior
- External crate API behavior (tower-lsp, lsp-types, tree-sitter, etc.)
- "PR #NNNN closed this" or "this is fixed by commit SHA"
- Standard library function behavior the fix depends on

## Evidence

- **Commits**: 1
- **Tests**: N/A (control-plane docs change, no Rust code)
- **Lint**: N/A (no Rust code changed)
- **Files**: 6 changed, +61/-1 lines

## Test Plan

- Read each modified file and verify the Research Verification section is present and correctly worded
- Verify the `needs-research-verification` label exists on GitHub
- On next claim-heavy PR, verify agents dispatch research-verifier before approving

## Unknowns

- The `plan-review-improve.md` command (which actually writes the plan-reviewed comment) could also mention this, but the spec said to add to `plan-review-stress.md` only — the stress-test is the natural checkpoint
- `needs-research-verification` label was created with color `#FBCA04` (same yellow as other `needs-*` labels)
- Control-plane lock was held for ~30 min by another agent (`agent-a998af37-terminal-skill-broaden`) editing different files (`scout-parser.md`, `scout-dap.md`, `accuracy-scout.md`). Lock was auto-cleared after TTL expiry — no file conflicts.