### PR TITLE
fix(ci-hygiene): pre-push hook self-heal + Windows os error 206 hint (#4220)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -1815,6 +1815,20 @@ if [ "$(git config --get core.bare 2>/dev/null || true)" = "true" ]; then
     fi
 fi
 
+# --- Self-heal stale hook installation (issue #4220) ---
+# When hooks/pre-push is updated in master, .git/hooks/pre-push is only
+# updated when install-githooks is re-run. Auto-copy when drift is detected.
+# Note: exec "$0" "$@" does NOT work here — git stdin is already consumed
+# before the hook executes. Copy and continue; the fresh hook takes effect
+# on the next push.
+REPO_ROOT_FOR_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$REPO_ROOT_FOR_HOOK" ] && [ -f "$REPO_ROOT_FOR_HOOK/hooks/pre-push" ]; then
+    if ! diff -q "$0" "$REPO_ROOT_FOR_HOOK/hooks/pre-push" >/dev/null 2>&1; then
+        echo "pre-push hook updated from hooks/pre-push (was stale — takes effect next push)"
+        cp "$REPO_ROOT_FOR_HOOK/hooks/pre-push" "$0" && chmod +x "$0" || true
+    fi
+fi
+
 # stdin provides: <local ref> <local sha> <remote ref> <remote sha>
 # Git sends all-zero SHA for deletions. Read all refs into an array first
 # so stdin is available for both the delete-check and the test-file scan.
@@ -2000,6 +2014,14 @@ if [ "$GATE_STATUS" -ne 0 ]; then
     fi
     if grep -qE 'clippy::|warning: .*-> .*\.rs' "$GATE_LOG" 2>/dev/null; then
         echo "   • Clippy warnings — look for the error above and fix the warnings"
+        HINTED=true
+    fi
+    if grep -qE 'os error 206|filename.*too long|ERROR_FILENAME_EXCED' "$GATE_LOG" 2>/dev/null; then
+        echo "   • Windows MAX_PATH (os error 206) — paths exceed 260 chars"
+        echo "     Fix A: Enable long paths (requires admin terminal):"
+        echo "       reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f"
+        echo "     Fix B: bash scripts/install-githooks.sh  (stale hook may be the cause)"
+        echo "     See: docs/contributing/FIRST_PR.md"
         HINTED=true
     fi
     if [ "$HINTED" = false ]; then
@@ -4330,6 +4352,29 @@ mod tests {
         assert!(
             hook.contains("cargo xtask fmt") || hook.contains("cargo fmt"),
             "hook must suggest the fmt fix command on fmt failures"
+        );
+    }
+
+    #[test]
+    fn pre_push_hook_has_stale_hook_self_heal() {
+        let hook = pre_push_hook_script();
+        // Issue #4220 — when hooks/pre-push is updated in master, the installed
+        // .git/hooks/pre-push is only updated when install-githooks is re-run.
+        // The hook must detect its own staleness and auto-copy the fresh version.
+        assert!(
+            hook.contains("REPO_ROOT_FOR_HOOK") && hook.contains("hooks/pre-push"),
+            "hook must self-heal stale installation (issue #4220)"
+        );
+    }
+
+    #[test]
+    fn pre_push_hook_has_os_error_206_hint() {
+        let hook = pre_push_hook_script();
+        // Issue #4220 — Windows MAX_PATH (os error 206) hint must appear in the
+        // gate-failure handler so contributors know how to fix it.
+        assert!(
+            hook.contains("os error 206") || hook.contains("LongPathsEnabled"),
+            "hook must hint at Windows MAX_PATH fix (issue #4220)"
         );
     }
 }

--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -35,6 +35,14 @@ just doctor
 
 Rust toolchain is pinned in `rust-toolchain.toml` (MSRV 1.92). `rustup` picks it up automatically.
 
+**Windows users:** Enable long path support before building (one-time, requires admin terminal):
+
+```
+reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
+```
+
+Without this, `cargo fmt` may fail with "os error 206" from deep worktree paths. Start a new terminal after setting the key.
+
 Install the pre-push hook so the fast gate runs before every push:
 
 ```bash
@@ -153,7 +161,7 @@ If the reviewer pushes a fix directly to your branch, that is normal. Check and 
 |------|---------|
 | Build LSP server | `cargo build -p perl-lsp-rs --release` |
 | Run all tests | `cargo test --workspace --lib` |
-| Format | `cargo fmt --all` |
+| Format | `cargo xtask fmt` |
 | Lint | `cargo clippy --workspace` |
 | Full merge gate | `just ci-gate` |
 | Environment check | `just doctor` |

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -35,6 +35,20 @@ if [ "$(git config --get core.bare 2>/dev/null || true)" = "true" ]; then
     fi
 fi
 
+# --- Self-heal stale hook installation (issue #4220) ---
+# When hooks/pre-push is updated in master, .git/hooks/pre-push is only
+# updated when install-githooks is re-run. Auto-copy when drift is detected.
+# Note: exec "$0" "$@" does NOT work here — git stdin is already consumed
+# before the hook executes. Copy and continue; the fresh hook takes effect
+# on the next push.
+REPO_ROOT_FOR_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$REPO_ROOT_FOR_HOOK" ] && [ -f "$REPO_ROOT_FOR_HOOK/hooks/pre-push" ]; then
+    if ! diff -q "$0" "$REPO_ROOT_FOR_HOOK/hooks/pre-push" >/dev/null 2>&1; then
+        echo "pre-push hook updated from hooks/pre-push (was stale — takes effect next push)"
+        cp "$REPO_ROOT_FOR_HOOK/hooks/pre-push" "$0" && chmod +x "$0" || true
+    fi
+fi
+
 # stdin provides: <local ref> <local sha> <remote ref> <remote sha>
 # Git sends all-zero SHA for deletions. Read all refs into an array first
 # so stdin is available for both the delete-check and the test-file scan.
@@ -220,6 +234,14 @@ if [ "$GATE_STATUS" -ne 0 ]; then
     fi
     if grep -qE 'clippy::|warning: .*-> .*\.rs' "$GATE_LOG" 2>/dev/null; then
         echo "   • Clippy warnings — look for the error above and fix the warnings"
+        HINTED=true
+    fi
+    if grep -qE 'os error 206|filename.*too long|ERROR_FILENAME_EXCED' "$GATE_LOG" 2>/dev/null; then
+        echo "   • Windows MAX_PATH (os error 206) — paths exceed 260 chars"
+        echo "     Fix A: Enable long paths (requires admin terminal):"
+        echo "       reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f"
+        echo "     Fix B: bash scripts/install-githooks.sh  (stale hook may be the cause)"
+        echo "     See: docs/contributing/FIRST_PR.md"
         HINTED=true
     fi
     if [ "$HINTED" = false ]; then

--- a/scripts/agent-preflight.sh
+++ b/scripts/agent-preflight.sh
@@ -140,6 +140,21 @@ else
     STASH_OK=true
 fi
 
+# ── Check 7: pre-push hook is current (Windows MAX_PATH guard) ──────────────
+# Warning-only — a stale hook does not block agent work, only push.
+
+REPO_ROOT_AGENT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+INSTALLED_HOOK="$(git rev-parse --git-common-dir 2>/dev/null)/hooks/pre-push"
+CHECKED_IN_HOOK="$REPO_ROOT_AGENT/hooks/pre-push"
+if [ -f "$INSTALLED_HOOK" ] && [ -f "$CHECKED_IN_HOOK" ]; then
+    if ! diff -q "$INSTALLED_HOOK" "$CHECKED_IN_HOOK" >/dev/null 2>&1; then
+        printf 'WARN pre-push hook is stale (Windows os error 206 risk)\n'
+        printf '     Fix: cargo xtask ci-hygiene install-githooks\n'
+    else
+        ok "pre-push hook is current"
+    fi
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds stale-hook self-heal block to the generated pre-push hook and `hooks/pre-push`: detects when the installed `.git/hooks/pre-push` has drifted from the checked-in template and auto-copies the fresh version on the current push (copy-and-continue pattern; `exec "$0" "$@"` is not viable for pre-push hooks because git stdin is already consumed)
- Adds Windows MAX_PATH (os error 206) hint to the gate-failure handler: detects `os error 206 / filename.*too long / ERROR_FILENAME_EXCED` in the gate log and prints the `LongPathsEnabled` registry fix one-liner plus stale-hook diagnosis
- Adds Check 7 (warning-only, no exit) to `scripts/agent-preflight.sh`: warns when installed pre-push hook differs from checked-in `hooks/pre-push` so agents know to reinstall before pushing
- Documents Windows `LongPathsEnabled` `reg add` one-liner in `docs/contributing/FIRST_PR.md` under dev environment setup; fixes Reference table `cargo fmt --all` → `cargo xtask fmt`

## Test plan

- [x] Two new unit tests added and passing: `pre_push_hook_has_stale_hook_self_heal`, `pre_push_hook_has_os_error_206_hint`
- [x] `checked_in_pre_push_hook_matches_generated_hook` passes (both files updated together)
- [x] Full `cargo test -p perl-ci-hygiene`: 27/27 passed
- [x] `cargo fmt -p perl-ci-hygiene -- --check`: clean
- [x] `cargo clippy -p perl-ci-hygiene -- -D warnings`: clean
- [ ] CI gate (blocked by C: disk full on this machine — environmental, not code)

## Key traps (for reviewers)

- `exec "$0" "$@"` does NOT work for pre-push hooks — git has already consumed stdin; copy-and-continue is the correct pattern
- `REPO_ROOT_FOR_HOOK` variable name was chosen to avoid collision with `REPO_ROOT` already used in the hook body (line ~1848)
- `cp ... && chmod +x "$0" || true` — the `|| true` ensures a read-only `.git/hooks/pre-push` does not abort the push
- Check 7 in agent-preflight.sh is warning-only (no exit code, does not increment FAIL counter) — a stale hook does not block agent work, only push

## Closes

Fixes #4220

## Coordination

Does NOT overlap with #4173 (single-crate proportional gate) — that issue also touches `crates/perl-ci-hygiene/src/main.rs` and `hooks/pre-push` but adds a separate tier; these PRs should be merged sequentially.