### PR TITLE
feat(completion): support require + Module->import visibility for ranking (#3476)

### DIFF
--- a/crates/perl-lsp-completion/src/completion.rs
+++ b/crates/perl-lsp-completion/src/completion.rs
@@ -124,13 +124,19 @@ use perl_workspace_index::workspace_index::WorkspaceIndex;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-/// Maps module_name -> Set of explicitly imported symbol names.
-///
-/// Semantics:
-/// - Entry MISSING: `use Module` with no args (import all of `@EXPORT`) — no filtering.
-/// - Entry with EMPTY set: `use Module qw()` (explicit empty qw import) — nothing in namespace.
-/// - Entry with non-empty set: `use Module qw(a b)` — only those symbols are imported.
-type ImportMap = HashMap<String, HashSet<String>>;
+/// Import visibility for a module in the current file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ImportVisibility {
+    /// All default exports are considered visible (e.g. `use Module;` or `Module->import()`).
+    All,
+    /// No imports are visible (e.g. `use Module qw()`).
+    ExplicitNone,
+    /// Only the listed symbols are visible.
+    Explicit(HashSet<String>),
+}
+
+/// Maps module_name -> import visibility in the current file.
+type ImportMap = HashMap<String, ImportVisibility>;
 
 const MOOSE_TYPE_CANDIDATES: &[&str] = &[
     "Any",
@@ -261,12 +267,46 @@ impl CompletionProvider {
         CompletionProvider { symbol_table, class_models, type_engine, workspace_index, import_map }
     }
 
-    /// Walk the top-level AST and build an `ImportMap` from `use` statements.
+    /// Walk the AST and build an `ImportMap` from `use` and
+    /// `require Module; Module->import(...)` statements.
     ///
     /// Only uppercase-starting module names are included (skips pragmas like
     /// `strict`, `warnings`, `feature`, `constant`, `utf8`, `lib`, `parent`, `base`).
     fn extract_import_map(ast: &Node) -> ImportMap {
         let mut map: ImportMap = HashMap::new();
+
+        fn merge_import_visibility(map: &mut ImportMap, module: &str, next: ImportVisibility) {
+            use std::collections::hash_map::Entry;
+            match map.entry(module.to_string()) {
+                Entry::Vacant(v) => {
+                    v.insert(next);
+                }
+                Entry::Occupied(mut o) => {
+                    let merged = match (o.get().clone(), next) {
+                        (ImportVisibility::All, _) | (_, ImportVisibility::All) => {
+                            ImportVisibility::All
+                        }
+                        (ImportVisibility::ExplicitNone, ImportVisibility::ExplicitNone) => {
+                            ImportVisibility::ExplicitNone
+                        }
+                        (ImportVisibility::ExplicitNone, ImportVisibility::Explicit(right)) => {
+                            ImportVisibility::Explicit(right)
+                        }
+                        (ImportVisibility::Explicit(left), ImportVisibility::ExplicitNone) => {
+                            ImportVisibility::Explicit(left)
+                        }
+                        (
+                            ImportVisibility::Explicit(mut left),
+                            ImportVisibility::Explicit(right),
+                        ) => {
+                            left.extend(right);
+                            ImportVisibility::Explicit(left)
+                        }
+                    };
+                    o.insert(merged);
+                }
+            }
+        }
 
         fn collect_import_symbols(
             module: &str,
@@ -334,6 +374,117 @@ impl CompletionProvider {
             (true, unresolved_tag)
         }
 
+        fn require_module_name(expr: &Node) -> Option<String> {
+            let args = match &expr.kind {
+                NodeKind::FunctionCall { name, args } if name == "require" => args,
+                _ => return None,
+            };
+            let arg = args.first()?;
+            match &arg.kind {
+                NodeKind::Identifier { name } => Some(name.clone()),
+                NodeKind::String { value, .. } => {
+                    Some(value.trim_end_matches(".pm").replace('/', "::"))
+                }
+                _ => None,
+            }
+        }
+
+        fn import_call(expr: &Node) -> Option<(String, &[Node])> {
+            match &expr.kind {
+                NodeKind::MethodCall { object, method, args } if method == "import" => {
+                    let NodeKind::Identifier { name } = &object.kind else {
+                        return None;
+                    };
+                    Some((name.clone(), args.as_slice()))
+                }
+                _ => None,
+            }
+        }
+
+        fn inner_expr(node: &Node) -> &Node {
+            if let NodeKind::ExpressionStatement { expression } = &node.kind {
+                expression.as_ref()
+            } else {
+                node
+            }
+        }
+
+        fn parse_import_args(module: &str, args: &[Node]) -> Option<ImportVisibility> {
+            if args.is_empty() {
+                return Some(ImportVisibility::All);
+            }
+
+            let mut symbols: HashSet<String> = HashSet::new();
+            let mut has_symbol_args = false;
+            let mut has_unresolved_tag = false;
+
+            for arg in args {
+                let token = match &arg.kind {
+                    NodeKind::String { value, .. } => value.clone(),
+                    NodeKind::Identifier { name } => name.clone(),
+                    NodeKind::ArrayLiteral { elements } => {
+                        for element in elements {
+                            let token = match &element.kind {
+                                NodeKind::String { value, .. } => value.as_str(),
+                                NodeKind::Identifier { name } => name.as_str(),
+                                _ => return None,
+                            };
+                            let (found, unresolved) =
+                                collect_import_symbols(module, token, &mut symbols);
+                            if found {
+                                has_symbol_args = true;
+                            }
+                            if unresolved {
+                                has_unresolved_tag = true;
+                            }
+                        }
+                        continue;
+                    }
+                    _ => return None,
+                };
+
+                let (found, unresolved) = collect_import_symbols(module, &token, &mut symbols);
+                if found {
+                    has_symbol_args = true;
+                }
+                if unresolved {
+                    has_unresolved_tag = true;
+                }
+            }
+
+            if has_unresolved_tag {
+                return None;
+            }
+
+            if has_symbol_args {
+                Some(ImportVisibility::Explicit(symbols))
+            } else {
+                Some(ImportVisibility::ExplicitNone)
+            }
+        }
+
+        fn collect_require_imports_from_statements(stmts: &[Node], map: &mut ImportMap) {
+            let required_modules: HashSet<String> =
+                stmts.iter().filter_map(|stmt| require_module_name(inner_expr(stmt))).collect();
+
+            if required_modules.is_empty() {
+                return;
+            }
+
+            for stmt in stmts {
+                let expr = inner_expr(stmt);
+                let Some((module, args)) = import_call(expr) else {
+                    continue;
+                };
+                if !required_modules.contains(&module) {
+                    continue;
+                }
+                if let Some(visibility) = parse_import_args(&module, args) {
+                    merge_import_visibility(map, &module, visibility);
+                }
+            }
+        }
+
         fn collect(node: &Node, map: &mut ImportMap) {
             match &node.kind {
                 NodeKind::Use { module, args, .. } => {
@@ -345,6 +496,7 @@ impl CompletionProvider {
 
                     // `use Module` with no args at all — import all of @EXPORT, no filtering
                     if args.is_empty() {
+                        merge_import_visibility(map, module, ImportVisibility::All);
                         return;
                     }
 
@@ -377,13 +529,14 @@ impl CompletionProvider {
                     }
 
                     if has_symbol_args {
-                        map.entry(module.clone()).or_default().extend(symbols);
+                        merge_import_visibility(map, module, ImportVisibility::Explicit(symbols));
                     } else {
                         // Explicit empty import: `use Module qw()`
-                        map.entry(module.clone()).or_default();
+                        merge_import_visibility(map, module, ImportVisibility::ExplicitNone);
                     }
                 }
                 NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                    collect_require_imports_from_statements(statements, map);
                     for stmt in statements {
                         collect(stmt, map);
                     }
@@ -1354,7 +1507,10 @@ impl CompletionProvider {
             }
         }
 
-        for (module_name, symbols) in &self.import_map {
+        for (module_name, visibility) in &self.import_map {
+            let ImportVisibility::Explicit(symbols) = visibility else {
+                continue;
+            };
             for symbol in symbols {
                 if !Self::looks_like_type_name(symbol) {
                     continue;

--- a/crates/perl-lsp-completion/src/completion/workspace.rs
+++ b/crates/perl-lsp-completion/src/completion/workspace.rs
@@ -5,7 +5,7 @@
 //! completion for `->` expressions, and general cross-file symbol completion.
 
 use super::{
-    auto_import,
+    ImportVisibility, auto_import,
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
@@ -25,7 +25,7 @@ pub fn add_workspace_symbol_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
-    import_map: &HashMap<String, HashSet<String>>,
+    import_map: &HashMap<String, ImportVisibility>,
 ) {
     // Only proceed if we have a workspace index
     let Some(index) = workspace_index else {
@@ -62,7 +62,7 @@ pub fn add_workspace_symbol_completions(
 
                 let (sort_prefix, detail) = match import_map.get(module) {
                     None => {
-                        // Module not in import_map: not used or `use Module` (import all).
+                        // Module not in import_map: no known import event for this module.
                         // Rank at tier 4 (after core builtins at tier 3).
                         let det = symbol
                             .container_name
@@ -70,12 +70,18 @@ pub fn add_workspace_symbol_completions(
                             .unwrap_or_else(|| "workspace".to_string());
                         ("4_", det)
                     }
-                    Some(imported_set) if imported_set.is_empty() => {
+                    Some(ImportVisibility::All) => {
+                        let det = format!("imported from {module}");
+                        ("2_", det)
+                    }
+                    Some(ImportVisibility::ExplicitNone) => {
                         // Explicit empty import `use Module qw()` — not in namespace.
                         // Rank at tier 5 (lowest, after all useful completions).
                         ("5_", "not imported".to_string())
                     }
-                    Some(imported_set) if imported_set.contains(&symbol.name) => {
+                    Some(ImportVisibility::Explicit(imported_set))
+                        if imported_set.contains(&symbol.name) =>
+                    {
                         // Symbol is explicitly imported — boost priority to tier 2
                         // (treated like a file-scope symbol).
                         let det = format!("imported from {module}");

--- a/crates/perl-lsp-completion/tests/import_map_tests.rs
+++ b/crates/perl-lsp-completion/tests/import_map_tests.rs
@@ -52,6 +52,21 @@ sub finddepth { }
     index
 }
 
+fn make_my_loader_index() -> Arc<WorkspaceIndex> {
+    let index = Arc::new(WorkspaceIndex::new());
+    let uri = must(Url::parse("file:///workspace/My/Loader.pm"));
+    let code = r#"package My::Loader;
+our @EXPORT = qw(load_data);
+our @EXPORT_OK = qw(process helper);
+sub load_data { }
+sub process { }
+sub helper { }
+1;
+"#;
+    must(index.index_file(uri, code.to_string()));
+    index
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: extract_import_map parses qw correctly
 // ---------------------------------------------------------------------------
@@ -240,6 +255,44 @@ fn workspace_completion_non_imported_stays_normal_priority() {
             max_item.sort_text
         );
     }
+}
+
+#[test]
+fn require_import_explicit_symbols_are_promoted() {
+    let source = "require My::Loader;\nMy::Loader->import('load_data', 'process');\nlo";
+    let index = make_my_loader_index();
+    let provider = parse_provider_with_index(source, index);
+    let items = provider.get_completions(source, source.len());
+
+    let load_item = must_some(
+        items
+            .iter()
+            .find(|i| i.label == "load_data" || i.insert_text.as_deref() == Some("load_data")),
+    );
+    assert!(
+        load_item.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")),
+        "load_data should be promoted for require+manual import; got: {:?}",
+        load_item.sort_text
+    );
+}
+
+#[test]
+fn require_import_default_import_promotes_exports() {
+    let source = "require My::Loader;\nMy::Loader->import();\nlo";
+    let index = make_my_loader_index();
+    let provider = parse_provider_with_index(source, index);
+    let items = provider.get_completions(source, source.len());
+
+    let load_item = must_some(
+        items
+            .iter()
+            .find(|i| i.label == "load_data" || i.insert_text.as_deref() == Some("load_data")),
+    );
+    assert!(
+        load_item.sort_text.as_deref().is_some_and(|s| s.starts_with("2_")),
+        "load_data should be promoted for require+import(); got: {:?}",
+        load_item.sort_text
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Implement the high-value completion side of #3476 by making manual `require` + `Module->import(...)` visible to completion ranking. 
- Distinguish `use Module;`, `use Module qw()`, and explicit imports so workspace completions can be promoted or downranked accurately.

### Description

- Introduce an `ImportVisibility` enum (`All`, `ExplicitNone`, `Explicit(...)`) and replace the raw `HashSet` import map with `ImportMap = HashMap<String, ImportVisibility>` to represent per-module visibility. 
- Extend `extract_import_map` to analyze both `use` statements and `require Module; Module->import(...)` patterns in AST statement lists, including literal string, `qw(...)`, and array-literal import forms, plus `Module->import()` mapped to `All`, and merge semantics across repeated import events. 
- Update workspace completion ranking to consult `ImportVisibility` so symbols from modules with `All` visibility (including `Module->import()`) are promoted, `ExplicitNone` remains downranked, and explicit-symbol imports are boosted. 
- Adjust imported-type completions to consume only explicit imported symbol sets under the new visibility model. 
- Add regression tests and a fixture module for `require + Module->import('sym', ...)` and `require + Module->import()` scenarios to verify promotion behavior.

### Testing

- Ran formatting: `cargo fmt --all` and it completed successfully. 
- Ran targeted tests: `cargo test -p perl-lsp-completion --test import_map_tests` and all tests passed (11 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd1e70d508333aca0fba5417c982c)