### PR TITLE
feat(workspace): complete workspace/configuration merge flow (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -330,14 +330,19 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
-        server
-            .pending_workspace_configuration_requests
-            .lock()
-            .insert(11, vec![uri1.clone(), uri2.clone()]);
+        server.pending_workspace_configuration_requests.lock().insert(
+            11,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri1.clone(), uri2.clone()],
+                includes_global_item: true,
+                created_at: std::time::Instant::now(),
+            },
+        );
 
         server.handle_client_response(Some(serde_json::json!({
             "id": 11,
             "result": [
+                { "workspace": { "useSystemInc": true } },
                 { "workspace": { "includePaths": ["api_lib"] } },
                 { "workspace": { "includePaths": ["ui_lib"] } }
             ]
@@ -352,6 +357,41 @@ include_paths = ["other_lib"]
         );
         assert!(
             folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
+        );
+        assert!(folder1_state.effective_workspace_config.use_system_inc);
+        assert!(folder2_state.effective_workspace_config.use_system_inc);
+    }
+
+    #[test]
+    fn handle_client_response_ignores_non_array_result() {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let folder = temp.path().join("folder");
+        std::fs::create_dir_all(&folder).expect("failed to create folder");
+        let uri = url::Url::from_directory_path(&folder).expect("failed to create uri").to_string();
+
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri.clone())
+                .with_path(folder.clone()),
+        );
+        server.pending_workspace_configuration_requests.lock().insert(
+            99,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri.clone()],
+                includes_global_item: true,
+                created_at: std::time::Instant::now(),
+            },
+        );
+
+        server.handle_client_response(Some(serde_json::json!({
+            "id": 99,
+            "result": { "workspace": { "includePaths": ["oops"] } }
+        })));
+
+        let folders = server.workspace_folders.lock();
+        let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
+        assert!(
+            !folder_state.effective_workspace_config.include_paths.contains(&"oops".to_string())
         );
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -105,6 +105,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering},
 };
+use std::time::Instant;
 use url::Url;
 
 #[cfg(feature = "workspace")]
@@ -138,6 +139,17 @@ fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str
                 || doc_uri.strip_prefix(folder_uri).is_some_and(|suffix| suffix.starts_with('/'))
         }
     }
+}
+
+/// Tracks metadata for a pending `workspace/configuration` reverse request.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    /// Workspace folder URIs requested in this call.
+    pub(crate) folder_uris: Vec<String>,
+    /// Whether the response includes an unscoped global `perl` settings item first.
+    pub(crate) includes_global_item: bool,
+    /// Request creation time used for stale-request cleanup.
+    pub(crate) created_at: Instant,
 }
 
 /// Lightweight view of a document for scan-heavy operations
@@ -220,7 +232,8 @@ pub struct LspServer {
     /// Atomic counter for generating unique request IDs
     next_request_id: Arc<AtomicI64>,
     /// Pending workspace/configuration reverse requests keyed by request ID.
-    pending_workspace_configuration_requests: Arc<Mutex<HashMap<i64, Vec<String>>>>,
+    pending_workspace_configuration_requests:
+        Arc<Mutex<HashMap<i64, PendingWorkspaceConfigurationRequest>>>,
     /// Active progress tokens for work done progress tracking
     progress_tokens: Arc<Mutex<HashSet<String>>>,
     /// Maps progress tokens to their originating request IDs for cancellation routing

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -24,10 +24,13 @@ use perl_workspace_ignore::is_skipped_dir_name;
 #[cfg(feature = "workspace")]
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 #[cfg(feature = "workspace")]
 use std::time::Instant;
 #[cfg(feature = "workspace")]
 use url::Url;
+
+const WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 // Note: WalkDir logic has been extracted to super::file_discovery.
 // These helper functions are retained for potential future use by
 // other workspace operations (e.g., file watcher filtering).
@@ -167,14 +170,27 @@ impl LspServer {
             return;
         }
 
+        let now = std::time::Instant::now();
+        self.pending_workspace_configuration_requests.lock().retain(|request_id, pending| {
+            let still_fresh = now.saturating_duration_since(pending.created_at)
+                <= WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT;
+            if !still_fresh {
+                tracing::warn!(
+                    request_id = *request_id,
+                    "Dropping stale workspace/configuration request"
+                );
+            }
+            still_fresh
+        });
+
         let folder_uris: Vec<String> =
             self.workspace_folders.lock().iter().map(|folder| folder.uri.clone()).collect();
         if folder_uris.is_empty() {
             return;
         }
 
-        let items: Vec<Value> =
-            folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })).collect();
+        let mut items: Vec<Value> = vec![json!({ "section": "perl" })];
+        items.extend(folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })));
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         if let Err(error) = self.outbound.send_request(
@@ -186,7 +202,14 @@ impl LspServer {
             return;
         }
 
-        self.pending_workspace_configuration_requests.lock().insert(request_id, folder_uris);
+        self.pending_workspace_configuration_requests.lock().insert(
+            request_id,
+            PendingWorkspaceConfigurationRequest {
+                folder_uris,
+                includes_global_item: true,
+                created_at: now,
+            },
+        );
     }
 
     /// Apply a `workspace/configuration` response for a previously sent request.
@@ -198,10 +221,19 @@ impl LspServer {
             return;
         };
 
-        let maybe_folder_uris = self.pending_workspace_configuration_requests.lock().remove(&id);
-        let Some(folder_uris) = maybe_folder_uris else {
+        let maybe_pending = self.pending_workspace_configuration_requests.lock().remove(&id);
+        let Some(pending) = maybe_pending else {
             return;
         };
+        let response_age = std::time::Instant::now().saturating_duration_since(pending.created_at);
+        if response_age > WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT {
+            tracing::warn!(
+                request_id = id,
+                age_ms = response_age.as_millis(),
+                "Ignoring stale workspace/configuration response"
+            );
+            return;
+        }
 
         if params.get("error").is_some() {
             tracing::debug!(
@@ -211,10 +243,18 @@ impl LspServer {
             return;
         }
 
-        let results = params.get("result").and_then(Value::as_array).cloned().unwrap_or_default();
+        let Some(results) = params.get("result").and_then(Value::as_array) else {
+            tracing::warn!(
+                request_id = id,
+                "workspace/configuration response was not an array; keeping TOML/default config"
+            );
+            return;
+        };
+        let global_settings = if pending.includes_global_item { results.first() } else { None };
+        let folder_results_start = usize::from(pending.includes_global_item);
 
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        for (idx, folder_uri) in pending.folder_uris.iter().enumerate() {
             let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
                 continue;
             };
@@ -224,8 +264,17 @@ impl LspServer {
                 project_config.apply_to_workspace_config(&mut effective_config);
             }
 
-            if let Some(perl_settings) = results.get(idx) {
+            if let Some(global_settings) = global_settings {
+                effective_config.update_from_value(global_settings);
+            }
+            if let Some(perl_settings) = results.get(folder_results_start + idx) {
                 effective_config.update_from_value(perl_settings);
+            } else {
+                tracing::warn!(
+                    request_id = id,
+                    folder_uri = %folder_uri,
+                    "workspace/configuration response missing folder item; using TOML/default config for folder"
+                );
             }
 
             folder.effective_workspace_config = effective_config;


### PR DESCRIPTION
### Motivation

- The existing implementation only partially supported server→client `workspace/configuration` responses and used a simple request→folder list mapping that could mis-handle global vs per-folder items and stale responses. 
- The change centralizes per-folder effective config handling and ensures client-provided settings merge cleanly with `.perl-lsp.toml` and built-in defaults. 

### Description

- Introduce a `PendingWorkspaceConfigurationRequest` metadata type and swap the pending-request map to track `folder_uris`, `includes_global_item`, and `created_at` for each request to enable deterministic interpretation and timeout-aware cleanup. (modified `crates/perl-lsp/src/runtime/mod.rs`).
- Send a single `workspace/configuration` request that includes a global `section: "perl"` item followed by folder-scoped `scopeUri` items, and record that the response will contain a global item first. (changed request building in `crates/perl-lsp/src/runtime/workspace.rs`).
- Add a `WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT` and prune/ignore stale pending requests and stale responses, validate the response payload shape (`result` must be an array), and log/skip malformed or missing items. (changes in `crates/perl-lsp/src/runtime/workspace.rs`).
- Merge order implemented for each folder: defaults/TOML → global client settings → folder-scoped client settings, and store the merged `WorkspaceConfig` on the folder state (`WorkspaceFolderState.effective_workspace_config`). (changes in `crates/perl-lsp/src/runtime/workspace.rs` and `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).
- Add unit coverage for per-folder application and malformed-response handling, including a test that verifies global+folder layering and a test that ensures non-array results are ignored. (tests updated/added in `crates/perl-lsp/src/runtime/lifecycle/workspace.rs`).

### Testing

- Ran formatter: `cargo fmt --all`, which completed successfully. 
- Ran targeted unit tests for the updated response logic: `cargo test -p perl-lsp-rs --lib handle_client_response_`, and the new/updated tests passed. 
- Ran the workspace resolution test suite: `cargo test -p perl-lsp-rs --test workspace_resolution_tests`, and all tests in that suite passed (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a7bee848333b45095d76f04c3fd)