### PR TITLE
docs: add release history surface with backfilled ledger (#4339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,7 +474,7 @@ Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://g
 - **Unused dev-dependencies removed** from 5 crates. (#4183, #4255)
 
 
-## [0.12.3] - 2026-04-08
+## [0.12.3] - 2026-04-09
 
 Release notes: [v0.12.3](docs/releases/v0.12.3.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3)
 
@@ -770,7 +770,7 @@ v0.12.2 publish run and post-publish testing:
 - **UX test harness framework** (#3297): systematic framework for UX regression
   tests with helpers for LSP, DAP, and extension surface validation.
 
-## [0.12.2] - 2026-04-08
+## [0.12.2] - 2026-04-04
 
 Release notes: [v0.12.2](docs/releases/v0.12.2.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2)
 
@@ -925,7 +925,7 @@ the remaining 21 (including `tree-sitter-perl-c`, `tree-sitter-perl-rs`,
   (#3284)
 - **test de-flake**: `empty_timer_reports_total` race condition fixed (#3278)
 
-## [0.12.1] - 2026-03-30
+## [0.12.1] - 2026-03-31
 
 Release notes: [v0.12.1](docs/releases/v0.12.1.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1)
 
@@ -951,7 +951,7 @@ aligned.
 - status and roadmap docs now treat `v0.12.0` as the latest published GitHub
   release and `v0.12.1` as the active fix-forward cut
 
-## [0.12.0] - 2026-03-24
+## [0.12.0] - 2026-03-30
 
 Release notes: [v0.12.0](docs/releases/v0.12.0.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0)
 
@@ -1039,6 +1039,8 @@ repeatable release flow.
 
 ## [0.10.0] - 2026-02-28
 
+Release notes: [v0.10.0](docs/releases/v0.10.0.md) (internal milestone — no GitHub Release)
+
 A major release campaign spanning 60+ PRs (#845-#911) focused on build reliability,
 security hardening, crates.io publishing readiness, documentation, and code quality.
 
@@ -1116,6 +1118,8 @@ security hardening, crates.io publishing readiness, documentation, and code qual
 
 ## [0.9.1] - 2026-02-20
 
+Release notes: [v0.9.1](docs/releases/v0.9.1.md) (tag only — no GitHub Release)
+
 ### Added
 - **Initial Public Alpha Release**: Substantially complete feature set for early testing.
 - **Enhanced LSP Features**: 99% coverage of LSP 3.18 methods (alpha-validated).
@@ -1139,6 +1143,8 @@ security hardening, crates.io publishing readiness, documentation, and code qual
 
 ## [0.9.0] - 2026-01-18
 
+Release notes: [v0.9.0](docs/releases/v0.9.0.md) (internal milestone — no tag or GitHub Release)
+
 ### Added
 - **Semantic Analyzer Phase 1**: 12/12 critical node handlers implemented.
 - **LSP textDocument/definition Integration**: Semantic-aware definition resolution.
@@ -1148,6 +1154,8 @@ security hardening, crates.io publishing readiness, documentation, and code qual
 - **LSP Coverage**: Increased to 82% of trackable features.
 
 ## [0.8.8] - 2025-12-01
+
+Release notes: [v0.8.8](docs/releases/v0.8.8.md) (internal milestone — no tag or GitHub Release)
 
 ### Added
 - **Initial Workspace Configuration Support**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.4] - 2026-04-12
 
+Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4)
+
 <!-- 2026-04-11 session: 46 PRs merged across navigation, pragma scoping, incremental parsing, workspace refactoring, Windows hardening, and CI hygiene -->
 <!-- 2026-04-12 session: ~25 PRs merged — DAP scorecard, rename perf, editor UX, diagnostics polish, hover improvements, workspace/config, completion ranking, Windows compat, CI hygiene -->
 
@@ -474,6 +476,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.3] - 2026-04-08
 
+Release notes: [v0.12.3](docs/releases/v0.12.3.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3)
+
 <!-- Pipeline rehearsal release — validates the full publish + extension + Docker cycle before v0.13.0 public alpha -->
 <!-- Rolls up publish pipeline fixes, UX P0 improvements, and CI hardening from Waves 10/11/12 -->
 
@@ -768,6 +772,8 @@ v0.12.2 publish run and post-publish testing:
 
 ## [0.12.2] - 2026-04-08
 
+Release notes: [v0.12.2](docs/releases/v0.12.2.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2)
+
 `v0.12.2` is the confidence-building release for the 0.12.x series. 89 commits
 across 59 PRs spanning new features, performance, testing, distribution, and
 documentation. The entire 0.12.x roadmap from v0.12.2 through v0.12.8 milestones
@@ -921,6 +927,8 @@ the remaining 21 (including `tree-sitter-perl-c`, `tree-sitter-perl-rs`,
 
 ## [0.12.1] - 2026-03-30
 
+Release notes: [v0.12.1](docs/releases/v0.12.1.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1)
+
 `v0.12.1` is the fix-forward cut after the initial public alpha release. It does
 not reopen the wider alpha scope; it closes the release-surface regressions that
 slipped into the first `v0.12.0` tag and keeps the install and publish story
@@ -944,6 +952,8 @@ aligned.
   release and `v0.12.1` as the active fix-forward cut
 
 ## [0.12.0] - 2026-03-24
+
+Release notes: [v0.12.0](docs/releases/v0.12.0.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0)
 
 `v0.12.0` is the initial public alpha for the native Rust Perl 5 toolchain. The
 headline change is not one feature in isolation; it is that the parser, language
@@ -993,6 +1003,8 @@ for normal editor use.
 For the detailed receipts behind this release, see [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) and [docs/project/status/index.md](docs/project/status/index.md).
 
 ## [0.11.0] - 2026-03-12
+
+Release notes: [v0.11.0](docs/releases/v0.11.0.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0)
 
 This release finalizes the 0.11.0 distribution pipeline across GitHub releases,
 crates.io, and the VS Code extension so the workspace can ship from a single,
@@ -1162,3 +1174,22 @@ During the alpha phase (pre-v0.15.0):
 - **Current Alpha (0.x.y)**: Active development and bug fixes.
 - **Breaking Changes**: Allowed in minor (0.x) releases.
 - **Security**: Critical patches prioritized for the latest alpha version.
+
+---
+
+## Links
+
+For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HISTORY.md).
+
+<!-- Compare ranges -->
+[0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
+[0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
+[0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2
+[0.12.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.11.0
+[0.10.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.1
+[0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
+[0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...HEAD

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ See [docs/README.md](docs/README.md) for the full crate map and design notes.
 | Troubleshooting | [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md) |
 | Current status and metrics | [docs/project/status/index.md](docs/project/status/index.md) |
 | Release roadmap | [docs/project/ROADMAP.md](docs/project/ROADMAP.md) |
+| Release history | [RELEASE_HISTORY.md](RELEASE_HISTORY.md) |
 | Full docs index | [docs/INDEX.md](docs/INDEX.md) |
 
 ## Contributing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -421,3 +421,49 @@ gh workflow run version-bump.yml \
 ```
 
 This creates a `release/vNEW_VERSION` branch with updated `Cargo.toml` and `CHANGELOG.md`, then opens a PR for review.
+
+---
+
+## Release History Updates
+
+Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RELEASE_HISTORY.md) for the canonical ledger.
+
+### Before publishing
+
+- [ ] Create `docs/releases/vX.Y.Z.md` (use an existing file as template)
+- [ ] Add a new row to `RELEASE_HISTORY.md` for vX.Y.Z (fill what you know; mark unknowns with `—`)
+- [ ] Ensure `CHANGELOG.md` has a `[X.Y.Z]` section with links to:
+  - `docs/releases/vX.Y.Z.md`
+  - GitHub Release URL
+  - Compare range `vPrev...vX.Y.Z`
+
+### After publishing
+
+- [ ] Capture GitHub Release metadata:
+  ```bash
+  gh release view vX.Y.Z --json tagName,publishedAt,url,body,assets,targetCommitish
+  ```
+- [ ] Update `docs/releases/vX.Y.Z.md` front-matter with:
+  - `release_date_utc` (from `publishedAt`)
+  - `tag_commit` (resolve tag to commit SHA)
+  - Actual asset list
+- [ ] Update `RELEASE_HISTORY.md` row with:
+  - Asset count and summary
+  - Channel outcomes (crates.io, VS Code Marketplace, Open VSX, Docker)
+
+### Verification
+
+```bash
+# Release-history surface consistency check
+# 1. Notes file exists
+test -f docs/releases/vX.Y.Z.md
+
+# 2. Ledger row exists
+grep 'X.Y.Z' RELEASE_HISTORY.md
+
+# 3. CHANGELOG section exists
+grep '\[X.Y.Z\]' CHANGELOG.md
+
+# 4. GitHub Release matches
+gh release view vX.Y.Z --json tagName,assets --jq '{tag: .tagName, assets: [.assets[].name]}'
+```

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -20,10 +20,10 @@ Tag commit timestamps may differ from release dates.
 | [0.12.1] | `v0.12.1` | [yes][gh-0.12.1] | 2026-03-31 | `7e8984b5` | [v0.12.0...v0.12.1] | 10 (+ VSIX) | 0.12.1 (2026-04-01) | [perl-lsp-rs][vsce] | [v0.12.1][n-0.12.1] |
 | [0.12.0] | `v0.12.0` | [yes][gh-0.12.0] | 2026-03-30 | `4c909c2d` | [v0.11.0...v0.12.0] | 10 (+ VSIX) | — | [perl-lsp-rs][vsce] | [v0.12.0][n-0.12.0] |
 | [0.11.0] | `v0.11.0` | [yes][gh-0.11.0] | 2026-03-12 | `d22ac734` | [v0.8.5...v0.11.0] | 11 (+ 2 VSIX) | — | [perl-lsp-rs][vsce] | [v0.11.0][n-0.11.0] |
-| 0.10.0 | — | — | 2026-02-28 (CL) | — | — | — | — | — | — |
+| [0.10.0] | — | — | 2026-02-28 (CL) | — | — | — | — | — | [v0.10.0][n-0.10.0] |
 | [0.9.1] | `v0.9.1` | — | 2026-02-20 (tag) | `c82a1604` | — | — | — | — | [v0.9.1][n-0.9.1] |
-| 0.9.0 | — | — | 2026-01-18 (CL) | — | — | — | — | — | — |
-| 0.8.8 | — | — | 2025-12-01 (CL) | — | — | — | — | — | — |
+| [0.9.0] | — | — | 2026-01-18 (CL) | — | — | — | — | — | [v0.9.0][n-0.9.0] |
+| [0.8.8] | — | — | 2025-12-01 (CL) | — | — | — | — | — | [v0.8.8][n-0.8.8] |
 | [0.8.5] | `v0.8.5` | [yes][gh-0.8.5] | 2025-08-24 | `ae75da03` | [v0.8.3...v0.8.5] | 2 (linux-x64 + checksum) | — | — | [v0.8.5][n-0.8.5] |
 | 0.8.3-rc1 | `v0.8.3-rc1` | — | 2025-08-15 (tag) | `150a22b1` | — | — | — | — | — |
 | [0.8.3] | `v0.8.3` | [yes][gh-0.8.3] | 2025-08-23 | `5331007a` | — | 0 (source-only) | — | — | [v0.8.3][n-0.8.3] |
@@ -61,7 +61,10 @@ Tag commit timestamps may differ from release dates.
 [n-0.12.1]: docs/releases/v0.12.1.md
 [n-0.12.0]: docs/releases/v0.12.0.md
 [n-0.11.0]: docs/releases/v0.11.0.md
+[n-0.10.0]: docs/releases/v0.10.0.md
 [n-0.9.1]: docs/releases/v0.9.1.md
+[n-0.9.0]: docs/releases/v0.9.0.md
+[n-0.8.8]: docs/releases/v0.8.8.md
 [n-0.8.5]: docs/releases/v0.8.5.md
 [n-0.8.3]: docs/releases/v0.8.3.md
 
@@ -72,7 +75,10 @@ Tag commit timestamps may differ from release dates.
 [0.12.1]: docs/releases/v0.12.1.md
 [0.12.0]: docs/releases/v0.12.0.md
 [0.11.0]: docs/releases/v0.11.0.md
+[0.10.0]: docs/releases/v0.10.0.md
 [0.9.1]: docs/releases/v0.9.1.md
+[0.9.0]: docs/releases/v0.9.0.md
+[0.8.8]: docs/releases/v0.8.8.md
 [0.8.5]: docs/releases/v0.8.5.md
 [0.8.3]: docs/releases/v0.8.3.md
 

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -1,0 +1,99 @@
+# Release History
+
+Canonical release ledger for [perl-lsp](https://github.com/EffortlessMetrics/perl-lsp).
+
+This file is:
+- **Backwards-looking** — records what shipped, not what is planned
+- **Append-only** — rows are not rewritten; corrections are additive with notes
+- **Cross-channel** — tracks GitHub assets, crates.io, editor marketplaces, and containers
+
+GitHub Release `publishedAt` is used as the release date when available.
+Tag commit timestamps may differ from release dates.
+
+## Release ledger
+
+| Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
+|---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.12.4] | `v0.12.4` | [yes][gh-0.12.4] | 2026-04-12 | `5ebb37aa` | [v0.12.3...v0.12.4] | 9 (7 binaries, SHA256SUMS, SBOM) | deferred | [perl-lsp-rs][vsce] | [v0.12.4][n-0.12.4] |
+| [0.12.3] | `v0.12.3` | [yes][gh-0.12.3] | 2026-04-09 | `a86af221` | [v0.12.2...v0.12.3] | 10 (+ VSIX) | deferred | [perl-lsp-rs][vsce] | [v0.12.3][n-0.12.3] |
+| [0.12.2] | `v0.12.2` | [yes][gh-0.12.2] | 2026-04-04 | `1c0620d8` | [v0.12.1...v0.12.2] | 9 | 0.12.2 (2026-04-08) | [perl-lsp-rs][vsce] | [v0.12.2][n-0.12.2] |
+| [0.12.1] | `v0.12.1` | [yes][gh-0.12.1] | 2026-03-31 | `7e8984b5` | [v0.12.0...v0.12.1] | 10 (+ VSIX) | 0.12.1 (2026-04-01) | [perl-lsp-rs][vsce] | [v0.12.1][n-0.12.1] |
+| [0.12.0] | `v0.12.0` | [yes][gh-0.12.0] | 2026-03-30 | `4c909c2d` | [v0.11.0...v0.12.0] | 10 (+ VSIX) | — | [perl-lsp-rs][vsce] | [v0.12.0][n-0.12.0] |
+| [0.11.0] | `v0.11.0` | [yes][gh-0.11.0] | 2026-03-12 | `d22ac734` | [v0.8.5...v0.11.0] | 11 (+ 2 VSIX) | — | [perl-lsp-rs][vsce] | [v0.11.0][n-0.11.0] |
+| 0.10.0 | — | — | 2026-02-28 (CL) | — | — | — | — | — | — |
+| [0.9.1] | `v0.9.1` | — | 2026-02-20 (tag) | `c82a1604` | — | — | — | — | [v0.9.1][n-0.9.1] |
+| 0.9.0 | — | — | 2026-01-18 (CL) | — | — | — | — | — | — |
+| 0.8.8 | — | — | 2025-12-01 (CL) | — | — | — | — | — | — |
+| [0.8.5] | `v0.8.5` | [yes][gh-0.8.5] | 2025-08-24 | `ae75da03` | [v0.8.3...v0.8.5] | 2 (linux-x64 + checksum) | — | — | [v0.8.5][n-0.8.5] |
+| 0.8.3-rc1 | `v0.8.3-rc1` | — | 2025-08-15 (tag) | `150a22b1` | — | — | — | — | — |
+| [0.8.3] | `v0.8.3` | [yes][gh-0.8.3] | 2025-08-23 | `5331007a` | — | 0 (source-only) | — | — | [v0.8.3][n-0.8.3] |
+| 0.8.2 | `v0.8.2` | — | 2025-08-12 (tag) | `0b962684` | — | — | — | — | — |
+| 0.8.0 | `v0.8.0` | — | 2025-08-11 (tag) | `2eeb06c5` | — | — | — | — | — |
+| 0.7.3 | `v0.7.3` | — | 2025-08-06 (tag) | `20751374` | — | — | — | — | — |
+| 0.7.2 | `v0.7.2` | — | 2025-08-06 (tag) | `a19ba90b` | — | — | — | — | — |
+| 0.5.0 | `v0.5.0` | — | 2025-08-03 (tag) | `60190640` | — | — | — | — | — |
+| 0.1.0-pest | `v0.1.0-pest` | — | 2025-07-20 (tag) | `4f92dc57` | — | — | — | — | — |
+
+### Legend
+
+- **"—"** = does not exist / not applicable
+- **"deferred"** = release published to GitHub but crates.io publish intentionally postponed
+- **"(CL)"** = date from CHANGELOG only (no tag or release exists)
+- **"(tag)"** = date from tag commit (no GitHub Release exists)
+- Versions without a tag or GitHub Release are CHANGELOG-only scope markers that never shipped as distinct artifacts
+- The v0.11.0 release included two VSIX files (`perl-lsp-0.11.0.vsix` and `perl-lsp-rs-0.11.0.vsix`) due to the extension rename
+
+### Eras
+
+| Era | Versions | Period | Focus |
+|-----|----------|--------|-------|
+| **Pest parser** | 0.1.0-pest — 0.5.0 | Jul — Aug 2025 | PEG grammar, initial AST |
+| **Native parser + LSP** | 0.7.x — 0.8.x | Aug 2025 | Recursive descent parser, first LSP features, first public releases |
+| **Feature buildout** | 0.9.x — 0.10.0 | Jan — Feb 2026 | Semantic analyzer, DAP, release orchestration |
+| **Public alpha** | 0.11.0 — 0.12.x | Mar — Apr 2026 | Multi-platform binaries, VS Code Marketplace, crates.io |
+
+## Links
+
+<!-- Notes files -->
+[n-0.12.4]: docs/releases/v0.12.4.md
+[n-0.12.3]: docs/releases/v0.12.3.md
+[n-0.12.2]: docs/releases/v0.12.2.md
+[n-0.12.1]: docs/releases/v0.12.1.md
+[n-0.12.0]: docs/releases/v0.12.0.md
+[n-0.11.0]: docs/releases/v0.11.0.md
+[n-0.9.1]: docs/releases/v0.9.1.md
+[n-0.8.5]: docs/releases/v0.8.5.md
+[n-0.8.3]: docs/releases/v0.8.3.md
+
+<!-- Version links (to notes files) -->
+[0.12.4]: docs/releases/v0.12.4.md
+[0.12.3]: docs/releases/v0.12.3.md
+[0.12.2]: docs/releases/v0.12.2.md
+[0.12.1]: docs/releases/v0.12.1.md
+[0.12.0]: docs/releases/v0.12.0.md
+[0.11.0]: docs/releases/v0.11.0.md
+[0.9.1]: docs/releases/v0.9.1.md
+[0.8.5]: docs/releases/v0.8.5.md
+[0.8.3]: docs/releases/v0.8.3.md
+
+<!-- GitHub Releases -->
+[gh-0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4
+[gh-0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3
+[gh-0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2
+[gh-0.12.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1
+[gh-0.12.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0
+[gh-0.11.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0
+[gh-0.8.5]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.5
+[gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
+
+<!-- Compare ranges -->
+[v0.12.3...v0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
+[v0.12.2...v0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
+[v0.12.1...v0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2
+[v0.12.0...v0.12.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.0...v0.12.1
+[v0.11.0...v0.12.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.11.0...v0.12.0
+[v0.8.5...v0.11.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.11.0
+[v0.8.3...v0.8.5]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.3...v0.8.5
+
+<!-- Channels -->
+[vsce]: https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -50,7 +50,7 @@ Tag commit timestamps may differ from release dates.
 | **Pest parser** | 0.1.0-pest — 0.5.0 | Jul — Aug 2025 | PEG grammar, initial AST |
 | **Native parser + LSP** | 0.7.x — 0.8.x | Aug 2025 | Recursive descent parser, first LSP features, first public releases |
 | **Feature buildout** | 0.9.x — 0.10.0 | Jan — Feb 2026 | Semantic analyzer, DAP, release orchestration |
-| **Announcement prep** | 0.11.0 — 0.12.x | Mar — Apr 2026 | Multi-platform binaries, VS Code Marketplace, crates.io |
+| **Platform availability** | 0.11.0 — 0.12.x | Mar — Apr 2026 | Multi-platform binaries, VS Code Marketplace, crates.io |
 
 ## Links
 

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -50,7 +50,7 @@ Tag commit timestamps may differ from release dates.
 | **Pest parser** | 0.1.0-pest — 0.5.0 | Jul — Aug 2025 | PEG grammar, initial AST |
 | **Native parser + LSP** | 0.7.x — 0.8.x | Aug 2025 | Recursive descent parser, first LSP features, first public releases |
 | **Feature buildout** | 0.9.x — 0.10.0 | Jan — Feb 2026 | Semantic analyzer, DAP, release orchestration |
-| **Public alpha** | 0.11.0 — 0.12.x | Mar — Apr 2026 | Multi-platform binaries, VS Code Marketplace, crates.io |
+| **Announcement prep** | 0.11.0 — 0.12.x | Mar — Apr 2026 | Multi-platform binaries, VS Code Marketplace, crates.io |
 
 ## Links
 

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -22,9 +22,10 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.12.3` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest GitHub/editor release** | `v0.12.3`, 2026-04-09 | GitHub Releases, VS Code Marketplace, Open VSX |
-| **crates.io line** | `v0.12.2`, 2026-04-07 | crates.io |
+| **Workspace version line** | `v0.12.4` | [`Cargo.toml`](../../Cargo.toml) |
+| **Latest GitHub/editor release** | `v0.12.4`, 2026-04-12 | GitHub Releases, VS Code Marketplace |
+| **crates.io line** | `v0.12.2`, 2026-04-08 | crates.io |
+| **Release history** | [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) | Canonical cross-channel ledger |
 | **Active milestone** | `v0.13.0` public alpha announcement | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -9,12 +9,12 @@
 ## Current Framing
 
 - Workspace version line: `v0.12.4`
-- Latest published GitHub/editor release: `v0.12.3` (GitHub Releases, VS Code Marketplace, and Open VSX public line, shipped 2026-04-09)
-- crates.io published line: `v0.12.2` (registry line, shipped 2026-04-07)
-- Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.3` line stable across GitHub Releases and the editor marketplaces
+- Latest published GitHub/editor release: `v0.12.4` (GitHub Releases and VS Code Marketplace, shipped 2026-04-12)
+- crates.io published line: `v0.12.2` (registry line, published 2026-04-08)
+- Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.4` line stable across GitHub Releases and the editor marketplaces
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: public release truth is intentionally split right now. GitHub Releases and the editor marketplaces are on `v0.12.3`; crates.io remains on `v0.12.2` until the registry window reopens. Milestone sections below can describe the intended `0.12.x` breakdown, but they must not blur that channel split.
+Publication discipline: public release truth is intentionally split right now. GitHub Releases and the editor marketplaces are on `v0.12.4`; crates.io remains on `v0.12.2` until the registry window reopens. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the full cross-channel ledger. Milestone sections below can describe the intended `0.12.x` breakdown, but they must not blur that channel split.
 
 ## How To Read This File
 
@@ -53,7 +53,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - DAP Phase 3 test suite (#435) already complete (20 tests, all AC criteria met)
 - 12 PRs merged + 6 issues discovered already-done
 
-## Prepared Scope: v0.12.4 Diagnostics & Semantics
+## Completed: v0.12.4 Diagnostics & Semantics (shipped 2026-04-12)
 
 - Semantic framework coverage: inheritance, exports (#3077, PR #3098)
 - Cross-platform DAP continue/interrupt signal handling (#3028, PR #3117)

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,54 @@
+---
+version: "0.10.0"
+tag: null
+release_date_utc: null
+changelog_date: "2026-02-28"
+tag_commit: null
+previous_tag: "v0.9.1"
+compare: null
+github_release: null
+notes_status: reconstructed-from-changelog
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets: []
+---
+
+# v0.10.0
+
+## Summary
+
+Internal milestone (no tag or GitHub Release). Major campaign spanning 60+
+PRs (#845-#911) focused on build reliability, security hardening, crates.io
+publishing readiness, documentation, and code quality. This was the release
+that made the workspace publishable.
+
+## Highlights
+
+- **Document highlight for modern Perl** — try/catch parameters, method/sub
+  signatures, and string interpolation.
+- **Feature governance microcrates** — extracted into 9 dedicated crates.
+- **Security hardening** — path traversal in DAP launch (HIGH), argument
+  injection in test runner (HIGH), safe evaluation bypass (MEDIUM), GitHub
+  Actions SHA-pinned.
+- **crates.io publishing readiness** — all crate metadata verified, publish
+  allowlist expanded, dry-run packaging unblocked.
+- **VS Code Marketplace readiness** — packaging fixes, runtime deps, npm
+  lockfile.
+- **Release orchestration** — turnkey PR-driven 0.x.y release workflow.
+- **Public API documentation** — comprehensive rustdoc for `perl-parser`
+  and leaf crates.
+- 80+ workspace crates version-bumped to 0.10.0.
+
+## Status
+
+This version appears in the CHANGELOG but was never tagged or released.
+It represents the internal campaign that made 0.11.0 (the first
+multi-platform release) possible.
+
+## Links
+
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -1,0 +1,61 @@
+---
+version: "0.11.0"
+tag: "v0.11.0"
+release_date_utc: "2026-03-12"
+tag_commit: "d22ac7346c832db6b92c41d354eb90099f8b5d53"
+previous_tag: "v0.8.5"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.11.0"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0"
+notes_status: canonical
+channels:
+  crates_io: not published
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: not published
+  docker: not published
+assets:
+  - perl-lsp-0.11.0-aarch64-apple-darwin.tar.gz
+  - perl-lsp-0.11.0-aarch64-unknown-linux-gnu.tar.gz
+  - perl-lsp-0.11.0-aarch64-unknown-linux-musl.tar.gz
+  - perl-lsp-0.11.0-x86_64-apple-darwin.tar.gz
+  - perl-lsp-0.11.0-x86_64-pc-windows-msvc.zip
+  - perl-lsp-0.11.0-x86_64-unknown-linux-gnu.tar.gz
+  - perl-lsp-0.11.0-x86_64-unknown-linux-musl.tar.gz
+  - perl-lsp-0.11.0.vsix
+  - perl-lsp-rs-0.11.0.vsix
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.11.0
+
+## Summary
+
+Finalizes the distribution pipeline across GitHub releases, crates.io, and the
+VS Code extension so the workspace can ship from a single, repeatable release
+flow. This release established the release orchestration that all subsequent
+0.12.x releases build on.
+
+## Highlights
+
+- **Turnkey release orchestration** — PR-driven release path covering version
+  bumping, changelog generation, tagging, GitHub release creation, crates.io
+  publishing, extension publishing, and downstream package manager automation.
+- **Topological crates.io publishing** — workspace publish automation computes
+  dependency order from `cargo metadata`.
+- **Extension rename** — both `perl-lsp-0.11.0.vsix` and
+  `perl-lsp-rs-0.11.0.vsix` are attached (transition from old to new name).
+- **Security hardening** — path traversal fix in debug adapter launch, argument
+  injection fix in test runner, safe evaluation bypass fix for iterator/IO ops.
+
+## Install / upgrade
+
+- **VS Code**: install `EffortlessMetrics.perl-lsp-rs` (new name as of this release).
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0). Verify with `SHA256SUMS`.
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0)
+- [Compare v0.8.5...v0.11.0](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.11.0)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/d22ac7346c832db6b92c41d354eb90099f8b5d53)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -29,12 +29,13 @@ assets:
 
 ## Summary
 
-First announcement-ready milestone for the native Rust Perl 5 toolchain. The
-parser, language server, debugger, install surface, and release process now
-line up well enough for normal editor use.
+First release targeting platform availability — VS Code Marketplace, crates.io,
+multi-platform binaries. The parser, language server, debugger, install surface,
+and release process now line up well enough for normal editor use.
 
-"Public alpha" is an announcement status — the repo itself has been public
-throughout development.
+The repo has been public throughout development. "Public alpha" means the
+project is available on real distribution channels for real testing, not a
+repo visibility change.
 
 ## Highlights
 

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -29,12 +29,12 @@ assets:
 
 ## Summary
 
-Initial public alpha for the native Rust Perl 5 toolchain. The parser, language
-server, debugger, install surface, and release process now line up well enough
-for normal editor use.
+First announcement-ready milestone for the native Rust Perl 5 toolchain. The
+parser, language server, debugger, install surface, and release process now
+line up well enough for normal editor use.
 
-This is the release where `perl-lsp` transitions from internal development to
-a usable tool for Perl developers.
+"Public alpha" is an announcement status — the repo itself has been public
+throughout development.
 
 ## Highlights
 

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -1,0 +1,61 @@
+---
+version: "0.12.0"
+tag: "v0.12.0"
+release_date_utc: "2026-03-30"
+tag_commit: "4c909c2dd782ab4afce1934c910ad9e7eec3c1d2"
+previous_tag: "v0.11.0"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.11.0...v0.12.0"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0"
+notes_status: canonical
+channels:
+  crates_io: not published
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: not published
+  docker: not published
+assets:
+  - perl-lsp-rs-0.12.0.vsix
+  - perllsp-0.12.0-aarch64-apple-darwin.tar.gz
+  - perllsp-0.12.0-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.0-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.12.0-x86_64-apple-darwin.tar.gz
+  - perllsp-0.12.0-x86_64-pc-windows-msvc.zip
+  - perllsp-0.12.0-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.0-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.12.0
+
+## Summary
+
+Initial public alpha for the native Rust Perl 5 toolchain. The parser, language
+server, debugger, install surface, and release process now line up well enough
+for normal editor use.
+
+This is the release where `perl-lsp` transitions from internal development to
+a usable tool for Perl developers.
+
+## Highlights
+
+- **Full 7-platform binary release** — aarch64 and x86_64 binaries for Linux
+  (glibc and musl), macOS, and Windows.
+- **VS Code extension** — `EffortlessMetrics.perl-lsp-rs` published to the
+  VS Code Marketplace with auto-download of the correct server binary.
+- **VSIX sideload** — `perl-lsp-rs-0.12.0.vsix` attached for offline installs.
+- **Release orchestration** — single-dispatch workflow covers tagging, builds,
+  crates.io, extension publishing, and Docker in parallel.
+
+## Install / upgrade
+
+- **VS Code**: install [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) from the Marketplace.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0). Verify with `SHA256SUMS`.
+- **VSIX**: `perl-lsp-rs-0.12.0.vsix` is attached for sideload installs.
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.0)
+- [Compare v0.11.0...v0.12.0](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.11.0...v0.12.0)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/4c909c2dd782ab4afce1934c910ad9e7eec3c1d2)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.12.1.md
+++ b/docs/releases/v0.12.1.md
@@ -29,9 +29,9 @@ assets:
 
 ## Summary
 
-Fix-forward cut after the initial public alpha release. Closes release-surface
-regressions that slipped into the first `v0.12.0` tag. Does not reopen wider
-alpha scope.
+Fix-forward cut after the v0.12.0 announcement milestone. Closes
+release-surface regressions that slipped into the first `v0.12.0` tag.
+Does not reopen wider scope.
 
 ## Highlights
 

--- a/docs/releases/v0.12.1.md
+++ b/docs/releases/v0.12.1.md
@@ -1,0 +1,60 @@
+---
+version: "0.12.1"
+tag: "v0.12.1"
+release_date_utc: "2026-03-31"
+tag_commit: "7e8984b5c24a1377fac8e4fcba7a4450eb674c14"
+previous_tag: "v0.12.0"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.0...v0.12.1"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1"
+notes_status: canonical
+channels:
+  crates_io: "0.12.1 (published 2026-04-01)"
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+assets:
+  - perl-lsp-rs-0.12.1.vsix
+  - perllsp-0.12.1-aarch64-apple-darwin.tar.gz
+  - perllsp-0.12.1-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.1-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.12.1-x86_64-apple-darwin.tar.gz
+  - perllsp-0.12.1-x86_64-pc-windows-msvc.zip
+  - perllsp-0.12.1-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.1-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.12.1
+
+## Summary
+
+Fix-forward cut after the initial public alpha release. Closes release-surface
+regressions that slipped into the first `v0.12.0` tag. Does not reopen wider
+alpha scope.
+
+## Highlights
+
+- **Restored README and release-facing docs** — the source snapshot no longer
+  presents hook-test fixture content as the project front page.
+- **Hardened hook-test fixture setup** — temporary repos must live outside the
+  real checkout; seed commits no longer write placeholder git identities into
+  repo config.
+- **Version alignment** — workspace, feature-catalog, VS Code extension, and
+  operator release surfaces all target `0.12.1`.
+
+## Install / upgrade
+
+- **VS Code**: install or update `EffortlessMetrics.perl-lsp-rs`.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1). Verify with `SHA256SUMS`.
+- **VSIX**: `perl-lsp-rs-0.12.1.vsix` is attached for sideload installs.
+- **Cargo**: `cargo install perllsp@0.12.1`
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.1)
+- [Compare v0.12.0...v0.12.1](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.0...v0.12.1)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/7e8984b5c24a1377fac8e4fcba7a4450eb674c14)
+- [docs.rs](https://docs.rs/crate/perllsp/0.12.1)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.12.2.md
+++ b/docs/releases/v0.12.2.md
@@ -1,0 +1,64 @@
+---
+version: "0.12.2"
+tag: "v0.12.2"
+release_date_utc: "2026-04-04"
+tag_commit: "1c0620d8ae6b0f09e7146cbd389a5d0619952b78"
+previous_tag: "v0.12.1"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2"
+notes_status: canonical
+channels:
+  crates_io: "0.12.2 (published 2026-04-08)"
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+assets:
+  - perllsp-0.12.2-aarch64-apple-darwin.tar.gz
+  - perllsp-0.12.2-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.2-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.12.2-x86_64-apple-darwin.tar.gz
+  - perllsp-0.12.2-x86_64-pc-windows-msvc.zip
+  - perllsp-0.12.2-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.2-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.12.2
+
+## Summary
+
+Confidence-building release for the 0.12.x series. 89 commits across 59 PRs
+spanning new features, performance, testing, distribution, and documentation.
+First successful crates.io publish run: 108 of 129 crates published.
+
+## Highlights
+
+- **Extract variable and subroutine code actions** — new refactoring code
+  actions for extracting expressions to variables and selected blocks to
+  subroutines.
+- **Subroutine inlining** — inline a subroutine call, replacing it with the
+  body of the called function.
+- **Dead code highlighting** — `DiagnosticTag::Unnecessary` surfaces unreachable
+  code in the editor.
+- **Context-sensitive quote-like operator parsing** — parser correctly handles
+  `s///`, `tr///`, `y///`, and `qr//` with context awareness.
+- **Semantic framework coverage** — complete inheritance and export analysis for
+  Moo/Moose/Exporter patterns.
+- **Windows package manager automation** — Scoop, Chocolatey, and winget
+  manifests auto-update on release.
+
+## Install / upgrade
+
+- **VS Code**: install or update `EffortlessMetrics.perl-lsp-rs`.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2). Verify with `SHA256SUMS`.
+- **Cargo**: `cargo install perllsp@0.12.2`
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2)
+- [Compare v0.12.1...v0.12.2](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/1c0620d8ae6b0f09e7146cbd389a5d0619952b78)
+- [docs.rs](https://docs.rs/crate/perllsp/0.12.2)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.12.3.md
+++ b/docs/releases/v0.12.3.md
@@ -30,7 +30,7 @@ assets:
 ## Summary
 
 Pipeline rehearsal release validating the full publish + extension + Docker cycle
-before the v0.13.0 announcement. Rolls up publish pipeline fixes, UX P0
+before v0.13.0 platform availability. Rolls up publish pipeline fixes, UX P0
 improvements, pre-announcement cleanup, and CI hardening.
 
 ## Highlights

--- a/docs/releases/v0.12.3.md
+++ b/docs/releases/v0.12.3.md
@@ -1,0 +1,61 @@
+---
+version: "0.12.3"
+tag: "v0.12.3"
+release_date_utc: "2026-04-09"
+tag_commit: "a86af2211169c2f7799f4b52256a3e34e576cbfd"
+previous_tag: "v0.12.2"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3"
+notes_status: canonical
+channels:
+  crates_io: deferred
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+assets:
+  - perl-lsp-rs-0.12.3.vsix
+  - perllsp-0.12.3-aarch64-apple-darwin.tar.gz
+  - perllsp-0.12.3-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.3-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.12.3-x86_64-apple-darwin.tar.gz
+  - perllsp-0.12.3-x86_64-pc-windows-msvc.zip
+  - perllsp-0.12.3-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.3-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.12.3
+
+## Summary
+
+Pipeline rehearsal release validating the full publish + extension + Docker cycle
+before the v0.13.0 public alpha. Rolls up publish pipeline fixes, UX P0
+improvements, pre-announcement cleanup, and CI hardening.
+
+## Highlights
+
+- **`tree-sitter-perl-c` first published to crates.io** — the conventional C
+  grammar binding ships as a proper leaf crate with vendored C sources,
+  shedding its `libclang`/bindgen dependency.
+- **Publish pipeline overhaul** — Tarjan SCC topological sort for dev-dependency
+  cycles, sparse-index verification replacing sleep-based polling, and rate
+  limit math fixes.
+- **Pre-announcement cleanup** — license file canonicalization, gitignore
+  hardening, README version sync, and extension rename stabilization.
+- **Version-sync automation** — `xtask bump-version` command covers docs,
+  Cargo.toml, and VS Code extension metadata.
+
+## Install / upgrade
+
+- **VS Code**: install or update `EffortlessMetrics.perl-lsp-rs`.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3). Verify with `SHA256SUMS`.
+- **VSIX**: `perl-lsp-rs-0.12.3.vsix` is attached to this release for sideload installs.
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3)
+- [Compare v0.12.2...v0.12.3](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/a86af2211169c2f7799f4b52256a3e34e576cbfd)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.12.3.md
+++ b/docs/releases/v0.12.3.md
@@ -30,7 +30,7 @@ assets:
 ## Summary
 
 Pipeline rehearsal release validating the full publish + extension + Docker cycle
-before the v0.13.0 public alpha. Rolls up publish pipeline fixes, UX P0
+before the v0.13.0 announcement. Rolls up publish pipeline fixes, UX P0
 improvements, pre-announcement cleanup, and CI hardening.
 
 ## Highlights

--- a/docs/releases/v0.12.4.md
+++ b/docs/releases/v0.12.4.md
@@ -1,0 +1,73 @@
+---
+version: "0.12.4"
+tag: "v0.12.4"
+release_date_utc: "2026-04-12"
+tag_commit: "5ebb37aad3ebedec59fb8626a5d82f6878199f7b"
+previous_tag: "v0.12.3"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4"
+notes_status: canonical
+channels:
+  crates_io: deferred
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+assets:
+  - perllsp-0.12.4-aarch64-apple-darwin.tar.gz
+  - perllsp-0.12.4-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.4-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.12.4-x86_64-apple-darwin.tar.gz
+  - perllsp-0.12.4-x86_64-pc-windows-msvc.zip
+  - perllsp-0.12.4-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.12.4-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.12.4
+
+## Summary
+
+Major patch release shipping inherited/role method navigation, pragma tracker
+correctness sweep, incremental parsing improvements, workspace file-operations
+refactoring, `workspace/configuration` reverse-request flow, Windows
+extended-length path fixes, and Perl::Critic diagnostics UX overhaul.
+
+~70 PRs merged across two sessions covering navigation, pragma scoping,
+incremental parsing, workspace refactoring, Windows hardening, diagnostics
+polish, hover improvements, completion ranking, and CI hygiene.
+
+## Highlights
+
+- **Inherited and role method navigation** — `goto-definition`, hover, and
+  workspace completion BFS through Moo/Moose `with 'Role'` and
+  `extends`/`use parent` chains. AUTOLOAD-backed method calls resolve through
+  the fallback path.
+- **Pragma tracker correctness sweep** — four independent false-negative paths
+  in `PragmaTracker` / `check_strict_warnings` fixed.
+- **Incremental parsing** — segment-based token cache with two-sided checkpoint
+  window replaces monolithic `TokenCache`.
+- **Workspace file-operations** — `workspace/willRenameFiles` plans edits across
+  unopened files; `workspace/willDeleteFiles` emits warnings for cross-file
+  reference breakage.
+- **`workspace/configuration` reverse-request** — server issues
+  `workspace/configuration` requests per folder when the client advertises the
+  capability.
+- **Windows extended-length path fix** — strips `\\?\` prefix before spawning
+  external commands (`perl.exe`, `prove`, `yath`).
+- **Perl::Critic diagnostics UX** — policy codes carry `source: "perlcritic"`,
+  missing binary and invalid profiles surface as workspace warnings.
+
+## Install / upgrade
+
+- **VS Code**: install or update the [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) extension.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4). Verify with `SHA256SUMS`.
+- **Source**: `cargo install perllsp` (once crates.io publish completes).
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4)
+- [Compare v0.12.3...v0.12.4](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/5ebb37aad3ebedec59fb8626a5d82f6878199f7b)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.8.3.md
+++ b/docs/releases/v0.8.3.md
@@ -1,0 +1,46 @@
+---
+version: "0.8.3"
+tag: "v0.8.3"
+release_date_utc: "2025-08-23"
+tag_commit: "5331007a215cfc0cef4e41cee958d62b2504527a"
+previous_tag: null
+compare: null
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3"
+notes_status: imported-from-github-release
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets: []
+---
+
+# v0.8.3
+
+## Summary
+
+First public release. Source-only (no pre-built binaries). Establishes the
+parser foundation with hash literal parsing, parenthesized expressions,
+quote-words support, and initial LSP go-to-definition and inlay hints.
+
+## Highlights
+
+- **Hash literal parsing** — `{ key => value }` correctly produces `HashLiteral`
+  nodes with context-aware block vs. expression handling.
+- **Parenthesized expressions** — word operators in parentheses parse correctly.
+- **Quote words (`qw`)** — `qw()` produces `ArrayLiteral` nodes with all
+  delimiter types supported.
+- **Go-to-definition** — uses `DeclarationProvider` for function location.
+- **Inlay hints** — recognizes `HashLiteral` nodes for key-value display.
+- 147 parser library tests passing.
+
+## Install / upgrade
+
+- **Source only**: `cargo install` from the repository at the `v0.8.3` tag.
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/5331007a215cfc0cef4e41cee958d62b2504527a)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.8.5.md
+++ b/docs/releases/v0.8.5.md
@@ -1,0 +1,49 @@
+---
+version: "0.8.5"
+tag: "v0.8.5"
+release_date_utc: "2025-08-24"
+tag_commit: "ae75da03226fa31c17e695b3c96fb0e4be687263"
+previous_tag: "v0.8.3"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.3...v0.8.5"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.5"
+notes_status: imported-from-github-release
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets:
+  - perl-lsp-v0.8.5-linux-x64.sha256
+  - perl-lsp-v0.8.5-linux-x64.tar.gz
+---
+
+# v0.8.5
+
+## Summary
+
+Early release adding typed `ServerCapabilities`, pull diagnostics support,
+stable error codes, and enhanced code descriptions with perldoc links.
+
+## Highlights
+
+- **Typed ServerCapabilities** — all LSP responses use the correct typed struct.
+- **Pull diagnostics** — LSP 3.17 pull-based diagnostics with
+  `interFileDependencies` and `workspaceDiagnostics` flags.
+- **Stable error codes** — standardized on `-32802` for request cancellations.
+- **Enhanced code descriptions** — diagnostics include perldoc links.
+- **Inlay hint anchoring** — parameter hints anchor correctly for both
+  parenthesized and non-parenthesized function calls.
+
+## Install / upgrade
+
+- **Binary**: download `perl-lsp-v0.8.5-linux-x64.tar.gz` from the
+  [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.5).
+  Verify with the attached `.sha256` file.
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.5)
+- [Compare v0.8.3...v0.8.5](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.3...v0.8.5)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/ae75da03226fa31c17e695b3c96fb0e4be687263)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.8.8.md
+++ b/docs/releases/v0.8.8.md
@@ -1,0 +1,41 @@
+---
+version: "0.8.8"
+tag: null
+release_date_utc: null
+changelog_date: "2025-12-01"
+tag_commit: null
+previous_tag: null
+compare: null
+github_release: null
+notes_status: reconstructed-from-changelog
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets: []
+---
+
+# v0.8.8
+
+## Summary
+
+Internal milestone (no tag or GitHub Release). Added initial workspace
+configuration support and enhanced formatting fallback.
+
+## Highlights
+
+- **Initial workspace configuration support**.
+- **Enhanced formatting fallback** — always-available capabilities with
+  perltidy integration.
+
+## Status
+
+CHANGELOG-only entry. No tag or release exists for this version.
+The v0.8.8 tag does not resolve in the repo — this was likely a CHANGELOG
+scope marker that was never cut as a release.
+
+## Links
+
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.8.8.md
+++ b/docs/releases/v0.8.8.md
@@ -20,8 +20,9 @@ assets: []
 
 ## Summary
 
-Internal milestone (no tag or GitHub Release). Added initial workspace
-configuration support and enhanced formatting fallback.
+Internal milestone (no tag or GitHub Release) from the push leading up to
+the 2025-12-10 DemoSwarm talk, where perl-parser was a key topic. Added
+initial workspace configuration support and enhanced formatting fallback.
 
 ## Highlights
 
@@ -29,11 +30,15 @@ configuration support and enhanced formatting fallback.
 - **Enhanced formatting fallback** — always-available capabilities with
   perltidy integration.
 
+## Context
+
+Part of the preparation for the 2025-12-10 DemoSwarm presentation.
+The perl-parser was a central demo topic, so this milestone focused on
+making the editor experience presentable (workspace config, formatting).
+
 ## Status
 
 CHANGELOG-only entry. No tag or release exists for this version.
-The v0.8.8 tag does not resolve in the repo — this was likely a CHANGELOG
-scope marker that was never cut as a release.
 
 ## Links
 

--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,0 +1,42 @@
+---
+version: "0.9.0"
+tag: null
+release_date_utc: null
+changelog_date: "2026-01-18"
+tag_commit: null
+previous_tag: null
+compare: null
+github_release: null
+notes_status: reconstructed-from-changelog
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets: []
+---
+
+# v0.9.0
+
+## Summary
+
+Internal milestone (no tag or GitHub Release). Introduced semantic analysis
+Phase 1 and cross-file navigation.
+
+## Highlights
+
+- **Semantic Analyzer Phase 1** — 12/12 critical node handlers implemented.
+- **LSP textDocument/definition integration** — semantic-aware definition
+  resolution.
+- **Enhanced cross-file navigation** — dual indexing strategy for improved
+  reference coverage.
+- **LSP coverage** increased to 82% of trackable features.
+
+## Status
+
+CHANGELOG-only entry. No tag or release exists for this version.
+
+## Links
+
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.9.1.md
+++ b/docs/releases/v0.9.1.md
@@ -1,0 +1,49 @@
+---
+version: "0.9.1"
+tag: "v0.9.1"
+release_date_utc: null
+tag_date: "2026-02-20"
+tag_commit: "c82a1604987f315868973a4e5804112e031cec92"
+previous_tag: null
+compare: null
+github_release: null
+notes_status: reconstructed-from-changelog
+channels:
+  crates_io: not published
+  vscode_marketplace: not published
+  open_vsx: not published
+  docker: not published
+assets: []
+---
+
+# v0.9.1
+
+## Summary
+
+Internal milestone (tag only, no GitHub Release). Represents the substantially
+complete feature set for early testing — semantic analyzer, DAP support, and LSP
+coverage at 99% of LSP 3.18 methods.
+
+## Highlights
+
+- **Complete semantic analyzer** — all NodeKind handlers implemented (Phases 1,
+  2, 3) with 100% AST node coverage.
+- **Debug Adapter Protocol (DAP) support** — Phase 1 bridge to
+  Perl::LanguageServer.
+- **LSP cancellation system** — thread-safe infrastructure for minimal latency.
+- **Advanced code actions** — AST-aware refactoring including extraction and
+  import optimization.
+- **Security hardening** — UTF-16 boundary fixes and path traversal prevention.
+- **MSRV bumped to 1.92** (Rust 2024 edition).
+- Full test suite running in 0.31s via adaptive threading.
+
+## Status
+
+This version was tagged but never published as a GitHub Release. It served as
+the internal alpha milestone before the v0.10.0 campaign.
+
+## Links
+
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/c82a1604987f315868973a4e5804112e031cec92)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)


### PR DESCRIPTION
## Summary

- Adds `RELEASE_HISTORY.md` as the canonical cross-channel release ledger at repo root
- Creates `docs/releases/vX.Y.Z.md` per-release note files (9 files) with YAML front-matter, curated summaries, and verified metadata
- Links each CHANGELOG version section to its release note file and GitHub Release
- Adds release-history update checklist to `RELEASE.md` for future releases

## Backfill details

All metadata backfilled from the GitHub Releases API (`gh release view --json`):
- **8 public releases** with GitHub Releases: v0.8.3, v0.8.5, v0.11.0, v0.12.0–v0.12.4
- **8 tag-only milestones** recorded: v0.1.0-pest through v0.9.1
- **3 CHANGELOG-only entries** documented as internal scope markers: 0.8.8, 0.9.0, 0.10.0
- Tag commit SHAs verified via `git rev-parse`
- Asset lists verified from release metadata
- crates.io publish dates sourced from docs.rs

## What this enables

Every future release creates one immutable note, one changelog section, one ledger row. The release playbook now has a pre/post checklist that keeps the surface consistent.

## Test plan

- [ ] `RELEASE_HISTORY.md` renders correctly on GitHub (table, links)
- [ ] `docs/releases/v0.12.4.md` front-matter is valid YAML
- [ ] All compare links resolve to valid GitHub compare pages
- [ ] `CHANGELOG.md` release note links point to existing files
- [ ] `RELEASE.md` checklist section is reachable from the ToC