### PR TITLE
feat(lsp): finalize workspace/configuration pull timing+merge (#3515)

### DIFF
--- a/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp/src/runtime/dispatch/lifecycle.rs
@@ -78,6 +78,10 @@ impl LspServer {
         self.initialized.store(true, Ordering::Release);
         tracing::info!("Server initialized");
 
+        // LSP 3.17: server->client requests must only be sent after initialize
+        // has completed. Pull workspace/configuration now that we're initialized.
+        self.request_workspace_configuration_for_folders();
+
         // Register file watchers for Perl files only if client supports it
         if self.client_capabilities.lock().dynamic_registration_support {
             self.register_file_watchers_async();

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -143,10 +143,7 @@ impl LspServer {
             }
         }
 
-        // Pull client-scoped workspace settings (if supported) and merge them
-        // as the highest-precedence layer over TOML-derived folder config.
         drop(folders);
-        self.request_workspace_configuration_for_folders();
     }
 }
 
@@ -198,6 +195,24 @@ mod tests {
         let server = LspServer::new();
         // Should not panic with empty workspace folders
         server.load_and_apply_project_config();
+    }
+
+    #[test]
+    fn load_and_apply_project_config_does_not_send_reverse_request_before_initialized() {
+        let server = LspServer::new();
+        server.client_capabilities.lock().workspace_configuration_support = true;
+
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let uri =
+            url::Url::from_directory_path(temp.path()).expect("failed to create uri").to_string();
+        server
+            .workspace_folders
+            .lock()
+            .push(crate::runtime::workspace_folder::WorkspaceFolderState::new(uri));
+
+        server.load_and_apply_project_config();
+
+        assert!(server.pending_workspace_configuration_requests.lock().is_empty());
     }
 
     #[test]
@@ -330,14 +345,19 @@ include_paths = ["other_lib"]
                 .with_path(folder2.clone()),
         );
 
-        server
-            .pending_workspace_configuration_requests
-            .lock()
-            .insert(11, vec![uri1.clone(), uri2.clone()]);
+        server.pending_workspace_configuration_requests.lock().insert(
+            11,
+            crate::runtime::PendingWorkspaceConfigurationRequest {
+                folder_uris: vec![uri1.clone(), uri2.clone()],
+                includes_global: true,
+                sent_at: std::time::Instant::now(),
+            },
+        );
 
         server.handle_client_response(Some(serde_json::json!({
             "id": 11,
             "result": [
+                { "workspace": { "useSystemInc": false } },
                 { "workspace": { "includePaths": ["api_lib"] } },
                 { "workspace": { "includePaths": ["ui_lib"] } }
             ]
@@ -353,5 +373,30 @@ include_paths = ["other_lib"]
         assert!(
             folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
         );
+        assert!(!folder1_state.effective_workspace_config.use_system_inc);
+        assert!(!folder2_state.effective_workspace_config.use_system_inc);
+    }
+
+    #[test]
+    fn initialized_notification_triggers_workspace_configuration_request() {
+        let server = LspServer::new();
+        server.client_capabilities.lock().workspace_configuration_support = true;
+
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let uri =
+            url::Url::from_directory_path(temp.path()).expect("failed to create uri").to_string();
+        server
+            .workspace_folders
+            .lock()
+            .push(crate::runtime::workspace_folder::WorkspaceFolderState::new(uri));
+
+        let _ = server.handle_request(crate::protocol::JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            id: None,
+            method: "initialized".to_string(),
+            params: None,
+        });
+
+        assert_eq!(server.pending_workspace_configuration_requests.lock().len(), 1);
     }
 }

--- a/crates/perl-lsp/src/runtime/mod.rs
+++ b/crates/perl-lsp/src/runtime/mod.rs
@@ -105,6 +105,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering},
 };
+use std::time::Instant;
 use url::Url;
 
 #[cfg(feature = "workspace")]
@@ -164,6 +165,13 @@ pub(crate) struct DocumentScanView {
     pub ast: Option<Arc<perl_parser::ast::Node>>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    pub(crate) folder_uris: Vec<String>,
+    pub(crate) includes_global: bool,
+    pub(crate) sent_at: Instant,
+}
+
 // Note: FQN_RE regex moved to language/navigation.rs
 
 // Note: Error codes and cancelled_response imported from crate::lsp::protocol
@@ -220,7 +228,8 @@ pub struct LspServer {
     /// Atomic counter for generating unique request IDs
     next_request_id: Arc<AtomicI64>,
     /// Pending workspace/configuration reverse requests keyed by request ID.
-    pending_workspace_configuration_requests: Arc<Mutex<HashMap<i64, Vec<String>>>>,
+    pending_workspace_configuration_requests:
+        Arc<Mutex<HashMap<i64, PendingWorkspaceConfigurationRequest>>>,
     /// Active progress tokens for work done progress tracking
     progress_tokens: Arc<Mutex<HashSet<String>>>,
     /// Maps progress tokens to their originating request IDs for cancellation routing

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -162,6 +162,11 @@ impl Drop for IndexingGuard {
 impl LspServer {
     /// Request `workspace/configuration` for each workspace folder (if supported).
     pub(crate) fn request_workspace_configuration_for_folders(&self) {
+        if !self.initialized.load(Ordering::Acquire) {
+            tracing::debug!("Skipping workspace/configuration request before initialized");
+            return;
+        }
+
         if !self.client_capabilities.lock().workspace_configuration_support {
             tracing::debug!("Client does not support workspace/configuration; using local config");
             return;
@@ -173,8 +178,9 @@ impl LspServer {
             return;
         }
 
-        let items: Vec<Value> =
-            folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })).collect();
+        let mut items: Vec<Value> = Vec::with_capacity(folder_uris.len() + 1);
+        items.push(json!({ "section": "perl" }));
+        items.extend(folder_uris.iter().map(|uri| json!({ "scopeUri": uri, "section": "perl" })));
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
 
         if let Err(error) = self.outbound.send_request(
@@ -186,7 +192,14 @@ impl LspServer {
             return;
         }
 
-        self.pending_workspace_configuration_requests.lock().insert(request_id, folder_uris);
+        self.pending_workspace_configuration_requests.lock().insert(
+            request_id,
+            PendingWorkspaceConfigurationRequest {
+                folder_uris,
+                includes_global: true,
+                sent_at: std::time::Instant::now(),
+            },
+        );
     }
 
     /// Apply a `workspace/configuration` response for a previously sent request.
@@ -198,8 +211,8 @@ impl LspServer {
             return;
         };
 
-        let maybe_folder_uris = self.pending_workspace_configuration_requests.lock().remove(&id);
-        let Some(folder_uris) = maybe_folder_uris else {
+        let maybe_pending = self.pending_workspace_configuration_requests.lock().remove(&id);
+        let Some(pending_request) = maybe_pending else {
             return;
         };
 
@@ -212,9 +225,11 @@ impl LspServer {
         }
 
         let results = params.get("result").and_then(Value::as_array).cloned().unwrap_or_default();
+        let global_settings = if pending_request.includes_global { results.first() } else { None };
+        let folder_result_offset = usize::from(pending_request.includes_global);
 
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        for (idx, folder_uri) in pending_request.folder_uris.iter().enumerate() {
             let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
                 continue;
             };
@@ -224,12 +239,23 @@ impl LspServer {
                 project_config.apply_to_workspace_config(&mut effective_config);
             }
 
-            if let Some(perl_settings) = results.get(idx) {
+            if let Some(global) = global_settings {
+                effective_config.update_from_value(global);
+            }
+
+            if let Some(perl_settings) = results.get(idx + folder_result_offset) {
                 effective_config.update_from_value(perl_settings);
             }
 
             folder.effective_workspace_config = effective_config;
         }
+
+        // Clear stale pending entries deterministically after successful processing.
+        const WORKSPACE_CONFIG_REQUEST_TIMEOUT: std::time::Duration =
+            std::time::Duration::from_secs(30);
+        self.pending_workspace_configuration_requests
+            .lock()
+            .retain(|_, request| request.sent_at.elapsed() < WORKSPACE_CONFIG_REQUEST_TIMEOUT);
     }
 
     /// Handle workspace/symbol request (v2 implementation with lifecycle-aware dispatch)


### PR DESCRIPTION
### Motivation

- Ensure `workspace/configuration` is used in an LSP-compliant way (server→client pull only after `initialized`) and avoid sending reverse requests during `initialize`.
- Replace a fragile request-id → folder list mapping with a typed pending request so global+per-folder responses can be merged deterministically per workspace folder.
- Provide a clear merge precedence (TOML baseline < client global < client folder) and deterministic cleanup for stale/orphaned reverse requests.

### Description

- Added a `PendingWorkspaceConfigurationRequest` typed entry and replaced the `HashMap<i64, Vec<String>>` pending registry with `HashMap<i64, PendingWorkspaceConfigurationRequest>` in `runtime/mod.rs`.
- Prevent `workspace/configuration` requests from being sent before initialization by guarding `request_workspace_configuration_for_folders` with `initialized` and calling it from `initialized` handling in `runtime/dispatch/lifecycle.rs`.
- Request both a global `ConfigurationItem` (`{ section: "perl" }`) and per-folder `ConfigurationItem`s (`{ scopeUri: <folder>, section: "perl" }`) in a single `workspace/configuration` call in `runtime/workspace.rs`.
- Merge response values per-folder in the order: defaults + `.perl-lsp.toml` baseline, then client global settings, then client folder-scoped settings; apply merged `WorkspaceConfig` into each `WorkspaceFolderState`'s `effective_workspace_config`.
- Add deterministic stale-pending cleanup (30s) to remove orphaned pending requests after processing.
- Keep `.perl-lsp.toml` loading during initialization focused on baseline config and do not trigger reverse requests from `load_and_apply_project_config` (reverse requests are now post-`initialized`).
- Added unit tests to cover: no reverse-request during initialize-time config load, `initialized` triggers the pull, and global+folder merge behavior applied per-folder (in `runtime/lifecycle/workspace.rs`).

### Testing

- Ran formatter: `cargo fmt --all` (succeeded).
- Ran targeted unit tests in the `perl-lsp-rs` crate (all succeeded):
  - `cargo test -p perl-lsp-rs --lib initialized_notification_triggers_workspace_configuration_request -- --nocapture` (passed).
  - `cargo test -p perl-lsp-rs --lib handle_client_response_applies_per_folder_workspace_config -- --nocapture` (passed).
  - `cargo test -p perl-lsp-rs --lib load_and_apply_project_config_does_not_send_reverse_request_before_initialized -- --nocapture` (passed).
- Note: a broader `cargo test` across the workspace exposed an unrelated compilation failure in an existing test (`workspace_permission_denied_test.rs`) unrelated to these changes; the focused tests that validate the workspace/configuration behavior passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db46eee5888333bd431c10f89b1744)