### PR TITLE
docs(vscode): replace deprecated VS Marketplace badges with static equivalents (#4329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
   <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/visual-studio-marketplace/i/EffortlessMetrics.perl-lsp-rs" alt="VSCode Marketplace Installs" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-180%20installs-0078D4" alt="VSCode Marketplace Installs (manual)" /></a>
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs" alt="Open VSX Downloads" /></a>
 </p>
+
+<p align="center"><sub>VS Marketplace installs badge is manually maintained (last checked: 2026-04-12) because Shields deprecated the Visual Studio Marketplace integration.</sub></p>
 
 ---
 

--- a/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
+++ b/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
@@ -221,7 +221,7 @@ Alternative if you want to capture VSCodium users:
 
 **Keywords hard cap is 5, not a soft suggestion.** The marketplace [documentation](https://code.visualstudio.com/api/references/extension-manifest) states: "Keywords to make it easier to find the extension. These are included with other extension Tags on the Marketplace. Limit to 5." The current 10-keyword list means the last 5 entries (`refactoring`, `code-completion`, `diagnostics`, `vscodium`, `open-vsx`) are silently dropped.
 
-**Shields.io badges work in README.** The four badges at the top of README.md use shields.io and will render correctly on both VS Marketplace (which uses `"markdown": "github"` rendering, already set) and Open VSX. They will show "not found" until the extension is actually published; that is expected and resolves automatically.
+**Do not use Shields for VS Marketplace install counts.** Shields deprecated the live `visual-studio-marketplace` badge route; the repo now uses manually maintained static badges (`img.shields.io/badge/...`) for VS Marketplace install counts in both `README.md` and `vscode-extension/README.md`. Update the count and last-checked date from publisher metrics after each release. Other Shields badges (crates.io, Open VSX, etc.) remain fine.
 
 **`"markdown": "github"` is already set** in package.json. This tells the marketplace to render README.md with GitHub-Flavored Markdown, which enables tables, checkboxes, and fenced code blocks. No action needed.
 

--- a/vscode-extension/PUBLISHING.md
+++ b/vscode-extension/PUBLISHING.md
@@ -126,6 +126,9 @@ vsce publish 0.5.1  # Specific version
 
 2. **Update Documentation**
    - Update main README.md with marketplace link
+   - Refresh the manually maintained VS Marketplace installs badge count/date in:
+     - `/README.md`
+     - `/vscode-extension/README.md`
    - Add installation instructions
    - Update CHANGELOG.md
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,9 +1,11 @@
 # Perl Language Server
 
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/EffortlessMetrics.perl-lsp-rs?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
-[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/EffortlessMetrics.perl-lsp-rs)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![Visual Studio Marketplace](https://img.shields.io/badge/VS%20Marketplace-live%20listing-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-180%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
+
+> VS Marketplace installs are manually maintained (last checked: 2026-04-12) because Shields deprecated Visual Studio Marketplace badge support.
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 


### PR DESCRIPTION
## Summary

- Replace all deprecated Shields `visual-studio-marketplace` badge URLs in `README.md` and `vscode-extension/README.md` with manually maintained static badge URLs (`img.shields.io/badge/...`)
- Add maintenance notes in both READMEs explaining the badge is manually maintained and showing the last-checked date
- Update `vscode-extension/PUBLISHING.md` to remind maintainers to refresh the badge count after each release
- Update `docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md` to warn against using the deprecated Shields route

Shields deprecated the `visual-studio-marketplace` integration, causing badges to show "no longer available" even for live extensions. This PR replaces all occurrences across the repo with static equivalents and adds process guardrails to keep them current.

Consolidated from Codex ensemble: best approach from #4327 (most complete file coverage) with punch list update from #4325/#4326.

## Test plan

- [ ] Verify no `img.shields.io/visual-studio-marketplace` URLs remain in the repo
- [ ] Verify README.md badge renders correctly on GitHub
- [ ] Verify vscode-extension/README.md badges render correctly on GitHub