### PR TITLE
feat(workspace): rewrite package declarations during module file rename (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -884,6 +884,20 @@ impl LspServer {
                     let new_module = path_to_module_name(new_uri);
 
                     if !old_module.is_empty() && !new_module.is_empty() {
+                        if !planned_workspace_texts.contains_key(old_uri) {
+                            if let Some(text) = self.read_workspace_text(old_uri) {
+                                planned_workspace_texts
+                                    .insert(old_uri.to_string(), (text.clone(), text));
+                            }
+                        }
+                        if let Some((_, current_text)) = planned_workspace_texts.get_mut(old_uri) {
+                            let planned =
+                                plan_module_rename_edits(current_text, &old_module, &new_module);
+                            if !planned.is_empty() {
+                                *current_text = apply_module_rename_edits(current_text, &planned);
+                            }
+                        }
+
                         // Find all files that reference the old module
                         // Note: Query operation - use coordinator.index() for consistency
                         #[cfg(feature = "workspace")]

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -1196,12 +1196,11 @@ fn test_will_rename_files_pure_parent_only() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
-/// Regression test: renaming a module whose own file is open must NOT appear in
-/// `changes` (the package file itself does not need a `use` line rewrite).
-/// Previously the warning-detection code could false-positive on `package OldModule;`
-/// inside the old file because it was not excluded from the unhandled-documents scan.
+/// Regression test: renaming a module whose own file is open should include
+/// package declaration edits for the renamed module file itself.
 #[test]
-fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::error::Error>> {
+fn test_will_rename_files_updates_package_declaration_in_renamed_file()
+-> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();
 
     let init_params = json!({
@@ -1235,11 +1234,18 @@ fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::er
     let changes =
         edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
 
-    // Solo.pm itself should NOT be in the changes map — it contains `package Solo;`
-    // but that line is not a `use Solo;` import that needs rewriting.
+    let solo_changes = changes
+        .get("file:///test/workspace/lib/Solo.pm")
+        .and_then(Value::as_array)
+        .ok_or("expected package declaration edits for Solo.pm")?;
+    let new_texts: Vec<String> = solo_changes
+        .iter()
+        .filter_map(|e| e.get("newText").and_then(Value::as_str).map(ToString::to_string))
+        .collect();
+
     assert!(
-        !changes.contains_key("file:///test/workspace/lib/Solo.pm"),
-        "the renamed file itself should not appear as a change target: {changes:?}"
+        new_texts.iter().any(|text| text.contains("package Renamed;")),
+        "expected package declaration rewrite in Solo.pm, got: {new_texts:?}"
     );
     Ok(())
 }

--- a/crates/perl-module-rename/src/lib.rs
+++ b/crates/perl-module-rename/src/lib.rs
@@ -41,6 +41,7 @@ pub struct ModuleLineEdit {
 /// - Static method calls: `Module::Name->method()` → `NewName->method()`
 /// - `@ISA` array assignments: `@ISA = ('Module::Name')` → `@ISA = ('NewName')`
 /// - `our @ISA = qw(Module::Name)` → `our @ISA = qw(NewName)`
+/// - Package declarations: `package Module::Name;` → `package NewName;`
 ///
 /// Legacy package separators (`Foo'Bar`) are also handled.
 #[must_use]
@@ -102,6 +103,18 @@ pub fn plan_module_rename_edits(
                     let candidate =
                         replace_module_name_prefix(current_line, old_variant, new_variant);
                     if candidate != current_line {
+                        rewritten = Some(candidate);
+                    }
+                }
+            }
+
+            // Check package declarations: `package Foo::Bar;`
+            {
+                let current_line = rewritten.as_deref().unwrap_or(line);
+                if line_references_package_declaration(current_line, old_variant) {
+                    let (candidate, changed) =
+                        replace_module_token(current_line, old_variant, new_variant);
+                    if changed {
                         rewritten = Some(candidate);
                     }
                 }
@@ -199,6 +212,19 @@ pub fn line_references_qualified_call(line: &str, module_name: &str) -> bool {
     false
 }
 
+/// Return `true` when `line` contains a package declaration referencing
+/// `module_name` as a standalone token.
+#[must_use]
+pub fn line_references_package_declaration(line: &str, module_name: &str) -> bool {
+    if line.is_empty() || module_name.is_empty() {
+        return false;
+    }
+    if !line.trim_start().starts_with("package ") {
+        return false;
+    }
+    perl_module_token::contains_module_token(line, module_name)
+}
+
 /// Replace `old_module::` namespace prefixes in `line` with `new_module::`.
 ///
 /// This handles qualified function calls like `Foo::Bar::baz()` where
@@ -280,7 +306,8 @@ pub fn apply_module_rename_edits(source: &str, edits: &[ModuleLineEdit]) -> Stri
 mod tests {
     use super::{
         ModuleLineEdit, apply_module_rename_edits, line_references_isa_assignment,
-        line_references_qualified_call, plan_module_rename_edits, replace_module_name_prefix,
+        line_references_package_declaration, line_references_qualified_call,
+        plan_module_rename_edits, replace_module_name_prefix,
     };
     use perl_module_token::{module_variant_pairs, replace_module_token};
 
@@ -385,6 +412,20 @@ mod tests {
             "Expected rewrite of use parent 'MyBase' to 'RenamedBase', got: {:?}",
             rewritten
         );
+    }
+
+    #[test]
+    fn plans_package_declaration_rename() {
+        let source = "package Foo::Bar;\n1;\n";
+        let edits = plan_module_rename_edits(source, "Foo::Bar", "Renamed::Pkg");
+        let rewritten = apply_module_rename_edits(source, &edits);
+        assert_eq!(rewritten, "package Renamed::Pkg;\n1;\n");
+    }
+
+    #[test]
+    fn package_declaration_detection_rejects_non_package_lines() {
+        assert!(!line_references_package_declaration("use Foo::Bar;", "Foo::Bar"));
+        assert!(line_references_package_declaration("package Foo::Bar;", "Foo::Bar"));
     }
 
     // ── @ISA assignment detection ─────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Module/file rename flows did not update the renamed file’s own `package` declaration, leaving package names out of sync after moves and weakening the workspace refactoring UX. 
- The `workspace/willRenameFiles` planner only applied edits to dependents and therefore missed in-file package rewrites that should be part of the same workspace edit transaction.

### Description

- Extend the module-rename planner (`plan_module_rename_edits`) to detect and rewrite `package Foo::Bar;` lines to the new module name. 
- Add `line_references_package_declaration` and apply package-declaration rewrites alongside existing import, `@ISA`, qualified-call, and prefix rewrites in `perl-module-rename`. 
- Update `workspace/willRenameFiles` planning to include the renamed module file itself by reading its workspace text, running `plan_module_rename_edits` on it, and including resulting edits in the aggregated `WorkspaceEdit`. 
- Add regression coverage: unit tests in `perl-module-rename` for package-declaration detection/rewrite and an integration test in `lsp_workspace_file_ops_tests` asserting the renamed module file receives a `package` rewrite edit.

### Testing

- Ran formatting with `cargo fmt --all` and it completed successfully. 
- Ran the module-rename unit tests via `cargo test -p perl-module-rename` including the package-declaration cases and they passed. 
- Ran the workspace file-ops integration test via `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests test_will_rename_files_updates_package_declaration_in_renamed_file -- --exact` and the targeted test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a9806c0833399eae52d043131b4)