### PR TITLE
test(ux): add absolute includePaths @INC conformance mode (#4067)

### DIFF
--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -11,6 +11,7 @@
 //! | Test function | Mode | Expected outcome |
 //! |---|---|---|
 //! | `scenario_14_relative_include_path` | `includePaths: ["lib"]` config | resolves |
+//! | `scenario_14_absolute_include_path` | `includePaths: ["/abs/path/to/lib"]` config | resolves |
 //! | `scenario_14_use_lib_lexical` | in-source `use lib 'lib'` | resolves |
 //! | `scenario_14_no_lib_cancellation` | `use lib` then `no lib` | NOT resolved |
 //! | `scenario_14_findbin_relative` | `use FindBin; use lib "$FindBin::Bin/lib"` | resolves |
@@ -76,6 +77,29 @@ fn send_include_paths(harness: &UxHarness, paths: &[&str]) {
         )
         .expect("didChangeConfiguration should not fail");
     // Allow the server to process the configuration change.
+    std::thread::sleep(Duration::from_millis(200));
+}
+
+/// Configure the server to use `includePaths` via workspace/didChangeConfiguration.
+fn send_include_paths_owned(harness: &UxHarness, paths: Vec<String>) {
+    let paths_json: Vec<serde_json::Value> =
+        paths.into_iter().map(serde_json::Value::String).collect();
+    harness
+        .client
+        .notify(
+            "workspace/didChangeConfiguration",
+            json!({
+                "settings": {
+                    "perl": {
+                        "workspace": {
+                            "includePaths": paths_json,
+                            "useSystemInc": false
+                        }
+                    }
+                }
+            }),
+        )
+        .expect("didChangeConfiguration should not fail");
     std::thread::sleep(Duration::from_millis(200));
 }
 
@@ -202,6 +226,70 @@ fn scenario_14_relative_include_path() {
     );
 
     // Hover result shape check (if non-null).
+    if let Some(hover) = hover_result {
+        assert!(
+            hover.get("contents").is_some(),
+            "Hover result must have 'contents' field: {:?}",
+            hover
+        );
+    }
+
+    harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_14_absolute_include_path() {
+    if !binary_available() {
+        eprintln!("SKIP scenario_14_absolute_include_path: perl-lsp binary not found");
+        return;
+    }
+
+    let harness = UxHarness::new(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .with_file("fixture.pl", RELATIVE_INCLUDE_SOURCE)
+            .with_file("lib/GreetModule.pm", RELATIVE_INCLUDE_MODULE),
+    )
+    .expect("Failed to create UX harness");
+
+    let abs_lib_path = harness.workspace.path("lib").to_string_lossy().into_owned();
+    send_include_paths_owned(&harness, vec![abs_lib_path]);
+
+    harness.open_file("fixture.pl", RELATIVE_INCLUDE_SOURCE).expect("didOpen should succeed");
+    std::thread::sleep(Duration::from_millis(500));
+
+    let diags = wait_diagnostics(&harness, "fixture.pl");
+    let pl701_absent = !has_pl701(&diags);
+
+    let defs = harness.definition("fixture.pl", 2, 4).expect("definition must not error");
+    let def_resolves = !defs.is_empty();
+
+    let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
+    let hover_ok = true;
+
+    print_conformance("absolute_include_path", pl701_absent, def_resolves, hover_ok);
+
+    if def_resolves && !pl701_absent {
+        panic!(
+            "Consumer inconsistency (absolute_include_path): goto-def resolved but PL701 fired.\n\
+             goto-def: {:?}\n\
+             diagnostics: {:?}",
+            defs, diags
+        );
+    }
+
+    assert!(
+        def_resolves,
+        "Expected goto-definition to resolve GreetModule via absolute includePaths.\n\
+         diagnostics: {:?}",
+        diags
+    );
+    assert!(
+        pl701_absent,
+        "Expected no PL701 for GreetModule when absolute includePaths is configured.\n\
+         diagnostics: {:?}",
+        diags
+    );
+
     if let Some(hover) = hover_result {
         assert!(
             hover.get("contents").is_some(),

--- a/docs/project/status/module_resolution.md
+++ b/docs/project/status/module_resolution.md
@@ -13,6 +13,7 @@ A `+` means the consumer produced the expected answer (resolved or not-resolved 
 | Resolution Mode | PL701 diagnostic | goto-definition | hover | Notes |
 |---|---|---|---|---|
 | Workspace `includePaths` | + | + | + | Config-driven: `includePaths: ["lib"]` |
+| Absolute `includePaths` root | + | + | + | Config-driven absolute path to `lib` |
 | Lexical `use lib` | + | + | + | In-source pragma extraction |
 | `no lib` cancellation | + | + | + | Position-aware negative case |
 | FindBin-relative | + | + | + | `$FindBin::Bin/lib` pattern |
@@ -32,6 +33,12 @@ Configured via `workspace/didChangeConfiguration`:
 ```
 
 Module lives at `lib/Module.pm` relative to the workspace root.
+
+### Absolute `includePaths` root
+
+Configured via `workspace/didChangeConfiguration` using an absolute filesystem
+path to the workspace-local `lib` directory. This validates that resolution
+does not depend on relative-path normalization only.
 
 ### Lexical `use lib`
 
@@ -67,7 +74,6 @@ environment variable. Requires `usePerl5lib: true` in workspace config.
 
 ## Follow-up Scope (PR 2)
 
-- `inc_absolute_include_path` — absolute path in `includePaths` config
 - `inc_perl5lib_env` — PERL5LIB separate from system @INC flag
 - `inc_nested_use_lib` — `use lib` inside `BEGIN` block
 - `inc_qw_use_lib` — `use lib qw(lib t/lib)` multi-path form

--- a/docs/reference/UX_TESTING.md
+++ b/docs/reference/UX_TESTING.md
@@ -42,7 +42,7 @@ either a prebuilt binary or an explicit `PERL_LSP_BIN=/path/to/perl-lsp`.
 | 11 | Hover | Request succeeds end-to-end and returns useful structure-or-empty without crashing |
 | 12 | Strict diagnostics | `publishDiagnostics` arrives and the payload shape stays valid |
 | 13 | Document symbols | Parsable files return structured document symbols |
-| 14 | `@INC` conformance | PL701, hover, and goto-definition stay consistent across 5 module-resolution modes |
+| 14 | `@INC` conformance | PL701, hover, and goto-definition stay consistent across 6 module-resolution modes |
 | 15 | Workspace symbols | `workspace/symbol` finds same-named symbols across workspace folders and carries `workspaceFolderUri` |
 | 16 | Folder removal | removing a workspace folder evicts its symbols from `workspace/symbol` results |
 | 17 | Deleted file churn | a `didChangeWatchedFiles` Deleted event removes stale symbols and definition targets |


### PR DESCRIPTION
### Motivation

- Ensure the `@INC` conformance matrix (consumer-consistency harness) covers absolute `includePaths` roots as required by the module-resolution scorecard in #4067. 
- Allow UX scenarios to pass runtime-generated absolute paths via configuration so tests exercise real-world absolute-path configurations.

### Description

- Add `scenario_14_absolute_include_path` to `crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs` to validate absolute `includePaths` resolution across PL701 diagnostics, goto-definition, and hover. 
- Add helper `send_include_paths_owned` to send owned `includePaths` values (vector of `String`) for runtime absolute paths. 
- Update `docs/project/status/module_resolution.md` to add an "Absolute `includePaths` root" row and document the mode in the resolution details. 
- Update `docs/reference/UX_TESTING.md` to reflect Scenario 14 now covers 6 module-resolution modes and remove the absolute-path item from the follow-up scope.

### Testing

- Ran `cargo fmt --all` successfully to format changes. 
- Ran `cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance` which executed 6 tests and returned `ok` for all tests (`6 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc24410a0c83339f46f81c80984fd5)