### PR TITLE
feat(diagnostics): generation-aware staleness guard for publish_diagnostics (#4279)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -539,8 +539,9 @@ fn read_usize_from_tokens(path: &Path, idx: usize) -> Result<usize> {
 fn cmd_preflight(_repo_root: &Path) -> Result<i32> {
     #[cfg(target_os = "linux")]
     {
-        let pids_used =
-            command_with_output(Path::new("/"), "ps", &["-e", "--no-headers"], &[])?.lines().count();
+        let pids_used = command_with_output(Path::new("/"), "ps", &["-e", "--no-headers"], &[])?
+            .lines()
+            .count();
         let pid_max = read_usize_from_path(Path::new("/proc/sys/kernel/pid_max"))?;
         let files_used = read_usize_from_tokens(Path::new("/proc/sys/fs/file-nr"), 1)?;
         let files_max = read_usize_from_path(Path::new("/proc/sys/fs/file-max"))?;
@@ -554,8 +555,7 @@ fn cmd_preflight(_repo_root: &Path) -> Result<i32> {
         let mut omp_num_threads = env::var("OMP_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
         let mut openblas_num_threads =
             env::var("OPENBLAS_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
-        let mut mkl_num_threads =
-            env::var("MKL_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
+        let mut mkl_num_threads = env::var("MKL_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
         let mut numexpr_num_threads =
             env::var("NUMEXPR_NUM_THREADS").unwrap_or_else(|_| "1".to_string());
 
@@ -668,7 +668,9 @@ fn cmd_e2e_gate(repo_root: &Path, cargo_args: &[String]) -> Result<i32> {
     {
         // flock is not available on Windows; run without external lock
         let _ = lock_path;
-        println!("warning: flock not available on this OS; running E2E tests without external lock");
+        println!(
+            "warning: flock not available on this OS; running E2E tests without external lock"
+        );
         command_status_strict(
             repo_root,
             "cargo",

--- a/crates/perl-lsp/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp/src/runtime/diagnostics.rs
@@ -88,13 +88,24 @@ impl LspServer {
                     doc.degradation_tier,
                     doc.line_starts.clone(),
                     doc.rope.clone(),
+                    Arc::clone(&doc.generation),
+                    doc.generation.load(Ordering::SeqCst),
                 )
             })
             // lock is released here
         };
 
-        let Some((ast_opt, text, parse_errors, version, degradation_tier, line_starts, rope)) =
-            snapshot
+        let Some((
+            ast_opt,
+            text,
+            parse_errors,
+            version,
+            degradation_tier,
+            line_starts,
+            rope,
+            generation,
+            gen_at_snapshot,
+        )) = snapshot
         else {
             return;
         };
@@ -219,6 +230,19 @@ impl LspServer {
                 })
                 .collect()
         };
+
+        // Generation-aware staleness guard: if a newer didChange arrived while
+        // diagnostics were being computed, discard this result — the debouncer
+        // will fire again for the latest version.
+        if generation.load(Ordering::SeqCst) != gen_at_snapshot {
+            tracing::debug!(
+                uri = %normalized_uri,
+                gen_at_snapshot,
+                current_gen = generation.load(Ordering::SeqCst),
+                "Skipping stale diagnostic publish (generation advanced during computation)"
+            );
+            return;
+        }
 
         tracing::debug!(
             count = lsp_diagnostics.len(),
@@ -1067,6 +1091,91 @@ fn builtin_violation_to_diagnostic(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+
+    /// Shared-buffer writer for capturing outbound LSP notifications in tests.
+    struct SharedVecWriter {
+        inner: StdArc<parking_lot::Mutex<Vec<u8>>>,
+    }
+    impl Write for SharedVecWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.inner.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    fn make_server_with_capture() -> (LspServer, StdArc<parking_lot::Mutex<Vec<u8>>>) {
+        let buf = StdArc::new(parking_lot::Mutex::new(Vec::<u8>::new()));
+        let writer = SharedVecWriter { inner: StdArc::clone(&buf) };
+        let server =
+            LspServer::with_io(Box::new(std::io::Cursor::new(Vec::<u8>::new())), Box::new(writer));
+        (server, buf)
+    }
+
+    /// Positive case: when no concurrent change arrives during diagnostic computation,
+    /// `publish_diagnostics` MUST send a `textDocument/publishDiagnostics` notification.
+    #[test]
+    fn stable_generation_publishes_diagnostics() {
+        let (server, buf) = make_server_with_capture();
+        let uri = "file:///stable_gen_test.pl";
+        server
+            .test_handle_did_open(Some(json!({
+                "textDocument": {"uri": uri, "languageId": "perl", "version": 1, "text": "my $x = 1;\n"}
+            })))
+            .unwrap();
+
+        // No concurrent change: generation is stable throughout, publish must fire.
+        server.publish_diagnostics(uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50)); // flush outbound writer
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes).unwrap_or_default();
+        assert!(
+            text.contains("publishDiagnostics"),
+            "stable generation must produce a publishDiagnostics notification; got: {text:?}"
+        );
+    }
+
+    /// Guard wire test: advancing the generation counter before `publish_diagnostics`
+    /// is called must not suppress publication — the snapshot captures the CURRENT
+    /// generation, so stable-during-computation is still the common case.
+    /// This confirms the guard does not false-positive.
+    #[test]
+    fn pre_advanced_generation_does_not_suppress_publish() {
+        let (server, buf) = make_server_with_capture();
+        let uri = "file:///pre_advanced_gen_test.pl";
+        server
+            .test_handle_did_open(Some(json!({
+                "textDocument": {"uri": uri, "languageId": "perl", "version": 1, "text": "my $y = 2;\n"}
+            })))
+            .unwrap();
+
+        // Advance generation BEFORE calling publish_diagnostics (simulates a prior
+        // didChange that already completed). The snapshot will read this new value,
+        // computation runs, and the guard check sees the same value → publishes.
+        {
+            let docs = server.documents.lock();
+            if let Some(doc) = docs.get(uri) {
+                doc.generation.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        server.publish_diagnostics(uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes).unwrap_or_default();
+        assert!(
+            text.contains("publishDiagnostics"),
+            "pre-advanced generation must not suppress publish (guard must not false-positive); got: {text:?}"
+        );
+    }
 
     #[test]
     fn builtin_violation_maps_gentle_to_error() {

--- a/xtask/src/tasks/update_status.rs
+++ b/xtask/src/tasks/update_status.rs
@@ -1072,10 +1072,7 @@ fn count_perl_files(dir: &Path) -> usize {
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.file_type().is_file()
-                && e.path()
-                    .extension()
-                    .map(|ext| ext == "pl" || ext == "pm")
-                    .unwrap_or(false)
+                && e.path().extension().map(|ext| ext == "pl" || ext == "pm").unwrap_or(false)
         })
         .count()
 }
@@ -1110,10 +1107,9 @@ fn generate_workspace_status(root: &Path, original: &str) -> Result<String> {
         .to_string();
 
     // Multi-root row (8 tests from PR #4137)
-    let multiroot_row =
-        "| **Multi-root integration tests** | 8 / 8 tests | 8 / 8 | \
+    let multiroot_row = "| **Multi-root integration tests** | 8 / 8 tests | 8 / 8 | \
          `just ci-workspace-multiroot` (nightly gate) |"
-            .to_string();
+        .to_string();
 
     // Fixture table — xlarge count is "~10 000 (generated)" since it is not committed.
     let fixtures_table = format!(
@@ -1703,10 +1699,7 @@ mod tests {
             );
         }
         // Key content checks
-        assert!(
-            result.contains("perl-workspace-index-slo"),
-            "SLO table must reference slo crate"
-        );
+        assert!(result.contains("perl-workspace-index-slo"), "SLO table must reference slo crate");
         assert!(result.contains("small"), "fixtures table must list small workspace");
         assert!(result.contains("xlarge"), "fixtures table must list xlarge workspace");
         Ok(())


### PR DESCRIPTION
## Summary

- Adds a generation-aware staleness guard to `publish_diagnostics` in `crates/perl-lsp/src/runtime/diagnostics.rs`
- Captures the document generation counter at snapshot time (`gen_at_snapshot`)
- After all slow diagnostic computation (scope analysis, perlcritic, dead-code), re-reads the generation counter
- If the counter advanced during computation (a concurrent `didChange` arrived), the publish is skipped — the debouncer will fire again for the fresh version

## Problem

Diagnostics are computed after the 250ms debounce fires, but if the user types again during computation, the result is stale by the time it's published. The generation counter existed to prevent stale AST overwrites in `text_sync.rs` (lines 789-809) but was not checked at publish time.

## Fix location

`crates/perl-lsp/src/runtime/diagnostics.rs:publish_diagnostics` — generation check added after the diagnostic computation block and before the `textDocument/publishDiagnostics` notify call.

## Tests

Two new unit tests in `runtime::diagnostics::tests`:
- `stable_generation_publishes_diagnostics` — verifies that when no concurrent change occurs, the notification IS sent (no false-positives)
- `pre_advanced_generation_does_not_suppress_publish` — verifies that a generation advance before (not during) computation does not suppress publication (guard snapshots the current value, computation runs, guard checks same value → publishes)

## Test plan

- [ ] `cargo test -p perl-lsp-rs --lib "diagnostics::tests"` — all 3 tests pass
- [ ] No changes to debounce timer or reparse logic
- [ ] No incremental parsing changes (separate issue)
- [ ] `cargo clippy -p perl-lsp-rs --lib` — clean
- [ ] `cargo fmt -p perl-lsp-rs -- --check` — clean

## Notes

The `formatting_test` failures in the CI suite are pre-existing and unrelated to this change. The pre-push hook fails with OS error 206 (Windows filename-too-long on worktrees) for `perl-ci-hygiene/src/main.rs` formatting drift — this is the known Windows worktree issue documented in the project memory, not caused by this PR.