### PR TITLE
feat(workspace): complete global+folder workspace/configuration layering (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -4,7 +4,6 @@
 
 use super::super::*;
 use perl_dap_platform::{PerlInterpreterResult, find_perl_interpreter};
-use perl_lsp_config::WorkspaceConfig;
 use std::sync::Once;
 
 /// Fires at most once per LSP session, when Perl is not found anywhere.
@@ -116,10 +115,8 @@ impl LspServer {
                             project_config.apply_to_server_config(&mut config);
                         }
 
-                        // Compute effective workspace config for this folder
-                        let mut effective_config = WorkspaceConfig::default();
-                        project_config.apply_to_workspace_config(&mut effective_config);
-                        folder.effective_workspace_config = effective_config;
+                        // Recompute effective config (defaults + project settings at startup).
+                        folder.recompute_effective_workspace_config();
                     }
                     Err(msg) => {
                         let user_msg = format!(
@@ -140,6 +137,9 @@ impl LspServer {
                         }
                     }
                 }
+            }
+            if folder.project_config.is_none() {
+                folder.recompute_effective_workspace_config();
             }
         }
 
@@ -330,14 +330,18 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
-        server
-            .pending_workspace_configuration_requests
-            .lock()
-            .insert(11, vec![uri1.clone(), uri2.clone()]);
+        server.pending_workspace_configuration_requests.lock().insert(
+            11,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                expects_global_item: true,
+                folder_uris: vec![uri1.clone(), uri2.clone()],
+            },
+        );
 
         server.handle_client_response(Some(serde_json::json!({
             "id": 11,
             "result": [
+                { "workspace": { "useSystemInc": true } },
                 { "workspace": { "includePaths": ["api_lib"] } },
                 { "workspace": { "includePaths": ["ui_lib"] } }
             ]
@@ -350,8 +354,10 @@ include_paths = ["other_lib"]
         assert!(
             folder1_state.effective_workspace_config.include_paths.contains(&"api_lib".to_string())
         );
+        assert!(folder1_state.effective_workspace_config.use_system_inc);
         assert!(
             folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
         );
+        assert!(folder2_state.effective_workspace_config.use_system_inc);
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -5,6 +5,15 @@
 
 use crate::runtime::workspace_folder::WorkspaceFolderState;
 
+/// Tracks an in-flight `workspace/configuration` pull request.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    /// Whether the first result entry is the unscoped global `section: perl` item.
+    pub expects_global_item: bool,
+    /// Folder URIs requested with `scopeUri`.
+    pub folder_uris: Vec<String>,
+}
+
 mod client_requests;
 mod constructors;
 pub(crate) mod diagnostic_debounce;
@@ -220,7 +229,8 @@ pub struct LspServer {
     /// Atomic counter for generating unique request IDs
     next_request_id: Arc<AtomicI64>,
     /// Pending workspace/configuration reverse requests keyed by request ID.
-    pending_workspace_configuration_requests: Arc<Mutex<HashMap<i64, Vec<String>>>>,
+    pending_workspace_configuration_requests:
+        Arc<Mutex<HashMap<i64, PendingWorkspaceConfigurationRequest>>>,
     /// Active progress tokens for work done progress tracking
     progress_tokens: Arc<Mutex<HashSet<String>>>,
     /// Maps progress tokens to their originating request IDs for cancellation routing

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -173,8 +173,8 @@ impl LspServer {
             return;
         }
 
-        let items: Vec<Value> =
-            folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })).collect();
+        let mut items: Vec<Value> = vec![json!({ "section": "perl" })];
+        items.extend(folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })));
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         if let Err(error) = self.outbound.send_request(
@@ -186,7 +186,10 @@ impl LspServer {
             return;
         }
 
-        self.pending_workspace_configuration_requests.lock().insert(request_id, folder_uris);
+        self.pending_workspace_configuration_requests.lock().insert(
+            request_id,
+            PendingWorkspaceConfigurationRequest { expects_global_item: true, folder_uris },
+        );
     }
 
     /// Apply a `workspace/configuration` response for a previously sent request.
@@ -198,8 +201,8 @@ impl LspServer {
             return;
         };
 
-        let maybe_folder_uris = self.pending_workspace_configuration_requests.lock().remove(&id);
-        let Some(folder_uris) = maybe_folder_uris else {
+        let pending = self.pending_workspace_configuration_requests.lock().remove(&id);
+        let Some(pending) = pending else {
             return;
         };
 
@@ -213,22 +216,23 @@ impl LspServer {
 
         let results = params.get("result").and_then(Value::as_array).cloned().unwrap_or_default();
 
+        let global_settings = pending
+            .expects_global_item
+            .then(|| results.first().cloned())
+            .flatten()
+            .filter(|value| !value.is_null());
+
+        let folder_offset = usize::from(pending.expects_global_item);
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        for (idx, folder_uri) in pending.folder_uris.iter().enumerate() {
             let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
                 continue;
             };
 
-            let mut effective_config = perl_lsp_config::WorkspaceConfig::default();
-            if let Some(project_config) = &folder.project_config {
-                project_config.apply_to_workspace_config(&mut effective_config);
-            }
-
-            if let Some(perl_settings) = results.get(idx) {
-                effective_config.update_from_value(perl_settings);
-            }
-
-            folder.effective_workspace_config = effective_config;
+            folder.client_global_settings = global_settings.clone();
+            folder.client_folder_settings =
+                results.get(idx + folder_offset).cloned().filter(|value| !value.is_null());
+            folder.recompute_effective_workspace_config();
         }
     }
 
@@ -675,6 +679,15 @@ impl LspServer {
                         tracing::debug!("Updated workspace config from perl settings");
                     }
 
+                    {
+                        let mut folders = self.workspace_folders.lock();
+                        for folder in folders.iter_mut() {
+                            folder.client_global_settings = Some(perl.clone());
+                            folder.client_folder_settings = None;
+                            folder.recompute_effective_workspace_config();
+                        }
+                    }
+
                     // Refresh AI backend when config changes (constructs or clears provider)
                     self.refresh_ai_backend();
 
@@ -688,6 +701,14 @@ impl LspServer {
 
         // Invalidate client-provided workspace/configuration values and re-fetch.
         self.pending_workspace_configuration_requests.lock().clear();
+        {
+            let mut folders = self.workspace_folders.lock();
+            for folder in folders.iter_mut() {
+                folder.client_global_settings = None;
+                folder.client_folder_settings = None;
+                folder.recompute_effective_workspace_config();
+            }
+        }
         self.request_workspace_configuration_for_folders();
     }
 

--- a/crates/perl-lsp/src/runtime/workspace_folder.rs
+++ b/crates/perl-lsp/src/runtime/workspace_folder.rs
@@ -10,6 +10,7 @@
 use std::path::PathBuf;
 
 use perl_lsp_config::{ProjectConfig, WorkspaceConfig};
+use serde_json::Value;
 
 /// State for a single workspace folder.
 ///
@@ -26,6 +27,10 @@ pub struct WorkspaceFolderState {
     pub name: Option<String>,
     /// Project configuration loaded from `.perl-lsp.toml` in this folder
     pub project_config: Option<ProjectConfig>,
+    /// Client-wide workspace settings from unscoped `workspace/configuration`.
+    pub client_global_settings: Option<Value>,
+    /// Folder-scoped workspace settings from `workspace/configuration(scopeUri=folder)`.
+    pub client_folder_settings: Option<Value>,
     /// Effective workspace configuration for this folder
     ///
     /// This will eventually be computed by merging:
@@ -44,6 +49,8 @@ impl WorkspaceFolderState {
             path: None,
             name: None,
             project_config: None,
+            client_global_settings: None,
+            client_folder_settings: None,
             effective_workspace_config: WorkspaceConfig::default(),
         }
     }
@@ -76,6 +83,22 @@ impl WorkspaceFolderState {
         self
     }
 
+    /// Recompute effective workspace config using precedence:
+    /// defaults < `.perl-lsp.toml` < client-global < client-folder.
+    pub fn recompute_effective_workspace_config(&mut self) {
+        let mut effective = WorkspaceConfig::default();
+        if let Some(project) = &self.project_config {
+            project.apply_to_workspace_config(&mut effective);
+        }
+        if let Some(global_settings) = &self.client_global_settings {
+            effective.update_from_value(global_settings);
+        }
+        if let Some(folder_settings) = &self.client_folder_settings {
+            effective.update_from_value(folder_settings);
+        }
+        self.effective_workspace_config = effective;
+    }
+
     /// Get the URI as a string reference.
     #[must_use]
     pub fn uri(&self) -> &str {
@@ -100,6 +123,8 @@ mod tests {
         assert!(folder.path.is_none());
         assert!(folder.name.is_none());
         assert!(folder.project_config.is_none());
+        assert!(folder.client_global_settings.is_none());
+        assert!(folder.client_folder_settings.is_none());
     }
 
     #[test]
@@ -152,5 +177,33 @@ mod tests {
         assert!(!config.include_paths.is_empty());
         assert_eq!(config.resolution_timeout_ms, 50);
         assert!(!config.use_system_inc);
+    }
+
+    #[test]
+    fn recompute_effective_workspace_config_merges_project_then_client_global() {
+        let mut folder = WorkspaceFolderState::new("file:///test/path".to_string());
+        let mut project = ProjectConfig::default();
+        project.perl.include_paths = vec!["project_lib".to_string()];
+        folder.project_config = Some(project);
+        folder.client_global_settings =
+            Some(serde_json::json!({ "workspace": { "useSystemInc": true } }));
+
+        folder.recompute_effective_workspace_config();
+
+        assert_eq!(folder.effective_workspace_config.include_paths, vec!["project_lib"]);
+        assert!(folder.effective_workspace_config.use_system_inc);
+    }
+
+    #[test]
+    fn recompute_effective_workspace_config_allows_folder_override() {
+        let mut folder = WorkspaceFolderState::new("file:///test/path".to_string());
+        folder.client_global_settings =
+            Some(serde_json::json!({ "workspace": { "includePaths": ["global_lib"] } }));
+        folder.client_folder_settings =
+            Some(serde_json::json!({ "workspace": { "includePaths": ["folder_lib"] } }));
+
+        folder.recompute_effective_workspace_config();
+
+        assert_eq!(folder.effective_workspace_config.include_paths, vec!["folder_lib"]);
     }
 }


### PR DESCRIPTION
### Motivation
- Implement full `workspace/configuration` pull support as a real v0.14 subsystem so client-configured settings can be merged with `.perl-lsp.toml` on a per-folder basis. 
- Ensure multi-root correctness with deterministic merging, event-driven invalidation, and a clean fallback when clients do not support `workspace/configuration`.

### Description
- Add an explicit `PendingWorkspaceConfigurationRequest` model and switch the pending-request registry to track `expects_global_item` plus the ordered `folder_uris` so responses can be merged deterministically into global+per-folder layers. (runtime state changes). 
- Extend `WorkspaceFolderState` with `client_global_settings` and `client_folder_settings` storage and add `recompute_effective_workspace_config()` that applies precedence: defaults → `.perl-lsp.toml` → client global → client folder. (folder model changes). 
- Send one unscoped `section: "perl"` item plus one `scopeUri` item per folder when requesting `workspace/configuration`, and apply the returned array into each folder by index, wiring global and folder-scoped values into the recompute path. (request/response wiring). 
- Update `didChangeConfiguration` handling to update server and workspace configs, push client-global values into folder state, invalidate cached pull results, recompute folder effective configs immediately, and re-request pull configs when the client supports them. 
- Update initialization to always recompute per-folder effective configs after loading `.perl-lsp.toml`, and add unit tests asserting merge precedence and global+folder application. (lifecycle + tests). 

### Testing
- Ran `cargo fmt --all` and formatting completed successfully. 
- Ran `cargo test -p perl-lsp-rs --lib handle_client_response_applies_per_folder_workspace_config` and the test passed. 
- Ran `cargo test -p perl-lsp-rs --lib recompute_effective_workspace_config` and the tests passed. 
- Existing and added unit tests exercising startup project-config loading, `workspace/configuration` response application, and recompute precedence were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db46eee5888333bd431c10f89b1744)