### PR TITLE
chore(deps): remove unused perl-tdd-support dev-deps from 5 crates (#4183)

### DIFF
--- a/crates/perl-ast-utils/Cargo.toml
+++ b/crates/perl-ast-utils/Cargo.toml
@@ -29,7 +29,6 @@ doctest = false
 perl-ast = { workspace = true }
 
 [dev-dependencies]
-perl-tdd-support = { workspace = true }
 perl-ast = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/perl-dap-types/Cargo.toml
+++ b/crates/perl-dap-types/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/lib.rs"
 serde = { workspace = true }
 
 [dev-dependencies]
-perl-tdd-support = { workspace = true }
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -27,7 +27,6 @@ perl-workspace-index = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-perl-tdd-support = { workspace = true }
 serde_json = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/perl-lsp-feature-policy/Cargo.toml
+++ b/crates/perl-lsp-feature-policy/Cargo.toml
@@ -20,9 +20,6 @@ perl-lsp-feature-contracts = { workspace = true }
 perl-lsp-feature-profile = { workspace = true }
 perl-lsp-feature-flags = { workspace = true }
 
-[dev-dependencies]
-perl-tdd-support = { workspace = true }
-
 [features]
 lsp-ga-lock = [
     "perl-lsp-feature-contracts/lsp-ga-lock",

--- a/crates/perl-symbol-surface/Cargo.toml
+++ b/crates/perl-symbol-surface/Cargo.toml
@@ -29,7 +29,6 @@ perl-ast = { workspace = true }
 perl-symbol-types = { workspace = true }
 
 [dev-dependencies]
-perl-tdd-support = { workspace = true }
 perl-ast = { workspace = true }
 perl-symbol-types = { workspace = true }
 


### PR DESCRIPTION
## Summary

Closes #4183

Removes `perl-tdd-support` from `[dev-dependencies]` in 5 crates where it was scaffolded but never imported. Verified zero usage via grep of `src/` and `tests/` in each crate before removal.

| Crate | Action | Verification |
|-------|--------|--------------|
| `perl-ast-utils` | removed `perl-tdd-support` | grep `perl_tdd_support` src/tests = 0 matches |
| `perl-dap-types` | removed `perl-tdd-support` | grep `perl_tdd_support` src/tests = 0 matches |
| `perl-dead-code` | removed `perl-tdd-support` | grep `perl_tdd_support` src/tests = 0 matches |
| `perl-lsp-feature-policy` | removed `perl-tdd-support` | grep `perl_tdd_support` src/tests = 0 matches |
| `perl-symbol-surface` | removed `perl-tdd-support` | grep `perl_tdd_support` src/tests = 0 matches |
| `perl-lsp-ai-provider` | already clean | no [dev-dependencies] entry exists in master |

**Not removed (false positives):**
- `perl-dap` / `perl-lsp-feature-contracts`: `perl-feature-catalog` is listed under `[build-dependencies]` and actively used in `build.rs` via `use perl_feature_catalog::{...}`. Machete false positive.
- `perllsp`: `perl-lsp-rs` is used via `pub use perl_lsp::*` in `src/lib.rs`. Machete false positive.

**Related:** PR #4197 covers issues #4176, #4179, #4181 (perl-parser nix/walkdir, perl-lsp-providers nix, tree-sitter-perl-c criterion/test-case). This PR covers only #4183.

## Test plan

- [x] `cargo check -p perl-ast-utils -p perl-dap-types -p perl-dead-code -p perl-lsp-ai-provider -p perl-lsp-feature-policy -p perl-symbol-surface` passes
- [x] grep for `perl_tdd_support` in each crate src + tests returns zero matches
- [x] Diff contains only `[dev-dependencies]` removals — no source changes