### PR TITLE
feat(lsp): merge workspace/configuration global+folder layers (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -330,14 +330,17 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
-        server
-            .pending_workspace_configuration_requests
-            .lock()
-            .insert(11, vec![uri1.clone(), uri2.clone()]);
+        server.pending_workspace_configuration_requests.lock().insert(
+            11,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri1.clone(), uri2.clone()],
+            },
+        );
 
         server.handle_client_response(Some(serde_json::json!({
             "id": 11,
             "result": [
+                {},
                 { "workspace": { "includePaths": ["api_lib"] } },
                 { "workspace": { "includePaths": ["ui_lib"] } }
             ]
@@ -353,5 +356,39 @@ include_paths = ["other_lib"]
         assert!(
             folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
         );
+    }
+
+    #[test]
+    fn handle_client_response_merges_global_then_folder_workspace_config() {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let folder = temp.path().join("folder");
+        std::fs::create_dir_all(&folder).expect("failed to create folder");
+
+        let uri = url::Url::from_directory_path(&folder)
+            .expect("failed to create folder uri")
+            .to_string();
+
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri.clone())
+                .with_path(folder.clone()),
+        );
+
+        server.pending_workspace_configuration_requests.lock().insert(
+            77,
+            crate::runtime::PendingWorkspaceConfigurationRequest { folder_uris: vec![uri.clone()] },
+        );
+
+        server.handle_client_response(Some(serde_json::json!({
+            "id": 77,
+            "result": [
+                { "workspace": { "resolutionTimeout": 900 } },
+                { "workspace": { "resolutionTimeout": 321 } }
+            ]
+        })));
+
+        let folders = server.workspace_folders.lock();
+        let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
+        assert_eq!(folder_state.effective_workspace_config.resolution_timeout_ms, 321);
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -164,6 +164,13 @@ pub(crate) struct DocumentScanView {
     pub ast: Option<Arc<perl_parser::ast::Node>>,
 }
 
+/// Pending context for a server-initiated `workspace/configuration` request.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    /// Workspace folder URIs requested with `scopeUri`.
+    pub folder_uris: Vec<String>,
+}
+
 // Note: FQN_RE regex moved to language/navigation.rs
 
 // Note: Error codes and cancelled_response imported from crate::lsp::protocol
@@ -220,7 +227,8 @@ pub struct LspServer {
     /// Atomic counter for generating unique request IDs
     next_request_id: Arc<AtomicI64>,
     /// Pending workspace/configuration reverse requests keyed by request ID.
-    pending_workspace_configuration_requests: Arc<Mutex<HashMap<i64, Vec<String>>>>,
+    pending_workspace_configuration_requests:
+        Arc<Mutex<HashMap<i64, PendingWorkspaceConfigurationRequest>>>,
     /// Active progress tokens for work done progress tracking
     progress_tokens: Arc<Mutex<HashSet<String>>>,
     /// Maps progress tokens to their originating request IDs for cancellation routing

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -173,8 +173,11 @@ impl LspServer {
             return;
         }
 
-        let items: Vec<Value> =
-            folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })).collect();
+        let mut items = Vec::with_capacity(folder_uris.len() + 1);
+        // Global `perl` section (no scopeUri) acts as client-global settings layer.
+        items.push(json!({ "section": "perl" }));
+        // Folder-scoped `perl` section entries provide per-workspace overrides.
+        items.extend(folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })));
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         if let Err(error) = self.outbound.send_request(
@@ -186,7 +189,9 @@ impl LspServer {
             return;
         }
 
-        self.pending_workspace_configuration_requests.lock().insert(request_id, folder_uris);
+        self.pending_workspace_configuration_requests
+            .lock()
+            .insert(request_id, PendingWorkspaceConfigurationRequest { folder_uris });
     }
 
     /// Apply a `workspace/configuration` response for a previously sent request.
@@ -198,8 +203,8 @@ impl LspServer {
             return;
         };
 
-        let maybe_folder_uris = self.pending_workspace_configuration_requests.lock().remove(&id);
-        let Some(folder_uris) = maybe_folder_uris else {
+        let maybe_request = self.pending_workspace_configuration_requests.lock().remove(&id);
+        let Some(request_context) = maybe_request else {
             return;
         };
 
@@ -212,9 +217,10 @@ impl LspServer {
         }
 
         let results = params.get("result").and_then(Value::as_array).cloned().unwrap_or_default();
+        let global_perl_settings = results.first().cloned();
 
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        for (idx, folder_uri) in request_context.folder_uris.iter().enumerate() {
             let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
                 continue;
             };
@@ -224,7 +230,12 @@ impl LspServer {
                 project_config.apply_to_workspace_config(&mut effective_config);
             }
 
-            if let Some(perl_settings) = results.get(idx) {
+            if let Some(perl_settings) = &global_perl_settings {
+                effective_config.update_from_value(perl_settings);
+            }
+
+            // +1 because results[0] is the unscoped global `perl` section.
+            if let Some(perl_settings) = results.get(idx + 1) {
                 effective_config.update_from_value(perl_settings);
             }
 


### PR DESCRIPTION
### Motivation

- Implement correct server→client `workspace/configuration` behavior so client settings can provide both a global `perl` section and per-folder overrides in one round-trip. 
- Ensure per-folder effective configuration merges layers with the intended precedence (defaults -> `.perl-lsp.toml` -> client global -> client folder) to support multi-root correctness.

### Description

- Introduce a typed `PendingWorkspaceConfigurationRequest` context and replace the raw `HashMap<i64, Vec<String>>` with `HashMap<i64, PendingWorkspaceConfigurationRequest>` to make pending reverse-request state explicit. 
- Change `request_workspace_configuration_for_folders()` to send one unscoped `perl` item first (client-global) and then one `scopeUri` `perl` item per workspace folder, allowing a single response to carry global+per-folder settings. 
- Update response handling in `handle_client_response()` to interpret `results[0]` as the global `perl` settings and `results[idx+1]` as the folder-scoped settings, merging them into each folder's `effective_workspace_config` after applying `.perl-lsp.toml` values. 
- Add and adjust lifecycle unit tests to validate per-folder application and that folder-scoped config overrides client-global config where appropriate. 

### Testing

- Ran `cargo fmt --all` (succeeded). 
- Executed targeted unit tests: `cargo test -p perl-lsp-rs --lib handle_client_response_`, which passed (tests validating per-folder application and global-then-folder precedence succeeded). 
- A full workspace test run surfaces unrelated pre-existing test issues in other test modules (compile-time usage of borrowed `Permissions` in an unrelated test), but those failures are not introduced by this change and do not affect the targeted workspace configuration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a7bee848333b45095d76f04c3fd)