### PR TITLE
feat(workspace): rewrite renamed module package declaration (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -884,6 +884,17 @@ impl LspServer {
                     let new_module = path_to_module_name(new_uri);
 
                     if !old_module.is_empty() && !new_module.is_empty() {
+                        if !planned_workspace_texts.contains_key(old_uri) {
+                            if let Some(text) = self.read_workspace_text(old_uri) {
+                                planned_workspace_texts
+                                    .insert(old_uri.to_string(), (text.clone(), text));
+                            }
+                        }
+                        if let Some((_, current_text)) = planned_workspace_texts.get_mut(old_uri) {
+                            *current_text =
+                                rewrite_package_declaration(current_text, &old_module, &new_module);
+                        }
+
                         // Find all files that reference the old module
                         // Note: Query operation - use coordinator.index() for consistency
                         #[cfg(feature = "workspace")]
@@ -1779,6 +1790,45 @@ fn build_module_rename_workspace_edits(original: &str, updated: &str) -> Vec<Val
 }
 
 #[cfg(feature = "workspace")]
+fn rewrite_package_declaration(source: &str, old_module: &str, new_module: &str) -> String {
+    source
+        .split('\n')
+        .map(|line| rewrite_package_declaration_line(line, old_module, new_module))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(feature = "workspace")]
+fn rewrite_package_declaration_line(line: &str, old_module: &str, new_module: &str) -> String {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('#') || old_module.is_empty() || new_module.is_empty() {
+        return line.to_string();
+    }
+
+    let prefix = "package ";
+    let Some(rest) = trimmed.strip_prefix(prefix) else {
+        return line.to_string();
+    };
+
+    let leading_len = line.len() - trimmed.len();
+    let semicolon_pos = rest.find(';');
+    let declaration = semicolon_pos.map_or(rest, |idx| &rest[..idx]).trim();
+    if declaration != old_module {
+        return line.to_string();
+    }
+
+    let mut rebuilt = String::with_capacity(line.len() + new_module.len());
+    rebuilt.push_str(&line[..leading_len]);
+    rebuilt.push_str(prefix);
+    rebuilt.push_str(new_module);
+    if let Some(idx) = semicolon_pos {
+        rebuilt.push(';');
+        rebuilt.push_str(&rest[idx + 1..]);
+    }
+    rebuilt
+}
+
+#[cfg(feature = "workspace")]
 fn collect_delete_target_module_names(
     index: &perl_parser::workspace_index::WorkspaceIndex,
     uri: &str,
@@ -1918,6 +1968,8 @@ pub(super) fn path_to_module_name(uri: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::module_name_appears_in_text;
+    #[cfg(feature = "workspace")]
+    use super::{rewrite_package_declaration, rewrite_package_declaration_line};
 
     #[test]
     fn test_module_name_appears_exact_match() {
@@ -1957,5 +2009,30 @@ mod tests {
     #[test]
     fn test_module_name_empty_returns_false() {
         assert!(!module_name_appears_in_text("anything", ""));
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn test_rewrite_package_declaration_line_rewrites_exact_package() {
+        assert_eq!(
+            rewrite_package_declaration_line("package Old::Name;", "Old::Name", "New::Name"),
+            "package New::Name;"
+        );
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn test_rewrite_package_declaration_line_preserves_comments() {
+        assert_eq!(
+            rewrite_package_declaration_line("package Old::Name; # keep", "Old::Name", "New::Name",),
+            "package New::Name; # keep"
+        );
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn test_rewrite_package_declaration_preserves_trailing_newline() {
+        let rewritten = rewrite_package_declaration("package Old;\n1;\n", "Old", "New");
+        assert_eq!(rewritten, "package New;\n1;\n");
     }
 }

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -1196,12 +1196,11 @@ fn test_will_rename_files_pure_parent_only() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
-/// Regression test: renaming a module whose own file is open must NOT appear in
-/// `changes` (the package file itself does not need a `use` line rewrite).
-/// Previously the warning-detection code could false-positive on `package OldModule;`
-/// inside the old file because it was not excluded from the unhandled-documents scan.
+/// Regression test: renaming a module file updates the package declaration in the
+/// renamed file itself so move/rename is self-consistent.
 #[test]
-fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::error::Error>> {
+fn test_will_rename_files_rewrites_package_declaration_in_renamed_file()
+-> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();
 
     let init_params = json!({
@@ -1235,11 +1234,17 @@ fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::er
     let changes =
         edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
 
-    // Solo.pm itself should NOT be in the changes map — it contains `package Solo;`
-    // but that line is not a `use Solo;` import that needs rewriting.
+    let self_changes = changes
+        .get("file:///test/workspace/lib/Solo.pm")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for renamed file package declaration")?;
+    let new_texts: Vec<String> = self_changes
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str).map(ToString::to_string))
+        .collect();
     assert!(
-        !changes.contains_key("file:///test/workspace/lib/Solo.pm"),
-        "the renamed file itself should not appear as a change target: {changes:?}"
+        new_texts.contains(&"package Renamed;".to_string()),
+        "expected package declaration rewrite in renamed file, got: {new_texts:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Ensure module file moves are self-consistent by updating the file's own `package ...;` declaration during a module file rename so the workspace edit is complete and deterministic.
- Close a practical gap in the `willRenameFiles` flow where dependent imports were updated but the renamed module's `package` line was left stale.

### Description

- Update `workspace/willRenameFiles` to plan and include edits for the renamed module file itself by loading its workspace text and applying a package-declaration rewrite pass. 
- Add `rewrite_package_declaration` and `rewrite_package_declaration_line` helpers that preserve indentation, inline comments, and trailing newlines while only rewriting exact `package` declarations. 
- Keep existing dependent-file import rewrites (via `plan_module_rename_edits`/`apply_module_rename_edits`) and merge renamed-file edits into the same `WorkspaceEdit`. 
- Replace the previous regression test with an end-to-end test asserting the renamed file receives a `package` rewrite and add unit tests for the new helpers.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran the workspace file-ops test suite with `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests -- --nocapture` and all relevant tests passed (`23 passed; 0 failed`). 
- Existing `willRenameFiles` and `willDeleteFiles` related tests were exercised and continue to pass in the updated test run. 
- Changes were committed and included in the PR branch as `feat(workspace): rewrite package declaration during module file rename`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db470ffca88333831bbda7a3b1f728)