### PR TITLE
feat(workspace): rewrite moved module package declaration in willRenameFiles (#3522)

### DIFF
--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -884,6 +884,22 @@ impl LspServer {
                     let new_module = path_to_module_name(new_uri);
 
                     if !old_module.is_empty() && !new_module.is_empty() {
+                        if !planned_workspace_texts.contains_key(old_uri) {
+                            if let Some(text) = self.read_workspace_text(old_uri) {
+                                planned_workspace_texts
+                                    .insert(old_uri.to_string(), (text.clone(), text));
+                            }
+                        }
+                        if let Some((_, current_text)) = planned_workspace_texts.get_mut(old_uri) {
+                            let planned =
+                                plan_module_rename_edits(current_text, &old_module, &new_module);
+                            if !planned.is_empty() {
+                                *current_text = apply_module_rename_edits(current_text, &planned);
+                            }
+                            *current_text =
+                                rewrite_package_declaration(current_text, &old_module, &new_module);
+                        }
+
                         // Find all files that reference the old module
                         // Note: Query operation - use coordinator.index() for consistency
                         #[cfg(feature = "workspace")]
@@ -1899,6 +1915,51 @@ pub(super) fn module_name_appears_in_text(text: &str, module_name: &str) -> bool
         }
     }
     false
+}
+
+#[cfg(feature = "workspace")]
+fn rewrite_package_declaration(text: &str, old_module: &str, new_module: &str) -> String {
+    text.split_inclusive('\n')
+        .map(|line| {
+            if line.trim_start().starts_with("package ") {
+                replace_module_token(line, old_module, new_module)
+            } else {
+                line.to_string()
+            }
+        })
+        .collect()
+}
+
+#[cfg(feature = "workspace")]
+fn replace_module_token(line: &str, old_module: &str, new_module: &str) -> String {
+    if old_module.is_empty() {
+        return line.to_string();
+    }
+
+    let bytes = line.as_bytes();
+    let name_len = old_module.len();
+    let mut start = 0usize;
+    while start + name_len <= bytes.len() {
+        if let Some(pos) = line[start..].find(old_module) {
+            let abs = start + pos;
+            let before_ok = abs == 0 || {
+                let c = bytes[abs - 1] as char;
+                !c.is_alphanumeric() && c != '_' && c != ':'
+            };
+            let after_index = abs + name_len;
+            let after_ok = after_index >= bytes.len() || {
+                let c = bytes[after_index] as char;
+                !c.is_alphanumeric() && c != '_' && c != ':'
+            };
+            if before_ok && after_ok {
+                return format!("{}{}{}", &line[..abs], new_module, &line[after_index..]);
+            }
+            start = abs + 1;
+        } else {
+            break;
+        }
+    }
+    line.to_string()
 }
 
 /// Convert a file path to a Perl module name

--- a/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
+++ b/crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs
@@ -618,6 +618,58 @@ fn test_will_rename_files_returns_module_import_edits() -> Result<(), Box<dyn st
 }
 
 #[test]
+fn test_will_rename_files_updates_renamed_module_package_declaration()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_test_server();
+
+    let init_params = json!({
+        "processId": 1234,
+        "rootUri": "file:///test/workspace",
+        "capabilities": {}
+    });
+    let _ = make_request(&server, "initialize", Some(init_params));
+    send_initialized(&server);
+
+    let module_open = json!({
+        "textDocument": {
+            "uri": "file:///test/workspace/lib/Internal/Util.pm",
+            "languageId": "perl",
+            "version": 1,
+            "text": "package Internal::Util;\n1;\n"
+        }
+    });
+    let _ = make_request(&server, "textDocument/didOpen", Some(module_open));
+
+    let params = json!({
+        "files": [
+            {
+                "oldUri": "file:///test/workspace/lib/Internal/Util.pm",
+                "newUri": "file:///test/workspace/lib/Public/Utils.pm"
+            }
+        ]
+    });
+
+    let edit = make_request(&server, "workspace/willRenameFiles", Some(params))?
+        .ok_or("expected workspace edit response")?;
+    let changes =
+        edit.get("changes").and_then(Value::as_object).ok_or("expected changes object")?;
+    let module_changes = changes
+        .get("file:///test/workspace/lib/Internal/Util.pm")
+        .and_then(Value::as_array)
+        .ok_or("expected edits for renamed module file")?;
+    let new_texts: Vec<String> = module_changes
+        .iter()
+        .filter_map(|entry| entry.get("newText").and_then(Value::as_str).map(ToString::to_string))
+        .collect();
+    assert!(
+        new_texts.contains(&"package Public::Utils;".to_string()),
+        "expected package declaration rewrite in renamed file edits: {new_texts:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_will_rename_files_coalesces_multi_rename_edits_per_line()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = create_test_server();


### PR DESCRIPTION
### Motivation

- `workspace/willRenameFiles` previously planned edits only for dependents and did not ensure the renamed module file updates its own `package` declaration, leaving moved modules inconsistent.
- Make module/file moves more correct and user-friendly by planning the in-file package rewrite alongside dependent edits so clients receive a coherent `WorkspaceEdit` for the move.

### Description

- When processing `workspace/willRenameFiles` precompute and include the renamed module file text in the planned edits map so the moved file itself is considered for rewrite. (`crates/perl-lsp/src/runtime/workspace.rs`)
- Apply existing `plan_module_rename_edits` to the renamed file and then run a new package-declaration rewrite pass to update `package Old::Name;` → `package New::Name;` where appropriate. The rewrite is token-boundary-safe to avoid partial matches. (`rewrite_package_declaration`, `replace_module_token` in `crates/perl-lsp/src/runtime/workspace.rs`)
- Keep the existing dependent-file planning logic; the new pass augments that by producing edits for the source module file itself when moving modules across paths.
- Add an integration test that verifies `workspace/willRenameFiles` returns edits for the renamed module file containing the rewritten `package` declaration. (`crates/perl-lsp/tests/lsp_workspace_file_ops_tests.rs`)

### Testing

- Ran formatter: `cargo fmt --all` (success).
- Ran targeted tests: `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests test_will_rename_files_updates_renamed_module_package_declaration` (passed) and `cargo test -p perl-lsp-rs --test lsp_workspace_file_ops_tests test_will_rename_files_returns_module_import_edits` (passed).
- The change is covered by the added integration test validating that the renamed module file receives a `package` declaration rewrite in the produced `WorkspaceEdit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db470ffca88333831bbda7a3b1f728)