### PR TITLE
fix(parser): handle undef() and coderef-call postfix on subscript expressions (#4169)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -601,6 +601,42 @@ impl<'a> Parser<'a> {
                     }
                 }
 
+                // `undef(LIST)` — undef with explicit argument list undefines variables.
+                // `EXPR(args)` where EXPR is a subscript or dereference — implicit coderef call.
+                // In Perl: `$h{cb}($arg)` and `$arr[0]($arg)` are valid coderef invocations
+                // without a mandatory `->`.  We handle this for the patterns that arise in
+                // real CPAN code; the test cases are driven by the expected_colon error bucket.
+                Some(TokenKind::LeftParen)
+                    if matches!(&expr.kind, NodeKind::Undef | NodeKind::Binary { .. }) =>
+                {
+                    // Disambiguate: `Undef` → `undef(LIST)` builtin call.
+                    // Everything else (subscript / deref Binary) → implicit coderef call.
+                    let args = self.parse_args()?;
+                    let start = expr.location.start;
+                    let end = self.previous_position();
+
+                    record_postfix_layer()?;
+                    expr = if matches!(&expr.kind, NodeKind::Undef) {
+                        Node::new(
+                            NodeKind::FunctionCall {
+                                name: "undef".to_string(),
+                                args,
+                            },
+                            SourceLocation { start, end },
+                        )
+                    } else {
+                        let mut all_args = vec![expr];
+                        all_args.extend(args);
+                        Node::new(
+                            NodeKind::FunctionCall {
+                                name: "->()".to_string(),
+                                args: all_args,
+                            },
+                            SourceLocation { start, end },
+                        )
+                    };
+                }
+
                 _ => {
                     // Check if this is a builtin function that can take bare arguments
                     if let NodeKind::Identifier { name } = &expr.kind {

--- a/crates/perl-parser-core/tests/fix_nested_ternary_label_4169.rs
+++ b/crates/perl-parser-core/tests/fix_nested_ternary_label_4169.rs
@@ -1,0 +1,128 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// Tests for issue #4169: ternary branches with call-like expressions
+//
+// Root cause: The postfix chain did not handle `LeftParen` after non-Identifier
+// expressions (subscripts, `undef`, deref results).  This caused
+// "expected ':', found '('" errors when a ternary then-branch ended with
+// a subscript or keyword that was immediately followed by a call `()`.
+//
+// Fix: added two cases to `parse_postfix_chain`:
+//   - `NodeKind::Undef` + `(` → `undef(LIST)` function call
+//   - `NodeKind::Binary` + `(` → implicit coderef invocation
+
+// === Core issue patterns from the bug report ===
+
+#[test]
+fn test_nested_ternary_simple_chain() {
+    // $a ? $b : $c ? $d : $e — right-associative nested ternary
+    assert_clean_parse(r#"my $result = $a ? $b : $c ? $d : $e;"#);
+}
+
+#[test]
+fn test_nested_ternary_fat_arrow_branches() {
+    // Ternary with fat arrow in branches: `key => 1` in then/else
+    assert_clean_parse(r#"my $pair = $flag ? key => 1 : other => 2;"#);
+}
+
+#[test]
+fn test_ternary_in_statement_modifier_position() {
+    // Ternary in statement modifier position with bare identifiers
+    assert_clean_parse(r#"print $a ? x : y if $cond;"#);
+}
+
+// === The actual bug: call syntax after ternary branches ===
+
+#[test]
+fn test_undef_parens_in_ternary_else_branch() {
+    // From POE — undef() with explicit parens in ternary else-branch.
+    // Previously: ERROR "expected ':', found '(' at position 41"
+    assert_clean_parse(r#"StderrEvent => ($conduit eq 'pty' ? undef() : 'stderr');"#);
+}
+
+#[test]
+fn test_coderef_hashref_call_in_ternary_then_branch() {
+    // From IO/Socket/SSL/Intercept.pm: $self->{serial}($old_cert,$hash)
+    // Previously: ERROR "expected ':', found '(' at position 61"
+    assert_clean_parse(
+        r#"my $serial = ref($self->{serial}) eq 'CODE' ? $self->{serial}($old_cert,$hash) : ++$self->{serial};"#,
+    );
+}
+
+#[test]
+fn test_array_subscript_coderef_call_in_ternary_then_branch() {
+    // From Mojo::Log::_format: ref $_[0] eq 'CODE' ? $_[0]() : @_
+    // Previously: ERROR "expected ':', found '(' at position 92"
+    assert_clean_parse(r#"my @msgs = ref $_[0] eq 'CODE' ? $_[0]() : @_;"#);
+}
+
+// === undef() as a function call (not just as a literal) ===
+
+#[test]
+fn test_undef_parens_standalone() {
+    // undef() called with no args — clears $_
+    assert_clean_parse(r#"undef();"#);
+}
+
+#[test]
+fn test_undef_parens_with_args() {
+    // undef($var) — undefines the variable
+    assert_clean_parse(r#"undef($x);"#);
+}
+
+#[test]
+fn test_undef_parens_in_assignment() {
+    // Assignment from undef()
+    assert_clean_parse(r#"my $x = undef();"#);
+}
+
+// === Implicit coderef calls (no arrow) ===
+
+#[test]
+fn test_array_subscript_coderef_call_no_arrow() {
+    // $handlers[0]($arg) — calling array element as coderef
+    assert_clean_parse(r#"$handlers[0]($arg);"#);
+}
+
+#[test]
+fn test_hash_subscript_coderef_call_no_arrow() {
+    // $dispatch{$key}($arg) — calling hash value as coderef
+    assert_clean_parse(r#"$dispatch{$key}($arg);"#);
+}
+
+#[test]
+fn test_hash_arrow_subscript_coderef_call_no_arrow() {
+    // $obj->{method}($self) — calling hash arrow value as coderef (without ->)
+    assert_clean_parse(r#"$self->{serial}($old, $hash);"#);
+}
+
+// === Regression guard: existing patterns still work ===
+
+#[test]
+fn test_nested_ternary_bare_identifiers() {
+    // Bare identifiers in ternary branches (no call parens)
+    assert_clean_parse(r#"my $x = $a ? foo : bar;"#);
+}
+
+#[test]
+fn test_triple_chained_ternary() {
+    // Three-level chain
+    assert_clean_parse(r#"my $r = $a ? $b : $c ? $d : $e ? $f : $g;"#);
+}
+
+#[test]
+fn test_multiline_chained_ternary() {
+    // CPAN-style multiline ternary with leading colons
+    assert_clean_parse(
+        r#"my $x = $a eq "foo" ? alpha
+         : $a eq "bar" ? beta
+         : gamma;"#,
+    );
+}
+
+#[test]
+fn test_ternary_with_method_call_in_then() {
+    // Method call in then-branch (already worked via arrow chain)
+    assert_clean_parse(r#"my $v = $a ? $obj->method($x) : $obj->other($y);"#);
+}


### PR DESCRIPTION
## Summary

- Fix `expected ':', found '('` errors when a ternary branch ends with a subscript/deref expression immediately followed by a call `()`
- Three CPAN patterns now parse correctly: `undef()`, `$_[0]()`, and `$self->{serial}($arg)` in ternary branches
- Adds 16 regression tests covering the issue patterns and related coderef-call scenarios

## Root Cause

`parse_postfix_chain` in `postfix.rs` only handled `LeftParen` when the current expression was a `NodeKind::Identifier`. Non-identifier expressions (`NodeKind::Undef`, `NodeKind::Binary` subscripts/derefs) fell through to the `_ =>` branch which does not parse call arguments. This left `(` as the next unconsumed token when `parse_ternary` returned, causing `expect(TokenKind::Colon)` to fail with `"expected ':', found '('"`.

## Changes

- `crates/perl-parser-core/src/engine/parser/expressions/postfix.rs` — Add `Some(LeftParen) if Undef | Binary` match arm in `parse_postfix_chain`: `Undef` → `undef(LIST)` call, `Binary` → implicit coderef invocation
- `crates/perl-parser-core/tests/fix_nested_ternary_label_4169.rs` — 16 regression tests (3 for the exact failing CPAN patterns, 13 for related coderef-call scenarios)

## Evidence

- **Commits**: 1
- **Tests fixed**: 3 (test_mojo_log_format, test_cpan_undef_parens_in_ternary, test_cpan_coderef_call_in_ternary in fix_expected_colon.rs)
- **New tests**: 16 (all passing)
- **Lint**: `cargo clippy -p perl-parser-core` — clean
- **Files**: 2 changed, +164/-0 lines
- **Pre-existing failure**: `test_custom_func_no_parens_ternary` (fix_ternary_stmt_start.rs) — confirmed broken on master before this change; tracked separately (calls.rs heuristic)

## Test Plan

```bash
export CARGO_TARGET_DIR="/tmp/test-verify"
cargo test -p perl-parser-core --test fix_nested_ternary_label_4169
cargo test -p perl-parser-core --test fix_expected_colon
```

## Unknowns

- `NodeKind::Binary` is a broad match that covers all binary node variants (subscript, deref, arithmetic, etc.). The guard only fires when `LeftParen` follows — arithmetic results like `$a + $b` are not callable in Perl, so this would produce a parse node but Perl itself would reject it at runtime. Considered acceptable since we parse permissively.
- The indirect-call heuristic (`is_ready $obj ? 1 : 0`) is a separate pre-existing bug in `calls.rs` — out of scope for this surgical fix.