### PR TITLE
chore(nix): add missing dev tools to flake.nix devShell and sync version (#4184)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
           just              # Command runner (justfile)
           cargo-nextest     # Fast test runner (used in CI)
           cargo-audit       # Security vulnerability scanner
+          cargo-llvm-cov    # Coverage reports (llvm-cov)
+          cargo-machete     # Unused dependency detection
+          cargo-semver-checks  # SemVer compliance checks
+          git-cliff         # Changelog generation
+          bacon             # Background cargo watcher
           gh                # GitHub CLI for PR operations
           jq                # JSON processing for scripts
           (python3.withPackages (ps: [ ps.pyyaml ]))  # Used by CI scripts
@@ -197,7 +202,7 @@
 
           perl-lsp = pkgs.rustPlatform.buildRustPackage {
             pname = "perl-lsp";
-            version = "0.9.1";  # Keep in sync with CLAUDE.md
+            version = "0.12.3";  # Keep in sync with CLAUDE.md
             src = self;
             cargoLock.lockFile = ./Cargo.lock;
 


### PR DESCRIPTION
## Summary

- Add `cargo-llvm-cov`, `cargo-machete`, `cargo-semver-checks`, `git-cliff`, and `bacon` to `ciTools` in `flake.nix` so `nix develop` provides the full local toolchain matching the justfile commands
- Bump `packages.perl-lsp.version` from `0.9.1` to `0.12.3` to match the CLAUDE.md latest release

## Changes

All 5 new tools are sourced from `pkgs` (nixpkgs), not `rust-overlay`, per spec constraint.

Tools added to `ciTools` so they appear in both `devShells.default` (developer shell) and `devShells.ci` (CI runner shell):

| Tool | Purpose |
|------|---------|
| `cargo-llvm-cov` | Coverage reports (`just coverage`, `just coverage-lcov`) |
| `cargo-machete` | Unused dependency detection (`cargo machete`) |
| `cargo-semver-checks` | SemVer compliance (`just semver-check`) |
| `git-cliff` | Changelog generation |
| `bacon` | Background cargo watcher for fast dev iteration |

## Test plan

- [ ] `nix develop` resolves all 5 new packages without error
- [ ] `nix develop -c cargo-llvm-cov --version` works
- [ ] `nix develop -c cargo machete --version` works
- [ ] `nix develop -c cargo semver-checks --version` works
- [ ] `nix develop -c git cliff --version` works
- [ ] `nix develop -c bacon --version` works
- [ ] `nix flake check` still passes (no sandbox regressions)

## Notes

Pre-push hook bypassed with `--no-verify` because `/tmp` disk was full (environmental issue out of band from this change, as per bypass policy in `.git/hooks/pre-push`).