### PR TITLE
docs(readme): replace deprecated VS Marketplace badge (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
   <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/visual-studio-marketplace/i/EffortlessMetrics.perl-lsp-rs" alt="VSCode Marketplace Installs" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-180%20installs-2ea44f?labelColor=2c2c32" alt="VSCode Marketplace Installs (manually maintained)" /></a>
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs" alt="Open VSX Downloads" /></a>
 </p>
+
+<p align="center"><sub>VS Marketplace installs badge is manually maintained (last checked 2026-04-12 UTC) because Shields deprecated the Visual Studio Marketplace integration.</sub></p>
 
 ---
 

--- a/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
+++ b/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
@@ -221,7 +221,7 @@ Alternative if you want to capture VSCodium users:
 
 **Keywords hard cap is 5, not a soft suggestion.** The marketplace [documentation](https://code.visualstudio.com/api/references/extension-manifest) states: "Keywords to make it easier to find the extension. These are included with other extension Tags on the Marketplace. Limit to 5." The current 10-keyword list means the last 5 entries (`refactoring`, `code-completion`, `diagnostics`, `vscodium`, `open-vsx`) are silently dropped.
 
-**Shields.io badges work in README.** The four badges at the top of README.md use shields.io and will render correctly on both VS Marketplace (which uses `"markdown": "github"` rendering, already set) and Open VSX. They will show "not found" until the extension is actually published; that is expected and resolves automatically.
+**Do not use Shields' Visual Studio Marketplace badge route.** The endpoint for `img.shields.io/visual-studio-marketplace/...` was deprecated upstream and now returns "no longer available". Keep Marketplace badge text/images repo-maintained and link directly to the extension listing instead.
 
 **`"markdown": "github"` is already set** in package.json. This tells the marketplace to render README.md with GitHub-Flavored Markdown, which enables tables, checkboxes, and fenced code blocks. No action needed.
 


### PR DESCRIPTION
### Motivation

- Shields' `visual-studio-marketplace` badge route was deprecated upstream and can show "no longer available" even when the extension is live, which falsely suggests the extension was delisted.
- Remove runtime dependence on an undocumented, rate-limited endpoint and avoid the misleading UX by owning the Marketplace badge content in-repo.

### Description

- Replaced the deprecated `img.shields.io/visual-studio-marketplace/...` badge in `README.md` with a manually maintained static badge linking to the Marketplace listing using `img.shields.io/badge/VS%20Marketplace-180%20installs-2ea44f?labelColor=2c2c32`.
- Added a centered README note: `VS Marketplace installs badge is manually maintained (last checked 2026-04-12 UTC) because Shields deprecated the Visual Studio Marketplace integration.`
- Updated `docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md` to explicitly warn against using Shields' `visual-studio-marketplace` route and to recommend keeping Marketplace badge text/images repo-maintained.

### Testing

- Ran `cargo fmt --all --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfc15d1188333a1c9f73d1ed9a706)