### PR TITLE
fix(perl-module-resolution): normalize path separators in resolve_absolute_path tests on Windows (#4154)

### DIFF
--- a/crates/perl-module-resolution/src/use_lib.rs
+++ b/crates/perl-module-resolution/src/use_lib.rs
@@ -485,7 +485,8 @@ mod tests {
         let paths =
             vec![UseLibPath { path: inside.to_string_lossy().to_string(), from_findbin: false }];
         let resolved = resolve_use_lib_paths(&paths, workspace.path(), None);
-        assert_eq!(resolved, vec![inside.to_string_lossy().to_string()]);
+        let expected = inside.to_string_lossy().replace('\\', "/");
+        assert_eq!(resolved, vec![expected]);
         Ok(())
     }
 
@@ -498,7 +499,8 @@ mod tests {
             from_findbin: false,
         }];
         let resolved = resolve_use_lib_paths(&paths, workspace.path(), None);
-        assert_eq!(resolved, vec![outside.path().join("lib").to_string_lossy().to_string()]);
+        let expected = outside.path().join("lib").to_string_lossy().replace('\\', "/");
+        assert_eq!(resolved, vec![expected]);
         Ok(())
     }
 

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 3051 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 3047 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 3051 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 3047 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->


### PR DESCRIPTION
## Summary
- Fixes two consistently-failing Windows tests in `perl-module-resolution`: `resolve_absolute_path_inside_workspace` and `resolve_absolute_path_outside_workspace_ignored`
- Root cause: `resolve_use_lib_paths` normalizes absolute paths to forward slashes via `normalize_relative_path_string`, but the test assertions compared against `to_string_lossy()` which preserves OS-native backslashes on Windows
- Fix: apply the same `.replace('\', "/")` normalization to the expected values in both test assertions

## Changes
- `crates/perl-module-resolution/src/use_lib.rs`: normalize expected values in two test assertions (+4/-2 lines)
- `docs/project/status/tests.md`: updated test count after test fix

## Evidence
- **Commits**: 2 (fix + status update)
- **Tests**: 144 passed, 0 failed (`cargo test -p perl-module-resolution`)
- **Lint**: clean (`cargo clippy -p perl-module-resolution --tests`)
- **Fmt**: clean (`cargo fmt --package perl-module-resolution`)
- **Files**: 1 source file changed, +4/-2 lines

## Test Plan
- Run `cargo test -p perl-module-resolution -- use_lib::tests::resolve_absolute_path` on Windows — both tests should pass
- Run `cargo test -p perl-module-resolution` — all 144 tests pass, no regressions

## Unknowns
- `resolve_findbin_path_with_file_dir` and `resolve_findbin_path_without_file_dir` use hardcoded Unix-style `/project` paths which are treated as relative on Windows (no drive letter). Both currently pass because they go through the `from_findbin` branch, not the `is_absolute()` branch. A follow-up scout could verify full Windows correctness of FindBin path resolution.

Closes #4154