### PR TITLE
feat(ux): surface actionable error when Perl interpreter not found on first open (#4182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "perl-ast-utils",
  "perl-content-length-framing",
  "perl-dap",
+ "perl-dap-platform",
  "perl-diagnostics-codes",
  "perl-incremental-parsing",
  "perl-keywords",

--- a/crates/perl-dap-platform/src/lib.rs
+++ b/crates/perl-dap-platform/src/lib.rs
@@ -15,6 +15,159 @@ const PERL_EXECUTABLE: &str = "perl.exe";
 #[cfg(not(windows))]
 const PERL_EXECUTABLE: &str = "perl";
 
+/// The result of Perl interpreter discovery.
+///
+/// Separates the "found on PATH" case from the "found via OS fallback" case
+/// so callers can log or surface different messages to users.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PerlInterpreterResult {
+    /// Perl was found via the configured `perl-lsp.perl.path` setting.
+    ConfiguredPath(PathBuf),
+    /// Perl was found on PATH (the normal case).
+    FoundOnPath(PathBuf),
+    /// Perl was NOT on PATH but was found at a well-known OS install location.
+    /// Carries the found path and a human-readable label (e.g. "Strawberry Perl").
+    FoundViaFallback { path: PathBuf, label: String },
+    /// No Perl interpreter found anywhere.
+    /// Carries the list of locations searched, for use in an error message.
+    NotFound { searched: Vec<String> },
+}
+
+/// Rank a Perl binary path for preference on Windows.
+///
+/// Returns a lower score for higher-priority interpreters.
+/// Strawberry Perl ranks best (1), then ActiveState (2), then msys/Git Bash (100).
+#[cfg(windows)]
+fn windows_perl_rank(path: &std::path::Path) -> u8 {
+    let s = path.to_string_lossy().to_ascii_lowercase();
+    if s.contains("strawberry") {
+        1
+    } else if s.contains("perl64") || s.contains("activestate") || s.contains("activeperl") {
+        2
+    } else if s.contains(r"\git\usr\bin") || s.contains("/git/usr/bin") || s.contains("msys") {
+        100
+    } else {
+        50
+    }
+}
+
+/// Collect all Perl executables found on PATH, ranked for Windows preference.
+///
+/// On non-Windows, returns at most the first match (ranking is N/A).
+/// On Windows, returns all matches sorted by [`windows_perl_rank`].
+fn find_all_perl_on_path(path_env: &str) -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = path_env
+        .split(PATH_SEPARATOR)
+        .map(|dir| PathBuf::from(dir).join(PERL_EXECUTABLE))
+        .filter(|p| p.exists() && p.is_file())
+        .collect();
+
+    #[cfg(windows)]
+    found.sort_by_key(|p| windows_perl_rank(p));
+
+    found
+}
+
+/// Canonical OS-specific fallback paths to probe when Perl is not on PATH.
+///
+/// Returns `(path, label)` pairs. Probed in order; first existing file wins.
+fn fallback_perl_paths() -> Vec<(PathBuf, &'static str)> {
+    #[cfg(windows)]
+    {
+        vec![
+            (PathBuf::from(r"C:\Strawberry\perl\bin\perl.exe"), "Strawberry Perl"),
+            (PathBuf::from(r"C:\Perl64\bin\perl.exe"), "ActiveState Perl (64-bit)"),
+            (
+                {
+                    let pf = env::var("ProgramFiles")
+                        .unwrap_or_else(|_| r"C:\Program Files".to_string());
+                    PathBuf::from(pf).join(r"Strawberry\perl\bin\perl.exe")
+                },
+                "Strawberry Perl (Program Files)",
+            ),
+        ]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            (PathBuf::from("/opt/homebrew/bin/perl"), "Homebrew Perl (Apple Silicon)"),
+            (PathBuf::from("/usr/local/bin/perl"), "Homebrew Perl (Intel)"),
+            (PathBuf::from("/usr/bin/perl"), "macOS system Perl"),
+        ]
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    {
+        // Linux and others
+        vec![
+            (PathBuf::from("/usr/bin/perl"), "system Perl"),
+            (PathBuf::from("/usr/local/bin/perl"), "local Perl"),
+        ]
+    }
+}
+
+/// Find the best available Perl interpreter with full cross-platform detection.
+///
+/// Detection order:
+/// 1. If `configured_path` is `Some` and non-empty, validate and return
+///    [`PerlInterpreterResult::ConfiguredPath`] (or [`PerlInterpreterResult::NotFound`]
+///    if the configured path is broken). Does **not** fall back silently.
+/// 2. Check toolchain managers (perlbrew, plenv) before PATH.
+/// 3. Walk PATH; on Windows, prefer Strawberry/ActiveState over msys/Git Bash perls.
+/// 4. If not on PATH, probe canonical OS install locations as a last resort.
+/// 5. If still not found, return [`PerlInterpreterResult::NotFound`] with searched paths.
+///
+/// # Examples
+///
+/// ```rust
+/// use perl_dap_platform::{find_perl_interpreter, PerlInterpreterResult};
+/// match find_perl_interpreter(None) {
+///     PerlInterpreterResult::FoundOnPath(p) => println!("Perl: {}", p.display()),
+///     PerlInterpreterResult::NotFound { searched } => eprintln!("Not found. Searched: {:?}", searched),
+///     _ => {}
+/// }
+/// ```
+pub fn find_perl_interpreter(configured_path: Option<&str>) -> PerlInterpreterResult {
+    // 1. Honour explicit config path — validate it exists, never silently fall back.
+    if let Some(cfg) = configured_path.filter(|s| !s.is_empty()) {
+        let p = PathBuf::from(cfg);
+        if p.exists() && p.is_file() {
+            return PerlInterpreterResult::ConfiguredPath(p);
+        } else {
+            return PerlInterpreterResult::NotFound {
+                searched: vec![format!("configured path: {cfg}")],
+            };
+        }
+    }
+
+    let mut searched: Vec<String> = vec!["PATH".to_string()];
+
+    // 2. Check toolchain managers (perlbrew, plenv) first.
+    if let Some(path) = detect_perlbrew_perl() {
+        return PerlInterpreterResult::FoundOnPath(path);
+    }
+    if let Some(path) = detect_plenv_perl() {
+        return PerlInterpreterResult::FoundOnPath(path);
+    }
+
+    // 3. Walk PATH, ranking results on Windows.
+    if let Ok(path_env) = env::var("PATH") {
+        let ranked = find_all_perl_on_path(&path_env);
+        if let Some(best) = ranked.into_iter().next() {
+            return PerlInterpreterResult::FoundOnPath(best);
+        }
+    }
+
+    // 4. Probe OS-specific fallback paths.
+    for (path, label) in fallback_perl_paths() {
+        searched.push(path.to_string_lossy().to_string());
+        if path.exists() && path.is_file() {
+            return PerlInterpreterResult::FoundViaFallback { path, label: label.to_string() };
+        }
+    }
+
+    PerlInterpreterResult::NotFound { searched }
+}
+
 /// Resolve the perl binary path on the current platform.
 ///
 /// Searches only the system `PATH`. For toolchain-aware resolution that
@@ -272,6 +425,96 @@ mod tests {
         assert!(
             !normalized.to_string_lossy().contains('\\'),
             "non-WSL path should not be Windows-escaped"
+        );
+    }
+
+    // ── find_perl_interpreter tests ────────────────────────────────────────
+
+    #[test]
+    fn find_perl_interpreter_configured_path_valid_returns_configured() {
+        use std::fs;
+        let tempdir = must(tempfile::tempdir());
+        let fake_perl = tempdir.path().join(PERL_EXECUTABLE);
+        must(fs::write(&fake_perl, ""));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = must(fs::metadata(&fake_perl)).permissions();
+            perms.set_mode(0o755);
+            must(fs::set_permissions(&fake_perl, perms));
+        }
+        let path_str = fake_perl.to_string_lossy().to_string();
+        let result = find_perl_interpreter(Some(&path_str));
+        assert!(
+            matches!(result, PerlInterpreterResult::ConfiguredPath(_)),
+            "expected ConfiguredPath, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn find_perl_interpreter_configured_path_missing_returns_not_found() {
+        let result = find_perl_interpreter(Some("/nonexistent/path/to/perl"));
+        match result {
+            PerlInterpreterResult::NotFound { searched } => {
+                assert!(
+                    searched.iter().any(|s| s.contains("configured")),
+                    "searched list should mention configured path: {searched:?}"
+                );
+            }
+            other => panic!("expected NotFound, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn find_perl_interpreter_empty_config_falls_back_to_path_detection() {
+        // Empty string should be treated as "not configured"
+        let result = find_perl_interpreter(Some(""));
+        // Should not return ConfiguredPath for empty string
+        assert!(
+            !matches!(result, PerlInterpreterResult::ConfiguredPath(_)),
+            "empty config should fall back to path detection"
+        );
+    }
+
+    #[test]
+    fn find_perl_interpreter_none_config_performs_detection() {
+        // With no config, should return Found* or NotFound (never ConfiguredPath)
+        let result = find_perl_interpreter(None);
+        assert!(
+            !matches!(result, PerlInterpreterResult::ConfiguredPath(_)),
+            "None config should not return ConfiguredPath"
+        );
+    }
+
+    #[test]
+    fn find_perl_interpreter_not_found_includes_searched_paths() {
+        // When configured path is broken, NotFound should list what was searched
+        let result = find_perl_interpreter(Some("/absolutely/not/a/real/path/perl"));
+        if let PerlInterpreterResult::NotFound { searched } = result {
+            assert!(!searched.is_empty(), "searched list should not be empty");
+        }
+        // If Perl is found on the system, the above test doesn't apply — that's fine
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_perl_rank_strawberry_is_best() {
+        let strawberry = std::path::Path::new(r"C:\Strawberry\perl\bin\perl.exe");
+        let msys = std::path::Path::new(r"C:\Program Files\Git\usr\bin\perl.exe");
+        assert!(
+            windows_perl_rank(strawberry) < windows_perl_rank(msys),
+            "Strawberry should rank better than msys perl"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_perl_rank_activestate_beats_msys() {
+        let active = std::path::Path::new(r"C:\Perl64\bin\perl.exe");
+        let msys = std::path::Path::new(r"C:\Program Files\Git\usr\bin\perl.exe");
+        assert!(
+            windows_perl_rank(active) < windows_perl_rank(msys),
+            "ActiveState should rank better than msys perl"
         );
     }
 }

--- a/crates/perl-dap-platform/src/lib.rs
+++ b/crates/perl-dap-platform/src/lib.rs
@@ -53,8 +53,8 @@ fn windows_perl_rank(path: &std::path::Path) -> u8 {
 
 /// Collect all Perl executables found on PATH, ranked for Windows preference.
 ///
-/// On non-Windows, returns at most the first match (ranking is N/A).
-/// On Windows, returns all matches sorted by [`windows_perl_rank`].
+/// On Windows, returns all matches sorted by [`windows_perl_rank`] so the caller
+/// can pick the best one. On non-Windows, returns candidates in PATH order (no ranking).
 fn find_all_perl_on_path(path_env: &str) -> Vec<PathBuf> {
     let mut found: Vec<PathBuf> = path_env
         .split(PATH_SEPARATOR)

--- a/crates/perl-lsp/Cargo.toml
+++ b/crates/perl-lsp/Cargo.toml
@@ -44,6 +44,7 @@ perl-lsp-feature-governance = { workspace = true }
 perl-lsp-tooling = { workspace = true }
 perl-subprocess-runtime = { workspace = true }
 perl-lsp-config = { workspace = true }
+perl-dap-platform = { workspace = true }
 perl-lsp-protocol = { workspace = true }
 perl-lsp-transport = { workspace = true }
 perl-lsp-code-actions = { workspace = true }

--- a/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/capabilities.rs
@@ -227,6 +227,10 @@ impl LspServer {
         // Load .perl-lsp.toml from workspace root (base layer; LSP config overrides later)
         self.load_and_apply_project_config();
 
+        // Detect Perl interpreter and surface an actionable error if not found.
+        // Runs after config load so that perl-lsp.perl.path is already applied.
+        self.check_perl_interpreter();
+
         // Construct the AI inline-completion backend if enabled in config
         self.refresh_ai_backend();
 

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -3,13 +3,81 @@
 //! Handles workspace folders and root URI/path management.
 
 use super::super::*;
+use perl_dap_platform::{PerlInterpreterResult, find_perl_interpreter};
 use perl_lsp_config::WorkspaceConfig;
+use std::sync::Once;
+
+/// Fires at most once per LSP session, when Perl is not found anywhere.
+static PERL_NOT_FOUND_WARNED: Once = Once::new();
 
 impl LspServer {
     /// Set the root path from the root URI during initialization
     pub(crate) fn set_root_uri(&self, root_uri: &str) {
         let root_path = super::super::source_path_from_uri(root_uri);
         *self.root_path.lock() = root_path;
+    }
+
+    /// Detect the Perl interpreter and surface an actionable message if not found.
+    ///
+    /// Called once during `handle_initialize`. Reads `perl-lsp.perl.path` from the
+    /// workspace config (if set), then falls back to full OS-aware detection. Emits:
+    ///
+    /// - `window/logMessage` (Info) if Perl was found via an OS fallback path so the
+    ///   user knows which interpreter will be used.
+    /// - `window/showMessage` (Error) **once per session** if no Perl interpreter is found
+    ///   anywhere, with actionable remediation text.
+    /// - `window/showMessage` (Error) **once per session** if `perl-lsp.perl.path` is set
+    ///   but the configured path does not exist.
+    ///
+    /// Does not alter any server state. Tracing fallback is preserved alongside user messages.
+    pub(crate) fn check_perl_interpreter(&self) {
+        let configured_path = self.workspace_config.lock().perl_path.clone();
+        let result = find_perl_interpreter(configured_path.as_deref());
+
+        match result {
+            PerlInterpreterResult::ConfiguredPath(ref path) => {
+                tracing::debug!(path = %path.display(), "Perl interpreter: using configured path");
+            }
+            PerlInterpreterResult::FoundOnPath(ref path) => {
+                tracing::debug!(path = %path.display(), "Perl interpreter: found on PATH");
+            }
+            PerlInterpreterResult::FoundViaFallback { ref path, ref label } => {
+                let msg = format!(
+                    "perl-lsp: Perl not found on PATH; using {label} at {}. \
+                     Add Perl to PATH or set `perl-lsp.perl.path` to suppress this message.",
+                    path.display()
+                );
+                tracing::info!(path = %path.display(), label = %label, "Perl interpreter found via fallback");
+                if let Err(e) = self.log_message(MessageType::Info, &msg) {
+                    tracing::warn!(error = %e, "Failed to send logMessage for perl fallback");
+                }
+            }
+            PerlInterpreterResult::NotFound { ref searched } => {
+                tracing::warn!(searched = ?searched, "Perl interpreter not found");
+                PERL_NOT_FOUND_WARNED.call_once(|| {
+                    let searched_str = searched.join(", ");
+                    let msg = if configured_path.as_deref().is_some_and(|p| !p.is_empty()) {
+                        format!(
+                            "perl-lsp: The configured Perl interpreter was not found. \
+                             Searched: {searched_str}. \
+                             Check `perl-lsp.perl.path` in your settings and reload the window \
+                             (Ctrl+Shift+P \u{2192} Developer: Reload Window)."
+                        )
+                    } else {
+                        format!(
+                            "perl-lsp: Perl interpreter not found on PATH. \
+                             Searched: {searched_str}. \
+                             Install Perl (https://strawberryperl.com on Windows, \
+                             `brew install perl` on macOS, or your system package manager) \
+                             and reload the window, or set `perl-lsp.perl.path` in settings."
+                        )
+                    };
+                    if let Err(e) = self.show_message(MessageType::Error, &msg) {
+                        tracing::warn!(error = %e, "Failed to send showMessage for perl not found");
+                    }
+                });
+            }
+        }
     }
 
     /// Load `.perl-lsp.toml` from each workspace folder and compute per-folder effective config.
@@ -85,6 +153,45 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn check_perl_interpreter_does_not_panic() {
+        let server = LspServer::new();
+        // Should complete without panicking regardless of Perl install state
+        server.check_perl_interpreter();
+    }
+
+    #[test]
+    fn check_perl_interpreter_broken_config_path_does_not_panic() {
+        let server = LspServer::new();
+        // Set a broken perl path in the workspace config
+        server.workspace_config.lock().perl_path =
+            Some("/nonexistent/path/to/perl/that/does/not/exist".to_string());
+        // Should not panic — message will fail to send silently (stdout in test mode)
+        server.check_perl_interpreter();
+    }
+
+    #[test]
+    fn check_perl_interpreter_valid_config_path_does_not_panic() {
+        use std::fs;
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        #[cfg(windows)]
+        let fake_perl = tempdir.path().join("perl.exe");
+        #[cfg(not(windows))]
+        let fake_perl = tempdir.path().join("perl");
+        fs::write(&fake_perl, "").expect("write fake perl");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&fake_perl).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&fake_perl, perms).expect("chmod");
+        }
+        let server = LspServer::new();
+        server.workspace_config.lock().perl_path = Some(fake_perl.to_string_lossy().to_string());
+        // Should not panic
+        server.check_perl_interpreter();
+    }
 
     #[test]
     fn load_and_apply_project_config_handles_empty_workspace_folders() {


### PR DESCRIPTION
## Summary

- Add `find_perl_interpreter()` to `perl-dap-platform` with cross-platform Perl detection: PATH (with Windows ranking), OS fallback paths, and perlbrew/plenv toolchain managers
- Add `check_perl_interpreter()` to `LspServer` called once during `handle_initialize`; emits `window/showMessage ERROR` if no Perl found, `window/logMessage INFO` if found via OS fallback
- On Windows, Strawberry Perl is preferred over Git Bash msys perl when multiple entries are on PATH; explicit `perl-lsp.perl.path` config is validated without silent fallback

## Changes

- `crates/perl-dap-platform/src/lib.rs` — New `PerlInterpreterResult` enum, `find_perl_interpreter()`, `windows_perl_rank()`, `find_all_perl_on_path()`, `fallback_perl_paths()` with 7 new tests + 2 Windows-specific tests
- `crates/perl-lsp/src/runtime/lifecycle/workspace.rs` — New `check_perl_interpreter()` method + `PERL_NOT_FOUND_WARNED` static Once + 3 new tests
- `crates/perl-lsp/src/runtime/lifecycle/capabilities.rs` — Call `check_perl_interpreter()` after `load_and_apply_project_config()` during initialization
- `crates/perl-lsp/Cargo.toml` — Add `perl-dap-platform` as direct dep

## Evidence

- **Commits**: 1
- **Tests**: 374 passed (359 perl-lsp-rs + 15 perl-dap-platform), 0 failed
- **Lint**: clippy clean, fmt clean for changed crates
- **Files**: 5 changed, +356/-0 lines

## Error Messages

**Not found on PATH (no config):**
```
perl-lsp: Perl interpreter not found on PATH. Searched: PATH, C:\Strawberry\perl\bin\perl.exe, C:\Perl64\bin\perl.exe, C:\Program Files\Strawberry\perl\bin\perl.exe. Install Perl (https://strawberryperl.com on Windows, `brew install perl` on macOS, or your system package manager) and reload the window, or set `perl-lsp.perl.path` in settings.
```

**Configured path broken:**
```
perl-lsp: The configured Perl interpreter was not found. Searched: configured path: /wrong/perl. Check `perl-lsp.perl.path` in your settings and reload the window (Ctrl+Shift+P → Developer: Reload Window).
```

**Found via fallback (logMessage INFO, not showMessage):**
```
perl-lsp: Perl not found on PATH; using Strawberry Perl at C:\Strawberry\perl\bin\perl.exe. Add Perl to PATH or set `perl-lsp.perl.path` to suppress this message.
```

## Test Plan

- [ ] Open a `.pl` file with Perl not on PATH and no fallback → `window/showMessage` ERROR appears
- [ ] Open a `.pl` file with Strawberry Perl installed at default path but not on PATH → `window/logMessage` INFO appears
- [ ] Set `perl-lsp.perl.path` to a nonexistent path → `window/showMessage` ERROR appears
- [ ] Normal use with Perl on PATH → no notification shown (debug log only)
- [ ] Notification appears exactly once per session (Once guard)

## Unknowns

- Detection runs at `handle_initialize` time, before `didChangeConfiguration` fires; if `perl-lsp.perl.path` is set via LSP settings (not TOML), it won't be set when `check_perl_interpreter` runs. The initial check uses `workspace_config.perl_path` which starts as `None`. A follow-up could add detection at `didChangeConfiguration` time too, but once-per-session semantics make this low priority.
- The Windows ranking heuristic checks path substrings (`\git\usr\bin`, `msys`) — unusual install locations may not match.

Closes #4182