### PR TITLE
feat(workspace): widen safe-delete dependent detection (#3513)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1087,6 +1087,11 @@ impl LspServer {
                             &deleting_uris,
                             &open_documents,
                         ));
+                        dependents.extend(collect_symbol_reference_delete_dependents(
+                            idx,
+                            uri,
+                            &deleting_uris,
+                        ));
                         let dependents: Vec<String> = dependents.into_iter().collect();
 
                         if !dependents.is_empty() {
@@ -1845,6 +1850,39 @@ fn collect_open_document_delete_dependents(
             !plan_module_rename_edits(text, module_name, "__PerlLspDeleteProbe__").is_empty()
         }) {
             dependents.insert(normalized_doc_uri);
+        }
+    }
+
+    dependents
+}
+
+#[cfg(feature = "workspace")]
+fn collect_symbol_reference_delete_dependents(
+    index: &perl_parser::workspace_index::WorkspaceIndex,
+    uri: &str,
+    deleting_uris: &std::collections::HashSet<String>,
+) -> std::collections::BTreeSet<String> {
+    let normalized_uri = perl_parser::workspace_index::uri_key(uri);
+    let mut dependents = std::collections::BTreeSet::new();
+
+    for symbol in index.file_symbols(uri) {
+        let mut names = std::collections::BTreeSet::new();
+        if !symbol.name.is_empty() {
+            names.insert(symbol.name.clone());
+        }
+        if let Some(qualified_name) = symbol.qualified_name {
+            if !qualified_name.is_empty() {
+                names.insert(qualified_name);
+            }
+        }
+
+        for symbol_name in names {
+            for reference in index.find_references(&symbol_name) {
+                let reference_uri = perl_parser::workspace_index::uri_key(&reference.uri);
+                if reference_uri != normalized_uri && !deleting_uris.contains(&reference_uri) {
+                    dependents.insert(reference_uri);
+                }
+            }
         }
     }
 

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -929,6 +929,63 @@ fn test_will_delete_files_aggregates_warning_for_multiple_unsafe_deletes()
 }
 
 #[test]
+fn test_will_delete_files_warns_for_cross_file_symbol_usage_without_module_import()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (server, output) = create_test_server_with_output();
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+    output.clear();
+
+    let utility_module = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/lib/Utility.pm",
+            "languageId": "perl",
+            "version": 1,
+            "text": "package Utility;\nsub helper { return 42; }\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(utility_module));
+
+    let consumer_script = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/bin/use_helper.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "use strict;\nuse warnings;\nprint helper();\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(consumer_script));
+    output.clear();
+
+    let params = json!({
+        "files": [
+            { "uri": "file:///test/workspace/lib/Utility.pm" }
+        ]
+    });
+
+    let edit = make_request(&server, "workspace/willDeleteFiles", Some(params))?
+        .ok_or("expected workspace edit response")?;
+    assert!(edit.is_object());
+
+    let message = wait_for_method(&output, "window/showMessage")
+        .ok_or("expected safe-delete warning notification")?;
+    let message_text =
+        message["params"]["message"].as_str().ok_or("expected warning message text")?;
+    assert!(
+        message_text.contains("dependent workspace file"),
+        "expected safe-delete warning to mention dependent files, got: {message_text}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();
 


### PR DESCRIPTION
### Motivation

- The existing `workspace/willDeleteFiles` preflight only checked module-import patterns and open-document probes, which can miss cross-file callers that reference symbols without explicit imports.
- Silent false-negatives on safe-delete can leave the workspace in a stale or broken state after a delete, so detection must include indexed symbol references. 
- Improve preflight correctness by using the workspace index `find_references` data in addition to existing heuristics.

### Description

- Added `collect_symbol_reference_delete_dependents(...)` which iterates `index.file_symbols(uri)`, gathers symbol names (unqualified and qualified), and queries `index.find_references(...)` to collect dependent URIs while normalizing and skipping co-deleted files. 
- Integrated this function into the `handle_will_delete_files` scanning path so symbol-reference-derived dependents are merged into the same warning pipeline used today. 
- Added an integration test `test_will_delete_files_warns_for_cross_file_symbol_usage_without_module_import` under `crates/perl-lsp/tests` that opens a module and a consumer script which calls a helper function without an explicit module import and asserts the safe-delete warning is emitted. 

### Testing

- Ran formatter with `cargo fmt --all`, which completed successfully. 
- Executed a targeted test run `cargo test -p perllsp test_will_delete_files_warns_for_cross_file_symbol_usage_without_module_import -- --nocapture`; the command completed but did not run any tests under that filter in this environment. 
- Started a wider build/test run with `CARGO_TARGET_DIR=target-test cargo test -p perl-lsp-rs test_will_delete_files_warns_for_cross_file_symbol_usage_without_module_import -- --nocapture`, which began a full workspace compilation in this environment and was still completing at handoff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3a9806c0833399eae52d043131b4)