### PR TITLE
style(fmt): fix formatting drift from #4190

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -539,8 +539,9 @@ fn read_usize_from_tokens(path: &Path, idx: usize) -> Result<usize> {
 fn cmd_preflight(_repo_root: &Path) -> Result<i32> {
     #[cfg(target_os = "linux")]
     {
-        let pids_used =
-            command_with_output(Path::new("/"), "ps", &["-e", "--no-headers"], &[])?.lines().count();
+        let pids_used = command_with_output(Path::new("/"), "ps", &["-e", "--no-headers"], &[])?
+            .lines()
+            .count();
         let pid_max = read_usize_from_path(Path::new("/proc/sys/kernel/pid_max"))?;
         let files_used = read_usize_from_tokens(Path::new("/proc/sys/fs/file-nr"), 1)?;
         let files_max = read_usize_from_path(Path::new("/proc/sys/fs/file-max"))?;
@@ -554,8 +555,7 @@ fn cmd_preflight(_repo_root: &Path) -> Result<i32> {
         let mut omp_num_threads = env::var("OMP_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
         let mut openblas_num_threads =
             env::var("OPENBLAS_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
-        let mut mkl_num_threads =
-            env::var("MKL_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
+        let mut mkl_num_threads = env::var("MKL_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
         let mut numexpr_num_threads =
             env::var("NUMEXPR_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
 
@@ -668,7 +668,9 @@ fn cmd_e2e_gate(repo_root: &Path, cargo_args: &[String]) -> Result<i32> {
     {
         // flock is not available on Windows; run without external lock
         let _ = lock_path;
-        println!("warning: flock not available on this OS; running E2E tests without external lock");
+        println!(
+            "warning: flock not available on this OS; running E2E tests without external lock"
+        );
         command_status_strict(
             repo_root,
             "cargo",

--- a/xtask/src/tasks/update_status.rs
+++ b/xtask/src/tasks/update_status.rs
@@ -1072,10 +1072,7 @@ fn count_perl_files(dir: &Path) -> usize {
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.file_type().is_file()
-                && e.path()
-                    .extension()
-                    .map(|ext| ext == "pl" || ext == "pm")
-                    .unwrap_or(false)
+                && e.path().extension().map(|ext| ext == "pl" || ext == "pm").unwrap_or(false)
         })
         .count()
 }
@@ -1110,10 +1107,9 @@ fn generate_workspace_status(root: &Path, original: &str) -> Result<String> {
         .to_string();
 
     // Multi-root row (8 tests from PR #4137)
-    let multiroot_row =
-        "| **Multi-root integration tests** | 8 / 8 tests | 8 / 8 | \
+    let multiroot_row = "| **Multi-root integration tests** | 8 / 8 tests | 8 / 8 | \
          `just ci-workspace-multiroot` (nightly gate) |"
-            .to_string();
+        .to_string();
 
     // Fixture table — xlarge count is "~10 000 (generated)" since it is not committed.
     let fixtures_table = format!(
@@ -1703,10 +1699,7 @@ mod tests {
             );
         }
         // Key content checks
-        assert!(
-            result.contains("perl-workspace-index-slo"),
-            "SLO table must reference slo crate"
-        );
+        assert!(result.contains("perl-workspace-index-slo"), "SLO table must reference slo crate");
         assert!(result.contains("small"), "fixtures table must list small workspace");
         assert!(result.contains("xlarge"), "fixtures table must list xlarge workspace");
         Ok(())


### PR DESCRIPTION
## Summary

- Applies the exact formatting changes that `cargo fmt --all` computed for master (2 files, 11 insertions, 16 deletions)
- Unblocks master CI which is currently red due to the auto-format step trying to push directly to master and being rejected by branch protection

## Files with formatting drift

- `crates/perl-ci-hygiene/src/main.rs` — 3 hunks: method chain reformatting in `cmd_preflight` and `cmd_e2e_gate`
- `xtask/src/tasks/update_status.rs` — 2 hunks: closure chain and string literal reformatting

## Verification

The diff is identical to commit `66ad641` that CI's auto-format step committed and then failed to push. Zero logic changes — pure whitespace/line-break adjustments by rustfmt.

## Hotfix policy

This is a pure-formatting PR. Marked merge-ready per docs-tier policy. No two-pass review required for whitespace-only changes.