### PR TITLE
chore: dead code cleanup — unused imports and stale wrapper (#4219)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1688,4 +1688,78 @@ mod tests {
         let adapter = DebugAdapter::new();
         assert!(!adapter.send_interrupt_signal(999_999));
     }
+
+    // ── context_re unit tests ─────────────────────────────────────────────────
+
+    /// Helper: apply context_re to `line` and return (file, line_num) if matched.
+    fn apply_context_re(line: &str) -> Option<(String, String)> {
+        let re = context_re()?;
+        let caps = re.captures(line)?;
+        let file = caps
+            .name("file")
+            .or_else(|| caps.name("file2"))
+            .map(|m| m.as_str().to_string())?;
+        let line_num = caps
+            .name("line")
+            .or_else(|| caps.name("line2"))
+            .map(|m| m.as_str().to_string())?;
+        Some((file, line_num))
+    }
+
+    #[test]
+    fn test_context_re_unix_path() {
+        let result = apply_context_re("main::(/path/to/file.pl:42):");
+        assert_eq!(result, Some(("/path/to/file.pl".to_string(), "42".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_windows_drive_letter_backslash() {
+        // Windows drive-letter path: colon followed by backslash must be captured
+        // as part of the file path, not treated as a line-number separator.
+        let result = apply_context_re(r"main::(C:\Users\name\file.pl:42):");
+        assert_eq!(result, Some((r"C:\Users\name\file.pl".to_string(), "42".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_windows_drive_letter_forward_slash() {
+        // Forward-slash Windows path from Git Bash / cross-platform tools.
+        let result = apply_context_re("main::(C:/Users/file.pl:7):");
+        assert_eq!(result, Some(("C:/Users/file.pl".to_string(), "7".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_unc_path() {
+        // UNC path (Windows network share).
+        let result = apply_context_re(r"main::(\\server\share\file.pl:5):");
+        assert_eq!(result, Some((r"\\server\share\file.pl".to_string(), "5".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_named_function() {
+        // Func::Name context line.
+        let result = apply_context_re("Foo::Bar::(/path/script.pl:10):");
+        assert_eq!(result, Some(("/path/script.pl".to_string(), "10".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_windows_path_named_function() {
+        // Func::Name context line with Windows path.
+        let result = apply_context_re(r"Foo::Bar::(C:\path\script.pl:10):");
+        assert_eq!(result, Some((r"C:\path\script.pl".to_string(), "10".to_string())));
+    }
+
+    #[test]
+    fn test_context_re_no_match_path_with_spaces() {
+        // Paths with spaces do not match — the character class excludes \s.
+        let result = apply_context_re("main::(/path with spaces/file.pl:5):");
+        assert!(result.is_none(), "paths with spaces should not match");
+    }
+
+    #[test]
+    fn test_context_re_colon_digit_is_line_separator() {
+        // Colon followed by digit is the line-number separator, not a path component.
+        // "/path/file.pl:42" should yield file="/path/file.pl", line="42".
+        let result = apply_context_re("main::(/path/file.pl:42):");
+        assert_eq!(result, Some(("/path/file.pl".to_string(), "42".to_string())));
+    }
 }

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1695,14 +1695,10 @@ mod tests {
     fn apply_context_re(line: &str) -> Option<(String, String)> {
         let re = context_re()?;
         let caps = re.captures(line)?;
-        let file = caps
-            .name("file")
-            .or_else(|| caps.name("file2"))
-            .map(|m| m.as_str().to_string())?;
-        let line_num = caps
-            .name("line")
-            .or_else(|| caps.name("line2"))
-            .map(|m| m.as_str().to_string())?;
+        let file =
+            caps.name("file").or_else(|| caps.name("file2")).map(|m| m.as_str().to_string())?;
+        let line_num =
+            caps.name("line").or_else(|| caps.name("line2")).map(|m| m.as_str().to_string())?;
         Some((file, line_num))
     }
 

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -810,8 +810,7 @@ DB<1>"#;
     #[test]
     pub(super) fn test_normalize_three_prompts_in_sequence() {
         // Three consecutive prompts — verifies loop handles arbitrary depth.
-        let result =
-            DebugAdapter::normalize_debugger_output_line("DB<1> DB<2> DB<3> my $x = 10;");
+        let result = DebugAdapter::normalize_debugger_output_line("DB<1> DB<2> DB<3> my $x = 10;");
         assert_eq!(result, "my $x = 10;");
     }
 }

--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -766,4 +766,52 @@ DB<1>"#;
         assert_eq!(filtered[1].name, "Foo::process");
         assert_eq!(filtered[2].name, "main::start");
     }
+
+    // ── normalize_debugger_output_line unit tests ──────────────────────────────
+
+    #[test]
+    pub(super) fn test_normalize_strips_single_db_prompt() {
+        // Single prompt: "DB<1> main::(/path/file.pl:5):" -> "main::(/path/file.pl:5):"
+        let result = DebugAdapter::normalize_debugger_output_line("DB<1> main::(/path/file.pl:5):");
+        assert_eq!(result, "main::(/path/file.pl:5):");
+    }
+
+    #[test]
+    pub(super) fn test_normalize_strips_multiple_db_prompts() {
+        // Multiple prompts on one line — the while-let fix handles these.
+        let result = DebugAdapter::normalize_debugger_output_line(
+            "  DB<1>   DB<2> main::(/path/file.pl:5):",
+        );
+        assert_eq!(result, "main::(/path/file.pl:5):");
+    }
+
+    #[test]
+    pub(super) fn test_normalize_strips_high_prompt_number() {
+        // Prompt number > 99 — ensures '>' search is not length-limited.
+        let result = DebugAdapter::normalize_debugger_output_line("DB<100> $x = 42");
+        assert_eq!(result, "$x = 42");
+    }
+
+    #[test]
+    pub(super) fn test_normalize_no_prompt_passthrough() {
+        // Lines without a prompt must pass through unchanged (modulo trim).
+        let result = DebugAdapter::normalize_debugger_output_line("  main::(/path/file.pl:5):");
+        assert_eq!(result, "main::(/path/file.pl:5):");
+    }
+
+    #[test]
+    pub(super) fn test_normalize_unclosed_prompt_passthrough() {
+        // Malformed "DB<" without closing '>' must not loop forever and must not panic.
+        let result = DebugAdapter::normalize_debugger_output_line("DB<incomplete");
+        // The loop exits because find('>') returns None; the fragment remains.
+        assert_eq!(result, "DB<incomplete");
+    }
+
+    #[test]
+    pub(super) fn test_normalize_three_prompts_in_sequence() {
+        // Three consecutive prompts — verifies loop handles arbitrary depth.
+        let result =
+            DebugAdapter::normalize_debugger_output_line("DB<1> DB<2> DB<3> my $x = 10;");
+        assert_eq!(result, "my $x = 10;");
+    }
 }

--- a/crates/perl-lsp-config/tests/behavioral.rs
+++ b/crates/perl-lsp-config/tests/behavioral.rs
@@ -12,9 +12,6 @@
 //! - WorkspaceConfig: cache cleared on use_system_inc → false transition
 
 use perl_lsp_config::{ServerConfig, WorkspaceConfig};
-use std::io::Write as _;
-
-type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 // ---------------------------------------------------------------------------
 // ServerConfig defaults
@@ -223,9 +220,12 @@ mod perl_interpreter_detection_tests {
     use super::*;
     use std::ffi::OsString;
     use std::fs;
+    use std::io::Write as _;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 

--- a/crates/perl-lsp/src/features/implementation_provider.rs
+++ b/crates/perl-lsp/src/features/implementation_provider.rs
@@ -227,21 +227,6 @@ impl ImplementationProvider {
         );
     }
 
-    /// Find packages that inherit from base_package in AST (legacy, returns LocationLink only)
-    #[cfg_attr(not(test), allow(dead_code))]
-    fn find_inheriting_packages(
-        &self,
-        node: &Node,
-        base_package: &str,
-        uri: &str,
-        source: &str,
-        results: &mut Vec<LocationLink>,
-    ) {
-        let mut named_results = Vec::new();
-        self.find_inheriting_packages_named(node, base_package, uri, source, &mut named_results);
-        results.extend(named_results.into_iter().map(|(_, link)| link));
-    }
-
     fn find_inheriting_packages_recursive(
         &self,
         node: &Node,


### PR DESCRIPTION
## Summary

- Move `std::io::Write as _` and `type TestResult` inside the `#[cfg(unix)]` module in `crates/perl-lsp-config/tests/behavioral.rs`. Both were flagged as unused on non-unix builds since they are only referenced inside the unix-gated module. Moving them inside the cfg gate fixes the warning on all platforms without breaking unix builds.

- Remove legacy `find_inheriting_packages` wrapper method in `crates/perl-lsp/src/features/implementation_provider.rs`. Grep confirms zero callers workspace-wide. The `cfg_attr(not(test), allow(dead_code))` guard was already silencing the warning. The `find_inheriting_packages_named` and `find_inheriting_packages_recursive` variants are the live paths.

## Verification

- Confirmed `TestResult` and `Write` are used inside `#[cfg(unix)]` (lines 262+) — move rather than delete prevents breaking unix builds
- Confirmed `find_inheriting_packages` has zero callers (`rg 'find_inheriting_packages\b' crates/` returns only the definition and `_named`/`_recursive` variants)
- `cargo clippy -p perl-lsp-config --tests -- -D unused_imports -D dead_code`: clean
- `cargo test -p perl-lsp-config --test behavioral`: 21 passed
- `cargo test -p perl-lsp-rs --test lsp_implementation_tests`: 8 passed

## Surprise Finding — #4222 False Positive

Issue #4222 claims `bail` is unused in `xtask/src/tasks/corpus.rs:6`. Verification shows `bail!` IS used on line 30 inside `#[cfg(not(feature = "parser-tasks"))]`. The import is only unused when the `parser-tasks` feature is enabled. No change made. Issue #4222 should be closed as a false positive.

## Closes

Closes #4219
Closes #4221