### PR TITLE
fix(ci): resolve clippy unused_mut and Linux test failure in perl-dap-platform (#4308)

### DIFF
--- a/crates/perl-dap-platform/src/lib.rs
+++ b/crates/perl-dap-platform/src/lib.rs
@@ -56,6 +56,7 @@ fn windows_perl_rank(path: &std::path::Path) -> u8 {
 /// On Windows, returns all matches sorted by [`windows_perl_rank`] so the caller
 /// can pick the best one. On non-Windows, returns candidates in PATH order (no ranking).
 fn find_all_perl_on_path(path_env: &str) -> Vec<PathBuf> {
+    #[allow(unused_mut)]
     let mut found: Vec<PathBuf> = path_env
         .split(PATH_SEPARATOR)
         .map(|dir| PathBuf::from(dir).join(PERL_EXECUTABLE))
@@ -523,13 +524,10 @@ mod tests {
     }
 
     #[test]
-    fn home_dir_fallback_is_not_slash_tmp() {
-        // When both HOME and USERPROFILE are absent, home_dir() must NOT return
-        // PathBuf::from("/tmp") because /tmp does not exist on Windows.
-        // It should return std::env::temp_dir() instead.
-        //
-        // We test the fallback by temporarily unsetting both env vars.
-        // This is safe because home_dir() is a pure function with no side effects.
+    fn home_dir_fallback_uses_temp_dir() {
+        // When both HOME and USERPROFILE are absent, home_dir() must return
+        // std::env::temp_dir() — not a hardcoded PathBuf::from("/tmp") which
+        // does not exist on Windows.
         let original_home = std::env::var("HOME").ok();
         let original_userprofile = std::env::var("USERPROFILE").ok();
 
@@ -540,6 +538,7 @@ mod tests {
         }
 
         let result = home_dir();
+        let expected = std::env::temp_dir();
 
         // Restore env vars.
         unsafe {
@@ -551,14 +550,11 @@ mod tests {
             }
         }
 
-        // The fallback must NOT be the literal "/tmp".
-        assert_ne!(
-            result,
-            std::path::PathBuf::from("/tmp"),
-            "home_dir() fallback must not return /tmp (broken on Windows): got {:?}",
-            result
+        // The fallback must match std::env::temp_dir(), not a hardcoded path.
+        assert_eq!(
+            result, expected,
+            "home_dir() fallback should be std::env::temp_dir(), got {result:?}"
         );
-        // The fallback must be non-empty.
         assert!(!result.as_os_str().is_empty(), "home_dir() must return a non-empty path");
     }
 }

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -24,7 +24,7 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | 10 modules (unverified) | run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->


### PR DESCRIPTION
## Summary

Fixes the red master CI gate (`clippy_full` + `unit_full` failures in `perl-dap-platform`):

- **Clippy**: `let mut found` in `find_all_perl_on_path()` — the `mut` is only needed on Windows (for `sort_by_key` inside `#[cfg(windows)]`), but clippy with `-D warnings` on Linux flags it as unused. Added `#[allow(unused_mut)]`.
- **Test**: `home_dir_fallback_is_not_slash_tmp` — asserted `result != PathBuf::from("/tmp")`, but on Linux `std::env::temp_dir()` IS `/tmp`, so the test always failed. Changed to assert `result == std::env::temp_dir()` which is the actual intent (verify we use the platform temp dir, not a hardcoded path).
- **Status**: Regenerated `docs/project/status/parser.md` to reflect current test counts.

## Test plan

- [x] `cargo clippy -p perl-dap-platform --lib -- -D warnings -A missing_docs` passes locally
- [x] `cargo test -p perl-dap-platform --lib` passes locally (16/16)
- [ ] CI Gate green on Linux runner (the target environment for the fix)