### PR TITLE
feat(workspace): improve module move + safe-delete preflight (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -884,6 +884,21 @@ impl LspServer {
                     let new_module = path_to_module_name(new_uri);
 
                     if !old_module.is_empty() && !new_module.is_empty() {
+                        if !planned_workspace_texts.contains_key(old_uri) {
+                            if let Some(text) = self.read_workspace_text(old_uri) {
+                                planned_workspace_texts
+                                    .insert(old_uri.to_string(), (text.clone(), text));
+                            }
+                        }
+
+                        if let Some((_, current_text)) = planned_workspace_texts.get_mut(old_uri) {
+                            let planned =
+                                plan_module_rename_edits(current_text, &old_module, &new_module);
+                            if !planned.is_empty() {
+                                *current_text = apply_module_rename_edits(current_text, &planned);
+                            }
+                        }
+
                         // Find all files that reference the old module
                         // Note: Query operation - use coordinator.index() for consistency
                         #[cfg(feature = "workspace")]
@@ -1817,6 +1832,34 @@ fn collect_cross_file_delete_dependents(
         for dependent_uri in index.find_dependents(&module_name) {
             if dependent_uri != normalized_uri && !deleting_uris.contains(&dependent_uri) {
                 dependents.insert(dependent_uri);
+            }
+        }
+    }
+
+    for symbol in index.file_symbols(uri) {
+        let is_cross_file_symbol = matches!(
+            symbol.kind,
+            SymbolKind::Subroutine | SymbolKind::Method | SymbolKind::Constant
+        );
+        if !is_cross_file_symbol {
+            continue;
+        }
+
+        let mut symbol_names = std::collections::BTreeSet::new();
+        if !symbol.name.is_empty() {
+            symbol_names.insert(symbol.name.clone());
+        }
+        if let Some(qualified_name) = symbol.qualified_name.as_ref() {
+            if !qualified_name.is_empty() {
+                symbol_names.insert(qualified_name.clone());
+            }
+        }
+
+        for symbol_name in symbol_names {
+            for location in index.find_references(&symbol_name) {
+                if location.uri != normalized_uri && !deleting_uris.contains(&location.uri) {
+                    dependents.insert(location.uri);
+                }
             }
         }
     }

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -1196,12 +1196,11 @@ fn test_will_rename_files_pure_parent_only() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
-/// Regression test: renaming a module whose own file is open must NOT appear in
-/// `changes` (the package file itself does not need a `use` line rewrite).
-/// Previously the warning-detection code could false-positive on `package OldModule;`
-/// inside the old file because it was not excluded from the unhandled-documents scan.
+/// Regression test: renaming a module rewrites the renamed file's package declaration
+/// in the same workspace edit so moved modules keep package and path aligned.
 #[test]
-fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::error::Error>> {
+fn test_will_rename_files_rewrites_renamed_package_file() -> Result<(), Box<dyn std::error::Error>>
+{
     let server = create_test_server();
 
     let init_params = json!({
@@ -1235,11 +1234,75 @@ fn test_will_rename_files_old_uri_not_in_changes() -> Result<(), Box<dyn std::er
     let changes =
         edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
 
-    // Solo.pm itself should NOT be in the changes map — it contains `package Solo;`
-    // but that line is not a `use Solo;` import that needs rewriting.
+    let solo_changes = changes
+        .get("file:///test/workspace/lib/Solo.pm")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for renamed package file")?;
+
+    let new_texts: Vec<String> = solo_changes
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str).map(ToString::to_string))
+        .collect();
+
     assert!(
-        !changes.contains_key("file:///test/workspace/lib/Solo.pm"),
-        "the renamed file itself should not appear as a change target: {changes:?}"
+        new_texts.contains(&"package Renamed;".to_string()),
+        "expected package declaration rewrite in renamed file edits: {new_texts:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_will_delete_files_warns_for_cross_file_subroutine_usage()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (server, output) = create_test_server_with_output();
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+    output.clear();
+
+    let module_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/lib/My/Math.pm",
+            "languageId": "perl",
+            "version": 1,
+            "text": "package My::Math;\nsub add { return $_[0] + $_[1]; }\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(module_open));
+
+    let dependent_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/main.pl",
+            "languageId": "perl",
+            "version": 1,
+            "text": "use My::Math;\nprint My::Math::add(2, 3);\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(dependent_open));
+    output.clear();
+
+    let params = json!({
+        "files": [
+            { "uri": "file:///test/workspace/lib/My/Math.pm" }
+        ]
+    });
+
+    let edit = make_request(&server, "workspace/willDeleteFiles", Some(params))?
+        .ok_or("expected workspace edit response")?;
+    assert!(edit.is_object());
+
+    let message = wait_for_method(&output, "window/showMessage")
+        .ok_or("expected safe-delete warning notification")?;
+    let message_text =
+        message["params"]["message"].as_str().ok_or("expected warning message text")?;
+    assert!(
+        message_text.contains("My/Math.pm") || message_text.contains("Math.pm"),
+        "expected warning message mentioning deleted file, got: {message_text}"
     );
     Ok(())
 }

--- a/crates/perl-module-rename/src/lib.rs
+++ b/crates/perl-module-rename/src/lib.rs
@@ -29,6 +29,7 @@ pub struct ModuleLineEdit {
 /// Supported import forms:
 /// - `use Module::Name;`
 /// - `require Module::Name;`
+/// - `package Module::Name;`
 /// - `use parent 'Module::Name';`
 /// - `use parent "Module::Name";`
 /// - `use parent qw(Module::Name Other);`
@@ -81,6 +82,18 @@ pub fn plan_module_rename_edits(
                 }
             }
 
+            // Check package declarations in moved module files.
+            {
+                let current_line = rewritten.as_deref().unwrap_or(line);
+                if line_references_package_declaration(current_line, old_variant) {
+                    let (candidate, changed) =
+                        replace_module_token(current_line, old_variant, new_variant);
+                    if changed {
+                        rewritten = Some(candidate);
+                    }
+                }
+            }
+
             // Check @ISA assignments: module name appears standalone in the line
             // (e.g. `@ISA = ('Foo::Bar')`, `our @ISA = qw(Foo::Bar)`)
             {
@@ -119,6 +132,21 @@ pub fn plan_module_rename_edits(
     }
 
     edits
+}
+
+/// Return `true` when `line` contains a `package` declaration that references
+/// `module_name` as a standalone token.
+#[must_use]
+pub fn line_references_package_declaration(line: &str, module_name: &str) -> bool {
+    if line.is_empty() || module_name.is_empty() {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with("package ") {
+        return false;
+    }
+
+    perl_module_token::contains_module_token(trimmed, module_name)
 }
 
 /// Return `true` when `line` contains an `@ISA` assignment that references
@@ -280,7 +308,8 @@ pub fn apply_module_rename_edits(source: &str, edits: &[ModuleLineEdit]) -> Stri
 mod tests {
     use super::{
         ModuleLineEdit, apply_module_rename_edits, line_references_isa_assignment,
-        line_references_qualified_call, plan_module_rename_edits, replace_module_name_prefix,
+        line_references_package_declaration, line_references_qualified_call,
+        plan_module_rename_edits, replace_module_name_prefix,
     };
     use perl_module_token::{module_variant_pairs, replace_module_token};
 
@@ -385,6 +414,19 @@ mod tests {
             "Expected rewrite of use parent 'MyBase' to 'RenamedBase', got: {:?}",
             rewritten
         );
+    }
+
+    #[test]
+    fn package_declaration_detected() {
+        assert!(line_references_package_declaration("package Foo::Bar;", "Foo::Bar"));
+    }
+
+    #[test]
+    fn package_declaration_rewritten() {
+        let source = "package Foo::Bar;\n1;\n";
+        let edits = plan_module_rename_edits(source, "Foo::Bar", "Renamed::Pkg");
+        let rewritten = apply_module_rename_edits(source, &edits);
+        assert_eq!(rewritten, "package Renamed::Pkg;\n1;\n");
     }
 
     // ── @ISA assignment detection ─────────────────────────────────────────────

--- a/crates/perl-module-rename/tests/module_rename_bdd.rs
+++ b/crates/perl-module-rename/tests/module_rename_bdd.rs
@@ -22,14 +22,13 @@ fn given_parent_and_base_statements_when_module_is_renamed_then_all_references_a
 }
 
 #[test]
-fn given_non_import_lines_when_module_is_renamed_then_source_is_unchanged() {
+fn given_package_and_string_literal_when_module_is_renamed_then_only_package_is_rewritten() {
     let source = "package My::Module;\nmy $s = 'My::Module';\n";
 
     let edits = plan_module_rename_edits(source, "My::Module", "My::Renamed");
     let rewritten = apply_module_rename_edits(source, &edits);
 
-    assert!(edits.is_empty());
-    assert_eq!(rewritten, source);
+    assert_eq!(rewritten, "package My::Renamed;\nmy $s = 'My::Module';\n");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Finish and harden the partially-landed workspace refactoring substrate so module moves and safe-delete preflight behave as true workspace operations rather than best-effort heuristics. 
- Ensure moved module files have their `package` declarations updated and that file-delete preflight catches cross-file callable/constant usages so deletes produce honest warnings.

### Description

- Include the renamed file itself in `workspace/willRenameFiles` planning and apply `plan_module_rename_edits` to the file’s own text so package declarations and in-file module references are rewritten alongside dependents (changes in `crates/perl-lsp/src/runtime/workspace.rs`).
- Extend the module-rename planner to detect and rewrite `package ...;` declarations by adding `line_references_package_declaration` and corresponding rewrite logic (changes in `crates/perl-module-rename/src/lib.rs`).
- Harden safe-delete preflight by scanning cross-file references to callable/constant symbols (subroutines, methods, constants) defined in the file being deleted and include those dependents in the warning aggregation (changes in `crates/perl-lsp/src/runtime/workspace.rs`).
- Add/update regression/unit tests to cover the renamed-file package rewrite and cross-file safe-delete warnings (changes in `crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs` and `crates/perl-module-rename/tests/module_rename_bdd.rs`).

### Testing

- Ran formatter: `cargo fmt --all` — succeeded.
- Ran module-rename unit and integration suite: `cargo test -p perl-module-rename` — all tests passed.
- Ran targeted LSP workspace file-ops tests: `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests test_will_rename_files_rewrites_renamed_package_file` and `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests test_will_delete_files_warns_for_cross_file_subroutine_usage` — both targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db470ffca88333831bbda7a3b1f728)