### PR TITLE
feat(import): complete require+manual import coverage (#3476)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -335,6 +335,93 @@ impl CompletionProvider {
         }
 
         fn collect(node: &Node, map: &mut ImportMap) {
+            fn inner_expr(node: &Node) -> &Node {
+                if let NodeKind::ExpressionStatement { expression } = &node.kind {
+                    expression.as_ref()
+                } else {
+                    node
+                }
+            }
+
+            fn normalize_require_module(arg: &Node) -> Option<String> {
+                match &arg.kind {
+                    NodeKind::Identifier { name } => Some(name.clone()),
+                    NodeKind::String { value, .. } => {
+                        let normalized = value
+                            .trim_matches('\'')
+                            .trim_matches('"')
+                            .trim_end_matches(".pm")
+                            .replace('/', "::");
+                        if normalized.is_empty() { None } else { Some(normalized) }
+                    }
+                    _ => None,
+                }
+            }
+
+            fn collect_method_import_symbols(
+                module: &str,
+                args: &[Node],
+                symbols: &mut HashSet<String>,
+            ) -> bool {
+                let mut has_any = false;
+                for arg in args {
+                    match &arg.kind {
+                        NodeKind::String { value, .. } => {
+                            let cleaned = value.trim_matches('\'').trim_matches('"');
+                            for token in cleaned.split_whitespace() {
+                                if token.is_empty() {
+                                    continue;
+                                }
+                                if token.starts_with(':') {
+                                    if let Some(expanded) = resolve_known_export_tag(module, token)
+                                    {
+                                        symbols.extend(
+                                            expanded.iter().map(|name| (*name).to_string()),
+                                        );
+                                    }
+                                } else {
+                                    symbols.insert(token.to_string());
+                                }
+                                has_any = true;
+                            }
+                        }
+                        NodeKind::Identifier { name } => {
+                            if name.starts_with("qw") {
+                                let content = name
+                                    .trim_start_matches("qw")
+                                    .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                                    .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                                for token in content.split_whitespace() {
+                                    if token.is_empty() {
+                                        continue;
+                                    }
+                                    if token.starts_with(':') {
+                                        if let Some(expanded) =
+                                            resolve_known_export_tag(module, token)
+                                        {
+                                            symbols.extend(
+                                                expanded.iter().map(|name| (*name).to_string()),
+                                            );
+                                        }
+                                    } else {
+                                        symbols.insert(token.to_string());
+                                    }
+                                    has_any = true;
+                                }
+                            } else {
+                                symbols.insert(name.clone());
+                                has_any = true;
+                            }
+                        }
+                        NodeKind::ArrayLiteral { elements } => {
+                            has_any |= collect_method_import_symbols(module, elements, symbols);
+                        }
+                        _ => {}
+                    }
+                }
+                has_any
+            }
+
             match &node.kind {
                 NodeKind::Use { module, args, .. } => {
                     // Skip pragmas: only process uppercase-starting module names
@@ -384,6 +471,41 @@ impl CompletionProvider {
                     }
                 }
                 NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                    let required_modules: HashSet<String> = statements
+                        .iter()
+                        .filter_map(|statement| {
+                            let expr = inner_expr(statement);
+                            if let NodeKind::FunctionCall { name, args } = &expr.kind {
+                                if name == "require" {
+                                    return args.first().and_then(normalize_require_module);
+                                }
+                            }
+                            None
+                        })
+                        .collect();
+
+                    if !required_modules.is_empty() {
+                        for statement in statements {
+                            let expr = inner_expr(statement);
+                            if let NodeKind::MethodCall { object, method, args } = &expr.kind {
+                                if method != "import" {
+                                    continue;
+                                }
+                                let NodeKind::Identifier { name: object_name } = &object.kind
+                                else {
+                                    continue;
+                                };
+                                if !required_modules.contains(object_name) {
+                                    continue;
+                                }
+                                let mut symbols = HashSet::new();
+                                if collect_method_import_symbols(object_name, args, &mut symbols) {
+                                    map.entry(object_name.clone()).or_default().extend(symbols);
+                                }
+                            }
+                        }
+                    }
+
                     for stmt in statements {
                         collect(stmt, map);
                     }

--- a/crates/perl-lsp-completion/tests/import_map_tests.rs
+++ b/crates/perl-lsp-completion/tests/import_map_tests.rs
@@ -310,3 +310,56 @@ fn extract_import_map_supports_mixed_tag_and_symbol_imports() {
         seek_set.sort_text
     );
 }
+
+#[test]
+fn extract_import_map_supports_require_manual_import_list() {
+    let source = "require List::Util;\nList::Util->import('sum', 'min');\nsu";
+    let index = make_list_util_index();
+    let provider = parse_provider_with_index(source, index);
+    let items = provider.get_completions(source, source.len());
+
+    let sum_item = must_some(
+        items.iter().find(|i| i.label == "sum" || i.insert_text.as_deref() == Some("sum")),
+    );
+    assert!(
+        sum_item.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")),
+        "sum should be promoted when imported via require+manual import; got: {:?}",
+        sum_item.sort_text
+    );
+}
+
+#[test]
+fn extract_import_map_supports_require_manual_import_qw() {
+    let source = "require List::Util;\nList::Util->import(qw(sum min));\nmi";
+    let index = make_list_util_index();
+    let provider = parse_provider_with_index(source, index);
+    let items = provider.get_completions(source, source.len());
+
+    let min_item = must_some(
+        items.iter().find(|i| i.label == "min" || i.insert_text.as_deref() == Some("min")),
+    );
+    assert!(
+        min_item.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")),
+        "min should be promoted when imported via require+qw import; got: {:?}",
+        min_item.sort_text
+    );
+}
+
+#[test]
+fn extract_import_map_supports_require_path_manual_tag_import() {
+    let source = "require 'File/Find.pm';\nFile::Find->import(':find');\nfi";
+    let index = make_file_find_index();
+    let provider = parse_provider_with_index(source, index);
+    let items = provider.get_completions(source, source.len());
+
+    let finddepth_item = must_some(
+        items
+            .iter()
+            .find(|i| i.label == "finddepth" || i.insert_text.as_deref() == Some("finddepth")),
+    );
+    assert!(
+        finddepth_item.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")),
+        "finddepth should be promoted when imported via require path + tag; got: {:?}",
+        finddepth_item.sort_text
+    );
+}

--- a/crates/perl-lsp/src/runtime/language/misc.rs
+++ b/crates/perl-lsp/src/runtime/language/misc.rs
@@ -1129,6 +1129,60 @@ impl LspServer {
     fn find_import_source(&self, ast: &crate::ast::Node, symbol_name: &str) -> Option<String> {
         use perl_parser::ast::NodeKind;
 
+        fn normalize_require_module(arg: &crate::ast::Node) -> Option<String> {
+            match &arg.kind {
+                NodeKind::Identifier { name } => Some(name.clone()),
+                NodeKind::String { value, .. } => {
+                    let normalized = value
+                        .trim_matches('\'')
+                        .trim_matches('"')
+                        .trim_end_matches(".pm")
+                        .replace('/', "::");
+                    if normalized.is_empty() { None } else { Some(normalized) }
+                }
+                _ => None,
+            }
+        }
+
+        fn arg_matches_symbol(module: &str, arg: &crate::ast::Node, symbol: &str) -> bool {
+            match &arg.kind {
+                NodeKind::String { value, .. } => {
+                    let cleaned = value.trim_matches('\'').trim_matches('"');
+                    cleaned == symbol
+                }
+                NodeKind::Identifier { name } => {
+                    if name == symbol {
+                        return true;
+                    }
+                    if name.starts_with("qw") {
+                        let content = name
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        return content.split_whitespace().any(|w| {
+                            w == symbol
+                                || (w.starts_with(':')
+                                    && resolve_known_export_tag(module, w)
+                                        .is_some_and(|expanded| expanded.contains(&symbol)))
+                        });
+                    }
+                    false
+                }
+                NodeKind::ArrayLiteral { elements } => {
+                    elements.iter().any(|el| arg_matches_symbol(module, el, symbol))
+                }
+                _ => false,
+            }
+        }
+
+        fn inner_expr(node: &crate::ast::Node) -> &crate::ast::Node {
+            if let NodeKind::ExpressionStatement { expression } = &node.kind {
+                expression.as_ref()
+            } else {
+                node
+            }
+        }
+
         fn find(node: &crate::ast::Node, name: &str) -> Option<String> {
             match &node.kind {
                 NodeKind::Use { module, args, .. } => {
@@ -1162,6 +1216,41 @@ impl LspServer {
                     }
                 }
                 NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                    let required_modules: Vec<String> = statements
+                        .iter()
+                        .filter_map(|stmt| {
+                            let expr = inner_expr(stmt);
+                            if let NodeKind::FunctionCall { name, args } = &expr.kind {
+                                if name == "require" {
+                                    return args.first().and_then(normalize_require_module);
+                                }
+                            }
+                            None
+                        })
+                        .collect();
+
+                    for stmt in statements {
+                        let expr = inner_expr(stmt);
+                        if let NodeKind::MethodCall { object, method, args } = &expr.kind {
+                            if method != "import" {
+                                continue;
+                            }
+                            let NodeKind::Identifier { name: obj_name } = &object.kind else {
+                                continue;
+                            };
+                            if !required_modules.iter().any(|module| module == obj_name) {
+                                continue;
+                            }
+                            if args.is_empty() {
+                                return Some(obj_name.clone());
+                            }
+                            for arg in args {
+                                if arg_matches_symbol(obj_name, arg, name) {
+                                    return Some(obj_name.clone());
+                                }
+                            }
+                        }
+                    }
                     for stmt in statements {
                         if let Some(src) = find(stmt, name) {
                             return Some(src);
@@ -1713,6 +1802,7 @@ impl LspServer {
 mod tests {
     use super::normalize_document_link_file_path;
     use crate::LspServer;
+    use crate::Parser;
     use crate::state::ClientCapabilities;
     use serde_json::json;
     use std::collections::HashSet;
@@ -1862,5 +1952,41 @@ mod tests {
             normalize_document_link_file_path(r"\\server\share\Thing.pm"),
             "//server/share/Thing.pm"
         );
+    }
+
+    #[test]
+    fn find_import_source_supports_require_manual_import() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let server =
+            LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
+        let source = "require List::Util;\nList::Util->import('sum');\nmy $x = sum();\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+
+        let source_module = server.find_import_source(&ast, "sum");
+        assert_eq!(
+            source_module.as_deref(),
+            Some("List::Util"),
+            "sum should resolve through require+manual import"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn find_import_source_supports_require_default_import() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let server =
+            LspServer::with_io(Box::new(Cursor::new(Vec::<u8>::new())), Box::new(Vec::<u8>::new()));
+        let source = "require List::Util;\nList::Util->import();\nmy $x = sum();\n";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+
+        let source_module = server.find_import_source(&ast, "sum");
+        assert_eq!(
+            source_module.as_deref(),
+            Some("List::Util"),
+            "sum should resolve through require+default import"
+        );
+        Ok(())
     }
 }

--- a/crates/perl-semantic-analyzer/src/analysis/declaration.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/declaration.rs
@@ -1391,6 +1391,12 @@ pub fn symbol_at_cursor(ast: &Node, offset: usize, current_pkg: &str) -> Option<
             if obj_name != expected_module {
                 return false;
             }
+            if args.is_empty() {
+                // `Module->import()` requests the module default export set.
+                // Without a global export table we conservatively treat this
+                // as a potential import source for declaration lookup.
+                return true;
+            }
             // Walk the argument list looking for the symbol.
             for arg in args {
                 if arg_node_matches_symbol(arg, symbol) {

--- a/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
+++ b/crates/perl-semantic-analyzer/tests/require_import_resolution.rs
@@ -89,3 +89,17 @@ load_data();
         "load_data() should NOT resolve to My::Loader without explicit import call"
     );
 }
+
+#[test]
+fn require_import_default_list_resolves_pkg() {
+    let code = r#"require My::Loader;
+My::Loader->import();
+load_data();
+"#;
+    let pkg = parse_and_symbol_at(code, "load_data()");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("My::Loader"),
+        "load_data() should resolve to My::Loader via require+default import, got: {pkg:?}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Close the static-analysis gap for literal `require Module; Module->import(...)` patterns so navigation, completion, hover, and diagnostics all see the same import facts.
- Normalize `require 'Foo/Bar.pm'` file-path forms and support default `Module->import()` semantics to avoid false negatives and improve completion ranking.

### Description
- Extend the completion import-map extraction to detect `require` + `Module->import(...)` pairs in `Program` and `Block` statement lists and normalize quoted require paths into `Foo::Bar` forms by updating `crates/perl-lsp-completion/src/completion.rs`.
- Add parsing of method-call import arguments (string lists, `qw(...)`, `ArrayLiteral`, and known export tags) and merge those symbols into the completion `ImportMap` to promote imported items in completion results.
- Treat `Module->import()` (empty arg list) as a default-import signal in declaration resolution by updating `crates/perl-semantic-analyzer/src/analysis/declaration.rs` so go-to/resolve can use default exports as a fallback.
- Mirror the same `require` + manual-import and default-import detection in the LSP runtime import-source checks used for hover/diagnostic classification by updating `crates/perl-lsp/src/runtime/language/misc.rs` and add unit tests for the runtime path.
- Add completion and analyzer unit tests to validate `require`+manual imports, `qw`-style imports, and quoted require-path + tag imports in `crates/perl-lsp-completion/tests/import_map_tests.rs` and `crates/perl-semantic-analyzer/tests/require_import_resolution.rs`.

### Testing
- Ran `cargo fmt --all` with no formatting errors.
- Ran `cargo test -p perl-semantic-analyzer --test require_import_resolution` and all tests passed (`6` tests, all ok).
- Ran `cargo test -p perl-lsp-completion --test import_map_tests` and all tests passed (`12` tests, all ok).
- Ran the LSP runtime unit tests exercising `find_import_source` and the new cases and they passed (added tests for explicit and default manual import; tests ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd1e70d508333aca0fba5417c982c)