### PR TITLE
feat(lsp): emit window/logMessage when workspace index enters Building state (#4190)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/mod.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/mod.rs
@@ -60,6 +60,12 @@ impl LspServer {
     ///
     /// Also transitions the index coordinator to Ready state if there are no
     /// workspace folders to scan (i.e., ready for single-file operation).
+    ///
+    /// When workspace folders exist but the index has not yet accumulated any
+    /// symbols (Building state), emits a `window/logMessage` so the user can
+    /// see in the Output panel that indexing is underway.  This explains why
+    /// workspace-wide features (go-to-definition, workspace/symbol, rename)
+    /// are temporarily degraded.
     pub(super) fn send_index_ready_notification(&self) -> io::Result<()> {
         #[cfg(feature = "workspace")]
         let (has_symbols, file_count, symbol_count) = {
@@ -92,13 +98,24 @@ impl LspServer {
                     "Index coordinator transitioned to Ready"
                 );
             } else {
-                // Workspace folders exist but no symbols indexed yet
+                // Workspace folders exist but no symbols indexed yet.
                 // Stay in Building state - files will be indexed as they're opened
-                // or when file watcher events are received
+                // or when file watcher events are received.
                 tracing::debug!(
                     workspace_folders = folders.len(),
                     "Index coordinator remaining in Building state, awaiting files"
                 );
+
+                // Notify the user so they understand why workspace features are
+                // temporarily degraded.  window/logMessage (Info=3) is non-intrusive
+                // — it appears in the Output panel without a popup dialog.
+                // Sent exactly once per Building transition (no per-file spam).
+                let msg = "Perl Language Server: Indexing workspace files. \
+                           Go-to-definition, completion, and workspace search will be \
+                           available when indexing completes.";
+                if let Err(e) = self.log_message(super::window::MessageType::Info, msg) {
+                    tracing::warn!(error = %e, "Failed to send index building log message");
+                }
             }
         }
 

--- a/crates/perl-lsp/tests/building_state_log_message_test.rs
+++ b/crates/perl-lsp/tests/building_state_log_message_test.rs
@@ -1,0 +1,172 @@
+//! Tests that the server emits a `window/logMessage` notification when the
+//! workspace index enters Building state (issue #4190).
+//!
+//! When the client opens a workspace folder but the index has not yet
+//! accumulated any symbols, the server stays in Building state.  The user
+//! sees degraded features (go-to-definition, workspace/symbol) with no
+//! explanation.  This test asserts that the server sends a
+//! `window/logMessage` (Info level) so the user can see the message in
+//! the Output panel.
+
+mod support;
+
+use std::thread;
+use std::time::{Duration, Instant};
+use support::lsp_harness::LspHarness;
+use support::test_workspace::TempWorkspace;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+/// Adaptive timeout: longer in CI / coverage environments.
+fn log_msg_timeout() -> Duration {
+    let is_ci = std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok();
+    let is_coverage = std::env::var("LLVM_PROFILE_FILE").is_ok()
+        || std::env::var("CARGO_LLVM_COV").is_ok()
+        || std::env::var("CARGO_LLVM_COV_TARGET_DIR").is_ok();
+    if is_ci || is_coverage { Duration::from_secs(10) } else { Duration::from_secs(5) }
+}
+
+/// Create a workspace with a few Perl files so the background indexer takes
+/// non-trivial time.  Also ensures workspace_folders is non-empty.
+fn make_workspace() -> Result<TempWorkspace, String> {
+    let ws = TempWorkspace::new()?;
+    for i in 0..5 {
+        ws.write(
+            &format!("lib/Mod{i}.pm"),
+            &format!("package Mod{i};\nsub new {{ return bless {{}} }}\n1;\n"),
+        )?;
+    }
+    Ok(ws)
+}
+
+/// Wait up to `timeout` for a `window/logMessage` whose text contains `needle`.
+///
+/// The test harness's `drain_notifications` stops as soon as any notification
+/// arrives in the pre-parsed buffer, which can miss messages that are written
+/// in a later outbound batch.  This helper polls in short slices to collect
+/// all notifications progressively.
+fn wait_for_log_message(
+    harness: &mut LspHarness,
+    needle: &str,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let start = Instant::now();
+    let slice_ms = 100u64;
+
+    loop {
+        // Drain whatever arrived in the last slice.
+        let batch = harness.drain_notifications(None, slice_ms);
+
+        for msg in batch {
+            if msg.get("method").and_then(|m| m.as_str()) == Some("window/logMessage") {
+                let text = msg.pointer("/params/message").and_then(|v| v.as_str()).unwrap_or("");
+                if text.to_lowercase().contains(&needle.to_lowercase()) {
+                    return Ok(msg);
+                }
+            }
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "window/logMessage containing '{}' not received within {:?}",
+                needle, timeout
+            ));
+        }
+
+        // Short sleep to avoid spinning when no messages are arriving.
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: server emits window/logMessage when index enters Building state.
+// ---------------------------------------------------------------------------
+#[test]
+fn building_state_emits_log_message() -> TestResult {
+    // Create a workspace directory so `workspace_folders` is non-empty.
+    let ws = make_workspace().map_err(|e| e.to_string())?;
+
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, None)?;
+
+    let building_msg = wait_for_log_message(&mut harness, "index", log_msg_timeout())
+        .map_err(|e| format!("Missing indexing log message: {e}"))?;
+
+    // Verify message type is Info (3) — non-intrusive.
+    let msg_type = building_msg.pointer("/params/type").and_then(|v| v.as_i64()).unwrap_or(0);
+
+    assert_eq!(
+        msg_type, 3,
+        "expected Info (type=3) log message, got type={msg_type} in msg={building_msg}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: message is sent only once per transition (no spam).
+// ---------------------------------------------------------------------------
+#[test]
+fn building_state_log_message_sent_once() -> TestResult {
+    let ws = make_workspace().map_err(|e| e.to_string())?;
+
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, None)?;
+
+    // Wait to collect all logMessage notifications for a fixed window.
+    let timeout = log_msg_timeout();
+    let start = Instant::now();
+    let mut indexing_msgs: Vec<serde_json::Value> = Vec::new();
+
+    while start.elapsed() < timeout {
+        let batch = harness.drain_notifications(None, 200);
+        for msg in batch {
+            if msg.get("method").and_then(|m| m.as_str()) == Some("window/logMessage")
+                && msg
+                    .pointer("/params/message")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_lowercase().contains("index"))
+                    .unwrap_or(false)
+            {
+                indexing_msgs.push(msg);
+            }
+        }
+        // Early exit once we've seen at least one and waited a bit for duplicates.
+        if !indexing_msgs.is_empty() && start.elapsed() > Duration::from_millis(500) {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    assert!(
+        indexing_msgs.len() <= 1,
+        "expected at most 1 indexing log message per Building transition, \
+         got {}: {indexing_msgs:?}",
+        indexing_msgs.len()
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: message mentions that features will be available when done.
+// ---------------------------------------------------------------------------
+#[test]
+fn building_log_message_is_actionable() -> TestResult {
+    let ws = make_workspace().map_err(|e| e.to_string())?;
+
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_with_root(&ws.root_uri, None)?;
+
+    // Best-effort: only validates content if message arrives.
+    // Test 1 is the authoritative presence check.
+    if let Ok(msg) = wait_for_log_message(&mut harness, "index", log_msg_timeout()) {
+        let text = msg.pointer("/params/message").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            text.to_lowercase().contains("available") || text.to_lowercase().contains("complet"),
+            "expected message to say features will become available, got: {text}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/perl-lsp/tests/support/message_framing.rs
+++ b/crates/perl-lsp/tests/support/message_framing.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 use parking_lot::{Condvar, Mutex};
+use perl_content_length_framing::ContentLengthFramer;
 use perl_lsp::LspServer;
 use serde_json::Value;
 use std::collections::VecDeque;
@@ -24,10 +25,18 @@ unsafe impl Send for SendableServer {}
 ///
 /// Every byte written by the LSP server flows through this writer. In
 /// addition to buffering the raw bytes (so that `LspHarness` can apply
-/// content-length framing), the writer eagerly parses the payload and
-/// routes server-initiated notifications and requests into dedicated
-/// queues so that `drain_notifications` / `wait_for_notification` can
-/// consume them without re-parsing.
+/// content-length framing), the writer eagerly parses ALL framed messages
+/// in each write call and routes server-initiated notifications and requests
+/// into dedicated queues so that `drain_notifications` / `wait_for_notification`
+/// can consume them without re-parsing.
+///
+/// # Correctness note
+///
+/// The outbound writer may coalesce multiple messages into a single `write()`
+/// call (batched I/O optimisation).  Previously the classification only parsed
+/// the FIRST JSON object it found, silently discarding subsequent messages in
+/// the same batch.  The fix is to use a `ContentLengthFramer` to extract every
+/// complete frame from the incoming bytes before classifying.
 pub(super) struct TestWriter {
     pub(super) buffer: Arc<Mutex<Vec<u8>>>,
     pub(super) signal: Arc<Condvar>,
@@ -41,23 +50,35 @@ impl Write for TestWriter {
             let mut buffer = self.buffer.lock();
             buffer.extend_from_slice(buf);
         }
-        // Parse and classify message outside buffer lock to avoid contention
-        let content = String::from_utf8_lossy(buf);
-        if let Some(json_start) = content.find('{') {
-            let json_str = &content[json_start..];
-            if let Ok(value) = serde_json::from_str::<Value>(json_str) {
-                let has_method = value.get("method").is_some();
-                let has_id = value.get("id").is_some();
-                if has_method && !has_id {
-                    // Server-initiated notification (no id)
-                    self.notifications.lock().push_back(value);
-                } else if has_method && has_id {
-                    // Server-initiated request (e.g., workspace/configuration)
-                    self.server_requests.lock().push_back(value);
+
+        // Parse and classify ALL framed messages in this batch.
+        // Using a ContentLengthFramer ensures that when the outbound writer
+        // coalesces multiple messages into one write() call, every message
+        // gets classified — not just the first one.
+        let mut framer = ContentLengthFramer::new();
+        framer.push(buf);
+
+        loop {
+            match framer.try_next() {
+                Ok(Some(body)) => {
+                    if let Ok(value) = serde_json::from_slice::<Value>(&body) {
+                        let has_method = value.get("method").is_some();
+                        let has_id = value.get("id").is_some();
+                        if has_method && !has_id {
+                            // Server-initiated notification (no id)
+                            self.notifications.lock().push_back(value);
+                        } else if has_method && has_id {
+                            // Server-initiated request (e.g., workspace/configuration)
+                            self.server_requests.lock().push_back(value);
+                        }
+                        // Responses (has id, no method) stay in the raw buffer only
+                    }
                 }
-                // Responses (has id, no method) stay in the raw buffer only
+                Ok(None) => break, // No more complete frames in this batch
+                Err(_) => break,   // Framing error — stop parsing this batch
             }
         }
+
         self.signal.notify_all();
         Ok(buf.len())
     }


### PR DESCRIPTION
## Summary

- Emit `window/logMessage` (Info, type=3) from `send_index_ready_notification` when the workspace index is in Building state (workspace folders present but no symbols indexed yet), so users see an explanation in the Output panel for temporarily degraded features
- The message reads: "Perl Language Server: Indexing workspace files. Go-to-definition, completion, and workspace search will be available when indexing completes."
- Fix pre-existing test harness bug: `TestWriter.write()` classified only the first JSON object per batch write call (using `content.find('{')` + single `serde_json::from_str`), silently discarding all messages coalesced in the same write batch. Fixed by using `ContentLengthFramer` to extract every complete frame.

## Test plan

- [ ] `building_state_emits_log_message` — server sends `window/logMessage` with type=3 (Info) containing "index" when initialized with a workspace folder
- [ ] `building_state_log_message_sent_once` — at most 1 such message per Building transition (no spam)
- [ ] `building_log_message_is_actionable` — message text says features will become "available" or "complet"(ed)
- [ ] Existing perl-lsp-rs test suite: all 400+ non-perltidy tests pass
- [ ] No clippy errors in changed files

Closes #4190