### PR TITLE
feat(config): merge global and scoped workspace/configuration (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -330,10 +330,13 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
-        server
-            .pending_workspace_configuration_requests
-            .lock()
-            .insert(11, vec![uri1.clone(), uri2.clone()]);
+        server.pending_workspace_configuration_requests.lock().insert(
+            11,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri1.clone(), uri2.clone()],
+                includes_global_item: false,
+            },
+        );
 
         server.handle_client_response(Some(serde_json::json!({
             "id": 11,
@@ -353,5 +356,41 @@ include_paths = ["other_lib"]
         assert!(
             folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
         );
+    }
+
+    #[test]
+    fn handle_client_response_merges_global_then_folder_workspace_config() {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let folder = temp.path().join("folder");
+        std::fs::create_dir_all(&folder).expect("failed to create folder");
+
+        let uri = url::Url::from_directory_path(&folder).expect("failed to create uri").to_string();
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri.clone())
+                .with_path(folder.clone()),
+        );
+
+        server.pending_workspace_configuration_requests.lock().insert(
+            12,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri.clone()],
+                includes_global_item: true,
+            },
+        );
+
+        server.handle_client_response(Some(serde_json::json!({
+            "id": 12,
+            "result": [
+                { "workspace": { "useSystemInc": true } },
+                { "workspace": { "includePaths": ["folder_lib"] } }
+            ]
+        })));
+
+        let folders = server.workspace_folders.lock();
+        let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
+
+        assert!(folder_state.effective_workspace_config.use_system_inc);
+        assert_eq!(folder_state.effective_workspace_config.include_paths, vec!["folder_lib"]);
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -164,6 +164,15 @@ pub(crate) struct DocumentScanView {
     pub ast: Option<Arc<perl_parser::ast::Node>>,
 }
 
+/// Metadata for an in-flight `workspace/configuration` request.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    /// Workspace folders queried via `scopeUri`.
+    pub folder_uris: Vec<String>,
+    /// Whether the request also included a global (unscoped) item.
+    pub includes_global_item: bool,
+}
+
 // Note: FQN_RE regex moved to language/navigation.rs
 
 // Note: Error codes and cancelled_response imported from crate::lsp::protocol
@@ -220,7 +229,8 @@ pub struct LspServer {
     /// Atomic counter for generating unique request IDs
     next_request_id: Arc<AtomicI64>,
     /// Pending workspace/configuration reverse requests keyed by request ID.
-    pending_workspace_configuration_requests: Arc<Mutex<HashMap<i64, Vec<String>>>>,
+    pending_workspace_configuration_requests:
+        Arc<Mutex<HashMap<i64, PendingWorkspaceConfigurationRequest>>>,
     /// Active progress tokens for work done progress tracking
     progress_tokens: Arc<Mutex<HashSet<String>>>,
     /// Maps progress tokens to their originating request IDs for cancellation routing

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -173,8 +173,11 @@ impl LspServer {
             return;
         }
 
-        let items: Vec<Value> =
-            folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })).collect();
+        // Request order is significant: response items map positionally.
+        // We request a global `perl` section first, followed by one item per
+        // workspace folder (scoped by URI).
+        let mut items: Vec<Value> = vec![json!({ "section": "perl" })];
+        items.extend(folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })));
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         if let Err(error) = self.outbound.send_request(
@@ -186,7 +189,10 @@ impl LspServer {
             return;
         }
 
-        self.pending_workspace_configuration_requests.lock().insert(request_id, folder_uris);
+        self.pending_workspace_configuration_requests.lock().insert(
+            request_id,
+            PendingWorkspaceConfigurationRequest { folder_uris, includes_global_item: true },
+        );
     }
 
     /// Apply a `workspace/configuration` response for a previously sent request.
@@ -199,7 +205,7 @@ impl LspServer {
         };
 
         let maybe_folder_uris = self.pending_workspace_configuration_requests.lock().remove(&id);
-        let Some(folder_uris) = maybe_folder_uris else {
+        let Some(request_meta) = maybe_folder_uris else {
             return;
         };
 
@@ -211,10 +217,25 @@ impl LspServer {
             return;
         }
 
-        let results = params.get("result").and_then(Value::as_array).cloned().unwrap_or_default();
+        let Some(results) = params.get("result").and_then(Value::as_array) else {
+            tracing::warn!(
+                request_id = id,
+                "workspace/configuration response missing array result; keeping TOML/default config"
+            );
+            return;
+        };
+
+        let mut next_index = 0usize;
+        let global_settings = if request_meta.includes_global_item {
+            let settings = results.first().cloned();
+            next_index = 1;
+            settings
+        } else {
+            None
+        };
 
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        for (idx, folder_uri) in request_meta.folder_uris.iter().enumerate() {
             let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
                 continue;
             };
@@ -224,7 +245,11 @@ impl LspServer {
                 project_config.apply_to_workspace_config(&mut effective_config);
             }
 
-            if let Some(perl_settings) = results.get(idx) {
+            if let Some(global_settings) = &global_settings {
+                effective_config.update_from_value(global_settings);
+            }
+
+            if let Some(perl_settings) = results.get(next_index + idx) {
                 effective_config.update_from_value(perl_settings);
             }
 


### PR DESCRIPTION
### Motivation

- The server must correctly request and apply client `workspace/configuration` values per the LSP spec, including a global `perl` section plus per-folder `scopeUri` items.  
- Existing code relied on positional mapping and a simple `Vec<String>` pending map which made mixing global+scoped items fragile.  
- We need deterministic merge precedence so TOML/defaults remain base and client settings (global then folder) override predictably.

### Description

- Introduced `PendingWorkspaceConfigurationRequest` to track in-flight `workspace/configuration` requests with `folder_uris: Vec<String>` and `includes_global_item: bool`, and switched the pending map to store that metadata (`pending_workspace_configuration_requests`).  
- Updated `request_workspace_configuration_for_folders` to build the request items with a global `perl` section first and then one `{ scopeUri, section: "perl" }` entry per workspace folder, and persist the new request metadata.  
- Updated `handle_client_response` to validate that `result` is an array, to extract the optional global result and then folder-scoped results positionally, and to merge settings in precedence order: defaults/TOML → global client settings → folder-scoped client settings.  
- Preserved fallback semantics on request error or malformed response so existing `.perl-lsp.toml` behavior remains for unsupported/errant clients.  
- Added a unit test to verify global+folder merge behavior and adjusted existing tests to use the new pending-request shape.  
- Key files changed: `crates/perl-lsp/src/runtime/mod.rs`, `crates/perl-lsp/src/runtime/workspace.rs`, and `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`.

### Testing

- Ran `cargo fmt --all` (succeeded).  
- Ran unit tests: `cargo test -p perl-lsp-rs --lib handle_client_response_merges_global_then_folder_workspace_config` (passed).  
- Ran unit tests: `cargo test -p perl-lsp-rs --lib handle_client_response_applies_per_folder_workspace_config` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a7bee848333b45095d76f04c3fd)