### PR TITLE
chore: bump version to 0.12.4 (#4272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.12.4] - 2026-04-12
 
 <!-- 2026-04-11 session: 46 PRs merged across navigation, pragma scoping, incremental parsing, workspace refactoring, Windows hardening, and CI hygiene -->
-<!-- 2026-04-12 session: 6 PRs merged — DAP scorecard, rename perf, editor UX receipt, research-verifier policy -->
+<!-- 2026-04-12 session: ~25 PRs merged — DAP scorecard, rename perf, editor UX, diagnostics polish, hover improvements, workspace/config, completion ranking, Windows compat, CI hygiene -->
 
 ### Headlines
 
@@ -406,6 +406,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stale 15 types/7 modifiers to the actual 23 types/13 modifiers, with all token
   types and modifiers listed in index order and Perl-specific extensions called out.
   (#4239)
+
+### Added (2026-04-12 session 2)
+
+- **Compile-time constants hover** — `__FILE__`, `__LINE__`, `__PACKAGE__`, and
+  `__SUB__` now show rich hover documentation with descriptions and caveats
+  (e.g. `__SUB__` in named subs vs anonymous subs). (#4270, #4294)
+
+- **Fast/slow diagnostic split** — parse errors are now published immediately
+  (~440ms sooner) via `publish_parse_errors_fast()`, then replaced by the full
+  diagnostic set on the 250ms debounce. Users see red squiggles while typing
+  without waiting for scope analysis or perlcritic. (#4279, #4305)
+
+- **Generation-aware staleness guard** — if a `didChange` arrives during slow
+  computation (scope analysis, perlcritic, dead-code), the stale diagnostic
+  result is suppressed and the debouncer re-fires for the latest version. (#4295)
+
+- **`require Module; Module->import('sym')` completion** — the two-statement
+  require+import pattern is now recognised for completion ranking alongside
+  `use Module` imports. (#3476, #4296)
+
+- **Module ranking tiers for completion** — completion candidates are ranked
+  by import tier (direct import > workspace > CPAN) with string-context
+  suppression and open-snippet triggers for module paths. (#4263, #4277)
+
+- **`workspace/configuration` folder propagation** — `didChangeConfiguration`
+  now eagerly propagates settings to each folder's `effective_workspace_config`,
+  closing a stale-settings window between notification and async pull response.
+  (#3515, #4289, #4307)
+
+- **Safe-delete widened dependent detection** — `workspace/willDeleteFiles`
+  now detects dependents via both `use` imports and `require` statements,
+  surfacing warnings for a broader set of cross-file references. (#3513, #4293)
+
+- **Package declaration rewrite during module rename** — `workspace/willRenameFiles`
+  now rewrites `package Foo::Bar` declarations inside the renamed file to match
+  the new module path. (#3522, #4291)
+
+### Fixed (2026-04-12 session 2)
+
+- **Package name hover** — hovering a qualified package name like `File::Path`
+  previously showed broken hover text because the tokenizer stopped at `:`.
+  New `get_package_name_at_position` scans across `::` separators to produce
+  correct rich hover with file path, POD, and MetaCPAN link. (#4282, #4306)
+
+- **Signature/Prototype AST byte-span** — `Signature` and `Prototype` nodes
+  now carry the correct byte span from the parser, fixing off-by-one ranges
+  in hover and semantic tokens. (#4243, #4281)
+
+- **Windows compatibility** — `/proc` reads guarded behind `cfg(target_os = "linux")`;
+  hardcoded `/tmp` paths replaced with `std::env::temp_dir()` for cross-platform
+  correctness. (#4229, #4278)
+
+### Tests / Quality (2026-04-12 session 2)
+
+- **Cross-folder rename verification** — integration tests verify rename operations
+  span both workspace roots correctly. (#3522, #4273, #4292)
+
+- **Import visibility regression tests** — unit tests for `require`+`import`
+  symbol resolution patterns. (#3476, #4286)
+
+- **Heredoc `unreachable!` ratchet coverage** — tests cover all 7 heredoc
+  unreachable patterns on both path separators. (#4245, #4274)
+
+- **Unused dev-dependencies removed** from 5 crates. (#4183, #4255)
 
 
 ## [0.12.3] - 2026-04-08

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.12.3 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md)
+**Latest Release**: 0.12.4 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md)
 
 ## Orchestration Model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,7 +1478,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1487,21 +1487,21 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-utils"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
 ]
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-builtins"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-builtins-phf",
  "perl-tdd-support",
@@ -1509,14 +1509,14 @@ dependencies = [
 
 [[package]]
 name = "perl-builtins-phf"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "phf",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "chrono",
  "clap",
@@ -1529,11 +1529,11 @@ dependencies = [
 
 [[package]]
 name = "perl-content-length-framing"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-corpus"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-breakpoint"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser",
  "perl-tdd-support",
@@ -1595,11 +1595,11 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-command-args"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-dap-config"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-eval"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-platform"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "perl-dap-command-args",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-security"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "perl-path-security",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-shell"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-dap-command-args",
  "perl-dap-platform",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-stack"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "once_cell",
  "perl-tdd-support",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-types"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-value"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap-variables"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "once_cell",
  "perl-dap-value",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-workspace-index",
  "serde",
@@ -1698,14 +1698,14 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics-codes"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perl-edit"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "perl-error"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "perl-feature-catalog"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
  "serde",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "perl-heredoc"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-position-tracking",
  "perl-tdd-support",
@@ -1745,14 +1745,14 @@ dependencies = [
 
 [[package]]
 name = "perl-heredoc-anti-patterns"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "regex",
 ]
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "lsp-types",
@@ -1768,11 +1768,11 @@ dependencies = [
 
 [[package]]
 name = "perl-keywords"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lexer"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "criterion",
  "memchr",
@@ -1786,11 +1786,11 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-ai-provider"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-inline-completion",
  "serde_json",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-cancellation"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
  "serde_json",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-capability-map"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-ids",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-actions"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast-utils",
  "perl-builtins",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-code-lens"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser",
  "perl-parser-core",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-color-provider"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "once_cell",
  "perl-position-tracking",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "criterion",
  "perl-keywords",
@@ -1870,14 +1870,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-completion-item"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser-core",
 ]
 
 [[package]]
 name = "perl-lsp-config"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-dap-platform",
  "serde",
@@ -1888,14 +1888,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-critic-parser"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-lsp-diagnostic-catalog"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-diagnostics-codes",
  "serde_json",
@@ -1903,11 +1903,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-diagnostic-types"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-diagnostics"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "insta",
  "perl-corpus",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-highlight"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
  "perl-parser",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-document-links"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-import",
  "perl-module-path",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-contracts"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-feature-catalog",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-flags"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-ids",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-governance"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-grid",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-grid"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-policy",
@@ -1985,11 +1985,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-ids"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-feature-policy"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-contracts",
  "perl-lsp-feature-flags",
@@ -1998,14 +1998,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-feature-profile"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-contracts",
 ]
 
 [[package]]
 name = "perl-lsp-feature-profile-cli"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-feature-policy",
  "perl-lsp-feature-profile",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-file-completion"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-completion-item",
  "perl-path-security",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-folding"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-formatting-types",
  "perl-lsp-tooling",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-formatting-types"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2050,11 +2050,11 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-import-management"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-inlay-hints"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-builtins",
  "perl-parser-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-inline-completion"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-position-tracking",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-input-validation"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "perl-lsp-limits",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-launcher"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "clap",
  "perl-lsp-feature-governance",
@@ -2098,14 +2098,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-limits"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-navigation"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2121,14 +2121,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-on-type-formatting"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "perl-lsp-performance"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "moka",
  "perl-parser-core",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-protocol"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-lsp-feature-contracts",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-providers"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-lsp-code-actions",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rename"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-keywords",
  "perl-parser-core",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2290,14 +2290,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-selection-range"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-semantic-tokens"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lexer",
  "perl-parser-core",
@@ -2308,15 +2308,15 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-symbol-query"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-text-utils"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-lsp-tooling"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-transport"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-content-length-framing",
  "perl-lsp-protocol",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-type-hierarchy"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser-core",
  "perl-position-tracking",
@@ -2353,14 +2353,14 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-uri"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
 ]
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-workspace-symbols"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-symbol-query",
  "perl-module-path",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-boundary"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-path",
  "perl-module-token",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-import-match"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-boundary",
  "perl-module-import",
@@ -2416,21 +2416,21 @@ dependencies = [
 
 [[package]]
 name = "perl-module-name"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-path"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-name",
 ]
 
 [[package]]
 name = "perl-module-reference"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-import",
  "perl-module-name",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-rename"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-import-match",
  "perl-module-path",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-resolution-path",
  "perl-module-resolution-uri",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-path"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-resolution-uri"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-path",
  "perl-path-security",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-boundary",
  "perl-module-name",
@@ -2496,14 +2496,14 @@ dependencies = [
 
 [[package]]
 name = "perl-module-token-core"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-module-token-parser"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-reference",
  "perl-module-token-core",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-normalize"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "tempfile",
  "thiserror",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "perl-path-security"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-path-normalize",
  "tempfile",
@@ -2607,18 +2607,18 @@ dependencies = [
 
 [[package]]
 name = "perl-percentile"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-pod"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -2631,21 +2631,21 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
 ]
 
 [[package]]
 name = "perl-qualified-name"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-quote"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
  "proptest",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-path",
  "perl-parser-core",
@@ -2669,14 +2669,14 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-parser-core",
  "perl-symbol-types",
@@ -2689,29 +2689,29 @@ dependencies = [
 
 [[package]]
 name = "perl-source-file"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-cursor"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol-index"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-symbol-surface"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast",
  "perl-symbol-types",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "perl-symbol-types"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -2739,18 +2739,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-text-line"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-module-token-parser",
  "perl-tdd-support",
@@ -2759,11 +2759,11 @@ dependencies = [
 
 [[package]]
 name = "perl-token"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-tokenizer"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-ast-v2",
  "perl-error",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -2786,14 +2786,14 @@ dependencies = [
 
 [[package]]
 name = "perl-uri-classify"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "url",
 ]
 
 [[package]]
 name = "perl-workspace-discovery"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-source-file",
  "perl-workspace-ignore",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-folder"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-uri",
  "proptest",
@@ -2816,11 +2816,11 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-ignore"
-version = "0.12.3"
+version = "0.12.4"
 
 [[package]]
 name = "perl-workspace-index"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-monitoring"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "parking_lot",
  "perl-tdd-support",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-slo"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "parking_lot",
  "perl-percentile",
@@ -2859,14 +2859,14 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace-index-state-machine"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "perllsp"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -4066,7 +4066,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "insta",
  "perl-ast",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -318,147 +318,147 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.3" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.4" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.12.3" }
-perl-quote = { path = "crates/perl-quote", version = "0.12.3" }
-perl-edit = { path = "crates/perl-edit", version = "0.12.3" }
-perl-builtins = { path = "crates/perl-builtins", version = "0.12.3" }
-perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.12.3" }
-perl-regex = { path = "crates/perl-regex", version = "0.12.3" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.12.3" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.12.3" }
-perl-ast = { path = "crates/perl-ast", version = "0.12.3" }
-perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.3" }
-perl-heredoc-anti-patterns = { path = "crates/perl-heredoc-anti-patterns", version = "0.12.3" }
-perl-error = { path = "crates/perl-error", version = "0.12.3" }
-perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.3" }
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.3" }
-perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.12.3" }
-perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.12.3" }
-perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.12.3" }
-perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.12.3" }
-perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.12.3" }
-perl-module-token = { path = "crates/perl-module-token", version = "0.12.3" }
-perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.12.3" }
-perl-module-name = { path = "crates/perl-module-name", version = "0.12.3" }
-perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.12.3" }
-perl-module-reference = { path = "crates/perl-module-reference", version = "0.12.3" }
-perl-module-import = { path = "crates/perl-module-import", version = "0.12.3" }
-perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.12.3" }
-perl-module-path = { path = "crates/perl-module-path", version = "0.12.3" }
-perl-module-rename = { path = "crates/perl-module-rename", version = "0.12.3" }
-perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.12.3" }
-perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.12.3" }
-perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.12.3" }
-perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.12.3" }
-perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.12.3" }
-perl-keywords = { path = "crates/perl-keywords", version = "0.12.3" }
-perl-source-file = { path = "crates/perl-source-file", version = "0.12.3" }
-perl-text-line = { path = "crates/perl-text-line", version = "0.12.3" }
-perl-line-index = { path = "crates/perl-line-index", version = "0.12.3" }
-perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.12.3" }
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.3" }
-perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.12.3" }
-perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.12.3" }
-perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.12.3" }
-perl-ast-utils = { path = "crates/perl-ast-utils", version = "0.12.3" }
-perl-symbol-surface = { path = "crates/perl-symbol-surface", version = "0.12.3" }
-perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.12.3" }
-perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.12.3" }
-perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.12.3" }
-perl-uri = { path = "crates/perl-uri", version = "0.12.3" }
-perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.12.3" }
-perl-percentile = { path = "crates/perl-percentile", version = "0.12.3" }
-perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.12.3" }
-perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.12.3" }
-perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.12.3" }
-perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.12.3" }
-perl-path-security = { path = "crates/perl-path-security", version = "0.12.3" }
-perl-pod = { path = "crates/perl-pod", version = "0.12.3" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.12.3" }
-perl-dap = { path = "crates/perl-dap", version = "0.12.3" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.3" }
-perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.12.3" }
-perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.12.3" }
-perl-dap-config = { path = "crates/perl-dap-config", version = "0.12.3" }
-perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.12.3" }
-perl-dap-value = { path = "crates/perl-dap-value", version = "0.12.3" }
-perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.12.3" }
-perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.12.3" }
-perl-dap-types = { path = "crates/perl-dap-types", version = "0.12.3" }
-perl-dap-security = { path = "crates/perl-dap-security", version = "0.12.3" }
-perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.12.3" }
-perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.12.3" }
-perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.12.3" }
-perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.12.3" }
-perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.12.3" }
-perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.12.3" }
+perl-token = { path = "crates/perl-token", version = "0.12.4" }
+perl-quote = { path = "crates/perl-quote", version = "0.12.4" }
+perl-edit = { path = "crates/perl-edit", version = "0.12.4" }
+perl-builtins = { path = "crates/perl-builtins", version = "0.12.4" }
+perl-builtins-phf = { path = "crates/perl-builtins-phf", version = "0.12.4" }
+perl-regex = { path = "crates/perl-regex", version = "0.12.4" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.12.4" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.12.4" }
+perl-ast = { path = "crates/perl-ast", version = "0.12.4" }
+perl-heredoc = { path = "crates/perl-heredoc", version = "0.12.4" }
+perl-heredoc-anti-patterns = { path = "crates/perl-heredoc-anti-patterns", version = "0.12.4" }
+perl-error = { path = "crates/perl-error", version = "0.12.4" }
+perl-tokenizer = { path = "crates/perl-tokenizer", version = "0.12.4" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.4" }
+perl-symbol-types = { path = "crates/perl-symbol-types", version = "0.12.4" }
+perl-symbol-cursor = { path = "crates/perl-symbol-cursor", version = "0.12.4" }
+perl-symbol-index = { path = "crates/perl-symbol-index", version = "0.12.4" }
+perl-module-boundary = { path = "crates/perl-module-boundary", version = "0.12.4" }
+perl-module-token-core = { path = "crates/perl-module-token-core", version = "0.12.4" }
+perl-module-token = { path = "crates/perl-module-token", version = "0.12.4" }
+perl-module-token-parser = { path = "crates/perl-module-token-parser", version = "0.12.4" }
+perl-module-name = { path = "crates/perl-module-name", version = "0.12.4" }
+perl-qualified-name = { path = "crates/perl-qualified-name", version = "0.12.4" }
+perl-module-reference = { path = "crates/perl-module-reference", version = "0.12.4" }
+perl-module-import = { path = "crates/perl-module-import", version = "0.12.4" }
+perl-module-import-match = { path = "crates/perl-module-import-match", version = "0.12.4" }
+perl-module-path = { path = "crates/perl-module-path", version = "0.12.4" }
+perl-module-rename = { path = "crates/perl-module-rename", version = "0.12.4" }
+perl-module-resolution = { path = "crates/perl-module-resolution", version = "0.12.4" }
+perl-module-resolution-path = { path = "crates/perl-module-resolution-path", version = "0.12.4" }
+perl-module-resolution-uri = { path = "crates/perl-module-resolution-uri", version = "0.12.4" }
+perl-workspace-folder = { path = "crates/perl-workspace-folder", version = "0.12.4" }
+perl-workspace-ignore = { path = "crates/perl-workspace-ignore", version = "0.12.4" }
+perl-keywords = { path = "crates/perl-keywords", version = "0.12.4" }
+perl-source-file = { path = "crates/perl-source-file", version = "0.12.4" }
+perl-text-line = { path = "crates/perl-text-line", version = "0.12.4" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.12.4" }
+perl-content-length-framing = { path = "crates/perl-content-length-framing", version = "0.12.4" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.4" }
+perl-lsp-document-highlight = { path = "crates/perl-lsp-document-highlight", version = "0.12.4" }
+perl-lsp-document-links = { path = "crates/perl-lsp-document-links", version = "0.12.4" }
+perl-lsp-performance = { path = "crates/perl-lsp-performance", version = "0.12.4" }
+perl-ast-utils = { path = "crates/perl-ast-utils", version = "0.12.4" }
+perl-symbol-surface = { path = "crates/perl-symbol-surface", version = "0.12.4" }
+perl-lsp-symbol-query = { path = "crates/perl-lsp-symbol-query", version = "0.12.4" }
+perl-lsp-input-validation = { path = "crates/perl-lsp-input-validation", version = "0.12.4" }
+perl-lsp-text-utils = { path = "crates/perl-lsp-text-utils", version = "0.12.4" }
+perl-uri = { path = "crates/perl-uri", version = "0.12.4" }
+perl-uri-classify = { path = "crates/perl-uri-classify", version = "0.12.4" }
+perl-percentile = { path = "crates/perl-percentile", version = "0.12.4" }
+perl-lsp-import-management = { path = "crates/perl-lsp-import-management", version = "0.12.4" }
+perl-lsp-critic-parser = { path = "crates/perl-lsp-critic-parser", version = "0.12.4" }
+perl-lsp-protocol = { path = "crates/perl-lsp-protocol", version = "0.12.4" }
+perl-path-normalize = { path = "crates/perl-path-normalize", version = "0.12.4" }
+perl-path-security = { path = "crates/perl-path-security", version = "0.12.4" }
+perl-pod = { path = "crates/perl-pod", version = "0.12.4" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.12.4" }
+perl-dap = { path = "crates/perl-dap", version = "0.12.4" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.4" }
+perl-dap-breakpoint = { path = "crates/perl-dap-breakpoint", version = "0.12.4" }
+perl-dap-eval = { path = "crates/perl-dap-eval", version = "0.12.4" }
+perl-dap-config = { path = "crates/perl-dap-config", version = "0.12.4" }
+perl-dap-platform = { path = "crates/perl-dap-platform", version = "0.12.4" }
+perl-dap-value = { path = "crates/perl-dap-value", version = "0.12.4" }
+perl-dap-command-args = { path = "crates/perl-dap-command-args", version = "0.12.4" }
+perl-dap-shell = { path = "crates/perl-dap-shell", version = "0.12.4" }
+perl-dap-types = { path = "crates/perl-dap-types", version = "0.12.4" }
+perl-dap-security = { path = "crates/perl-dap-security", version = "0.12.4" }
+perl-dap-stack = { path = "crates/perl-dap-stack", version = "0.12.4" }
+perl-dap-variables = { path = "crates/perl-dap-variables", version = "0.12.4" }
+perl-feature-catalog = { path = "crates/perl-feature-catalog", version = "0.12.4" }
+perl-lsp-feature-flags = { path = "crates/perl-lsp-feature-flags", version = "0.12.4" }
+perl-lsp-feature-ids = { path = "crates/perl-lsp-feature-ids", version = "0.12.4" }
+perl-lsp-capability-map = { path = "crates/perl-lsp-capability-map", version = "0.12.4" }
 
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.3" }
-perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.12.3" }
-perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.12.3" }
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.3" }
-perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.12.3" }
-perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.12.3" }
-perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.12.3" }
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.3" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.12.3" }
-perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.12.3" }
-perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.12.3" }
-perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.12.3" }
-perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.12.3" }
-perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.12.3" }
-perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.12.3" }
-perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.12.3" }
-perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.12.3" }
-perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.12.3" }
-perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.12.3" }
-perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.12.3" }
-perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.12.3" }
-perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.12.3" }
-perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.12.3" }
-perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.12.3" }
-perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.12.3" }
-perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.12.3" }
-perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.12.3" }
-perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.12.3" }
-perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.12.3" }
-perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.12.3" }
-perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.12.3" }
-perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.12.3" }
-perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.12.3" }
-perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.3" }
-perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.3" }
-perl-lsp-ai-provider = { path = "crates/perl-lsp-ai-provider", version = "0.12.3" }
-perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.3" }
-perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.3" }
-perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.3" }
-perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.3" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.4" }
+perl-lsp-transport = { path = "crates/perl-lsp-transport", version = "0.12.4" }
+perl-lsp-tooling = { path = "crates/perl-lsp-tooling", version = "0.12.4" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.4" }
+perl-lsp-on-type-formatting = { path = "crates/perl-lsp-on-type-formatting", version = "0.12.4" }
+perl-lsp-formatting-types = { path = "crates/perl-lsp-formatting-types", version = "0.12.4" }
+perl-lsp-formatting = { path = "crates/perl-lsp-formatting", version = "0.12.4" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.4" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.12.4" }
+perl-lsp-diagnostic-types = { path = "crates/perl-lsp-diagnostic-types", version = "0.12.4" }
+perl-lsp-diagnostics = { path = "crates/perl-lsp-diagnostics", version = "0.12.4" }
+perl-lsp-semantic-tokens = { path = "crates/perl-lsp-semantic-tokens", version = "0.12.4" }
+perl-lsp-inlay-hints = { path = "crates/perl-lsp-inlay-hints", version = "0.12.4" }
+perl-lsp-code-lens = { path = "crates/perl-lsp-code-lens", version = "0.12.4" }
+perl-lsp-feature-contracts = { path = "crates/perl-lsp-feature-contracts", version = "0.12.4" }
+perl-lsp-color-provider = { path = "crates/perl-lsp-color-provider", version = "0.12.4" }
+perl-lsp-cancellation = { path = "crates/perl-lsp-cancellation", version = "0.12.4" }
+perl-lsp-limits = { path = "crates/perl-lsp-limits", version = "0.12.4" }
+perl-lsp-uri = { path = "crates/perl-lsp-uri", version = "0.12.4" }
+perl-lsp-config = { path = "crates/perl-lsp-config", version = "0.12.4" }
+perl-lsp-feature-profile = { path = "crates/perl-lsp-feature-profile", version = "0.12.4" }
+perl-lsp-feature-profile-cli = { path = "crates/perl-lsp-feature-profile-cli", version = "0.12.4" }
+perl-lsp-feature-policy = { path = "crates/perl-lsp-feature-policy", version = "0.12.4" }
+perl-lsp-feature-grid = { path = "crates/perl-lsp-feature-grid", version = "0.12.4" }
+perl-lsp-feature-governance = { path = "crates/perl-lsp-feature-governance", version = "0.12.4" }
+perl-lsp-launcher = { path = "crates/perl-lsp-launcher", version = "0.12.4" }
+perl-lsp-diagnostic-catalog = { path = "crates/perl-lsp-diagnostic-catalog", version = "0.12.4" }
+perl-lsp-navigation = { path = "crates/perl-lsp-navigation", version = "0.12.4" }
+perl-lsp-type-hierarchy = { path = "crates/perl-lsp-type-hierarchy", version = "0.12.4" }
+perl-lsp-workspace-symbols = { path = "crates/perl-lsp-workspace-symbols", version = "0.12.4" }
+perl-lsp-rename = { path = "crates/perl-lsp-rename", version = "0.12.4" }
+perl-lsp-completion = { path = "crates/perl-lsp-completion", version = "0.12.4" }
+perl-lsp-file-completion = { path = "crates/perl-lsp-file-completion", version = "0.12.4" }
+perl-lsp-completion-item = { path = "crates/perl-lsp-completion-item", version = "0.12.4" }
+perl-lsp-inline-completion = { path = "crates/perl-lsp-inline-completion", version = "0.12.4" }
+perl-lsp-ai-provider = { path = "crates/perl-lsp-ai-provider", version = "0.12.4" }
+perl-lsp-code-actions = { path = "crates/perl-lsp-code-actions", version = "0.12.4" }
+perl-lsp-folding = { path = "crates/perl-lsp-folding", version = "0.12.4" }
+perl-lsp-selection-range = { path = "crates/perl-lsp-selection-range", version = "0.12.4" }
+perl-diagnostics-codes = { path = "crates/perl-diagnostics-codes", version = "0.12.4" }
 # Tier 3: Two-level dependencies
-perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.12.3" }
-perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.12.3" }
-perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.12.3" }
-perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.12.3" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.3" }
-perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.12.3" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.3" }
+perl-workspace-index = { path = "crates/perl-workspace-index", version = "0.12.4" }
+perl-workspace-index-monitoring = { path = "crates/perl-workspace-index-monitoring", version = "0.12.4" }
+perl-workspace-index-state-machine = { path = "crates/perl-workspace-index-state-machine", version = "0.12.4" }
+perl-workspace-index-slo = { path = "crates/perl-workspace-index-slo", version = "0.12.4" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.4" }
+perl-workspace-discovery = { path = "crates/perl-workspace-discovery", version = "0.12.4" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.4" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.3" }
-perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.12.3", default-features = false }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.4" }
+perl-lsp-providers = { path = "crates/perl-lsp-providers", version = "0.12.4", default-features = false }
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.12.3" }
-perl-lsp-rs = { path = "crates/perl-lsp", version = "0.12.3" }
+perl-parser = { path = "crates/perl-parser", version = "0.12.4" }
+perl-lsp-rs = { path = "crates/perl-lsp", version = "0.12.4" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.3" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.4" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.12.3" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.12.3" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.12.4" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.12.4" }
 tree-sitter = "0.26.8"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 
 ## Status
 
-**Current release: v0.12.3** — public alpha. The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
+**Current release: v0.12.4** — public alpha. The 0.12.x line is building parser corpus confidence, diagnostic hardening, and distribution coverage toward the v0.13.0 public alpha announcement. See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for the milestone ladder and [docs/project/status/index.md](docs/project/status/index.md) for live metrics.
 
 ### What the numbers mean (and don't)
 

--- a/crates/perl-builtins/Cargo.toml
+++ b/crates/perl-builtins/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["perl", "builtins", "parser", "lsp", "signatures"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.12.3" }
+perl-builtins-phf = { path = "../perl-builtins-phf", version = "0.12.4" }
 
 [dev-dependencies]
 perl-tdd-support = { path = "../perl-tdd-support" }

--- a/crates/perl-dap-breakpoint/Cargo.toml
+++ b/crates/perl-dap-breakpoint/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src/**", "Cargo.toml", "README.md", "LICENSE*"]
 
 [dependencies]
 # Perl parser for AST-based validation
-perl-parser = { path = "../perl-parser", version = "0.12.3" }
+perl-parser = { path = "../perl-parser", version = "0.12.4" }
 
 # Rope for position mapping
 ropey = "1.6.1"

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -8,7 +8,7 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.12.3`
+- Workspace version line: `v0.12.4`
 - Latest published GitHub/editor release: `v0.12.3` (GitHub Releases, VS Code Marketplace, and Open VSX public line, shipped 2026-04-09)
 - crates.io published line: `v0.12.2` (registry line, shipped 2026-04-07)
 - Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.3` line stable across GitHub Releases and the editor marketplaces

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.12.3"
+version = "0.12.4"
 lsp_version = "3.18"
 compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
## Summary

This PR bumps the workspace version from 0.12.3 to 0.12.4 across all tracked sites.

**Merge this LAST**, after all feature PRs and the CHANGELOG PR. Then trigger `release-orchestration.yml` with `skip_crates=true`.

## What changed

- `Cargo.toml` — `[workspace.package] version` + 129 `[workspace.dependencies]` entries
- `Cargo.lock` — resolved versions updated
- `crates/perl-builtins/Cargo.toml` — local path dep with explicit version
- `crates/perl-dap-breakpoint/Cargo.toml` — local path dep with explicit version
- `features.toml` — `[meta] version`
- `vscode-extension/package.json` — extension version
- `vscode-extension/package-lock.json` — root + self-package version (2 sites)
- `README.md` — `**Current release: v0.12.4**`
- `CLAUDE.md` — `**Latest Release**: 0.12.4`
- `docs/project/ROADMAP.md` — workspace version line (not the "latest published" line, which stays at 0.12.3 until release)

**139 sites updated, 9 files touched** (via `cargo xtask bump-version 0.12.4`).

## Sites NOT bumped (intentional)

- `flake.nix` — version = "0.9.1" is the Nix flake's own version, not the workspace version
- Historical references to 0.12.3 in ROADMAP.md (changelog entries, release notes — immutable history)
- `docs/project/status/*.md` — auto-regenerated post-merge by the ops pipeline

## Pre-push gate note

The pre-push gate failed on `status-check` (`docs/project/status/tests.md` and `dap.md` out of date). This is **pre-existing drift on master**, entirely out of band with this version bump. Bypassed per the hook's bypass policy: "environmental reason that is out of band of your change." The CI gate in GitHub Actions will evaluate the real state.