### PR TITLE
feat(diagnostics): enhance PL701 with @INC search paths context (#4187)

### DIFF
--- a/crates/perl-lsp-diagnostics/src/diagnostics.rs
+++ b/crates/perl-lsp-diagnostics/src/diagnostics.rs
@@ -65,16 +65,22 @@ impl DiagnosticsProvider {
         source: &str,
         module_resolver: Option<&dyn Fn(&str) -> bool>,
     ) -> Vec<Diagnostic> {
-        self.get_diagnostics_with_path(ast, parse_errors, source, module_resolver, None)
+        self.get_diagnostics_with_path(ast, parse_errors, source, module_resolver, &[], None)
     }
 
     /// Generate diagnostics for the given AST with optional source-path context.
+    ///
+    /// `module_search_paths` is the list of `@INC` paths that were searched during
+    /// module resolution. When non-empty, PL701 diagnostics include these paths so
+    /// the user can see where perl-lsp looked. Pass `&[]` when the paths are not
+    /// available.
     pub fn get_diagnostics_with_path(
         &self,
         ast: &std::sync::Arc<Node>,
         parse_errors: &[ParseError],
         source: &str,
         module_resolver: Option<&dyn Fn(&str) -> bool>,
+        module_search_paths: &[String],
         source_path: Option<&Path>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
@@ -172,6 +178,7 @@ impl DiagnosticsProvider {
                 ast,
                 source,
                 resolver,
+                module_search_paths,
                 &mut diagnostics,
             );
         }

--- a/crates/perl-lsp-diagnostics/src/lints/missing_module.rs
+++ b/crates/perl-lsp-diagnostics/src/lints/missing_module.rs
@@ -167,6 +167,10 @@ pub const CORE_MODULES: &[&str] = &[
 /// * `source` — Source text (used for context; not searched directly here)
 /// * `resolver` — Callback: `fn(module_name: &str) -> bool`. Return `true` if
 ///   the module is found (workspace or configured include paths).
+/// * `search_paths` — The `@INC` paths that were searched. Included in the
+///   diagnostic message so the user knows where perl-lsp looked. Pass `&[]`
+///   when the paths are not available. If more than 10 entries are provided,
+///   only the first 10 are shown followed by "... and N more".
 /// * `diagnostics` — Output vector; new diagnostics are pushed here
 ///
 /// # Skipped inputs
@@ -178,6 +182,7 @@ pub fn check_missing_modules<F>(
     node: &Node,
     _source: &str,
     resolver: F,
+    search_paths: &[String],
     diagnostics: &mut Vec<Diagnostic>,
 ) where
     F: Fn(&str) -> bool,
@@ -216,17 +221,38 @@ pub fn check_missing_modules<F>(
             continue;
         }
 
+        let message = if search_paths.is_empty() {
+            format!("Module '{}' not found in workspace or configured include paths", module_str)
+        } else {
+            const MAX_SHOWN: usize = 10;
+            let shown = search_paths.len().min(MAX_SHOWN);
+            let path_list = search_paths[..shown].join(", ");
+            if search_paths.len() > MAX_SHOWN {
+                let remaining = search_paths.len() - MAX_SHOWN;
+                format!(
+                    "Module '{}' not found. Searched @INC: {}, ... and {} more. \
+                     Add to lib path or install the module.",
+                    module_str, path_list, remaining
+                )
+            } else {
+                format!(
+                    "Module '{}' not found. Searched @INC: {}. \
+                     Add to lib path or install the module.",
+                    module_str, path_list
+                )
+            }
+        };
         diagnostics.push(Diagnostic {
             range: (*start, *end),
             severity: DiagnosticSeverity::Warning,
             code: Some(DiagnosticCode::ModuleNotFound.as_str().to_string()),
-            message: format!(
-                "Module '{}' not found in workspace or configured include paths",
-                module_str
-            ),
+            message,
             related_information: vec![],
             tags: vec![],
-            suggestion: Some(format!("Install with: cpanm {} or add to cpanfile", module_str)),
+            suggestion: Some(format!(
+                "Install with: cpanm {} or add to .perl-lsp.toml: include_paths",
+                module_str
+            )),
         });
     }
 }
@@ -252,7 +278,7 @@ mod tests {
         let source = "use Missing::Module;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].code.as_deref(), Some("PL701"));
         assert!(diags[0].message.contains("Missing::Module"));
@@ -263,7 +289,7 @@ mod tests {
         let source = "use Foo::Bar;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_finds_foo, &mut diags);
+        check_missing_modules(&ast, source, resolver_finds_foo, &[], &mut diags);
         assert!(diags.is_empty());
     }
 
@@ -272,7 +298,7 @@ mod tests {
         for source in &["use 5.010;\n", "use v5.38;\n"] {
             let ast = must(Parser::new(source).parse());
             let mut diags = vec![];
-            check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+            check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
             assert!(diags.is_empty(), "version-only use should not be flagged: {}", source);
         }
     }
@@ -285,7 +311,7 @@ mod tests {
             let source = format!("use {};\n", module);
             let ast = must(Parser::new(&source).parse());
             let mut diags = vec![];
-            check_missing_modules(&ast, &source, resolver_never_finds, &mut diags);
+            check_missing_modules(&ast, &source, resolver_never_finds, &[], &mut diags);
             assert!(diags.is_empty(), "core module {} should not be flagged", module);
         }
     }
@@ -297,7 +323,7 @@ mod tests {
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
         // resolver_finds_foo only returns true for "Foo::Bar" (bare, no version)
-        check_missing_modules(&ast, source, resolver_finds_foo, &mut diags);
+        check_missing_modules(&ast, source, resolver_finds_foo, &[], &mut diags);
         assert!(diags.is_empty(), "versioned use should strip version before resolver lookup");
     }
 
@@ -306,7 +332,7 @@ mod tests {
         let source = "use Missing::Mod;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(diags.len(), 1);
         let (start, end) = diags[0].range;
         assert!(start < end, "range start must be before end");
@@ -318,7 +344,7 @@ mod tests {
         let source = "use Anything::AtAll;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_always_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_always_finds, &[], &mut diags);
         assert!(diags.is_empty());
     }
 
@@ -327,7 +353,7 @@ mod tests {
         let source = "use Missing::One;\nuse Missing::Two;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(diags.len(), 2);
         assert!(diags.iter().all(|d| d.code.as_deref() == Some("PL701")));
     }
@@ -337,7 +363,7 @@ mod tests {
         let source = "use Foo::Bar;\nuse Missing::One;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_finds_foo, &mut diags);
+        check_missing_modules(&ast, source, resolver_finds_foo, &[], &mut diags);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("Missing::One"));
     }
@@ -347,7 +373,7 @@ mod tests {
         let source = "use Missing::Module;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, DiagnosticSeverity::Warning);
     }
@@ -363,7 +389,7 @@ mod tests {
         let source = "use if $^O eq 'MSWin32', 'Win32';\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert!(
             diags.is_empty(),
             "`use if` conditional form must not emit PL701 (got {} diagnostics)",
@@ -379,7 +405,7 @@ mod tests {
         let source = "use List::MoreUtils qw(any all);\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(
             diags.len(),
             1,
@@ -404,6 +430,7 @@ mod tests {
                 call_count.set(call_count.get() + 1);
                 false
             },
+            &[],
             &mut diags,
         );
         assert_eq!(diags.len(), 5, "five distinct missing modules should each emit PL701");
@@ -430,7 +457,7 @@ mod tests {
             SourceLocation { start: 0, end: 4 },
         );
         let mut diags = vec![];
-        check_missing_modules(&program, "", resolver_never_finds, &mut diags);
+        check_missing_modules(&program, "", resolver_never_finds, &[], &mut diags);
         assert!(
             diags.is_empty(),
             "empty module name from error-recovery must not emit PL701 (got {} diagnostics)",
@@ -444,12 +471,91 @@ mod tests {
         let source = "use Some::Package;\n";
         let ast = must(Parser::new(source).parse());
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         assert_eq!(diags.len(), 1);
         let suggestion = diags[0].suggestion.as_deref().unwrap_or("");
         assert!(
             suggestion.contains("Some::Package"),
             "suggestion should mention the module name; got: {suggestion:?}"
+        );
+    }
+
+    // --- @INC context tests (PL701 enhancement) ---
+
+    /// When search_paths are provided, the diagnostic message must include them
+    /// so the user can see where perl-lsp looked for the module.
+    #[test]
+    fn pl701_message_includes_search_paths_when_provided() {
+        let source = "use My::Missing::Mod;\n";
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        let paths = vec!["/usr/lib/perl5".to_string(), "/home/user/perl/lib".to_string()];
+        check_missing_modules(&ast, source, resolver_never_finds, &paths, &mut diags);
+        assert_eq!(diags.len(), 1);
+        let msg = &diags[0].message;
+        assert!(
+            msg.contains("/usr/lib/perl5"),
+            "message should contain first search path; got: {msg:?}"
+        );
+        assert!(
+            msg.contains("/home/user/perl/lib"),
+            "message should contain second search path; got: {msg:?}"
+        );
+    }
+
+    /// When search_paths is empty, the diagnostic should fall back gracefully
+    /// (no crash, still emits PL701 with the module name).
+    #[test]
+    fn pl701_message_with_empty_search_paths_still_emits_diagnostic() {
+        let source = "use My::Missing::Mod;\n";
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
+        assert_eq!(diags.len(), 1, "should still emit PL701 with empty search paths");
+        assert_eq!(diags[0].code.as_deref(), Some("PL701"));
+        assert!(diags[0].message.contains("My::Missing::Mod"));
+    }
+
+    /// When @INC list is very long (>10 entries), the message should truncate
+    /// with "... and N more" rather than dumping all paths.
+    #[test]
+    fn pl701_message_truncates_long_inc_list() {
+        let source = "use My::Missing::Mod;\n";
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        let paths: Vec<String> = (1..=15).map(|i| format!("/path/dir{}", i)).collect();
+        check_missing_modules(&ast, source, resolver_never_finds, &paths, &mut diags);
+        assert_eq!(diags.len(), 1);
+        let msg = &diags[0].message;
+        assert!(
+            msg.contains("and") && msg.contains("more"),
+            "long @INC list should be truncated with '... and N more'; got: {msg:?}"
+        );
+        // Should NOT dump all 15 paths
+        assert!(
+            !msg.contains("/path/dir15"),
+            "path beyond truncation limit should not appear in message; got: {msg:?}"
+        );
+    }
+
+    /// The suggestion field should mention the module name and a config path hint
+    /// so the user knows both how to install and how to configure @INC.
+    #[test]
+    fn pl701_suggestion_mentions_module_and_config_hint() {
+        let source = "use My::Package;\n";
+        let ast = must(Parser::new(source).parse());
+        let mut diags = vec![];
+        let paths = vec!["/usr/lib/perl5".to_string()];
+        check_missing_modules(&ast, source, resolver_never_finds, &paths, &mut diags);
+        assert_eq!(diags.len(), 1);
+        let suggestion = diags[0].suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("My::Package"),
+            "suggestion should mention the module name; got: {suggestion:?}"
+        );
+        assert!(
+            suggestion.contains(".perl-lsp.toml") || suggestion.contains("include_paths"),
+            "suggestion should mention config path hint; got: {suggestion:?}"
         );
     }
 
@@ -463,7 +569,7 @@ mod tests {
         let output = Parser::new(source).parse_with_recovery();
         let ast = output.ast;
         let mut diags = vec![];
-        check_missing_modules(&ast, source, resolver_never_finds, &mut diags);
+        check_missing_modules(&ast, source, resolver_never_finds, &[], &mut diags);
         // Must not panic; if the Use node was recovered, we get PL701.
         // If recovery omitted it entirely we get 0. Either is acceptable — but not a panic.
         let pl701_count = diags.iter().filter(|d| d.code.as_deref() == Some("PL701")).count();

--- a/crates/perl-lsp/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp/src/features/diagnostics/pull.rs
@@ -134,6 +134,7 @@ impl PullDiagnosticsProvider {
                         &parse_errors,
                         content,
                         None,
+                        &[],
                         source_path.as_deref(),
                     )
                     .into_iter()
@@ -159,6 +160,7 @@ impl PullDiagnosticsProvider {
                     &doc_state.parse_errors,
                     &doc_state.text,
                     None,
+                    &[],
                     source_path.as_deref(),
                 )
                 .into_iter()

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -109,12 +109,18 @@ impl LspServer {
             let resolver = |module: &str| {
                 self.resolve_module_to_path_with_doc(module, Some(&text), Some(uri)).is_some()
             };
+            let search_paths: Vec<String> = self
+                .include_paths_for_doc(uri)
+                .into_iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
             let source_path = source_path_from_uri(uri);
             let mut diagnostics = provider.get_diagnostics_with_path(
                 ast,
                 &parse_errors,
                 &text,
                 Some(&resolver),
+                &search_paths,
                 source_path.as_deref(),
             );
 
@@ -280,12 +286,18 @@ impl LspServer {
                         self.resolve_module_to_path_with_doc(module, Some(&doc.text), Some(uri))
                             .is_some()
                     };
+                    let search_paths: Vec<String> = self
+                        .include_paths_for_doc(uri)
+                        .into_iter()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .collect();
                     let source_path = source_path_from_uri(uri);
                     let mut diagnostics = provider.get_diagnostics_with_path(
                         ast,
                         &doc.parse_errors,
                         &doc.text,
                         Some(&resolver),
+                        &search_paths,
                         source_path.as_deref(),
                     );
 
@@ -521,12 +533,18 @@ impl LspServer {
                     self.resolve_module_to_path_with_doc(module, Some(&doc.text), Some(uri_str))
                         .is_some()
                 };
+                let search_paths: Vec<String> = self
+                    .include_paths_for_doc(uri_str)
+                    .into_iter()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .collect();
                 let source_path = source_path_from_uri(uri_str);
                 let mut diagnostics = provider.get_diagnostics_with_path(
                     ast,
                     &doc.parse_errors,
                     &doc.text,
                     Some(&resolver),
+                    &search_paths,
                     source_path.as_deref(),
                 );
 

--- a/crates/perl-lsp/src/runtime/text_sync.rs
+++ b/crates/perl-lsp/src/runtime/text_sync.rs
@@ -966,6 +966,7 @@ impl LspServer {
                         &doc.parse_errors,
                         &doc.text,
                         None,
+                        &[],
                         source_path.as_deref(),
                     );
 


### PR DESCRIPTION
## Summary

- PL701 (module not found) diagnostic now includes the `@INC` paths that were searched, so users know exactly where perl-lsp looked for the missing module
- Long path lists (>10 entries) are truncated with "... and N more" to keep the message readable
- Falls back gracefully to the original message format when no paths are available (e.g., callers that pass `&[]`)

## Changes

- `crates/perl-lsp-diagnostics/src/lints/missing_module.rs` — Added `search_paths: &[String]` parameter to `check_missing_modules`; conditional message format with truncation at 10 paths; updated suggestion to mention `.perl-lsp.toml: include_paths`; 4 new tests covering the path-context scenarios
- `crates/perl-lsp-diagnostics/src/diagnostics.rs` — Added `module_search_paths: &[String]` to `get_diagnostics_with_path` signature; `get_diagnostics` delegates with `&[]`
- `crates/perl-lsp/src/runtime/diagnostics.rs` — 3 call sites now compute `include_paths_for_doc(uri)` and pass them to `get_diagnostics_with_path`
- `crates/perl-lsp/src/runtime/text_sync.rs` — Updated call site (no resolver here, passes `&[]`)
- `crates/perl-lsp/src/features/diagnostics/pull.rs` — Updated 2 call sites (no resolver, pass `&[]`)

## Message format

When `@INC` paths are available:
```
Module 'Foo::Bar' not found. Searched @INC: /usr/lib/perl5, /home/user/lib. Add to lib path or install the module.
```

When `@INC` list > 10 entries:
```
Module 'Foo::Bar' not found. Searched @INC: /path/1, ..., /path/10, ... and 5 more. Add to lib path or install the module.
```

When no paths available (fallback):
```
Module 'Foo::Bar' not found in workspace or configured include paths
```

## Evidence

- **Commits**: 1
- **Tests**: 75 passed, 0 failed (perl-lsp-diagnostics --lib); 20/20 missing_module tests pass
- **Lint**: clippy clean on perl-lsp-diagnostics and perl-lsp-rs
- **Files**: 5 changed, +155/-21 lines
- **Pre-existing failures**: `use_lib` 2 tests fail on master too (confirmed); `gold_fixtures_diagnostics_suite` fails on master too

## Test plan

- [ ] `cargo test -p perl-lsp-diagnostics --lib -- missing_module` — 20 tests green
- [ ] Confirm PL701 diagnostic in a real project shows the `@INC` paths used
- [ ] Confirm >10 `@INC` entries triggers truncation

## Unknowns

- The `pull.rs` and `text_sync.rs` call sites pass `None` for the resolver (PL701 lint doesn't run there), so they use `&[]` for paths — this is correct but means pull-diagnostics don't show `@INC` paths. That's a pre-existing scope gap, not introduced here.
- `PullDiagnosticsProvider` does not wire up the module resolver at all; improving that is out of scope for this PR.

Closes #4187