### PR TITLE
feat(workspace): strengthen safe-delete dependency preflight (#4068)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -1087,17 +1087,31 @@ impl LspServer {
                             &deleting_uris,
                             &open_documents,
                         ));
+                        let (symbol_dependents, symbol_reference_examples) =
+                            collect_symbol_reference_delete_dependents(idx, uri, &deleting_uris);
+                        dependents.extend(symbol_dependents);
                         let dependents: Vec<String> = dependents.into_iter().collect();
 
                         if !dependents.is_empty() {
-                            let examples: Vec<String> =
+                            let mut examples: Vec<String> =
                                 dependents.iter().take(3).map(|uri| short_uri(uri)).collect();
+                            examples.extend(symbol_reference_examples.into_iter().take(2));
+                            let module_delete =
+                                !collect_delete_target_module_names(idx, uri).is_empty();
                             tracing::warn!(
                                 uri,
                                 dependent_file_count = dependents.len(),
                                 "Safe delete detected dependent workspace files"
                             );
-                            unsafe_deletes.push((short_uri(uri), dependents.len(), examples));
+                            unsafe_deletes.push((
+                                if module_delete {
+                                    format!("{} (module)", short_uri(uri))
+                                } else {
+                                    format!("{} (file)", short_uri(uri))
+                                },
+                                dependents.len(),
+                                examples,
+                            ));
                         }
                     }
 
@@ -1849,6 +1863,49 @@ fn collect_open_document_delete_dependents(
     }
 
     dependents
+}
+
+#[cfg(feature = "workspace")]
+fn collect_symbol_reference_delete_dependents(
+    index: &perl_parser::workspace_index::WorkspaceIndex,
+    uri: &str,
+    deleting_uris: &std::collections::HashSet<String>,
+) -> (std::collections::BTreeSet<String>, Vec<String>) {
+    let normalized_uri = perl_parser::workspace_index::uri_key(uri);
+    let mut dependents = std::collections::BTreeSet::new();
+    let mut examples = std::collections::BTreeSet::new();
+
+    for symbol in index.file_symbols(uri) {
+        let mut candidates = std::collections::BTreeSet::new();
+        if let Some(qualified) = symbol.qualified_name {
+            if !qualified.is_empty() {
+                candidates.insert(qualified);
+            }
+        }
+        if !symbol.name.is_empty() {
+            candidates.insert(symbol.name);
+        }
+
+        for candidate in candidates {
+            for location in index.find_references(&candidate) {
+                let ref_uri = perl_parser::workspace_index::uri_key(location.uri.as_str());
+                if ref_uri == normalized_uri || deleting_uris.contains(&ref_uri) {
+                    continue;
+                }
+
+                dependents.insert(ref_uri.clone());
+                if examples.len() < 5 {
+                    examples.insert(format!(
+                        "{}:{}",
+                        short_uri(ref_uri.as_str()),
+                        location.range.start.line + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    (dependents, examples.into_iter().collect())
 }
 
 fn short_uri(uri: &str) -> String {

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -929,6 +929,66 @@ fn test_will_delete_files_aggregates_warning_for_multiple_unsafe_deletes()
 }
 
 #[test]
+fn test_will_delete_files_warning_includes_reference_examples()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (server, output) = create_test_server_with_output();
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+    output.clear();
+
+    let module_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/lib/Tools.pm",
+            "languageId": "perl",
+            "version": 1,
+            "text": "package Tools;\nsub run { return 1; }\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(module_open));
+
+    let dependent_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/bin/main.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "use Tools;\nprint Tools::run();\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(dependent_open));
+    output.clear();
+
+    let params = json!({
+        "files": [
+            { "uri": "file:///test/workspace/lib/Tools.pm" }
+        ]
+    });
+
+    let _edit = make_request(&server, "workspace/willDeleteFiles", Some(params))?
+        .ok_or("expected workspace edit response")?;
+
+    let message = wait_for_method(&output, "window/showMessage")
+        .ok_or("expected safe-delete warning with reference examples")?;
+    let message_text =
+        message["params"]["message"].as_str().ok_or("expected warning message text")?;
+    assert!(
+        message_text.contains("main.pl"),
+        "expected dependent file mention in warning, got: {message_text}"
+    );
+    assert!(
+        message_text.contains(':'),
+        "expected line-oriented reference example in warning, got: {message_text}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_apply_edit_single_line() -> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();
 


### PR DESCRIPTION
### Motivation

- `workspace/willDeleteFiles` previously returned an empty edit and only gave coarse warnings, leaving safe-delete preflight incomplete for cross-file symbol references. 
- The change closes an important gap in workspace refactoring correctness by using the workspace index to surface real cross-file callers before a delete proceeds.

### Description

- Added `collect_symbol_reference_delete_dependents` which scans `file_symbols` + `find_references` from the workspace index and returns dependent URIs plus concise `file:line` examples. 
- Merged symbol-reference dependents into the `workspace/willDeleteFiles` preflight so warnings combine module-dependent detection, open-document probes, and indexed symbol references. 
- Enhanced warning text to tag entries as `(module)` or `(file)` and to include short example locations (e.g. `main.pl:12`) to aid triage, and added the test `test_will_delete_files_warning_includes_reference_examples`. 
- Changed files: `crates/perl-lsp/src/runtime/workspace.rs` and `crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs`.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully. 
- An initial attempt with `cargo test -p perl-lsp --test lsp_workspace_file_ops_tests -- will_delete_files` failed due to an incorrect package id (tooling mismatch). 
- Final verification used `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests -- will_delete_files` and the targeted tests passed: 3 tests ran and all succeeded (`test_will_delete_files_aggregates_warning_for_multiple_unsafe_deletes`, `test_will_delete_files_warning_includes_reference_examples`, `test_will_delete_files_skips_warnings_for_co_deleted_dependents`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db470ffca88333831bbda7a3b1f728)