### PR TITLE
docs(vscode): replace deprecated marketplace installs badge (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
   <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/visual-studio-marketplace/i/EffortlessMetrics.perl-lsp-rs" alt="VSCode Marketplace Installs" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="docs/assets/badges/vscode-marketplace-installs.svg" alt="VSCode Marketplace Installs (last checked 2026-04-12)" /></a>
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs" alt="Open VSX Downloads" /></a>
 </p>
+
+<p align="center"><sub>VS Marketplace installs badge is repo-maintained (last checked: 2026-04-12) because Shields deprecated live VS Marketplace install badges.</sub></p>
 
 ---
 

--- a/docs/assets/badges/vscode-marketplace-installs.svg
+++ b/docs/assets/badges/vscode-marketplace-installs.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="210" height="20" role="img" aria-label="VS Marketplace installs: 180">
+  <title>VS Marketplace installs: 180 (last checked 2026-04-12)</title>
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <rect rx="3" width="140" height="20" fill="#555"/>
+  <rect rx="3" x="140" width="70" height="20" fill="#007acc"/>
+  <path fill="#007acc" d="M140 0h4v20h-4z"/>
+  <rect rx="3" width="210" height="20" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text x="70" y="15" fill="#010101" fill-opacity=".3">VS Marketplace installs</text>
+    <text x="70" y="14">VS Marketplace installs</text>
+    <text x="175" y="15" fill="#010101" fill-opacity=".3">180</text>
+    <text x="175" y="14">180</text>
+  </g>
+</svg>

--- a/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
+++ b/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
@@ -221,7 +221,7 @@ Alternative if you want to capture VSCodium users:
 
 **Keywords hard cap is 5, not a soft suggestion.** The marketplace [documentation](https://code.visualstudio.com/api/references/extension-manifest) states: "Keywords to make it easier to find the extension. These are included with other extension Tags on the Marketplace. Limit to 5." The current 10-keyword list means the last 5 entries (`refactoring`, `code-completion`, `diagnostics`, `vscodium`, `open-vsx`) are silently dropped.
 
-**Shields.io badges work in README.** The four badges at the top of README.md use shields.io and will render correctly on both VS Marketplace (which uses `"markdown": "github"` rendering, already set) and Open VSX. They will show "not found" until the extension is actually published; that is expected and resolves automatically.
+**Do not use Shields for VS Marketplace install counts.** Shields deprecated the live VS Marketplace install badge route; use the repo-owned static badge (`docs/assets/badges/vscode-marketplace-installs.svg`) and update it manually from publisher metrics when needed. Other Shields badges in README remain fine.
 
 **`"markdown": "github"` is already set** in package.json. This tells the marketplace to render README.md with GitHub-Flavored Markdown, which enables tables, checkboxes, and fenced code blocks. No action needed.
 


### PR DESCRIPTION
### Motivation
- Shields deprecated the live Visual Studio Marketplace install badge route which produced misleading “no longer available” images for an otherwise live extension, so the repo should stop depending on that external, undocumented endpoint.
- The install count should be owned by the repository to avoid flaky third-party badge failures and to allow a clear last-checked timestamp for the metric.

### Description
- Replaced the Shields VS Marketplace badge in `README.md` with a repo-owned static SVG at `docs/assets/badges/vscode-marketplace-installs.svg` and left the badge linked to the Marketplace listing via `https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs`.
- Added a short explanatory footnote under the badges in `README.md` explaining the badge is repo-maintained and showing the last-checked date (`2026-04-12`).
- Added the static SVG asset `docs/assets/badges/vscode-marketplace-installs.svg` (shows `180` installs, last checked `2026-04-12`).
- Updated `docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md` to warn maintainers not to use Shields for VS Marketplace install counts and to point them to the repo-owned badge workflow.

### Testing
- Ran `cargo fmt --all --check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfc15d1188333a1c9f73d1ed9a706)