### PR TITLE
fix(workspace): eagerly propagate didChangeConfiguration to folder effective configs (#3515)

### DIFF
--- a/crates/perl-dap/features_sot.toml
+++ b/crates/perl-dap/features_sot.toml
@@ -5,7 +5,7 @@
 [meta]
 version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 100  # 118 total features (87 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
+compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -1091,6 +1091,16 @@ tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
+
+[[feature]]
+id = "lsp.diagnostic.markup_message_support"
+spec = "LSP 3.18"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs"]
+description = "Markdown-formatted diagnostic messages (textDocument.diagnostic.markupMessageSupport) — server includes messageMarkup in diagnostic data when client opts in"
 
 [[feature]]
 id = "lsp.text_document_content"

--- a/crates/perl-lsp-feature-contracts/features_sot.toml
+++ b/crates/perl-lsp-feature-contracts/features_sot.toml
@@ -5,7 +5,7 @@
 [meta]
 version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 100  # 118 total features (87 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
+compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -1091,6 +1091,16 @@ tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
+
+[[feature]]
+id = "lsp.diagnostic.markup_message_support"
+spec = "LSP 3.18"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs"]
+description = "Markdown-formatted diagnostic messages (textDocument.diagnostic.markupMessageSupport) — server includes messageMarkup in diagnostic data when client opts in"
 
 [[feature]]
 id = "lsp.text_document_content"

--- a/crates/perl-lsp/features_sot.toml
+++ b/crates/perl-lsp/features_sot.toml
@@ -5,7 +5,7 @@
 [meta]
 version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 100  # 118 total features (87 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
+compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -1091,6 +1091,16 @@ tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
+
+[[feature]]
+id = "lsp.diagnostic.markup_message_support"
+spec = "LSP 3.18"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs"]
+description = "Markdown-formatted diagnostic messages (textDocument.diagnostic.markupMessageSupport) — server includes messageMarkup in diagnostic data when client opts in"
 
 [[feature]]
 id = "lsp.text_document_content"

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -3,7 +3,7 @@
 //! Handles workspace folders and root URI/path management.
 
 use super::super::*;
-use perl_dap_platform::{find_perl_interpreter, PerlInterpreterResult};
+use perl_dap_platform::{PerlInterpreterResult, find_perl_interpreter};
 use perl_lsp_config::WorkspaceConfig;
 use std::sync::Once;
 
@@ -262,17 +262,21 @@ include_paths = ["other_lib"]
 
         let folder1_state = folders.iter().find(|f| f.uri == uri1).unwrap();
         assert!(folder1_state.project_config.is_some());
-        assert!(folder1_state
-            .effective_workspace_config
-            .include_paths
-            .contains(&"custom_lib".to_string()));
+        assert!(
+            folder1_state
+                .effective_workspace_config
+                .include_paths
+                .contains(&"custom_lib".to_string())
+        );
 
         let folder2_state = folders.iter().find(|f| f.uri == uri2).unwrap();
         assert!(folder2_state.project_config.is_some());
-        assert!(folder2_state
-            .effective_workspace_config
-            .include_paths
-            .contains(&"other_lib".to_string()));
+        assert!(
+            folder2_state
+                .effective_workspace_config
+                .include_paths
+                .contains(&"other_lib".to_string())
+        );
     }
 
     #[test]
@@ -348,14 +352,12 @@ include_paths = ["other_lib"]
         let folder1_state = folders.iter().find(|f| f.uri == uri1).expect("missing folder1");
         let folder2_state = folders.iter().find(|f| f.uri == uri2).expect("missing folder2");
 
-        assert!(folder1_state
-            .effective_workspace_config
-            .include_paths
-            .contains(&"api_lib".to_string()));
-        assert!(folder2_state
-            .effective_workspace_config
-            .include_paths
-            .contains(&"ui_lib".to_string()));
+        assert!(
+            folder1_state.effective_workspace_config.include_paths.contains(&"api_lib".to_string())
+        );
+        assert!(
+            folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
+        );
         assert!(folder1_state.effective_workspace_config.use_system_inc);
         assert!(folder2_state.effective_workspace_config.use_system_inc);
     }
@@ -388,10 +390,9 @@ include_paths = ["other_lib"]
 
         let folders = server.workspace_folders.lock();
         let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
-        assert!(!folder_state
-            .effective_workspace_config
-            .include_paths
-            .contains(&"oops".to_string()));
+        assert!(
+            !folder_state.effective_workspace_config.include_paths.contains(&"oops".to_string())
+        );
     }
 
     #[test]

--- a/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp/src/runtime/lifecycle/workspace.rs
@@ -3,7 +3,7 @@
 //! Handles workspace folders and root URI/path management.
 
 use super::super::*;
-use perl_dap_platform::{PerlInterpreterResult, find_perl_interpreter};
+use perl_dap_platform::{find_perl_interpreter, PerlInterpreterResult};
 use perl_lsp_config::WorkspaceConfig;
 use std::sync::Once;
 
@@ -262,21 +262,17 @@ include_paths = ["other_lib"]
 
         let folder1_state = folders.iter().find(|f| f.uri == uri1).unwrap();
         assert!(folder1_state.project_config.is_some());
-        assert!(
-            folder1_state
-                .effective_workspace_config
-                .include_paths
-                .contains(&"custom_lib".to_string())
-        );
+        assert!(folder1_state
+            .effective_workspace_config
+            .include_paths
+            .contains(&"custom_lib".to_string()));
 
         let folder2_state = folders.iter().find(|f| f.uri == uri2).unwrap();
         assert!(folder2_state.project_config.is_some());
-        assert!(
-            folder2_state
-                .effective_workspace_config
-                .include_paths
-                .contains(&"other_lib".to_string())
-        );
+        assert!(folder2_state
+            .effective_workspace_config
+            .include_paths
+            .contains(&"other_lib".to_string()));
     }
 
     #[test]
@@ -352,12 +348,14 @@ include_paths = ["other_lib"]
         let folder1_state = folders.iter().find(|f| f.uri == uri1).expect("missing folder1");
         let folder2_state = folders.iter().find(|f| f.uri == uri2).expect("missing folder2");
 
-        assert!(
-            folder1_state.effective_workspace_config.include_paths.contains(&"api_lib".to_string())
-        );
-        assert!(
-            folder2_state.effective_workspace_config.include_paths.contains(&"ui_lib".to_string())
-        );
+        assert!(folder1_state
+            .effective_workspace_config
+            .include_paths
+            .contains(&"api_lib".to_string()));
+        assert!(folder2_state
+            .effective_workspace_config
+            .include_paths
+            .contains(&"ui_lib".to_string()));
         assert!(folder1_state.effective_workspace_config.use_system_inc);
         assert!(folder2_state.effective_workspace_config.use_system_inc);
     }
@@ -390,8 +388,59 @@ include_paths = ["other_lib"]
 
         let folders = server.workspace_folders.lock();
         let folder_state = folders.iter().find(|f| f.uri == uri).expect("missing folder");
-        assert!(
-            !folder_state.effective_workspace_config.include_paths.contains(&"oops".to_string())
+        assert!(!folder_state
+            .effective_workspace_config
+            .include_paths
+            .contains(&"oops".to_string()));
+    }
+
+    #[test]
+    fn did_change_configuration_updates_folder_effective_configs() {
+        let server = LspServer::new();
+        let temp = tempfile::tempdir().expect("failed to create temp dir");
+        let folder1 = temp.path().join("folder1");
+        let folder2 = temp.path().join("folder2");
+        std::fs::create_dir_all(&folder1).expect("failed to create folder1");
+        std::fs::create_dir_all(&folder2).expect("failed to create folder2");
+
+        let uri1 =
+            url::Url::from_directory_path(&folder1).expect("failed to create uri1").to_string();
+        let uri2 =
+            url::Url::from_directory_path(&folder2).expect("failed to create uri2").to_string();
+
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri1)
+                .with_path(folder1.clone()),
         );
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(uri2)
+                .with_path(folder2.clone()),
+        );
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "workspace": {
+                        "includePaths": ["client_lib"],
+                        "useSystemInc": true
+                    }
+                }
+            }
+        })));
+
+        let folders = server.workspace_folders.lock();
+        assert_eq!(folders.len(), 2);
+        for folder in folders.iter() {
+            assert!(
+                folder.effective_workspace_config.include_paths.contains(&"client_lib".to_string()),
+                "folder {} missing client_lib in effective include_paths",
+                folder.uri
+            );
+            assert!(
+                folder.effective_workspace_config.use_system_inc,
+                "folder {} should have use_system_inc=true from didChangeConfiguration",
+                folder.uri
+            );
+        }
     }
 }

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 #[cfg(feature = "workspace")]
-use crate::runtime::routing::{route_index_access, IndexAccessMode};
+use crate::runtime::routing::{IndexAccessMode, route_index_access};
 use crate::state::workspace_symbol_cap;
 use perl_module_path::file_path_to_module_name;
 use perl_module_rename::{apply_module_rename_edits, plan_module_rename_edits};

--- a/crates/perl-lsp/src/runtime/workspace.rs
+++ b/crates/perl-lsp/src/runtime/workspace.rs
@@ -10,7 +10,7 @@
 
 use super::*;
 #[cfg(feature = "workspace")]
-use crate::runtime::routing::{IndexAccessMode, route_index_access};
+use crate::runtime::routing::{route_index_access, IndexAccessMode};
 use crate::state::workspace_symbol_cap;
 use perl_module_path::file_path_to_module_name;
 use perl_module_rename::{apply_module_rename_edits, plan_module_rename_edits};
@@ -722,6 +722,23 @@ impl LspServer {
                         let mut workspace_config = self.workspace_config.lock();
                         workspace_config.update_from_value(perl);
                         tracing::debug!("Updated workspace config from perl settings");
+                    }
+
+                    // Apply global client settings to each folder's effective config immediately.
+                    // The async workspace/configuration pull that follows will refine per-folder
+                    // settings once the client responds, but we update now so the window between
+                    // didChangeConfiguration arrival and the pull response doesn't leave folders
+                    // with stale settings.
+                    {
+                        let mut folders = self.workspace_folders.lock();
+                        for folder in folders.iter_mut() {
+                            let mut effective_config = perl_lsp_config::WorkspaceConfig::default();
+                            if let Some(project_config) = &folder.project_config {
+                                project_config.apply_to_workspace_config(&mut effective_config);
+                            }
+                            effective_config.update_from_value(perl);
+                            folder.effective_workspace_config = effective_config;
+                        }
                     }
 
                     // Refresh AI backend when config changes (constructs or clears provider)

--- a/crates/perl-parser/features_sot.toml
+++ b/crates/perl-parser/features_sot.toml
@@ -5,7 +5,7 @@
 [meta]
 version = "0.12.3"
 lsp_version = "3.18"
-compliance_percent = 100  # 118 total features (87 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
+compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 53/53 advertised
 
 # Text Document Features
 
@@ -1091,6 +1091,16 @@ tests = ["crates/perl-lsp/tests/lsp_window_tests.rs"]
 description = "Server telemetry events (telemetry/event)"
 
 # LSP 3.18 Additions
+
+[[feature]]
+id = "lsp.diagnostic.markup_message_support"
+spec = "LSP 3.18"
+area = "text_document"
+maturity = "ga"
+advertised = true
+counts_in_coverage = false
+tests = ["crates/perl-lsp/tests/lsp_diagnostic_enrichment_test.rs"]
+description = "Markdown-formatted diagnostic messages (textDocument.diagnostic.markupMessageSupport) — server includes messageMarkup in diagnostic data when client opts in"
 
 [[feature]]
 id = "lsp.text_document_content"

--- a/docs/project/status/tests.md
+++ b/docs/project/status/tests.md
@@ -6,13 +6,13 @@
 ## Test Counts
 
 <!-- BEGIN: TESTS_TABLE_ROWS -->
-| **Tier A Tests** | 3087 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
+| **Tier A Tests** | 3088 lib tests (discovered), 2 ignores (tracked) | 100% pass | PASS |
 | **Tracked Test Debt** | 0 (0 bug, 0 manual) | 0 | Near-zero |
 <!-- END: TESTS_TABLE_ROWS -->
 
 ## Computed Metrics
 
 <!-- BEGIN: TESTS_METRICS_BULLETS -->
-- **Test Status**: 3087 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
+- **Test Status**: 3088 lib tests (Tier A), 2 ignores tracked (0 total tracked debt: 0 bug, 0 manual)
 - **Docs (perl-parser)**: missing_docs warnings = 0 (baseline 0)
 <!-- END: TESTS_METRICS_BULLETS -->


### PR DESCRIPTION
## Summary

Follow-up to #4289 which landed the core `workspace/configuration` pull
infrastructure. That PR hardened request tracking but left a gap: when
the client fires `workspace/didChangeConfiguration`, the global perl
settings were applied to the server's own config but NOT to each
folder's `effective_workspace_config`. The per-folder update only
happened after the async pull response arrived, leaving a window where
folders used stale settings.

- **Fix**: after updating global `workspace_config` in
  `handle_did_change_configuration`, immediately iterate folders and
  rebuild each `effective_workspace_config` from
  `defaults → project_config → client_settings`. The async pull that
  follows will refine per-folder scoped settings, but the eagerly applied
  global settings remove the stale window.

- **Test**: `did_change_configuration_updates_folder_effective_configs`
  verifies that both folders in a two-root workspace receive updated
  `include_paths` and `use_system_inc` from the push notification
  before any pull response arrives.

- **Chore**: sync four vendored `features_sot.toml` files to the
  workspace root `features.toml` (the `lsp.diagnostic.markup_message_support`
  feature added in PR #4099 was missing from the vendored copies, causing
  `vendored_feature_catalogs_match_workspace_root_catalog` to fail).

## Test plan

- [ ] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- did_change_configuration` — new test passes
- [ ] `cargo test -p perl-feature-catalog --tests -- vendored_feature_catalogs_match_workspace_root_catalog` — catalog sync passes
- [ ] `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib` — all 364 lib tests pass