### PR TITLE
feat(vscode-ext): wire startup diagnosis cache into all crash messages (#4193)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -35,25 +35,42 @@ let stateChangeDisposable: vscode.Disposable | undefined;
 const COEXISTENCE_GUIDE_URL =
     'https://github.com/EffortlessMetrics/perl-lsp/blob/master/vscode-extension/README.md#extension-coexistence';
 /**
- * Cached diagnostic message from the last startup failure.
- * Set by `initializeLanguageClient` when the LSP fails to start; read by
- * command handlers that need to surface a "server not running" message so
- * they can report the specific root cause rather than a generic "restart" message.
+ * Cached startup diagnosis from the last server failure.
+ *
+ * Set when the LSP fails to start (`initializeLanguageClient`) or when the
+ * server stops unexpectedly mid-session (`bindClientState`). Read by
+ * `serverNotRunningMessage()` so every "server not running" surface shows the
+ * specific root cause (e.g. "glibc mismatch") instead of a generic hint.
+ *
+ * Cleared to `undefined` when the server starts successfully so a stale
+ * failure from a previous session is not shown after a successful restart.
  */
-let lastStartupDiagnostic: string | undefined;
+let lastStartupDiagnosis: StartupErrorDiagnosis | undefined;
 
 /**
  * Return the best available "server not running" message to show the user.
  *
- * When a startup failure has been diagnosed (i.e. `lastStartupDiagnostic` is
- * set), that specific message is returned so the user can see the root cause
- * (e.g. "Perl interpreter not found" rather than a generic restart prompt).
- * Falls back to a brief actionable message for the case where the server was
- * never started in this session.
+ * When a startup failure has been diagnosed (`lastStartupDiagnosis` is set),
+ * formats and returns the specific root cause so the user sees an actionable
+ * message (e.g. "glibc mismatch — install from source") instead of a generic
+ * restart prompt.
+ *
+ * Exported so unit tests can verify the message without a full extension host.
  */
-function serverNotRunningMessage(): string {
-    return lastStartupDiagnostic ??
-        'Perl Language Server is not running. Run the Health Check (Command Palette: "Perl: Run Health Check") to diagnose the issue.';
+export function serverNotRunningMessage(): string {
+    if (lastStartupDiagnosis) {
+        return formatStartupFailureDialog(lastStartupDiagnosis, undefined);
+    }
+    return 'Perl Language Server is not running. Run the Health Check (Command Palette: "Perl: Run Health Check") to diagnose the issue.';
+}
+
+/**
+ * Test helper — inject a cached diagnosis without going through the full
+ * startup path.  Only exported for use in unit tests.
+ * @internal
+ */
+export function _setLastStartupDiagnosisForTest(diagnosis: StartupErrorDiagnosis | undefined): void {
+    lastStartupDiagnosis = diagnosis;
 }
 
 type PerlCriticSettings = {
@@ -1041,7 +1058,7 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
         // Probe the binary to get an actionable OS-level diagnosis (#3280).
         // If the probe result is Unknown (binary gave no useful output), fall
         // back to the health check (#3312) which can detect missing Perl etc.
-        // lastStartupDiagnostic is updated so that serverNotRunningMessage() in
+        // lastStartupDiagnosis is updated so that serverNotRunningMessage() in
         // command handlers surfaces the specific root cause rather than a generic prompt.
         const probeResult = currentServerPath
             ? await probeStartupFailure(currentServerPath)
@@ -1051,8 +1068,12 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
             const onboarding = new OnboardingManager(context, outputChannel);
             healthMsg = await onboarding.runStartupDiagnostics(currentServerPath ?? null);
         }
+        // Cache the structured diagnosis so serverNotRunningMessage() can format
+        // it; when healthMsg overrides the hint, wrap it as a synthetic diagnosis.
+        lastStartupDiagnosis = healthMsg && probeResult.kind === StartupErrorKind.Unknown
+            ? { kind: StartupErrorKind.Unknown, hint: healthMsg, remediation: probeResult.remediation }
+            : probeResult;
         const dialogMessage = formatStartupFailureDialog(probeResult, healthMsg);
-        lastStartupDiagnostic = dialogMessage;
 
         const choice = await vscode.window.showErrorMessage(
             dialogMessage,
@@ -1083,9 +1104,9 @@ async function initializeLanguageClient(context: vscode.ExtensionContext): Promi
     // Initialize streaming inline completion controller (config-gated)
     refreshStreamingController(client);
 
-    // Clear any stale startup diagnostic — the server started successfully so
+    // Clear any stale startup diagnosis — the server started successfully so
     // the root cause (e.g. missing Perl) no longer applies.
-    lastStartupDiagnostic = undefined;
+    lastStartupDiagnosis = undefined;
     outputChannel.appendLine('Perl Language Server started successfully');
     return true;
 }
@@ -1827,6 +1848,25 @@ function bindClientState(languageClient: LanguageClient) {
         // vscode-languageclient State values match ClientState numeric values:
         // Stopped = 1, Running = 2, Starting = 3
         healthWidget?.onStateChange(event.newState as unknown as ClientState);
+
+        // When the server stops unexpectedly after a successful start (mid-session
+        // crash), capture a generic diagnosis so serverNotRunningMessage() returns
+        // an actionable hint instead of the stale "not running" fallback.
+        // We can't run probeStartupFailure here (async) so we set a generic
+        // "server stopped" diagnosis; the user can run Health Check for details.
+        //
+        // Note: event.newState / oldState are vscode-languageclient's `State` enum
+        // which shares numeric values with ClientState (Stopped=1, Running=2) but
+        // is a distinct nominal type, so we cast to number for comparison.
+        const newStateNum = event.newState as unknown as number;
+        const oldStateNum = event.oldState as unknown as number;
+        if (newStateNum === ClientState.Stopped && oldStateNum === ClientState.Running) {
+            lastStartupDiagnosis = {
+                kind: StartupErrorKind.Unknown,
+                hint: 'The Perl Language Server stopped unexpectedly. Check the Output panel for details.',
+                remediation: 'Try restarting the server (Command Palette: "Perl: Restart Server") or run the Health Check.',
+            };
+        }
     });
 }
 

--- a/vscode-extension/src/test/startupError.test.ts
+++ b/vscode-extension/src/test/startupError.test.ts
@@ -13,7 +13,18 @@
  *
  * The user-visible error message must include an actionable hint (not just
  * "corrupted or incompatible") and a specific remediation step.
+ *
+ * Also covers the diagnosis cache introduced in #4193:
+ *   - serverNotRunningMessage() returns the cached diagnosis hint when set
+ *   - serverNotRunningMessage() returns the generic fallback when no cache
+ *   - Cache can be cleared (simulates successful server restart)
  */
+
+jest.mock('vscode-languageclient/node', () => ({
+  LanguageClient: class {},
+  Trace: { Off: 'off', Messages: 'messages', Verbose: 'verbose' },
+  TransportKind: { stdio: 0 },
+}));
 
 import {
   classifyStartupError,
@@ -21,6 +32,10 @@ import {
   StartupErrorKind,
   selectBestDiagnosis,
 } from '../startupDiagnosis';
+import {
+  serverNotRunningMessage,
+  _setLastStartupDiagnosisForTest,
+} from '../extension';
 
 // ---------------------------------------------------------------------------
 // classifyStartupError — pure classification of stderr/stdout text
@@ -272,5 +287,72 @@ describe('formatStartupFailureDialog', () => {
     expect(message).toContain('Perl Language Server failed to start.');
     expect(message).toContain('glibc');
     expect(message).not.toContain('Perl interpreter not found...');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serverNotRunningMessage — diagnosis cache integration (#4193)
+//
+// When a StartupErrorDiagnosis is cached via lastStartupDiagnosis,
+// serverNotRunningMessage() must format and return it so users see the
+// specific root cause (e.g. "glibc mismatch") rather than a generic hint.
+// When no diagnosis is cached, the generic fallback must be returned.
+// ---------------------------------------------------------------------------
+
+describe('serverNotRunningMessage diagnosis cache (#4193)', () => {
+  afterEach(() => {
+    // Reset cache after each test to prevent state leak
+    _setLastStartupDiagnosisForTest(undefined);
+  });
+
+  test('returns generic fallback when no diagnosis is cached', () => {
+    _setLastStartupDiagnosisForTest(undefined);
+    const msg = serverNotRunningMessage();
+    expect(msg).toContain('Perl Language Server is not running');
+    expect(msg).toContain('Health Check');
+  });
+
+  test('returns formatted diagnosis when glibc mismatch is cached', () => {
+    const diagnosis = classifyStartupError(
+      "error while loading shared libraries: libc.so.6: version `GLIBC_2.32' not found",
+    );
+    _setLastStartupDiagnosisForTest(diagnosis);
+
+    const msg = serverNotRunningMessage();
+    expect(msg).toContain('glibc');
+    expect(msg).toContain('cargo install');
+    // Must not show generic fallback when diagnosis is present
+    expect(msg).not.toBe('Perl Language Server is not running. Run the Health Check (Command Palette: "Perl: Run Health Check") to diagnose the issue.');
+  });
+
+  test('returns formatted diagnosis when permission denied is cached', () => {
+    const diagnosis = classifyStartupError('Permission denied');
+    _setLastStartupDiagnosisForTest(diagnosis);
+
+    const msg = serverNotRunningMessage();
+    expect(msg).toContain('permission');
+    expect(msg).toContain('chmod');
+  });
+
+  test('returns generic fallback after cache is cleared (simulates successful restart)', () => {
+    // Set a diagnosis, then clear it (as initializeLanguageClient does on success)
+    _setLastStartupDiagnosisForTest(classifyStartupError('Permission denied'));
+    _setLastStartupDiagnosisForTest(undefined);
+
+    const msg = serverNotRunningMessage();
+    expect(msg).toContain('Perl Language Server is not running');
+  });
+
+  test('mid-session crash diagnosis is surfaced via serverNotRunningMessage', () => {
+    // Simulate what bindClientState sets when server stops unexpectedly
+    _setLastStartupDiagnosisForTest({
+      kind: StartupErrorKind.Unknown,
+      hint: 'The Perl Language Server stopped unexpectedly. Check the Output panel for details.',
+      remediation: 'Try restarting the server (Command Palette: "Perl: Restart Server") or run the Health Check.',
+    });
+
+    const msg = serverNotRunningMessage();
+    expect(msg).toContain('stopped unexpectedly');
+    expect(msg).toContain('Restart Server');
   });
 });


### PR DESCRIPTION
## Summary

- Replaces the unstructured `lastStartupDiagnostic: string` cache with a typed `lastStartupDiagnosis: StartupErrorDiagnosis` struct so every "server not running" surface displays the classified root cause (glibc mismatch, permission denied, etc.) instead of a generic restart hint
- Wires diagnosis capture into `bindClientState`: when the server transitions Running→Stopped mid-session (unexpected crash), sets a "stopped unexpectedly" diagnosis so the user sees an actionable message
- Exports `serverNotRunningMessage()` and `_setLastStartupDiagnosisForTest()` so the cache lifecycle can be tested without a full extension host
- Adds 5 new tests covering: generic fallback, glibc mismatch, permission denied, cache clear on restart, mid-session crash path

## How caching works

`lastStartupDiagnosis: StartupErrorDiagnosis | undefined` is a module-level variable. Two code paths write it:

1. `initializeLanguageClient()` — on `client.start()` failure, runs `probeStartupFailure` + optional health check, then caches the structured diagnosis. On successful start, clears the cache.
2. `bindClientState()` — on `Running → Stopped` state transition (mid-session crash), sets a generic `Unknown`-kind diagnosis so later `serverNotRunningMessage()` calls are still informative.

`serverNotRunningMessage()` formats the cached diagnosis via `formatStartupFailureDialog()` or returns the generic fallback when no diagnosis is cached.

## Files touched

- `vscode-extension/src/extension.ts` — diagnosis cache + wiring
- `vscode-extension/src/test/startupError.test.ts` — 5 new cache tests

## Test plan

- [x] `npm test` — 512 tests, 20 suites all pass
- [x] `tsc --noEmit` — no TypeScript errors
- [x] Existing `startupError.test.ts` tests all pass (24 tests unchanged + 5 new = 29 total)
- [x] Cache lifecycle: set diagnosis → message shows diagnosis; clear cache → message shows generic fallback
- [x] Mid-session crash: `Running → Stopped` state change sets "stopped unexpectedly" diagnosis

Closes #4193