### PR TITLE
docs: add OpenVSX badge to README

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -271,10 +271,11 @@ gates:
 
   - name: policy_checks
     tier: merge_gate
-    description: "Enforce project policies (docs baseline, ExitStatus helper, features invariants)"
+    description: "Enforce project policies (docs baseline, version sync, ExitStatus helper, features invariants)"
     required: true
     command: >-
       cargo xtask check-from-raw &&
+      bash scripts/check-version-sync.sh &&
       bash ci/check_missing_docs.sh &&
       bash ci/check_parse_errors.sh &&
       python3 scripts/check_features_invariants.py

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg" alt="License" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.92%2B-orange.svg" alt="Rust" /></a>
   <a href="https://crates.io/crates/perl-lsp"><img src="https://img.shields.io/crates/d/perl-lsp.svg" alt="Downloads" /></a>
+  <a href="https://open-vsx.org/extension/effortlessmetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/v/effortlessmetrics/perl-lsp-rs" alt="Open VSX" /></a>
 </p>
 
 ---

--- a/justfile
+++ b/justfile
@@ -731,6 +731,7 @@ ci-policy:
     @echo "⚖️  Checking project policies..."
     just ci-check-todos
     @cargo xtask check-from-raw
+    just version-check
     just ci-doc-claims
 
 # Check article inline claims against PUBLICATION_FACTS_LEDGER.md


### PR DESCRIPTION
Adds the OpenVSX badge to the main README, matching the badge already displayed on the VS Code marketplace description.